### PR TITLE
ci: bundle part six

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
+      - uses: extractions/setup-just@v1
+      # Setup go for building drivechain-server
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+      # Setup go for building bdk-cli
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
 
       # Note: This workflow uses the latest stable version of the Dart SDK.
       # You can specify other versions if desired, see documentation here:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,9 @@ jobs:
           echo "Unlocking keychain"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
 
+          echo "Setting keychain timeout to 20 minutes"
+          security set-keychain-settings -t 1200 -l ~/Library/Keychains/build.keychain
+
           echo "Importing certificate into keychain"
           security import ./certificate.p12 -k ~/Library/Keychains/build.keychain -P ${{ secrets.MACOS_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,60 +2,56 @@ name: Build Clients
 
 on:
   push:
-    branches: ["master"]
+    branches: [master]
     paths:
+      - 'drivechain-server/**'
       - 'clients/scripts/**'
-      - 'clients/sidesail/**'
       - 'clients/bitwindow/**'
+      - 'clients/sidesail/**'
+      - '.github/workflows/**'
   pull_request:
-    branches: ["master"]
+    branches: [master]
     paths:
+      - 'drivechain-server/**'
       - 'clients/scripts/**'
-      - 'clients/sidesail/**'
       - 'clients/bitwindow/**'
+      - 'clients/sidesail/**'
       - '.github/workflows/**'
 
-defaults:
-  run:
-    working-directory: clients
-
 jobs:
-
   build:
     strategy:
       fail-fast: false
       matrix:
         include:
-          # SideSail builds on
-          # os: [ubuntu-latest, macos-latest, windows-latest]
-          # chain: [testchain, ethereum, zcash] (but not zcash for windows)
+          # Sidesail testchain builds for all os'es
           - os: ubuntu-latest
             client: sidesail
             chain: testchain
+          - os: macos-latest
+            client: sidesail
+            chain: testchain
+          - os: windows-latest
+            client: sidesail
+            chain: testchain
+          # Sidesail ethereum builds for all os'es
           - os: ubuntu-latest
             client: sidesail
             chain: ethereum
+          - os: macos-latest
+            client: sidesail
+            chain: ethereum
+          - os: windows-latest
+            client: sidesail
+            chain: ethereum
+          # Sidesail zcash does not build for windows
           - os: ubuntu-latest
             client: sidesail
             chain: zcash
           - os: macos-latest
             client: sidesail
-            chain: testchain
-          - os: macos-latest
-            client: sidesail
-            chain: ethereum
-          - os: macos-latest
-            client: sidesail
             chain: zcash
-          - os: windows-latest
-            client: sidesail
-            chain: testchain
-          - os: windows-latest
-            client: sidesail
-            chain: ethereum
-          # BitWindow builds on
-          # os: [ubuntu-latest, macos-latest, windows-latest]
-          # chain: [''] (no chain)
+          # BitWindow builds for all os'es
           - os: ubuntu-latest
             client: bitwindow
             chain: ''
@@ -71,7 +67,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: clients # must be specified here as well, otherwise overwrites top most
+        working-directory: clients
 
     steps:
       - uses: actions/checkout@v4
@@ -87,21 +83,18 @@ jobs:
           toolchain: stable
 
 
-      # Note: This workflow uses the latest stable version of the Dart SDK.
-      # You can specify other versions if desired, see documentation here:
-      # https://github.com/dart-lang/setup-dart/blob/main/README.md
+      - name: Create assets/bin directory
+        run: |
+          mkdir -p ${{ matrix.client }}/assets/bin
+
+      # This workflow uses the latest stable version of the Dart SDK.
       - uses: dart-lang/setup-dart@v1
       - name: Install dependencies
         run: |
           cd ${{ matrix.client }}
           flutter pub get
 
-
-      - name: Create necessary directories
-        run: |
-          mkdir -p ${{ matrix.client }}/assets/bin
-
-      # standard macOS sed has subtle differences from gnu
+       # standard macOS sed has subtle differences from gnu
       - name: Install GNU sed on macOS
         if: runner.os == 'macOS'
         run: |
@@ -141,13 +134,8 @@ jobs:
           echo Certificate subject: "'$cert_subject'"
 
           cn_part=$(grep -o 'CN = "[^"]*"' <<< "$cert_subject")
-          echo CN part: "'$cn_part'"
-
           cn_value=$(sed 's/CN = "\(.*\)"/\1/' <<< "$cn_part")
-          echo CN value: "'$cn_value'"
-
-          echo "Determined code sign identity: '$cn_value'"
-
+          echo "Determined code sign identity"
           echo "CODESIGN_IDENTITY=$cn_value" >> $GITHUB_ENV
 
           echo "Creating notarization API key file"
@@ -160,7 +148,7 @@ jobs:
             chain_param="none"
           fi
           
-          # Everything after first line is only relevant for macOS
+          # Everything after the first line is only relevant for macOS
           ./scripts/build-app.sh ${{ runner.os }} ${{ matrix.client }} "$chain_param" \
             "$CODESIGN_IDENTITY" $PWD/notarization_api_key.p8 \
             ${{ secrets.GODOT_MACOS_NOTARIZATION_API_KEY_ID }} \
@@ -175,7 +163,10 @@ jobs:
   upload-artifacts-to-releases-drivechain-info:
     name: Upload artifacts to releases.drivechain.info
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: build
+    defaults:
+      run:
+        working-directory: clients
     # avoid uploading on PRs
     # prettier-ignore
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'LayerTwo-Labs'

--- a/.github/workflows/drivechain-server.yml
+++ b/.github/workflows/drivechain-server.yml
@@ -1,4 +1,4 @@
-name: Drivechain server
+name: Drivechain Server
 
 on:
   pull_request:
@@ -42,7 +42,13 @@ jobs:
 
   go-build:
     name: go-build
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: drivechain-server
     steps:
       - uses: extractions/setup-just@v1
       - uses: actions/checkout@v4
@@ -51,4 +57,25 @@ jobs:
         with:
           go-version: "1.22"
 
-      - run: just build
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Build bdk-cli
+        run: just build-bdk-cli
+
+      - name: Build drivechain-server
+        run: just build-go
+
+      - name: Determine artifact name
+        id: artifact-name
+        run: |
+          echo "name=drivechain-server-${{ matrix.os }}" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.artifact-name.outputs.name }}
+          path: |
+            drivechain-server/bin/drivechain-server
+            drivechain-server/bin/bdk-cli
+          if-no-files-found: error

--- a/.github/workflows/drivechain-server.yml
+++ b/.github/workflows/drivechain-server.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -44,7 +44,7 @@ jobs:
     name: go-build
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -55,27 +55,28 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
 
       - name: Build bdk-cli
-        run: just build-bdk-cli
-
-      - name: Build drivechain-server
-        run: just build-go
-
-      - name: Determine artifact name
-        id: artifact-name
         run: |
-          echo "name=drivechain-server-${{ matrix.os }}" >> $GITHUB_OUTPUT
-
+          just build-bdk-cli
+          mv bin/bdk-cli${{ runner.os == 'Windows' && '.exe' || '' }} bin/bdk-cli${{ runner.os == 'Windows' && '.exe' || '' }}-${{ runner.os }}
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.artifact-name.outputs.name }}
-          path: |
-            drivechain-server/bin/drivechain-server
-            drivechain-server/bin/bdk-cli
+          name: bdk-cli${{ runner.os == 'Windows' && '.exe' || '' }}-${{ runner.os }}
+          path: drivechain-server/bin
+          if-no-files-found: error
+
+      - name: Build drivechain-server
+        run: |
+          just build-go
+          mv bin/drivechain-server bin/drivechain-server-${{ runner.os }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: drivechain-server-${{ runner.os }}
+          path: drivechain-server/bin
           if-no-files-found: error

--- a/clients/bitwindow/scripts/download-binaries.sh
+++ b/clients/bitwindow/scripts/download-binaries.sh
@@ -109,4 +109,28 @@ if ! test -f $assets_dir/$enforcer; then
     echo "Enforcer binary renamed to $enforcer"
 fi
 
+echo Going back to $old_cwd
+cd $old_cwd
+
+cd ../../drivechain-server
+server_cwd=$(pwd)
+
+# Build bdk-cli and drivechain-server
+echo "Building bdk-cli and drivechain-server in $server_cwd"
+
+# Build bdk-cli
+echo "Building bdk-cli"
+just build-bdk-cli
+
+# Build drivechain-server
+echo "Building drivechain-server"
+just build-go
+
+# Move the built binaries to the assets directory
+mv bin/bdk-cli $assets_dir/
+mv bin/drivechain-server $assets_dir/
+
+echo "bdk-cli and drivechain-server have been built and moved to $assets_dir"
+
+echo Going back to $old_cwd
 cd $old_cwd

--- a/clients/scripts/build-app.sh
+++ b/clients/scripts/build-app.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 
-# This script orchestrates the build process for clients in the sub-folder of this directory.
-# for different platforms (Linux, macOS, Windows).
-# All sub-folders that want to use this script need these scripts
-# to be present:
-# 1. set-app-name.sh
-# 2. download-binaries.sh
-# 3. flavorize-<linux/macos/windows>.sh
+# This script orchestrates the build process for all clients in this directory, for various
+# OSes (Linux, macOS, Windows).
+# All clients that want to use this script need these scripts:
+# 1. set-app-name.sh - must set the app name and create build-vars.env (if any)
+# 2. download-binaries.sh - responsible for populating the assets/bin directory.
+# 3. flavorize-<linux/macos/windows>.sh - responsible for setting name, icon etc. for the os.
 
 set -e
 
-platform=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+os=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 client="$2"
 chain=$(echo "$3" | tr '[:upper:]' '[:lower:]')
 identity="$4"
@@ -18,69 +17,52 @@ notarization_key_path="$5"
 notarization_key_id="$6"
 notarization_issuer_id="$7"
 
-if test -z "$platform" -o -z "$client"; then
+# Convert github actions os names names to a format we expect
+case "$os" in
+    windows-latest) os="windows" ;;
+    linux-latest)   os="linux" ;;
+    macos-latest)   os="macos" ;;
+esac
+
+if test -z "$os" -o -z "$client"; then
     echo "Usage: $0 <linux/macos/windows> <sidesail/launcher/bitwindow> [chain] [code_sign_identity] [notarization_key_path] [notarization_key_id] [notarization_issuer_id]"
     exit 1
 fi
 
-client_dir="$client"
+old_cwd=$(pwd)
+cleanup() {
+    rm -f "$client_dir/build-vars.env"
+    git checkout -f "$client_dir/macos"
+    git checkout -f "$client_dir/linux"
+    git checkout -f "$client_dir/windows"
+    echo "Cleaned up successfully"
+    cd $old_cwd
+}
+trap cleanup EXIT
 
+client_dir="$client"
 if [ ! -d "$client_dir" ]; then
     echo "Error: Client directory $client_dir does not exist."
     exit 1
 fi
-
-# Enter the directory of the client we're building for
 cd "$client_dir"
 
-cleanup() {
-    rm -f "$client_dir/build-vars.env"
-    echo "Cleaned up successfully"
-    cd ../
-}
-# run cleanup on exit
-trap cleanup EXIT
-
-# set-app-name.sh is required in the client directory. 
-if [ ! -f "./scripts/set-app-name.sh" ]; then
-    echo "set-app-name.sh is required, does not exist in ./$client_dir/scripts/"
-    exit 1
-fi
-
-# Run set-app-name.sh to set $app_name and create build-vars.env
 source ./scripts/set-app-name.sh "$chain"
-
-# Check that set-app-name.sh did its job
 if [ -z "$app_name" ]; then
     echo "Error: set-app-name.sh did not set a valid app name"
     exit 1
 fi
-
-# Print the app_name for debugging
 echo "App name set to: $app_name"
 
-# download-binaries.sh is required in the client directory. 
-if [ ! -f "./scripts/download-binaries.sh" ]; then
-    echo "download-binaries.sh is required, does not exist in ./$client_dir/scripts/"
-    exit 1
-fi
+echo "Downloading $client_dir binaries for $os"
+bash ./scripts/download-binaries.sh "$os" "$chain"
 
-echo "Downloading $client_dir binaries for $platform"
-bash ./scripts/download-binaries.sh "$platform" "$chain"
+echo "Flavorizing $client_dir for $os"
+bash ./scripts/flavorize-"$os".sh "$app_name"
 
-# flavorize-<platform>.sh is required in the client directory. 
-if [ ! -f "./scripts/flavorize-$platform.sh" ]; then
-    echo "Error: flavorize-$platform.sh does not exist in ./$client_dir/scripts/"
-    exit 1
-fi
-
-echo "Flavorizing $client_dir for $platform"
-bash ./scripts/flavorize-"$platform".sh "$app_name"
-
-# Return to the parent directory to run the platform-specific build script
+# Return to the parent directory to run the os-specific build script
 cd ../
-
 echo "Building $client_dir $app_name release"
-bash ./scripts/build-"$platform".sh "$app_name" "$client_dir" \
+bash ./scripts/build-"$os".sh "$app_name" "$client_dir" \
     "$identity" "$notarization_key_path" \
     "$notarization_key_id" "$notarization_issuer_id"

--- a/clients/scripts/build-app.sh
+++ b/clients/scripts/build-app.sh
@@ -35,8 +35,9 @@ cleanup() {
     git checkout -f "$client_dir/macos"
     git checkout -f "$client_dir/linux"
     git checkout -f "$client_dir/windows"
-    echo "Cleaned up successfully"
+    echo "Cleaned up all files"
     cd $old_cwd
+    echo "Back to $old_cwd"
 }
 trap cleanup EXIT
 

--- a/drivechain-server/.gitignore
+++ b/drivechain-server/.gitignore
@@ -1,6 +1,4 @@
 drivechain-server
-/bdk/bin/
-/bdk/.crates*
-/enforcer/bin/
-/enforcer/.crates*
+bin/
+.crates*
 /*.mdb

--- a/drivechain-server/Justfile
+++ b/drivechain-server/Justfile
@@ -44,19 +44,38 @@ build-bdk-cli:
 build-enforcer:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ ! -f "./enforcer/bin/bip300301_enforcer" ]; then
-        echo "Building enforcer..."
-        mkdir -p ./enforcer/bin
-        if ! command -v rustc &> /dev/null; then
-            echo "Error: Rust is not installed. Please install Rust and try again."
+
+    # Download the correct binary for the current OS
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        enforcer_version_postfix="apple-darwin"
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        enforcer_version_postfix="unknown-linux-gnu"
+    else
+        echo "Unsupported operating system: $OSTYPE"
+        exit 1
+    fi
+
+    binary_name="bip300301_enforcer"
+    if ! test -f ./bin/$binary_name; then
+        # Setup
+        echo "Downloading $binary_name..."
+        mkdir -p ./bin
+        # Download
+        enforcer_zip=bip300301-enforcer-latest-x86_64-$enforcer_version_postfix.zip
+        curl --fail -O https://releases.drivechain.info/$enforcer_zip
+        # Unpack
+        echo unpacking: unzip $enforcer_zip
+        unzip $enforcer_zip
+        enforcer_binary=$(find . -name "bip300301_enforcer*" -print -quit)
+        if [ -z "$enforcer_binary" ]; then
+            echo "Error: Could not find the enforcer binary in the extracted files."
             exit 1
         fi
-        cargo install \
-        --git https://github.com/LayerTwo-Labs/bip300301_enforcer.git \
-        --branch master \
-        --root ./enforcer \
-        --bin bip300301_enforcer
-        echo "enforcer has been built to ./enforcer/bin/bip300301_enforcer"
+        # Move
+        mv "$enforcer_binary" ./bin/$binary_name
+        echo "$binary_name has been downloaded to ./bin/$binary_name"
+        # Clean up
+        rm $enforcer_zip
     else
-        echo "enforcer already exists, skipping build"
+        echo "$binary_name already exists in ./bin/$binary_name, skipping download"
     fi

--- a/drivechain-server/Justfile
+++ b/drivechain-server/Justfile
@@ -4,7 +4,9 @@ build-go:
 build: build-bdk-cli build-enforcer build-go
 
 clean:
-    rm -rf ./bdk/bin
+    rm -r ./bin
+    rm -r bip300301_enforcer.mdb
+    rm -r .crates*
     go clean
 
 lint:
@@ -21,7 +23,7 @@ gen-enforcer:
 build-bdk-cli:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ ! -f "./bdk/bin/bdk-cli" ]; then
+    if [ ! -f "./bin/bdk-cli" ]; then
         echo "Building bdk-cli..."
         mkdir -p ./bin
         if ! command -v rustc &> /dev/null; then
@@ -31,10 +33,10 @@ build-bdk-cli:
         cargo install \
         --git https://github.com/bitcoindevkit/bdk-cli.git \
         --tag v0.27.1 \
-        --root ./bdk \
+        --root . \
         --no-default-features \
         --features=key-value-db,compiler,electrum
-        echo "bdk-cli has been built to ./bdk/bin/bdk-cli"
+        echo "bdk-cli has been built to ./bin/bdk-cli"
     else
         echo "bdk-cli already exists, skipping build"
     fi


### PR DESCRIPTION
This PR:
It also
1. Shuffles around where drivechain-server binaries are built to. Now everything is built to drivechain-server/bin.
2. Downloads precompiled binary for bip300301-enforcer from releases.drivechain.info. Prior to this, we downloaded the git folder, and tried to build it ourselves.
3. Bundles all binaries needed for bitwindows to work, that weren't already bundled, e.g: drivechain-server and bdk-cli.
