### PR TITLE
drivechain-server: add zmqpubsequence and addnode to docker-compose

### DIFF
--- a/clients/bitwindow/lib/main.dart
+++ b/clients/bitwindow/lib/main.dart
@@ -183,8 +183,9 @@ Future<void> initEnforcer(
   Logger log,
 ) async {
   final enforcer = GetIt.I.get<EnforcerRPC>();
-  final binary = 'bip300301-enforcer';
 
+  // TODO: Find a way to ping the enforcer
+  final binary = 'bip300301-enforcer';
   await enforcer.initBinary(context, binary);
 
   log.i('mainchain init: successfully started enforcer');

--- a/clients/bitwindow/lib/servers/mainchain_rpc.dart
+++ b/clients/bitwindow/lib/servers/mainchain_rpc.dart
@@ -110,7 +110,6 @@ class MainchainRPCLive extends MainchainRPC {
 
     final sidechainArgs = [
       '-datadir=$dataDir',
-      '-zmqpubsequence=tcp://0.0.0.0:29000',
       '-signet',
       '-server',
       '-addnode=drivechain.live:8383',
@@ -123,6 +122,7 @@ class MainchainRPCLive extends MainchainRPC {
       '-debug=net',
       '-txindex',
       '-fallbackfee=0.00021',
+      '-zmqpubsequence=tcp://0.0.0.0:29000',
     ];
 
     // Check if the data directory exists before starting the node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
      - -debug=net
      - -txindex
      - -fallbackfee=0.00021
+     - -zmqpubsequence=tcp://0.0.0.0:29000
+     - -addnode=drivechain.live:8383
 
   zside:
     image: barebitcoin/zside:latest

--- a/drivechain-server/api/bitcoind/bitcoind.go
+++ b/drivechain-server/api/bitcoind/bitcoind.go
@@ -9,7 +9,6 @@ import (
 	"connectrpc.com/connect"
 	pb "github.com/LayerTwo-Labs/sidesail/drivechain-server/gen/bitcoind/v1"
 	rpc "github.com/LayerTwo-Labs/sidesail/drivechain-server/gen/bitcoind/v1/bitcoindv1connect"
-	validatorrpc "github.com/LayerTwo-Labs/sidesail/drivechain-server/gen/cusf/mainchain/v1/mainchainv1connect"
 	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	coreproxy "github.com/barebitcoin/btc-buf/server"
 	"github.com/btcsuite/btcd/btcutil"
@@ -22,17 +21,16 @@ var _ rpc.BitcoindServiceHandler = new(Server)
 
 // New creates a new Server
 func New(
-	bitcoind *coreproxy.Bitcoind, enforcer validatorrpc.ValidatorServiceClient,
+	bitcoind *coreproxy.Bitcoind,
 ) *Server {
 	s := &Server{
-		bitcoind: bitcoind, enforcer: enforcer,
+		bitcoind: bitcoind,
 	}
 	return s
 }
 
 type Server struct {
 	bitcoind *coreproxy.Bitcoind
-	enforcer validatorrpc.ValidatorServiceClient
 }
 
 // EstimateSmartFee implements drivechainv1connect.DrivechainServiceHandler.

--- a/drivechain-server/dial/dial.go
+++ b/drivechain-server/dial/dial.go
@@ -34,7 +34,7 @@ func Enforcer(ctx context.Context, url string) (rpc.ValidatorServiceClient, erro
 	var tip *connect.Response[pb.GetChainTipResponse]
 	var blockHash *chainhash.Hash
 	var err error
-	for attempt := range 5 {
+	for attempt := range 3 {
 		tip, err = client.GetChainTip(ctx, connect.NewRequest(&pb.GetChainTipRequest{}))
 		if err == nil {
 			blockHash, err = chainhash.NewHash([]byte(tip.Msg.BlockHeaderInfo.BlockHash.Hex.Value))
@@ -53,7 +53,7 @@ func Enforcer(ctx context.Context, url string) (rpc.ValidatorServiceClient, erro
 		}
 	}
 	if err != nil {
-		return nil, fmt.Errorf("get mainchain tip and parse blockhash after 5 attempts: %w", err)
+		return client, fmt.Errorf("get mainchain tip and parse blockhash after 3 attempts: %w", err)
 	}
 
 	zerolog.Ctx(ctx).Debug().

--- a/drivechain-server/main.go
+++ b/drivechain-server/main.go
@@ -77,7 +77,9 @@ func realMain(ctx context.Context) error {
 
 	enforcer, err := dial.Enforcer(ctx, conf.EnforcerHost)
 	if err != nil {
-		return fmt.Errorf("connect to enforcer: %w", err)
+		log.Error().Err(err).Msg("connect to enforcer")
+		// enforcer does not work right now, but we still want to test
+		// the rest of the server
 	}
 
 	log.Info().Msgf("blockchain info: %s", info.Msg.String())

--- a/drivechain-server/server/server.go
+++ b/drivechain-server/server/server.go
@@ -36,7 +36,7 @@ func New(
 	srv := &Server{mux: mux}
 
 	Register(srv, bitcoindv1connect.NewBitcoindServiceHandler, bitcoindv1connect.BitcoindServiceHandler(api_bitcoind.New(
-		bitcoind, enforcer,
+		bitcoind,
 	)))
 	drivechainClient := drivechainv1connect.DrivechainServiceHandler(api_drivechain.New(
 		bitcoind, enforcer,


### PR DESCRIPTION
The bip300301-enforcer needs a parameter for where it should create it's database. ./ doesn't quite cut it. When the binary is embedded, it doesn't necessarily have write rights to whereever it's launched. So I need to add that as a param!