### PR TITLE
bitwindow: write non-colorized, pretty-printed logs to file

### DIFF
--- a/servers/bitwindow/Justfile
+++ b/servers/bitwindow/Justfile
@@ -1,5 +1,5 @@
 build-go:
-    go build -o ./bin/bitwindowd .
+    go build -v -o ./bin/bitwindowd .
 
 build: build-enforcer build-go
 

--- a/servers/bitwindow/main.go
+++ b/servers/bitwindow/main.go
@@ -50,7 +50,9 @@ func main() {
 func realMain(ctx context.Context) error {
 	conf, err := readConfig()
 	if err != nil {
+		if !flags.WroteHelp(err) {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("read config")
+		}
 		return err
 	}
 


### PR DESCRIPTION
I thought the root cause #448 was to be found here, but that turned out to be false. Anyways, makes sure we write pretty, non-colorized logs to file. 