### PR TITLE
clients/sail_ui: fix download concurrency issues in launcher

### DIFF
--- a/clients/sail_ui/lib/providers/binary_provider.dart
+++ b/clients/sail_ui/lib/providers/binary_provider.dart
@@ -32,10 +32,10 @@ class BinaryProvider extends ChangeNotifier {
   final Directory datadir;
   late List<Binary> binaries;
   StreamSubscription<FileSystemEvent>? _dirWatcher;
-  bool _isDownloading = false;
-
-  // Track download status for each binary
+  
+  // Track download status and active downloads for each binary
   final _downloadStates = <String, DownloadState>{};
+  final _activeDownloads = <String, bool>{};
 
   // Stream controller for status updates
   final _statusController = StreamController<Map<String, DownloadState>>.broadcast();
@@ -80,9 +80,9 @@ class BinaryProvider extends ChangeNotifier {
     // Watch the assets directory for changes
     final assetsDir = Directory(path.join(datadir.path, 'assets'));
     _dirWatcher = assetsDir.watch(recursive: true).listen((event) {
-      // Skip if we're currently downloading/extracting
-      if (_isDownloading) {
-        _log('Ignoring file system event during download: ${event.path}');
+      // Skip if the changed file is in a downloads directory
+      if (event.path.contains(path.join('assets', 'downloads'))) {
+        _log('Ignoring file system event in downloads directory: ${event.path}');
         return;
       }
 
@@ -265,7 +265,13 @@ class BinaryProvider extends ChangeNotifier {
   }
 
   Future<void> downloadBinary(Binary binary) async {
-    _isDownloading = true;
+    // Check if already downloading
+    if (_activeDownloads[binary.name] == true) {
+      _log('Download already in progress for ${binary.name}');
+      return;
+    }
+    
+    _activeDownloads[binary.name] = true;
     try {
       final releaseDate = await binary.downloadAndExtract(
         datadir,
@@ -287,7 +293,7 @@ class BinaryProvider extends ChangeNotifier {
       );
       binary = binary.copyWith(download: updatedConfig);
     } finally {
-      _isDownloading = false;
+      _activeDownloads[binary.name] = false;
     }
   }
 


### PR DESCRIPTION
The problem occurs in the downloadAndExtract method of the Binary class. Here's what's happening:

The error occurs when trying to extract a zip file, with the error message indicating the zip file doesn't exist at the expected path.

The critical section is in the _setupDirectories and _download methods:

_setupDirectories creates the downloads directory and sets up the zip file path
_download downloads the file to this path
The issue appears to be a race condition where multiple concurrent downloads are trying to:
Create/clean the same downloads directory
Download and write to files in this shared directory
Extract files from this shared directory
The problem is that the cleanup operation at the end of a successful download deletes the entire downloads directory, which could affect other ongoing downloads.

-------------

Let me summarize the changes made to fix the concurrent download issues:

In binaries.dart:
Modified _setupDirectories to create unique download directories using timestamps
Updated _cleanup to only delete the specific download directory and clean up empty parent directory
This prevents downloads from interfering with each other's files
In binary_provider.dart:
Replaced global _isDownloading flag with per-binary tracking using _activeDownloads map
Added check to prevent multiple concurrent downloads of the same binary
Updated file system watcher to ignore events in download directories
This ensures proper download state tracking and prevents duplicate downloads
These changes should resolve the unzip failures by:

Isolating each download in its own unique directory
Preventing cleanup operations from affecting other downloads
Properly managing concurrent downloads at the provider level

