### PR TITLE
2025 02 17 deps

### DIFF
--- a/clients/bitwindow/pubspec.lock
+++ b/clients/bitwindow/pubspec.lock
@@ -130,18 +130,18 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "74691599a5bc750dc96a6b4bfd48f7d9d66453eab04c7f4063134800d6a5c573"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.14"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:

--- a/clients/bitwindow/pubspec.lock
+++ b/clients/bitwindow/pubspec.lock
@@ -958,10 +958,10 @@ packages:
     dependency: "direct main"
     description:
       name: synchronized
-      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
+      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0+3"
+    version: "3.3.1"
   term_glyph:
     dependency: transitive
     description:

--- a/clients/bitwindow/pubspec.lock
+++ b/clients/bitwindow/pubspec.lock
@@ -1179,5 +1179,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.24.0"

--- a/clients/bitwindow/pubspec.yaml
+++ b/clients/bitwindow/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   protobuf: ^3.1.0
   dotted_border: ^2.1.0
   window_manager: ^0.4.3
-  synchronized: ^3.3.0+3
+  synchronized: ^3.3.1
   flutter_markdown: ^0.7.6
   path: ^1.9.0
   url_launcher: ^6.3.1

--- a/clients/bitwindow/pubspec.yaml
+++ b/clients/bitwindow/pubspec.yaml
@@ -54,7 +54,7 @@ dev_dependencies:
 
   flutter_lints: ^5.0.0
   auto_route_generator: ^9.3.1
-  build_runner: ^2.4.13
+  build_runner: ^2.4.15
   msix: ^3.16.8
 
 flutter:

--- a/clients/faucet/pubspec.lock
+++ b/clients/faucet/pubspec.lock
@@ -885,10 +885,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
+      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0+3"
+    version: "3.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1098,5 +1098,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.24.0"

--- a/clients/launcher/pubspec.lock
+++ b/clients/launcher/pubspec.lock
@@ -114,18 +114,18 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "99d3980049739a985cf9b21f30881f46db3ebc62c5b8d5e60e27440876b1ba1e"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "74691599a5bc750dc96a6b4bfd48f7d9d66453eab04c7f4063134800d6a5c573"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.14"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:

--- a/clients/launcher/pubspec.lock
+++ b/clients/launcher/pubspec.lock
@@ -942,10 +942,10 @@ packages:
     dependency: "direct main"
     description:
       name: synchronized
-      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
+      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0+3"
+    version: "3.3.1"
   term_glyph:
     dependency: transitive
     description:

--- a/clients/launcher/pubspec.lock
+++ b/clients/launcher/pubspec.lock
@@ -458,10 +458,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   http2:
     dependency: transitive
     description:
@@ -1163,5 +1163,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/clients/launcher/pubspec.yaml
+++ b/clients/launcher/pubspec.yaml
@@ -50,7 +50,7 @@ dev_dependencies:
 
   flutter_lints: ^5.0.0
   auto_route_generator: ^9.3.1
-  build_runner: ^2.4.13
+  build_runner: ^2.4.15
   msix: ^3.16.8
 
 flutter:

--- a/clients/launcher/pubspec.yaml
+++ b/clients/launcher/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   protobuf: ^3.1.0
   dotted_border: ^2.1.0
   window_manager: ^0.4.3
-  synchronized: ^3.3.0+3
+  synchronized: ^3.3.1
   provider: ^6.1.2
   dart_bip32_bip44: ^0.2.0
   bip39_mnemonic: ^3.0.7

--- a/clients/sail_ui/pubspec.lock
+++ b/clients/sail_ui/pubspec.lock
@@ -783,10 +783,10 @@ packages:
     dependency: "direct main"
     description:
       name: synchronized
-      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
+      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0+3"
+    version: "3.3.1"
   term_glyph:
     dependency: transitive
     description:

--- a/clients/sail_ui/pubspec.lock
+++ b/clients/sail_ui/pubspec.lock
@@ -98,18 +98,18 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "74691599a5bc750dc96a6b4bfd48f7d9d66453eab04c7f4063134800d6a5c573"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.14"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:

--- a/clients/sail_ui/pubspec.lock
+++ b/clients/sail_ui/pubspec.lock
@@ -988,5 +988,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.24.0"

--- a/clients/sail_ui/pubspec.lock
+++ b/clients/sail_ui/pubspec.lock
@@ -394,10 +394,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   http2:
     dependency: transitive
     description:

--- a/clients/sail_ui/pubspec.yaml
+++ b/clients/sail_ui/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   get_it: ^7.7.0
   collection: ^1.18.0
   path_provider: ^2.1.5
-  synchronized: ^3.3.0+3
+  synchronized: ^3.3.1
   flutter_markdown: ^0.7.6
   url_launcher: ^6.3.1
   connectrpc: ^0.3.0

--- a/clients/sail_ui/pubspec.yaml
+++ b/clients/sail_ui/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   desktop_multi_window: ^0.2.1
   web: ^1.1.0
 
-  http: any
+  http: 1.3.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/clients/sail_ui/pubspec.yaml
+++ b/clients/sail_ui/pubspec.yaml
@@ -42,7 +42,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^5.0.0
   auto_route_generator: ^9.3.1
-  build_runner: ^2.4.14
+  build_runner: ^2.4.15
 
 flutter:
   assets:

--- a/clients/sidesail/pubspec.lock
+++ b/clients/sidesail/pubspec.lock
@@ -894,10 +894,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
+      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0+3"
+    version: "3.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1124,5 +1124,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.24.0"

--- a/clients/sidesail/pubspec.lock
+++ b/clients/sidesail/pubspec.lock
@@ -5,18 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "67.0.0"
+    version: "76.0.0"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "6.11.0"
   archive:
     dependency: transitive
     description:
@@ -93,26 +98,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.13"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.1"
+    version: "8.0.0"
   built_collection:
     dependency: transitive
     description:
@@ -230,10 +235,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
+      sha256: "7306ab8a2359a48d22310ad823521d723acfed60ee1f7e37388e8986853b6820"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.6"
+    version: "2.3.8"
   desktop_multi_window:
     dependency: transitive
     description:
@@ -569,6 +574,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3-main.0"
   markdown:
     dependency: transitive
     description:

--- a/clients/sidesail/pubspec.yaml
+++ b/clients/sidesail/pubspec.yaml
@@ -49,7 +49,7 @@ dev_dependencies:
 
   flutter_lints: ^5.0.0
   auto_route_generator: ^9.0.0
-  build_runner: ^2.4.13
+  build_runner: ^2.4.15
   msix: ^3.16.8
 
 flutter:


### PR DESCRIPTION
- **build(deps): bump build_runner in /clients/bitwindow**
- **build(deps): bump synchronized in /clients/bitwindow**
- **build(deps): bump synchronized in /clients/launcher**
- **build(deps): bump build_runner in /clients/launcher**
- **build(deps): bump build_runner from 2.4.14 to 2.4.15 in /clients/sail_ui**
- **build(deps): bump http from 1.2.2 to 1.3.0 in /clients/sail_ui**
- **build(deps): bump synchronized from 3.3.0+3 to 3.3.1 in /clients/sail_ui**
- **build(deps): bump build_runner in /clients/sidesail**
- **bump deps**
