### PR TITLE
ci: allow long ptahs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,8 +131,8 @@ jobs:
 
       - name: Setup build directory
         run: |
-          # Create shorter build directory name
-          BUILD_DIR="build-${{ matrix.os }}"
+          # Create build directory name, to avoid caching assets/bin across OSes
+          BUILD_DIR="b-${{ matrix.os }}"
           mkdir -p "$BUILD_DIR"
           # Copy source files to build directory
           cp -r ${{ matrix.client }} "$BUILD_DIR/"

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -13,6 +13,7 @@ lower_app_name=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
 
 cd $client_dir
 
+
 # Dirty hack: we're running the big build script
 # from within bash in WSL, and we need to go back
 # to Windows land when doing the Flutter build.
@@ -20,6 +21,7 @@ cd $client_dir
 # Screwing around with app names and such doesn't play
 # nice with the Flutter caches. Do a proper clean
 # before building.
+git config --system core.longpaths true
 clean_cmd="flutter clean"
 build_cmd="flutter build windows --dart-define-from-file=build-vars.env"
 


### PR DESCRIPTION
Fixes a bug where sentry wouldn't build on macos: https://stackoverflow.com/questions/22575662/filename-too-long-in-git-for-windows