### PR TITLE
bitwindow: refetch misc stuff on health status change

### DIFF
--- a/bitwindow/lib/pages/root_page.dart
+++ b/bitwindow/lib/pages/root_page.dart
@@ -512,6 +512,7 @@ class _StatusBarState extends State<StatusBar> {
     super.initState();
     _timer = Timer.periodic(const Duration(seconds: 1), (_) => setState(() {}));
     balanceProvider.addListener(setstate);
+    blockchainProvider.addListener(setstate);
   }
 
   void setstate() {

--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -131,10 +131,12 @@ class SidechainsViewModel extends BaseViewModel {
     sidechainProvider
       ..addListener(notifyListeners)
       ..addListener(errorListener);
+    sidechainProvider.fetch();
     addressController.addListener(notifyListeners);
     depositAmountController.addListener(notifyListeners);
     feeController.addListener(notifyListeners);
   }
+
   List<SidechainOverview?> get sidechains => sidechainProvider.sidechains;
 
   List<SidechainOverview?> _sortedSidechains = [];

--- a/bitwindow/lib/pages/wallet/wallet_receive.dart
+++ b/bitwindow/lib/pages/wallet/wallet_receive.dart
@@ -6,6 +6,7 @@ import 'package:get_it/get_it.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:sail_ui/gen/bitwindowd/v1/bitwindowd.pb.dart';
 import 'package:sail_ui/gen/wallet/v1/wallet.pb.dart';
+import 'package:sail_ui/rpcs/bitwindow_api.dart';
 import 'package:sail_ui/sail_ui.dart';
 import 'package:stacked/stacked.dart';
 
@@ -247,6 +248,7 @@ class _ReceiveAddressesTableState extends State<ReceiveAddressesTable> {
 
 class ReceivePageViewModel extends BaseViewModel {
   final AddressBookProvider _addressBookProvider = GetIt.I<AddressBookProvider>();
+  final BitwindowRPC _bitwindowRPC = GetIt.I<BitwindowRPC>();
   TransactionProvider get transactionsProvider => GetIt.I<TransactionProvider>();
 
   @override
@@ -267,6 +269,9 @@ class ReceivePageViewModel extends BaseViewModel {
   bool sortAscending = true;
 
   void init() {
+    // bitwindowrpc has a health stream that notifies listener. when it changes, we should try to
+    // regenerate an address!
+    _bitwindowRPC.addListener(generateNewAddress);
     transactionsProvider.addListener(notifyListeners);
     _addressBookProvider.addListener(notifyListeners);
     _txProvider.addListener(notifyListeners);

--- a/bitwindow/lib/providers/blockchain_provider.dart
+++ b/bitwindow/lib/providers/blockchain_provider.dart
@@ -11,7 +11,7 @@ import 'package:sail_ui/rpcs/mainchain_rpc.dart';
 
 class BlockchainProvider extends ChangeNotifier {
   Logger get log => GetIt.I.get<Logger>();
-  BitwindowRPC get api => GetIt.I.get<BitwindowRPC>();
+  BitwindowRPC get bitwindowd => GetIt.I.get<BitwindowRPC>();
   MainchainRPC get mainchain => GetIt.I.get<MainchainRPC>();
   BlockInfoProvider get infoProvider => GetIt.I.get<BlockInfoProvider>();
 
@@ -32,18 +32,19 @@ class BlockchainProvider extends ChangeNotifier {
   BlockchainProvider() {
     _startFetchTimer();
     mainchain.addListener(fetch);
+    bitwindowd.addListener(fetch);
     infoProvider.addListener(notifyListeners);
   }
 
   // call this function from anywhere to refetch blockchain info
   Future<void> fetch() async {
-    if (!api.connected || _isFetching) return;
+    if (!bitwindowd.connected || _isFetching) return;
     _isFetching = true;
 
     try {
-      final newPeers = await api.bitcoind.listPeers();
-      final newTXs = await api.bitcoind.listRecentTransactions();
-      final (newBlocks, hasMore) = await api.bitcoind.listBlocks();
+      final newPeers = await bitwindowd.bitcoind.listPeers();
+      final newTXs = await bitwindowd.bitcoind.listRecentTransactions();
+      final (newBlocks, hasMore) = await bitwindowd.bitcoind.listBlocks();
 
       if (_dataHasChanged(newPeers, newTXs, newBlocks)) {
         peers = newPeers;
@@ -118,7 +119,7 @@ class BlockchainProvider extends ChangeNotifier {
     isLoadingMoreBlocks = true;
     try {
       final lastBlock = blocks.last;
-      final (moreBlocks, hasMore) = await api.bitcoind.listBlocks(
+      final (moreBlocks, hasMore) = await bitwindowd.bitcoind.listBlocks(
         startHeight: lastBlock.height - 1,
       );
 

--- a/bitwindow/lib/providers/sidechain_provider.dart
+++ b/bitwindow/lib/providers/sidechain_provider.dart
@@ -3,11 +3,14 @@ import 'dart:async';
 import 'package:bitwindow/providers/blockchain_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
 import 'package:sail_ui/gen/drivechain/v1/drivechain.pb.dart';
 import 'package:sail_ui/gen/wallet/v1/wallet.pb.dart';
 import 'package:sail_ui/rpcs/bitwindow_api.dart';
 
 class SidechainProvider extends ChangeNotifier {
+  Logger get log => GetIt.I.get<Logger>();
+
   BlockchainProvider get blockchainProvider => GetIt.I.get<BlockchainProvider>();
   BitwindowRPC get api => GetIt.I.get<BitwindowRPC>();
 
@@ -54,6 +57,7 @@ class SidechainProvider extends ChangeNotifier {
         error = null;
       }
     } catch (e) {
+      log.e('could not fetch sidechains: $e');
       error = e.toString();
     } finally {
       _isFetching = false;

--- a/bitwindow/server/gen/health/v1/health.pb.go
+++ b/bitwindow/server/gen/health/v1/health.pb.go
@@ -186,9 +186,10 @@ const file_health_v1_health_proto_rawDesc = "" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eSTATUS_SERVING\x10\x01\x12\x16\n" +
 	"\x12STATUS_NOT_SERVING\x10\x02\x12\x1a\n" +
-	"\x16STATUS_SERVICE_UNKNOWN\x10\x032J\n" +
+	"\x16STATUS_SERVICE_UNKNOWN\x10\x032\x87\x01\n" +
 	"\rHealthService\x129\n" +
-	"\x05Check\x12\x16.google.protobuf.Empty\x1a\x18.health.v1.CheckResponseB\xac\x01\n" +
+	"\x05Check\x12\x16.google.protobuf.Empty\x1a\x18.health.v1.CheckResponse\x12;\n" +
+	"\x05Watch\x12\x16.google.protobuf.Empty\x1a\x18.health.v1.CheckResponse0\x01B\xac\x01\n" +
 	"\rcom.health.v1B\vHealthProtoP\x01ZIgithub.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/health/v1;healthv1\xa2\x02\x03HXX\xaa\x02\tHealth.V1\xca\x02\tHealth\\V1\xe2\x02\x15Health\\V1\\GPBMetadata\xea\x02\n" +
 	"Health::V1b\x06proto3"
 
@@ -216,9 +217,11 @@ var file_health_v1_health_proto_depIdxs = []int32{
 	2, // 0: health.v1.CheckResponse.service_statuses:type_name -> health.v1.CheckResponse.ServiceStatus
 	0, // 1: health.v1.CheckResponse.ServiceStatus.status:type_name -> health.v1.CheckResponse.Status
 	3, // 2: health.v1.HealthService.Check:input_type -> google.protobuf.Empty
-	1, // 3: health.v1.HealthService.Check:output_type -> health.v1.CheckResponse
-	3, // [3:4] is the sub-list for method output_type
-	2, // [2:3] is the sub-list for method input_type
+	3, // 3: health.v1.HealthService.Watch:input_type -> google.protobuf.Empty
+	1, // 4: health.v1.HealthService.Check:output_type -> health.v1.CheckResponse
+	1, // 5: health.v1.HealthService.Watch:output_type -> health.v1.CheckResponse
+	4, // [4:6] is the sub-list for method output_type
+	2, // [2:4] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
 	2, // [2:2] is the sub-list for extension extendee
 	0, // [0:2] is the sub-list for field type_name

--- a/bitwindow/server/proto/health/v1/health.proto
+++ b/bitwindow/server/proto/health/v1/health.proto
@@ -6,7 +6,12 @@ import "google/protobuf/empty.proto";
 
 service HealthService {
   // Check status of requested services
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
   rpc Check(google.protobuf.Empty) returns (CheckResponse);
+
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc Watch(google.protobuf.Empty) returns (stream CheckResponse);
 }
 
 message CheckResponse {

--- a/bitwindow/test/mocks/api_mock.dart
+++ b/bitwindow/test/mocks/api_mock.dart
@@ -4,6 +4,7 @@ import 'package:sail_ui/classes/rpc_connection.dart';
 import 'package:sail_ui/gen/bitcoind/v1/bitcoind.pb.dart';
 import 'package:sail_ui/gen/bitwindowd/v1/bitwindowd.pb.dart';
 import 'package:sail_ui/gen/drivechain/v1/drivechain.pb.dart';
+import 'package:sail_ui/gen/health/v1/health.pb.dart';
 import 'package:sail_ui/gen/misc/v1/misc.pb.dart';
 import 'package:sail_ui/gen/wallet/v1/wallet.pb.dart';
 import 'package:sail_ui/rpcs/bitwindow_api.dart';
@@ -19,6 +20,8 @@ class MockAPI extends BitwindowRPC {
   final DrivechainAPI drivechain = MockDrivechainAPI();
   @override
   final MiscAPI misc = MockMiscAPI();
+  @override
+  final HealthAPI health = MockHealthAPI();
 
   MockAPI({
     required super.conf,
@@ -395,5 +398,17 @@ class MockMiscAPI implements MiscAPI {
   @override
   Future<List<Topic>> listTopics() async {
     return [];
+  }
+}
+
+class MockHealthAPI implements HealthAPI {
+  @override
+  Future<CheckResponse> check() async {
+    return CheckResponse();
+  }
+
+  @override
+  Stream<CheckResponse> watch() {
+    return Stream.periodic(const Duration(seconds: 1)).map((_) => CheckResponse());
   }
 }

--- a/sail_ui/lib/classes/rpc_connection.dart
+++ b/sail_ui/lib/classes/rpc_connection.dart
@@ -49,6 +49,9 @@ abstract class RPCConnection extends ChangeNotifier {
   // accept connections
   List<String> startupErrors();
 
+  // Override this function if you want to do something when connection changes status.
+  void onConnectionStateChanged(bool isConnected) {}
+
   /// Returns confirmed and unconfirmed balance.
   Future<(double, double)> balance();
 
@@ -83,6 +86,7 @@ abstract class RPCConnection extends ChangeNotifier {
         // We were previously disconnected, or had an error. Wipe that,
         // set the correct new state, and notify listeners
         _shouldNotify = true;
+        onConnectionStateChanged(true);
       }
       connected = true;
       connectionError = null;
@@ -140,6 +144,7 @@ abstract class RPCConnection extends ChangeNotifier {
         // or we have a new error on our hands that must be shown
         initializingBinary = false;
         _shouldNotify = true;
+        onConnectionStateChanged(false);
         // we have a new error on our hands!
         log.e('could not test connection ${binary.connectionString}: ${newError ?? ''}!');
       }
@@ -155,7 +160,6 @@ abstract class RPCConnection extends ChangeNotifier {
     } finally {
       _testing = false;
       if (_shouldNotify) {
-        // Only notify listeners if something actually changed
         notifyListeners();
       }
       _shouldNotify = false;

--- a/sail_ui/lib/gen/health/v1/health.connect.client.dart
+++ b/sail_ui/lib/gen/health/v1/health.connect.client.dart
@@ -10,6 +10,7 @@ import "health.connect.spec.dart" as specs;
 
 extension type HealthServiceClient (connect.Transport _transport) {
   /// Check status of requested services
+  /// buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
   Future<healthv1health.CheckResponse> check(
     googleprotobufempty.Empty input, {
     connect.Headers? headers,
@@ -19,6 +20,25 @@ extension type HealthServiceClient (connect.Transport _transport) {
   }) {
     return connect.Client(_transport).unary(
       specs.HealthService.check,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
+  /// buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  /// buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  Stream<healthv1health.CheckResponse> watch(
+    googleprotobufempty.Empty input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).server(
+      specs.HealthService.watch,
       input,
       signal: signal,
       headers: headers,

--- a/sail_ui/lib/gen/health/v1/health.connect.spec.dart
+++ b/sail_ui/lib/gen/health/v1/health.connect.spec.dart
@@ -12,9 +12,19 @@ abstract final class HealthService {
   static const name = 'health.v1.HealthService';
 
   /// Check status of requested services
+  /// buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
   static const check = connect.Spec(
     '/$name/Check',
     connect.StreamType.unary,
+    googleprotobufempty.Empty.new,
+    healthv1health.CheckResponse.new,
+  );
+
+  /// buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  /// buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  static const watch = connect.Spec(
+    '/$name/Watch',
+    connect.StreamType.server,
     googleprotobufempty.Empty.new,
     healthv1health.CheckResponse.new,
   );

--- a/sail_ui/lib/gen/health/v1/health.pb.dart
+++ b/sail_ui/lib/gen/health/v1/health.pb.dart
@@ -136,6 +136,9 @@ class HealthServiceApi {
   $async.Future<CheckResponse> check_($pb.ClientContext? ctx, $1.Empty request) =>
     _client.invoke<CheckResponse>(ctx, 'HealthService', 'Check', request, CheckResponse())
   ;
+  $async.Future<CheckResponse> watch($pb.ClientContext? ctx, $1.Empty request) =>
+    _client.invoke<CheckResponse>(ctx, 'HealthService', 'Watch', request, CheckResponse())
+  ;
 }
 
 

--- a/sail_ui/lib/gen/health/v1/health.pbjson.dart
+++ b/sail_ui/lib/gen/health/v1/health.pbjson.dart
@@ -58,6 +58,7 @@ const $core.Map<$core.String, $core.dynamic> HealthServiceBase$json = {
   '1': 'HealthService',
   '2': [
     {'1': 'Check', '2': '.google.protobuf.Empty', '3': '.health.v1.CheckResponse'},
+    {'1': 'Watch', '2': '.google.protobuf.Empty', '3': '.health.v1.CheckResponse', '6': true},
   ],
 };
 
@@ -71,5 +72,6 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> HealthServ
 /// Descriptor for `HealthService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
 final $typed_data.Uint8List healthServiceDescriptor = $convert.base64Decode(
     'Cg1IZWFsdGhTZXJ2aWNlEjkKBUNoZWNrEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhguaGVhbH'
-    'RoLnYxLkNoZWNrUmVzcG9uc2U=');
+    'RoLnYxLkNoZWNrUmVzcG9uc2USOwoFV2F0Y2gSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaGC5o'
+    'ZWFsdGgudjEuQ2hlY2tSZXNwb25zZTAB');
 

--- a/sail_ui/lib/gen/health/v1/health.pbserver.dart
+++ b/sail_ui/lib/gen/health/v1/health.pbserver.dart
@@ -23,10 +23,12 @@ export 'health.pb.dart';
 
 abstract class HealthServiceBase extends $pb.GeneratedService {
   $async.Future<$5.CheckResponse> check($pb.ServerContext ctx, $1.Empty request);
+  $async.Future<$5.CheckResponse> watch($pb.ServerContext ctx, $1.Empty request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
       case 'Check': return $1.Empty();
+      case 'Watch': return $1.Empty();
       default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
@@ -34,6 +36,7 @@ abstract class HealthServiceBase extends $pb.GeneratedService {
   $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
       case 'Check': return this.check(ctx, request as $1.Empty);
+      case 'Watch': return this.watch(ctx, request as $1.Empty);
       default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }

--- a/sail_ui/lib/mocks/mocks.dart
+++ b/sail_ui/lib/mocks/mocks.dart
@@ -248,6 +248,19 @@ class MockBitwindowRPC extends BitwindowRPC {
   String? _error;
 
   @override
+  WalletAPI get wallet => throw UnimplementedError();
+  @override
+  BitwindowAPI get bitwindowd => throw UnimplementedError();
+  @override
+  BitcoindAPI get bitcoind => throw UnimplementedError();
+  @override
+  DrivechainAPI get drivechain => throw UnimplementedError();
+  @override
+  MiscAPI get misc => throw UnimplementedError();
+  @override
+  HealthAPI get health => throw UnimplementedError();
+
+  @override
   bool get connected => _connected;
   @override
   bool get initializingBinary => _initializing;
@@ -290,15 +303,6 @@ class MockBitwindowRPC extends BitwindowRPC {
   }
 
   @override
-  BitcoindAPI get bitcoind => throw UnimplementedError();
-
-  @override
-  DrivechainAPI get drivechain => throw UnimplementedError();
-
-  @override
-  MiscAPI get misc => throw UnimplementedError();
-
-  @override
   Future<int> ping() {
     return Future.value(0);
   }
@@ -307,11 +311,6 @@ class MockBitwindowRPC extends BitwindowRPC {
   List<String> startupErrors() {
     return [];
   }
-
-  @override
-  WalletAPI get wallet => throw UnimplementedError();
-  @override
-  BitwindowAPI get bitwindowd => throw UnimplementedError();
 
   @override
   Future<BlockchainInfo> getBlockchainInfo() {

--- a/sail_ui/lib/rpcs/bitwindow_api.dart
+++ b/sail_ui/lib/rpcs/bitwindow_api.dart
@@ -83,15 +83,17 @@ class BitwindowRPCLive extends BitwindowRPC {
     final conf = await readConf();
     final logPath = binary.logPath();
 
-    final instance = BitwindowRPCLive._create(
+    final liveInstance = BitwindowRPCLive._create(
       conf: conf,
       binary: binary,
       logPath: logPath,
       restartOnFailure: true,
     );
 
-    instance._init(transport);
-    return instance;
+    liveInstance._init(transport);
+    // must test connection before moving on, in case it is already running!
+    await liveInstance.testConnection();
+    return liveInstance;
   }
 
   void _init(Transport transport) {

--- a/sail_ui/lib/rpcs/enforcer_rpc.dart
+++ b/sail_ui/lib/rpcs/enforcer_rpc.dart
@@ -60,16 +60,17 @@ class EnforcerLive extends EnforcerRPC {
     );
     final logPath = binary.logPath();
 
-    final instance = EnforcerLive._create(
+    final liveInstance = EnforcerLive._create(
       launcherAppDir: launcherAppDir,
       conf: conf,
       binary: binary,
       logPath: logPath,
       restartOnFailure: true,
     );
-
-    instance._init(transport);
-    return instance;
+    // must test connection before moving on, in case it is already running!
+    await liveInstance.testConnection();
+    liveInstance._init(transport);
+    return liveInstance;
   }
 
   void _init(Transport transport) {

--- a/sail_ui/lib/rpcs/mainchain_rpc.dart
+++ b/sail_ui/lib/rpcs/mainchain_rpc.dart
@@ -70,6 +70,8 @@ class MainchainRPCLive extends MainchainRPC {
       restartOnFailure: false,
     );
     container.init();
+    // must test connection before moving on, in case it is already running!
+    await container.testConnection();
     return container;
   }
 


### PR DESCRIPTION
Bitwindow starts before the enforcer and bitcoind is ready. Because of that, the UI tries to fetch addresses+transactions lists etc. before the backend is ready.

Prior to this PR, the user got stuck with an error message "enforcer not available".

In this PR, we listen to bitwindows health stream, and tries to refetch data every time the health status changes. If bitwindow goes from "enforcer not available" --> "available", all components requiring data from the enforcer will attempt a refresh.