### PR TITLE
bitwindow/mainchain: increase rpcthreads

### DIFF
--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -531,6 +531,15 @@ class RecentDepositsTable extends ViewModelWidget<SidechainsViewModel> {
       sortAscending: viewModel.depositSortAscending,
       sortColumnIndex: ['txid', 'amount', 'fee', 'confirmations'].indexOf(viewModel.depositSortColumn),
       onSort: (columnIndex, ascending) => viewModel.sortDeposits(viewModel.depositSortColumn),
+      onDoubleTap: (rowId) => showTransactionDetails(context, rowId),
+      contextMenuItems: (rowId) {
+        return [
+          SailMenuItem(
+            onSelected: () => showTransactionDetails(context, rowId),
+            child: SailText.primary12('Show Transaction Details'),
+          ),
+        ];
+      },
     );
   }
 }

--- a/bitwindow/lib/pages/wallet/wallet_send.dart
+++ b/bitwindow/lib/pages/wallet/wallet_send.dart
@@ -618,7 +618,9 @@ class SendPageViewModel extends BaseViewModel {
   void removeRecipient(int index) {
     recipients[index].removeListener(_onRecipientChanged);
     recipients.removeAt(index);
-    selectedRecipientIndex = index - 1;
+    if (index != 0) {
+      selectedRecipientIndex = index - 1;
+    }
     notifyListeners();
   }
 }

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -60,12 +60,15 @@ func (p *Parser) Run(ctx context.Context) error {
 
 		case <-alertTicker.C:
 			if processing {
+				zerolog.Ctx(ctx).Trace().
+					Msgf("bitcoind_engine/parser: still processing block, skipping alert tick")
 				continue
 			}
 
 			// nolint:ineffassign
 			processing = true
 			if err := p.handleBlockTick(ctx); err != nil {
+				processing = false
 				zerolog.Ctx(ctx).Error().
 					Err(err).
 					Msgf("bitcoind_engine/parser: could not handle tick")

--- a/sail_ui/lib/rpcs/mainchain_rpc.dart
+++ b/sail_ui/lib/rpcs/mainchain_rpc.dart
@@ -143,7 +143,10 @@ class MainchainRPCLive extends MainchainRPC {
     if (mainchainConf.hasConfFile) {
       // the conf file exists, and should take total precedence
       log.i('Mainchain conf file is present, not adding sidechain args');
-      return [];
+      return [
+        '-rpcthreads=40',
+        '-rpcworkqueue=100',
+      ];
     }
 
     // only add sidechain args if the conf file is not present


### PR DESCRIPTION
bitwindow tries to sync 30 blocks in parallell. when it does, it kind of overloads bitcoin core when it has default settings. This increases parallellity by setting
```
-rpcthreads=40
-rpcworkqueue=100
```