### PR TITLE
bitwindow: remove ZMQ address argument from enforcer

### DIFF
--- a/sail_ui/lib/rpcs/enforcer_rpc.dart
+++ b/sail_ui/lib/rpcs/enforcer_rpc.dart
@@ -103,7 +103,6 @@ class EnforcerLive extends EnforcerRPC {
       '--node-rpc-pass=${mainchainConf.password}',
       '--node-rpc-user=${mainchainConf.username}',
       '--node-rpc-addr=$host:${mainchainConf.port}',
-      '--node-zmq-addr-sequence=tcp://$host:29000',
       '--enable-wallet',
       walletArg,
       if (binary.extraBootArgs.isNotEmpty) ...binary.extraBootArgs,


### PR DESCRIPTION
After https://github.com/LayerTwo-Labs/bip300301_enforcer/pull/219 was merged, this is no longer necessary to provide as an argument.