### PR TITLE
back to work bump

### DIFF
--- a/bitassets/pubspec.lock
+++ b/bitassets/pubspec.lock
@@ -1313,10 +1313,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"
+      sha256: "51d50168ab267d344b975b15390426b1243600d436770d3f13de67e55b05ec16"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
+    version: "0.5.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   auto_route: ^10.1.0
   get_it: ^7.7.0
   qr_flutter: ^4.1.0
-  window_manager: ^0.4.3
+  window_manager: ^0.5.0
   collection: ^1.18.0
   stacked: ^3.4.3
   desktop_multi_window: ^0.2.1

--- a/bitnames/pubspec.lock
+++ b/bitnames/pubspec.lock
@@ -1313,10 +1313,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"
+      sha256: "51d50168ab267d344b975b15390426b1243600d436770d3f13de67e55b05ec16"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
+    version: "0.5.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   auto_route: ^10.1.0
   get_it: ^7.7.0
   qr_flutter: ^4.1.0
-  window_manager: ^0.4.3
+  window_manager: ^0.5.0
   collection: ^1.18.0
   stacked: ^3.4.3
   desktop_multi_window: ^0.2.1

--- a/bitwindow/pubspec.lock
+++ b/bitwindow/pubspec.lock
@@ -1393,10 +1393,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"
+      sha256: "51d50168ab267d344b975b15390426b1243600d436770d3f13de67e55b05ec16"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
+    version: "0.5.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   meta: ^1.16.0
   protobuf: ^4.1.0
   dotted_border: ^3.0.1
-  window_manager: ^0.4.3
+  window_manager: ^0.5.0
   synchronized: ^3.3.1
   skeletonizer: ^2.0.1 
   flutter_markdown: ^0.7.7

--- a/launcher/pubspec.lock
+++ b/launcher/pubspec.lock
@@ -1137,10 +1137,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"
+      sha256: "51d50168ab267d344b975b15390426b1243600d436770d3f13de67e55b05ec16"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
+    version: "0.5.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/launcher/pubspec.yaml
+++ b/launcher/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.16.0
   protobuf: ^4.1.0
   dotted_border: ^3.0.1
-  window_manager: ^0.4.3
+  window_manager: ^0.5.0
   synchronized: ^3.3.1
   provider: ^6.1.4
   dart_bip32_bip44: ^0.2.0

--- a/thunder/pubspec.lock
+++ b/thunder/pubspec.lock
@@ -1305,10 +1305,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"
+      sha256: "51d50168ab267d344b975b15390426b1243600d436770d3f13de67e55b05ec16"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
+    version: "0.5.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   auto_route: ^10.1.0
   get_it: ^7.7.0
   qr_flutter: ^4.1.0
-  window_manager: ^0.4.3
+  window_manager: ^0.5.0
   collection: ^1.18.0
   stacked: ^3.4.3
   desktop_multi_window: ^0.2.1

--- a/zside/pubspec.lock
+++ b/zside/pubspec.lock
@@ -1089,10 +1089,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"
+      sha256: "51d50168ab267d344b975b15390426b1243600d436770d3f13de67e55b05ec16"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
+    version: "0.5.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   auto_route: ^10.1.0
   get_it: ^7.7.0
   qr_flutter: ^4.1.0
-  window_manager: ^0.4.3
+  window_manager: ^0.5.0
   collection: ^1.18.0
   stacked: ^3.4.3
   desktop_multi_window: ^0.2.1


### PR DESCRIPTION
- **build(deps): bump window_manager from 0.4.3 to 0.5.0 in /bitwindow**
- **build(deps): bump window_manager from 0.4.3 to 0.5.0 in /zside**
- **build(deps): bump window_manager from 0.4.3 to 0.5.0 in /bitassets**
- **build(deps): bump window_manager from 0.4.3 to 0.5.0 in /bitnames**
- **build(deps): bump window_manager from 0.4.3 to 0.5.0 in /launcher**
- **build(deps): bump window_manager from 0.4.3 to 0.5.0 in /thunder**
