### PR TITLE
bitwindow/server: expose datadir knob, add sync bench flag

### DIFF
--- a/bitwindow/server/config/config.go
+++ b/bitwindow/server/config/config.go
@@ -1,11 +1,13 @@
-package main
+package config
 
 import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
+	dir "github.com/LayerTwo-Labs/sidesail/bitwindow/server/dir"
 	"github.com/jessevdk/go-flags"
 )
 
@@ -18,15 +20,18 @@ type Config struct {
 	EnforcerHost string `long:"enforcer.host" description:"host:port for connecting to the enforcer server" default:"localhost:50051"`
 
 	APIHost string `long:"api.host" env:"API_HOST" description:"public address for the connect server" default:"localhost:8080"`
+	Datadir string `long:"datadir" description:"Path to the data directory" default:""`
 
 	LogPath  string `long:"log.path" description:"Path to write logs to"`
 	LogLevel string `long:"log.level" description:"Log level" default:"info" env:"LOG_LEVEL"`
 
 	GuiBootedMainchain bool `long:"gui-booted-mainchain" description:"Set to true if GUI booted this process. Used by this application to shutdown everything correctly."`
 	GuiBootedEnforcer  bool `long:"gui-booted-enforcer" description:"Set to true if GUI booted this process. Used by this application to shutdown everything correctly."`
+
+	SyncToHeight uint32 `long:"sync-to-height" description:"Sync to this height and then exit"`
 }
 
-func readConfig() (Config, error) {
+func Parse() (Config, error) {
 	var conf Config
 	parser := flags.NewParser(&conf, flags.AllowBoolValues|flags.Default)
 
@@ -51,6 +56,24 @@ func readConfig() (Config, error) {
 
 		conf.BitcoinCoreRpcUser = user
 		conf.BitcoinCoreRpcPassword = password
+	}
+
+	if conf.Datadir == "" {
+		datadir, err := dir.DefaultDataDir()
+		if err != nil {
+			return Config{}, fmt.Errorf("get data directory: %w", err)
+		}
+		conf.Datadir = datadir
+	}
+
+	if conf.LogPath == "" {
+		conf.LogPath = filepath.Join(conf.Datadir, "server.log")
+	}
+
+	// Ensure the directory exists
+	err := os.MkdirAll(conf.Datadir, 0755)
+	if err != nil && !os.IsExist(err) {
+		return Config{}, fmt.Errorf("create data directory: %w", err)
 	}
 
 	return conf, nil

--- a/bitwindow/server/database/db.go
+++ b/bitwindow/server/database/db.go
@@ -6,18 +6,14 @@ import (
 	"fmt"
 	"path/filepath"
 
-	dir "github.com/LayerTwo-Labs/sidesail/bitwindow/server/dir"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/config"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/rs/zerolog"
 )
 
 // New creates a new SQLite database and runs all migrations
-func New(ctx context.Context) (*sql.DB, error) {
-	datadir, err := dir.GetDataDir()
-	if err != nil {
-		return nil, fmt.Errorf("could not get data directory: %v", err)
-	}
-	dbpath := filepath.Join(datadir, "bitwindow.db")
+func New(ctx context.Context, conf config.Config) (*sql.DB, error) {
+	dbpath := filepath.Join(conf.Datadir, "bitwindow.db")
 
 	zerolog.Ctx(ctx).Debug().
 		Str("path", dbpath).
@@ -33,7 +29,7 @@ func New(ctx context.Context) (*sql.DB, error) {
 			return nil, fmt.Errorf("could not close database nor run migrations: %v", err)
 		}
 
-		return nil, fmt.Errorf("could not run migrations: %v", err)
+		return nil, fmt.Errorf("run migrations: %v", err)
 	}
 
 	return db, nil

--- a/bitwindow/server/dir/dir.go
+++ b/bitwindow/server/dir/dir.go
@@ -7,7 +7,8 @@ import (
 	"runtime"
 )
 
-func GetDataDir() (string, error) {
+func DefaultDataDir() (string, error) {
+
 	var dir string
 	const appName = "bitwindow"
 
@@ -36,12 +37,6 @@ func GetDataDir() (string, error) {
 		dir = filepath.Join(appData, appName)
 	default:
 		return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
-	}
-
-	// Ensure the directory exists
-	err := os.MkdirAll(dir, 0755)
-	if err != nil && !os.IsExist(err) {
-		return "", err
 	}
 
 	return dir, nil


### PR DESCRIPTION
1. Make it possible to configure the datadir of the bitwindow daemon
2. Add a new `sync-to-height` flag. If this is provided, the daemon exits after syncing to this height. Useful for benchmarking sync performance by tracking durations until specific heights. 