### PR TITLE
bitwindow: more error tolerant ZMQ engine startup

### DIFF
--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -97,7 +97,8 @@ func (p *Parser) Run(ctx context.Context) error {
 				Msgf("bitcoind_engine/parser: processing block tick")
 
 			if err := p.handleBlockTick(ctx); err != nil {
-				return fmt.Errorf("handle block tick: %w", err)
+				zerolog.Ctx(ctx).Err(err).Msgf("unable to handle block tick")
+				continue
 			}
 
 			zerolog.Ctx(ctx).Trace().

--- a/bitwindow/server/engines/zmq_engine.go
+++ b/bitwindow/server/engines/zmq_engine.go
@@ -51,9 +51,6 @@ func (e *ZMQ) Subscribe() <-chan *wire.MsgTx {
 
 // Run starts the ZMQ engine and begins listening for raw transaction notifications
 func (e *ZMQ) Run(ctx context.Context) error {
-	logger := zerolog.Ctx(ctx)
-	logger.Info().Msg("starting ZMQ engine for raw transactions")
-
 	subCh, cancel, err := e.inner.SubscribeRawTx(ctx)
 	if err != nil {
 		return err
@@ -82,8 +79,9 @@ func (e *ZMQ) Run(ctx context.Context) error {
 	// Wait for context cancellation or error
 	select {
 	case <-ctx.Done():
-		logger.Info().Msg("ZMQ engine shutting down")
+		zerolog.Ctx(ctx).Info().Msg("ZMQ engine shutting down")
 		return nil
+
 	case err := <-errChan:
 
 		if err != nil {


### PR DESCRIPTION
Avoid taking down the entire system. Run a bunch of attempts, and sleep in between.