### PR TITLE
use patched core

### DIFF
--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -50,10 +50,10 @@
         "binary": "bitcoind",
         "files": {
           "default": {
-            "base_url": "https://bitcoincore.org/bin/bitcoin-core-30.2/",
-            "linux": "bitcoin-30.2-x86_64-linux-gnu.tar.gz",
-            "macos": "bitcoin-30.2-x86_64-apple-darwin.tar.gz",
-            "windows": "bitcoin-30.2-win64.zip"
+            "base_url": "https://releases.drivechain.info/",
+            "linux": "L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip",
+            "macos": "L1-bitcoin-patched-latest-x86_64-apple-darwin.zip",
+            "windows": "L1-bitcoin-patched-latest-x86_64-w64-msvc.zip"
           },
           "forknet": {
             "base_url": "https://releases.drivechain.info/",

--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -51,9 +51,9 @@
         "files": {
           "default": {
             "base_url": "https://releases.drivechain.info/",
-            "linux": "L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip",
-            "macos": "L1-bitcoin-patched-latest-x86_64-apple-darwin.zip",
-            "windows": "L1-bitcoin-patched-latest-x86_64-w64-msvc.zip"
+            "linux": "L1-bitcoin-patched-v30.2-x86_64-unknown-linux-gnu.zip",
+            "macos": "L1-bitcoin-patched-v30.2-x86_64-apple-darwin.zip",
+            "windows": "L1-bitcoin-patched-v30.2-x86_64-w64-msvc.zip"
           },
           "forknet": {
             "base_url": "https://releases.drivechain.info/",

--- a/sail_ui/assets/migrations/001_chains_config.json
+++ b/sail_ui/assets/migrations/001_chains_config.json
@@ -29,10 +29,10 @@
         "binary": "bitcoind",
         "files": {
           "default": {
-            "base_url": "https://bitcoincore.org/bin/bitcoin-core-30.2/",
-            "linux": "bitcoin-30.2-x86_64-linux-gnu.tar.gz",
-            "macos": "bitcoin-30.2-x86_64-apple-darwin.tar.gz",
-            "windows": "bitcoin-30.2-win64.zip"
+            "base_url": "https://releases.drivechain.info/",
+            "linux": "L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip",
+            "macos": "L1-bitcoin-patched-latest-x86_64-apple-darwin.zip",
+            "windows": "L1-bitcoin-patched-latest-x86_64-w64-msvc.zip"
           },
           "forknet": {
             "base_url": "https://releases.drivechain.info/",

--- a/sail_ui/assets/migrations/001_chains_config.json
+++ b/sail_ui/assets/migrations/001_chains_config.json
@@ -30,9 +30,9 @@
         "files": {
           "default": {
             "base_url": "https://releases.drivechain.info/",
-            "linux": "L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip",
-            "macos": "L1-bitcoin-patched-latest-x86_64-apple-darwin.zip",
-            "windows": "L1-bitcoin-patched-latest-x86_64-w64-msvc.zip"
+            "linux": "L1-bitcoin-patched-v30.2-x86_64-unknown-linux-gnu.zip",
+            "macos": "L1-bitcoin-patched-v30.2-x86_64-apple-darwin.zip",
+            "windows": "L1-bitcoin-patched-v30.2-x86_64-w64-msvc.zip"
           },
           "forknet": {
             "base_url": "https://releases.drivechain.info/",

--- a/sail_ui/lib/config/binaries.dart
+++ b/sail_ui/lib/config/binaries.dart
@@ -1019,16 +1019,15 @@ class BitcoinCore extends Binary {
                downloadConfig: DownloadConfig(
                  baseUrls: {
                    ...allNetworksUrl(
-                     'https://bitcoincore.org/bin/bitcoin-core-30.2/',
+                     'https://releases.drivechain.info/',
                    ),
-                   BitcoinNetwork.BITCOIN_NETWORK_FORKNET: 'https://releases.drivechain.info/',
                  },
                  binary: 'bitcoind',
                  files: {
                    ...allNetworks({
-                     OS.linux: 'bitcoin-30.2-x86_64-linux-gnu.tar.gz',
-                     OS.macos: 'bitcoin-30.2-x86_64-apple-darwin.tar.gz',
-                     OS.windows: 'bitcoin-30.2-win64.zip',
+                     OS.linux: 'L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip',
+                     OS.macos: 'L1-bitcoin-patched-latest-x86_64-apple-darwin.zip',
+                     OS.windows: 'L1-bitcoin-patched-latest-x86_64-w64-msvc.zip',
                    }),
                    BitcoinNetwork.BITCOIN_NETWORK_FORKNET: {
                      OS.linux: 'L1-bitcoin-patched-forknet-x86_64-unknown-linux-gnu.zip',

--- a/sail_ui/lib/config/binaries.dart
+++ b/sail_ui/lib/config/binaries.dart
@@ -1025,9 +1025,9 @@ class BitcoinCore extends Binary {
                  binary: 'bitcoind',
                  files: {
                    ...allNetworks({
-                     OS.linux: 'L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip',
-                     OS.macos: 'L1-bitcoin-patched-latest-x86_64-apple-darwin.zip',
-                     OS.windows: 'L1-bitcoin-patched-latest-x86_64-w64-msvc.zip',
+                     OS.linux: 'L1-bitcoin-patched-v30.2-x86_64-unknown-linux-gnu.zip',
+                     OS.macos: 'L1-bitcoin-patched-v30.2-x86_64-apple-darwin.zip',
+                     OS.windows: 'L1-bitcoin-patched-v30.2-x86_64-w64-msvc.zip',
                    }),
                    BitcoinNetwork.BITCOIN_NETWORK_FORKNET: {
                      OS.linux: 'L1-bitcoin-patched-forknet-x86_64-unknown-linux-gnu.zip',

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -50,10 +50,10 @@
         "binary": "bitcoind",
         "files": {
           "default": {
-            "base_url": "https://bitcoincore.org/bin/bitcoin-core-30.2/",
-            "linux": "bitcoin-30.2-x86_64-linux-gnu.tar.gz",
-            "macos": "bitcoin-30.2-x86_64-apple-darwin.tar.gz",
-            "windows": "bitcoin-30.2-win64.zip"
+            "base_url": "https://releases.drivechain.info/",
+            "linux": "L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip",
+            "macos": "L1-bitcoin-patched-latest-x86_64-apple-darwin.zip",
+            "windows": "L1-bitcoin-patched-latest-x86_64-w64-msvc.zip"
           },
           "forknet": {
             "base_url": "https://releases.drivechain.info/",

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -51,9 +51,9 @@
         "files": {
           "default": {
             "base_url": "https://releases.drivechain.info/",
-            "linux": "L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip",
-            "macos": "L1-bitcoin-patched-latest-x86_64-apple-darwin.zip",
-            "windows": "L1-bitcoin-patched-latest-x86_64-w64-msvc.zip"
+            "linux": "L1-bitcoin-patched-v30.2-x86_64-unknown-linux-gnu.zip",
+            "macos": "L1-bitcoin-patched-v30.2-x86_64-apple-darwin.zip",
+            "windows": "L1-bitcoin-patched-v30.2-x86_64-w64-msvc.zip"
           },
           "forknet": {
             "base_url": "https://releases.drivechain.info/",

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -50,10 +50,10 @@
         "binary": "bitcoind",
         "files": {
           "default": {
-            "base_url": "https://bitcoincore.org/bin/bitcoin-core-30.2/",
-            "linux": "bitcoin-30.2-x86_64-linux-gnu.tar.gz",
-            "macos": "bitcoin-30.2-x86_64-apple-darwin.tar.gz",
-            "windows": "bitcoin-30.2-win64.zip"
+            "base_url": "https://releases.drivechain.info/",
+            "linux": "L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip",
+            "macos": "L1-bitcoin-patched-latest-x86_64-apple-darwin.zip",
+            "windows": "L1-bitcoin-patched-latest-x86_64-w64-msvc.zip"
           },
           "forknet": {
             "base_url": "https://releases.drivechain.info/",

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -51,9 +51,9 @@
         "files": {
           "default": {
             "base_url": "https://releases.drivechain.info/",
-            "linux": "L1-bitcoin-patched-latest-x86_64-unknown-linux-gnu.zip",
-            "macos": "L1-bitcoin-patched-latest-x86_64-apple-darwin.zip",
-            "windows": "L1-bitcoin-patched-latest-x86_64-w64-msvc.zip"
+            "linux": "L1-bitcoin-patched-v30.2-x86_64-unknown-linux-gnu.zip",
+            "macos": "L1-bitcoin-patched-v30.2-x86_64-apple-darwin.zip",
+            "windows": "L1-bitcoin-patched-v30.2-x86_64-w64-msvc.zip"
           },
           "forknet": {
             "base_url": "https://releases.drivechain.info/",


### PR DESCRIPTION
- **feat: download Bitcoin Core from releases.drivechain.info**
- **fix: pin Bitcoin Core downloads to v30.2 instead of latest alias**
