### PR TITLE
feat: embed orchestratorctl into BitWindow

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.185
+version: 1.0.186
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.184
+version: 1.0.185
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.32
+version: 0.2.33
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/scripts/download-binaries.sh
+++ b/bitwindow/scripts/download-binaries.sh
@@ -46,4 +46,17 @@ fi
 
 echo "orchestratord has been built and moved to $assets_dir"
 
+# Build orchestratorctl
+echo "Building orchestratorctl"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    GOARCH=amd64 go build -o "$assets_dir/orchestratorctl" ./cmd/orchestratorctl
+elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+    go build -o "$assets_dir/orchestratorctl.exe" ./cmd/orchestratorctl
+else
+    go build -o "$assets_dir/orchestratorctl" ./cmd/orchestratorctl
+fi
+
+echo "orchestratorctl has been built and moved to $assets_dir"
+
 cd $original_cwd

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.57
+version: 1.0.58
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/widgets/console/integrated_console_view.dart
+++ b/sail_ui/lib/widgets/console/integrated_console_view.dart
@@ -140,6 +140,7 @@ class _IntegratedConsoleViewState extends State<IntegratedConsoleView> {
       'CoinShift': 'coinshift-cli',
       'ZSide': 'zside-cli',
       'GRPCurl': 'grpcurl',
+      'Orchestratord': 'orchestratorctl',
     };
 
     for (final binary in allBinaries) {
@@ -217,6 +218,7 @@ class _IntegratedConsoleViewState extends State<IntegratedConsoleView> {
       'bitnames-cli': 'Bitnames sidechain',
       'bitassets-cli': 'BitAssets sidechain',
       'zside-cli': 'ZSide sidechain',
+      'orchestratorctl': 'Orchestrator management',
     };
 
     terminal.write(

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.186
+version: 1.0.187
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.57
+version: 1.0.58
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.184
+version: 1.0.185
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
- Add orchestratorctl build step to download-binaries.sh alongside
  orchestratord, targeting bitwindow/assets/bin/
- Register orchestratorctl in the integrated console's binary-to-CLI
  map so it appears on PATH and in the SideShell welcome message
