### PR TITLE
bitwindow: restore pre-backend-migration reset UI

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.193
+version: 1.0.194
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.192
+version: 1.0.193
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/lib/pages/settings/settings_reset.dart
+++ b/bitwindow/lib/pages/settings/settings_reset.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:bitwindow/main.dart' show rebootBitwindowBackend;
 import 'package:bitwindow/pages/root_page.dart' show setRootPageNavigatingAway;
@@ -18,6 +19,7 @@ class SettingsReset extends StatefulWidget {
 
 class _SettingsResetState extends State<SettingsReset> {
   Logger get log => GetIt.I.get<Logger>();
+  Directory get appDir => GetIt.I.get<BinaryProvider>().appDir;
 
   bool _deleteNodeSoftware = false;
   bool _deleteBlockchainData = false;
@@ -156,18 +158,77 @@ class _SettingsResetState extends State<SettingsReset> {
   }
 
   Future<void> _executeReset(BuildContext context) async {
+    final binaryProvider = GetIt.I.get<BinaryProvider>();
+    final orchestrator = GetIt.I.get<OrchestratorRPC>();
+
+    final binariesToReset = [
+      ...coreBinaries,
+      if (_alsoResetSidechains) ...sidechainBinaries,
+    ];
+
+    // Ask orchestrator what it would delete — server is source of truth.
+    final PreviewResetDataResponse preview;
+    try {
+      preview = await orchestrator.previewResetData(
+        deleteNodeSoftware: _deleteNodeSoftware,
+        deleteBlockchainData: _deleteBlockchainData,
+        deleteLogs: _deleteLogs,
+        deleteSettings: _deleteSettings,
+        deleteWalletFiles: _deleteWalletFiles,
+        alsoResetSidechains: _alsoResetSidechains,
+      );
+    } catch (e) {
+      log.e('previewResetData failed: $e');
+      if (!context.mounted) return;
+      await showDialog(
+        context: context,
+        builder: (context) => SailAlertCard(
+          title: 'Preview Failed',
+          subtitle: 'Could not compute reset preview: $e',
+          onConfirm: () async => Navigator.of(context).pop(),
+        ),
+      );
+      return;
+    }
+
+    final filesToDelete = preview.files.map((f) => DeleteItem(path: f.path)).toList();
+
+    if (filesToDelete.isEmpty) {
+      if (!context.mounted) return;
+      await showDialog(
+        context: context,
+        builder: (context) => SailAlertCard(
+          title: 'Nothing to Delete',
+          subtitle: 'No files found matching your selection.',
+          onConfirm: () async => Navigator.of(context).pop(),
+        ),
+      );
+      return;
+    }
+
     if (!context.mounted) return;
 
-    // Show confirmation dialog
+    // Show confirmation page with file list - orchestrator performs deletion.
     final confirmed = await Navigator.of(context).push<bool>(
       MaterialPageRoute(
-        builder: (_) => _ResetConfirmationPage(
-          deleteBlockchainData: _deleteBlockchainData,
+        builder: (_) => ResetConfirmationPage(
+          filesToDelete: filesToDelete,
+          binariesToReset: binariesToReset,
+          appDir: appDir,
+          binaryProvider: binaryProvider,
           deleteNodeSoftware: _deleteNodeSoftware,
-          deleteLogs: _deleteLogs,
-          deleteSettings: _deleteSettings,
-          deleteWalletFiles: _deleteWalletFiles,
-          alsoResetSidechains: _alsoResetSidechains,
+          log: log,
+          preDeleteAction: _deleteWalletFiles || _obliterateEverything
+              ? () => GetIt.I.get<WalletWriterProvider>().deleteAllWallets()
+              : null,
+          orchestratorDelete: () => orchestrator.streamResetData(
+            deleteNodeSoftware: _deleteNodeSoftware,
+            deleteBlockchainData: _deleteBlockchainData,
+            deleteLogs: _deleteLogs,
+            deleteSettings: _deleteSettings,
+            deleteWalletFiles: _deleteWalletFiles,
+            alsoResetSidechains: _alsoResetSidechains,
+          ),
         ),
       ),
     );
@@ -192,448 +253,5 @@ class _SettingsResetState extends State<SettingsReset> {
         await router.replaceAll([SailCreateWalletRoute(homeRoute: const RootRoute())]);
       }
     }
-  }
-}
-
-/// Confirmation page that previews files via orchestrator, then streams deletion.
-class _ResetConfirmationPage extends StatefulWidget {
-  final bool deleteBlockchainData;
-  final bool deleteNodeSoftware;
-  final bool deleteLogs;
-  final bool deleteSettings;
-  final bool deleteWalletFiles;
-  final bool alsoResetSidechains;
-
-  const _ResetConfirmationPage({
-    required this.deleteBlockchainData,
-    required this.deleteNodeSoftware,
-    required this.deleteLogs,
-    required this.deleteSettings,
-    required this.deleteWalletFiles,
-    required this.alsoResetSidechains,
-  });
-
-  @override
-  State<_ResetConfirmationPage> createState() => _ResetConfirmationPageState();
-}
-
-class _ResetConfirmationPageState extends State<_ResetConfirmationPage> {
-  Logger get log => GetIt.I.get<Logger>();
-  OrchestratorRPC get orchestrator => GetIt.I.get<OrchestratorRPC>();
-
-  // Preview state
-  bool _isLoadingPreview = true;
-  String? _previewError;
-  List<ResetFileInfo> _previewFiles = [];
-
-  // Deletion state
-  bool _isResetting = false;
-  bool _resetComplete = false;
-  String? _errorMessage;
-  final List<StreamResetDataResponse> _deletionEvents = [];
-  int _deletedCount = 0;
-  int _failedCount = 0;
-
-  /// Group preview files by category for display.
-  Map<String, List<ResetFileInfo>> get _filesByCategory {
-    final map = <String, List<ResetFileInfo>>{};
-    for (final f in _previewFiles) {
-      map.putIfAbsent(f.category, () => []).add(f);
-    }
-    return map;
-  }
-
-  String _categoryDisplayName(String category) {
-    switch (category) {
-      case 'blockchain_data':
-        return 'Blockchain Data';
-      case 'node_software':
-        return 'Node Software & Binaries';
-      case 'logs':
-        return 'Log Files';
-      case 'settings':
-        return 'Settings & Configuration';
-      case 'wallet':
-        return 'Wallet Files';
-      default:
-        return category;
-    }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _loadPreview();
-  }
-
-  Future<void> _loadPreview() async {
-    try {
-      final response = await orchestrator.previewResetData(
-        deleteBlockchainData: widget.deleteBlockchainData,
-        deleteNodeSoftware: widget.deleteNodeSoftware,
-        deleteLogs: widget.deleteLogs,
-        deleteSettings: widget.deleteSettings,
-        deleteWalletFiles: widget.deleteWalletFiles,
-        alsoResetSidechains: widget.alsoResetSidechains,
-      );
-
-      if (mounted) {
-        setState(() {
-          _previewFiles = response.files;
-          _isLoadingPreview = false;
-        });
-      }
-    } catch (e) {
-      log.e('Preview failed: $e');
-      if (mounted) {
-        setState(() {
-          _previewError = e.toString();
-          _isLoadingPreview = false;
-        });
-      }
-    }
-  }
-
-  Future<void> _startReset() async {
-    setState(() {
-      _isResetting = true;
-      _errorMessage = null;
-    });
-
-    try {
-      final stream = orchestrator.streamResetData(
-        deleteBlockchainData: widget.deleteBlockchainData,
-        deleteNodeSoftware: widget.deleteNodeSoftware,
-        deleteLogs: widget.deleteLogs,
-        deleteSettings: widget.deleteSettings,
-        deleteWalletFiles: widget.deleteWalletFiles,
-        alsoResetSidechains: widget.alsoResetSidechains,
-      );
-
-      await for (final event in stream) {
-        if (!mounted) break;
-
-        if (event.done) {
-          setState(() {
-            _deletedCount = event.deletedCount;
-            _failedCount = event.failedCount;
-            _resetComplete = true;
-            if (event.failedCount > 0) {
-              _errorMessage = '${event.failedCount} items failed to delete';
-            }
-          });
-        } else {
-          setState(() {
-            _deletionEvents.add(event);
-            _deletedCount = event.deletedCount;
-            _failedCount = event.failedCount;
-          });
-        }
-      }
-
-      // Stream ended without a done event — mark complete.
-      if (mounted && !_resetComplete) {
-        setState(() {
-          _resetComplete = true;
-        });
-      }
-    } catch (e) {
-      log.e('Reset failed: $e');
-      if (mounted) {
-        setState(() {
-          _resetComplete = true;
-          _errorMessage = e.toString();
-        });
-      }
-    }
-  }
-
-  void _handleBack() {
-    Navigator.of(context).pop(_isResetting);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = SailTheme.of(context);
-
-    return PopScope(
-      canPop: !_isResetting || _resetComplete,
-      onPopInvokedWithResult: (didPop, result) {
-        if (!didPop && _resetComplete) {
-          Navigator.of(context).pop(true);
-        }
-      },
-      child: Scaffold(
-        backgroundColor: theme.colors.background,
-        appBar: AppBar(
-          backgroundColor: theme.colors.background,
-          foregroundColor: theme.colors.text,
-          leading: IconButton(
-            icon: const Icon(Icons.arrow_back),
-            onPressed: _isResetting && !_resetComplete ? null : _handleBack,
-          ),
-        ),
-        body: SafeArea(
-          child: Stack(
-            children: [
-              Center(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 32.0),
-                  child: SizedBox(
-                    width: 800,
-                    child: SingleChildScrollView(
-                      padding: const EdgeInsets.only(bottom: 100),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          const SizedBox(height: 30),
-                          SailRow(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            spacing: SailStyleValues.padding12,
-                            children: [
-                              if (_resetComplete && _errorMessage == null)
-                                Icon(
-                                  Icons.check_circle,
-                                  color: theme.colors.success,
-                                  size: 32,
-                                )
-                              else
-                                SailSVG.fromAsset(
-                                  SailSVGAsset.iconWarning,
-                                  color: theme.colors.error,
-                                  width: 32,
-                                  height: 32,
-                                ),
-                              SailText.primary24(
-                                _resetComplete
-                                    ? 'Reset Complete'
-                                    : _isResetting
-                                    ? 'Resetting...'
-                                    : 'Confirm Reset',
-                                bold: true,
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 16),
-                          if (_isLoadingPreview)
-                            SailRow(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              spacing: SailStyleValues.padding08,
-                              children: [
-                                SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                    color: theme.colors.primary,
-                                  ),
-                                ),
-                                SailText.secondary13('Loading preview...'),
-                              ],
-                            )
-                          else if (_previewError != null)
-                            SailText.secondary13(
-                              'Failed to load preview: $_previewError',
-                              color: theme.colors.error,
-                            )
-                          else if (_isResetting && !_resetComplete)
-                            SailRow(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              spacing: SailStyleValues.padding08,
-                              children: [
-                                SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                    color: theme.colors.primary,
-                                  ),
-                                ),
-                                SailText.secondary13(
-                                  'Deleting... $_deletedCount deleted, $_failedCount failed',
-                                ),
-                              ],
-                            )
-                          else if (_resetComplete)
-                            SailText.secondary13(
-                              'Deleted $_deletedCount items'
-                              '${_failedCount > 0 ? ', $_failedCount failed' : ''}',
-                            )
-                          else
-                            SailText.secondary13(
-                              'The following ${_previewFiles.length} files/directories will be deleted:',
-                            ),
-                          if (_errorMessage != null) ...[
-                            const SizedBox(height: 8),
-                            SailText.secondary13(
-                              _errorMessage!,
-                              color: theme.colors.error,
-                            ),
-                          ],
-                          const SizedBox(height: 24),
-                          DecoratedBox(
-                            decoration: BoxDecoration(
-                              color: theme.colors.backgroundSecondary,
-                              borderRadius: SailStyleValues.borderRadiusSmall,
-                            ),
-                            child: Padding(
-                              padding: const EdgeInsets.all(SailStyleValues.padding12),
-                              child: _resetComplete
-                                  ? _buildDeletionResultList(theme)
-                                  : _isResetting
-                                  ? _buildDeletionProgressList(theme)
-                                  : _buildPreviewList(theme),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-              BottomActionBar(
-                children: [
-                  if (!_isResetting && !_isLoadingPreview && _previewError == null) ...[
-                    SailButton(
-                      label: 'Cancel',
-                      onPressed: () async => Navigator.of(context).pop(false),
-                    ),
-                    const SizedBox(width: SailStyleValues.padding12),
-                    SailButton(
-                      label: 'Reset ${_filesByCategory.length} categories',
-                      variant: ButtonVariant.destructive,
-                      onPressed: () async => await _startReset(),
-                    ),
-                  ] else if (_resetComplete)
-                    SailButton(
-                      label: 'Continue',
-                      variant: ButtonVariant.primary,
-                      onPressed: () async => _handleBack(),
-                    )
-                  else if (_previewError != null)
-                    SailButton(
-                      label: 'Back',
-                      onPressed: () async => Navigator.of(context).pop(false),
-                    ),
-                ],
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  /// Preview: show files grouped by category.
-  Widget _buildPreviewList(SailThemeData theme) {
-    if (_previewFiles.isEmpty) {
-      return SailText.secondary13('No files found to delete.');
-    }
-
-    final categories = _filesByCategory;
-    final widgets = <Widget>[];
-
-    for (final entry in categories.entries) {
-      widgets.add(
-        Padding(
-          padding: const EdgeInsets.only(top: 8, bottom: 4),
-          child: SailRow(
-            spacing: SailStyleValues.padding08,
-            children: [
-              Icon(Icons.delete_outline, size: 16, color: theme.colors.error),
-              SailText.secondary13(
-                '${_categoryDisplayName(entry.key)} (${entry.value.length} items)',
-                bold: true,
-              ),
-            ],
-          ),
-        ),
-      );
-
-      for (final file in entry.value) {
-        widgets.add(
-          Padding(
-            padding: const EdgeInsets.only(left: 24, top: 2, bottom: 2),
-            child: SailText.secondary12(
-              file.path,
-              monospace: true,
-            ),
-          ),
-        );
-      }
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: widgets,
-    );
-  }
-
-  /// During deletion: show live stream of events.
-  Widget _buildDeletionProgressList(SailThemeData theme) {
-    if (_deletionEvents.isEmpty) {
-      return SailText.secondary13('Stopping binaries...');
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: _deletionEvents.map((evt) {
-        final isSuccess = evt.success;
-        return Padding(
-          padding: const EdgeInsets.symmetric(vertical: 2),
-          child: SailRow(
-            spacing: SailStyleValues.padding08,
-            children: [
-              Icon(
-                isSuccess ? Icons.check_circle : Icons.error,
-                size: 16,
-                color: isSuccess ? theme.colors.success : theme.colors.error,
-              ),
-              Expanded(
-                child: SailText.secondary12(
-                  isSuccess ? evt.path : '${evt.path}: ${evt.error}',
-                  monospace: true,
-                  color: isSuccess ? null : theme.colors.error,
-                ),
-              ),
-            ],
-          ),
-        );
-      }).toList(),
-    );
-  }
-
-  /// After deletion: show final results.
-  Widget _buildDeletionResultList(SailThemeData theme) {
-    if (_deletionEvents.isEmpty) {
-      return SailText.secondary13('No items were deleted.');
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: _deletionEvents.map((evt) {
-        final isSuccess = evt.success;
-        return Padding(
-          padding: const EdgeInsets.symmetric(vertical: 2),
-          child: SailRow(
-            spacing: SailStyleValues.padding08,
-            children: [
-              Icon(
-                isSuccess ? Icons.check_circle : Icons.error,
-                size: 16,
-                color: isSuccess ? theme.colors.success : theme.colors.error,
-              ),
-              Expanded(
-                child: SailText.secondary12(
-                  isSuccess ? evt.path : '${evt.path}: ${evt.error}',
-                  monospace: true,
-                  color: isSuccess ? null : theme.colors.error,
-                ),
-              ),
-            ],
-          ),
-        );
-      }).toList(),
-    );
   }
 }

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.40
+version: 0.2.41
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.65
+version: 1.0.66
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/widgets/reset/path_tree_view.dart
+++ b/sail_ui/lib/widgets/reset/path_tree_view.dart
@@ -50,10 +50,12 @@ class TreeNode {
             isDirectory: nodeIsDirectory,
           );
 
-          // If this is a leaf node (in original paths) and it's a directory,
-          // collapse it by default since it represents an entire directory deletion
+          // Leaf directory in the paths list → whole dir gets deleted.
+          // Collapse by default but populate children so the user can expand
+          // to see exactly what's inside before confirming.
           if (isLast && nodeIsDirectory && pathsSet.contains(partialPath)) {
             defaultCollapsed.add(partialPath);
+            await _populateChildren(current.children[part]!, partialPath);
           }
         } else if (!isLast) {
           current.children[part]!.isDirectory = true;
@@ -63,6 +65,31 @@ class TreeNode {
     }
 
     return (root, defaultCollapsed);
+  }
+
+  /// Walk a real directory and attach its contents as TreeNode children so
+  /// a leaf directory in the paths list can be expanded in the UI.
+  static Future<void> _populateChildren(TreeNode node, String dirPath) async {
+    try {
+      final entities = await Directory(dirPath).list(followLinks: false).toList();
+      entities.sort((a, b) => a.path.compareTo(b.path));
+      for (final entity in entities) {
+        final name = path.basename(entity.path);
+        if (node.children.containsKey(name)) continue;
+        final isDir = entity is Directory;
+        final child = TreeNode(
+          name: name,
+          fullPath: entity.path,
+          isDirectory: isDir,
+        );
+        node.children[name] = child;
+        if (isDir) {
+          await _populateChildren(child, entity.path);
+        }
+      }
+    } catch (_) {
+      // Permission / I/O — skip silently so the preview still renders.
+    }
   }
 }
 

--- a/sail_ui/lib/widgets/reset/reset_confirmation_page.dart
+++ b/sail_ui/lib/widgets/reset/reset_confirmation_page.dart
@@ -13,6 +13,10 @@ class ResetConfirmationPage extends StatefulWidget {
   final bool deleteNodeSoftware;
   final Logger log;
   final Future<void> Function()? preDeleteAction;
+  // When provided, deletion is delegated to the orchestrator: server stops
+  // binaries and deletes, streaming one event per path. Null → legacy
+  // client-side deletion via Binary methods (still used by sidechain apps).
+  final Stream<StreamResetDataResponse> Function()? orchestratorDelete;
 
   const ResetConfirmationPage({
     super.key,
@@ -23,6 +27,7 @@ class ResetConfirmationPage extends StatefulWidget {
     required this.deleteNodeSoftware,
     required this.log,
     this.preDeleteAction,
+    this.orchestratorDelete,
   });
 
   @override
@@ -95,6 +100,23 @@ class _ResetConfirmationPageState extends State<ResetConfirmationPage> {
       await widget.preDeleteAction!();
     }
 
+    if (widget.orchestratorDelete != null) {
+      await _runOrchestratorDelete();
+    } else {
+      await _runClientDelete();
+    }
+
+    // Re-download binaries if needed (server doesn't repopulate bin/).
+    if (widget.deleteNodeSoftware) {
+      await copyBinariesFromAssets(widget.log, widget.appDir);
+    }
+
+    if (mounted) {
+      setState(() => _deletionComplete = true);
+    }
+  }
+
+  Future<void> _runClientDelete() async {
     // Stop binaries first
     await Future.wait(
       widget.binariesToReset.map((b) => widget.binaryProvider.stop(b)),
@@ -142,14 +164,43 @@ class _ResetConfirmationPageState extends State<ResetConfirmationPage> {
 
       await Future.delayed(const Duration(milliseconds: 50));
     }
+  }
 
-    // Re-download binaries if needed
-    if (widget.deleteNodeSoftware) {
-      await copyBinariesFromAssets(widget.log, widget.appDir);
+  Future<void> _runOrchestratorDelete() async {
+    // Orchestrator stops binaries server-side; no client-side stop needed.
+    final pathToItem = <String, DeleteItem>{};
+    for (final item in widget.filesToDelete) {
+      pathToItem[item.path] = item;
     }
 
-    if (mounted) {
-      setState(() => _deletionComplete = true);
+    var seen = 0;
+    try {
+      await for (final event in widget.orchestratorDelete!()) {
+        if (!mounted) return;
+        if (event.done) break;
+        setState(() {
+          _stoppingBinaries = false;
+          _currentIndex = seen;
+          final item = pathToItem[event.path];
+          if (item != null) {
+            item.status = event.success ? DeleteItemStatus.success : DeleteItemStatus.error;
+            if (!event.success) item.errorMessage = event.error;
+          }
+        });
+        seen++;
+      }
+    } catch (e) {
+      widget.log.e('Orchestrator reset stream failed: $e');
+      if (mounted) {
+        setState(() {
+          for (final item in widget.filesToDelete) {
+            if (item.status == DeleteItemStatus.pending || item.status == DeleteItemStatus.inProgress) {
+              item.status = DeleteItemStatus.error;
+              item.errorMessage = e.toString();
+            }
+          }
+        });
+      }
     }
   }
 

--- a/sidechain-orchestrator/config/binaries.go
+++ b/sidechain-orchestrator/config/binaries.go
@@ -99,6 +99,30 @@ func (b BinaryDirConfig) RootDirNetwork(network Network) string {
 	return filepath.Join(b.AppDir(), subdir)
 }
 
+// DatadirNetwork returns the network-aware datadir used for most file lookups.
+// For bitcoind, if bitcoinOverride is non-empty it is used as the base (from
+// the user's `datadir=` setting in bitwindow-bitcoin.conf); otherwise we fall
+// back to the platform default. bitcoind and bitwindowd add a per-network
+// subdir (e.g. "signet/"); other binaries keep the flat root dir.
+// Dart: Binary.datadir() + Binary.datadirNetwork() (L1537-1591)
+func (b BinaryDirConfig) DatadirNetwork(network Network, bitcoinOverride string) string {
+	baseDir := b.RootDirNetwork(network)
+	if b.BinaryName == "bitcoind" && bitcoinOverride != "" {
+		baseDir = bitcoinOverride
+	}
+	switch b.BinaryName {
+	case "bitcoind":
+		if network == NetworkMainnet || network == NetworkForknet {
+			return baseDir
+		}
+		return filepath.Join(baseDir, network.ReadableName())
+	case "bitwindowd":
+		return filepath.Join(baseDir, network.ReadableName())
+	default:
+		return baseDir
+	}
+}
+
 // RootDir returns the root data directory (same for all networks).
 // Panics if directories differ per network.
 // Dart: Binary.rootDir() (L1529-1535)
@@ -246,10 +270,16 @@ var (
 )
 
 // DirConfigByName returns the BinaryDirConfig for a given binary name.
+// Matches against the JSON key, display Name, or BinaryName (case-insensitive).
+// The JSON-key match is what lets runtime config names like "enforcer" resolve
+// to the dir config keyed under "enforcer" despite its BinaryName being
+// "bip300301-enforcer".
 func DirConfigByName(name string) (BinaryDirConfig, bool) {
 	lower := strings.ToLower(name)
-	for _, d := range loadDirConfigs() {
-		if strings.ToLower(d.Name) == lower || strings.ToLower(d.BinaryName) == lower {
+	for key, d := range loadDirConfigs() {
+		if strings.ToLower(key) == lower ||
+			strings.ToLower(d.Name) == lower ||
+			strings.ToLower(d.BinaryName) == lower {
 			return d, true
 		}
 	}

--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -143,12 +143,18 @@ drivechain=1
 `
 	}
 
+	// Pin datadir to the Drivechain dir so bitcoind doesn't fall back to
+	// Bitcoin Core's standard datadir (~/Library/Application Support/Bitcoin
+	// on macOS, etc.).
+	datadir := m.rootDirNetwork(m.Network)
+
 	return fmt.Sprintf(`%s%d
 
 # Generated code. Any changes to this file *will* get overwritten.
 # source: bitwindow bitcoin config settings
 
 # Common settings for all networks
+datadir=%s
 rpcuser=user
 rpcpassword=password
 server=1
@@ -184,7 +190,7 @@ acceptnonstdtxn=1
 
 # Regtest-specific settings
 [regtest]
-`, bitcoinConfVersionCommentPrefix, BitcoinConfMigrationsVersion, currentNetwork, mainSection)
+`, bitcoinConfVersionCommentPrefix, BitcoinConfMigrationsVersion, datadir, currentNetwork, mainSection)
 }
 
 // SaveConfig writes the current config to disk.

--- a/sidechain-orchestrator/connection_monitor.go
+++ b/sidechain-orchestrator/connection_monitor.go
@@ -232,6 +232,22 @@ func (m *ConnectionMonitor) InitializingBinary() bool {
 	return m.initializingBinary
 }
 
+// SetInitializing flips the initializing flag and fires onChange so the
+// frontend sees the transition immediately (before the next 1s ping).
+// Orchestrator calls this around process.Start so the UI shows an "initializing"
+// spinner instead of a red X during the fresh-boot window where testConnection
+// is still failing.
+func (m *ConnectionMonitor) SetInitializing(v bool) {
+	m.mu.Lock()
+	if m.initializingBinary == v {
+		m.mu.Unlock()
+		return
+	}
+	m.initializingBinary = v
+	m.mu.Unlock()
+	m.notifyChange()
+}
+
 // ConnectModeOnly returns whether the monitor is in connect-mode-only
 // (willfully stopped, only watching for external restart).
 func (m *ConnectionMonitor) ConnectModeOnly() bool {
@@ -322,6 +338,7 @@ func (m *ConnectionMonitor) testConnection(ctx context.Context) {
 		m.completedStartup = true
 		m.restartCount = 0
 		m.hasCrashError = false // clear crash error on successful reconnection
+		m.initializingBinary = false
 	} else if isConnectModeOnly {
 		// Dart L119-124: in connect-mode-only, just stay clean disconnected
 		m.connected = false
@@ -592,6 +609,7 @@ func (m *ConnectionMonitor) MarkStopped() {
 	// Dart L371-378: cleanup
 	m.connected = false
 	m.stoppingBinary = false
+	m.initializingBinary = false
 	m.connectionError = ""
 	m.startupError = ""
 	m.hasCrashError = false

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -419,6 +419,33 @@ func (o *Orchestrator) RecentLogs(name string, n int) ([]LogEntry, error) {
 	return proc.RecentLogs(n), nil
 }
 
+// prefetchBinary downloads a binary in the background and signals completion
+// on the returned channel (nil = success, non-nil = failure). Used to
+// parallelise enforcer + target downloads with bitcoind's IBD so the binaries
+// are already on disk when it's their turn to start.
+//
+// Safe to call even if the binary is already downloaded — DownloadManager
+// short-circuits with a single Done message in that case.
+func (o *Orchestrator) prefetchBinary(ctx context.Context, cfg BinaryConfig) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		defer close(done)
+		progressCh, err := o.download.Download(ctx, cfg, o.Network, false)
+		if err != nil {
+			done <- err
+			return
+		}
+		for p := range progressCh {
+			if p.Error != nil {
+				done <- p.Error
+				return
+			}
+		}
+		done <- nil
+	}()
+	return done
+}
+
 // StartWithL1 starts a binary along with its dependency chain:
 // Bitcoin Core -> wait for wallet/IBD -> Enforcer -> target binary.
 func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts StartOpts) (<-chan StartupProgress, error) {
@@ -433,8 +460,18 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 		defer close(ch)
 
 		if opts.Immediate {
-			o.startTargetOnly(ctx, config, opts, ch)
+			o.startTargetOnly(ctx, config, opts, ch, nil)
 			return
+		}
+
+		// Kick off enforcer + target downloads in parallel with bitcoind's IBD.
+		// By the time we need to start them, they're already on disk. If the
+		// prefetch is still running when we need to start, we block on its
+		// completion — which is no worse than the old sequential flow.
+		enforcerPrefetch := o.prefetchBinary(ctx, o.configs["enforcer"])
+		var targetPrefetch <-chan error
+		if config.Name != "enforcer" {
+			targetPrefetch = o.prefetchBinary(ctx, config)
 		}
 
 		// Auto-build core args if none provided and config manager is available
@@ -508,6 +545,12 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 				o.log.Info().Str("binary", "bitcoind").Int("pid", pid).Msg("adopted externally-running process")
 			}
 		} else {
+			// Mark as initializing BEFORE we start doing work. Covers the whole
+			// download → process.Start → wait-for-connection window so the UI
+			// shows a spinner instead of a red X. testConnection clears this on
+			// the first successful ping; error paths below clear it explicitly.
+			coreMon.SetInitializing(true)
+
 			// Dart L216-217: only start restart timer if this process starts the binary!
 			coreArgs := opts.CoreArgs // capture for closure
 			coreMon.StartRestartTimer(ctx,
@@ -560,15 +603,18 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 
 			downloadCh, err := o.download.Download(ctx, o.configs["bitcoind"], o.Network, false)
 			if err != nil {
+				coreMon.SetInitializing(false)
 				ch <- StartupProgress{Error: fmt.Errorf("download bitcoind: %w", err)}
 				return
 			}
 			if err := forwardDownload(downloadCh, ch, "downloading-bitcoind"); err != nil {
+				coreMon.SetInitializing(false)
 				ch <- StartupProgress{Error: fmt.Errorf("download bitcoind: %w", err)}
 				return
 			}
 
 			if _, err := o.process.Start(ctx, o.configs["bitcoind"], opts.CoreArgs, nil); err != nil {
+				coreMon.SetInitializing(false)
 				ch <- StartupProgress{Error: fmt.Errorf("start bitcoind: %w", err)}
 				return
 			}
@@ -577,6 +623,7 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 			// Wait for the connection timer to detect bitcoind is healthy
 			ch <- StartupProgress{Stage: "waiting-bitcoind", Message: "waiting for Bitcoin Core to accept connections..."}
 			if err := waitForConnectedOrExit(ctx, coreMon, coreProc); err != nil {
+				coreMon.SetInitializing(false)
 				ch <- StartupProgress{Error: fmt.Errorf("wait for bitcoind: %w", err)}
 				return
 			}
@@ -584,18 +631,20 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 
 		// Wait for wallet + IBD, then start enforcer.
 		if !opts.Immediate {
-			o.startEnforcerWhenReady(ctx, opts)
+			o.startEnforcerWhenReady(ctx, opts, enforcerPrefetch)
 		}
 
 		// Start the target after enforcer is ready.
-		o.startTargetOnly(ctx, config, opts, ch)
+		o.startTargetOnly(ctx, config, opts, ch, targetPrefetch)
 	}()
 
 	return ch, nil
 }
 
 // startEnforcerWhenReady waits for wallet + IBD completion, then starts the enforcer.
-func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpts) {
+// If prefetched is non-nil, the enforcer binary is already being downloaded
+// in parallel and we wait on its completion instead of starting a new download.
+func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpts, prefetched <-chan error) {
 	// 1. Wait for wallet to exist — enforcer needs the L1 seed.
 	if o.WalletSvc != nil && !o.WalletSvc.HasWallet() {
 		o.log.Info().Msg("waiting for wallet before starting enforcer")
@@ -612,17 +661,38 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 	// 2. Wait for IBD to complete — enforcer needs a fully synced chain.
 	client, err := o.CoreStatusClient()
 	if err == nil {
-		o.log.Info().Msg("waiting for IBD to complete before starting enforcer")
+		o.log.Info().
+			Str("core_rpc", fmt.Sprintf("localhost:%d", o.BitcoinConf.GetRPCPort())).
+			Msg("waiting for IBD to complete before starting enforcer")
+		var lastErr error
+		var errCount int
 		for {
 			complete, err := client.IsIBDComplete(ctx)
-			if err == nil && complete {
-				break
+			if err == nil {
+				if complete {
+					break
+				}
+				// Mid-IBD, bitcoind is reachable: nothing to log, just wait.
+			} else {
+				errCount++
+				// Surface the RPC error the first time and then once a
+				// minute so a persistent misconfig (wrong port / creds)
+				// doesn't hide behind silent retries.
+				if errCount == 1 || errCount%12 == 0 {
+					o.log.Warn().Err(err).Int("attempts", errCount).
+						Msg("IBD check RPC failed; will keep retrying")
+				}
+				lastErr = err
 			}
 			select {
 			case <-ctx.Done():
 				return
 			case <-time.After(5 * time.Second):
 			}
+		}
+		if lastErr != nil {
+			o.log.Info().Int("recovered_after", errCount).
+				Msg("IBD check recovered after earlier RPC errors")
 		}
 		o.log.Info().Msg("IBD complete, proceeding with enforcer")
 	}
@@ -660,6 +730,10 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 		return
 	}
 
+	// Mark initializing for the download + start window. testConnection clears
+	// this on the first successful ping; error paths below clear it explicitly.
+	enforcerMon.SetInitializing(true)
+
 	enfOpts := opts
 	enforcerMon.StartRestartTimer(ctx,
 		func(restartCtx context.Context) error {
@@ -680,19 +754,31 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 		},
 	)
 
-	downloadCh, err := o.download.Download(ctx, enforcerCfg, o.Network, false)
-	if err != nil {
-		o.log.Error().Err(err).Msg("failed to download enforcer")
-		return
-	}
-	for progress := range downloadCh {
-		if progress.Error != nil {
-			o.log.Error().Err(progress.Error).Msg("enforcer download error")
+	if prefetched != nil {
+		// Download was kicked off in parallel with bitcoind IBD.
+		if err := <-prefetched; err != nil {
+			enforcerMon.SetInitializing(false)
+			o.log.Error().Err(err).Msg("enforcer prefetch download failed")
 			return
+		}
+	} else {
+		downloadCh, err := o.download.Download(ctx, enforcerCfg, o.Network, false)
+		if err != nil {
+			enforcerMon.SetInitializing(false)
+			o.log.Error().Err(err).Msg("failed to download enforcer")
+			return
+		}
+		for progress := range downloadCh {
+			if progress.Error != nil {
+				enforcerMon.SetInitializing(false)
+				o.log.Error().Err(progress.Error).Msg("enforcer download error")
+				return
+			}
 		}
 	}
 
 	if _, err := o.process.Start(ctx, enforcerCfg, opts.EnforcerArgs, nil); err != nil {
+		enforcerMon.SetInitializing(false)
 		o.log.Error().Err(err).Msg("failed to start enforcer")
 		return
 	}
@@ -700,7 +786,9 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 	o.log.Info().Msg("enforcer started")
 }
 
-func (o *Orchestrator) startTargetOnly(ctx context.Context, config BinaryConfig, opts StartOpts, ch chan<- StartupProgress) {
+// If prefetched is non-nil, the target binary is already being downloaded in
+// parallel and we wait on its completion instead of starting a new download.
+func (o *Orchestrator) startTargetOnly(ctx context.Context, config BinaryConfig, opts StartOpts, ch chan<- StartupProgress, prefetched <-chan error) {
 	targetChecker := NewHealthChecker(config)
 	targetMon := o.getOrCreateMonitor(config.Name, targetChecker, nil)
 
@@ -722,16 +810,33 @@ func (o *Orchestrator) startTargetOnly(ctx context.Context, config BinaryConfig,
 		return
 	}
 
-	ch <- StartupProgress{Stage: "downloading-" + config.Name, Message: fmt.Sprintf("downloading %s...", config.DisplayName)}
+	// Mark initializing for the download + start + wait window. testConnection
+	// clears this on the first successful ping; error paths below clear it
+	// explicitly.
+	targetMon.SetInitializing(true)
 
-	downloadCh, err := o.download.Download(ctx, config, o.Network, false)
-	if err != nil {
-		ch <- StartupProgress{Error: fmt.Errorf("download %s: %w", config.Name, err)}
-		return
-	}
-	if err := forwardDownload(downloadCh, ch, "downloading-"+config.Name); err != nil {
-		ch <- StartupProgress{Error: fmt.Errorf("download %s: %w", config.Name, err)}
-		return
+	if prefetched != nil {
+		// Download was kicked off in parallel with bitcoind IBD.
+		ch <- StartupProgress{Stage: "downloading-" + config.Name, Message: fmt.Sprintf("waiting for %s download...", config.DisplayName)}
+		if err := <-prefetched; err != nil {
+			targetMon.SetInitializing(false)
+			ch <- StartupProgress{Error: fmt.Errorf("download %s: %w", config.Name, err)}
+			return
+		}
+	} else {
+		ch <- StartupProgress{Stage: "downloading-" + config.Name, Message: fmt.Sprintf("downloading %s...", config.DisplayName)}
+
+		downloadCh, err := o.download.Download(ctx, config, o.Network, false)
+		if err != nil {
+			targetMon.SetInitializing(false)
+			ch <- StartupProgress{Error: fmt.Errorf("download %s: %w", config.Name, err)}
+			return
+		}
+		if err := forwardDownload(downloadCh, ch, "downloading-"+config.Name); err != nil {
+			targetMon.SetInitializing(false)
+			ch <- StartupProgress{Error: fmt.Errorf("download %s: %w", config.Name, err)}
+			return
+		}
 	}
 
 	// If already running (e.g. enforcer started as a dep), just wait for connection.
@@ -739,6 +844,7 @@ func (o *Orchestrator) startTargetOnly(ctx context.Context, config BinaryConfig,
 		o.log.Info().Str("binary", config.Name).Msg("process already running, waiting for connection")
 		ch <- StartupProgress{Stage: "waiting-" + config.Name, Message: fmt.Sprintf("waiting for %s...", config.DisplayName)}
 		if err := waitForConnectedOrExit(ctx, targetMon, o.process.Get(config.Name)); err != nil {
+			targetMon.SetInitializing(false)
 			ch <- StartupProgress{Error: fmt.Errorf("wait for %s: %w", config.Name, err)}
 			return
 		}
@@ -775,6 +881,7 @@ func (o *Orchestrator) startTargetOnly(ctx context.Context, config BinaryConfig,
 	)
 
 	if _, err := o.process.Start(ctx, config, targetArgs, targetEnv); err != nil {
+		targetMon.SetInitializing(false)
 		ch <- StartupProgress{Error: fmt.Errorf("start %s: %w", config.Name, err)}
 		return
 	}
@@ -782,6 +889,7 @@ func (o *Orchestrator) startTargetOnly(ctx context.Context, config BinaryConfig,
 
 	ch <- StartupProgress{Stage: "waiting-" + config.Name, Message: fmt.Sprintf("waiting for %s to accept connections...", config.DisplayName)}
 	if err := waitForConnectedOrExit(ctx, targetMon, targetProc); err != nil {
+		targetMon.SetInitializing(false)
 		ch <- StartupProgress{Error: fmt.Errorf("wait for %s: %w", config.Name, err)}
 		return
 	}

--- a/sidechain-orchestrator/reset.go
+++ b/sidechain-orchestrator/reset.go
@@ -38,6 +38,31 @@ type ResetEvent struct {
 	FailedCount  int
 }
 
+type pathEntry struct {
+	path     string
+	category string
+}
+
+// collectPathEntries returns the deduplicated, deterministic list that preview
+// and deletion MUST share — otherwise their counts diverge and the UI desyncs.
+func (o *Orchestrator) collectPathEntries(cat ResetCategory) []pathEntry {
+	pathsByCategory := o.collectPaths(cat)
+	order := []string{"blockchain_data", "node_software", "logs", "settings", "wallet"}
+
+	var entries []pathEntry
+	seen := make(map[string]bool)
+	for _, category := range order {
+		for _, p := range pathsByCategory[category] {
+			if seen[p] {
+				continue
+			}
+			seen[p] = true
+			entries = append(entries, pathEntry{path: p, category: category})
+		}
+	}
+	return entries
+}
+
 // categoryLabel maps category flags to human-readable labels.
 func categoryLabel(cat string) string {
 	switch cat {
@@ -75,8 +100,18 @@ func (o *Orchestrator) collectPaths(cat ResetCategory) map[string][]string {
 
 	binDir := BinDir(o.BitwindowDir)
 
+	// User may have overridden bitcoind's datadir in bitwindow-bitcoin.conf;
+	// honour that so reset targets the right place on disk.
+	bitcoinOverride := ""
+	if o.BitcoinConf != nil {
+		bitcoinOverride = o.BitcoinConf.DetectedDataDir
+	}
+
 	for _, dc := range targets {
-		networkDir := dc.RootDirNetwork(network)
+		// Use the network-aware datadir so we hit bitcoind's signet/ subdir
+		// (blocks, chainstate, wallets) and bitwindowd's signet/ subdir
+		// (bitwindow.db, wallet.json). Other binaries get the flat root.
+		networkDir := dc.DatadirNetwork(network, bitcoinOverride)
 
 		if cat.DeleteBlockchainData {
 			result["blockchain_data"] = append(result["blockchain_data"],
@@ -119,23 +154,21 @@ func (o *Orchestrator) collectPaths(cat ResetCategory) map[string][]string {
 // PreviewResetData returns the list of files/directories that would be deleted
 // for the given categories, without performing any deletions.
 func (o *Orchestrator) PreviewResetData(cat ResetCategory) ([]ResetFileInfo, error) {
-	pathsByCategory := o.collectPaths(cat)
+	entries := o.collectPathEntries(cat)
 
 	var files []ResetFileInfo
-	for category, paths := range pathsByCategory {
-		for _, p := range paths {
-			info := ResetFileInfo{
-				Path:     p,
-				Category: category,
-			}
-			if fi, err := os.Stat(p); err == nil {
-				info.IsDirectory = fi.IsDir()
-				if !fi.IsDir() {
-					info.SizeBytes = fi.Size()
-				}
-			}
-			files = append(files, info)
+	for _, e := range entries {
+		info := ResetFileInfo{
+			Path:     e.path,
+			Category: e.category,
 		}
+		if fi, err := os.Stat(e.path); err == nil {
+			info.IsDirectory = fi.IsDir()
+			if !fi.IsDir() {
+				info.SizeBytes = fi.Size()
+			}
+		}
+		files = append(files, info)
 	}
 
 	return files, nil
@@ -173,23 +206,7 @@ func (o *Orchestrator) StreamResetData(ctx context.Context, cat ResetCategory) (
 		}
 	}
 
-	pathsByCategory := o.collectPaths(cat)
-
-	// Flatten to ordered list for deletion.
-	type pathEntry struct {
-		path     string
-		category string
-	}
-	var entries []pathEntry
-	seen := make(map[string]bool)
-	for category, paths := range pathsByCategory {
-		for _, p := range paths {
-			if !seen[p] {
-				seen[p] = true
-				entries = append(entries, pathEntry{path: p, category: category})
-			}
-		}
-	}
+	entries := o.collectPathEntries(cat)
 
 	events := make(chan ResetEvent, len(entries)+1)
 

--- a/sidechain-orchestrator/reset_test.go
+++ b/sidechain-orchestrator/reset_test.go
@@ -155,28 +155,29 @@ func TestPreviewResetData_StatsExistingFiles(t *testing.T) {
 func TestPreviewResetData_DirectoryMarked(t *testing.T) {
 	o := newResetTestOrchestrator(t)
 
-	// Seed a directory that will be picked up (e.g. blocks dir for bitcoind).
-	// We need to figure out the network dir for bitcoind and create a "blocks"
-	// directory inside it.
-	cfg, ok := o.configs["bitcoind"]
-	if !ok {
-		t.Skip("bitcoind config not present in defaults")
-	}
-	_ = cfg
-	// Use collectPaths to discover what paths would be looked up, then
-	// create one as a directory.
+	// Pick any blockchain_data path that doesn't already exist (orchestrator
+	// init seeds a few files like bitwindow-enforcer.conf), create it as a
+	// directory, and verify preview reports IsDirectory=true.
 	paths := o.collectPaths(ResetCategory{DeleteBlockchainData: true})
-	if bcPaths, ok := paths["blockchain_data"]; ok && len(bcPaths) > 0 {
-		// Create the first path as a directory.
-		seedDir(t, bcPaths[0])
+	bcPaths := paths["blockchain_data"]
+	var target string
+	for _, p := range bcPaths {
+		if _, err := os.Stat(p); os.IsNotExist(err) {
+			target = p
+			break
+		}
+	}
+	if target == "" {
+		t.Skip("no unused blockchain_data path available to seed")
+	}
+	seedDir(t, target)
 
-		files, err := o.PreviewResetData(ResetCategory{DeleteBlockchainData: true})
-		require.NoError(t, err)
-		for _, f := range files {
-			if f.Path == bcPaths[0] {
-				assert.True(t, f.IsDirectory)
-				assert.Zero(t, f.SizeBytes, "directories should report 0 size")
-			}
+	files, err := o.PreviewResetData(ResetCategory{DeleteBlockchainData: true})
+	require.NoError(t, err)
+	for _, f := range files {
+		if f.Path == target {
+			assert.True(t, f.IsDirectory)
+			assert.Zero(t, f.SizeBytes, "directories should report 0 size")
 		}
 	}
 }

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.194
+version: 1.0.195
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.65
+version: 1.0.66
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.192
+version: 1.0.193
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
Restores the pre-migration reset UI. Keeps the orchestrator RPCs under the hood via a new optional callback on ResetConfirmationPage.