### PR TITLE
scripts: pre-commit formats in place and re-stages

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,9 @@
 format:
     bash scripts/format.sh
 
+setup:
+    bash scripts/install-hooks.sh
+
 gen-router:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Install the repo's git hooks into .git/hooks/ so they fire on commit.
+set -euo pipefail
+
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+
+ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
+chmod +x scripts/pre-commit.sh
+
+echo "installed: .git/hooks/pre-commit -> scripts/pre-commit.sh"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Run `dart format --set-exit-if-changed` on staged Dart files.
-# Skips generated (lib/gen/**) and tooling (.dart_tool/**) paths.
+# Run `dart format` on staged Dart files and re-stage the result so the
+# commit always has formatted code. Skips generated (lib/gen/**) and
+# tooling (.dart_tool/**) paths.
 # Install: ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
 
 set -euo pipefail
@@ -14,11 +15,19 @@ if [ -z "$files" ]; then
   exit 0
 fi
 
-export PATH="/opt/homebrew/share/flutter/bin:$PATH"
+# Flutter bundles `dart`. Add common install locations so the hook works
+# under `git commit` (which doesn't inherit a login shell's PATH).
+export PATH="/opt/homebrew/share/flutter/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
 if ! command -v dart >/dev/null 2>&1; then
-  echo "pre-commit: dart not found on PATH, skipping format check" >&2
+  echo "pre-commit: dart not found on PATH, skipping format" >&2
   exit 0
 fi
 
-echo "$files" | xargs dart format --set-exit-if-changed
+# Format in place, then re-stage any file the formatter changed.
+# shellcheck disable=SC2086
+echo "$files" | xargs dart format
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  git add -- "$f"
+done <<<"$files"


### PR DESCRIPTION
Auto-formats staged Dart files before commit and re-stages them, so the CI format check can't catch what a hook should've caught.