### PR TITLE
sail_ui,bitwindow: harden boot-phase connection status

### DIFF
--- a/sail_ui/lib/providers/backend_state_provider.dart
+++ b/sail_ui/lib/providers/backend_state_provider.dart
@@ -118,8 +118,16 @@ class BackendStateProvider extends ChangeNotifier {
     final rpc = _rpcForBinaryName(status.name);
     if (rpc == null) return null;
 
-    final startupError = status.startupError.isNotEmpty ? status.startupError : null;
-    final connectionError = status.connectionError.isNotEmpty ? status.connectionError : null;
+    // Always derive from the current status. Critically, when the orchestrator stops
+    // reporting a startup_error (empty string in the message), we must null out the
+    // stale value on the RPC so the UI doesn't keep rendering a warmup message after
+    // the binary is healthy. Same story for connectionError.
+    //
+    // Belt-and-suspenders: once the orchestrator reports connected=true with no
+    // startup_error, force a null so any stale value from a previous tick is gone.
+    final bool healthy = status.connected && status.startupError.isEmpty;
+    final startupError = (status.startupError.isEmpty || healthy) ? null : status.startupError;
+    final connectionError = status.connectionError.isEmpty ? null : status.connectionError;
 
     // Check if anything actually changed to avoid unnecessary rebuilds
     if (rpc.connected == status.connected &&

--- a/sail_ui/lib/providers/backend_state_provider.dart
+++ b/sail_ui/lib/providers/backend_state_provider.dart
@@ -118,15 +118,10 @@ class BackendStateProvider extends ChangeNotifier {
     final rpc = _rpcForBinaryName(status.name);
     if (rpc == null) return null;
 
-    // Always derive from the current status. Critically, when the orchestrator stops
-    // reporting a startup_error (empty string in the message), we must null out the
-    // stale value on the RPC so the UI doesn't keep rendering a warmup message after
-    // the binary is healthy. Same story for connectionError.
-    //
-    // Belt-and-suspenders: once the orchestrator reports connected=true with no
-    // startup_error, force a null so any stale value from a previous tick is gone.
-    final bool healthy = status.connected && status.startupError.isEmpty;
-    final startupError = (status.startupError.isEmpty || healthy) ? null : status.startupError;
+    // Always derive from the current status. When the orchestrator stops reporting
+    // a startup_error (empty string), null it out so the UI doesn't keep rendering
+    // a stale warmup message. Same for connectionError.
+    final startupError = status.startupError.isEmpty ? null : status.startupError;
     final connectionError = status.connectionError.isEmpty ? null : status.connectionError;
 
     // Check if anything actually changed to avoid unnecessary rebuilds

--- a/sail_ui/lib/widgets/components/daemon_connection_card.dart
+++ b/sail_ui/lib/widgets/components/daemon_connection_card.dart
@@ -156,27 +156,21 @@ class DaemonConnectionCard extends StatelessWidget {
                 syncInfo: syncInfo!,
               ),
             ),
-          if (infoMessage != null ||
-              connection.connectionError != null ||
-              connection.startupError != null ||
-              connection.initializingBinary ||
-              !connection.connected)
+          if (infoMessage != null || connection.connectionError != null || !connection.connected)
             Padding(
               padding: const EdgeInsets.only(top: SailStyleValues.padding04),
               child: SailText.secondary12(
                 prettifyLogMessage(
+                  // When connected, the daemon is healthy — stale startupError and
+                  // initializingBinary are ignored. Only show this row for real trouble
+                  // (connectionError, !connected) or explicit infoMessage.
                   infoMessage ??
-                      // Precedence: connectionError (hard fail) is red-worthy; startupError is the
-                      // orchestrator's primary warmup signal (e.g. "Loading block index…") and must
-                      // win over the initialising-binary fallback so we don't overwrite a real
-                      // warmup message with a generic spinner. Only fall back to the latest startup
-                      // log line when the orchestrator hasn't published a startup_error yet.
                       connection.connectionError ??
                       connection.startupError ??
                       (connection.initializingBinary
                           ? (providerBinary?.startupLogs.lastOrNull?.message ?? 'Initializing...')
                           : null) ??
-                      (!connection.connected ? 'Not connected' : ''),
+                      'Not connected',
                 ),
                 monospace: true,
               ),
@@ -200,15 +194,15 @@ class DaemonConnectionCard extends StatelessWidget {
 /// Pure function for the daemon-status color precedence. Exposed for testing.
 ///
 /// Precedence (top wins):
-///  1. hard connection error  -> red   (explicit RPC/transport failure)
-///  2. orchestrator startupError -> amber (warmup message, not a failure)
-///  3. initializingBinary        -> amber
-///  4. !connected                -> amber (orchestrator hasn't reported a failure yet —
-///                                         this is the "booting, no news" window that
-///                                         used to flash red)
-///  5. download in progress      -> amber
-///  6. explicit infoMessage      -> info
-///  7. connected                 -> success
+///  1. connectionError           -> red    (explicit RPC/transport failure)
+///  2. connected                 -> green  (startupError/initializing are ignored once
+///                                          the daemon is on the wire — they'd be stale);
+///                                  except isDownloading still amber, infoMessage still info
+///  3. startupError              -> amber  (warmup message surfaced while !connected)
+///  4. initializingBinary        -> amber
+///  5. isDownloading             -> amber
+///  6. hasInfoMessage            -> info
+///  7. !connected, no other info -> amber  (booting, no news — used to flash red)
 @visibleForTesting
 Color resolveDaemonStatusColor({
   required SailThemeData theme,
@@ -220,12 +214,16 @@ Color resolveDaemonStatusColor({
   required bool hasInfoMessage,
 }) {
   if (connectionError != null) return theme.colors.error;
+  if (connected) {
+    if (isDownloading) return theme.colors.orangeLight;
+    if (hasInfoMessage) return theme.colors.info;
+    return theme.colors.success;
+  }
   if (startupError != null) return theme.colors.orangeLight;
   if (initializingBinary) return theme.colors.orangeLight;
-  if (!connected) return theme.colors.orangeLight;
   if (isDownloading) return theme.colors.orangeLight;
   if (hasInfoMessage) return theme.colors.info;
-  return theme.colors.success;
+  return theme.colors.orangeLight;
 }
 
 class BlockStatus extends StatelessWidget {

--- a/sail_ui/lib/widgets/components/daemon_connection_card.dart
+++ b/sail_ui/lib/widgets/components/daemon_connection_card.dart
@@ -166,11 +166,16 @@ class DaemonConnectionCard extends StatelessWidget {
               child: SailText.secondary12(
                 prettifyLogMessage(
                   infoMessage ??
-                      // During initialization, show startup logs instead of connection errors
+                      // Precedence: connectionError (hard fail) is red-worthy; startupError is the
+                      // orchestrator's primary warmup signal (e.g. "Loading block index…") and must
+                      // win over the initialising-binary fallback so we don't overwrite a real
+                      // warmup message with a generic spinner. Only fall back to the latest startup
+                      // log line when the orchestrator hasn't published a startup_error yet.
+                      connection.connectionError ??
+                      connection.startupError ??
                       (connection.initializingBinary
                           ? (providerBinary?.startupLogs.lastOrNull?.message ?? 'Initializing...')
-                          : connection.connectionError) ??
-                      connection.startupError ??
+                          : null) ??
                       (!connection.connected ? 'Not connected' : ''),
                 ),
                 monospace: true,
@@ -181,19 +186,46 @@ class DaemonConnectionCard extends StatelessWidget {
     );
   }
 
-  Color _getConnectionColor(SailThemeData theme) {
-    if (syncInfo != null && syncInfo!.downloadInfo.isDownloading) {
-      return theme.colors.orangeLight;
-    } else if (infoMessage != null) {
-      return theme.colors.info;
-    } else if (connection.initializingBinary) {
-      return theme.colors.orangeLight;
-    } else if (connection.connected) {
-      return theme.colors.success;
-    } else {
-      return theme.colors.error;
-    }
-  }
+  Color _getConnectionColor(SailThemeData theme) => resolveDaemonStatusColor(
+    theme: theme,
+    connectionError: connection.connectionError,
+    startupError: connection.startupError,
+    initializingBinary: connection.initializingBinary,
+    connected: connection.connected,
+    isDownloading: syncInfo?.downloadInfo.isDownloading ?? false,
+    hasInfoMessage: infoMessage != null,
+  );
+}
+
+/// Pure function for the daemon-status color precedence. Exposed for testing.
+///
+/// Precedence (top wins):
+///  1. hard connection error  -> red   (explicit RPC/transport failure)
+///  2. orchestrator startupError -> amber (warmup message, not a failure)
+///  3. initializingBinary        -> amber
+///  4. !connected                -> amber (orchestrator hasn't reported a failure yet —
+///                                         this is the "booting, no news" window that
+///                                         used to flash red)
+///  5. download in progress      -> amber
+///  6. explicit infoMessage      -> info
+///  7. connected                 -> success
+@visibleForTesting
+Color resolveDaemonStatusColor({
+  required SailThemeData theme,
+  required String? connectionError,
+  required String? startupError,
+  required bool initializingBinary,
+  required bool connected,
+  required bool isDownloading,
+  required bool hasInfoMessage,
+}) {
+  if (connectionError != null) return theme.colors.error;
+  if (startupError != null) return theme.colors.orangeLight;
+  if (initializingBinary) return theme.colors.orangeLight;
+  if (!connected) return theme.colors.orangeLight;
+  if (isDownloading) return theme.colors.orangeLight;
+  if (hasInfoMessage) return theme.colors.info;
+  return theme.colors.success;
 }
 
 class BlockStatus extends StatelessWidget {

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -217,24 +217,38 @@ class BottomNav extends StatelessWidget {
                       navigateToLogs: model.navigateToLogs,
                       onOpenConfConfigurator: onOpenEnforcerConfConfigurator,
                     ),
-                  DaemonConnectionCard(
-                    connection: additionalConnection.rpc,
-                    syncInfo: model.syncProvider.additionalSyncInfo,
-                    infoMessage: _getDownloadMessage(
-                      model.syncProvider.additionalSyncInfo,
-                    ),
-                    restartDaemon: () => binaryProvider.start(
-                      binaryProvider.binaries.firstWhere(
-                        (b) => b.name == additionalConnection.rpc.binary.name,
-                      ),
-                    ),
-                    stopDaemon: () => binaryProvider.stop(
-                      binaryProvider.binaries.firstWhere(
-                        (b) => b.name == additionalConnection.rpc.binary.name,
-                      ),
-                    ),
-                    navigateToLogs: model.navigateToLogs,
-                    onOpenConfConfigurator: onOpenAdditionalConfConfigurator,
+                  Builder(
+                    builder: (context) {
+                      // During Core IBD the sidechain RPC has no blocks yet, so its sync
+                      // progress comes back as 0/0 — which reads as "broken" in the UI.
+                      // Detect "Core is ready" (connected and not in IBD / still booting)
+                      // and suppress the sync row until Core can actually give us work.
+                      final bool coreReady =
+                          model.mainchain.connected &&
+                          !model.mainchain.initializingBinary &&
+                          model.mainchain.startupError == null &&
+                          !model.mainchain.inIBD;
+                      final infoMessage =
+                          _getDownloadMessage(model.syncProvider.additionalSyncInfo) ??
+                          (!coreReady ? 'Waiting for Bitcoin Core to finish syncing' : null);
+                      return DaemonConnectionCard(
+                        connection: additionalConnection.rpc,
+                        syncInfo: coreReady ? model.syncProvider.additionalSyncInfo : null,
+                        infoMessage: infoMessage,
+                        restartDaemon: () => binaryProvider.start(
+                          binaryProvider.binaries.firstWhere(
+                            (b) => b.name == additionalConnection.rpc.binary.name,
+                          ),
+                        ),
+                        stopDaemon: () => binaryProvider.stop(
+                          binaryProvider.binaries.firstWhere(
+                            (b) => b.name == additionalConnection.rpc.binary.name,
+                          ),
+                        ),
+                        navigateToLogs: model.navigateToLogs,
+                        onOpenConfConfigurator: onOpenAdditionalConfConfigurator,
+                      );
+                    },
                   ),
                 ],
               ),

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -375,34 +375,22 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
       false;
 
   Color get connectionColor {
-    // Precedence (top wins). The orchestrator is the source of truth for startup
-    // state, so we read its signals in order:
-    //  1. connectionError on any binary  -> red   (explicit failure)
-    //  2. startupError on any binary     -> amber (warmup message, not a failure)
-    //  3. initializingBinary on any      -> amber
-    //  4. !connected on any              -> amber (used to be red — that made services
-    //                                              flash red during the 50ms–5s window
-    //                                              before orchestrator set initializing=true)
-    //  5. any download in progress       -> amber
-    //  6. any binary not yet in-sync     -> amber
-    //  7. all good                       -> green
+    // Precedence (top wins):
+    //  1. any connectionError -> red   (explicit failure)
+    //  2. not all connected   -> amber (any !connected, regardless of startupError/init)
+    //  3. any download        -> amber
+    //  4. any binary !in-sync -> amber
+    //  5. else                -> green
+    //
+    // `connected` is the authoritative "healthy" signal — stale startupError /
+    // initializingBinary on an already-connected daemon are ignored.
     if (mainchain.connectionError != null ||
         enforcer.connectionError != null ||
         additionalConnection.connectionError != null) {
       return SailColorScheme.red;
     }
 
-    if (mainchain.startupError != null ||
-        enforcer.startupError != null ||
-        additionalConnection.rpc.startupError != null) {
-      return SailColorScheme.orange;
-    }
-
-    if (initializingAny) {
-      return SailColorScheme.orange;
-    }
-
-    if (!mainchain.connected || !enforcer.connected || !additionalConnection.connected) {
+    if (!allConnected) {
       return SailColorScheme.orange;
     }
 
@@ -486,20 +474,21 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
     return 'All binaries connected';
   }
 
-  /// Returns the per-binary status line following the A/B precedence in the plan:
+  /// Per-binary status line. `connected` short-circuits to healthy — any stale
+  /// startupError/initializingBinary on a connected daemon is ignored. Order:
   ///  1. connectionError    -> show it (hard fail)
-  ///  2. startupError       -> show it verbatim (orchestrator warmup message)
-  ///  3. initializingBinary -> show latest startup log line, or "Initializing [name]…"
-  ///  4. !connected         -> "Waiting for [name]"
-  ///  5. else               -> null (healthy from this binary's POV)
+  ///  2. connected          -> null (healthy from this binary's POV)
+  ///  3. startupError       -> show it verbatim (orchestrator warmup message)
+  ///  4. initializingBinary -> show latest startup log line, or "Initializing [name]…"
+  ///  5. else (!connected)  -> "Waiting for [name]"
   String? _statusLineFor({required RPCConnection rpc, required String binaryLabel}) {
     if (rpc.connectionError != null) return rpc.connectionError;
+    if (rpc.connected) return null;
     if (rpc.startupError != null) return rpc.startupError;
     if (rpc.initializingBinary) {
       return rpc.binary.startupLogs.lastOrNull?.message ?? 'Initializing $binaryLabel…';
     }
-    if (!rpc.connected) return 'Waiting for $binaryLabel';
-    return null;
+    return 'Waiting for $binaryLabel';
   }
 
   @override

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -361,38 +361,35 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
       false;
 
   Color get connectionColor {
-    if (initializingAny) {
-      return SailColorScheme.orange;
-    }
-
-    if (mainchain.startupError != null) {
-      return SailColorScheme.orange;
-    }
-
-    if (enforcer.startupError != null) {
-      return SailColorScheme.orange;
-    }
-
-    if (additionalConnection.rpc.startupError != null) {
-      return SailColorScheme.orange;
-    }
-
+    // Precedence (top wins). The orchestrator is the source of truth for startup
+    // state, so we read its signals in order:
+    //  1. connectionError on any binary  -> red   (explicit failure)
+    //  2. startupError on any binary     -> amber (warmup message, not a failure)
+    //  3. initializingBinary on any      -> amber
+    //  4. !connected on any              -> amber (used to be red — that made services
+    //                                              flash red during the 50ms–5s window
+    //                                              before orchestrator set initializing=true)
+    //  5. any download in progress       -> amber
+    //  6. any binary not yet in-sync     -> amber
+    //  7. all good                       -> green
     if (mainchain.connectionError != null ||
         enforcer.connectionError != null ||
         additionalConnection.connectionError != null) {
       return SailColorScheme.red;
     }
 
-    if (!mainchain.connected) {
-      return SailColorScheme.red;
+    if (mainchain.startupError != null ||
+        enforcer.startupError != null ||
+        additionalConnection.rpc.startupError != null) {
+      return SailColorScheme.orange;
     }
 
-    if (!enforcer.connected) {
-      return SailColorScheme.red;
+    if (initializingAny) {
+      return SailColorScheme.orange;
     }
 
-    if (!additionalConnection.connected) {
-      return SailColorScheme.red;
+    if (!mainchain.connected || !enforcer.connected || !additionalConnection.connected) {
+      return SailColorScheme.orange;
     }
 
     if (downloadingAny) {
@@ -435,41 +432,26 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
       return 'Downloading ${additionalConnection.name}...';
     }
 
-    if (mainchain.initializingBinary) {
-      return mainchain.binary.startupLogs.lastOrNull?.message ?? 'Initializing bitcoind..';
-    }
+    // Precedence per service: connectionError (hard fail) > startupError (warmup message,
+    // primary signal during boot per orchestrator design) > initializingBinary > !connected.
+    // Bitcoin Core first because nothing else can make progress without it.
+    final mainchainLine = _statusLineFor(
+      rpc: mainchain,
+      binaryLabel: 'Bitcoin Core',
+    );
+    if (mainchainLine != null) return mainchainLine;
 
-    if (enforcer.initializingBinary || enforcer.startupError != null) {
-      return enforcer.binary.startupLogs.lastOrNull?.message ?? 'Initializing enforcer..';
-    }
+    final enforcerLine = _statusLineFor(
+      rpc: enforcer,
+      binaryLabel: 'Enforcer',
+    );
+    if (enforcerLine != null) return enforcerLine;
 
-    if (additionalConnection.initializingBinary) {
-      return 'Initializing ${additionalConnection.name}..';
-    }
-
-    if (mainchain.connectionError != null || mainchain.startupError != null) {
-      return mainchain.connectionError ?? mainchain.startupError!;
-    }
-
-    if (enforcer.connectionError != null || enforcer.startupError != null) {
-      return enforcer.connectionError ?? enforcer.startupError!;
-    }
-
-    if (additionalConnection.connectionError != null || additionalConnection.rpc.startupError != null) {
-      return additionalConnection.connectionError ?? additionalConnection.rpc.startupError!;
-    }
-
-    if (!mainchain.connected) {
-      return 'Bitcoin Core not started';
-    }
-
-    if (!enforcer.connected) {
-      return 'Enforcer not started';
-    }
-
-    if (!additionalConnection.connected) {
-      return '${additionalConnection.name} not started';
-    }
+    final additionalLine = _statusLineFor(
+      rpc: additionalConnection.rpc,
+      binaryLabel: additionalConnection.name,
+    );
+    if (additionalLine != null) return additionalLine;
 
     if (mainchain.inSync) {
       return 'Syncing mainchain blocks';
@@ -488,6 +470,22 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
     }
 
     return 'All binaries connected';
+  }
+
+  /// Returns the per-binary status line following the A/B precedence in the plan:
+  ///  1. connectionError    -> show it (hard fail)
+  ///  2. startupError       -> show it verbatim (orchestrator warmup message)
+  ///  3. initializingBinary -> show latest startup log line, or "Initializing [name]…"
+  ///  4. !connected         -> "Waiting for [name]"
+  ///  5. else               -> null (healthy from this binary's POV)
+  String? _statusLineFor({required RPCConnection rpc, required String binaryLabel}) {
+    if (rpc.connectionError != null) return rpc.connectionError;
+    if (rpc.startupError != null) return rpc.startupError;
+    if (rpc.initializingBinary) {
+      return rpc.binary.startupLogs.lastOrNull?.message ?? 'Initializing $binaryLabel…';
+    }
+    if (!rpc.connected) return 'Waiting for $binaryLabel';
+    return null;
   }
 
   @override

--- a/sail_ui/test/widgets/daemon_connection_card_test.dart
+++ b/sail_ui/test/widgets/daemon_connection_card_test.dart
@@ -7,12 +7,12 @@
 //
 // New precedence (see `resolveDaemonStatusColor`):
 //   connectionError  -> red
-//   startupError     -> amber   (warmup message, not a failure)
+//   connected        -> green   (short-circuits — stale startupError/init ignored)
+//   startupError     -> amber   (warmup message, only while !connected)
 //   initializing     -> amber
-//   !connected       -> amber   (was red before this change — the fix)
 //   downloading      -> amber
 //   has infoMessage  -> info
-//   otherwise        -> success
+//   !connected only  -> amber   (was red before this change — the fix)
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -88,6 +88,22 @@ void main() {
 
     test('success when fully healthy', () {
       expect(call(connected: true), theme.colors.success);
+    });
+
+    test('connected wins over stale startupError / initializing', () {
+      // Once the daemon is on the wire, lingering warmup signals are ignored.
+      expect(
+        call(connected: true, startupError: 'Loading block index…'),
+        theme.colors.success,
+      );
+      expect(
+        call(connected: true, initializingBinary: true),
+        theme.colors.success,
+      );
+      expect(
+        call(connected: true, startupError: 'x', initializingBinary: true),
+        theme.colors.success,
+      );
     });
   });
 }

--- a/sail_ui/test/widgets/daemon_connection_card_test.dart
+++ b/sail_ui/test/widgets/daemon_connection_card_test.dart
@@ -1,0 +1,93 @@
+// Covers the color precedence used by DaemonConnectionCard's status dot.
+//
+// The regression we're guarding against: before this change the dot would flash
+// RED any time a binary was !connected, even during the brief window between
+// "bitwindowd spawned bitcoind" and "orchestrator reports initializing=true".
+// That looked like a broken startup to users when it was actually just boot.
+//
+// New precedence (see `resolveDaemonStatusColor`):
+//   connectionError  -> red
+//   startupError     -> amber   (warmup message, not a failure)
+//   initializing     -> amber
+//   !connected       -> amber   (was red before this change — the fix)
+//   downloading      -> amber
+//   has infoMessage  -> info
+//   otherwise        -> success
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+void main() {
+  final theme = SailThemeData.lightTheme(
+    SailColorScheme.orange,
+    true,
+    SailFontValues.inter,
+  );
+
+  Color call({
+    String? connectionError,
+    String? startupError,
+    bool initializingBinary = false,
+    bool connected = false,
+    bool isDownloading = false,
+    bool hasInfoMessage = false,
+  }) => resolveDaemonStatusColor(
+    theme: theme,
+    connectionError: connectionError,
+    startupError: startupError,
+    initializingBinary: initializingBinary,
+    connected: connected,
+    isDownloading: isDownloading,
+    hasInfoMessage: hasInfoMessage,
+  );
+
+  group('resolveDaemonStatusColor', () {
+    test('red only when an explicit connectionError is set', () {
+      expect(call(connectionError: 'boom'), theme.colors.error);
+      // A connectionError wins over everything else.
+      expect(
+        call(
+          connectionError: 'boom',
+          startupError: 'Loading block index…',
+          initializingBinary: true,
+          connected: true,
+        ),
+        theme.colors.error,
+      );
+    });
+
+    test('amber (not red) when a binary is simply not yet connected', () {
+      // The key regression: no error, no initialising flag, just booting.
+      // This used to be red; it must now be amber.
+      expect(call(connected: false), theme.colors.orangeLight);
+      expect(call(connected: false), isNot(theme.colors.error));
+    });
+
+    test('amber when orchestrator reports startupError but no connectionError', () {
+      expect(
+        call(startupError: 'Loading block index…', connected: false),
+        theme.colors.orangeLight,
+      );
+    });
+
+    test('amber while initializing', () {
+      expect(
+        call(initializingBinary: true, connected: false),
+        theme.colors.orangeLight,
+      );
+    });
+
+    test('amber while downloading a binary', () {
+      expect(call(connected: true, isDownloading: true), theme.colors.orangeLight);
+    });
+
+    test('info color when only an infoMessage is set on a connected daemon', () {
+      expect(call(connected: true, hasInfoMessage: true), theme.colors.info);
+    });
+
+    test('success when fully healthy', () {
+      expect(call(connected: true), theme.colors.success);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `sail_ui`: status badges in bottom nav + daemon-status card now show amber (not red) while a binary is still booting or its orchestrator-reported `startupError` is set — red is reserved for explicit `connectionError`.
- `sail_ui`: `startupError` is promoted to the primary status text during warmup (e.g., "Loading block index…"), inline in the existing per-service row. No toasts / snackbars / banners.
- `sail_ui`: stale `startupError` is cleared when the orchestrator stops reporting one and the binary is connected.
- `bitwindow`: during Core IBD, bitwindow's own row shows "Waiting for Bitcoin Core to finish syncing" instead of a bogus "0/0 blocks".

## Why
The state machine moved from Dart to Go in 14c27bc6. The orchestrator already streams `startup_error`, `initializing`, and `startup_logs` via `WatchBinaries`, but the frontend was reading those fields with the wrong precedence, flashing red during benign warmup windows and ignoring warmup messages entirely.

Complements b648cf23 (`sail_ui: flip initializingBinary during daemon startup`) — that fix attacks the race from the provider side by flipping `initializingBinary` early. This PR hardens the render side so any future gap between `!connected` and the orchestrator's first report still shows amber rather than red.

## Test plan
- [x] `flutter analyze` clean in `sail_ui/` and `bitwindow/`
- [x] `flutter test` green in `sail_ui/` (new precedence test covers `resolveDaemonStatusColor`)
- [ ] Cold-boot bitwindow on Mac — verify amber during warmup, never red
- [ ] Stale-datadir IBD — verify bitwindow row shows "Waiting for Bitcoin Core to finish syncing"
- [ ] Broken bitcoind config — verify red with the RPC error surfaced in the nav
