### PR TITLE
orchestrator: harden bitcoind and enforcer health checks

### DIFF
--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -123,7 +123,8 @@
       "chain_layer": 1,
       "color": "green",
       "health_check": {
-        "type": "tcp"
+        "type": "connect_rpc",
+        "rpc_method": "cusf.mainchain.v1.ValidatorService/GetChainTip"
       },
       "dependencies": ["bitcoind"],
       "startup_log_patterns": [

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -123,7 +123,8 @@
       "chain_layer": 1,
       "color": "green",
       "health_check": {
-        "type": "tcp"
+        "type": "connect_rpc",
+        "rpc_method": "cusf.mainchain.v1.ValidatorService/GetChainTip"
       },
       "dependencies": ["bitcoind"],
       "startup_log_patterns": [

--- a/sidechain-orchestrator/config.go
+++ b/sidechain-orchestrator/config.go
@@ -11,8 +11,9 @@ import (
 type HealthCheckType int
 
 const (
-	HealthCheckTCP     HealthCheckType = iota
-	HealthCheckJSONRPC                 // JSON-RPC call (e.g. getblockcount)
+	HealthCheckTCP        HealthCheckType = iota
+	HealthCheckJSONRPC                    // JSON-RPC call (e.g. getblockcount)
+	HealthCheckConnectRPC                 // Connect-JSON POST (e.g. cusf.mainchain.v1.ValidatorService/GetChainTip)
 )
 
 type DownloadSource int

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -123,7 +123,8 @@
       "chain_layer": 1,
       "color": "green",
       "health_check": {
-        "type": "tcp"
+        "type": "connect_rpc",
+        "rpc_method": "cusf.mainchain.v1.ValidatorService/GetChainTip"
       },
       "dependencies": ["bitcoind"],
       "startup_log_patterns": [

--- a/sidechain-orchestrator/config_loader.go
+++ b/sidechain-orchestrator/config_loader.go
@@ -206,6 +206,9 @@ func jsonToBinaryConfig(key string, jb jsonBinaryConf) BinaryConfig {
 		case "jsonrpc":
 			bc.HealthCheckType = HealthCheckJSONRPC
 			bc.HealthCheckRPC = jb.HealthCheck.RPCMethod
+		case "connect_rpc":
+			bc.HealthCheckType = HealthCheckConnectRPC
+			bc.HealthCheckRPC = jb.HealthCheck.RPCMethod
 		default:
 			bc.HealthCheckType = HealthCheckTCP
 		}

--- a/sidechain-orchestrator/connection_monitor.go
+++ b/sidechain-orchestrator/connection_monitor.go
@@ -128,8 +128,13 @@ var bitcoindStartupPatterns = []string{
 
 // Enforcer startup messages.
 // Dart: enforcer_rpc.dart L154-156
+// Also covers warmup messages returned by the ValidatorService Connect RPC
+// during initial sync (e.g. GetChainTip returns "validator is not synced yet"
+// until the enforcer has caught up to the mainchain tip).
 var enforcerStartupPatterns = []string{
 	"Validator is not synced",
+	"validator is not synced",
+	"not synced",
 }
 
 // NewConnectionMonitor creates a monitor for a binary.

--- a/sidechain-orchestrator/health.go
+++ b/sidechain-orchestrator/health.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -93,6 +94,53 @@ func (h *JSONRPCHealthCheck) Check(ctx context.Context) error {
 	return nil
 }
 
+// ConnectRPCHealthCheck POSTs an empty JSON body to a Connect-JSON endpoint and
+// inspects the response. On Connect-JSON, success is HTTP 200 with a JSON body
+// that has no `code` field; failure is HTTP 4xx/5xx with
+// `{"code":"...","message":"..."}`. Warmup errors (daemon up, not ready) come
+// back here as an error message that the connection monitor pattern-matches
+// into startupError — e.g. the enforcer returning "Validator is not synced"
+// while still catching up to the mainchain tip.
+type ConnectRPCHealthCheck struct {
+	URL     string // e.g. "http://localhost:50051/cusf.mainchain.v1.ValidatorService/GetChainTip"
+	Timeout time.Duration
+}
+
+func (h *ConnectRPCHealthCheck) Check(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, h.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.URL, strings.NewReader("{}"))
+	if err != nil {
+		return fmt.Errorf("build Connect request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("Connect %s: %w", h.URL, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // cleanup
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read Connect response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var cerr struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(body, &cerr) == nil && cerr.Message != "" {
+			return fmt.Errorf("%s", cerr.Message)
+		}
+		return fmt.Errorf("Connect HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
 // HealthCheckOpts provides optional configuration for health checkers.
 type HealthCheckOpts struct {
 	User     string
@@ -121,6 +169,12 @@ func NewHealthChecker(config BinaryConfig, opts ...HealthCheckOpts) HealthChecke
 			User:     opt.User,
 			Password: opt.Password,
 			Timeout:  timeout,
+		}
+	case HealthCheckConnectRPC:
+		path := strings.TrimPrefix(config.HealthCheckRPC, "/")
+		return &ConnectRPCHealthCheck{
+			URL:     fmt.Sprintf("http://%s:%d/%s", host, config.Port, path),
+			Timeout: timeout,
 		}
 	default:
 		return &TCPHealthCheck{

--- a/sidechain-orchestrator/health.go
+++ b/sidechain-orchestrator/health.go
@@ -71,7 +71,20 @@ func (h *JSONRPCHealthCheck) Check(ctx context.Context) error {
 		return fmt.Errorf("JSON-RPC %s: %w", h.Method, err)
 	}
 	defer resp.Body.Close() //nolint:errcheck // cleanup
-	_, _ = io.Copy(io.Discard, resp.Body)
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read JSON-RPC %s response: %w", h.Method, err)
+	}
+
+	// bitcoind during warmup returns HTTP 200 with an embedded JSON-RPC error
+	// (e.g. code -28 "Loading block index…"). We must parse the body rather
+	// than trust the HTTP status, otherwise the orchestrator flips
+	// connected=true while the daemon is still booting.
+	var rpcResp jsonRPCResponse
+	if jerr := json.Unmarshal(respBody, &rpcResp); jerr == nil && rpcResp.Error != nil {
+		return fmt.Errorf("%s: %s", h.Method, rpcResp.Error.Message)
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("JSON-RPC %s returned HTTP %d", h.Method, resp.StatusCode)

--- a/sidechain-orchestrator/health_test.go
+++ b/sidechain-orchestrator/health_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,4 +51,64 @@ func TestJSONRPCHealthCheck_Happy(t *testing.T) {
 
 	err := h.Check(context.Background())
 	require.NoError(t, err)
+}
+
+// The enforcer reports warmup via Connect error "Validator is not synced"
+// while still catching up. The health check must return that message verbatim
+// so the connection monitor pattern-matches it into startupError.
+func TestConnectRPCHealthCheck_WarmupError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"code":"unavailable","message":"Validator is not synced"}`))
+	}))
+	defer srv.Close()
+
+	h := &ConnectRPCHealthCheck{
+		URL:     srv.URL + "/cusf.mainchain.v1.ValidatorService/GetChainTip",
+		Timeout: 2 * time.Second,
+	}
+
+	err := h.Check(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, "Validator is not synced", err.Error())
+}
+
+func TestConnectRPCHealthCheck_Happy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"blockHeaderInfo":{"height":"800000"}}`))
+	}))
+	defer srv.Close()
+
+	h := &ConnectRPCHealthCheck{
+		URL:     srv.URL + "/cusf.mainchain.v1.ValidatorService/GetChainTip",
+		Timeout: 2 * time.Second,
+	}
+
+	err := h.Check(context.Background())
+	require.NoError(t, err)
+}
+
+// Unparseable HTTP error responses should still surface a useful error so the
+// UI doesn't silently hold on to a stale "connected" state.
+func TestConnectRPCHealthCheck_OpaqueHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("nginx: bad gateway"))
+	}))
+	defer srv.Close()
+
+	h := &ConnectRPCHealthCheck{
+		URL:     srv.URL + "/cusf.mainchain.v1.ValidatorService/GetChainTip",
+		Timeout: 2 * time.Second,
+	}
+
+	err := h.Check(context.Background())
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "HTTP 500"))
 }

--- a/sidechain-orchestrator/health_test.go
+++ b/sidechain-orchestrator/health_test.go
@@ -1,0 +1,53 @@
+package orchestrator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bitcoind during warmup returns HTTP 200 with a JSON-RPC error body
+// (code -28 "Loading block index…"). The health check must surface that as
+// an error so the monitor can route it to startupError instead of flipping
+// connected=true.
+func TestJSONRPCHealthCheck_WarmupError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":null,"error":{"code":-28,"message":"Loading block index..."},"id":1}`))
+	}))
+	defer srv.Close()
+
+	h := &JSONRPCHealthCheck{
+		URL:     srv.URL,
+		Method:  "getblockcount",
+		Timeout: 2 * time.Second,
+	}
+
+	err := h.Check(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Loading block index")
+}
+
+func TestJSONRPCHealthCheck_Happy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":123,"error":null,"id":1}`))
+	}))
+	defer srv.Close()
+
+	h := &JSONRPCHealthCheck{
+		URL:     srv.URL,
+		Method:  "getblockcount",
+		Timeout: 2 * time.Second,
+	}
+
+	err := h.Check(context.Background())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Bitcoind: JSONRPCHealthCheck parses the response body so -28 "Loading block index…" flows to startupError instead of masquerading as connected.
Enforcer: new ConnectRPCHealthCheck probes GetChainTip (what the old Dart frontend did) instead of a TCP-only port check; "Validator is not synced" surfaces as startupError while the validator is still catching up.

TODO:
- [ ] Cold-boot bitwindow: verify bitcoind row shows "Loading block index…" amber (not green) during warmup.
- [ ] Verify enforcer row shows "Validator is not synced" amber until synced, then green.