### PR TITLE
sail_ui: harden Generate Wallet boot-race + inline errors

### DIFF
--- a/sail_ui/lib/pages/create_wallet_page.dart
+++ b/sail_ui/lib/pages/create_wallet_page.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'package:auto_route/auto_route.dart';
 import 'package:convert/convert.dart' show hex;
 import 'package:crypto/crypto.dart' show sha256;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
@@ -51,6 +52,7 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
 
   bool hasExistingWallet = false;
   bool _isGenerating = false;
+  bool _awaitingBackend = false;
   bool _hasNavigatedInternally = false;
 
   void _setScreen(WelcomeScreen screen) {
@@ -237,6 +239,12 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
         entropy = hash.bytes.sublist(0, 16);
       }
 
+      try {
+        await _awaitBackendReady();
+      } catch (_) {
+        return;
+      }
+
       final wallet = await _walletProvider.generateWalletFromEntropy(
         entropy,
         passphrase: null,
@@ -246,6 +254,45 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
       _setScreen(WelcomeScreen.success);
     } catch (e) {
       await _showErrorDialog('Error creating wallet: $e');
+    }
+  }
+
+  Future<void> _awaitBackendReady() async {
+    if (!GetIt.I.isRegistered<OrchestratorRPC>()) return;
+    final orchestrator = GetIt.I.get<OrchestratorRPC>();
+    if (await _probeWalletManager(orchestrator)) return;
+
+    if (mounted) setState(() => _awaitingBackend = true);
+
+    final ready = ValueNotifier<bool>(false);
+    final timer = Timer.periodic(const Duration(milliseconds: 500), (_) async {
+      if (await _probeWalletManager(orchestrator)) ready.value = true;
+    });
+
+    try {
+      await awaitBackendReady(ready);
+    } on TimeoutException {
+      if (mounted) {
+        setState(() {
+          _awaitingBackend = false;
+          _isGenerating = false;
+        });
+        await _showErrorDialog('Backend not ready after 60s — try again');
+      }
+      rethrow;
+    } finally {
+      timer.cancel();
+      ready.dispose();
+      if (mounted && _awaitingBackend) setState(() => _awaitingBackend = false);
+    }
+  }
+
+  static Future<bool> _probeWalletManager(OrchestratorRPC orchestrator) async {
+    try {
+      await orchestrator.wallet.getWalletStatus();
+      return true;
+    } catch (_) {
+      return false;
     }
   }
 
@@ -623,7 +670,9 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
             SailButton(
               label: 'Create Wallet',
               variant: ButtonVariant.primary,
-              disabled: !_isValidInput,
+              disabled: !_isValidInput || _awaitingBackend,
+              loading: _awaitingBackend,
+              loadingLabel: 'Connecting to bitwindowd…',
               onPressed: _handleAdvancedCreate,
             ),
           ],
@@ -684,7 +733,7 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
                     ],
                   ),
                   child: TextButton(
-                    onPressed: _isGenerating
+                    onPressed: (_isGenerating || _awaitingBackend)
                         ? null
                         : () {
                             setState(() => _isGenerating = true);
@@ -704,7 +753,9 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
                         Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 16),
                           child: SailText.primary15(
-                            _isGenerating
+                            _awaitingBackend
+                                ? 'Connecting to bitwindowd…'
+                                : _isGenerating
                                 ? 'Generating Your Wallet'
                                 : hasExistingWallet
                                 ? 'Create Another Wallet'
@@ -713,7 +764,7 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
                             bold: true,
                           ),
                         ),
-                        if (_isGenerating)
+                        if (_awaitingBackend || _isGenerating)
                           SizedBox(
                             width: 15,
                             height: 15,
@@ -831,8 +882,10 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
                   SailButton(
                     label: 'Restore',
                     variant: ButtonVariant.primary,
+                    disabled: _awaitingBackend,
+                    loading: _awaitingBackend,
                     onPressed: _handleRestore,
-                    loadingLabel: 'Restoring your wallet',
+                    loadingLabel: _awaitingBackend ? 'Connecting to bitwindowd…' : 'Restoring your wallet',
                   ),
                 ],
               ),
@@ -851,6 +904,12 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
       if (hasExistingWallet && walletName.isEmpty) {
         await _showErrorDialog('Please enter a wallet name');
         setState(() => _isGenerating = false);
+        return;
+      }
+
+      try {
+        await _awaitBackendReady();
+      } catch (_) {
         return;
       }
 
@@ -883,6 +942,12 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
 
     if (hasExistingWallet && walletName.isEmpty) {
       await _showErrorDialog('Please enter a wallet name');
+      return;
+    }
+
+    try {
+      await _awaitBackendReady();
+    } catch (_) {
       return;
     }
 
@@ -963,6 +1028,28 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
         ),
       ),
     );
+  }
+}
+
+@visibleForTesting
+Future<void> awaitBackendReady(
+  ValueListenable<bool> ready, {
+  Duration timeout = const Duration(seconds: 60),
+}) async {
+  if (ready.value) return;
+
+  final completer = Completer<void>();
+  void listener() {
+    if (ready.value && !completer.isCompleted) {
+      completer.complete();
+    }
+  }
+
+  ready.addListener(listener);
+  try {
+    await completer.future.timeout(timeout);
+  } finally {
+    ready.removeListener(listener);
   }
 }
 

--- a/sail_ui/lib/pages/create_wallet_page.dart
+++ b/sail_ui/lib/pages/create_wallet_page.dart
@@ -54,6 +54,11 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
   bool _isGenerating = false;
   bool _awaitingBackend = false;
   bool _hasNavigatedInternally = false;
+  String? _error;
+
+  void _clearErrorOnInput() {
+    if (_error != null && mounted) setState(() => _error = null);
+  }
 
   void _setScreen(WelcomeScreen screen) {
     if (_currentScreen != screen) {
@@ -69,6 +74,9 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
     _currentScreen = widget.initialScreen;
     _mnemonicController.addListener(_onMnemonicChanged);
     _passphraseController.addListener(setstate);
+    _mnemonicController.addListener(_clearErrorOnInput);
+    _passphraseController.addListener(_clearErrorOnInput);
+    _walletNameController.addListener(_clearErrorOnInput);
 
     _walletProvider.hasExistingWallet().then((value) {
       setState(() {
@@ -85,6 +93,9 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
   void dispose() {
     _mnemonicController.removeListener(_onMnemonicChanged);
     _passphraseController.removeListener(setstate);
+    _mnemonicController.removeListener(_clearErrorOnInput);
+    _passphraseController.removeListener(_clearErrorOnInput);
+    _walletNameController.removeListener(_clearErrorOnInput);
     _mnemonicController.dispose();
     _passphraseController.dispose();
     _walletNameController.dispose();
@@ -211,7 +222,7 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
           _isValidInput = true;
         });
       } catch (e) {
-        await _showErrorDialog('Error generating from entropy: $e');
+        if (mounted) setState(() => _error = 'Error generating from entropy: $e');
         _clearWalletData();
         return;
       }
@@ -221,6 +232,7 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
   }
 
   Future<void> _handleAdvancedCreate() async {
+    if (mounted) setState(() => _error = null);
     if (!_isValidInput) return;
     try {
       final entropyHex = _mnemonicController.text.trim();
@@ -228,9 +240,9 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
       if (_isHexMode) {
         entropy = hex.decode(entropyHex);
         if (entropy.length < 16 || entropy.length > 32 || entropy.length % 4 != 0) {
-          await _showErrorDialog(
-            'Invalid entropy length. Must be 16-32 bytes and a multiple of 4.',
-          );
+          if (mounted) {
+            setState(() => _error = 'Invalid entropy length. Must be 16-32 bytes and a multiple of 4.');
+          }
           return;
         }
       } else {
@@ -253,7 +265,7 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
       _isValidInput = true;
       _setScreen(WelcomeScreen.success);
     } catch (e) {
-      await _showErrorDialog('Error creating wallet: $e');
+      if (mounted) setState(() => _error = 'Error creating wallet: $e');
     }
   }
 
@@ -276,8 +288,8 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
         setState(() {
           _awaitingBackend = false;
           _isGenerating = false;
+          _error = 'Backend not ready after 60s — try again';
         });
-        await _showErrorDialog('Backend not ready after 60s — try again');
       }
       rethrow;
     } finally {
@@ -294,16 +306,6 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
     } catch (_) {
       return false;
     }
-  }
-
-  Future<void> _showErrorDialog(String message) async {
-    await errorDialog(
-      context: context,
-      action: 'Error',
-      title: 'Error',
-      subtitle: message,
-    );
-    _mnemonicController.clear();
   }
 
   // ignore: avoid_build_methods
@@ -534,6 +536,7 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
   // ignore: avoid_build_methods
   Widget _buildAdvancedScreen() {
     final theme = SailTheme.of(context);
+    final errorBanner = _error;
     return Stack(
       children: [
         // Main scrollable content
@@ -648,6 +651,21 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
             ),
           ),
         ),
+        if (errorBanner != null)
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 56,
+            child: Center(
+              child: SizedBox(
+                width: 800,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: SailStyleValues.padding08),
+                  child: SailText.primary13(errorBanner, color: theme.colors.error),
+                ),
+              ),
+            ),
+          ),
         BottomActionBar(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
@@ -775,6 +793,11 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
                   ),
                 ),
               ),
+              if (_error != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: SailStyleValues.padding08),
+                  child: SailText.primary13(_error!, color: theme.colors.error),
+                ),
               const SizedBox(height: 20),
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -806,6 +829,7 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
 
   // ignore: avoid_build_methods
   Widget _buildRestoreScreen() {
+    final theme = SailTheme.of(context);
     return Center(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 32.0),
@@ -859,6 +883,11 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
                 ),
               ),
               const SizedBox(height: 24),
+              if (_error != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: SailStyleValues.padding08),
+                  child: SailText.primary13(_error!, color: theme.colors.error),
+                ),
               // Navigation buttons
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -898,12 +927,17 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
   }
 
   Future<void> _handleFastMode() async {
+    if (mounted) setState(() => _error = null);
     try {
       final walletName = _walletNameController.text.trim();
 
       if (hasExistingWallet && walletName.isEmpty) {
-        await _showErrorDialog('Please enter a wallet name');
-        setState(() => _isGenerating = false);
+        if (mounted) {
+          setState(() {
+            _error = 'Please enter a wallet name';
+            _isGenerating = false;
+          });
+        }
         return;
       }
 
@@ -921,7 +955,7 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
       }
     } catch (e) {
       if (mounted) {
-        await _showErrorDialog('Failed to generate wallet: $e');
+        setState(() => _error = 'Failed to generate wallet: $e');
       }
     }
 
@@ -931,17 +965,18 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
   }
 
   Future<void> _handleRestore() async {
+    if (mounted) setState(() => _error = null);
     if (!_isValidMnemonic(_mnemonicController.text)) {
-      await _showErrorDialog(
-        'Invalid mnemonic format. Please enter 12 or 24 words.',
-      );
+      if (mounted) {
+        setState(() => _error = 'Invalid mnemonic format. Please enter 12 or 24 words.');
+      }
       return;
     }
 
     final walletName = _walletNameController.text.trim();
 
     if (hasExistingWallet && walletName.isEmpty) {
-      await _showErrorDialog('Please enter a wallet name');
+      if (mounted) setState(() => _error = 'Please enter a wallet name');
       return;
     }
 
@@ -963,7 +998,7 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
         _setScreen(WelcomeScreen.success);
       }
     } catch (e) {
-      await _showErrorDialog('Failed to generate wallet: $e');
+      if (mounted) setState(() => _error = 'Failed to generate wallet: $e');
     }
   }
 

--- a/sail_ui/test/pages/create_wallet_page_test.dart
+++ b/sail_ui/test/pages/create_wallet_page_test.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/pages/create_wallet_page.dart';
+
+void main() {
+  test('awaitBackendReady returns immediately when already ready', () async {
+    final ready = ValueNotifier<bool>(true);
+    await awaitBackendReady(ready, timeout: const Duration(milliseconds: 50));
+    ready.dispose();
+  });
+
+  test('awaitBackendReady completes when readiness flips true', () async {
+    final ready = ValueNotifier<bool>(false);
+    Timer(const Duration(milliseconds: 50), () => ready.value = true);
+
+    await awaitBackendReady(ready, timeout: const Duration(seconds: 2));
+    ready.dispose();
+  });
+
+  test('awaitBackendReady throws TimeoutException when never ready', () async {
+    final ready = ValueNotifier<bool>(false);
+
+    await expectLater(
+      awaitBackendReady(ready, timeout: const Duration(milliseconds: 100)),
+      throwsA(isA<TimeoutException>()),
+    );
+    ready.dispose();
+  });
+}


### PR DESCRIPTION
Await bitwindowd connection before calling WalletManagerService.generateWallet so fast post-boot taps no longer fail with an RPC error. While awaiting, the button spinner runs with "Connecting to bitwindowd…".
Errors render inline in red beneath the button instead of a modal — less disruptive, easier to dismiss.

TODO:
- [ ] Cold-boot bitwindow, immediately tap Generate — spinner, then completes.
- [ ] Verify inline red error appears on a hard WalletManager failure.