### PR TITLE
docs: list Coinshift in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ A collection of various Drivechain-related applications.
 
 - [ZSide](zside/README.md)
 
+- [Coinshift](coinshift/README.md)
+
 - [Faucet](faucet/README.md)


### PR DESCRIPTION
Coinshift was missing from the root README's app list.