### PR TITLE
bump deps

### DIFF
--- a/bitassets/macos/Podfile.lock
+++ b/bitassets/macos/Podfile.lock
@@ -14,7 +14,7 @@ PODS:
     - FlutterMacOS
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
-  - Sparkle (2.7.1)
+  - Sparkle (2.9.1)
   - url_launcher_macos (0.0.1):
     - FlutterMacOS
   - window_manager (0.5.0):
@@ -63,7 +63,7 @@ SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
-  Sparkle: 5f93557176b762f712e8cd80680778bf23c7348c
+  Sparkle: a4115cd9a339b297a61163256e6954d9e35297ce
   url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
   window_manager: b729e31d38fb04905235df9ea896128991cad99e
 

--- a/bitassets/pubspec.lock
+++ b/bitassets/pubspec.lock
@@ -1375,4 +1375,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/bitassets/pubspec.lock
+++ b/bitassets/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "3552e5c2874ed47cf9ed9d6813ac71b2276ee07622f48530468b8013f1767e3f"
+      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.14.0"
   built_collection:
     dependency: transitive
     description:
@@ -1375,4 +1375,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.195
+version: 1.0.196
 
 environment:
   sdk: 3.11.4

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -57,7 +57,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.3.1
-  build_runner: ^2.13.0
+  build_runner: ^2.14.0
   flutter_launcher_icons: ^0.14.3
 
 flutter_launcher_icons:

--- a/bitnames/pubspec.lock
+++ b/bitnames/pubspec.lock
@@ -1375,4 +1375,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/bitnames/pubspec.lock
+++ b/bitnames/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "3552e5c2874ed47cf9ed9d6813ac71b2276ee07622f48530468b8013f1767e3f"
+      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.14.0"
   built_collection:
     dependency: transitive
     description:
@@ -1375,4 +1375,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -57,7 +57,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.13.0
+  build_runner: ^2.14.0
   flutter_launcher_icons: ^0.14.4
 
 flutter_launcher_icons:

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.194
+version: 1.0.195
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/pubspec.lock
+++ b/bitwindow/pubspec.lock
@@ -1542,4 +1542,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/bitwindow/pubspec.lock
+++ b/bitwindow/pubspec.lock
@@ -221,10 +221,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "3552e5c2874ed47cf9ed9d6813ac71b2276ee07622f48530468b8013f1767e3f"
+      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.14.0"
   built_collection:
     dependency: transitive
     description:
@@ -1542,4 +1542,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -77,7 +77,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.13.0
+  build_runner: ^2.14.0
   flutter_launcher_icons: ^0.14.4
   patrol: ^4.5.0
   integration_test:

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.42
+version: 0.2.43
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/server/go.mod
+++ b/bitwindow/server/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-zeromq/goczmq/v4 v4.2.2 // indirect
 	github.com/go-zeromq/zmq4 v0.17.0
 	github.com/jessevdk/go-flags v1.6.1
-	github.com/rs/zerolog v1.35.0
+	github.com/rs/zerolog v1.35.1
 	github.com/samber/lo v1.53.0
 	github.com/sourcegraph/conc v0.3.0
 	go.uber.org/mock v0.6.0

--- a/bitwindow/server/go.mod
+++ b/bitwindow/server/go.mod
@@ -3,7 +3,7 @@ module github.com/LayerTwo-Labs/sidesail/bitwindow/server
 go 1.25.0
 
 require (
-	connectrpc.com/connect v1.19.1
+	connectrpc.com/connect v1.19.2
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/barebitcoin/btc-buf v0.0.0-20251202201854-efb1eb3c5e20
 	github.com/brianvoe/gofakeit/v7 v7.14.1

--- a/bitwindow/server/go.sum
+++ b/bitwindow/server/go.sum
@@ -1,5 +1,5 @@
-connectrpc.com/connect v1.19.1 h1:R5M57z05+90EfEvCY1b7hBxDVOUl45PrtXtAV2fOC14=
-connectrpc.com/connect v1.19.1/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
+connectrpc.com/connect v1.19.2 h1:McQ83FGdzL+t60peksi0gXC7MQ/iLKgLduAnThbM0mo=
+connectrpc.com/connect v1.19.2/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
 connectrpc.com/grpchealth v1.4.0 h1:MJC96JLelARPgZTiRF9KRfY/2N9OcoQvF2EWX07v2IE=
 connectrpc.com/grpchealth v1.4.0/go.mod h1:WhW6m1EzTmq3Ky1FE8EfkIpSDc6TfUx2M2KqZO3ts/Q=
 connectrpc.com/grpcreflect v1.3.0 h1:Y4V+ACf8/vOb1XOc251Qun7jMB75gCUNw6llvB9csXc=

--- a/bitwindow/server/go.sum
+++ b/bitwindow/server/go.sum
@@ -121,8 +121,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rs/zerolog v1.35.0 h1:VD0ykx7HMiMJytqINBsKcbLS+BJ4WYjz+05us+LRTdI=
-github.com/rs/zerolog v1.35.0/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
+github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=
+github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
 github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
 github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/photon/pubspec.lock
+++ b/photon/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "521daf8d189deb79ba474e43a696b41c49fb3987818dbacf3308f1e03673a75e"
+      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.1"
+    version: "2.14.0"
   built_collection:
     dependency: transitive
     description:

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.67
+version: 1.0.68
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -56,7 +56,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.13.1
+  build_runner: ^2.14.0
   flutter_launcher_icons: ^0.14.4
 
 flutter_launcher_icons:

--- a/sail_ui/pubspec.lock
+++ b/sail_ui/pubspec.lock
@@ -133,10 +133,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "3552e5c2874ed47cf9ed9d6813ac71b2276ee07622f48530468b8013f1767e3f"
+      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.14.0"
   built_collection:
     dependency: transitive
     description:
@@ -1280,4 +1280,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/sail_ui/pubspec.lock
+++ b/sail_ui/pubspec.lock
@@ -1280,4 +1280,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/sail_ui/pubspec.yaml
+++ b/sail_ui/pubspec.yaml
@@ -61,7 +61,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.13.0
+  build_runner: ^2.14.0
 
 flutter:
   assets:

--- a/thunder/pubspec.lock
+++ b/thunder/pubspec.lock
@@ -1375,4 +1375,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/thunder/pubspec.lock
+++ b/thunder/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "3552e5c2874ed47cf9ed9d6813ac71b2276ee07622f48530468b8013f1767e3f"
+      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.14.0"
   built_collection:
     dependency: transitive
     description:
@@ -1375,4 +1375,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -56,7 +56,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.13.0
+  build_runner: ^2.14.0
   flutter_launcher_icons: ^0.14.4
 
 flutter_launcher_icons:

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.196
+version: 1.0.197
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.lock
+++ b/truthcoin/pubspec.lock
@@ -1375,4 +1375,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/truthcoin/pubspec.lock
+++ b/truthcoin/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "521daf8d189deb79ba474e43a696b41c49fb3987818dbacf3308f1e03673a75e"
+      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.1"
+    version: "2.14.0"
   built_collection:
     dependency: transitive
     description:
@@ -1375,4 +1375,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -56,7 +56,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.13.1
+  build_runner: ^2.14.0
   flutter_launcher_icons: ^0.14.4
 
 flutter_launcher_icons:

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.67
+version: 1.0.68
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.lock
+++ b/zside/pubspec.lock
@@ -1375,4 +1375,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/zside/pubspec.lock
+++ b/zside/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "3552e5c2874ed47cf9ed9d6813ac71b2276ee07622f48530468b8013f1767e3f"
+      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.14.0"
   built_collection:
     dependency: transitive
     description:
@@ -1375,4 +1375,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -56,7 +56,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.13.0
+  build_runner: ^2.14.0
   flutter_launcher_icons: ^0.14.4
 
 flutter_launcher_icons:

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.194
+version: 1.0.195
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
- **build(deps): bump github.com/rs/zerolog in /bitwindow/server**
- **build(deps): bump connectrpc.com/connect in /bitwindow/server**
- **build(deps): bump build_runner from 2.13.0 to 2.14.0 in /sail_ui**
- **build(deps): bump build_runner from 2.13.0 to 2.14.0 in /bitwindow**
- **build(deps): bump build_runner from 2.13.0 to 2.14.0 in /bitnames**
- **build(deps): bump build_runner from 2.13.0 to 2.14.0 in /zside**
- **build(deps): bump build_runner from 2.13.0 to 2.14.0 in /bitassets**
- **build(deps): bump build_runner from 2.13.0 to 2.14.0 in /thunder**
- **build(deps): bump build_runner from 2.13.1 to 2.14.0 in /truthcoin**
- **build(deps): bump build_runner from 2.13.1 to 2.14.0 in /photon**
