### PR TITLE
orchestrator: wait for header sync, not full IBD

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.196
+version: 1.0.197
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.197
+version: 1.0.198
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.45
+version: 0.2.46
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.70
+version: 1.0.71
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/mocks/mocks.dart
+++ b/sail_ui/lib/mocks/mocks.dart
@@ -59,9 +59,6 @@ class MockMainchainRPC extends MainchainRPC {
   }
 
   @override
-  Future<void> waitForIBD() async {}
-
-  @override
   Future<BlockchainInfo> getBlockchainInfo() async {
     return BlockchainInfo(
       chain: 'test',
@@ -91,11 +88,6 @@ class MockMainchainRPC extends MainchainRPC {
   @override
   Future<List<String>> binaryArgs() {
     return Future.value([]);
-  }
-
-  @override
-  Future<void> waitForHeaderSync() async {
-    return;
   }
 
   @override
@@ -136,11 +128,6 @@ class MockMainchainRPC extends MainchainRPC {
   @override
   Future<TxOutsetInfo> getTxOutsetInfo() {
     throw UnimplementedError();
-  }
-
-  @override
-  Future<void> waitForSync() async {
-    return;
   }
 
   @override

--- a/sail_ui/lib/rpcs/mainchain_rpc.dart
+++ b/sail_ui/lib/rpcs/mainchain_rpc.dart
@@ -29,9 +29,6 @@ abstract class MainchainRPC extends RPCConnection {
   bool inHeaderSync = true;
   bool inSync = true;
 
-  Future<void> waitForIBD();
-  Future<void> waitForHeaderSync();
-  Future<void> waitForSync();
   Future<dynamic> callRAW(String method, [List<dynamic>? params]);
   List<String> getMethods();
   Future<List<PeerInfo>> getPeerInfo();
@@ -151,48 +148,6 @@ class MainchainRPCLive extends MainchainRPC {
     log.d('Args after deduplication: $args');
 
     return args;
-  }
-
-  @override
-  Future<void> waitForIBD() async {
-    int lastLoggedThousand = 0;
-    while (inIBD) {
-      try {
-        final info = await getBlockchainInfo();
-        int currentThousand = (info.blocks / 1000).floor();
-        if (currentThousand > lastLoggedThousand) {
-          log.w('Synced ${info.headers} headers');
-          lastLoggedThousand = currentThousand;
-        }
-      } finally {
-        await Future.delayed(const Duration(seconds: 1));
-      }
-    }
-  }
-
-  @override
-  Future<void> waitForSync() async {
-    int lastLoggedThousand = 0;
-    while (inSync) {
-      try {
-        final info = await getBlockchainInfo();
-        int currentThousand = (info.blocks / 1000).floor();
-        if (currentThousand > lastLoggedThousand) {
-          log.w('Synced ${info.blocks}/${info.headers} blocks');
-          lastLoggedThousand = currentThousand;
-        }
-      } finally {
-        await Future.delayed(const Duration(seconds: 1));
-      }
-    }
-  }
-
-  @override
-  Future<void> waitForHeaderSync() async {
-    while (inHeaderSync) {
-      // pollIBDStatus() is responsible for updating the syncedHeaders
-      await Future.delayed(const Duration(seconds: 1));
-    }
   }
 
   @override

--- a/sail_ui/lib/rpcs/mainchain_rpc.dart
+++ b/sail_ui/lib/rpcs/mainchain_rpc.dart
@@ -84,9 +84,13 @@ class MainchainRPCLive extends MainchainRPC {
       try {
         final info = await getBlockchainInfo();
 
-        // Update header sync status
+        // Update header sync status. Header download runs ahead of block
+        // validation — `info.headers` is the count Core has received from
+        // peers. A fresh node boots with 0/0 and the header count jumps to
+        // the chain tip within seconds once peers connect. Require at least
+        // 10 headers so we don't declare "header sync done" mid-bootstrap.
         final wasInHeaderSync = inHeaderSync;
-        inHeaderSync = info.blocks < 10;
+        inHeaderSync = info.headers < 10;
 
         // Update IBD status
         final wasInIBD = inIBD;

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -219,18 +219,19 @@ class BottomNav extends StatelessWidget {
                     ),
                   Builder(
                     builder: (context) {
-                      // During Core IBD the sidechain RPC has no blocks yet, so its sync
-                      // progress comes back as 0/0 — which reads as "broken" in the UI.
-                      // Detect "Core is ready" (connected and not in IBD / still booting)
-                      // and suppress the sync row until Core can actually give us work.
+                      // During Core's header sync the sidechain RPC has no chain state yet,
+                      // so its sync progress comes back as 0/0 — reads as "broken" in the UI.
+                      // Once headers are synced, Core can answer block queries even while
+                      // block IBD is still running, so release the card then — waiting for
+                      // full IBD made users stare at a dead UI for the whole chain download.
                       final bool coreReady =
                           model.mainchain.connected &&
                           !model.mainchain.initializingBinary &&
                           model.mainchain.startupError == null &&
-                          !model.mainchain.inIBD;
+                          !model.mainchain.inHeaderSync;
                       final infoMessage =
                           _getDownloadMessage(model.syncProvider.additionalSyncInfo) ??
-                          (!coreReady ? 'Waiting for Bitcoin Core to finish syncing' : null);
+                          (!coreReady ? 'Waiting for Bitcoin Core header sync' : null);
                       return DaemonConnectionCard(
                         connection: additionalConnection.rpc,
                         syncInfo: coreReady ? model.syncProvider.additionalSyncInfo : null,

--- a/sail_ui/pubspec.lock
+++ b/sail_ui/pubspec.lock
@@ -1280,4 +1280,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/sail_ui/pubspec.lock
+++ b/sail_ui/pubspec.lock
@@ -1280,4 +1280,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/sidechain-orchestrator/health.go
+++ b/sidechain-orchestrator/health.go
@@ -282,23 +282,6 @@ func (c *CoreStatusClient) call(ctx context.Context, method string, params ...in
 	return rpcResp.Result, nil
 }
 
-// IsIBDComplete checks if Bitcoin Core has finished initial block download.
-func (c *CoreStatusClient) IsIBDComplete(ctx context.Context) (bool, error) {
-	result, err := c.call(ctx, "getblockchaininfo")
-	if err != nil {
-		return false, err
-	}
-
-	var info struct {
-		InitialBlockDownload bool `json:"initialblockdownload"`
-	}
-	if err := json.Unmarshal(result, &info); err != nil {
-		return false, fmt.Errorf("decode getblockchaininfo: %w", err)
-	}
-
-	return !info.InitialBlockDownload, nil
-}
-
 // IsHeaderSyncComplete reports whether Bitcoin Core has finished downloading
 // headers — block IBD may still be in progress. Enforcer only needs headers
 // to start validating BIP300/301 activity (it syncs blocks alongside Core),

--- a/sidechain-orchestrator/health.go
+++ b/sidechain-orchestrator/health.go
@@ -299,6 +299,36 @@ func (c *CoreStatusClient) IsIBDComplete(ctx context.Context) (bool, error) {
 	return !info.InitialBlockDownload, nil
 }
 
+// IsHeaderSyncComplete reports whether Bitcoin Core has finished downloading
+// headers — block IBD may still be in progress. Enforcer only needs headers
+// to start validating BIP300/301 activity (it syncs blocks alongside Core),
+// so gating on IBD forces users to wait for the full chain when they don't
+// have to. Signal: headers > 0 AND headers >= blocks AND we're past the
+// "still connecting / no chain" bootstrap phase (headers > 10).
+func (c *CoreStatusClient) IsHeaderSyncComplete(ctx context.Context) (bool, error) {
+	result, err := c.call(ctx, "getblockchaininfo")
+	if err != nil {
+		return false, err
+	}
+
+	var info struct {
+		Blocks  int64 `json:"blocks"`
+		Headers int64 `json:"headers"`
+	}
+	if err := json.Unmarshal(result, &info); err != nil {
+		return false, fmt.Errorf("decode getblockchaininfo: %w", err)
+	}
+
+	// Header sync happens ahead of block validation: headers >= blocks during
+	// IBD, and both equal at tip. A fresh node reports 0/0 until peers start
+	// feeding headers — require at least 10 headers to avoid false positives
+	// before any peer connects.
+	if info.Headers < 10 {
+		return false, nil
+	}
+	return info.Headers >= info.Blocks, nil
+}
+
 // IsWalletLoaded checks if a wallet is loaded in Bitcoin Core.
 func (c *CoreStatusClient) IsWalletLoaded(ctx context.Context) (bool, error) {
 	result, err := c.call(ctx, "getwalletinfo")

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -665,21 +665,25 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 		o.log.Info().Msg("wallet created")
 	}
 
-	// 2. Wait for IBD to complete — enforcer needs a fully synced chain.
+	// 2. Wait for HEADER sync to complete — enforcer starts once Core has
+	// the header chain and validates blocks in parallel as Core downloads
+	// them. Waiting for full IBD here kept enforcer offline for the entire
+	// chain download, which is minutes-to-hours of dead UI for no benefit.
 	client, err := o.CoreStatusClient()
 	if err == nil {
 		o.log.Info().
 			Str("core_rpc", fmt.Sprintf("localhost:%d", o.BitcoinConf.GetRPCPort())).
-			Msg("waiting for IBD to complete before starting enforcer")
+			Msg("waiting for header sync before starting enforcer")
 		var lastErr error
 		var errCount int
 		for {
-			complete, err := client.IsIBDComplete(ctx)
+			complete, err := client.IsHeaderSyncComplete(ctx)
 			if err == nil {
 				if complete {
 					break
 				}
-				// Mid-IBD, bitcoind is reachable: nothing to log, just wait.
+				// Headers still coming in, bitcoind is reachable: nothing to
+				// log, just wait.
 			} else {
 				errCount++
 				// Surface the RPC error the first time and then once a
@@ -687,7 +691,7 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 				// doesn't hide behind silent retries.
 				if errCount == 1 || errCount%12 == 0 {
 					o.log.Warn().Err(err).Int("attempts", errCount).
-						Msg("IBD check RPC failed; will keep retrying")
+						Msg("header-sync check RPC failed; will keep retrying")
 				}
 				lastErr = err
 			}
@@ -699,9 +703,9 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 		}
 		if lastErr != nil {
 			o.log.Info().Int("recovered_after", errCount).
-				Msg("IBD check recovered after earlier RPC errors")
+				Msg("header-sync check recovered after earlier RPC errors")
 		}
-		o.log.Info().Msg("IBD complete, proceeding with enforcer")
+		o.log.Info().Msg("header sync complete, proceeding with enforcer")
 	}
 
 	enforcerCfg := o.configs["enforcer"]

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.199
+version: 1.0.200
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.70
+version: 1.0.71
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.197
+version: 1.0.198
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
Enforcer + BitWindow daemon card both gated on full IBD completion, which kept them offline for the entire block download. Switched both to wait on header sync instead — enforcer syncs blocks in parallel with Core once headers are in.

Also removed dead \`waitForIBD\` / \`waitForHeaderSync\` / \`waitForSync\` (zero callers in repo).