### PR TITLE
sail_ui, orchestrator: enforcer header-sync gate + crash fixes

### DIFF
--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -499,7 +499,9 @@ class _BitwindowAppContent extends StatelessWidget {
         // this case on their own.
         return _ErrorBoundary(
           child: WalletLostListener(
-            createWalletRoute: () => SailCreateWalletRoute(homeRoute: const RootRoute()),
+            onWalletLost: () => GetIt.I.get<AppRouter>().replaceAll([
+              SailCreateWalletRoute(homeRoute: const RootRoute()),
+            ]),
             child: Scaffold(
               body: child ?? const SizedBox.shrink(),
               bottomNavigationBar: const PersistentStatusBar(),

--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -123,8 +123,7 @@
       "chain_layer": 1,
       "color": "green",
       "health_check": {
-        "type": "connect_rpc",
-        "rpc_method": "cusf.mainchain.v1.ValidatorService/GetChainTip"
+        "type": "tcp"
       },
       "dependencies": ["bitcoind"],
       "startup_log_patterns": [

--- a/sail_ui/lib/routing/wallet_lost_listener.dart
+++ b/sail_ui/lib/routing/wallet_lost_listener.dart
@@ -1,28 +1,31 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:sail_ui/providers/wallet_reader_provider.dart';
 
-/// Watches WalletReaderProvider.hasWalletOnDisk and pushes the
-/// create-wallet route when it transitions `true -> false`. Mid-session
-/// WalletGuard (an AutoRouteGuard) only fires on navigation, so a user
-/// sitting on the Overview page while someone manually deletes
-/// wallet.json would never be prompted. This listener closes that gap.
+/// Watches WalletReaderProvider.hasWalletOnDisk and invokes
+/// [onWalletLost] when it transitions `true -> false`. WalletGuard
+/// (an AutoRouteGuard) only fires on navigation, so a user sitting on
+/// the Overview page while someone manually deletes wallet.json would
+/// never be prompted. This listener closes that gap.
 ///
-/// Placement: wrap the child that lives *inside* `MaterialApp.router`
-/// (typically the app shell beneath AutoRouter), so AutoRouter.of(context)
-/// resolves to the app's root router.
+/// The caller owns routing — [onWalletLost] typically reaches the app's
+/// root router via GetIt (e.g. `GetIt.I.get<AppRouter>().replaceAll(...)`).
+/// Routing through `AutoRouter.of(context)` is unsafe here because this
+/// widget is wrapped in `MaterialApp.router`'s `builder`, where the
+/// AutoRouter sits *below* (in `child`), not above — so the lookup
+/// throws.
 class WalletLostListener extends StatefulWidget {
   final Widget child;
 
-  /// Factory for the create-wallet route — same contract as WalletGuard.
-  final PageRouteInfo Function() createWalletRoute;
+  /// Invoked when wallet.json transitions from present to absent.
+  /// Called from the listener callback, not during build.
+  final void Function() onWalletLost;
 
   const WalletLostListener({
     super.key,
     required this.child,
-    required this.createWalletRoute,
+    required this.onWalletLost,
   });
 
   @override
@@ -67,10 +70,8 @@ class _WalletLostListenerState extends State<WalletLostListener> {
     if (!lost) return;
     if (!mounted) return;
 
-    _log.w('WalletLostListener: wallet.json disappeared, routing to create-wallet');
-    // replaceAll so the user can't back-button into a dead Overview page
-    // against an enforcer that refuses to boot without an L1 seed.
-    AutoRouter.of(context).replaceAll([widget.createWalletRoute()]);
+    _log.w('WalletLostListener: wallet.json disappeared, invoking onWalletLost');
+    widget.onWalletLost();
   }
 
   @override

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -123,8 +123,7 @@
       "chain_layer": 1,
       "color": "green",
       "health_check": {
-        "type": "connect_rpc",
-        "rpc_method": "cusf.mainchain.v1.ValidatorService/GetChainTip"
+        "type": "tcp"
       },
       "dependencies": ["bitcoind"],
       "startup_log_patterns": [

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -123,8 +123,7 @@
       "chain_layer": 1,
       "color": "green",
       "health_check": {
-        "type": "connect_rpc",
-        "rpc_method": "cusf.mainchain.v1.ValidatorService/GetChainTip"
+        "type": "tcp"
       },
       "dependencies": ["bitcoind"],
       "startup_log_patterns": [


### PR DESCRIPTION
Three commits on this branch, ordered:

1. **orchestrator: start enforcer after header sync, not full IBD** (75ddf6e2) — gates enforcer start on header sync rather than full block download. Header download finishes in seconds vs. minutes-to-hours for full IBD; enforcer can validate BIP300/301 activity in parallel as Core downloads blocks.

2. **sail_ui: fix WalletLostListener AutoRouter context lookup** (4999e06a) — the listener wraps \`MaterialApp.router\`'s \`builder\` child; AutoRouter sits below in \`child\`, not above. \`AutoRouter.of(context)\` walks up and throws. Refactored to a callback the caller (bitwindow/main.dart) builds via \`GetIt.I.get<AppRouter>()\`.

3. **orchestrator: switch enforcer health check to TCP** (1d097330) — enforcer is gRPC over h2c only. \`ConnectRPCHealthCheck\` POSTs HTTP/1.1 + JSON and gets back HTTP/2 SETTINGS bytes (\`\\x00\\x00\\x12\\x04...\`), which Go parses as a malformed HTTP response and floods the daemon-status panel. TCP check matches the actual signal we need ("is enforcer listening?"); per-RPC errors still surface through the wallet/transaction clients.