### PR TITLE
bitwindow: misc imps

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.197
+version: 1.0.198
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.198
+version: 1.0.199
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/lib/pages/wallet/wallet_page.dart
+++ b/bitwindow/lib/pages/wallet/wallet_page.dart
@@ -18,6 +18,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
 import 'package:sail_ui/sail_ui.dart';
 import 'package:stacked/stacked.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -245,9 +246,25 @@ class _GetCoinsButtonState extends State<GetCoinsButton> {
           onPressed: () => launchUrl(Uri.parse(url)),
         );
       }
-    } catch (error) {
+    } catch (error, stackTrace) {
+      final log = GetIt.I.get<Logger>();
+      String userMessage = error.toString();
+      if (error is DioException) {
+        log.e(
+          'faucet claim failed: status=${error.response?.statusCode} '
+          'body=${error.response?.data} type=${error.type} message=${error.message}',
+          error: error,
+          stackTrace: stackTrace,
+        );
+        final body = error.response?.data;
+        if (body is Map && body['message'] is String) {
+          userMessage = body['message'] as String;
+        }
+      } else {
+        log.e('faucet claim failed', error: error, stackTrace: stackTrace);
+      }
       if (mounted) {
-        showSnackBar(context, 'Failed to claim from faucet: ${error.toString()}');
+        showSnackBar(context, 'Failed to claim from faucet: $userMessage');
       }
     } finally {
       if (mounted) {

--- a/bitwindow/lib/pages/wallet/wallet_receive.dart
+++ b/bitwindow/lib/pages/wallet/wallet_receive.dart
@@ -99,8 +99,8 @@ class ReceiveTab extends StatelessWidget {
                         Expanded(
                           child: SailTextField(
                             loading: LoadingDetails(
-                              enabled: model.address.isEmpty,
-                              description: 'Waiting for enforcer to start and wallet to sync..',
+                              enabled: model.bip47PaymentCode.isEmpty,
+                              description: 'Waiting for wallet to sync..',
                             ),
                             controller: TextEditingController(text: model.bip47PaymentCode),
                             hintText: 'A Drivechain address',
@@ -112,11 +112,6 @@ class ReceiveTab extends StatelessWidget {
                         ),
                       ],
                     ),
-                    if (model.bip47PaymentCode.isEmpty)
-                      SailButton(
-                        label: 'Generate Bip47 Payment Code',
-                        onPressed: model.generateNewAddress,
-                      ),
                   ],
                 ),
               ),
@@ -332,6 +327,10 @@ class ReceivePageViewModel extends BaseViewModel {
     _bitwindowRPC.addListener(generateNewAddress);
     transactionsProvider.addListener(notifyListeners);
     _addressBookProvider.addListener(notifyListeners);
+    _hdWalletProvider.addListener(notifyListeners);
+    if (!_hdWalletProvider.isInitialized) {
+      _hdWalletProvider.init();
+    }
     generateNewAddress();
   }
 
@@ -339,6 +338,7 @@ class ReceivePageViewModel extends BaseViewModel {
   void dispose() {
     transactionsProvider.removeListener(notifyListeners);
     _addressBookProvider.removeListener(notifyListeners);
+    _hdWalletProvider.removeListener(notifyListeners);
     super.dispose();
   }
 
@@ -346,18 +346,6 @@ class ReceivePageViewModel extends BaseViewModel {
     try {
       modelError = null;
       await transactionsProvider.fetch();
-    } catch (e) {
-      if (e.toString() != modelError) {
-        modelError = e.toString();
-        notifyListeners();
-      }
-    }
-  }
-
-  Future<void> generateBip47PaymentCode() async {
-    try {
-      modelError = null;
-      await _hdWalletProvider.loadMnemonic();
     } catch (e) {
       if (e.toString() != modelError) {
         modelError = e.toString();

--- a/bitwindow/lib/providers/hd_wallet_provider.dart
+++ b/bitwindow/lib/providers/hd_wallet_provider.dart
@@ -18,7 +18,6 @@ class HDWalletProvider extends ChangeNotifier {
   bool _initialized = false;
   final bool _isProcessing = false;
   String? _mnemonic;
-  String _bip47PaymentCode = '';
 
   String? get seedHex => _seedHex;
   String? get masterKey => _masterKey;
@@ -26,9 +25,22 @@ class HDWalletProvider extends ChangeNotifier {
   bool get isInitialized => _initialized;
   bool get isProcessing => _isProcessing;
   String? get mnemonic => _mnemonic;
-  String get bip47PaymentCode => _bip47PaymentCode;
 
-  HDWalletProvider();
+  /// BIP47 v3 payment code — computed server-side by the orchestrator and
+  /// delivered on the WatchWalletData stream. No local crypto involved.
+  String get bip47PaymentCode => GetIt.I.get<WalletReaderProvider>().activeWallet?.bip47PaymentCode ?? '';
+
+  HDWalletProvider() {
+    // Forward wallet-state changes so listeners (e.g. the receive page)
+    // rebuild when bip47PaymentCode arrives.
+    GetIt.I.get<WalletReaderProvider>().addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    GetIt.I.get<WalletReaderProvider>().removeListener(notifyListeners);
+    super.dispose();
+  }
 
   Future<void> init() async {
     if (_initialized) return;
@@ -45,6 +57,7 @@ class HDWalletProvider extends ChangeNotifier {
   Future<bool> loadMnemonic() async {
     try {
       await _loadMnemonic();
+      notifyListeners();
       return true;
     } catch (e) {
       _error = "Couldn't load wallet mnemonic: $e";
@@ -64,10 +77,12 @@ class HDWalletProvider extends ChangeNotifier {
   }
 
   Future<void> _loadMnemonic() async {
+    log.i('HDWalletProvider: _loadMnemonic start');
     try {
       // Use WalletWriterProvider to load L1 mnemonic (supports both old and new structure)
       final walletProvider = GetIt.I.get<WalletWriterProvider>();
       final l1Mnemonic = await walletProvider.getL1Starter();
+      log.i('HDWalletProvider: getL1Starter returned len=${l1Mnemonic?.length ?? -1}');
 
       if (l1Mnemonic == null || l1Mnemonic.isEmpty) {
         throw Exception('Could not load L1 wallet mnemonic');
@@ -82,21 +97,10 @@ class HDWalletProvider extends ChangeNotifier {
       final masterKey = chain.forPath('m');
       _masterKey = masterKey.privateKeyHex();
 
-      try {
-        final extendedPublicKey = (masterKey as ExtendedPrivateKey).publicKey();
-        final masterQ = extendedPublicKey.q;
-        if (masterQ != null) {
-          final masterPubKeyBytes = masterQ.getEncoded(true);
-          final masterPubKeyHex = hex.encode(masterPubKeyBytes);
-          _bip47PaymentCode = _generateBip47v3PaymentCode(masterPubKeyHex);
-        }
-      } catch (e) {
-        _bip47PaymentCode = '';
-      }
-
       _error = null;
       _initialized = true;
-    } catch (e) {
+    } catch (e, st) {
+      log.e('HDWalletProvider: _loadMnemonic failed', error: e, stackTrace: st);
       _error = "Couldn't load wallet for HD Explorer";
       _seedHex = _masterKey = _mnemonic = null;
       _initialized = false;
@@ -109,7 +113,6 @@ class HDWalletProvider extends ChangeNotifier {
     _seedHex = null;
     _masterKey = null;
     _mnemonic = null;
-    _bip47PaymentCode = '';
     _error = null;
     notifyListeners();
   }
@@ -143,40 +146,6 @@ class HDWalletProvider extends ChangeNotifier {
     final ripemd160 = RIPEMD160Digest();
     final sha256Result = sha256Digest.process(data);
     return ripemd160.process(sha256Result);
-  }
-
-  String _generateBip47v3PaymentCode(String masterPubKeyHex) {
-    try {
-      if (masterPubKeyHex.length != 66) {
-        return '';
-      }
-
-      final pubKeyBytes = hex.decode(masterPubKeyHex);
-      if (pubKeyBytes.length != 33) {
-        return '';
-      }
-
-      final binaryPayload = Uint8List(34);
-      binaryPayload[0] = 0x03;
-      binaryPayload.setRange(1, 34, pubKeyBytes);
-
-      final versionedPayload = Uint8List(35);
-      versionedPayload[0] = 0x22;
-      versionedPayload.setRange(1, 35, binaryPayload);
-
-      final sha256Digest = SHA256Digest();
-      final hash1 = sha256Digest.process(versionedPayload);
-      final hash2 = sha256Digest.process(hash1);
-      final checksum = hash2.sublist(0, 4);
-
-      final finalBytes = Uint8List(39);
-      finalBytes.setRange(0, 35, versionedPayload);
-      finalBytes.setRange(35, 39, checksum);
-
-      return base58.encode(finalBytes);
-    } catch (e) {
-      return '';
-    }
   }
 
   bool _validateExtendedKey(String extendedKey) {

--- a/bitwindow/lib/providers/sidechain_provider.dart
+++ b/bitwindow/lib/providers/sidechain_provider.dart
@@ -26,9 +26,14 @@ class SidechainProvider extends ChangeNotifier {
 
   String? error;
 
+  /// Last wallet ID we fetched for. Used to detect an actual wallet switch
+  /// (vs. the stream just delivering a periodic refresh of the same wallet).
+  String? _lastWalletId;
+
   SidechainProvider() {
     _syncProvider.addListener(_onSync);
     _walletReader.addListener(_onWalletChanged);
+    _lastWalletId = _walletReader.activeWalletId;
     fetch();
   }
 
@@ -39,10 +44,16 @@ class SidechainProvider extends ChangeNotifier {
   }
 
   void _onWalletChanged() {
-    // Clear and refetch when wallet changes since deposits are per-wallet
-    sidechains = List.filled(256, null);
-    sidechainProposals = [];
-    notifyListeners();
+    final currentId = _walletReader.activeWalletId;
+    if (currentId == _lastWalletId) {
+      // Same wallet, unrelated stream tick. No refetch needed.
+      return;
+    }
+    _lastWalletId = currentId;
+
+    // Actual wallet switch: refetch. The old data stays visible until fetch
+    // completes and atomically replaces `sidechains` — no clear-to-empty
+    // intermediate state.
     fetch();
   }
 

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.46
+version: 0.2.47
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -426,15 +426,20 @@ func (s *Server) CreateAddressBookEntry(ctx context.Context, req *connect.Reques
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	address, err := btcutil.DecodeAddress(req.Msg.Address, s.walletEngine.GetChainParams())
-	if err != nil {
-		err = fmt.Errorf("invalid address: %w", err)
+	addr := strings.TrimSpace(req.Msg.Address)
+	kind := addressbook.ClassifyAddress(addr)
+	if kind == pb.AddressType_ADDRESS_TYPE_UNKNOWN || kind == pb.AddressType_ADDRESS_TYPE_UNSPECIFIED {
+		err := fmt.Errorf(
+			"invalid address %q: must be (1) a Bitcoin address on any network, "+
+				"(2) a Drivechain deposit address s<slot>_<addr>_<checksum>, or "+
+				"(3) a BIP47 v3 payment code", addr,
+		)
 		zerolog.Ctx(ctx).Error().Err(err).Msg("invalid address format")
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
 	// User-added addresses don't belong to a specific wallet (nil walletId)
-	if err := addressbook.Create(ctx, s.db, nil, req.Msg.Label, address.String(), direction); err != nil {
+	if err := addressbook.Create(ctx, s.db, nil, req.Msg.Label, addr, direction); err != nil {
 		// Check if this is a unique constraint error for address+direction
 		if err.Error() == addressbook.ErrUniqueAddress {
 			// Get the existing entry to update
@@ -446,7 +451,7 @@ func (s *Server) CreateAddressBookEntry(ctx context.Context, req *connect.Reques
 
 			// Find the entry with matching address and direction
 			for _, entry := range entries {
-				if entry.Address == req.Msg.Address && entry.Direction == direction {
+				if entry.Address == addr && entry.Direction == direction {
 					// Update its label instead
 					if err := addressbook.UpdateLabel(ctx, s.db, entry.ID, req.Msg.Label); err != nil {
 						zerolog.Ctx(ctx).Error().Err(err).Msg("could not update address book entry label")
@@ -468,7 +473,7 @@ func (s *Server) CreateAddressBookEntry(ctx context.Context, req *connect.Reques
 	}
 
 	entry, ok := lo.Find(entries, func(entry addressbook.Entry) bool {
-		return entry.Address == req.Msg.Address && entry.Direction == direction
+		return entry.Address == addr && entry.Direction == direction
 	})
 	if !ok {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not find newly created address book entry")
@@ -492,6 +497,7 @@ func EntryToProto(entry *addressbook.Entry) *pb.AddressBookEntry {
 		Direction:  addressbook.DirectionToProto(entry.Direction),
 		CreateTime: timestamppb.New(entry.CreatedAt),
 		WalletId:   walletId,
+		Type:       addressbook.ClassifyAddress(entry.Address),
 	}
 }
 
@@ -503,19 +509,8 @@ func (s *Server) ListAddressBook(ctx context.Context, req *connect.Request[empty
 	}
 
 	var pbEntries []*pb.AddressBookEntry
-	for _, entry := range entries {
-		walletId := ""
-		if entry.WalletID != nil {
-			walletId = *entry.WalletID
-		}
-		pbEntries = append(pbEntries, &pb.AddressBookEntry{
-			Id:         entry.ID,
-			Label:      entry.Label,
-			Address:    entry.Address,
-			Direction:  addressbook.DirectionToProto(entry.Direction),
-			CreateTime: timestamppb.New(entry.CreatedAt),
-			WalletId:   walletId,
-		})
+	for i := range entries {
+		pbEntries = append(pbEntries, EntryToProto(&entries[i]))
 	}
 
 	return connect.NewResponse(&pb.ListAddressBookResponse{

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -51,6 +51,15 @@ type Parser struct {
 	mu       sync.Mutex
 	topics   []opreturns.TopicInfo
 	m4Engine *M4Engine
+
+	// Dedicated sink for coinnews sync events. Nil => logging disabled.
+	coinnewsLog *zerolog.Logger
+}
+
+// SetCoinnewsLogger attaches a dedicated logger for coinnews sync events.
+// Passing nil disables coinnews-sync logging.
+func (p *Parser) SetCoinnewsLogger(logger *zerolog.Logger) {
+	p.coinnewsLog = logger
 }
 
 // Run runs the engine. It checks if a new block has been mined,
@@ -596,6 +605,8 @@ func (p *Parser) handleOpReturns(
 			Int("vout", vout).
 			Msgf("bitcoind_engine/parser: found OP_RETURN")
 
+		p.logCoinnews(txid, vout, data, height)
+
 		// Always fetch fee for OP_RETURN transactions. This avoids a race
 		// condition where blocks are processed in parallel and a topic
 		// created in one block isn't yet registered when a news article
@@ -632,6 +643,62 @@ func (p *Parser) handleOpReturns(
 	}
 
 	return opReturns, nil
+}
+
+// logCoinnews emits a detailed line to the dedicated coinnews-sync log when
+// the OP_RETURN's first 4 bytes match a known coin_news_topics entry.
+// No-op if no logger is attached (SetCoinnewsLogger not called).
+func (p *Parser) logCoinnews(txid string, vout int, data []byte, height *uint32) {
+	if p.coinnewsLog == nil || len(data) < 4 {
+		return
+	}
+
+	p.mu.Lock()
+	topicHex := hex.EncodeToString(data[:4])
+	var topicName string
+	for _, t := range p.topics {
+		if t.ID.String() == topicHex {
+			topicName = t.Name
+			break
+		}
+	}
+	p.mu.Unlock()
+
+	if topicName == "" {
+		return // not a coinnews entry
+	}
+
+	// Skip topic-creation OP_RETURNs — bytes 5..7 == "new" (0x6e6577).
+	if len(data) >= 8 && bytes.Equal(data[4:7], []byte("new")) {
+		return
+	}
+
+	payload := data[4:]
+	payloadHex := hex.EncodeToString(payload)
+	// Trim trailing NULs for the text preview; those are padding, not content.
+	textPreview := string(bytes.TrimRight(payload, "\x00"))
+	if len(textPreview) > 120 {
+		textPreview = textPreview[:120]
+	}
+
+	heightVal := int64(-1)
+	if height != nil {
+		heightVal = int64(*height)
+	}
+
+	evt := p.coinnewsLog.Info().
+		Str("txid", txid).
+		Int("vout", vout).
+		Int64("height", heightVal).
+		Str("topic_hex", topicHex).
+		Str("topic_name", topicName).
+		Int("payload_bytes", len(payload)).
+		Str("payload_hex", payloadHex).
+		Str("text_preview", textPreview)
+	if height == nil {
+		evt = evt.Str("source", "mempool")
+	}
+	evt.Msg("coinnews synced")
 }
 
 // parseOPReturnData extracts the actual data from an OP_RETURN script by handling

--- a/bitwindow/server/gen/bitwindowd/v1/bitwindowd.pb.go
+++ b/bitwindow/server/gen/bitwindowd/v1/bitwindowd.pb.go
@@ -133,6 +133,61 @@ func (BitcoinNetwork) EnumDescriptor() ([]byte, []int) {
 	return file_bitwindowd_v1_bitwindowd_proto_rawDescGZIP(), []int{1}
 }
 
+type AddressType int32
+
+const (
+	AddressType_ADDRESS_TYPE_UNSPECIFIED        AddressType = 0
+	AddressType_ADDRESS_TYPE_UNKNOWN            AddressType = 1
+	AddressType_ADDRESS_TYPE_BITCOIN_L1         AddressType = 2
+	AddressType_ADDRESS_TYPE_DRIVECHAIN_DEPOSIT AddressType = 3
+	AddressType_ADDRESS_TYPE_BIP47_PAYMENT_CODE AddressType = 4
+)
+
+// Enum value maps for AddressType.
+var (
+	AddressType_name = map[int32]string{
+		0: "ADDRESS_TYPE_UNSPECIFIED",
+		1: "ADDRESS_TYPE_UNKNOWN",
+		2: "ADDRESS_TYPE_BITCOIN_L1",
+		3: "ADDRESS_TYPE_DRIVECHAIN_DEPOSIT",
+		4: "ADDRESS_TYPE_BIP47_PAYMENT_CODE",
+	}
+	AddressType_value = map[string]int32{
+		"ADDRESS_TYPE_UNSPECIFIED":        0,
+		"ADDRESS_TYPE_UNKNOWN":            1,
+		"ADDRESS_TYPE_BITCOIN_L1":         2,
+		"ADDRESS_TYPE_DRIVECHAIN_DEPOSIT": 3,
+		"ADDRESS_TYPE_BIP47_PAYMENT_CODE": 4,
+	}
+)
+
+func (x AddressType) Enum() *AddressType {
+	p := new(AddressType)
+	*p = x
+	return p
+}
+
+func (x AddressType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AddressType) Descriptor() protoreflect.EnumDescriptor {
+	return file_bitwindowd_v1_bitwindowd_proto_enumTypes[2].Descriptor()
+}
+
+func (AddressType) Type() protoreflect.EnumType {
+	return &file_bitwindowd_v1_bitwindowd_proto_enumTypes[2]
+}
+
+func (x AddressType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AddressType.Descriptor instead.
+func (AddressType) EnumDescriptor() ([]byte, []int) {
+	return file_bitwindowd_v1_bitwindowd_proto_rawDescGZIP(), []int{2}
+}
+
 type BitwindowdServiceStopRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// If true, only stop bitwindow itself without stopping downstream services (enforcer, bitcoind)
@@ -1139,13 +1194,16 @@ func (x *CreateAddressBookEntryResponse) GetEntry() *AddressBookEntry {
 }
 
 type AddressBookEntry struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	Label         string                 `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty"`
-	Address       string                 `protobuf:"bytes,3,opt,name=address,proto3" json:"address,omitempty"`
-	Direction     Direction              `protobuf:"varint,4,opt,name=direction,proto3,enum=bitwindowd.v1.Direction" json:"direction,omitempty"`
-	CreateTime    *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=create_time,json=createTime,proto3" json:"create_time,omitempty"`
-	WalletId      string                 `protobuf:"bytes,6,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Id         int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Label      string                 `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty"`
+	Address    string                 `protobuf:"bytes,3,opt,name=address,proto3" json:"address,omitempty"`
+	Direction  Direction              `protobuf:"varint,4,opt,name=direction,proto3,enum=bitwindowd.v1.Direction" json:"direction,omitempty"`
+	CreateTime *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=create_time,json=createTime,proto3" json:"create_time,omitempty"`
+	WalletId   string                 `protobuf:"bytes,6,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	// Classified server-side on every read from the stored `address` string.
+	// Not persisted.
+	Type          AddressType `protobuf:"varint,7,opt,name=type,proto3,enum=bitwindowd.v1.AddressType" json:"type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1220,6 +1278,13 @@ func (x *AddressBookEntry) GetWalletId() string {
 		return x.WalletId
 	}
 	return ""
+}
+
+func (x *AddressBookEntry) GetType() AddressType {
+	if x != nil {
+		return x.Type
+	}
+	return AddressType_ADDRESS_TYPE_UNSPECIFIED
 }
 
 type ListAddressBookResponse struct {
@@ -2510,7 +2575,7 @@ const file_bitwindowd_v1_bitwindowd_proto_rawDesc = "" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\x126\n" +
 	"\tdirection\x18\x03 \x01(\x0e2\x18.bitwindowd.v1.DirectionR\tdirection\"W\n" +
 	"\x1eCreateAddressBookEntryResponse\x125\n" +
-	"\x05entry\x18\x01 \x01(\v2\x1f.bitwindowd.v1.AddressBookEntryR\x05entry\"\xe4\x01\n" +
+	"\x05entry\x18\x01 \x01(\v2\x1f.bitwindowd.v1.AddressBookEntryR\x05entry\"\x94\x02\n" +
 	"\x10AddressBookEntry\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x14\n" +
 	"\x05label\x18\x02 \x01(\tR\x05label\x12\x18\n" +
@@ -2518,7 +2583,8 @@ const file_bitwindowd_v1_bitwindowd_proto_rawDesc = "" +
 	"\tdirection\x18\x04 \x01(\x0e2\x18.bitwindowd.v1.DirectionR\tdirection\x12;\n" +
 	"\vcreate_time\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"createTime\x12\x1b\n" +
-	"\twallet_id\x18\x06 \x01(\tR\bwalletId\"T\n" +
+	"\twallet_id\x18\x06 \x01(\tR\bwalletId\x12.\n" +
+	"\x04type\x18\a \x01(\x0e2\x1a.bitwindowd.v1.AddressTypeR\x04type\"T\n" +
 	"\x17ListAddressBookResponse\x129\n" +
 	"\aentries\x18\x01 \x03(\v2\x1f.bitwindowd.v1.AddressBookEntryR\aentries\"_\n" +
 	"\x1dUpdateAddressBookEntryRequest\x12\x0e\n" +
@@ -2631,7 +2697,13 @@ const file_bitwindowd_v1_bitwindowd_proto_rawDesc = "" +
 	"\x17BITCOIN_NETWORK_REGTEST\x10\x03\x12\x1a\n" +
 	"\x16BITCOIN_NETWORK_SIGNET\x10\x04\x12\x1b\n" +
 	"\x17BITCOIN_NETWORK_TESTNET\x10\x05\x12\x1b\n" +
-	"\x17BITCOIN_NETWORK_FORKNET\x10\x062\xaf\x0e\n" +
+	"\x17BITCOIN_NETWORK_FORKNET\x10\x06*\xac\x01\n" +
+	"\vAddressType\x12\x1c\n" +
+	"\x18ADDRESS_TYPE_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14ADDRESS_TYPE_UNKNOWN\x10\x01\x12\x1b\n" +
+	"\x17ADDRESS_TYPE_BITCOIN_L1\x10\x02\x12#\n" +
+	"\x1fADDRESS_TYPE_DRIVECHAIN_DEPOSIT\x10\x03\x12#\n" +
+	"\x1fADDRESS_TYPE_BIP47_PAYMENT_CODE\x10\x042\xaf\x0e\n" +
 	"\x11BitwindowdService\x12K\n" +
 	"\x04Stop\x12+.bitwindowd.v1.BitwindowdServiceStopRequest\x1a\x16.google.protobuf.Empty\x12k\n" +
 	"\x12StartManagedBinary\x12(.bitwindowd.v1.StartManagedBinaryRequest\x1a).bitwindowd.v1.StartManagedBinaryResponse0\x01\x12T\n" +
@@ -2669,114 +2741,116 @@ func file_bitwindowd_v1_bitwindowd_proto_rawDescGZIP() []byte {
 	return file_bitwindowd_v1_bitwindowd_proto_rawDescData
 }
 
-var file_bitwindowd_v1_bitwindowd_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_bitwindowd_v1_bitwindowd_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_bitwindowd_v1_bitwindowd_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
 var file_bitwindowd_v1_bitwindowd_proto_goTypes = []any{
 	(Direction)(0),                          // 0: bitwindowd.v1.Direction
 	(BitcoinNetwork)(0),                     // 1: bitwindowd.v1.BitcoinNetwork
-	(*BitwindowdServiceStopRequest)(nil),    // 2: bitwindowd.v1.BitwindowdServiceStopRequest
-	(*StartManagedBinaryRequest)(nil),       // 3: bitwindowd.v1.StartManagedBinaryRequest
-	(*StartManagedBinaryResponse)(nil),      // 4: bitwindowd.v1.StartManagedBinaryResponse
-	(*StopManagedBinaryRequest)(nil),        // 5: bitwindowd.v1.StopManagedBinaryRequest
-	(*DownloadManagedBinaryRequest)(nil),    // 6: bitwindowd.v1.DownloadManagedBinaryRequest
-	(*DownloadManagedBinaryResponse)(nil),   // 7: bitwindowd.v1.DownloadManagedBinaryResponse
-	(*ShutdownManagedBinariesRequest)(nil),  // 8: bitwindowd.v1.ShutdownManagedBinariesRequest
-	(*ShutdownManagedBinariesResponse)(nil), // 9: bitwindowd.v1.ShutdownManagedBinariesResponse
-	(*CreateDenialRequest)(nil),             // 10: bitwindowd.v1.CreateDenialRequest
-	(*DenialInfo)(nil),                      // 11: bitwindowd.v1.DenialInfo
-	(*ExecutedDenial)(nil),                  // 12: bitwindowd.v1.ExecutedDenial
-	(*CancelDenialRequest)(nil),             // 13: bitwindowd.v1.CancelDenialRequest
-	(*PauseDenialRequest)(nil),              // 14: bitwindowd.v1.PauseDenialRequest
-	(*ResumeDenialRequest)(nil),             // 15: bitwindowd.v1.ResumeDenialRequest
-	(*CreateAddressBookEntryRequest)(nil),   // 16: bitwindowd.v1.CreateAddressBookEntryRequest
-	(*CreateAddressBookEntryResponse)(nil),  // 17: bitwindowd.v1.CreateAddressBookEntryResponse
-	(*AddressBookEntry)(nil),                // 18: bitwindowd.v1.AddressBookEntry
-	(*ListAddressBookResponse)(nil),         // 19: bitwindowd.v1.ListAddressBookResponse
-	(*UpdateAddressBookEntryRequest)(nil),   // 20: bitwindowd.v1.UpdateAddressBookEntryRequest
-	(*DeleteAddressBookEntryRequest)(nil),   // 21: bitwindowd.v1.DeleteAddressBookEntryRequest
-	(*GetSyncInfoResponse)(nil),             // 22: bitwindowd.v1.GetSyncInfoResponse
-	(*SetTransactionNoteRequest)(nil),       // 23: bitwindowd.v1.SetTransactionNoteRequest
-	(*GetFireplaceStatsResponse)(nil),       // 24: bitwindowd.v1.GetFireplaceStatsResponse
-	(*ListRecentTransactionsRequest)(nil),   // 25: bitwindowd.v1.ListRecentTransactionsRequest
-	(*ListRecentTransactionsResponse)(nil),  // 26: bitwindowd.v1.ListRecentTransactionsResponse
-	(*RecentTransaction)(nil),               // 27: bitwindowd.v1.RecentTransaction
-	(*ListBlocksRequest)(nil),               // 28: bitwindowd.v1.ListBlocksRequest
-	(*Block)(nil),                           // 29: bitwindowd.v1.Block
-	(*ListBlocksResponse)(nil),              // 30: bitwindowd.v1.ListBlocksResponse
-	(*MineBlocksResponse)(nil),              // 31: bitwindowd.v1.MineBlocksResponse
-	(*GetNetworkStatsResponse)(nil),         // 32: bitwindowd.v1.GetNetworkStatsResponse
-	(*ProcessBandwidth)(nil),                // 33: bitwindowd.v1.ProcessBandwidth
-	(*MineBlocksResponse_HashRate)(nil),     // 34: bitwindowd.v1.MineBlocksResponse.HashRate
-	(*MineBlocksResponse_BlockFound)(nil),   // 35: bitwindowd.v1.MineBlocksResponse.BlockFound
-	(*timestamppb.Timestamp)(nil),           // 36: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                   // 37: google.protobuf.Empty
+	(AddressType)(0),                        // 2: bitwindowd.v1.AddressType
+	(*BitwindowdServiceStopRequest)(nil),    // 3: bitwindowd.v1.BitwindowdServiceStopRequest
+	(*StartManagedBinaryRequest)(nil),       // 4: bitwindowd.v1.StartManagedBinaryRequest
+	(*StartManagedBinaryResponse)(nil),      // 5: bitwindowd.v1.StartManagedBinaryResponse
+	(*StopManagedBinaryRequest)(nil),        // 6: bitwindowd.v1.StopManagedBinaryRequest
+	(*DownloadManagedBinaryRequest)(nil),    // 7: bitwindowd.v1.DownloadManagedBinaryRequest
+	(*DownloadManagedBinaryResponse)(nil),   // 8: bitwindowd.v1.DownloadManagedBinaryResponse
+	(*ShutdownManagedBinariesRequest)(nil),  // 9: bitwindowd.v1.ShutdownManagedBinariesRequest
+	(*ShutdownManagedBinariesResponse)(nil), // 10: bitwindowd.v1.ShutdownManagedBinariesResponse
+	(*CreateDenialRequest)(nil),             // 11: bitwindowd.v1.CreateDenialRequest
+	(*DenialInfo)(nil),                      // 12: bitwindowd.v1.DenialInfo
+	(*ExecutedDenial)(nil),                  // 13: bitwindowd.v1.ExecutedDenial
+	(*CancelDenialRequest)(nil),             // 14: bitwindowd.v1.CancelDenialRequest
+	(*PauseDenialRequest)(nil),              // 15: bitwindowd.v1.PauseDenialRequest
+	(*ResumeDenialRequest)(nil),             // 16: bitwindowd.v1.ResumeDenialRequest
+	(*CreateAddressBookEntryRequest)(nil),   // 17: bitwindowd.v1.CreateAddressBookEntryRequest
+	(*CreateAddressBookEntryResponse)(nil),  // 18: bitwindowd.v1.CreateAddressBookEntryResponse
+	(*AddressBookEntry)(nil),                // 19: bitwindowd.v1.AddressBookEntry
+	(*ListAddressBookResponse)(nil),         // 20: bitwindowd.v1.ListAddressBookResponse
+	(*UpdateAddressBookEntryRequest)(nil),   // 21: bitwindowd.v1.UpdateAddressBookEntryRequest
+	(*DeleteAddressBookEntryRequest)(nil),   // 22: bitwindowd.v1.DeleteAddressBookEntryRequest
+	(*GetSyncInfoResponse)(nil),             // 23: bitwindowd.v1.GetSyncInfoResponse
+	(*SetTransactionNoteRequest)(nil),       // 24: bitwindowd.v1.SetTransactionNoteRequest
+	(*GetFireplaceStatsResponse)(nil),       // 25: bitwindowd.v1.GetFireplaceStatsResponse
+	(*ListRecentTransactionsRequest)(nil),   // 26: bitwindowd.v1.ListRecentTransactionsRequest
+	(*ListRecentTransactionsResponse)(nil),  // 27: bitwindowd.v1.ListRecentTransactionsResponse
+	(*RecentTransaction)(nil),               // 28: bitwindowd.v1.RecentTransaction
+	(*ListBlocksRequest)(nil),               // 29: bitwindowd.v1.ListBlocksRequest
+	(*Block)(nil),                           // 30: bitwindowd.v1.Block
+	(*ListBlocksResponse)(nil),              // 31: bitwindowd.v1.ListBlocksResponse
+	(*MineBlocksResponse)(nil),              // 32: bitwindowd.v1.MineBlocksResponse
+	(*GetNetworkStatsResponse)(nil),         // 33: bitwindowd.v1.GetNetworkStatsResponse
+	(*ProcessBandwidth)(nil),                // 34: bitwindowd.v1.ProcessBandwidth
+	(*MineBlocksResponse_HashRate)(nil),     // 35: bitwindowd.v1.MineBlocksResponse.HashRate
+	(*MineBlocksResponse_BlockFound)(nil),   // 36: bitwindowd.v1.MineBlocksResponse.BlockFound
+	(*timestamppb.Timestamp)(nil),           // 37: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                   // 38: google.protobuf.Empty
 }
 var file_bitwindowd_v1_bitwindowd_proto_depIdxs = []int32{
-	36, // 0: bitwindowd.v1.DenialInfo.create_time:type_name -> google.protobuf.Timestamp
-	36, // 1: bitwindowd.v1.DenialInfo.cancel_time:type_name -> google.protobuf.Timestamp
-	36, // 2: bitwindowd.v1.DenialInfo.next_execution_time:type_name -> google.protobuf.Timestamp
-	12, // 3: bitwindowd.v1.DenialInfo.executions:type_name -> bitwindowd.v1.ExecutedDenial
-	36, // 4: bitwindowd.v1.DenialInfo.paused_at:type_name -> google.protobuf.Timestamp
-	36, // 5: bitwindowd.v1.ExecutedDenial.create_time:type_name -> google.protobuf.Timestamp
+	37, // 0: bitwindowd.v1.DenialInfo.create_time:type_name -> google.protobuf.Timestamp
+	37, // 1: bitwindowd.v1.DenialInfo.cancel_time:type_name -> google.protobuf.Timestamp
+	37, // 2: bitwindowd.v1.DenialInfo.next_execution_time:type_name -> google.protobuf.Timestamp
+	13, // 3: bitwindowd.v1.DenialInfo.executions:type_name -> bitwindowd.v1.ExecutedDenial
+	37, // 4: bitwindowd.v1.DenialInfo.paused_at:type_name -> google.protobuf.Timestamp
+	37, // 5: bitwindowd.v1.ExecutedDenial.create_time:type_name -> google.protobuf.Timestamp
 	0,  // 6: bitwindowd.v1.CreateAddressBookEntryRequest.direction:type_name -> bitwindowd.v1.Direction
-	18, // 7: bitwindowd.v1.CreateAddressBookEntryResponse.entry:type_name -> bitwindowd.v1.AddressBookEntry
+	19, // 7: bitwindowd.v1.CreateAddressBookEntryResponse.entry:type_name -> bitwindowd.v1.AddressBookEntry
 	0,  // 8: bitwindowd.v1.AddressBookEntry.direction:type_name -> bitwindowd.v1.Direction
-	36, // 9: bitwindowd.v1.AddressBookEntry.create_time:type_name -> google.protobuf.Timestamp
-	18, // 10: bitwindowd.v1.ListAddressBookResponse.entries:type_name -> bitwindowd.v1.AddressBookEntry
-	36, // 11: bitwindowd.v1.GetSyncInfoResponse.tip_block_processed_at:type_name -> google.protobuf.Timestamp
-	27, // 12: bitwindowd.v1.ListRecentTransactionsResponse.transactions:type_name -> bitwindowd.v1.RecentTransaction
-	36, // 13: bitwindowd.v1.RecentTransaction.time:type_name -> google.protobuf.Timestamp
-	36, // 14: bitwindowd.v1.Block.block_time:type_name -> google.protobuf.Timestamp
-	29, // 15: bitwindowd.v1.ListBlocksResponse.recent_blocks:type_name -> bitwindowd.v1.Block
-	35, // 16: bitwindowd.v1.MineBlocksResponse.block_found:type_name -> bitwindowd.v1.MineBlocksResponse.BlockFound
-	34, // 17: bitwindowd.v1.MineBlocksResponse.hash_rate:type_name -> bitwindowd.v1.MineBlocksResponse.HashRate
-	33, // 18: bitwindowd.v1.GetNetworkStatsResponse.bitcoind_bandwidth:type_name -> bitwindowd.v1.ProcessBandwidth
-	33, // 19: bitwindowd.v1.GetNetworkStatsResponse.enforcer_bandwidth:type_name -> bitwindowd.v1.ProcessBandwidth
-	2,  // 20: bitwindowd.v1.BitwindowdService.Stop:input_type -> bitwindowd.v1.BitwindowdServiceStopRequest
-	3,  // 21: bitwindowd.v1.BitwindowdService.StartManagedBinary:input_type -> bitwindowd.v1.StartManagedBinaryRequest
-	5,  // 22: bitwindowd.v1.BitwindowdService.StopManagedBinary:input_type -> bitwindowd.v1.StopManagedBinaryRequest
-	6,  // 23: bitwindowd.v1.BitwindowdService.DownloadManagedBinary:input_type -> bitwindowd.v1.DownloadManagedBinaryRequest
-	8,  // 24: bitwindowd.v1.BitwindowdService.ShutdownManagedBinaries:input_type -> bitwindowd.v1.ShutdownManagedBinariesRequest
-	37, // 25: bitwindowd.v1.BitwindowdService.MineBlocks:input_type -> google.protobuf.Empty
-	10, // 26: bitwindowd.v1.BitwindowdService.CreateDenial:input_type -> bitwindowd.v1.CreateDenialRequest
-	13, // 27: bitwindowd.v1.BitwindowdService.CancelDenial:input_type -> bitwindowd.v1.CancelDenialRequest
-	14, // 28: bitwindowd.v1.BitwindowdService.PauseDenial:input_type -> bitwindowd.v1.PauseDenialRequest
-	15, // 29: bitwindowd.v1.BitwindowdService.ResumeDenial:input_type -> bitwindowd.v1.ResumeDenialRequest
-	16, // 30: bitwindowd.v1.BitwindowdService.CreateAddressBookEntry:input_type -> bitwindowd.v1.CreateAddressBookEntryRequest
-	37, // 31: bitwindowd.v1.BitwindowdService.ListAddressBook:input_type -> google.protobuf.Empty
-	20, // 32: bitwindowd.v1.BitwindowdService.UpdateAddressBookEntry:input_type -> bitwindowd.v1.UpdateAddressBookEntryRequest
-	21, // 33: bitwindowd.v1.BitwindowdService.DeleteAddressBookEntry:input_type -> bitwindowd.v1.DeleteAddressBookEntryRequest
-	37, // 34: bitwindowd.v1.BitwindowdService.GetSyncInfo:input_type -> google.protobuf.Empty
-	23, // 35: bitwindowd.v1.BitwindowdService.SetTransactionNote:input_type -> bitwindowd.v1.SetTransactionNoteRequest
-	37, // 36: bitwindowd.v1.BitwindowdService.GetFireplaceStats:input_type -> google.protobuf.Empty
-	25, // 37: bitwindowd.v1.BitwindowdService.ListRecentTransactions:input_type -> bitwindowd.v1.ListRecentTransactionsRequest
-	28, // 38: bitwindowd.v1.BitwindowdService.ListBlocks:input_type -> bitwindowd.v1.ListBlocksRequest
-	37, // 39: bitwindowd.v1.BitwindowdService.GetNetworkStats:input_type -> google.protobuf.Empty
-	37, // 40: bitwindowd.v1.BitwindowdService.Stop:output_type -> google.protobuf.Empty
-	4,  // 41: bitwindowd.v1.BitwindowdService.StartManagedBinary:output_type -> bitwindowd.v1.StartManagedBinaryResponse
-	37, // 42: bitwindowd.v1.BitwindowdService.StopManagedBinary:output_type -> google.protobuf.Empty
-	7,  // 43: bitwindowd.v1.BitwindowdService.DownloadManagedBinary:output_type -> bitwindowd.v1.DownloadManagedBinaryResponse
-	9,  // 44: bitwindowd.v1.BitwindowdService.ShutdownManagedBinaries:output_type -> bitwindowd.v1.ShutdownManagedBinariesResponse
-	31, // 45: bitwindowd.v1.BitwindowdService.MineBlocks:output_type -> bitwindowd.v1.MineBlocksResponse
-	37, // 46: bitwindowd.v1.BitwindowdService.CreateDenial:output_type -> google.protobuf.Empty
-	37, // 47: bitwindowd.v1.BitwindowdService.CancelDenial:output_type -> google.protobuf.Empty
-	37, // 48: bitwindowd.v1.BitwindowdService.PauseDenial:output_type -> google.protobuf.Empty
-	37, // 49: bitwindowd.v1.BitwindowdService.ResumeDenial:output_type -> google.protobuf.Empty
-	17, // 50: bitwindowd.v1.BitwindowdService.CreateAddressBookEntry:output_type -> bitwindowd.v1.CreateAddressBookEntryResponse
-	19, // 51: bitwindowd.v1.BitwindowdService.ListAddressBook:output_type -> bitwindowd.v1.ListAddressBookResponse
-	37, // 52: bitwindowd.v1.BitwindowdService.UpdateAddressBookEntry:output_type -> google.protobuf.Empty
-	37, // 53: bitwindowd.v1.BitwindowdService.DeleteAddressBookEntry:output_type -> google.protobuf.Empty
-	22, // 54: bitwindowd.v1.BitwindowdService.GetSyncInfo:output_type -> bitwindowd.v1.GetSyncInfoResponse
-	37, // 55: bitwindowd.v1.BitwindowdService.SetTransactionNote:output_type -> google.protobuf.Empty
-	24, // 56: bitwindowd.v1.BitwindowdService.GetFireplaceStats:output_type -> bitwindowd.v1.GetFireplaceStatsResponse
-	26, // 57: bitwindowd.v1.BitwindowdService.ListRecentTransactions:output_type -> bitwindowd.v1.ListRecentTransactionsResponse
-	30, // 58: bitwindowd.v1.BitwindowdService.ListBlocks:output_type -> bitwindowd.v1.ListBlocksResponse
-	32, // 59: bitwindowd.v1.BitwindowdService.GetNetworkStats:output_type -> bitwindowd.v1.GetNetworkStatsResponse
-	40, // [40:60] is the sub-list for method output_type
-	20, // [20:40] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	37, // 9: bitwindowd.v1.AddressBookEntry.create_time:type_name -> google.protobuf.Timestamp
+	2,  // 10: bitwindowd.v1.AddressBookEntry.type:type_name -> bitwindowd.v1.AddressType
+	19, // 11: bitwindowd.v1.ListAddressBookResponse.entries:type_name -> bitwindowd.v1.AddressBookEntry
+	37, // 12: bitwindowd.v1.GetSyncInfoResponse.tip_block_processed_at:type_name -> google.protobuf.Timestamp
+	28, // 13: bitwindowd.v1.ListRecentTransactionsResponse.transactions:type_name -> bitwindowd.v1.RecentTransaction
+	37, // 14: bitwindowd.v1.RecentTransaction.time:type_name -> google.protobuf.Timestamp
+	37, // 15: bitwindowd.v1.Block.block_time:type_name -> google.protobuf.Timestamp
+	30, // 16: bitwindowd.v1.ListBlocksResponse.recent_blocks:type_name -> bitwindowd.v1.Block
+	36, // 17: bitwindowd.v1.MineBlocksResponse.block_found:type_name -> bitwindowd.v1.MineBlocksResponse.BlockFound
+	35, // 18: bitwindowd.v1.MineBlocksResponse.hash_rate:type_name -> bitwindowd.v1.MineBlocksResponse.HashRate
+	34, // 19: bitwindowd.v1.GetNetworkStatsResponse.bitcoind_bandwidth:type_name -> bitwindowd.v1.ProcessBandwidth
+	34, // 20: bitwindowd.v1.GetNetworkStatsResponse.enforcer_bandwidth:type_name -> bitwindowd.v1.ProcessBandwidth
+	3,  // 21: bitwindowd.v1.BitwindowdService.Stop:input_type -> bitwindowd.v1.BitwindowdServiceStopRequest
+	4,  // 22: bitwindowd.v1.BitwindowdService.StartManagedBinary:input_type -> bitwindowd.v1.StartManagedBinaryRequest
+	6,  // 23: bitwindowd.v1.BitwindowdService.StopManagedBinary:input_type -> bitwindowd.v1.StopManagedBinaryRequest
+	7,  // 24: bitwindowd.v1.BitwindowdService.DownloadManagedBinary:input_type -> bitwindowd.v1.DownloadManagedBinaryRequest
+	9,  // 25: bitwindowd.v1.BitwindowdService.ShutdownManagedBinaries:input_type -> bitwindowd.v1.ShutdownManagedBinariesRequest
+	38, // 26: bitwindowd.v1.BitwindowdService.MineBlocks:input_type -> google.protobuf.Empty
+	11, // 27: bitwindowd.v1.BitwindowdService.CreateDenial:input_type -> bitwindowd.v1.CreateDenialRequest
+	14, // 28: bitwindowd.v1.BitwindowdService.CancelDenial:input_type -> bitwindowd.v1.CancelDenialRequest
+	15, // 29: bitwindowd.v1.BitwindowdService.PauseDenial:input_type -> bitwindowd.v1.PauseDenialRequest
+	16, // 30: bitwindowd.v1.BitwindowdService.ResumeDenial:input_type -> bitwindowd.v1.ResumeDenialRequest
+	17, // 31: bitwindowd.v1.BitwindowdService.CreateAddressBookEntry:input_type -> bitwindowd.v1.CreateAddressBookEntryRequest
+	38, // 32: bitwindowd.v1.BitwindowdService.ListAddressBook:input_type -> google.protobuf.Empty
+	21, // 33: bitwindowd.v1.BitwindowdService.UpdateAddressBookEntry:input_type -> bitwindowd.v1.UpdateAddressBookEntryRequest
+	22, // 34: bitwindowd.v1.BitwindowdService.DeleteAddressBookEntry:input_type -> bitwindowd.v1.DeleteAddressBookEntryRequest
+	38, // 35: bitwindowd.v1.BitwindowdService.GetSyncInfo:input_type -> google.protobuf.Empty
+	24, // 36: bitwindowd.v1.BitwindowdService.SetTransactionNote:input_type -> bitwindowd.v1.SetTransactionNoteRequest
+	38, // 37: bitwindowd.v1.BitwindowdService.GetFireplaceStats:input_type -> google.protobuf.Empty
+	26, // 38: bitwindowd.v1.BitwindowdService.ListRecentTransactions:input_type -> bitwindowd.v1.ListRecentTransactionsRequest
+	29, // 39: bitwindowd.v1.BitwindowdService.ListBlocks:input_type -> bitwindowd.v1.ListBlocksRequest
+	38, // 40: bitwindowd.v1.BitwindowdService.GetNetworkStats:input_type -> google.protobuf.Empty
+	38, // 41: bitwindowd.v1.BitwindowdService.Stop:output_type -> google.protobuf.Empty
+	5,  // 42: bitwindowd.v1.BitwindowdService.StartManagedBinary:output_type -> bitwindowd.v1.StartManagedBinaryResponse
+	38, // 43: bitwindowd.v1.BitwindowdService.StopManagedBinary:output_type -> google.protobuf.Empty
+	8,  // 44: bitwindowd.v1.BitwindowdService.DownloadManagedBinary:output_type -> bitwindowd.v1.DownloadManagedBinaryResponse
+	10, // 45: bitwindowd.v1.BitwindowdService.ShutdownManagedBinaries:output_type -> bitwindowd.v1.ShutdownManagedBinariesResponse
+	32, // 46: bitwindowd.v1.BitwindowdService.MineBlocks:output_type -> bitwindowd.v1.MineBlocksResponse
+	38, // 47: bitwindowd.v1.BitwindowdService.CreateDenial:output_type -> google.protobuf.Empty
+	38, // 48: bitwindowd.v1.BitwindowdService.CancelDenial:output_type -> google.protobuf.Empty
+	38, // 49: bitwindowd.v1.BitwindowdService.PauseDenial:output_type -> google.protobuf.Empty
+	38, // 50: bitwindowd.v1.BitwindowdService.ResumeDenial:output_type -> google.protobuf.Empty
+	18, // 51: bitwindowd.v1.BitwindowdService.CreateAddressBookEntry:output_type -> bitwindowd.v1.CreateAddressBookEntryResponse
+	20, // 52: bitwindowd.v1.BitwindowdService.ListAddressBook:output_type -> bitwindowd.v1.ListAddressBookResponse
+	38, // 53: bitwindowd.v1.BitwindowdService.UpdateAddressBookEntry:output_type -> google.protobuf.Empty
+	38, // 54: bitwindowd.v1.BitwindowdService.DeleteAddressBookEntry:output_type -> google.protobuf.Empty
+	23, // 55: bitwindowd.v1.BitwindowdService.GetSyncInfo:output_type -> bitwindowd.v1.GetSyncInfoResponse
+	38, // 56: bitwindowd.v1.BitwindowdService.SetTransactionNote:output_type -> google.protobuf.Empty
+	25, // 57: bitwindowd.v1.BitwindowdService.GetFireplaceStats:output_type -> bitwindowd.v1.GetFireplaceStatsResponse
+	27, // 58: bitwindowd.v1.BitwindowdService.ListRecentTransactions:output_type -> bitwindowd.v1.ListRecentTransactionsResponse
+	31, // 59: bitwindowd.v1.BitwindowdService.ListBlocks:output_type -> bitwindowd.v1.ListBlocksResponse
+	33, // 60: bitwindowd.v1.BitwindowdService.GetNetworkStats:output_type -> bitwindowd.v1.GetNetworkStatsResponse
+	41, // [41:61] is the sub-list for method output_type
+	21, // [21:41] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_bitwindowd_v1_bitwindowd_proto_init() }
@@ -2795,7 +2869,7 @@ func file_bitwindowd_v1_bitwindowd_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_bitwindowd_v1_bitwindowd_proto_rawDesc), len(file_bitwindowd_v1_bitwindowd_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      3,
 			NumMessages:   34,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/bitwindow/server/main.go
+++ b/bitwindow/server/main.go
@@ -300,6 +300,23 @@ func realMain(ctx context.Context, cancelCtx context.CancelFunc) error {
 	}()
 
 	bitcoinEngine := engines.NewBitcoind(srv.Bitcoind, db, conf)
+
+	// Dedicated log stream for coinnews sync. Pretty-printed, one line per
+	// coinnews OP_RETURN seen at parse time. Sits next to the main server log.
+	coinnewsLogPath := filepath.Join(filepath.Dir(conf.LogPath), "coinnews-sync.log")
+	if coinnewsFile, err := os.OpenFile(coinnewsLogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666); err != nil {
+		log.Warn().Err(err).Str("path", coinnewsLogPath).Msg("could not open coinnews-sync.log, skipping dedicated log")
+	} else {
+		coinnewsWriter := zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
+			w.Out = coinnewsFile
+			w.NoColor = true
+			w.TimeFormat = time.DateTime + ".000"
+		})
+		coinnewsLogger := zerolog.New(coinnewsWriter).With().Timestamp().Logger()
+		bitcoinEngine.SetCoinnewsLogger(&coinnewsLogger)
+		log.Info().Str("path", coinnewsLogPath).Msg("coinnews sync log enabled")
+	}
+
 	deniabilityEngine := engines.NewDeniability(srv.Wallet, srv.Bitcoind, db, srv.WalletEngine)
 
 	log.Info().Msgf("server: listening on %s", conf.APIHost)

--- a/bitwindow/server/models/addressbook/classify.go
+++ b/bitwindow/server/models/addressbook/classify.go
@@ -1,0 +1,64 @@
+package addressbook
+
+import (
+	"strings"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/base58"
+	"github.com/btcsuite/btcd/chaincfg"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/drivechain"
+	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/bitwindowd/v1"
+)
+
+var allChainParams = []*chaincfg.Params{
+	&chaincfg.MainNetParams,
+	&chaincfg.SigNetParams,
+	&chaincfg.TestNet3Params,
+	&chaincfg.RegressionNetParams,
+}
+
+// ClassifyAddress inspects the input string and returns the address type it
+// represents. Pure function — no DB, no network — so it is safe to call on
+// every read of ListAddressBook. Returns ADDRESS_TYPE_UNKNOWN if nothing
+// matches and ADDRESS_TYPE_UNSPECIFIED for the empty string.
+//
+// Ordering (cheapest → most expensive):
+//  1. BIP47 v3: base58-decode to 39 bytes with leading 0x22 0x03.
+//  2. Drivechain deposit: strict 3-part s<slot>_<addr>_<checksum> with
+//     valid checksum and an embedded L1 address that decodes on some net.
+//  3. Bitcoin L1 on any of mainnet / signet / testnet3 / regtest.
+func ClassifyAddress(s string) pb.AddressType {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return pb.AddressType_ADDRESS_TYPE_UNSPECIFIED
+	}
+
+	if raw := base58.Decode(s); len(raw) == 39 && raw[0] == 0x22 && raw[1] == 0x03 {
+		return pb.AddressType_ADDRESS_TYPE_BIP47_PAYMENT_CODE
+	}
+
+	if strings.Count(s, "_") == 2 {
+		slot, addr, checksum, err := drivechain.DecodeDepositAddress(s)
+		if err == nil && slot != nil && checksum != nil {
+			if _, ok := decodeL1Any(addr); ok {
+				return pb.AddressType_ADDRESS_TYPE_DRIVECHAIN_DEPOSIT
+			}
+		}
+	}
+
+	if _, ok := decodeL1Any(s); ok {
+		return pb.AddressType_ADDRESS_TYPE_BITCOIN_L1
+	}
+
+	return pb.AddressType_ADDRESS_TYPE_UNKNOWN
+}
+
+func decodeL1Any(s string) (btcutil.Address, bool) {
+	for _, p := range allChainParams {
+		if a, err := btcutil.DecodeAddress(s, p); err == nil {
+			return a, true
+		}
+	}
+	return nil, false
+}

--- a/bitwindow/server/models/addressbook/classify.go
+++ b/bitwindow/server/models/addressbook/classify.go
@@ -41,24 +41,24 @@ func ClassifyAddress(s string) pb.AddressType {
 	if strings.Count(s, "_") == 2 {
 		slot, addr, checksum, err := drivechain.DecodeDepositAddress(s)
 		if err == nil && slot != nil && checksum != nil {
-			if _, ok := decodeL1Any(addr); ok {
+			if decodeL1Any(addr) {
 				return pb.AddressType_ADDRESS_TYPE_DRIVECHAIN_DEPOSIT
 			}
 		}
 	}
 
-	if _, ok := decodeL1Any(s); ok {
+	if decodeL1Any(s) {
 		return pb.AddressType_ADDRESS_TYPE_BITCOIN_L1
 	}
 
 	return pb.AddressType_ADDRESS_TYPE_UNKNOWN
 }
 
-func decodeL1Any(s string) (btcutil.Address, bool) {
+func decodeL1Any(s string) bool {
 	for _, p := range allChainParams {
-		if a, err := btcutil.DecodeAddress(s, p); err == nil {
-			return a, true
+		if _, err := btcutil.DecodeAddress(s, p); err == nil {
+			return true
 		}
 	}
-	return nil, false
+	return false
 }

--- a/bitwindow/server/models/addressbook/classify_test.go
+++ b/bitwindow/server/models/addressbook/classify_test.go
@@ -24,8 +24,8 @@ func buildBIP47V3(t *testing.T, compressedPubKey []byte) string {
 	copy(payload[2:], compressedPubKey)
 	h1 := sha256.Sum256(payload)
 	h2 := sha256.Sum256(h1[:])
-	full := append(payload, h2[:4]...)
-	return base58.Encode(full)
+	payload = append(payload, h2[:4]...)
+	return base58.Encode(payload)
 }
 
 func depositChecksum(slot int, addr string) string {

--- a/bitwindow/server/models/addressbook/classify_test.go
+++ b/bitwindow/server/models/addressbook/classify_test.go
@@ -1,0 +1,89 @@
+package addressbook
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/base58"
+
+	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/bitwindowd/v1"
+)
+
+// buildBIP47V3 returns the base58-encoded v3 payment code for a given
+// 33-byte compressed pubkey. Layout: 0x22 || 0x03 || pubkey(33B) || sha256d(..)[:4]
+func buildBIP47V3(t *testing.T, compressedPubKey []byte) string {
+	t.Helper()
+	if len(compressedPubKey) != 33 {
+		t.Fatalf("pubkey must be 33 bytes, got %d", len(compressedPubKey))
+	}
+	payload := make([]byte, 35)
+	payload[0] = 0x22
+	payload[1] = 0x03
+	copy(payload[2:], compressedPubKey)
+	h1 := sha256.Sum256(payload)
+	h2 := sha256.Sum256(h1[:])
+	full := append(payload, h2[:4]...)
+	return base58.Encode(full)
+}
+
+func depositChecksum(slot int, addr string) string {
+	input := fmt.Sprintf("s%d_%s_", slot, addr)
+	h := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(h[:3])
+}
+
+func TestClassifyAddress(t *testing.T) {
+	// L1 addresses known to decode against their respective network params.
+	const mainnetP2PKH = "1BoatSLRHtKNngkdXEeobR76b53LETtpyT"
+	const signetBech32 = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+	const regtestBech32 = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080"
+
+	// Real BIP47 v3 payment code, computed at test time from a fixed pubkey.
+	samplePubKey := make([]byte, 33)
+	samplePubKey[0] = 0x02
+	for i := 1; i < 33; i++ {
+		samplePubKey[i] = byte(i)
+	}
+	bip47Code := buildBIP47V3(t, samplePubKey)
+
+	goodChecksum := depositChecksum(0, mainnetP2PKH)
+	validDeposit := fmt.Sprintf("s0_%s_%s", mainnetP2PKH, goodChecksum)
+	badChecksumDeposit := fmt.Sprintf("s0_%s_deadbe", mainnetP2PKH)
+	depositWithJunkAddr := fmt.Sprintf("s0_notAnAddress_%s", depositChecksum(0, "notAnAddress"))
+	slotOnly := fmt.Sprintf("s9_%s", mainnetP2PKH)
+
+	cases := []struct {
+		name  string
+		input string
+		want  pb.AddressType
+	}{
+		{"empty", "", pb.AddressType_ADDRESS_TYPE_UNSPECIFIED},
+		{"whitespace only", "   ", pb.AddressType_ADDRESS_TYPE_UNSPECIFIED},
+		{"garbage", "not-an-address", pb.AddressType_ADDRESS_TYPE_UNKNOWN},
+
+		{"bip47 v3 payment code", bip47Code, pb.AddressType_ADDRESS_TYPE_BIP47_PAYMENT_CODE},
+
+		{"mainnet p2pkh", mainnetP2PKH, pb.AddressType_ADDRESS_TYPE_BITCOIN_L1},
+		{"signet bech32", signetBech32, pb.AddressType_ADDRESS_TYPE_BITCOIN_L1},
+		{"regtest bech32", regtestBech32, pb.AddressType_ADDRESS_TYPE_BITCOIN_L1},
+
+		// Trim behaviour — trailing newline from paste.
+		{"trimmed whitespace around l1", "  " + mainnetP2PKH + "\n", pb.AddressType_ADDRESS_TYPE_BITCOIN_L1},
+
+		{"valid 3-part deposit", validDeposit, pb.AddressType_ADDRESS_TYPE_DRIVECHAIN_DEPOSIT},
+		{"deposit with bad checksum", badChecksumDeposit, pb.AddressType_ADDRESS_TYPE_UNKNOWN},
+		{"deposit with non-address body", depositWithJunkAddr, pb.AddressType_ADDRESS_TYPE_UNKNOWN},
+		{"slot-only no checksum", slotOnly, pb.AddressType_ADDRESS_TYPE_UNKNOWN},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyAddress(tc.input)
+			if got != tc.want {
+				t.Fatalf("ClassifyAddress(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/bitwindow/server/models/opreturns/opreturns.go
+++ b/bitwindow/server/models/opreturns/opreturns.go
@@ -414,6 +414,13 @@ func ListCoinNews(ctx context.Context, db *sql.DB) ([]CoinNews, error) {
 
 		// Remove all the whitespace padding
 		headline = strings.TrimRight(headline, string([]byte{0}))
+		content = strings.TrimRight(content, string([]byte{0}))
+
+		// Skip empty entries — junk posts where the payload is just a
+		// space+null padding (headline blank, content blank).
+		if strings.TrimSpace(headline) == "" && strings.TrimSpace(content) == "" {
+			continue
+		}
 
 		coinNews = append(coinNews, CoinNews{
 			ID:        opReturn.ID,

--- a/bitwindow/server/proto/bitwindowd/v1/bitwindowd.proto
+++ b/bitwindow/server/proto/bitwindowd/v1/bitwindowd.proto
@@ -167,6 +167,14 @@ enum BitcoinNetwork {
   BITCOIN_NETWORK_FORKNET = 6;
 }
 
+enum AddressType {
+  ADDRESS_TYPE_UNSPECIFIED = 0;
+  ADDRESS_TYPE_UNKNOWN = 1;
+  ADDRESS_TYPE_BITCOIN_L1 = 2;
+  ADDRESS_TYPE_DRIVECHAIN_DEPOSIT = 3;
+  ADDRESS_TYPE_BIP47_PAYMENT_CODE = 4;
+}
+
 message AddressBookEntry {
   int64 id = 1;
   string label = 2;
@@ -174,6 +182,9 @@ message AddressBookEntry {
   Direction direction = 4;
   google.protobuf.Timestamp create_time = 5;
   string wallet_id = 6;
+  // Classified server-side on every read from the stored `address` string.
+  // Not persisted.
+  AddressType type = 7;
 }
 
 message ListAddressBookResponse {

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.71
+version: 1.0.72
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.pb.dart
+++ b/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.pb.dart
@@ -1346,6 +1346,7 @@ class AddressBookEntry extends $pb.GeneratedMessage {
     Direction? direction,
     $0.Timestamp? createTime,
     $core.String? walletId,
+    AddressType? type,
   }) {
     final $result = create();
     if (id != null) {
@@ -1366,6 +1367,9 @@ class AddressBookEntry extends $pb.GeneratedMessage {
     if (walletId != null) {
       $result.walletId = walletId;
     }
+    if (type != null) {
+      $result.type = type;
+    }
     return $result;
   }
   AddressBookEntry._() : super();
@@ -1379,6 +1383,7 @@ class AddressBookEntry extends $pb.GeneratedMessage {
     ..e<Direction>(4, _omitFieldNames ? '' : 'direction', $pb.PbFieldType.OE, defaultOrMaker: Direction.DIRECTION_UNSPECIFIED, valueOf: Direction.valueOf, enumValues: Direction.values)
     ..aOM<$0.Timestamp>(5, _omitFieldNames ? '' : 'createTime', subBuilder: $0.Timestamp.create)
     ..aOS(6, _omitFieldNames ? '' : 'walletId')
+    ..e<AddressType>(7, _omitFieldNames ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: AddressType.ADDRESS_TYPE_UNSPECIFIED, valueOf: AddressType.valueOf, enumValues: AddressType.values)
     ..hasRequiredFields = false
   ;
 
@@ -1458,6 +1463,17 @@ class AddressBookEntry extends $pb.GeneratedMessage {
   $core.bool hasWalletId() => $_has(5);
   @$pb.TagNumber(6)
   void clearWalletId() => clearField(6);
+
+  /// Classified server-side on every read from the stored `address` string.
+  /// Not persisted.
+  @$pb.TagNumber(7)
+  AddressType get type => $_getN(6);
+  @$pb.TagNumber(7)
+  set type(AddressType v) { setField(7, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasType() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearType() => clearField(7);
 }
 
 class ListAddressBookResponse extends $pb.GeneratedMessage {

--- a/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.pbenum.dart
+++ b/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.pbenum.dart
@@ -55,5 +55,26 @@ class BitcoinNetwork extends $pb.ProtobufEnum {
   const BitcoinNetwork._($core.int v, $core.String n) : super(v, n);
 }
 
+class AddressType extends $pb.ProtobufEnum {
+  static const AddressType ADDRESS_TYPE_UNSPECIFIED = AddressType._(0, _omitEnumNames ? '' : 'ADDRESS_TYPE_UNSPECIFIED');
+  static const AddressType ADDRESS_TYPE_UNKNOWN = AddressType._(1, _omitEnumNames ? '' : 'ADDRESS_TYPE_UNKNOWN');
+  static const AddressType ADDRESS_TYPE_BITCOIN_L1 = AddressType._(2, _omitEnumNames ? '' : 'ADDRESS_TYPE_BITCOIN_L1');
+  static const AddressType ADDRESS_TYPE_DRIVECHAIN_DEPOSIT = AddressType._(3, _omitEnumNames ? '' : 'ADDRESS_TYPE_DRIVECHAIN_DEPOSIT');
+  static const AddressType ADDRESS_TYPE_BIP47_PAYMENT_CODE = AddressType._(4, _omitEnumNames ? '' : 'ADDRESS_TYPE_BIP47_PAYMENT_CODE');
+
+  static const $core.List<AddressType> values = <AddressType> [
+    ADDRESS_TYPE_UNSPECIFIED,
+    ADDRESS_TYPE_UNKNOWN,
+    ADDRESS_TYPE_BITCOIN_L1,
+    ADDRESS_TYPE_DRIVECHAIN_DEPOSIT,
+    ADDRESS_TYPE_BIP47_PAYMENT_CODE,
+  ];
+
+  static final $core.Map<$core.int, AddressType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static AddressType? valueOf($core.int value) => _byValue[value];
+
+  const AddressType._($core.int v, $core.String n) : super(v, n);
+}
+
 
 const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.pbjson.dart
+++ b/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.pbjson.dart
@@ -52,6 +52,25 @@ final $typed_data.Uint8List bitcoinNetworkDescriptor = $convert.base64Decode(
     'QklUQ09JTl9ORVRXT1JLX1JFR1RFU1QQAxIaChZCSVRDT0lOX05FVFdPUktfU0lHTkVUEAQSGw'
     'oXQklUQ09JTl9ORVRXT1JLX1RFU1RORVQQBRIbChdCSVRDT0lOX05FVFdPUktfRk9SS05FVBAG');
 
+@$core.Deprecated('Use addressTypeDescriptor instead')
+const AddressType$json = {
+  '1': 'AddressType',
+  '2': [
+    {'1': 'ADDRESS_TYPE_UNSPECIFIED', '2': 0},
+    {'1': 'ADDRESS_TYPE_UNKNOWN', '2': 1},
+    {'1': 'ADDRESS_TYPE_BITCOIN_L1', '2': 2},
+    {'1': 'ADDRESS_TYPE_DRIVECHAIN_DEPOSIT', '2': 3},
+    {'1': 'ADDRESS_TYPE_BIP47_PAYMENT_CODE', '2': 4},
+  ],
+};
+
+/// Descriptor for `AddressType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List addressTypeDescriptor = $convert.base64Decode(
+    'CgtBZGRyZXNzVHlwZRIcChhBRERSRVNTX1RZUEVfVU5TUEVDSUZJRUQQABIYChRBRERSRVNTX1'
+    'RZUEVfVU5LTk9XThABEhsKF0FERFJFU1NfVFlQRV9CSVRDT0lOX0wxEAISIwofQUREUkVTU19U'
+    'WVBFX0RSSVZFQ0hBSU5fREVQT1NJVBADEiMKH0FERFJFU1NfVFlQRV9CSVA0N19QQVlNRU5UX0'
+    'NPREUQBA==');
+
 @$core.Deprecated('Use bitwindowdServiceStopRequestDescriptor instead')
 const BitwindowdServiceStopRequest$json = {
   '1': 'BitwindowdServiceStopRequest',
@@ -329,6 +348,7 @@ const AddressBookEntry$json = {
     {'1': 'direction', '3': 4, '4': 1, '5': 14, '6': '.bitwindowd.v1.Direction', '10': 'direction'},
     {'1': 'create_time', '3': 5, '4': 1, '5': 11, '6': '.google.protobuf.Timestamp', '10': 'createTime'},
     {'1': 'wallet_id', '3': 6, '4': 1, '5': 9, '10': 'walletId'},
+    {'1': 'type', '3': 7, '4': 1, '5': 14, '6': '.bitwindowd.v1.AddressType', '10': 'type'},
   ],
 };
 
@@ -338,7 +358,7 @@ final $typed_data.Uint8List addressBookEntryDescriptor = $convert.base64Decode(
     'wSGAoHYWRkcmVzcxgDIAEoCVIHYWRkcmVzcxI2CglkaXJlY3Rpb24YBCABKA4yGC5iaXR3aW5k'
     'b3dkLnYxLkRpcmVjdGlvblIJZGlyZWN0aW9uEjsKC2NyZWF0ZV90aW1lGAUgASgLMhouZ29vZ2'
     'xlLnByb3RvYnVmLlRpbWVzdGFtcFIKY3JlYXRlVGltZRIbCgl3YWxsZXRfaWQYBiABKAlSCHdh'
-    'bGxldElk');
+    'bGxldElkEi4KBHR5cGUYByABKA4yGi5iaXR3aW5kb3dkLnYxLkFkZHJlc3NUeXBlUgR0eXBl');
 
 @$core.Deprecated('Use listAddressBookResponseDescriptor instead')
 const ListAddressBookResponse$json = {

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -710,6 +710,7 @@ class WalletMetadata extends $pb.GeneratedMessage {
     $core.String? walletType,
     $core.String? gradientJson,
     $core.String? createdAt,
+    $core.String? bip47PaymentCode,
   }) {
     final $result = create();
     if (id != null) {
@@ -727,6 +728,9 @@ class WalletMetadata extends $pb.GeneratedMessage {
     if (createdAt != null) {
       $result.createdAt = createdAt;
     }
+    if (bip47PaymentCode != null) {
+      $result.bip47PaymentCode = bip47PaymentCode;
+    }
     return $result;
   }
   WalletMetadata._() : super();
@@ -739,6 +743,7 @@ class WalletMetadata extends $pb.GeneratedMessage {
     ..aOS(3, _omitFieldNames ? '' : 'walletType')
     ..aOS(4, _omitFieldNames ? '' : 'gradientJson')
     ..aOS(5, _omitFieldNames ? '' : 'createdAt')
+    ..aOS(6, _omitFieldNames ? '' : 'bip47PaymentCode')
     ..hasRequiredFields = false
   ;
 
@@ -807,6 +812,17 @@ class WalletMetadata extends $pb.GeneratedMessage {
   $core.bool hasCreatedAt() => $_has(4);
   @$pb.TagNumber(5)
   void clearCreatedAt() => clearField(5);
+
+  /// BIP47 v3 payment code derived from the wallet's master pubkey.
+  /// Deterministic per wallet, never changes. Empty for watch-only wallets.
+  @$pb.TagNumber(6)
+  $core.String get bip47PaymentCode => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set bip47PaymentCode($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasBip47PaymentCode() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearBip47PaymentCode() => clearField(6);
 }
 
 class ListWalletsRequest extends $pb.GeneratedMessage {

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -3669,10 +3669,14 @@ class GetWalletSeedRequest extends $pb.GeneratedMessage {
 class GetWalletSeedResponse extends $pb.GeneratedMessage {
   factory GetWalletSeedResponse({
     $core.String? seedHex,
+    $core.String? mnemonic,
   }) {
     final $result = create();
     if (seedHex != null) {
       $result.seedHex = seedHex;
+    }
+    if (mnemonic != null) {
+      $result.mnemonic = mnemonic;
     }
     return $result;
   }
@@ -3682,6 +3686,7 @@ class GetWalletSeedResponse extends $pb.GeneratedMessage {
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletSeedResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'seedHex')
+    ..aOS(2, _omitFieldNames ? '' : 'mnemonic')
     ..hasRequiredFields = false
   ;
 
@@ -3714,6 +3719,16 @@ class GetWalletSeedResponse extends $pb.GeneratedMessage {
   $core.bool hasSeedHex() => $_has(0);
   @$pb.TagNumber(1)
   void clearSeedHex() => clearField(1);
+
+  /// BIP39 mnemonic words for the wallet. Sensitive — treat like seed_hex.
+  @$pb.TagNumber(2)
+  $core.String get mnemonic => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set mnemonic($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMnemonic() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMnemonic() => clearField(2);
 }
 
 class WatchWalletDataResponse extends $pb.GeneratedMessage {

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -806,12 +806,14 @@ const GetWalletSeedResponse$json = {
   '1': 'GetWalletSeedResponse',
   '2': [
     {'1': 'seed_hex', '3': 1, '4': 1, '5': 9, '10': 'seedHex'},
+    {'1': 'mnemonic', '3': 2, '4': 1, '5': 9, '10': 'mnemonic'},
   ],
 };
 
 /// Descriptor for `GetWalletSeedResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List getWalletSeedResponseDescriptor = $convert.base64Decode(
-    'ChVHZXRXYWxsZXRTZWVkUmVzcG9uc2USGQoIc2VlZF9oZXgYASABKAlSB3NlZWRIZXg=');
+    'ChVHZXRXYWxsZXRTZWVkUmVzcG9uc2USGQoIc2VlZF9oZXgYASABKAlSB3NlZWRIZXgSGgoIbW'
+    '5lbW9uaWMYAiABKAlSCG1uZW1vbmlj');
 
 @$core.Deprecated('Use watchWalletDataResponseDescriptor instead')
 const WatchWalletDataResponse$json = {

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -186,6 +186,7 @@ const WalletMetadata$json = {
     {'1': 'wallet_type', '3': 3, '4': 1, '5': 9, '10': 'walletType'},
     {'1': 'gradient_json', '3': 4, '4': 1, '5': 9, '10': 'gradientJson'},
     {'1': 'created_at', '3': 5, '4': 1, '5': 9, '10': 'createdAt'},
+    {'1': 'bip47_payment_code', '3': 6, '4': 1, '5': 9, '10': 'bip47PaymentCode'},
   ],
 };
 
@@ -193,7 +194,8 @@ const WalletMetadata$json = {
 final $typed_data.Uint8List walletMetadataDescriptor = $convert.base64Decode(
     'Cg5XYWxsZXRNZXRhZGF0YRIOCgJpZBgBIAEoCVICaWQSEgoEbmFtZRgCIAEoCVIEbmFtZRIfCg'
     't3YWxsZXRfdHlwZRgDIAEoCVIKd2FsbGV0VHlwZRIjCg1ncmFkaWVudF9qc29uGAQgASgJUgxn'
-    'cmFkaWVudEpzb24SHQoKY3JlYXRlZF9hdBgFIAEoCVIJY3JlYXRlZEF0');
+    'cmFkaWVudEpzb24SHQoKY3JlYXRlZF9hdBgFIAEoCVIJY3JlYXRlZEF0EiwKEmJpcDQ3X3BheW'
+    '1lbnRfY29kZRgGIAEoCVIQYmlwNDdQYXltZW50Q29kZQ==');
 
 @$core.Deprecated('Use listWalletsRequestDescriptor instead')
 const ListWalletsRequest$json = {

--- a/sail_ui/lib/models/wallet_data.dart
+++ b/sail_ui/lib/models/wallet_data.dart
@@ -13,6 +13,9 @@ class WalletData {
   final WalletGradient gradient;
   final DateTime createdAt;
   final BinaryType walletType;
+  // BIP47 v3 payment code from orchestrator's WatchWalletData stream.
+  // Not persisted — populated only from the proto, not from wallet.json.
+  final String bip47PaymentCode;
 
   WalletData({
     required this.version,
@@ -24,6 +27,7 @@ class WalletData {
     required this.gradient,
     required this.createdAt,
     required this.walletType,
+    this.bip47PaymentCode = '',
   });
 
   Map<String, dynamic> toJson() {

--- a/sail_ui/lib/providers/backend_state_provider.dart
+++ b/sail_ui/lib/providers/backend_state_provider.dart
@@ -90,18 +90,12 @@ class BackendStateProvider extends ChangeNotifier {
       onError: (error) {
         _log.w('BackendStateProvider: watchBinaries error: $error');
 
-        // Backend is gone — mark all orchestrator-managed binaries as disconnected.
-        for (final status in binaries.values) {
-          final rpc = _rpcForBinaryName(status.name);
-          if (rpc != null) {
-            rpc.connected = false;
-            rpc.initializingBinary = false;
-            rpc.stoppingBinary = false;
-            rpc.markStateChanged();
-          }
-        }
-        binaries.clear();
-        notifyListeners();
+        // Do NOT clear `binaries` or flip RPCs to disconnected on a transient
+        // stream error — the reconnect takes ~2s and clearing makes the
+        // sidechain list UI vanish and re-appear ("spasm"). The stream pushes
+        // the full state on reconnect, so last-known state is fine to keep.
+        // If the backend is genuinely gone, individual RPC calls will fail
+        // and those code paths set their own disconnected state.
 
         // Stream broke — retry after delay
         Future.delayed(const Duration(seconds: 2), () {

--- a/sail_ui/lib/providers/wallet_reader_provider.dart
+++ b/sail_ui/lib/providers/wallet_reader_provider.dart
@@ -140,6 +140,7 @@ class WalletReaderProvider extends ChangeNotifier {
           (t) => t.name == protoWallet.walletType,
           orElse: () => BinaryType.enforcer,
         ),
+        bip47PaymentCode: protoWallet.bip47PaymentCode,
       );
     }).toList();
 

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -129,7 +129,9 @@ func (h *WalletHandler) RemoveEncryption(ctx context.Context, req *connect.Reque
 }
 
 func (h *WalletHandler) ListWallets(ctx context.Context, req *connect.Request[pb.ListWalletsRequest]) (*connect.Response[pb.ListWalletsResponse], error) {
-	wallets := h.svc.ListWallets()
+	// Use GetAllWallets so we can access the seed for BIP47 derivation —
+	// parity with sendWalletData. ListWallets (metadata-only) can't see it.
+	wallets := h.svc.GetAllWallets()
 	pbWallets := make([]*pb.WalletMetadata, len(wallets))
 	for i, w := range wallets {
 		var gradientJSON string
@@ -137,11 +139,12 @@ func (h *WalletHandler) ListWallets(ctx context.Context, req *connect.Request[pb
 			gradientJSON = string(w.Gradient)
 		}
 		pbWallets[i] = &pb.WalletMetadata{
-			Id:           w.ID,
-			Name:         w.Name,
-			WalletType:   w.WalletType,
-			GradientJson: gradientJSON,
-			CreatedAt:    w.CreatedAt.Format(time.RFC3339),
+			Id:               w.ID,
+			Name:             w.Name,
+			WalletType:       w.WalletType,
+			GradientJson:     gradientJSON,
+			CreatedAt:        w.CreatedAt.Format(time.RFC3339),
+			Bip47PaymentCode: wallet.Bip47V3PaymentCodeFromSeed(w.Master.SeedHex),
 		}
 	}
 	return connect.NewResponse(&pb.ListWalletsResponse{
@@ -1034,7 +1037,8 @@ func (h *WalletHandler) GetWalletSeed(ctx context.Context, req *connect.Request[
 		for _, w := range wallets {
 			if w.WalletType == "enforcer" {
 				return connect.NewResponse(&pb.GetWalletSeedResponse{
-					SeedHex: w.Master.SeedHex,
+					SeedHex:  w.Master.SeedHex,
+					Mnemonic: w.Master.Mnemonic,
 				}), nil
 			}
 		}
@@ -1044,7 +1048,8 @@ func (h *WalletHandler) GetWalletSeed(ctx context.Context, req *connect.Request[
 	for _, w := range wallets {
 		if w.ID == walletID {
 			return connect.NewResponse(&pb.GetWalletSeedResponse{
-				SeedHex: w.Master.SeedHex,
+				SeedHex:  w.Master.SeedHex,
+				Mnemonic: w.Master.Mnemonic,
 			}), nil
 		}
 	}

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -1101,7 +1101,7 @@ func (h *WalletHandler) WatchWalletData(ctx context.Context, req *connect.Reques
 }
 
 func (h *WalletHandler) sendWalletData(ctx context.Context, stream *connect.ServerStream[pb.WatchWalletDataResponse]) error {
-	wallets := h.svc.ListWallets()
+	wallets := h.svc.GetAllWallets()
 	pbWallets := make([]*pb.WalletMetadata, len(wallets))
 	for i, w := range wallets {
 		var gradientJSON string
@@ -1109,11 +1109,12 @@ func (h *WalletHandler) sendWalletData(ctx context.Context, stream *connect.Serv
 			gradientJSON = string(w.Gradient)
 		}
 		pbWallets[i] = &pb.WalletMetadata{
-			Id:           w.ID,
-			Name:         w.Name,
-			WalletType:   w.WalletType,
-			GradientJson: gradientJSON,
-			CreatedAt:    w.CreatedAt.Format(time.RFC3339),
+			Id:               w.ID,
+			Name:             w.Name,
+			WalletType:       w.WalletType,
+			GradientJson:     gradientJSON,
+			CreatedAt:        w.CreatedAt.Format(time.RFC3339),
+			Bip47PaymentCode: wallet.Bip47V3PaymentCodeFromSeed(w.Master.SeedHex),
 		}
 	}
 

--- a/sidechain-orchestrator/commands/commands.go
+++ b/sidechain-orchestrator/commands/commands.go
@@ -76,6 +76,7 @@ func Commands() []*cli.Command {
 		updateCommand,
 		whichCommand,
 		walletCommand,
+		resetCommand,
 	}
 
 	// Add sidechain proxy commands

--- a/sidechain-orchestrator/commands/reset.go
+++ b/sidechain-orchestrator/commands/reset.go
@@ -1,0 +1,160 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"connectrpc.com/connect"
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
+	"github.com/urfave/cli/v2"
+)
+
+var resetCommand = &cli.Command{
+	Name:  "reset",
+	Usage: "Preview or run a data reset via orchestratord",
+	Subcommands: []*cli.Command{
+		resetPreviewCommand,
+		resetRunCommand,
+	},
+}
+
+func resetCategoryFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{Name: "blockchain-data", Usage: "include blockchain data"},
+		&cli.BoolFlag{Name: "node-software", Usage: "include downloaded node binaries"},
+		&cli.BoolFlag{Name: "logs", Usage: "include log files"},
+		&cli.BoolFlag{Name: "settings", Usage: "include config / settings files"},
+		&cli.BoolFlag{Name: "wallets", Usage: "include wallet files (DANGEROUS)"},
+		&cli.BoolFlag{Name: "sidechains", Usage: "cascade the reset to sidechain data too"},
+	}
+}
+
+func resetCategoriesFromCtx(cctx *cli.Context) (blockchain, software, logs, settings, wallets, sidechains bool) {
+	return cctx.Bool("blockchain-data"),
+		cctx.Bool("node-software"),
+		cctx.Bool("logs"),
+		cctx.Bool("settings"),
+		cctx.Bool("wallets"),
+		cctx.Bool("sidechains")
+}
+
+func ensureAnyResetCategory(cctx *cli.Context) error {
+	blockchain, software, logs, settings, wallets, _ := resetCategoriesFromCtx(cctx)
+	if !(blockchain || software || logs || settings || wallets) {
+		return fmt.Errorf("pick at least one category: --blockchain-data, --node-software, --logs, --settings, --wallets")
+	}
+	return nil
+}
+
+var resetPreviewCommand = &cli.Command{
+	Name:  "preview",
+	Usage: "List what a reset would delete without touching anything",
+	Flags: resetCategoryFlags(),
+	Action: func(cctx *cli.Context) error {
+		if err := ensureAnyResetCategory(cctx); err != nil {
+			return err
+		}
+		client := newClient(cctx)
+		blockchain, software, logs, settings, wallets, sidechains := resetCategoriesFromCtx(cctx)
+		resp, err := client.PreviewResetData(cctx.Context, connect.NewRequest(&pb.PreviewResetDataRequest{
+			DeleteBlockchainData: blockchain,
+			DeleteNodeSoftware:   software,
+			DeleteLogs:           logs,
+			DeleteSettings:       settings,
+			DeleteWalletFiles:    wallets,
+			AlsoResetSidechains:  sidechains,
+		}))
+		if err != nil {
+			return err
+		}
+		if len(resp.Msg.Files) == 0 {
+			fmt.Println("nothing to delete")
+			return nil
+		}
+
+		var totalBytes int64
+		tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+		fmt.Fprintln(tw, "CATEGORY\tSIZE\tPATH\tKIND")
+		for _, f := range resp.Msg.Files {
+			kind := "file"
+			if f.IsDirectory {
+				kind = "dir"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", f.Category, humanBytes(f.SizeBytes), f.Path, kind)
+			totalBytes += f.SizeBytes
+		}
+		if err := tw.Flush(); err != nil {
+			return err
+		}
+		fmt.Printf("\n%d items, %s total\n", len(resp.Msg.Files), humanBytes(totalBytes))
+		return nil
+	},
+}
+
+var resetRunCommand = &cli.Command{
+	Name:  "run",
+	Usage: "Execute a reset — streams progress as files are deleted",
+	Flags: append(resetCategoryFlags(), &cli.BoolFlag{Name: "yes", Usage: "skip the confirmation prompt"}),
+	Action: func(cctx *cli.Context) error {
+		if err := ensureAnyResetCategory(cctx); err != nil {
+			return err
+		}
+		prompt := "this will delete data via orchestratord. proceed?"
+		if cctx.Bool("wallets") {
+			prompt = "this will delete WALLET files (⚠️ funds at risk). proceed?"
+		}
+		if err := confirmOrAbort(cctx, prompt); err != nil {
+			return err
+		}
+
+		client := newClient(cctx)
+		blockchain, software, logs, settings, wallets, sidechains := resetCategoriesFromCtx(cctx)
+		stream, err := client.StreamResetData(cctx.Context, connect.NewRequest(&pb.StreamResetDataRequest{
+			DeleteBlockchainData: blockchain,
+			DeleteNodeSoftware:   software,
+			DeleteLogs:           logs,
+			DeleteSettings:       settings,
+			DeleteWalletFiles:    wallets,
+			AlsoResetSidechains:  sidechains,
+		}))
+		if err != nil {
+			return err
+		}
+
+		var last *pb.StreamResetDataResponse
+		for stream.Receive() {
+			msg := stream.Msg()
+			last = msg
+			if msg.Done {
+				break
+			}
+			status := "ok"
+			if !msg.Success {
+				status = fmt.Sprintf("FAIL (%s)", msg.Error)
+			}
+			fmt.Printf("  %-8s %s  %s\n", status, msg.Category, msg.Path)
+		}
+		if err := stream.Err(); err != nil {
+			return err
+		}
+		if last != nil && last.Done {
+			fmt.Printf("\ndeleted %d, failed %d\n", last.DeletedCount, last.FailedCount)
+		}
+		return nil
+	},
+}
+
+// humanBytes turns a byte count into a short human-readable string: 1.2 MB etc.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for i := n / unit; i >= unit; i /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/sidechain-orchestrator/commands/wallet.go
+++ b/sidechain-orchestrator/commands/wallet.go
@@ -3,12 +3,19 @@ package commands
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
 
 	"connectrpc.com/connect"
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	rpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
 	"github.com/urfave/cli/v2"
 )
+
+const satsPerBTC = 100_000_000
 
 func newWalletClient(cctx *cli.Context) rpc.WalletManagerServiceClient {
 	addr := cctx.String("rpcserver")
@@ -18,6 +25,44 @@ func newWalletClient(cctx *cli.Context) rpc.WalletManagerServiceClient {
 		url,
 		connect.WithGRPC(),
 	)
+}
+
+// resolveWalletID returns the positional wallet-id arg, falling back to the
+// active wallet ID from GetWalletStatus when no arg was given. Returns a
+// friendly error if no wallet is active.
+func resolveWalletID(cctx *cli.Context, client rpc.WalletManagerServiceClient) (string, error) {
+	if cctx.NArg() >= 1 {
+		return cctx.Args().First(), nil
+	}
+	resp, err := client.GetWalletStatus(cctx.Context, connect.NewRequest(&pb.GetWalletStatusRequest{}))
+	if err != nil {
+		return "", fmt.Errorf("get wallet status: %w", err)
+	}
+	if !resp.Msg.HasWallet || resp.Msg.ActiveWalletId == "" {
+		return "", fmt.Errorf("no active wallet — pass a wallet id or run `wallet setactive <id>`")
+	}
+	return resp.Msg.ActiveWalletId, nil
+}
+
+// confirmOrAbort prompts on stdin unless `--yes` was passed. Returns an error
+// if the user declines.
+func confirmOrAbort(cctx *cli.Context, prompt string) error {
+	if cctx.Bool("yes") {
+		return nil
+	}
+	fmt.Print(prompt + " [y/N] ")
+	if !confirmYes() {
+		return fmt.Errorf("aborted")
+	}
+	return nil
+}
+
+func satsToBtc(sats float64) string {
+	return fmt.Sprintf("%.8f", sats/float64(satsPerBTC))
+}
+
+func satsToBtcInt(sats int64) string {
+	return fmt.Sprintf("%.8f", float64(sats)/float64(satsPerBTC))
 }
 
 var walletCommand = &cli.Command{
@@ -32,7 +77,22 @@ var walletCommand = &cli.Command{
 		walletLockCommand,
 		walletUnlockCommand,
 		walletEncryptCommand,
-		walletMnemonicCommand,
+		walletChangePasswordCommand,
+		walletRemoveEncryptionCommand,
+		walletRenameCommand,
+		walletSeedCommand,
+		walletBalanceCommand,
+		walletNewAddressCommand,
+		walletAddressesCommand,
+		walletTransactionsCommand,
+		walletUnspentCommand,
+		walletSendCommand,
+		walletTxCommand,
+		walletBumpFeeCommand,
+		walletDeriveCommand,
+		walletWatchOnlyCreateCommand,
+		walletCoreCreateCommand,
+		walletEnsureCoreCommand,
 	},
 }
 
@@ -103,6 +163,13 @@ var walletCreateCommand = &cli.Command{
 var walletListCommand = &cli.Command{
 	Name:  "list",
 	Usage: "List all wallets",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "verbose",
+			Aliases: []string{"v"},
+			Usage:   "include gradient JSON column",
+		},
+	},
 	Action: func(cctx *cli.Context) error {
 		client := newWalletClient(cctx)
 		resp, err := client.ListWallets(cctx.Context, connect.NewRequest(&pb.ListWalletsRequest{}))
@@ -115,10 +182,34 @@ var walletListCommand = &cli.Command{
 			return nil
 		}
 
-		for _, w := range resp.Msg.Wallets {
-			fmt.Printf("  %-20s %-14s %s\n", w.Name, w.WalletType, w.Id)
+		activeID := resp.Msg.ActiveWalletId
+		tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+		verbose := cctx.Bool("verbose")
+		if verbose {
+			fmt.Fprintln(tw, "ACTIVE\tID\tNAME\tTYPE\tCREATED\tBIP47\tGRADIENT")
+		} else {
+			fmt.Fprintln(tw, "ACTIVE\tID\tNAME\tTYPE\tCREATED\tBIP47")
 		}
-		return nil
+		for _, w := range resp.Msg.Wallets {
+			marker := " "
+			if w.Id == activeID {
+				marker = "*"
+			}
+			bip47 := w.Bip47PaymentCode
+			if bip47 == "" {
+				bip47 = "-"
+			}
+			if verbose {
+				grad := w.GradientJson
+				if grad == "" {
+					grad = "-"
+				}
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", marker, w.Id, w.Name, w.WalletType, w.CreatedAt, bip47, grad)
+			} else {
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", marker, w.Id, w.Name, w.WalletType, w.CreatedAt, bip47)
+			}
+		}
+		return tw.Flush()
 	},
 }
 
@@ -247,26 +338,566 @@ var walletEncryptCommand = &cli.Command{
 	},
 }
 
-var walletMnemonicCommand = &cli.Command{
-	Name:      "mnemonic",
-	Usage:     "Show the mnemonic for a wallet",
+var walletChangePasswordCommand = &cli.Command{
+	Name:  "change-password",
+	Usage: "Change the wallet encryption password",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "old", Usage: "current password", Required: true},
+		&cli.StringFlag{Name: "new", Usage: "new password", Required: true},
+		&cli.BoolFlag{Name: "yes", Usage: "skip the confirmation prompt"},
+	},
+	Action: func(cctx *cli.Context) error {
+		if err := confirmOrAbort(cctx, "change wallet encryption password?"); err != nil {
+			return err
+		}
+		client := newWalletClient(cctx)
+		_, err := client.ChangePassword(cctx.Context, connect.NewRequest(&pb.ChangePasswordRequest{
+			OldPassword: cctx.String("old"),
+			NewPassword: cctx.String("new"),
+		}))
+		if err != nil {
+			return err
+		}
+		fmt.Println("password changed")
+		return nil
+	},
+}
+
+var walletRemoveEncryptionCommand = &cli.Command{
+	Name:  "remove-encryption",
+	Usage: "Remove wallet encryption (keeps funds, removes password)",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "password", Usage: "current password", Required: true},
+		&cli.BoolFlag{Name: "yes", Usage: "skip the confirmation prompt"},
+	},
+	Action: func(cctx *cli.Context) error {
+		if err := confirmOrAbort(cctx, "remove wallet encryption (wallet will become unencrypted)?"); err != nil {
+			return err
+		}
+		client := newWalletClient(cctx)
+		_, err := client.RemoveEncryption(cctx.Context, connect.NewRequest(&pb.RemoveEncryptionRequest{
+			Password: cctx.String("password"),
+		}))
+		if err != nil {
+			return err
+		}
+		fmt.Println("encryption removed")
+		return nil
+	},
+}
+
+var walletRenameCommand = &cli.Command{
+	Name:      "rename",
+	Usage:     "Update a wallet's name or gradient metadata",
 	ArgsUsage: "<wallet-id>",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "name", Usage: "new wallet name", Required: true},
+		&cli.StringFlag{Name: "gradient", Usage: "gradient JSON (optional)"},
+	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() < 1 {
-			return fmt.Errorf("usage: orchestratorctl wallet mnemonic <wallet-id>")
+			return fmt.Errorf("usage: orchestratorctl wallet rename <wallet-id> --name NAME [--gradient JSON]")
+		}
+		client := newWalletClient(cctx)
+		_, err := client.UpdateWalletMetadata(cctx.Context, connect.NewRequest(&pb.UpdateWalletMetadataRequest{
+			WalletId:     cctx.Args().First(),
+			Name:         cctx.String("name"),
+			GradientJson: cctx.String("gradient"),
+		}))
+		if err != nil {
+			return err
+		}
+		fmt.Println("metadata updated")
+		return nil
+	},
+}
+
+var walletSeedCommand = &cli.Command{
+	Name:      "seed",
+	Aliases:   []string{"mnemonic"},
+	Usage:     "Show the seed + mnemonic for a wallet (SENSITIVE)",
+	ArgsUsage: "<wallet-id>",
+	Description: "Prints the 64-byte BIP39 seed as hex and the mnemonic words.\n" +
+		"Pass an empty wallet-id or '-' to read the active enforcer wallet.",
+	Action: func(cctx *cli.Context) error {
+		walletID := ""
+		if cctx.NArg() >= 1 && cctx.Args().First() != "-" {
+			walletID = cctx.Args().First()
 		}
 
 		client := newWalletClient(cctx)
-
 		resp, err := client.GetWalletSeed(cctx.Context, connect.NewRequest(&pb.GetWalletSeedRequest{
-			WalletId: cctx.Args().First(),
+			WalletId: walletID,
 		}))
 		if err != nil {
 			return err
 		}
 
 		fmt.Print("⚠️  SENSITIVE — do not share!\n\n")
-		fmt.Printf("seed: %s\n", resp.Msg.SeedHex)
+		fmt.Printf("seed:     %s\n", resp.Msg.SeedHex)
+		if resp.Msg.Mnemonic != "" {
+			fmt.Printf("mnemonic: %s\n", resp.Msg.Mnemonic)
+		}
 		return nil
 	},
+}
+
+var walletBalanceCommand = &cli.Command{
+	Name:      "balance",
+	Usage:     "Show the balance of a wallet",
+	ArgsUsage: "[wallet-id]",
+	Action: func(cctx *cli.Context) error {
+		client := newWalletClient(cctx)
+		walletID, err := resolveWalletID(cctx, client)
+		if err != nil {
+			return err
+		}
+		resp, err := client.GetBalance(cctx.Context, connect.NewRequest(&pb.GetBalanceRequest{WalletId: walletID}))
+		if err != nil {
+			return err
+		}
+		fmt.Printf("confirmed:   %s BTC (%.0f sats)\n", satsToBtc(resp.Msg.ConfirmedSats), resp.Msg.ConfirmedSats)
+		fmt.Printf("unconfirmed: %s BTC (%.0f sats)\n", satsToBtc(resp.Msg.UnconfirmedSats), resp.Msg.UnconfirmedSats)
+		return nil
+	},
+}
+
+var walletNewAddressCommand = &cli.Command{
+	Name:      "new-address",
+	Usage:     "Generate a fresh receive address",
+	ArgsUsage: "[wallet-id]",
+	Action: func(cctx *cli.Context) error {
+		client := newWalletClient(cctx)
+		walletID, err := resolveWalletID(cctx, client)
+		if err != nil {
+			return err
+		}
+		resp, err := client.GetNewAddress(cctx.Context, connect.NewRequest(&pb.GetNewAddressRequest{WalletId: walletID}))
+		if err != nil {
+			return err
+		}
+		fmt.Println(resp.Msg.Address)
+		return nil
+	},
+}
+
+var walletAddressesCommand = &cli.Command{
+	Name:      "addresses",
+	Usage:     "List receive addresses for a wallet",
+	ArgsUsage: "[wallet-id]",
+	Action: func(cctx *cli.Context) error {
+		client := newWalletClient(cctx)
+		walletID, err := resolveWalletID(cctx, client)
+		if err != nil {
+			return err
+		}
+		resp, err := client.ListReceiveAddresses(cctx.Context, connect.NewRequest(&pb.ListReceiveAddressesRequest{WalletId: walletID}))
+		if err != nil {
+			return err
+		}
+		if len(resp.Msg.Addresses) == 0 {
+			fmt.Println("no receive addresses")
+			return nil
+		}
+		tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+		fmt.Fprintln(tw, "ADDRESS\tRECEIVED (BTC)\tTX COUNT\tLABEL")
+		for _, a := range resp.Msg.Addresses {
+			label := a.Label
+			if label == "" {
+				label = "-"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%d\t%s\n", a.Address, satsToBtcInt(a.AmountSats), a.TxCount, label)
+		}
+		return tw.Flush()
+	},
+}
+
+var walletTransactionsCommand = &cli.Command{
+	Name:      "transactions",
+	Aliases:   []string{"txs"},
+	Usage:     "List recent transactions",
+	ArgsUsage: "[wallet-id]",
+	Flags: []cli.Flag{
+		&cli.IntFlag{Name: "count", Usage: "max transactions to return", Value: 100},
+	},
+	Action: func(cctx *cli.Context) error {
+		client := newWalletClient(cctx)
+		walletID, err := resolveWalletID(cctx, client)
+		if err != nil {
+			return err
+		}
+		resp, err := client.ListTransactions(cctx.Context, connect.NewRequest(&pb.ListTransactionsRequest{
+			WalletId: walletID,
+			Count:    int32(cctx.Int("count")),
+		}))
+		if err != nil {
+			return err
+		}
+		if len(resp.Msg.Transactions) == 0 {
+			fmt.Println("no transactions")
+			return nil
+		}
+		tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+		fmt.Fprintln(tw, "TIME\tCATEGORY\tAMOUNT (BTC)\tCONF\tTXID")
+		for _, t := range resp.Msg.Transactions {
+			ts := "-"
+			if t.Time != 0 {
+				ts = time.Unix(t.Time, 0).Format("2006-01-02 15:04")
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n", ts, t.Category, satsToBtcInt(t.AmountSats), t.Confirmations, t.Txid)
+		}
+		return tw.Flush()
+	},
+}
+
+var walletUnspentCommand = &cli.Command{
+	Name:      "unspent",
+	Aliases:   []string{"utxos"},
+	Usage:     "List unspent outputs owned by a wallet",
+	ArgsUsage: "[wallet-id]",
+	Action: func(cctx *cli.Context) error {
+		client := newWalletClient(cctx)
+		walletID, err := resolveWalletID(cctx, client)
+		if err != nil {
+			return err
+		}
+		resp, err := client.ListUnspent(cctx.Context, connect.NewRequest(&pb.ListUnspentRequest{WalletId: walletID}))
+		if err != nil {
+			return err
+		}
+		if len(resp.Msg.Utxos) == 0 {
+			fmt.Println("no unspent outputs")
+			return nil
+		}
+		tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+		fmt.Fprintln(tw, "OUTPOINT\tADDRESS\tBTC\tCONF\tLABEL")
+		for _, u := range resp.Msg.Utxos {
+			label := u.Label
+			if label == "" {
+				label = "-"
+			}
+			fmt.Fprintf(tw, "%s:%d\t%s\t%s\t%d\t%s\n", u.Txid, u.Vout, u.Address, satsToBtcInt(u.AmountSats), u.Confirmations, label)
+		}
+		return tw.Flush()
+	},
+}
+
+var walletSendCommand = &cli.Command{
+	Name:      "send",
+	Usage:     "Send sats from the wallet",
+	ArgsUsage: "[wallet-id]",
+	Description: "Single recipient via --to/--sats, or multi-recipient via --destination=ADDR:SATS (repeatable).\n" +
+		"Either a feerate (--fee-rate, sat/vB) or a fixed fee (--fixed-fee-sats) may be given.",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "to", Usage: "recipient address (single-recipient shortcut)"},
+		&cli.Int64Flag{Name: "sats", Usage: "amount in satoshis for --to"},
+		&cli.StringSliceFlag{Name: "destination", Usage: "ADDR:SATS (repeatable)"},
+		&cli.Int64Flag{Name: "fee-rate", Usage: "sat/vbyte (0 = default)"},
+		&cli.Int64Flag{Name: "fixed-fee-sats", Usage: "exact fee in sats"},
+		&cli.BoolFlag{Name: "subtract-fee", Usage: "deduct fee from the recipient amount"},
+		&cli.StringFlag{Name: "op-return", Usage: "OP_RETURN payload, UTF-8"},
+		&cli.StringFlag{Name: "op-return-hex", Usage: "OP_RETURN payload, raw hex (takes precedence over --op-return)"},
+		&cli.BoolFlag{Name: "yes", Usage: "skip the confirmation prompt"},
+	},
+	Action: func(cctx *cli.Context) error {
+		client := newWalletClient(cctx)
+		walletID, err := resolveWalletID(cctx, client)
+		if err != nil {
+			return err
+		}
+
+		destinations, err := parseSendDestinations(cctx)
+		if err != nil {
+			return err
+		}
+
+		opReturnHex := cctx.String("op-return-hex")
+		if opReturnHex == "" && cctx.String("op-return") != "" {
+			opReturnHex = hexEncode([]byte(cctx.String("op-return")))
+		}
+
+		summary := describeSend(walletID, destinations, cctx)
+		fmt.Println(summary)
+		if err := confirmOrAbort(cctx, "send?"); err != nil {
+			return err
+		}
+
+		resp, err := client.SendTransaction(cctx.Context, connect.NewRequest(&pb.SendTransactionRequest{
+			WalletId:              walletID,
+			Destinations:          destinations,
+			FeeRateSatPerVbyte:    cctx.Int64("fee-rate"),
+			FixedFeeSats:          cctx.Int64("fixed-fee-sats"),
+			SubtractFeeFromAmount: cctx.Bool("subtract-fee"),
+			OpReturnHex:           opReturnHex,
+		}))
+		if err != nil {
+			return err
+		}
+		fmt.Printf("sent: %s\n", resp.Msg.Txid)
+		return nil
+	},
+}
+
+var walletTxCommand = &cli.Command{
+	Name:      "tx",
+	Usage:     "Show transaction details by txid",
+	ArgsUsage: "[wallet-id] <txid>",
+	Action: func(cctx *cli.Context) error {
+		if cctx.NArg() == 0 {
+			return fmt.Errorf("usage: orchestratorctl wallet tx [wallet-id] <txid>")
+		}
+		client := newWalletClient(cctx)
+
+		var walletID, txid string
+		switch cctx.NArg() {
+		case 1:
+			id, err := resolveWalletID(cctx, client)
+			if err != nil {
+				return err
+			}
+			walletID = id
+			txid = cctx.Args().First()
+		default:
+			walletID = cctx.Args().First()
+			txid = cctx.Args().Get(1)
+		}
+
+		resp, err := client.GetTransactionDetails(cctx.Context, connect.NewRequest(&pb.GetTransactionDetailsRequest{
+			WalletId: walletID,
+			Txid:     txid,
+		}))
+		if err != nil {
+			return err
+		}
+		m := resp.Msg
+		fmt.Printf("txid:           %s\n", m.Transaction.Txid)
+		fmt.Printf("confirmations:  %d\n", m.Confirmations)
+		fmt.Printf("blockhash:      %s\n", m.Blockhash)
+		if m.BlockTime != 0 {
+			fmt.Printf("block_time:     %s\n", time.Unix(m.BlockTime, 0).Format(time.RFC3339))
+		}
+		fmt.Printf("size:           %d bytes (%d vB, %d WU)\n", m.SizeBytes, m.VsizeVbytes, m.WeightWu)
+		fmt.Printf("fee:            %s BTC (%d sats @ %.2f sat/vB)\n", satsToBtcInt(m.FeeSats), m.FeeSats, m.FeeRateSatVb)
+		fmt.Printf("total input:    %s BTC\n", satsToBtcInt(m.TotalInputSats))
+		fmt.Printf("total output:   %s BTC\n", satsToBtcInt(m.TotalOutputSats))
+
+		if len(m.Inputs) > 0 {
+			fmt.Println("\ninputs:")
+			tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+			fmt.Fprintln(tw, "  IDX\tPREV\tADDRESS\tSATS")
+			for _, in := range m.Inputs {
+				fmt.Fprintf(tw, "  %d\t%s:%d\t%s\t%d\n", in.Index, in.PrevTxid, in.PrevVout, in.Address, in.ValueSats)
+			}
+			_ = tw.Flush()
+		}
+		if len(m.Outputs) > 0 {
+			fmt.Println("\noutputs:")
+			tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+			fmt.Fprintln(tw, "  IDX\tADDRESS\tSATS\tTYPE")
+			for _, out := range m.Outputs {
+				fmt.Fprintf(tw, "  %d\t%s\t%d\t%s\n", out.Index, out.Address, out.ValueSats, out.ScriptType)
+			}
+			_ = tw.Flush()
+		}
+		return nil
+	},
+}
+
+var walletBumpFeeCommand = &cli.Command{
+	Name:      "bump-fee",
+	Usage:     "Replace a transaction with a higher-fee version (RBF)",
+	ArgsUsage: "[wallet-id] <txid>",
+	Flags: []cli.Flag{
+		&cli.Int64Flag{Name: "fee-rate", Usage: "new fee rate in sat/vB (0 = automatic)"},
+	},
+	Action: func(cctx *cli.Context) error {
+		if cctx.NArg() == 0 {
+			return fmt.Errorf("usage: orchestratorctl wallet bump-fee [wallet-id] <txid> [--fee-rate N]")
+		}
+		client := newWalletClient(cctx)
+		var walletID, txid string
+		switch cctx.NArg() {
+		case 1:
+			id, err := resolveWalletID(cctx, client)
+			if err != nil {
+				return err
+			}
+			walletID = id
+			txid = cctx.Args().First()
+		default:
+			walletID = cctx.Args().First()
+			txid = cctx.Args().Get(1)
+		}
+
+		resp, err := client.BumpFee(cctx.Context, connect.NewRequest(&pb.BumpFeeRequest{
+			WalletId:   walletID,
+			Txid:       txid,
+			NewFeeRate: cctx.Int64("fee-rate"),
+		}))
+		if err != nil {
+			return err
+		}
+		fmt.Printf("replaced txid: %s\n", resp.Msg.NewTxid)
+		return nil
+	},
+}
+
+var walletDeriveCommand = &cli.Command{
+	Name:      "derive",
+	Usage:     "Derive a range of addresses without consuming them",
+	ArgsUsage: "[wallet-id]",
+	Flags: []cli.Flag{
+		&cli.IntFlag{Name: "start", Usage: "start index (inclusive)", Value: 0},
+		&cli.IntFlag{Name: "count", Usage: "how many to derive", Value: 10},
+	},
+	Action: func(cctx *cli.Context) error {
+		client := newWalletClient(cctx)
+		walletID, err := resolveWalletID(cctx, client)
+		if err != nil {
+			return err
+		}
+		resp, err := client.DeriveAddresses(cctx.Context, connect.NewRequest(&pb.DeriveAddressesRequest{
+			WalletId:   walletID,
+			StartIndex: int32(cctx.Int("start")),
+			Count:      int32(cctx.Int("count")),
+		}))
+		if err != nil {
+			return err
+		}
+		for i, a := range resp.Msg.Addresses {
+			fmt.Printf("%d\t%s\n", int(cctx.Int("start"))+i, a)
+		}
+		return nil
+	},
+}
+
+var walletWatchOnlyCreateCommand = &cli.Command{
+	Name:  "watch-only-create",
+	Usage: "Create a watch-only wallet from an xpub or descriptor",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "name", Usage: "wallet name", Required: true},
+		&cli.StringFlag{Name: "xpub-or-descriptor", Usage: "xpub or output descriptor", Required: true},
+		&cli.StringFlag{Name: "gradient", Usage: "gradient JSON (optional)"},
+	},
+	Action: func(cctx *cli.Context) error {
+		client := newWalletClient(cctx)
+		resp, err := client.CreateWatchOnlyWallet(cctx.Context, connect.NewRequest(&pb.CreateWatchOnlyWalletRequest{
+			Name:             cctx.String("name"),
+			XpubOrDescriptor: cctx.String("xpub-or-descriptor"),
+			GradientJson:     cctx.String("gradient"),
+		}))
+		if err != nil {
+			return err
+		}
+		fmt.Printf("watch-only wallet created: %s\n", resp.Msg.WalletId)
+		return nil
+	},
+}
+
+var walletCoreCreateCommand = &cli.Command{
+	Name:      "core-create",
+	Usage:     "Materialise a wallet.json entry as a Bitcoin Core descriptor wallet",
+	ArgsUsage: "[wallet-id]",
+	Action: func(cctx *cli.Context) error {
+		client := newWalletClient(cctx)
+		walletID, err := resolveWalletID(cctx, client)
+		if err != nil {
+			return err
+		}
+		resp, err := client.CreateBitcoinCoreWallet(cctx.Context, connect.NewRequest(&pb.CreateBitcoinCoreWalletRequest{
+			WalletId: walletID,
+		}))
+		if err != nil {
+			return err
+		}
+		fmt.Printf("core wallet ready: %s\n", resp.Msg.CoreWalletName)
+		return nil
+	},
+}
+
+var walletEnsureCoreCommand = &cli.Command{
+	Name:  "ensure-core",
+	Usage: "Create missing Bitcoin Core wallets for every entry in wallet.json",
+	Action: func(cctx *cli.Context) error {
+		client := newWalletClient(cctx)
+		resp, err := client.EnsureCoreWallets(cctx.Context, connect.NewRequest(&pb.EnsureCoreWalletsRequest{}))
+		if err != nil {
+			return err
+		}
+		fmt.Printf("synced %d wallet(s)\n", resp.Msg.SyncedCount)
+		return nil
+	},
+}
+
+// parseSendDestinations combines --to/--sats and --destination flags into a
+// single map. Returns an error if no destination is provided or values can't
+// be parsed.
+func parseSendDestinations(cctx *cli.Context) (map[string]int64, error) {
+	dests := map[string]int64{}
+	if to := cctx.String("to"); to != "" {
+		sats := cctx.Int64("sats")
+		if sats <= 0 {
+			return nil, fmt.Errorf("--to requires --sats > 0")
+		}
+		dests[to] = sats
+	}
+	for _, d := range cctx.StringSlice("destination") {
+		addr, satsStr, ok := strings.Cut(d, ":")
+		if !ok {
+			return nil, fmt.Errorf("invalid --destination %q (expected ADDR:SATS)", d)
+		}
+		sats, err := strconv.ParseInt(satsStr, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sats in --destination %q: %w", d, err)
+		}
+		if sats <= 0 {
+			return nil, fmt.Errorf("destination %q has non-positive sats", addr)
+		}
+		if _, exists := dests[addr]; exists {
+			return nil, fmt.Errorf("duplicate destination address %q", addr)
+		}
+		dests[addr] = sats
+	}
+	if len(dests) == 0 {
+		return nil, fmt.Errorf("no destinations — pass --to/--sats or --destination=ADDR:SATS")
+	}
+	return dests, nil
+}
+
+// describeSend returns a human-readable summary of a send request for use in
+// the pre-confirmation prompt.
+func describeSend(walletID string, dests map[string]int64, cctx *cli.Context) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "wallet: %s\n", walletID)
+	for addr, sats := range dests {
+		fmt.Fprintf(&b, "  → %s: %s BTC (%d sats)\n", addr, satsToBtcInt(sats), sats)
+	}
+	if fr := cctx.Int64("fee-rate"); fr > 0 {
+		fmt.Fprintf(&b, "fee rate: %d sat/vB\n", fr)
+	}
+	if ff := cctx.Int64("fixed-fee-sats"); ff > 0 {
+		fmt.Fprintf(&b, "fixed fee: %d sats\n", ff)
+	}
+	if cctx.Bool("subtract-fee") {
+		b.WriteString("subtract fee from amount: yes\n")
+	}
+	if op := cctx.String("op-return"); op != "" {
+		fmt.Fprintf(&b, "op_return: %s\n", op)
+	}
+	if op := cctx.String("op-return-hex"); op != "" {
+		fmt.Fprintf(&b, "op_return_hex: %s\n", op)
+	}
+	return b.String()
+}
+
+// hexEncode is a tiny wrapper that avoids pulling in the full encoding/hex
+// import surface for a single call site.
+func hexEncode(data []byte) string {
+	const hexDigits = "0123456789abcdef"
+	out := make([]byte, len(data)*2)
+	for i, b := range data {
+		out[i*2] = hexDigits[b>>4]
+		out[i*2+1] = hexDigits[b&0x0f]
+	}
+	return string(out)
 }

--- a/sidechain-orchestrator/connection_monitor.go
+++ b/sidechain-orchestrator/connection_monitor.go
@@ -253,6 +253,22 @@ func (m *ConnectionMonitor) SetInitializing(v bool) {
 	m.notifyChange()
 }
 
+// SetStopping flips the stopping flag and fires onChange so the frontend
+// sees the transition immediately. Orchestrator calls SetStopping(true)
+// right before signalling the process, so the UI can badge the binary as
+// "stopping" during the shutdown window (between signal and exit).
+// MarkStopped resets the flag to false once the process is actually gone.
+func (m *ConnectionMonitor) SetStopping(v bool) {
+	m.mu.Lock()
+	if m.stoppingBinary == v {
+		m.mu.Unlock()
+		return
+	}
+	m.stoppingBinary = v
+	m.mu.Unlock()
+	m.notifyChange()
+}
+
 // ConnectModeOnly returns whether the monitor is in connect-mode-only
 // (willfully stopped, only watching for external restart).
 func (m *ConnectionMonitor) ConnectModeOnly() bool {

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -3024,8 +3024,10 @@ func (x *GetWalletSeedRequest) GetWalletId() string {
 }
 
 type GetWalletSeedResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SeedHex       string                 `protobuf:"bytes,1,opt,name=seed_hex,json=seedHex,proto3" json:"seed_hex,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	SeedHex string                 `protobuf:"bytes,1,opt,name=seed_hex,json=seedHex,proto3" json:"seed_hex,omitempty"`
+	// BIP39 mnemonic words for the wallet. Sensitive — treat like seed_hex.
+	Mnemonic      string `protobuf:"bytes,2,opt,name=mnemonic,proto3" json:"mnemonic,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3063,6 +3065,13 @@ func (*GetWalletSeedResponse) Descriptor() ([]byte, []int) {
 func (x *GetWalletSeedResponse) GetSeedHex() string {
 	if x != nil {
 		return x.SeedHex
+	}
+	return ""
+}
+
+func (x *GetWalletSeedResponse) GetMnemonic() string {
+	if x != nil {
+		return x.Mnemonic
 	}
 	return ""
 }
@@ -3372,9 +3381,10 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x17DeriveAddressesResponse\x12\x1c\n" +
 	"\taddresses\x18\x01 \x03(\tR\taddresses\"3\n" +
 	"\x14GetWalletSeedRequest\x12\x1b\n" +
-	"\twallet_id\x18\x01 \x01(\tR\bwalletId\"2\n" +
+	"\twallet_id\x18\x01 \x01(\tR\bwalletId\"N\n" +
 	"\x15GetWalletSeedResponse\x12\x19\n" +
-	"\bseed_hex\x18\x01 \x01(\tR\aseedHex\"\xaa\x02\n" +
+	"\bseed_hex\x18\x01 \x01(\tR\aseedHex\x12\x1a\n" +
+	"\bmnemonic\x18\x02 \x01(\tR\bmnemonic\"\xaa\x02\n" +
 	"\x17WatchWalletDataResponse\x12\x1d\n" +
 	"\n" +
 	"has_wallet\x18\x01 \x01(\bR\thasWallet\x12\x1c\n" +

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -647,14 +647,17 @@ func (*RemoveEncryptionResponse) Descriptor() ([]byte, []int) {
 }
 
 type WalletMetadata struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	WalletType    string                 `protobuf:"bytes,3,opt,name=wallet_type,json=walletType,proto3" json:"wallet_type,omitempty"`
-	GradientJson  string                 `protobuf:"bytes,4,opt,name=gradient_json,json=gradientJson,proto3" json:"gradient_json,omitempty"`
-	CreatedAt     string                 `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"` // ISO 8601
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Id           string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name         string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	WalletType   string                 `protobuf:"bytes,3,opt,name=wallet_type,json=walletType,proto3" json:"wallet_type,omitempty"`
+	GradientJson string                 `protobuf:"bytes,4,opt,name=gradient_json,json=gradientJson,proto3" json:"gradient_json,omitempty"`
+	CreatedAt    string                 `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"` // ISO 8601
+	// BIP47 v3 payment code derived from the wallet's master pubkey.
+	// Deterministic per wallet, never changes. Empty for watch-only wallets.
+	Bip47PaymentCode string `protobuf:"bytes,6,opt,name=bip47_payment_code,json=bip47PaymentCode,proto3" json:"bip47_payment_code,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *WalletMetadata) Reset() {
@@ -718,6 +721,13 @@ func (x *WalletMetadata) GetGradientJson() string {
 func (x *WalletMetadata) GetCreatedAt() string {
 	if x != nil {
 		return x.CreatedAt
+	}
+	return ""
+}
+
+func (x *WalletMetadata) GetBip47PaymentCode() string {
+	if x != nil {
+		return x.Bip47PaymentCode
 	}
 	return ""
 }
@@ -3188,7 +3198,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x16ChangePasswordResponse\"5\n" +
 	"\x17RemoveEncryptionRequest\x12\x1a\n" +
 	"\bpassword\x18\x01 \x01(\tR\bpassword\"\x1a\n" +
-	"\x18RemoveEncryptionResponse\"\x99\x01\n" +
+	"\x18RemoveEncryptionResponse\"\xc7\x01\n" +
 	"\x0eWalletMetadata\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1f\n" +
@@ -3196,7 +3206,8 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"walletType\x12#\n" +
 	"\rgradient_json\x18\x04 \x01(\tR\fgradientJson\x12\x1d\n" +
 	"\n" +
-	"created_at\x18\x05 \x01(\tR\tcreatedAt\"\x14\n" +
+	"created_at\x18\x05 \x01(\tR\tcreatedAt\x12,\n" +
+	"\x12bip47_payment_code\x18\x06 \x01(\tR\x10bip47PaymentCode\"\x14\n" +
 	"\x12ListWalletsRequest\"{\n" +
 	"\x13ListWalletsResponse\x12:\n" +
 	"\awallets\x18\x01 \x03(\v2 .walletmanager.v1.WalletMetadataR\awallets\x12(\n" +

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -321,6 +321,15 @@ func (o *Orchestrator) Start(ctx context.Context, name string, args []string, en
 // Stop stops a running binary and marks its monitor as stopped so
 // the restart timer won't automatically bring it back.
 func (o *Orchestrator) Stop(ctx context.Context, name string, force bool) error {
+	// Flip "stopping" before sending the signal so the frontend shows
+	// a stopping badge during the graceful-shutdown window. MarkStopped
+	// below clears the flag once the process has actually exited.
+	o.monitorsMu.Lock()
+	if mon, ok := o.monitors[name]; ok {
+		mon.SetStopping(true)
+	}
+	o.monitorsMu.Unlock()
+
 	err := o.process.Stop(ctx, name, force)
 
 	// Always mark the monitor as stopped, even if process.Stop failed
@@ -1002,6 +1011,15 @@ func (o *Orchestrator) ShutdownAll(ctx context.Context, force bool) (<-chan Shut
 				CompletedCount: completed,
 				CurrentBinary:  name,
 			}
+
+			// Flip stopping so the frontend shows a shutdown badge for the
+			// duration of this binary's graceful-kill window. MarkStopped
+			// below clears it.
+			o.monitorsMu.Lock()
+			if mon, ok := o.monitors[name]; ok {
+				mon.SetStopping(true)
+			}
+			o.monitorsMu.Unlock()
 
 			if !force && o.stopBinaryViaRPC(ctx, name) {
 				o.monitorsMu.Lock()

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -119,6 +119,9 @@ message WalletMetadata {
   string wallet_type = 3;
   string gradient_json = 4;
   string created_at = 5; // ISO 8601
+  // BIP47 v3 payment code derived from the wallet's master pubkey.
+  // Deterministic per wallet, never changes. Empty for watch-only wallets.
+  string bip47_payment_code = 6;
 }
 
 message ListWalletsRequest {}

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -364,6 +364,8 @@ message GetWalletSeedRequest {
 
 message GetWalletSeedResponse {
   string seed_hex = 1;
+  // BIP39 mnemonic words for the wallet. Sensitive — treat like seed_hex.
+  string mnemonic = 2;
 }
 
 // ============================================================================

--- a/sidechain-orchestrator/wallet/core_wallet.go
+++ b/sidechain-orchestrator/wallet/core_wallet.go
@@ -326,6 +326,32 @@ func masterFingerprint(masterKey *bip32.Key) string {
 	return hex.EncodeToString(h[:4])
 }
 
+// Bip47V3PaymentCodeFromSeed derives a BIP47 v3 payment code from a BIP32 seed.
+// Layout: version(0x22) || prefix(0x03) || compressed_master_pubkey(33B) || base58check.
+// Returns "" if seedHex is empty or malformed.
+func Bip47V3PaymentCodeFromSeed(seedHex string) string {
+	if seedHex == "" {
+		return ""
+	}
+	seed, err := hex.DecodeString(seedHex)
+	if err != nil {
+		return ""
+	}
+	masterKey, err := bip32.NewMasterKey(seed)
+	if err != nil {
+		return ""
+	}
+	pubKey := masterKey.PublicKey().Key // 33-byte compressed
+	if len(pubKey) != 33 {
+		return ""
+	}
+	payload := make([]byte, 35)
+	payload[0] = 0x22
+	payload[1] = 0x03
+	copy(payload[2:], pubKey)
+	return base58CheckEncode(payload)
+}
+
 // hash160 computes RIPEMD160(SHA256(data)).
 func hash160(data []byte) []byte {
 	sha := sha256.Sum256(data)

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.200
+version: 1.0.201
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.71
+version: 1.0.72
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.198
+version: 1.0.199
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
- **bitwindow: log faucet errors and show server message**
- **bitwindow: classify address book entries as L1/deposit/BIP47**
- **orchestrator: derive BIP47 payment code and stream to client**
- **bitwindow: add coinnews sync log, drop empty entries**
- **sail_ui: keep binary state on watchBinaries reconnect**
- **bitwindow: only refetch sidechains on actual wallet switch**
- **orchestrator: flip stopping flag during graceful shutdown**
