### PR TITLE
bitwindow: stamp coin news with block time, not sync time

### DIFF
--- a/bitwindow/server/database/migrations/033_coin_news_block_time_backfill.sql
+++ b/bitwindow/server/database/migrations/033_coin_news_block_time_backfill.sql
@@ -1,0 +1,15 @@
+-- Pre-fix, op_returns.created_at was stamped with time.Now() at sync, not the
+-- block timestamp. Rewrite confirmed rows from processed_blocks.block_time so
+-- existing CoinNews entries display the actual posting date. Mempool rows
+-- (height IS NULL) keep their wall-clock timestamp.
+UPDATE op_returns
+SET created_at = (
+    SELECT block_time
+    FROM processed_blocks
+    WHERE processed_blocks.height = op_returns.height
+)
+WHERE op_returns.height IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM processed_blocks
+    WHERE processed_blocks.height = op_returns.height
+  );

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -538,7 +538,7 @@ func (p *Parser) getBlock(ctx context.Context, height uint32) (*wire.MsgBlock, e
 
 // finds all OP_RETURN outputs for a specific tx
 func (p *Parser) handleOpReturns(
-	ctx context.Context, tx *wire.MsgTx, height *uint32, _ *time.Time,
+	ctx context.Context, tx *wire.MsgTx, height *uint32, createdAt *time.Time,
 ) ([]opreturns.OPReturn, error) {
 	txid := tx.TxID()
 
@@ -634,11 +634,12 @@ func (p *Parser) handleOpReturns(
 		}
 
 		opReturns = append(opReturns, opreturns.OPReturn{
-			TxID:   txid,
-			Data:   data,
-			Vout:   int32(vout),
-			Height: height,
-			Fee:    fee,
+			TxID:      txid,
+			Data:      data,
+			Vout:      int32(vout),
+			Height:    height,
+			Fee:       fee,
+			CreatedAt: createdAt,
 		})
 	}
 


### PR DESCRIPTION
Closes #1655.

`handleOpReturns` ignored the block timestamp parameter, so `Persist` fell back to `time.Now()` and stamped every confirmed OP_RETURN with the sync date. Use the block time on construction and backfill historical rows from `processed_blocks.block_time`.