### PR TITLE
sail_ui: render Ctrl labels for menu shortcuts on Linux/Windows

### DIFF
--- a/sail_ui/lib/widgets/platform_menu.dart
+++ b/sail_ui/lib/widgets/platform_menu.dart
@@ -174,12 +174,14 @@ class _MenuButtonState extends State<_MenuButton> {
   String _getShortcutLabel(MenuSerializableShortcut shortcut) {
     if (shortcut is SingleActivator) {
       final List<String> keys = [];
-      if (shortcut.meta) keys.add('⌘');
-      if (shortcut.shift) keys.add('⇧');
-      if (shortcut.alt) keys.add('⌥');
-      if (shortcut.control) keys.add('⌃');
+      // Shortcuts are authored with `meta: true` for macOS Cmd. macOS hits the
+      // native PlatformMenuBar path above, so this branch only runs on
+      // Linux/Windows — map meta to Ctrl instead of rendering ⌘.
+      if (shortcut.control || shortcut.meta) keys.add('Ctrl');
+      if (shortcut.shift) keys.add('Shift');
+      if (shortcut.alt) keys.add('Alt');
       keys.add(shortcut.trigger.keyLabel);
-      return keys.join(' ');
+      return keys.join('+');
     }
     return '';
   }


### PR DESCRIPTION
Closes #1658.

The custom non-Mac menu renderer was rendering ⌘/⇧/⌥/⌃ glyphs verbatim, so Linux users saw `⌘ Q` next to Quit etc. macOS still hits the native `PlatformMenuBar` path; this branch only runs on Linux/Windows, so map `meta` to `Ctrl` and use text labels (Ctrl/Shift/Alt joined with +).