### PR TITLE
bitwindow: stop crashing Starters tab when a mnemonic is unset

### DIFF
--- a/bitwindow/lib/widgets/starters_tab.dart
+++ b/bitwindow/lib/widgets/starters_tab.dart
@@ -313,7 +313,7 @@ TableRow mnemonicRow(
   BuildContext context,
   StartersPageViewModel viewModel,
   String name,
-  String mnemonic,
+  String? mnemonic,
   bool isRevealed,
   bool hasMnemonic,
 ) {
@@ -339,7 +339,7 @@ TableRow mnemonicRow(
       Padding(
         padding: const EdgeInsets.all(12.0),
         child: SailText.secondary13(
-          hasMnemonic ? (isRevealed ? mnemonic : '••••••••••••') : 'No starter generated',
+          hasMnemonic ? (isRevealed ? (mnemonic ?? '') : '••••••••••••') : 'No starter generated',
           color: hasMnemonic ? SailTheme.of(context).colors.text : SailTheme.of(context).colors.textSecondary,
         ),
       ),
@@ -351,7 +351,7 @@ TableRow mnemonicRow(
           children: [
             if (hasMnemonic) ...[
               CopyButton(
-                text: mnemonic,
+                text: mnemonic!,
               ),
               const SizedBox(width: 8),
               if (!isRevealed)


### PR DESCRIPTION
Closes #1660.

`mnemonicRow` declared `String mnemonic` (non-nullable), but `getL1Starter()` and `getSidechainStarter(slot)` can return null when a starter has not been derived yet. The `Map<String, dynamic>` carrying the null then failed the implicit cast at the call site → `type Null is not a subtype of type String`. Make the parameter nullable; the existing `hasMnemonic` branch already gates rendering.