### PR TITLE
bitwindow: regression-test coin news block-time backfill

### DIFF
--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.47
+version: 0.2.48
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/server/database/migrations/033_coin_news_block_time_backfill.sql
+++ b/bitwindow/server/database/migrations/033_coin_news_block_time_backfill.sql
@@ -1,0 +1,15 @@
+-- Pre-fix, op_returns.created_at was stamped with time.Now() at sync, not the
+-- block timestamp. Rewrite confirmed rows from processed_blocks.block_time so
+-- existing CoinNews entries display the actual posting date. Mempool rows
+-- (height IS NULL) keep their wall-clock timestamp.
+UPDATE op_returns
+SET created_at = (
+    SELECT block_time
+    FROM processed_blocks
+    WHERE processed_blocks.height = op_returns.height
+)
+WHERE op_returns.height IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM processed_blocks
+    WHERE processed_blocks.height = op_returns.height
+  );

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -538,7 +538,7 @@ func (p *Parser) getBlock(ctx context.Context, height uint32) (*wire.MsgBlock, e
 
 // finds all OP_RETURN outputs for a specific tx
 func (p *Parser) handleOpReturns(
-	ctx context.Context, tx *wire.MsgTx, height *uint32, _ *time.Time,
+	ctx context.Context, tx *wire.MsgTx, height *uint32, createdAt *time.Time,
 ) ([]opreturns.OPReturn, error) {
 	txid := tx.TxID()
 
@@ -634,11 +634,12 @@ func (p *Parser) handleOpReturns(
 		}
 
 		opReturns = append(opReturns, opreturns.OPReturn{
-			TxID:   txid,
-			Data:   data,
-			Vout:   int32(vout),
-			Height: height,
-			Fee:    fee,
+			TxID:      txid,
+			Data:      data,
+			Vout:      int32(vout),
+			Height:    height,
+			Fee:       fee,
+			CreatedAt: createdAt,
 		})
 	}
 

--- a/bitwindow/server/models/opreturns/opreturns_test.go
+++ b/bitwindow/server/models/opreturns/opreturns_test.go
@@ -243,3 +243,63 @@ func TestListCoinNews_NewPrefixedHeadlineSurvivesDecode(t *testing.T) {
 	require.Len(t, news, 1)
 	assert.Equal(t, headline, news[0].Headline)
 }
+
+// TestBackfillCoinNewsBlockTime regresses #1655: pre-fix, op_returns.created_at
+// was stamped with sync wall time instead of the block time. Migration 033
+// rewrites confirmed rows from processed_blocks.block_time. Mempool rows
+// (height NULL) and rows with no matching processed_blocks entry are left
+// alone.
+//
+// SQL is duplicated from migrations/033_coin_news_block_time_backfill.sql —
+// keep them in sync.
+func TestBackfillCoinNewsBlockTime(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	confirmedHeight := uint32(800000)
+	orphanHeight := uint32(800001) // no processed_blocks row
+	blockTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	syncTime := time.Date(2026, 4, 25, 8, 0, 0, 0, time.UTC)
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO processed_blocks (height, block_hash, block_time, txids)
+		VALUES (?, ?, ?, ?)
+	`, confirmedHeight, "deadbeef", blockTime, "")
+	require.NoError(t, err)
+
+	require.NoError(t, Persist(ctx, db, []OPReturn{
+		{Height: &confirmedHeight, TxID: "confirmed", Vout: 0, Data: []byte{0xa1, 0xa1, 0xa1, 0xa1}, CreatedAt: &syncTime},
+		{Height: &orphanHeight, TxID: "orphan", Vout: 0, Data: []byte{0xa1, 0xa1, 0xa1, 0xa1}, CreatedAt: &syncTime},
+		{Height: nil, TxID: "mempool", Vout: 0, Data: []byte{0xa1, 0xa1, 0xa1, 0xa1}, CreatedAt: &syncTime},
+	}))
+
+	const backfillSQL = `
+		UPDATE op_returns
+		SET created_at = (
+			SELECT block_time FROM processed_blocks
+			WHERE processed_blocks.height = op_returns.height
+		)
+		WHERE op_returns.height IS NOT NULL
+		  AND EXISTS (
+			SELECT 1 FROM processed_blocks
+			WHERE processed_blocks.height = op_returns.height
+		);`
+	_, err = db.ExecContext(ctx, backfillSQL)
+	require.NoError(t, err)
+
+	got := func(txid string) time.Time {
+		t.Helper()
+		var ts time.Time
+		require.NoError(t, db.QueryRowContext(ctx,
+			`SELECT created_at FROM op_returns WHERE txid = ?`, txid,
+		).Scan(&ts))
+		return ts
+	}
+
+	assert.WithinDuration(t, blockTime, got("confirmed"), time.Second,
+		"confirmed row with matching processed_blocks must adopt block_time")
+	assert.WithinDuration(t, syncTime, got("orphan"), time.Second,
+		"row without a matching processed_blocks entry must be left alone")
+	assert.WithinDuration(t, syncTime, got("mempool"), time.Second,
+		"mempool row (NULL height) must be left alone")
+}


### PR DESCRIPTION
Adds the test #1663 was missing. Locks in three behaviours of migration 033:

- confirmed op_returns adopt the matching `processed_blocks.block_time`
- rows whose height has no `processed_blocks` row are left alone (no NULL violation)
- mempool rows (`height IS NULL`) keep their wall-clock timestamp

Stacks on #1663 — once that merges this PR will show only the test diff against master.