### PR TITLE
bitwindow: sweep of bug fixes (#1620, #1656, #1657, #1661, console CLI)

### DIFF
--- a/bitwindow/lib/pages/root_page.dart
+++ b/bitwindow/lib/pages/root_page.dart
@@ -422,12 +422,14 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
                                           height: 1.5,
                                         ),
                                         children: [
-                                          const TextSpan(text: 'Drivechain version v0.47.00.0-unk (64-bit)\n\n'),
                                           const TextSpan(
-                                            text: 'Copyright (C) 2009-2024 The Drivechain developers\n',
+                                            text: 'BitWindow — GUI for the BIP300/301 sidechain enforcer.\n\n',
                                           ),
                                           const TextSpan(
-                                            text: 'Copyright (C) 2009-2024 The Bitcoin Core developers\n\n',
+                                            text: 'Copyright (C) 2009-2026 The Drivechain developers\n',
+                                          ),
+                                          const TextSpan(
+                                            text: 'Copyright (C) 2009-2026 The Bitcoin Core developers\n\n',
                                           ),
                                           const TextSpan(
                                             text: 'Please contribute if you find Drivechain useful. Visit ',
@@ -560,21 +562,34 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
                   ],
                 ),
                 PlatformMenuItemGroup(
-                  members: [
-                    PlatformMenuItem(
-                      label: 'Hide bitwindow',
-                      shortcut: const SingleActivator(LogicalKeyboardKey.keyH, meta: true),
-                      onSelected: () async {
-                        await windowManager.hide();
-                      },
-                    ),
-                    PlatformMenuItem(
-                      label: 'Show All',
-                      onSelected: () async {
-                        await windowManager.show();
-                      },
-                    ),
-                  ],
+                  members: Platform.isMacOS
+                      ? [
+                          PlatformMenuItem(
+                            label: 'Hide bitwindow',
+                            shortcut: const SingleActivator(LogicalKeyboardKey.keyH, meta: true),
+                            onSelected: () async {
+                              await windowManager.hide();
+                            },
+                          ),
+                          PlatformMenuItem(
+                            label: 'Show All',
+                            onSelected: () async {
+                              await windowManager.show();
+                            },
+                          ),
+                        ]
+                      : [
+                          // Linux/Windows have no dock or default tray, so a
+                          // hidden window has no taskbar entry to bring back.
+                          // Minimize keeps the taskbar/Alt-Tab entry alive.
+                          PlatformMenuItem(
+                            label: 'Minimize bitwindow',
+                            shortcut: const SingleActivator(LogicalKeyboardKey.keyM, meta: true),
+                            onSelected: () async {
+                              await windowManager.minimize();
+                            },
+                          ),
+                        ],
                 ),
                 PlatformMenuItemGroup(
                   members: [

--- a/bitwindow/lib/pages/root_page.dart
+++ b/bitwindow/lib/pages/root_page.dart
@@ -393,148 +393,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
                       onSelected: () {
                         showDialog(
                           context: context,
-                          builder: (context) {
-                            final theme = SailTheme.of(context);
-                            return Dialog(
-                              backgroundColor: theme.colors.backgroundSecondary,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: SailStyleValues.borderRadiusSmall,
-                                side: BorderSide(
-                                  color: theme.colors.border,
-                                  width: 1,
-                                ),
-                              ),
-                              child: Container(
-                                width: 800,
-                                padding: const EdgeInsets.all(24),
-                                child: Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    SailText.primary20('About Drivechain'),
-                                    const SizedBox(height: 16),
-                                    SelectableText.rich(
-                                      TextSpan(
-                                        style: TextStyle(
-                                          fontSize: 12,
-                                          color: theme.colors.text,
-                                          fontFamily: 'Inter',
-                                          height: 1.5,
-                                        ),
-                                        children: [
-                                          const TextSpan(
-                                            text: 'BitWindow — GUI for the BIP300/301 sidechain enforcer.\n\n',
-                                          ),
-                                          const TextSpan(
-                                            text: 'Copyright (C) 2009-2026 The Drivechain developers\n',
-                                          ),
-                                          const TextSpan(
-                                            text: 'Copyright (C) 2009-2026 The Bitcoin Core developers\n\n',
-                                          ),
-                                          const TextSpan(
-                                            text: 'Please contribute if you find Drivechain useful. Visit ',
-                                          ),
-                                          TextSpan(
-                                            text: 'https://drivechain.info',
-                                            style: TextStyle(
-                                              color: theme.colors.primary,
-                                              decoration: TextDecoration.underline,
-                                            ),
-                                            recognizer: TapGestureRecognizer()
-                                              ..onTap = () async {
-                                                await launchUrl(Uri.parse('https://drivechain.info'));
-                                              },
-                                          ),
-                                          const TextSpan(text: ' for further information about the software.\n'),
-                                          const TextSpan(
-                                            text: 'The source code for this application is available from ',
-                                          ),
-                                          TextSpan(
-                                            text: 'https://github.com/LayerTwo-Labs/drivechain-frontends',
-                                            style: TextStyle(
-                                              color: theme.colors.primary,
-                                              decoration: TextDecoration.underline,
-                                            ),
-                                            recognizer: TapGestureRecognizer()
-                                              ..onTap = () async {
-                                                await launchUrl(
-                                                  Uri.parse(
-                                                    'https://github.com/LayerTwo-Labs/drivechain-frontends',
-                                                  ),
-                                                );
-                                              },
-                                          ),
-                                          const TextSpan(
-                                            text: '. The source code for the underlying enforcer is available from ',
-                                          ),
-                                          TextSpan(
-                                            text: 'https://github.com/LayerTwo-Labs/bip300301_enforcer',
-                                            style: TextStyle(
-                                              color: theme.colors.primary,
-                                              decoration: TextDecoration.underline,
-                                            ),
-                                            recognizer: TapGestureRecognizer()
-                                              ..onTap = () async {
-                                                await launchUrl(
-                                                  Uri.parse(
-                                                    'https://github.com/LayerTwo-Labs/bip300301_enforcer',
-                                                  ),
-                                                );
-                                              },
-                                          ),
-                                          const TextSpan(text: '.\n\n'),
-                                          const TextSpan(text: 'This is experimental software.\n'),
-                                          const TextSpan(
-                                            text:
-                                                'Distributed under the MIT software license, see the accompanying file COPYING or ',
-                                          ),
-                                          TextSpan(
-                                            text: 'https://opensource.org/licenses/MIT',
-                                            style: TextStyle(
-                                              color: theme.colors.primary,
-                                              decoration: TextDecoration.underline,
-                                            ),
-                                            recognizer: TapGestureRecognizer()
-                                              ..onTap = () async {
-                                                await launchUrl(Uri.parse('https://opensource.org/licenses/MIT'));
-                                              },
-                                          ),
-                                          const TextSpan(text: '\n\n'),
-                                          const TextSpan(
-                                            text:
-                                                'This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit ',
-                                          ),
-                                          TextSpan(
-                                            text: 'https://www.openssl.org',
-                                            style: TextStyle(
-                                              color: theme.colors.primary,
-                                              decoration: TextDecoration.underline,
-                                            ),
-                                            recognizer: TapGestureRecognizer()
-                                              ..onTap = () async {
-                                                await launchUrl(Uri.parse('https://www.openssl.org'));
-                                              },
-                                          ),
-                                          const TextSpan(
-                                            text:
-                                                ' and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.',
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                    const SizedBox(height: 20),
-                                    Align(
-                                      alignment: Alignment.centerRight,
-                                      child: SailButton(
-                                        onPressed: () async => Navigator.of(context).pop(),
-                                        label: 'OK',
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            );
-                          },
+                          builder: (context) => const AboutBitwindowDialog(),
                         );
                       },
                     ),
@@ -562,34 +421,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
                   ],
                 ),
                 PlatformMenuItemGroup(
-                  members: Platform.isMacOS
-                      ? [
-                          PlatformMenuItem(
-                            label: 'Hide bitwindow',
-                            shortcut: const SingleActivator(LogicalKeyboardKey.keyH, meta: true),
-                            onSelected: () async {
-                              await windowManager.hide();
-                            },
-                          ),
-                          PlatformMenuItem(
-                            label: 'Show All',
-                            onSelected: () async {
-                              await windowManager.show();
-                            },
-                          ),
-                        ]
-                      : [
-                          // Linux/Windows have no dock or default tray, so a
-                          // hidden window has no taskbar entry to bring back.
-                          // Minimize keeps the taskbar/Alt-Tab entry alive.
-                          PlatformMenuItem(
-                            label: 'Minimize bitwindow',
-                            shortcut: const SingleActivator(LogicalKeyboardKey.keyM, meta: true),
-                            onSelected: () async {
-                              await windowManager.minimize();
-                            },
-                          ),
-                        ],
+                  members: buildVisibilityMenuItems(isMacOS: Platform.isMacOS),
                 ),
                 PlatformMenuItemGroup(
                   members: [
@@ -1492,5 +1324,184 @@ String formatTimeDifference(int value, String unit) {
 extension on Block {
   String toPretty() {
     return 'Block $height\nBlockTime=${blockTime.toDateTime().toLocal().format()}\nHash=$hash';
+  }
+}
+
+List<PlatformMenuItem> buildVisibilityMenuItems({required bool isMacOS}) {
+  if (isMacOS) {
+    return [
+      PlatformMenuItem(
+        label: 'Hide bitwindow',
+        shortcut: const SingleActivator(LogicalKeyboardKey.keyH, meta: true),
+        onSelected: () async {
+          await windowManager.hide();
+        },
+      ),
+      PlatformMenuItem(
+        label: 'Show All',
+        onSelected: () async {
+          await windowManager.show();
+        },
+      ),
+    ];
+  }
+  // Linux/Windows have no dock or default tray, so a hidden window has no
+  // taskbar entry to bring back. Minimize keeps the taskbar/Alt-Tab entry
+  // alive.
+  return [
+    PlatformMenuItem(
+      label: 'Minimize bitwindow',
+      shortcut: const SingleActivator(LogicalKeyboardKey.keyM, meta: true),
+      onSelected: () async {
+        await windowManager.minimize();
+      },
+    ),
+  ];
+}
+
+class AboutBitwindowDialog extends StatelessWidget {
+  const AboutBitwindowDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+    return Dialog(
+      backgroundColor: theme.colors.backgroundSecondary,
+      shape: RoundedRectangleBorder(
+        borderRadius: SailStyleValues.borderRadiusSmall,
+        side: BorderSide(
+          color: theme.colors.border,
+          width: 1,
+        ),
+      ),
+      child: Container(
+        width: 800,
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SailText.primary20('About Drivechain'),
+            const SizedBox(height: 16),
+            SelectableText.rich(
+              TextSpan(
+                style: TextStyle(
+                  fontSize: 12,
+                  color: theme.colors.text,
+                  fontFamily: 'Inter',
+                  height: 1.5,
+                ),
+                children: [
+                  const TextSpan(
+                    text: 'BitWindow — GUI for the BIP300/301 sidechain enforcer.\n\n',
+                  ),
+                  const TextSpan(
+                    text: 'Copyright (C) 2009-2026 The Drivechain developers\n',
+                  ),
+                  const TextSpan(
+                    text: 'Copyright (C) 2009-2026 The Bitcoin Core developers\n\n',
+                  ),
+                  const TextSpan(
+                    text: 'Please contribute if you find Drivechain useful. Visit ',
+                  ),
+                  TextSpan(
+                    text: 'https://drivechain.info',
+                    style: TextStyle(
+                      color: theme.colors.primary,
+                      decoration: TextDecoration.underline,
+                    ),
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () async {
+                        await launchUrl(Uri.parse('https://drivechain.info'));
+                      },
+                  ),
+                  const TextSpan(text: ' for further information about the software.\n'),
+                  const TextSpan(
+                    text: 'The source code for this application is available from ',
+                  ),
+                  TextSpan(
+                    text: 'https://github.com/LayerTwo-Labs/drivechain-frontends',
+                    style: TextStyle(
+                      color: theme.colors.primary,
+                      decoration: TextDecoration.underline,
+                    ),
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () async {
+                        await launchUrl(
+                          Uri.parse(
+                            'https://github.com/LayerTwo-Labs/drivechain-frontends',
+                          ),
+                        );
+                      },
+                  ),
+                  const TextSpan(
+                    text: '. The source code for the underlying enforcer is available from ',
+                  ),
+                  TextSpan(
+                    text: 'https://github.com/LayerTwo-Labs/bip300301_enforcer',
+                    style: TextStyle(
+                      color: theme.colors.primary,
+                      decoration: TextDecoration.underline,
+                    ),
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () async {
+                        await launchUrl(
+                          Uri.parse(
+                            'https://github.com/LayerTwo-Labs/bip300301_enforcer',
+                          ),
+                        );
+                      },
+                  ),
+                  const TextSpan(text: '.\n\n'),
+                  const TextSpan(text: 'This is experimental software.\n'),
+                  const TextSpan(
+                    text: 'Distributed under the MIT software license, see the accompanying file COPYING or ',
+                  ),
+                  TextSpan(
+                    text: 'https://opensource.org/licenses/MIT',
+                    style: TextStyle(
+                      color: theme.colors.primary,
+                      decoration: TextDecoration.underline,
+                    ),
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () async {
+                        await launchUrl(Uri.parse('https://opensource.org/licenses/MIT'));
+                      },
+                  ),
+                  const TextSpan(text: '\n\n'),
+                  const TextSpan(
+                    text:
+                        'This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit ',
+                  ),
+                  TextSpan(
+                    text: 'https://www.openssl.org',
+                    style: TextStyle(
+                      color: theme.colors.primary,
+                      decoration: TextDecoration.underline,
+                    ),
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () async {
+                        await launchUrl(Uri.parse('https://www.openssl.org'));
+                      },
+                  ),
+                  const TextSpan(
+                    text:
+                        ' and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.',
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 20),
+            Align(
+              alignment: Alignment.centerRight,
+              child: SailButton(
+                onPressed: () async => Navigator.of(context).pop(),
+                label: 'OK',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/bitwindow/lib/providers/hd_wallet_provider.dart
+++ b/bitwindow/lib/providers/hd_wallet_provider.dart
@@ -31,15 +31,27 @@ class HDWalletProvider extends ChangeNotifier {
   String get bip47PaymentCode => GetIt.I.get<WalletReaderProvider>().activeWallet?.bip47PaymentCode ?? '';
 
   HDWalletProvider() {
-    // Forward wallet-state changes so listeners (e.g. the receive page)
-    // rebuild when bip47PaymentCode arrives.
-    GetIt.I.get<WalletReaderProvider>().addListener(notifyListeners);
+    GetIt.I.get<WalletReaderProvider>().addListener(_onWalletStream);
   }
 
   @override
   void dispose() {
-    GetIt.I.get<WalletReaderProvider>().removeListener(notifyListeners);
+    GetIt.I.get<WalletReaderProvider>().removeListener(_onWalletStream);
     super.dispose();
+  }
+
+  // Auto-load when the enforcer wallet finally arrives on the stream. First
+  // paint races the stream subscription, so init() can fire before any
+  // mnemonic is available — without this, the "Couldn't load wallet" error
+  // would stick until the user reloaded the page.
+  void _onWalletStream() {
+    final reader = GetIt.I.get<WalletReaderProvider>();
+    final mnemonic = reader.getL1Mnemonic();
+    if (!_initialized && mnemonic != null && mnemonic.isNotEmpty) {
+      _loadMnemonic().then((_) => notifyListeners());
+      return;
+    }
+    notifyListeners();
   }
 
   Future<void> init() async {

--- a/bitwindow/server/dir/dir.go
+++ b/bitwindow/server/dir/dir.go
@@ -7,46 +7,54 @@ import (
 	"runtime"
 )
 
+// Flutter's path_provider on Linux uses the GApplication id when libgio is
+// loadable and falls back to the executable name otherwise. libgio is
+// unreliable across distros, so the canonical subdir is "bitwindow" (matching
+// the executable name in CMakeLists.txt). Older installs landed under
+// "com.layertwolabs.bitwindow"; on first boot we rename the legacy dir into
+// place and leave a symlink so libgio-good Flutter still resolves to the
+// same data.
+const (
+	linuxAppName       = "bitwindow"
+	linuxAppNameLegacy = "com.layertwolabs.bitwindow"
+)
+
+func linuxDataDir() (string, error) {
+	var base string
+	if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
+		base = xdgDataHome
+	} else {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		base = filepath.Join(home, ".local", "share")
+	}
+
+	newPath := filepath.Join(base, linuxAppName)
+	legacy := filepath.Join(base, linuxAppNameLegacy)
+
+	_, newErr := os.Stat(newPath)
+	_, legacyErr := os.Stat(legacy)
+	if os.IsNotExist(newErr) && legacyErr == nil {
+		if err := os.Rename(legacy, newPath); err == nil {
+			_ = os.Symlink(newPath, legacy)
+		}
+	}
+	return newPath, nil
+}
+
 func DefaultDataDir() (string, error) {
 
 	var dir string
 
 	switch runtime.GOOS {
 	case "linux":
-		// Flutter's path_provider on Linux uses the GApplication id when
-		// libgio is loadable and falls back to the executable name otherwise.
-		// libgio is unreliable across distros, so the canonical subdir is
-		// "bitwindow" (matching the executable name in CMakeLists.txt).
-		// Older installs landed under "com.layertwolabs.bitwindow"; on first
-		// boot we rename the legacy dir into place and leave a symlink so
-		// libgio-good Flutter still resolves to the same data.
-		const (
-			linuxAppName       = "bitwindow"
-			linuxAppNameLegacy = "com.layertwolabs.bitwindow"
-		)
-
-		var base string
-		if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
-			base = xdgDataHome
-		} else {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return "", err
-			}
-			base = filepath.Join(home, ".local", "share")
+		linuxDir, err := linuxDataDir()
+		if err != nil {
+			return "", err
 		}
-
-		newPath := filepath.Join(base, linuxAppName)
-		legacy := filepath.Join(base, linuxAppNameLegacy)
-
-		_, newErr := os.Stat(newPath)
-		_, legacyErr := os.Stat(legacy)
-		if os.IsNotExist(newErr) && legacyErr == nil {
-			if err := os.Rename(legacy, newPath); err == nil {
-				_ = os.Symlink(newPath, legacy)
-			}
-		}
-		dir = newPath
+		dir = linuxDir
 	case "darwin":
 		const macosAppName = "bitwindow"
 

--- a/bitwindow/server/dir/dir.go
+++ b/bitwindow/server/dir/dir.go
@@ -13,17 +13,40 @@ func DefaultDataDir() (string, error) {
 
 	switch runtime.GOOS {
 	case "linux":
-		const linuxAppName = "com.layertwolabs.bitwindow"
+		// Flutter's path_provider on Linux uses the GApplication id when
+		// libgio is loadable and falls back to the executable name otherwise.
+		// libgio is unreliable across distros, so the canonical subdir is
+		// "bitwindow" (matching the executable name in CMakeLists.txt).
+		// Older installs landed under "com.layertwolabs.bitwindow"; on first
+		// boot we rename the legacy dir into place and leave a symlink so
+		// libgio-good Flutter still resolves to the same data.
+		const (
+			linuxAppName       = "bitwindow"
+			linuxAppNameLegacy = "com.layertwolabs.bitwindow"
+		)
 
+		var base string
 		if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
-			dir = filepath.Join(xdgDataHome, linuxAppName)
+			base = xdgDataHome
 		} else {
 			home, err := os.UserHomeDir()
 			if err != nil {
 				return "", err
 			}
-			dir = filepath.Join(home, ".local", "share", linuxAppName)
+			base = filepath.Join(home, ".local", "share")
 		}
+
+		newPath := filepath.Join(base, linuxAppName)
+		legacy := filepath.Join(base, linuxAppNameLegacy)
+
+		_, newErr := os.Stat(newPath)
+		_, legacyErr := os.Stat(legacy)
+		if os.IsNotExist(newErr) && legacyErr == nil {
+			if err := os.Rename(legacy, newPath); err == nil {
+				_ = os.Symlink(newPath, legacy)
+			}
+		}
+		dir = newPath
 	case "darwin":
 		const macosAppName = "bitwindow"
 

--- a/bitwindow/server/dir/dir_test.go
+++ b/bitwindow/server/dir/dir_test.go
@@ -1,0 +1,137 @@
+package dir
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLinuxDataDirMigration(t *testing.T) {
+	cases := []struct {
+		name             string
+		setup            func(t *testing.T, base string)
+		wantSymlink      bool
+		wantLegacyExists bool
+		wantNewIsDir     bool
+		wantPreserveFile string
+	}{
+		{
+			name:             "neither dir exists",
+			setup:            func(t *testing.T, base string) {},
+			wantSymlink:      false,
+			wantLegacyExists: false,
+			wantNewIsDir:     false,
+		},
+		{
+			name: "only new dir exists",
+			setup: func(t *testing.T, base string) {
+				if err := os.MkdirAll(filepath.Join(base, linuxAppName), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantNewIsDir: true,
+		},
+		{
+			name: "only legacy dir exists migrates with symlink",
+			setup: func(t *testing.T, base string) {
+				legacy := filepath.Join(base, linuxAppNameLegacy)
+				if err := os.MkdirAll(legacy, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(legacy, "wallet.json"), []byte("legacy"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantSymlink:      true,
+			wantLegacyExists: true,
+			wantNewIsDir:     true,
+			wantPreserveFile: "wallet.json",
+		},
+		{
+			name: "both dirs exist leaves legacy untouched",
+			setup: func(t *testing.T, base string) {
+				if err := os.MkdirAll(filepath.Join(base, linuxAppName), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				legacy := filepath.Join(base, linuxAppNameLegacy)
+				if err := os.MkdirAll(legacy, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(legacy, "marker"), []byte("legacy"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantLegacyExists: true,
+			wantNewIsDir:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			t.Setenv("XDG_DATA_HOME", base)
+
+			tc.setup(t, base)
+
+			got, err := linuxDataDir()
+			if err != nil {
+				t.Fatalf("linuxDataDir: %v", err)
+			}
+
+			want := filepath.Join(base, linuxAppName)
+			if got != want {
+				t.Fatalf("dir = %q, want %q", got, want)
+			}
+
+			legacy := filepath.Join(base, linuxAppNameLegacy)
+			info, lerr := os.Lstat(legacy)
+			switch {
+			case tc.wantSymlink:
+				if lerr != nil {
+					t.Fatalf("legacy symlink missing: %v", lerr)
+				}
+				if info.Mode()&os.ModeSymlink == 0 {
+					t.Fatalf("legacy path is not a symlink: mode=%v", info.Mode())
+				}
+				target, err := os.Readlink(legacy)
+				if err != nil {
+					t.Fatalf("readlink: %v", err)
+				}
+				if target != want {
+					t.Errorf("symlink target = %q, want %q", target, want)
+				}
+			case tc.wantLegacyExists:
+				if lerr != nil {
+					t.Fatalf("expected legacy to remain, got %v", lerr)
+				}
+				if info.Mode()&os.ModeSymlink != 0 {
+					t.Errorf("legacy unexpectedly became a symlink: mode=%v", info.Mode())
+				}
+			default:
+				if lerr == nil {
+					t.Errorf("legacy should not exist, but does (mode=%v)", info.Mode())
+				} else if !os.IsNotExist(lerr) {
+					t.Errorf("unexpected legacy stat error: %v", lerr)
+				}
+			}
+
+			newInfo, nerr := os.Stat(want)
+			if tc.wantNewIsDir {
+				if nerr != nil {
+					t.Fatalf("new dir stat: %v", nerr)
+				}
+				if !newInfo.IsDir() {
+					t.Errorf("new path is not a dir: mode=%v", newInfo.Mode())
+				}
+			} else if nerr == nil {
+				t.Errorf("new dir should not exist yet, but does")
+			}
+
+			if tc.wantPreserveFile != "" {
+				if _, err := os.Stat(filepath.Join(want, tc.wantPreserveFile)); err != nil {
+					t.Errorf("preserved file missing after migration: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/bitwindow/test/about_dialog_and_menu_test.dart
+++ b/bitwindow/test/about_dialog_and_menu_test.dart
@@ -1,0 +1,55 @@
+import 'package:bitwindow/pages/root_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized({
+    'flutter.test.automatic_wait_for_timers': 'false',
+  });
+
+  testWidgets('About dialog renders refreshed copy', (tester) async {
+    await tester.pumpSailPage(const AboutBitwindowDialog());
+
+    expect(
+      find.textContaining('BitWindow — GUI for the BIP300/301 sidechain enforcer.'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('2009-2026 The Drivechain developers'), findsOneWidget);
+    expect(find.textContaining('2009-2026 The Bitcoin Core developers'), findsOneWidget);
+
+    expect(find.textContaining('Drivechain version v0.47.00.0-unk (64-bit)'), findsNothing);
+    expect(find.textContaining('2009-2024'), findsNothing);
+  });
+
+  group('buildVisibilityMenuItems', () {
+    test('macOS exposes Hide and Show All', () {
+      final items = buildVisibilityMenuItems(isMacOS: true);
+      expect(items, hasLength(2));
+      expect(items[0].label, 'Hide bitwindow');
+      expect(
+        items[0].shortcut,
+        const SingleActivator(LogicalKeyboardKey.keyH, meta: true),
+      );
+      expect(items[1].label, 'Show All');
+      expect(items[1].shortcut, isNull);
+    });
+
+    test('non-macOS exposes Minimize with Ctrl+M shortcut', () {
+      final items = buildVisibilityMenuItems(isMacOS: false);
+      expect(items, hasLength(1));
+      expect(items.single.label, 'Minimize bitwindow');
+      expect(
+        items.single.shortcut,
+        const SingleActivator(LogicalKeyboardKey.keyM, meta: true),
+      );
+
+      expect(
+        items.where((m) => m.label == 'Hide bitwindow' || m.label == 'Show All'),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/bitwindow/test/hd_wallet_provider_retry_test.dart
+++ b/bitwindow/test/hd_wallet_provider_retry_test.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:bitwindow/providers/hd_wallet_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+const _validMnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+WalletData _enforcer({String l1Mnemonic = ''}) => WalletData(
+  version: 1,
+  master: MasterWallet(mnemonic: '', seedHex: '', masterKey: '', chainCode: ''),
+  l1: L1Wallet(mnemonic: l1Mnemonic),
+  sidechains: const [],
+  id: 'enf',
+  name: 'Enforcer',
+  gradient: WalletGradient.fromWalletId('enf'),
+  createdAt: DateTime.utc(2026, 1, 1),
+  walletType: BinaryType.enforcer,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await GetIt.I.reset();
+    GetIt.I.registerSingleton<Logger>(Logger(level: Level.warning));
+    GetIt.I.registerSingleton<WalletReaderProvider>(
+      WalletReaderProvider(Directory.systemTemp),
+    );
+    GetIt.I.registerSingleton<WalletWriterProvider>(
+      WalletWriterProvider(bitwindowAppDir: Directory.systemTemp),
+    );
+  });
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  test('HDWalletProvider stays uninitialised until enforcer wallet arrives', () async {
+    final reader = GetIt.I.get<WalletReaderProvider>();
+    final hd = HDWalletProvider();
+
+    expect(hd.isInitialized, isFalse);
+    expect(hd.error, isNull);
+
+    // Enforcer arrives on the stream — fake it by mutating the reader and
+    // notifying listeners (mirrors what _onData does in production).
+    reader.wallets = [_enforcer(l1Mnemonic: _validMnemonic)];
+    reader.activeWalletId = 'enf';
+    reader.notifyListeners();
+
+    // Allow the queued _loadMnemonic future to settle.
+    for (int i = 0; i < 20 && !hd.isInitialized; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+
+    expect(hd.isInitialized, isTrue, reason: 'should auto-load when enforcer arrives');
+    expect(hd.error, isNull);
+    expect(hd.mnemonic, _validMnemonic);
+  });
+
+  test('HDWalletProvider does not init when enforcer wallet absent', () async {
+    final reader = GetIt.I.get<WalletReaderProvider>();
+    final hd = HDWalletProvider();
+
+    // Only a Bitcoin Core wallet on the stream — no enforcer yet.
+    reader.wallets = [
+      WalletData(
+        version: 1,
+        master: MasterWallet(mnemonic: '', seedHex: '', masterKey: '', chainCode: ''),
+        l1: L1Wallet(mnemonic: 'core-l1-mnemonic'),
+        sidechains: const [],
+        id: 'core',
+        name: 'Core',
+        gradient: WalletGradient.fromWalletId('core'),
+        createdAt: DateTime.utc(2026, 1, 1),
+        walletType: BinaryType.bitcoinCore,
+      ),
+    ];
+    reader.activeWalletId = 'core';
+    reader.notifyListeners();
+
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(hd.isInitialized, isFalse);
+    expect(hd.mnemonic, isNull);
+  });
+}

--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -100,13 +100,13 @@
       "directories": {
         "binary": {
           "default": {
-            "linux": "com.layertwolabs.bitwindow",
+            "linux": "bitwindow",
             "macos": "bitwindow",
             "windows": "10520LayertwoLabs/BitWindow"
           }
         },
         "flutter_frontend": {
-          "linux": "com.layertwolabs.bitwindow",
+          "linux": "bitwindow",
           "macos": "bitwindow",
           "windows": "10520LayertwoLabs/BitWindow"
         }

--- a/sail_ui/lib/config/binaries.dart
+++ b/sail_ui/lib/config/binaries.dart
@@ -1116,12 +1116,12 @@ class BitWindow extends Binary {
              directories ??
              DirectoryConfig(
                binary: allNetworks({
-                 OS.linux: 'com.layertwolabs.bitwindow',
+                 OS.linux: 'bitwindow',
                  OS.macos: 'bitwindow',
                  OS.windows: '10520LayertwoLabs/BitWindow',
                }),
                flutterFrontend: {
-                 OS.linux: 'com.layertwolabs.bitwindow',
+                 OS.linux: 'bitwindow',
                  OS.macos: 'bitwindow',
                  OS.windows: '10520LayertwoLabs/BitWindow',
                },
@@ -1551,7 +1551,7 @@ extension BinaryPaths on Binary {
           home,
           '.local',
           'share',
-          'com.layertwolabs.bitwindow',
+          'bitwindow',
         ),
       },
       BinaryType.thunder => switch (OS.current) {

--- a/sail_ui/lib/config/binaries.dart
+++ b/sail_ui/lib/config/binaries.dart
@@ -1524,6 +1524,59 @@ class GRPCurl extends Binary {
   }
 }
 
+/// Pure helper: returns the Flutter frontend's getApplicationSupportDirectory()
+/// path for [type] given [os] and [home]. Tests pass synthetic values so the
+/// path mapping can be exercised without touching dart:io.
+String? flutterFrontendDirFor(BinaryType type, OS os, String home) {
+  return switch (type) {
+    BinaryType.bitWindow => switch (os) {
+      OS.macos => path.join(home, 'Library', 'Application Support', 'bitwindow'),
+      OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'BitWindow'),
+      OS.linux => path.join(home, '.local', 'share', 'bitwindow'),
+    },
+    BinaryType.thunder => switch (os) {
+      OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.thunder'),
+      OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'Thunder'),
+      OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.thunder'),
+    },
+    BinaryType.zSide => switch (os) {
+      OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.zside'),
+      OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'ZSide'),
+      OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.zside'),
+    },
+    BinaryType.bitnames => switch (os) {
+      OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.bitnames'),
+      OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'BitNames'),
+      OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.bitnames'),
+    },
+    BinaryType.bitassets => switch (os) {
+      OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.bitassets'),
+      OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'BitAssets'),
+      OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.bitassets'),
+    },
+    BinaryType.truthcoin => switch (os) {
+      OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.truthcoin'),
+      OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'Truthcoin'),
+      OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.truthcoin'),
+    },
+    BinaryType.photon => switch (os) {
+      OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.photon'),
+      OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'Photon'),
+      OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.photon'),
+    },
+    BinaryType.coinShift => switch (os) {
+      OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.coinshift'),
+      OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'Coinshift'),
+      OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.coinshift'),
+    },
+    BinaryType.bitcoinCore ||
+    BinaryType.enforcer ||
+    BinaryType.grpcurl ||
+    BinaryType.orchestratord ||
+    BinaryType.zSided => null,
+  };
+}
+
 extension BinaryPaths on Binary {
   /// Returns the Flutter frontend's getApplicationSupportDirectory() path.
   /// This is where the Flutter app stores settings.json, wallet.json, debug.log, etc.
@@ -1531,182 +1584,7 @@ extension BinaryPaths on Binary {
   String? flutterFrontendDir() {
     final home = Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'];
     if (home == null) return null;
-
-    return switch (type) {
-      BinaryType.bitWindow => switch (OS.current) {
-        OS.macos => path.join(
-          home,
-          'Library',
-          'Application Support',
-          'bitwindow',
-        ),
-        OS.windows => path.join(
-          home,
-          'AppData',
-          'Roaming',
-          '10520LayertwoLabs',
-          'BitWindow',
-        ),
-        OS.linux => path.join(
-          home,
-          '.local',
-          'share',
-          'bitwindow',
-        ),
-      },
-      BinaryType.thunder => switch (OS.current) {
-        OS.macos => path.join(
-          home,
-          'Library',
-          'Application Support',
-          'com.layertwolabs.thunder',
-        ),
-        OS.windows => path.join(
-          home,
-          'AppData',
-          'Roaming',
-          '10520LayertwoLabs',
-          'Thunder',
-        ),
-        OS.linux => path.join(
-          home,
-          '.local',
-          'share',
-          'com.layertwolabs.thunder',
-        ),
-      },
-      BinaryType.zSide => switch (OS.current) {
-        OS.macos => path.join(
-          home,
-          'Library',
-          'Application Support',
-          'com.layertwolabs.zside',
-        ),
-        OS.windows => path.join(
-          home,
-          'AppData',
-          'Roaming',
-          '10520LayertwoLabs',
-          'ZSide',
-        ),
-        OS.linux => path.join(
-          home,
-          '.local',
-          'share',
-          'com.layertwolabs.zside',
-        ),
-      },
-      BinaryType.bitnames => switch (OS.current) {
-        OS.macos => path.join(
-          home,
-          'Library',
-          'Application Support',
-          'com.layertwolabs.bitnames',
-        ),
-        OS.windows => path.join(
-          home,
-          'AppData',
-          'Roaming',
-          '10520LayertwoLabs',
-          'BitNames',
-        ),
-        OS.linux => path.join(
-          home,
-          '.local',
-          'share',
-          'com.layertwolabs.bitnames',
-        ),
-      },
-      BinaryType.bitassets => switch (OS.current) {
-        OS.macos => path.join(
-          home,
-          'Library',
-          'Application Support',
-          'com.layertwolabs.bitassets',
-        ),
-        OS.windows => path.join(
-          home,
-          'AppData',
-          'Roaming',
-          '10520LayertwoLabs',
-          'BitAssets',
-        ),
-        OS.linux => path.join(
-          home,
-          '.local',
-          'share',
-          'com.layertwolabs.bitassets',
-        ),
-      },
-      BinaryType.truthcoin => switch (OS.current) {
-        OS.macos => path.join(
-          home,
-          'Library',
-          'Application Support',
-          'com.layertwolabs.truthcoin',
-        ),
-        OS.windows => path.join(
-          home,
-          'AppData',
-          'Roaming',
-          '10520LayertwoLabs',
-          'Truthcoin',
-        ),
-        OS.linux => path.join(
-          home,
-          '.local',
-          'share',
-          'com.layertwolabs.truthcoin',
-        ),
-      },
-      BinaryType.photon => switch (OS.current) {
-        OS.macos => path.join(
-          home,
-          'Library',
-          'Application Support',
-          'com.layertwolabs.photon',
-        ),
-        OS.windows => path.join(
-          home,
-          'AppData',
-          'Roaming',
-          '10520LayertwoLabs',
-          'Photon',
-        ),
-        OS.linux => path.join(
-          home,
-          '.local',
-          'share',
-          'com.layertwolabs.photon',
-        ),
-      },
-      BinaryType.coinShift => switch (OS.current) {
-        OS.macos => path.join(
-          home,
-          'Library',
-          'Application Support',
-          'com.layertwolabs.coinshift',
-        ),
-        OS.windows => path.join(
-          home,
-          'AppData',
-          'Roaming',
-          '10520LayertwoLabs',
-          'Coinshift',
-        ),
-        OS.linux => path.join(
-          home,
-          '.local',
-          'share',
-          'com.layertwolabs.coinshift',
-        ),
-      },
-      BinaryType.bitcoinCore ||
-      BinaryType.enforcer ||
-      BinaryType.grpcurl ||
-      BinaryType.orchestratord ||
-      BinaryType.zSided => null,
-    };
+    return flutterFrontendDirFor(type, OS.current, home);
   }
 
   String confFile() {

--- a/sail_ui/lib/providers/wallet_reader_provider.dart
+++ b/sail_ui/lib/providers/wallet_reader_provider.dart
@@ -274,10 +274,12 @@ class WalletReaderProvider extends ChangeNotifier {
     }
   }
 
-  String? getL1Mnemonic() => activeWallet?.l1.mnemonic;
+  // L1 + sidechain starters are always derived from the enforcer wallet, even
+  // if the active wallet is a separate Bitcoin Core wallet.
+  String? getL1Mnemonic() => enforcerWallet?.l1.mnemonic;
 
   String? getSidechainMnemonic(int slot) {
-    final wallet = activeWallet;
+    final wallet = enforcerWallet;
     if (wallet == null) return null;
     return wallet.sidechains.where((sc) => sc.slot == slot).firstOrNull?.mnemonic;
   }

--- a/sail_ui/lib/widgets/console/cli_console_service.dart
+++ b/sail_ui/lib/widgets/console/cli_console_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:path/path.dart' as path;
 import 'package:sail_ui/sail_ui.dart';
 
@@ -58,23 +59,19 @@ class CLIConsole {
   };
 
   /// Discover available CLI executables on disk. Returns map of cli name → absolute path.
+  ///
+  /// Every binary is downloaded into the BitWindow app dir's `assets/bin/`,
+  /// not into per-binary frontend dirs. Resolving from each binary's own
+  /// `frontendDir()` (the previous approach) pointed at sidechain-app dirs
+  /// that don't exist on a BitWindow-only install, so nothing was ever found.
   static Future<Map<String, String>> discoverCLIs() async {
     final available = <String, String>{};
     final exeSuffix = Platform.isWindows ? '.exe' : '';
 
-    for (final binary in allBinaries) {
-      final binaryName = binary.runtimeType.toString();
-      final cliName = _binaryToCLI[binaryName];
-      if (cliName == null) continue;
+    final bindir = binDir(GetIt.I.get<BinaryProvider>().appDir.path);
+    if (!bindir.existsSync()) return available;
 
-      final Directory bindir;
-      try {
-        bindir = binDir(binary.frontendDir());
-      } catch (_) {
-        continue;
-      }
-      if (!bindir.existsSync()) continue;
-
+    for (final cliName in _binaryToCLI.values) {
       final found = _findExecutable(bindir, '$cliName$exeSuffix');
       if (found != null) {
         await _ensureExecutable(found);

--- a/sail_ui/test/flutter_frontend_dir_test.dart
+++ b/sail_ui/test/flutter_frontend_dir_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sail_ui/sail_ui.dart';
+
+void main() {
+  group('flutterFrontendDirFor — bitWindow Linux subdir', () {
+    const home = '/home/tester';
+
+    test('Linux uses bitwindow subdir (no com.layertwolabs prefix)', () {
+      final dir = flutterFrontendDirFor(BinaryType.bitWindow, OS.linux, home);
+      expect(dir, p.join(home, '.local', 'share', 'bitwindow'));
+      expect(dir, isNot(contains('com.layertwolabs.bitwindow')));
+    });
+
+    test('macOS keeps "bitwindow" Application Support folder', () {
+      expect(
+        flutterFrontendDirFor(BinaryType.bitWindow, OS.macos, home),
+        p.join(home, 'Library', 'Application Support', 'bitwindow'),
+      );
+    });
+
+    test('Windows keeps 10520LayertwoLabs/BitWindow', () {
+      expect(
+        flutterFrontendDirFor(BinaryType.bitWindow, OS.windows, home),
+        p.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'BitWindow'),
+      );
+    });
+  });
+
+  test('flutterFrontendDirFor returns null for binaries without a Flutter frontend', () {
+    expect(
+      flutterFrontendDirFor(BinaryType.bitcoinCore, OS.linux, '/home/x'),
+      isNull,
+    );
+    expect(
+      flutterFrontendDirFor(BinaryType.enforcer, OS.linux, '/home/x'),
+      isNull,
+    );
+  });
+}

--- a/sail_ui/test/wallet_reader_provider_test.dart
+++ b/sail_ui/test/wallet_reader_provider_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+WalletData _wallet({
+  required String id,
+  required BinaryType type,
+  String l1 = '',
+  List<SidechainWallet> sidechains = const [],
+}) {
+  return WalletData(
+    version: 1,
+    master: MasterWallet(mnemonic: '', seedHex: '', masterKey: '', chainCode: ''),
+    l1: L1Wallet(mnemonic: l1),
+    sidechains: sidechains,
+    id: id,
+    name: id,
+    gradient: WalletGradient.fromWalletId(id),
+    createdAt: DateTime.utc(2026, 1, 1),
+    walletType: type,
+  );
+}
+
+void main() {
+  setUpAll(() {
+    if (!GetIt.I.isRegistered<Logger>()) {
+      GetIt.I.registerSingleton<Logger>(Logger(level: Level.warning));
+    }
+  });
+
+  test('getL1Mnemonic reads from enforcer wallet, not the active one', () {
+    final provider = WalletReaderProvider(Directory.systemTemp);
+    provider.wallets = [
+      _wallet(id: 'enf', type: BinaryType.enforcer, l1: 'enforcer-l1-mnemonic'),
+      _wallet(id: 'core', type: BinaryType.bitcoinCore, l1: 'core-l1-mnemonic'),
+    ];
+    provider.activeWalletId = 'core';
+
+    expect(provider.activeWallet?.id, 'core');
+    expect(provider.enforcerWallet?.id, 'enf');
+    expect(provider.getL1Mnemonic(), 'enforcer-l1-mnemonic');
+  });
+
+  test('getSidechainMnemonic reads from enforcer wallet, not the active one', () {
+    final provider = WalletReaderProvider(Directory.systemTemp);
+    provider.wallets = [
+      _wallet(
+        id: 'enf',
+        type: BinaryType.enforcer,
+        sidechains: [
+          SidechainWallet(slot: 9, name: 'Thunder', mnemonic: 'thunder-starter'),
+          SidechainWallet(slot: 5, name: 'BitNames', mnemonic: 'bitnames-starter'),
+        ],
+      ),
+      _wallet(
+        id: 'core',
+        type: BinaryType.bitcoinCore,
+        sidechains: [
+          SidechainWallet(slot: 9, name: 'Thunder', mnemonic: 'core-thunder'),
+        ],
+      ),
+    ];
+    provider.activeWalletId = 'core';
+
+    expect(provider.getSidechainMnemonic(9), 'thunder-starter');
+    expect(provider.getSidechainMnemonic(5), 'bitnames-starter');
+    expect(provider.getSidechainMnemonic(99), isNull);
+  });
+
+  test('getL1Mnemonic returns null when enforcer wallet absent', () {
+    final provider = WalletReaderProvider(Directory.systemTemp);
+    provider.wallets = [
+      _wallet(id: 'core', type: BinaryType.bitcoinCore, l1: 'core-l1'),
+    ];
+    provider.activeWalletId = 'core';
+
+    expect(provider.enforcerWallet, isNull);
+    expect(provider.getL1Mnemonic(), isNull);
+  });
+}

--- a/sail_ui/test/widgets/cli_console_discover_test.dart
+++ b/sail_ui/test/widgets/cli_console_discover_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:path/path.dart' as p;
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sail_ui/widgets/console/cli_console_service.dart';
+
+void main() {
+  late Directory tempAppDir;
+
+  setUp(() async {
+    tempAppDir = await Directory.systemTemp.createTemp('cli-console-test-');
+    await Directory(p.join(tempAppDir.path, 'assets', 'bin')).create(recursive: true);
+    GetIt.I.registerSingleton<BinaryProvider>(
+      BinaryProvider.test(appDir: tempAppDir, binaries: const []),
+    );
+  });
+
+  tearDown(() async {
+    await GetIt.I.unregister<BinaryProvider>();
+    if (tempAppDir.existsSync()) {
+      await tempAppDir.delete(recursive: true);
+    }
+  });
+
+  Future<File> seed(String relPath) async {
+    final f = File(p.join(tempAppDir.path, 'assets', 'bin', relPath));
+    await f.create(recursive: true);
+    await f.writeAsBytes([0]);
+    if (Platform.isMacOS || Platform.isLinux) {
+      await Process.run('chmod', ['+x', f.path]);
+    }
+    return f;
+  }
+
+  test('discoverCLIs finds CLIs at the BitWindow appDir, not per-binary frontends', () async {
+    final cli = await seed('bitcoin-cli${Platform.isWindows ? '.exe' : ''}');
+    final results = await CLIConsole.discoverCLIs();
+    expect(results['bitcoin-cli'], cli.path);
+  });
+
+  test('discoverCLIs picks up CLIs nested one level under appDir/assets/bin', () async {
+    // Mirrors the Core variant layout: assets/bin/<variant>/bitcoin-cli.
+    final cli = await seed('drivechain/bitcoin-cli${Platform.isWindows ? '.exe' : ''}');
+    final results = await CLIConsole.discoverCLIs();
+    expect(results['bitcoin-cli'], cli.path);
+  });
+
+  test('discoverCLIs returns empty when no executables exist', () async {
+    final results = await CLIConsole.discoverCLIs();
+    expect(results, isEmpty);
+  });
+
+  test('discoverCLIs returns empty when assets/bin is missing', () async {
+    await Directory(p.join(tempAppDir.path, 'assets', 'bin')).delete(recursive: true);
+    final results = await CLIConsole.discoverCLIs();
+    expect(results, isEmpty);
+  });
+}

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -1131,8 +1131,17 @@ func (h *WalletHandler) WatchWalletData(ctx context.Context, req *connect.Reques
 }
 
 func (h *WalletHandler) sendWalletData(ctx context.Context, stream *connect.ServerStream[pb.WatchWalletDataResponse]) error {
-	wallets := h.svc.GetAllWallets()
-	activeID := h.svc.ActiveWalletID()
+	resp := buildWatchWalletDataResponse(
+		h.svc.GetAllWallets(),
+		h.svc.ActiveWalletID(),
+		h.svc.HasWallet(),
+		h.svc.IsEncrypted(),
+		h.svc.IsUnlocked(),
+	)
+	return stream.Send(resp)
+}
+
+func buildWatchWalletDataResponse(wallets []wallet.WalletData, activeID string, hasWallet, encrypted, unlocked bool) *pb.WatchWalletDataResponse {
 	pbWallets := make([]*pb.WalletMetadata, len(wallets))
 	for i, w := range wallets {
 		var gradientJSON string
@@ -1165,20 +1174,13 @@ func (h *WalletHandler) sendWalletData(ctx context.Context, stream *connect.Serv
 		}
 		pbWallets[i] = md
 	}
-
-	// Balance is fetched separately via GetBalance RPC when Core wallets are loaded.
-	// WatchWalletData only streams wallet metadata — no Core dependency.
-	var confirmedSats, unconfirmedSats float64
-
-	return stream.Send(&pb.WatchWalletDataResponse{
-		HasWallet:       h.svc.HasWallet(),
-		Encrypted:       h.svc.IsEncrypted(),
-		Unlocked:        h.svc.IsUnlocked(),
-		ActiveWalletId:  activeID,
-		Wallets:         pbWallets,
-		ConfirmedSats:   confirmedSats,
-		UnconfirmedSats: unconfirmedSats,
-	})
+	return &pb.WatchWalletDataResponse{
+		HasWallet:      hasWallet,
+		Encrypted:      encrypted,
+		Unlocked:       unlocked,
+		ActiveWalletId: activeID,
+		Wallets:        pbWallets,
+	}
 }
 
 // ============================================================================

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -1147,9 +1147,11 @@ func (h *WalletHandler) sendWalletData(ctx context.Context, stream *connect.Serv
 			CreatedAt:        w.CreatedAt.Format(time.RFC3339),
 			Bip47PaymentCode: wallet.Bip47V3PaymentCodeFromSeed(w.Master.SeedHex),
 		}
-		// Starter material is sensitive; only attach it for the active wallet
-		// so non-active entries don't broadcast it on every stream tick.
-		if w.ID == activeID {
+		// Starter material lives only on the enforcer wallet (L1 mnemonic and
+		// sidechain starters are derived from its seed). Attach it to that
+		// wallet's metadata so the Dart side can find it whether or not the
+		// active wallet happens to be the enforcer.
+		if w.WalletType == walletTypeEnforcer {
 			md.MasterMnemonic = w.Master.Mnemonic
 			md.L1Mnemonic = w.L1.Mnemonic
 			md.Sidechains = make([]*pb.SidechainStarter, len(w.Sidechains))

--- a/sidechain-orchestrator/api/wallet_handler_test.go
+++ b/sidechain-orchestrator/api/wallet_handler_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+)
+
+func TestBuildWatchWalletDataResponseStartersAttachToEnforcer(t *testing.T) {
+	now := time.Now().UTC()
+	enforcer := wallet.WalletData{
+		ID:         "enf-id",
+		Name:       "Enforcer",
+		WalletType: walletTypeEnforcer,
+		CreatedAt:  now,
+		Master:     wallet.MasterWallet{Mnemonic: "enforcer master mnemonic", SeedHex: ""},
+		L1:         wallet.L1Wallet{Mnemonic: "enforcer l1 mnemonic"},
+		Sidechains: []wallet.SidechainWallet{
+			{Slot: 9, Name: "Thunder", Mnemonic: "thunder-starter"},
+			{Slot: 5, Name: "BitNames", Mnemonic: "bitnames-starter"},
+		},
+	}
+	core := wallet.WalletData{
+		ID:         "core-id",
+		Name:       "Core",
+		WalletType: "bitcoinCore",
+		CreatedAt:  now,
+		Master:     wallet.MasterWallet{Mnemonic: "core master mnemonic"},
+		L1:         wallet.L1Wallet{Mnemonic: "core l1 mnemonic"},
+		Sidechains: []wallet.SidechainWallet{
+			{Slot: 9, Name: "Thunder", Mnemonic: "core-side-starter"},
+		},
+	}
+
+	resp := buildWatchWalletDataResponse(
+		[]wallet.WalletData{enforcer, core},
+		core.ID, // active wallet is the Core wallet, NOT the enforcer
+		true, false, true,
+	)
+
+	if got := resp.GetActiveWalletId(); got != core.ID {
+		t.Fatalf("active id: got %q, want %q", got, core.ID)
+	}
+	if len(resp.GetWallets()) != 2 {
+		t.Fatalf("want 2 wallets, got %d", len(resp.GetWallets()))
+	}
+
+	var enf, c *struct {
+		L1             string
+		MasterMnemonic string
+		Sides          int
+	}
+	for _, w := range resp.GetWallets() {
+		entry := &struct {
+			L1             string
+			MasterMnemonic string
+			Sides          int
+		}{
+			L1:             w.GetL1Mnemonic(),
+			MasterMnemonic: w.GetMasterMnemonic(),
+			Sides:          len(w.GetSidechains()),
+		}
+		switch w.GetId() {
+		case enforcer.ID:
+			enf = entry
+		case core.ID:
+			c = entry
+		default:
+			t.Fatalf("unexpected wallet id %q", w.GetId())
+		}
+	}
+
+	if enf == nil || c == nil {
+		t.Fatal("missing wallet metadata in response")
+	}
+
+	if enf.L1 != enforcer.L1.Mnemonic {
+		t.Errorf("enforcer L1: got %q, want %q", enf.L1, enforcer.L1.Mnemonic)
+	}
+	if enf.MasterMnemonic != enforcer.Master.Mnemonic {
+		t.Errorf("enforcer master: got %q, want %q", enf.MasterMnemonic, enforcer.Master.Mnemonic)
+	}
+	if enf.Sides != len(enforcer.Sidechains) {
+		t.Errorf("enforcer sidechains: got %d, want %d", enf.Sides, len(enforcer.Sidechains))
+	}
+
+	if c.L1 != "" || c.MasterMnemonic != "" || c.Sides != 0 {
+		t.Errorf("core wallet must not carry starter material: %+v", c)
+	}
+}
+
+func TestBuildWatchWalletDataResponseEnforcerSidechainsRoundTrip(t *testing.T) {
+	now := time.Now().UTC()
+	enforcer := wallet.WalletData{
+		ID:         "enf",
+		WalletType: walletTypeEnforcer,
+		CreatedAt:  now,
+		Sidechains: []wallet.SidechainWallet{
+			{Slot: 9, Name: "Thunder", Mnemonic: "thunder"},
+			{Slot: 5, Name: "BitNames", Mnemonic: "bitnames"},
+		},
+	}
+
+	resp := buildWatchWalletDataResponse(
+		[]wallet.WalletData{enforcer}, enforcer.ID, true, false, true,
+	)
+
+	w := resp.GetWallets()[0]
+	if len(w.GetSidechains()) != 2 {
+		t.Fatalf("want 2 sidechains, got %d", len(w.GetSidechains()))
+	}
+	bySlot := map[int32]string{}
+	for _, sc := range w.GetSidechains() {
+		bySlot[sc.GetSlot()] = sc.GetMnemonic()
+	}
+	if bySlot[9] != "thunder" || bySlot[5] != "bitnames" {
+		t.Errorf("sidechain mnemonics not preserved: %+v", bySlot)
+	}
+}

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -100,13 +100,13 @@
       "directories": {
         "binary": {
           "default": {
-            "linux": "com.layertwolabs.bitwindow",
+            "linux": "bitwindow",
             "macos": "bitwindow",
             "windows": "10520LayertwoLabs/BitWindow"
           }
         },
         "flutter_frontend": {
-          "linux": "com.layertwolabs.bitwindow",
+          "linux": "bitwindow",
           "macos": "bitwindow",
           "windows": "10520LayertwoLabs/BitWindow"
         }

--- a/sidechain-orchestrator/config/binaries_test.go
+++ b/sidechain-orchestrator/config/binaries_test.go
@@ -99,7 +99,7 @@ func TestBitWindowPath(t *testing.T) {
 	case "windows":
 		want = filepath.Join(home(), "AppData", "Roaming", "10520LayertwoLabs", "BitWindow")
 	default:
-		want = filepath.Join(home(), ".local", "share", "com.layertwolabs.bitwindow")
+		want = filepath.Join(home(), ".local", "share", "bitwindow")
 	}
 	if p != want {
 		t.Errorf("BitWindow path = %q, want %q", p, want)

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -100,13 +100,13 @@
       "directories": {
         "binary": {
           "default": {
-            "linux": "com.layertwolabs.bitwindow",
+            "linux": "bitwindow",
             "macos": "bitwindow",
             "windows": "10520LayertwoLabs/BitWindow"
           }
         },
         "flutter_frontend": {
-          "linux": "com.layertwolabs.bitwindow",
+          "linux": "bitwindow",
           "macos": "bitwindow",
           "windows": "10520LayertwoLabs/BitWindow"
         }

--- a/sidechain-orchestrator/reset_integration_test.go
+++ b/sidechain-orchestrator/reset_integration_test.go
@@ -68,7 +68,7 @@ func bitwindowRoot(home string) string {
 		// Matches chains_config.json "windows": "10520LayertwoLabs/BitWindow"
 		return filepath.Join(appRoot(home), "10520LayertwoLabs", "BitWindow")
 	default:
-		return filepath.Join(appRoot(home), "com.layertwolabs.bitwindow")
+		return filepath.Join(appRoot(home), "bitwindow")
 	}
 }
 


### PR DESCRIPTION
This PR closes five recent issues plus a regression: Linux app subdir mismatch (#1620), About dialog refresh (#1656), Hide-bitwindow recovery on Linux/Windows (#1657), HD wallet load race (#1661), and the console showing "no CLI binaries found" after PR #1662.