### PR TITLE
wallet: drop empty default gradient, fall back per wallet ID

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.201
+version: 1.0.202
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.202
+version: 1.0.203
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.50
+version: 0.2.51
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.75
+version: 1.0.76
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/providers/wallet_reader_provider.dart
+++ b/sail_ui/lib/providers/wallet_reader_provider.dart
@@ -108,7 +108,13 @@ class WalletReaderProvider extends ChangeNotifier {
       WalletGradient gradient = WalletGradient.fromWalletId(protoWallet.id);
       if (protoWallet.gradientJson.isNotEmpty) {
         try {
-          gradient = WalletGradient.fromJsonString(protoWallet.gradientJson);
+          final parsed = WalletGradient.fromJsonString(protoWallet.gradientJson);
+          // Legacy default {"background_svg":""} parses cleanly but would
+          // render an empty avatar; keep the deterministic fallback in that
+          // case.
+          if ((parsed.backgroundSvg ?? '').isNotEmpty) {
+            gradient = parsed;
+          }
         } catch (_) {}
       }
 

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -338,14 +338,14 @@ func (s *Service) LoadMasterStarter() map[string]interface{} {
 		return nil
 	}
 	return map[string]interface{}{
-		"mnemonic":          w.Master.Mnemonic,
-		"seed_hex":          w.Master.SeedHex,
-		"master_key":        w.Master.MasterKey,
-		"chain_code":        w.Master.ChainCode,
-		"bip39_binary":      w.Master.BIP39Binary,
-		"bip39_checksum":    w.Master.BIP39Checksum,
+		"mnemonic":           w.Master.Mnemonic,
+		"seed_hex":           w.Master.SeedHex,
+		"master_key":         w.Master.MasterKey,
+		"chain_code":         w.Master.ChainCode,
+		"bip39_binary":       w.Master.BIP39Binary,
+		"bip39_checksum":     w.Master.BIP39Checksum,
 		"bip39_checksum_hex": w.Master.BIP39ChecksumHex,
-		"name":              w.Master.Name,
+		"name":               w.Master.Name,
 	}
 }
 
@@ -492,10 +492,12 @@ func (s *Service) GenerateWallet(name, customMnemonic, passphrase string, slots 
 		Int("sidechain_count", len(wallet.Sidechains)).
 		Msg("wallet keys derived")
 
-	// Set ID, gradient, timestamp
+	// Set ID and timestamp. Leave Gradient nil so the Dart side derives a
+	// deterministic visual via WalletGradient.fromWalletId; storing a stub
+	// like {"background_svg":""} would round-trip as an unrenderable avatar.
 	wallet.ID = generateWalletID()
 	wallet.CreatedAt = time.Now()
-	wallet.Gradient = defaultGradient(wallet.ID)
+	wallet.Gradient = nil
 
 	// Add to list and set as active
 	s.wallets = append(s.wallets, *wallet)
@@ -1275,9 +1277,4 @@ func generateWalletID() string {
 	b := make([]byte, 16)
 	_, _ = rand.Read(b)
 	return strings.ToUpper(hex.EncodeToString(b))
-}
-
-// defaultGradient returns a simple default gradient JSON for a wallet.
-func defaultGradient(walletID string) json.RawMessage {
-	return json.RawMessage(`{"background_svg":""}`)
 }

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.204
+version: 1.0.205
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.75
+version: 1.0.76
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.202
+version: 1.0.203
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
## Summary
- Orchestrator no longer saves `{"background_svg":""}` for new wallets (caused empty avatars in the wallet dropdown).
- Dart `_onData` ignores a parsed gradient with empty `backgroundSvg`, so legacy wallets carrying the stub still render via `WalletGradient.fromWalletId`.

## Test plan
- [ ] Boot bitwindow against an existing wallet.json with `gradient:{"background_svg":""}` — wallet shows up in the top-left dropdown with a deterministic background.
- [ ] Create a fresh wallet — wallet.json now omits the stub, dropdown still renders.