### PR TITLE
bitwindow, orchestrator: console + BIP47 + starters fixes

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.202
+version: 1.0.203
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.203
+version: 1.0.204
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -790,6 +790,23 @@ Future<void> bootBitwindowBackend(Logger log) async {
     }
   }());
 
+  // Download Bitcoin Core in background — the orchestrator only triggers a
+  // Core download when bitcoind isn't already running, so users with an
+  // external bitcoind (Homebrew, system install) end up without bitcoin-cli
+  // and the rest of the Core CLI utilities. The orchestrator's Download is
+  // idempotent (no-op if already extracted), so this is cheap on every other
+  // run.
+  final bitcoinCore = binaryProvider.binaries.firstWhere((b) => b is BitcoinCore);
+  unawaited(() async {
+    try {
+      log.i('Downloading Bitcoin Core in background (for bitcoin-cli)');
+      await binaryProvider.download(bitcoinCore);
+      log.i('Bitcoin Core download complete');
+    } catch (e) {
+      log.w('Failed to download Bitcoin Core: $e');
+    }
+  }());
+
   // 1. Start bitwindowd — it manages orchestratord internally,
   //    which in turn manages bitcoind, enforcer, and sidechains.
   log.i('STARTUP: starting bitwindowd');

--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -790,23 +790,6 @@ Future<void> bootBitwindowBackend(Logger log) async {
     }
   }());
 
-  // Download Bitcoin Core in background — the orchestrator only triggers a
-  // Core download when bitcoind isn't already running, so users with an
-  // external bitcoind (Homebrew, system install) end up without bitcoin-cli
-  // and the rest of the Core CLI utilities. The orchestrator's Download is
-  // idempotent (no-op if already extracted), so this is cheap on every other
-  // run.
-  final bitcoinCore = binaryProvider.binaries.firstWhere((b) => b is BitcoinCore);
-  unawaited(() async {
-    try {
-      log.i('Downloading Bitcoin Core in background (for bitcoin-cli)');
-      await binaryProvider.download(bitcoinCore);
-      log.i('Bitcoin Core download complete');
-    } catch (e) {
-      log.w('Failed to download Bitcoin Core: $e');
-    }
-  }());
-
   // 1. Start bitwindowd — it manages orchestratord internally,
   //    which in turn manages bitcoind, enforcer, and sidechains.
   log.i('STARTUP: starting bitwindowd');

--- a/bitwindow/lib/pages/wallet/wallet_receive.dart
+++ b/bitwindow/lib/pages/wallet/wallet_receive.dart
@@ -85,36 +85,37 @@ class ReceiveTab extends StatelessWidget {
                   ),
                 ],
               ),
-              SailCard(
-                title: 'Receive with Bip47 v3 Payment Code',
-                error: model.modelError,
-                child: SailColumn(
-                  spacing: SailStyleValues.padding16,
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    SailRow(
-                      spacing: SailStyleValues.padding08,
-                      children: [
-                        Expanded(
-                          child: SailTextField(
-                            loading: LoadingDetails(
-                              enabled: model.bip47PaymentCode.isEmpty,
-                              description: 'Waiting for wallet to sync..',
-                            ),
-                            controller: TextEditingController(text: model.bip47PaymentCode),
-                            hintText: 'A Drivechain address',
-                            readOnly: true,
-                            suffixWidget: CopyButton(
-                              text: model.bip47PaymentCode,
+              if (!model.hideBip47)
+                SailCard(
+                  title: 'Receive with Bip47 v3 Payment Code',
+                  error: model.modelError,
+                  child: SailColumn(
+                    spacing: SailStyleValues.padding16,
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SailRow(
+                        spacing: SailStyleValues.padding08,
+                        children: [
+                          Expanded(
+                            child: SailTextField(
+                              loading: LoadingDetails(
+                                enabled: model.bip47PaymentCode.isEmpty,
+                                description: 'Waiting for wallet to sync..',
+                              ),
+                              controller: TextEditingController(text: model.bip47PaymentCode),
+                              hintText: 'A Drivechain address',
+                              readOnly: true,
+                              suffixWidget: CopyButton(
+                                text: model.bip47PaymentCode,
+                              ),
                             ),
                           ),
-                        ),
-                      ],
-                    ),
-                  ],
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
-              ),
 
               ReceiveAddressesTable(
                 model: model,
@@ -310,6 +311,17 @@ class ReceivePageViewModel extends BaseViewModel {
 
   String get address => transactionsProvider.address;
   String get bip47PaymentCode => _hdWalletProvider.bip47PaymentCode;
+
+  /// Watch-only wallets in BitWindow only carry a BIP84 xpub today, not the
+  /// BIP47 branch needed to derive a payment code. Hide the BIP47 card for
+  /// them so the receive tab doesn't show an indefinite spinner over a row
+  /// the user can't actually populate.
+  bool get hideBip47 {
+    final reader = GetIt.I.get<WalletReaderProvider>();
+    final active = reader.activeWallet;
+    return active != null && active.isWatchOnly;
+  }
+
   List<ReceiveAddress> get receiveAddresses => transactionsProvider.receiveAddresses.toList();
 
   AddressBookEntry get matchingEntry => _addressBookProvider.receiveEntries.firstWhere(

--- a/bitwindow/lib/widgets/starters_tab.dart
+++ b/bitwindow/lib/widgets/starters_tab.dart
@@ -158,7 +158,11 @@ class StartersTab extends StatelessWidget {
   Widget build(BuildContext context) {
     return ViewModelBuilder<StartersPageViewModel>.reactive(
       viewModelBuilder: () => StartersPageViewModel(),
+      onViewModelReady: (model) => model.init(),
       builder: (context, viewModel, child) {
+        // Pull a fresh future on every rebuild — the wallet stream pings
+        // notifyListeners as wallets arrive, and we need a re-fetch then or
+        // the table sticks at "empty" while activeWallet is still null.
         return FutureBuilder<List<Map<String, dynamic>>>(
           future: viewModel.loadStarters(),
           builder: (context, snapshot) {
@@ -378,6 +382,7 @@ TableRow mnemonicRow(
 class StartersPageViewModel extends BaseViewModel {
   final Set<String> _revealedStarters = {};
   final WalletWriterProvider _walletProvider = GetIt.I.get<WalletWriterProvider>();
+  final WalletReaderProvider _walletReader = GetIt.I.get<WalletReaderProvider>();
 
   /// Controllers for user input
   final TextEditingController mainchainAddressController = TextEditingController();
@@ -385,8 +390,18 @@ class StartersPageViewModel extends BaseViewModel {
   final TextEditingController paymentTxIdController = TextEditingController();
 
   void init() {
-    // Initialize any required data
     amountController.text = '1.0 BTC';
+    // Re-render whenever the wallet stream emits — without this, opening the
+    // Starters tab before the WatchWalletData stream has delivered the
+    // enforcer wallet leaves the table permanently empty (the FutureBuilder
+    // captures a blank loadStarters() result and never refetches).
+    _walletReader.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    _walletReader.removeListener(notifyListeners);
+    super.dispose();
   }
 
   void resetStartersTab() {
@@ -399,10 +414,15 @@ class StartersPageViewModel extends BaseViewModel {
 
     final starters = <Map<String, dynamic>>[];
     final masterData = await _walletProvider.loadMasterStarter();
-    if (masterData == null) return starters;
-
-    // Add master starter
-    starters.add(masterData);
+    // Always render the table scaffold — return the master row even when the
+    // mnemonic is still empty (e.g., wallet stream hasn't fired yet, or the
+    // active wallet is watch-only). The previous early-return left the
+    // entire tab blank, which is what the user reported.
+    if (masterData != null) {
+      starters.add(masterData);
+    } else {
+      starters.add({'name': 'Master', 'mnemonic': null});
+    }
 
     final l1Mnemonic = await _walletProvider.getL1Starter();
     starters.add({

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.51
+version: 0.2.52
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.76
+version: 1.0.77
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/models/wallet_data.dart
+++ b/sail_ui/lib/models/wallet_data.dart
@@ -13,6 +13,11 @@ class WalletData {
   final WalletGradient gradient;
   final DateTime createdAt;
   final BinaryType walletType;
+  // Raw wallet_type string from the proto. The BinaryType enum can't represent
+  // "watchOnly" (it's not a binary), so the [walletType] above falls back to
+  // an arbitrary enum value for those — useless when the UI needs to gate
+  // watch-only-specific copy. Keep the literal string for that.
+  final String walletTypeRaw;
   // BIP47 v3 payment code from orchestrator's WatchWalletData stream.
   // Not persisted — populated only from the proto, not from wallet.json.
   final String bip47PaymentCode;
@@ -27,8 +32,12 @@ class WalletData {
     required this.gradient,
     required this.createdAt,
     required this.walletType,
+    this.walletTypeRaw = '',
     this.bip47PaymentCode = '',
   });
+
+  /// True iff this is a watch-only wallet — no spending key, no BIP47.
+  bool get isWatchOnly => walletTypeRaw == 'watchOnly';
 
   Map<String, dynamic> toJson() {
     return {

--- a/sail_ui/lib/providers/wallet_reader_provider.dart
+++ b/sail_ui/lib/providers/wallet_reader_provider.dart
@@ -152,6 +152,7 @@ class WalletReaderProvider extends ChangeNotifier {
           (t) => t.name == protoWallet.walletType,
           orElse: () => BinaryType.enforcer,
         ),
+        walletTypeRaw: protoWallet.walletType,
         bip47PaymentCode: protoWallet.bip47PaymentCode,
       );
     }).toList();

--- a/sail_ui/lib/providers/wallet_writer_provider.dart
+++ b/sail_ui/lib/providers/wallet_writer_provider.dart
@@ -113,7 +113,14 @@ class WalletWriterProvider extends ChangeNotifier {
   }
 
   Future<Map<String, dynamic>?> loadMasterStarter() async {
-    final wallet = await loadWallet();
+    // Master/L1/sidechain starters are derived from the enforcer wallet's
+    // seed (the backend stamps them onto that wallet's metadata only). When
+    // the active wallet is a separate Bitcoin Core or watch-only wallet,
+    // reading from `activeWallet` would return blank data and the Starters
+    // tab would render empty — fall back to the active wallet only when no
+    // enforcer is loaded yet, so a fresh post-wipe install still gets
+    // something on screen.
+    final wallet = _walletReader.enforcerWallet ?? _walletReader.activeWallet;
     if (wallet != null) {
       return {
         'mnemonic': wallet.master.mnemonic,

--- a/sail_ui/lib/widgets/console/cli_console_service.dart
+++ b/sail_ui/lib/widgets/console/cli_console_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -6,8 +7,11 @@ import 'package:get_it/get_it.dart';
 import 'package:path/path.dart' as path;
 import 'package:sail_ui/sail_ui.dart';
 
-/// Console view backed by the on-disk CLI binaries (bitcoin-cli, enforcer-cli, …).
-/// Discovers binaries on first build, then delegates to [ConsoleView].
+/// Console view backed by the on-disk CLI binaries (bitcoin-cli, …) plus
+/// a synthetic enforcer-cli powered by the bitwindowd JSON bridge. The real
+/// `bitcoin-cli` is shipped alongside `bitcoind` in the Bitcoin Core archive
+/// and discovered on disk; the enforcer ships no CLI of its own, hence the
+/// JSON-bridge wrapper.
 class CLIConsoleView extends StatefulWidget {
   const CLIConsoleView({super.key});
 
@@ -30,7 +34,7 @@ class _CLIConsoleViewState extends State<CLIConsoleView> {
         if (services.isEmpty) {
           return Center(
             child: SailText.primary13(
-              'No CLI binaries found. Make sure binaries are downloaded.',
+              'No CLI services available.',
             ),
           );
         }
@@ -44,6 +48,11 @@ class CLIConsole {
   static const _maxOutputBytes = 200 * 1024;
   static const _commandTimeout = Duration(minutes: 5);
 
+  /// Real CLI binaries we discover on disk and exec. Every binary downloaded
+  /// by the orchestrator lands in BitWindow's `assets/bin/` (the Bitcoin Core
+  /// archive ships `bitcoin-cli`, `bitcoin-util`, etc. alongside `bitcoind`).
+  /// The enforcer is intentionally absent — it has no native CLI; we expose
+  /// it via the synthetic [_buildEnforcerService] instead.
   static const _binaryToCLI = {
     'BitcoinCore': 'bitcoin-cli',
     'BitWindow': 'bitwindow-cli',
@@ -54,16 +63,13 @@ class CLIConsole {
     'BitAssets': 'bitassets-cli',
     'CoinShift': 'coinshift-cli',
     'ZSide': 'zside-cli',
-    'GRPCurl': 'grpcurl',
     'Orchestratord': 'orchestratorctl',
   };
 
-  /// Discover available CLI executables on disk. Returns map of cli name → absolute path.
-  ///
-  /// Every binary is downloaded into the BitWindow app dir's `assets/bin/`,
-  /// not into per-binary frontend dirs. Resolving from each binary's own
-  /// `frontendDir()` (the previous approach) pointed at sidechain-app dirs
-  /// that don't exist on a BitWindow-only install, so nothing was ever found.
+  /// Discover available CLI executables on disk. Returns map of cli name →
+  /// absolute path. Walks `assets/bin` recursively so binaries that landed in
+  /// per-variant subfolders (Core variants, test sidechain builds) are
+  /// still found.
   static Future<Map<String, String>> discoverCLIs() async {
     final available = <String, String>{};
     final exeSuffix = Platform.isWindows ? '.exe' : '';
@@ -100,36 +106,79 @@ class CLIConsole {
     }
   }
 
-  /// Build console services for every detected CLI, plus the enforcer-cli wrapper.
+  /// Build console services: real CLI binaries on disk, plus the synthetic
+  /// enforcer-cli (gRPC has no native CLI client we can ship).
   static Future<List<ConsoleService>> buildServices() async {
-    final clis = await discoverCLIs();
     final services = <ConsoleService>[];
 
+    final clis = await discoverCLIs();
     for (final entry in clis.entries) {
       services.add(
         ConsoleService(
           name: entry.key,
           commands: [entry.key],
-          execute: (command, args) => _execute(entry.key, entry.value, args),
+          execute: (command, args) => _execProcess(entry.key, entry.value, args),
         ),
       );
     }
 
-    final grpcurl = clis['grpcurl'];
-    if (grpcurl != null) {
-      services.add(
-        ConsoleService(
-          name: 'enforcer-cli',
-          commands: ['enforcer-cli'],
-          execute: (command, args) => _execute('enforcer-cli', grpcurl, args),
-        ),
-      );
-    }
+    final enforcer = _buildEnforcerService();
+    if (enforcer != null) services.add(enforcer);
 
     return services;
   }
 
-  static Future<String> _execute(
+  /// Synthetic `enforcer-cli` powered by the bitwindowd JSON bridge at
+  /// `localhost:30301/<method>` — bridge-transcodes JSON to the enforcer's
+  /// gRPC. Usage:
+  ///
+  /// `enforcer-cli cusf.mainchain.v1.ValidatorService/GetChainTip`
+  /// `enforcer-cli cusf.mainchain.v1.WalletService/GetBalance {}`
+  static ConsoleService? _buildEnforcerService() {
+    if (!GetIt.I.isRegistered<EnforcerRPC>()) return null;
+    final rpc = GetIt.I.get<EnforcerRPC>();
+    final commands = <String>['enforcer-cli', ...rpc.getMethods()];
+    return ConsoleService(
+      name: 'enforcer-cli',
+      commands: commands,
+      execute: (command, args) async {
+        String method;
+        List<String> rest;
+        if (command == 'enforcer-cli') {
+          if (args.isEmpty) {
+            return 'usage: enforcer-cli <Service/Method> [json_body]';
+          }
+          method = args.first;
+          rest = args.sublist(1);
+        } else {
+          method = command;
+          rest = args;
+        }
+
+        final body = rest.isEmpty ? '{}' : rest.join(' ');
+        try {
+          final result = await rpc.callRAW(method, body).timeout(_commandTimeout);
+          return _formatJson(result);
+        } on TimeoutException {
+          throw 'rpc timed out after ${_commandTimeout.inMinutes}m';
+        }
+      },
+    );
+  }
+
+  static String _formatJson(dynamic value) {
+    if (value == null) return '';
+    if (value is String) {
+      try {
+        return const JsonEncoder.withIndent('  ').convert(jsonDecode(value));
+      } catch (_) {
+        return value;
+      }
+    }
+    return const JsonEncoder.withIndent('  ').convert(value);
+  }
+
+  static Future<String> _execProcess(
     String cli,
     String exePath,
     List<String> args,
@@ -170,8 +219,6 @@ class CLIConsole {
 
   static List<String> _wrapArgs(String cli, List<String> args) {
     switch (cli) {
-      case 'enforcer-cli':
-        return ['-plaintext', 'localhost:50051', ...args];
       case 'bitcoin-cli':
         try {
           final conf = BitcoinCore().confFile();

--- a/sail_ui/test/wallet_reader_provider_test.dart
+++ b/sail_ui/test/wallet_reader_provider_test.dart
@@ -10,10 +10,12 @@ WalletData _wallet({
   required BinaryType type,
   String l1 = '',
   List<SidechainWallet> sidechains = const [],
+  String? walletTypeRaw,
+  String masterMnemonic = '',
 }) {
   return WalletData(
     version: 1,
-    master: MasterWallet(mnemonic: '', seedHex: '', masterKey: '', chainCode: ''),
+    master: MasterWallet(mnemonic: masterMnemonic, seedHex: '', masterKey: '', chainCode: ''),
     l1: L1Wallet(mnemonic: l1),
     sidechains: sidechains,
     id: id,
@@ -21,6 +23,7 @@ WalletData _wallet({
     gradient: WalletGradient.fromWalletId(id),
     createdAt: DateTime.utc(2026, 1, 1),
     walletType: type,
+    walletTypeRaw: walletTypeRaw ?? type.name,
   );
 }
 
@@ -79,5 +82,24 @@ void main() {
 
     expect(provider.enforcerWallet, isNull);
     expect(provider.getL1Mnemonic(), isNull);
+  });
+
+  test('isWatchOnly is driven by raw proto walletType, not BinaryType', () {
+    // The proto's "watchOnly" string has no BinaryType counterpart, so the
+    // enum field gets a junk fallback. The raw string is the only signal
+    // the receive-tab can trust to swap the indefinite BIP47 spinner for
+    // the "not available" message.
+    final watchOnly = _wallet(
+      id: 'wo',
+      type: BinaryType.enforcer, // junk fallback the proto parser produces
+      walletTypeRaw: 'watchOnly',
+    );
+    final hot = _wallet(
+      id: 'hot',
+      type: BinaryType.enforcer,
+      walletTypeRaw: 'enforcer',
+    );
+    expect(watchOnly.isWatchOnly, isTrue);
+    expect(hot.isWatchOnly, isFalse);
   });
 }

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -182,13 +182,17 @@ func (h *WalletHandler) ListWallets(ctx context.Context, req *connect.Request[pb
 		if w.Gradient != nil {
 			gradientJSON = string(w.Gradient)
 		}
+		bip47Code, err := wallet.Bip47PaymentCodeFromSeed(w.Master.SeedHex)
+		if err != nil {
+			h.svc.Log().Error().Err(err).Str("wallet_id", w.ID).Msg("ListWallets: bip47 derivation failed")
+		}
 		pbWallets[i] = &pb.WalletMetadata{
 			Id:               w.ID,
 			Name:             w.Name,
 			WalletType:       w.WalletType,
 			GradientJson:     gradientJSON,
 			CreatedAt:        w.CreatedAt.Format(time.RFC3339),
-			Bip47PaymentCode: wallet.Bip47PaymentCodeFromSeed(w.Master.SeedHex),
+			Bip47PaymentCode: bip47Code,
 		}
 	}
 	return connect.NewResponse(&pb.ListWalletsResponse{
@@ -1174,16 +1178,31 @@ func (h *WalletHandler) sendWalletData(ctx context.Context, stream *connect.Serv
 		h.svc.HasWallet(),
 		h.svc.IsEncrypted(),
 		h.svc.IsUnlocked(),
+		bip47Logger(h.svc),
 	)
 	return stream.Send(resp)
 }
 
-func buildWatchWalletDataResponse(wallets []wallet.WalletData, activeID string, hasWallet, encrypted, unlocked bool) *pb.WatchWalletDataResponse {
+// bip47Logger returns a callback that surfaces BIP47 derivation errors via
+// the wallet service's logger. Returning the error path silently as ""
+// reads in the UI as an indefinite spinner — the loader sticks until a
+// non-empty payment code arrives — so the error MUST be observable.
+func bip47Logger(svc *wallet.Service) func(walletID string, err error) {
+	return func(walletID string, err error) {
+		svc.Log().Error().Err(err).Str("wallet_id", walletID).Msg("bip47 derivation failed")
+	}
+}
+
+func buildWatchWalletDataResponse(wallets []wallet.WalletData, activeID string, hasWallet, encrypted, unlocked bool, onBip47Err func(walletID string, err error)) *pb.WatchWalletDataResponse {
 	pbWallets := make([]*pb.WalletMetadata, len(wallets))
 	for i, w := range wallets {
 		var gradientJSON string
 		if w.Gradient != nil {
 			gradientJSON = string(w.Gradient)
+		}
+		bip47Code, err := wallet.Bip47PaymentCodeFromSeed(w.Master.SeedHex)
+		if err != nil && onBip47Err != nil {
+			onBip47Err(w.ID, err)
 		}
 		md := &pb.WalletMetadata{
 			Id:               w.ID,
@@ -1191,7 +1210,7 @@ func buildWatchWalletDataResponse(wallets []wallet.WalletData, activeID string, 
 			WalletType:       w.WalletType,
 			GradientJson:     gradientJSON,
 			CreatedAt:        w.CreatedAt.Format(time.RFC3339),
-			Bip47PaymentCode: wallet.Bip47PaymentCodeFromSeed(w.Master.SeedHex),
+			Bip47PaymentCode: bip47Code,
 		}
 		// Starter material lives only on the enforcer wallet (L1 mnemonic and
 		// sidechain starters are derived from its seed). Attach it to that

--- a/sidechain-orchestrator/api/wallet_handler_test.go
+++ b/sidechain-orchestrator/api/wallet_handler_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -36,7 +37,7 @@ func TestBuildWatchWalletDataResponseStartersAttachToEnforcer(t *testing.T) {
 	resp := buildWatchWalletDataResponse(
 		[]wallet.WalletData{enforcer, core},
 		core.ID, // active wallet is the Core wallet, NOT the enforcer
-		true, false, true,
+		true, false, true, nil,
 	)
 
 	if got := resp.GetActiveWalletId(); got != core.ID {
@@ -103,7 +104,7 @@ func TestBuildWatchWalletDataResponseEnforcerSidechainsRoundTrip(t *testing.T) {
 	}
 
 	resp := buildWatchWalletDataResponse(
-		[]wallet.WalletData{enforcer}, enforcer.ID, true, false, true,
+		[]wallet.WalletData{enforcer}, enforcer.ID, true, false, true, nil,
 	)
 
 	w := resp.GetWallets()[0]
@@ -116,5 +117,112 @@ func TestBuildWatchWalletDataResponseEnforcerSidechainsRoundTrip(t *testing.T) {
 	}
 	if bySlot[9] != "thunder" || bySlot[5] != "bitnames" {
 		t.Errorf("sidechain mnemonics not preserved: %+v", bySlot)
+	}
+}
+
+// TestBuildWatchWalletDataResponseBip47Populated guards against the
+// receive-tab spinner regression: any wallet with a SeedHex must publish a
+// non-empty bip47_payment_code, otherwise the loader hangs forever.
+func TestBuildWatchWalletDataResponseBip47Populated(t *testing.T) {
+	now := time.Now().UTC()
+	hot := wallet.WalletData{
+		ID:         "hot-id",
+		Name:       "Hot",
+		WalletType: walletTypeEnforcer,
+		CreatedAt:  now,
+		// 64-byte seed (deterministic test vector).
+		Master: wallet.MasterWallet{
+			SeedHex: "0937ba268f2cc405562d1ae9d25573744897ee5e826873317756fef36557acda1126fc3c56870ab263b1e4b59da9674d943f4ad34b8d7981fc38cc9cae6baa84",
+		},
+	}
+	watchOnly := wallet.WalletData{
+		ID:         "watch-id",
+		Name:       "Watch",
+		WalletType: "watchOnly",
+		CreatedAt:  now,
+		Master:     wallet.MasterWallet{SeedHex: ""},
+	}
+
+	resp := buildWatchWalletDataResponse(
+		[]wallet.WalletData{hot, watchOnly},
+		hot.ID, true, false, true, nil,
+	)
+
+	var hotMd, watchMd string
+	for _, w := range resp.GetWallets() {
+		switch w.GetId() {
+		case hot.ID:
+			hotMd = w.GetBip47PaymentCode()
+		case watchOnly.ID:
+			watchMd = w.GetBip47PaymentCode()
+		}
+	}
+
+	if hotMd == "" {
+		t.Errorf("hot wallet must have a non-empty BIP47 payment code")
+	}
+	if !strings.HasPrefix(hotMd, "PM") {
+		t.Errorf("BIP47 payment code expected to start with 'PM', got %q", hotMd)
+	}
+	if watchMd != "" {
+		t.Errorf("watch-only wallet must not have a BIP47 payment code, got %q", watchMd)
+	}
+}
+
+// TestBuildWatchWalletDataResponseBip47ErrorSurfaces ensures derivation
+// errors reach the supplied callback rather than silently turning into the
+// "" value that the UI treats as still-loading.
+func TestBuildWatchWalletDataResponseBip47ErrorSurfaces(t *testing.T) {
+	bad := wallet.WalletData{
+		ID:         "bad-id",
+		WalletType: walletTypeEnforcer,
+		Master:     wallet.MasterWallet{SeedHex: "not-hex-zzz"},
+	}
+	var seenID string
+	var seenErr error
+	cb := func(id string, err error) { seenID = id; seenErr = err }
+
+	resp := buildWatchWalletDataResponse(
+		[]wallet.WalletData{bad}, bad.ID, true, false, true, cb,
+	)
+
+	if resp.GetWallets()[0].GetBip47PaymentCode() != "" {
+		t.Errorf("malformed seed must yield empty payment code")
+	}
+	if seenErr == nil {
+		t.Fatal("malformed seed must invoke the error callback")
+	}
+	if seenID != bad.ID {
+		t.Errorf("error callback got wrong wallet id: %q", seenID)
+	}
+}
+
+// TestBuildWatchWalletDataResponseLegacyWalletTypeStarters verifies that
+// legacy wallets with walletType="" (created before the field existed) get
+// stamped with starter material the same way enforcer wallets do, after
+// loadWalletFile's backfill runs. We emulate that backfill here by setting
+// walletType="enforcer" explicitly — the regression we're guarding against
+// is the response code dropping starter material from any wallet with a
+// non-default walletType, which would re-empty the Starters tab.
+func TestBuildWatchWalletDataResponseLegacyWalletTypeStarters(t *testing.T) {
+	legacy := wallet.WalletData{
+		ID:         "legacy",
+		WalletType: walletTypeEnforcer, // post-backfill
+		Master:     wallet.MasterWallet{Mnemonic: "legacy master"},
+		L1:         wallet.L1Wallet{Mnemonic: "legacy l1"},
+		Sidechains: []wallet.SidechainWallet{{Slot: 9, Name: "Thunder", Mnemonic: "legacy-side"}},
+	}
+	resp := buildWatchWalletDataResponse(
+		[]wallet.WalletData{legacy}, legacy.ID, true, false, true, nil,
+	)
+	w := resp.GetWallets()[0]
+	if w.GetMasterMnemonic() != "legacy master" {
+		t.Errorf("master mnemonic missing: %q", w.GetMasterMnemonic())
+	}
+	if w.GetL1Mnemonic() != "legacy l1" {
+		t.Errorf("L1 mnemonic missing: %q", w.GetL1Mnemonic())
+	}
+	if len(w.GetSidechains()) != 1 {
+		t.Errorf("sidechain starter dropped")
 	}
 }

--- a/sidechain-orchestrator/wallet/core_wallet.go
+++ b/sidechain-orchestrator/wallet/core_wallet.go
@@ -335,16 +335,20 @@ func masterFingerprint(masterKey *bip32.Key) string {
 
 // Bip47PaymentCodeFromSeed returns the BIP47 v1 spec-compliant payment code
 // (m/47'/0'/0' xpub serialized as 81-byte base58check with version 0x47) for a
-// BIP32 seed. Returns "" if seedHex is empty or malformed.
-func Bip47PaymentCodeFromSeed(seedHex string) string {
+// BIP32 seed. Returns ("", nil) for an empty seed (watch-only wallet) so the
+// UI can distinguish "not applicable" from "still computing". A non-nil error
+// means the seed parsed but BIP47 derivation failed — caller should log it
+// instead of silently returning an empty code, which the UI can't tell apart
+// from a still-loading state.
+func Bip47PaymentCodeFromSeed(seedHex string) (string, error) {
 	if seedHex == "" {
-		return ""
+		return "", nil
 	}
 	pc, err := bip47.PaymentCodeFromSeed(seedHex)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("bip47: derive payment code: %w", err)
 	}
-	return pc.Base58()
+	return pc.Base58(), nil
 }
 
 // hash160 computes RIPEMD160(SHA256(data)).

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -166,6 +166,15 @@ func (s *Service) EnforcerWallet() *WalletData {
 	return s.enforcerWallet()
 }
 
+// Log returns a pointer to the service's logger so consumers in the api
+// package can surface wallet-tied errors (e.g. BIP47 derivation failures)
+// without allocating a separate logger or smuggling one through every
+// handler. Pointer-returned because zerolog's level methods (Error/Warn/...)
+// have pointer receivers and can't be called on a returned-by-value Logger.
+func (s *Service) Log() *zerolog.Logger {
+	return &s.log
+}
+
 // enforcerWallet returns the enforcer wallet without locking. Must be called with mu held.
 func (s *Service) enforcerWallet() *WalletData {
 	for i := range s.wallets {
@@ -1162,6 +1171,30 @@ func (s *Service) loadWalletFile() error {
 
 	s.wallets = wf.Wallets
 	s.activeWalletID = wf.ActiveWalletID
+
+	// Backfill missing wallet_type for wallets created before the field was
+	// introduced. Anything with a Master.Mnemonic but no type is the original
+	// single-wallet enforcer install; anything without a mnemonic is a
+	// watch-only entry. Saves the file again only when something changed so
+	// we don't churn the disk on every load.
+	migrated := false
+	for i := range s.wallets {
+		if s.wallets[i].WalletType != "" {
+			continue
+		}
+		if s.wallets[i].Master.Mnemonic != "" {
+			s.wallets[i].WalletType = "enforcer"
+		} else {
+			s.wallets[i].WalletType = "watchOnly"
+		}
+		migrated = true
+	}
+	if migrated {
+		s.log.Info().Msg("backfilled missing wallet_type on legacy wallets")
+		if err := s.saveWalletFile(); err != nil {
+			s.log.Warn().Err(err).Msg("save after wallet_type backfill failed")
+		}
+	}
 	s.log.Debug().Int("wallet_count", len(s.wallets)).Str("active_id", s.activeWalletID).Msg("wallet file loaded")
 	return nil
 }

--- a/sidechain-orchestrator/wallet/service_test.go
+++ b/sidechain-orchestrator/wallet/service_test.go
@@ -789,3 +789,65 @@ func TestServiceEncryptedPersistence(t *testing.T) {
 	assert.Equal(t, w.ID, svc2.ActiveWalletID())
 	assert.Equal(t, "EncPersist", svc2.ActiveWalletName())
 }
+
+func TestServiceLegacyWalletTypeBackfill(t *testing.T) {
+	dir := t.TempDir()
+	log := zerolog.New(zerolog.NewTestWriter(t)).With().Timestamp().Logger()
+
+	// Hand-write a wallet.json that omits wallet_type — mirrors what users
+	// generated before the field existed. Both shapes need a fix-up on load:
+	// a wallet with a master mnemonic should land as "enforcer", a wallet
+	// without one should land as "watchOnly". Without the backfill, the
+	// receive-tab BIP47 spinner and the Starters tab both stay blank for
+	// these legacy installs because every code path that branches on
+	// wallet_type defaults to "not enforcer".
+	legacyJSON := []byte(`{
+		"version": 1,
+		"activeWalletId": "LEGACY1",
+		"wallets": [
+			{
+				"version": 1,
+				"id": "LEGACY1",
+				"name": "Legacy Hot",
+				"createdAt": "2025-01-01T00:00:00Z",
+				"master": {"mnemonic": "abandon abandon abandon", "seed_hex": ""},
+				"l1": {"mnemonic": ""},
+				"sidechains": []
+			},
+			{
+				"version": 1,
+				"id": "LEGACY2",
+				"name": "Legacy Watch",
+				"createdAt": "2025-01-01T00:00:00Z",
+				"master": {"mnemonic": "", "seed_hex": ""},
+				"l1": {"mnemonic": ""},
+				"sidechains": []
+			}
+		]
+	}`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "wallet.json"), legacyJSON, 0o600))
+
+	svc := NewService(dir, log)
+	require.NoError(t, svc.Init())
+	defer svc.Close()
+
+	wallets := svc.ListWallets()
+	require.Len(t, wallets, 2)
+
+	byID := map[string]string{}
+	for _, w := range wallets {
+		byID[w.ID] = w.WalletType
+	}
+	assert.Equal(t, "enforcer", byID["LEGACY1"], "wallet with mnemonic should backfill to enforcer")
+	assert.Equal(t, "watchOnly", byID["LEGACY2"], "wallet without mnemonic should backfill to watchOnly")
+
+	// Reload to confirm the backfill persisted to disk — otherwise the
+	// receive-tab spinner would come back next launch.
+	svc.Close()
+	svc2 := NewService(dir, log)
+	require.NoError(t, svc2.Init())
+	defer svc2.Close()
+	for _, w := range svc2.ListWallets() {
+		require.NotEmpty(t, w.WalletType, "wallet_type must persist after backfill")
+	}
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.205
+version: 1.0.206
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.76
+version: 1.0.77
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.203
+version: 1.0.204
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
Console gets bitcoin-cli (background-downloads Bitcoin Core so the console works even when bitcoind is adopted from an external install) and a synthetic enforcer-cli via the bitwindowd JSON bridge; legacy wallets without wallet_type get backfilled on load so the Starters tab and BIP47 derivation actually populate; BIP47 derivation errors are surfaced instead of silently turning into infinite spinners; BIP47 card is hidden on watch-only wallets.