### PR TITLE
wallet: seed reader state via direct RPC, don't wait on stream

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.203
+version: 1.0.204
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.204
+version: 1.0.205
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -835,7 +835,17 @@ Future<void> bootBitwindowBackend(Logger log) async {
     log.w('STARTUP: proceeding without orchestratord readiness confirmation');
   }
 
-  // 3. Stream binary logs and start watching state.
+  // 3. Now that orchestratord is up, re-seed the wallet reader. The
+  //    earlier init() in setupBitwindow runs before any backend exists, so
+  //    its listWallets/getWalletStatus calls fail and the provider sits
+  //    empty until the WatchWalletData stream eventually delivers — which
+  //    can lag long enough that the wallet dropdown, BIP47 card and
+  //    starters tab render empty against an already-loaded wallet.
+  if (orchestratorReady && GetIt.I.isRegistered<WalletReaderProvider>()) {
+    unawaited(GetIt.I.get<WalletReaderProvider>().init());
+  }
+
+  // 4. Stream binary logs and start watching state.
   _streamBinaryLogs(orchestrator, 'bitcoind', BinaryType.bitcoinCore, log);
   _streamBinaryLogs(orchestrator, 'enforcer', BinaryType.enforcer, log);
   _streamBinaryLogs(orchestrator, 'bitwindow', BinaryType.bitWindow, log);

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.52
+version: 0.2.53
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.77
+version: 1.0.78
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/providers/wallet_reader_provider.dart
+++ b/sail_ui/lib/providers/wallet_reader_provider.dart
@@ -88,23 +88,34 @@ class WalletReaderProvider extends ChangeNotifier {
   }
 
   void _onData(dynamic resp) {
+    _applyState(
+      protoWallets: resp.wallets,
+      newActiveId: resp.activeWalletId.isEmpty ? null : resp.activeWalletId as String,
+      newHasWalletOnDisk: resp.hasWallet as bool,
+    );
+  }
+
+  void _applyState({
+    required Iterable<dynamic> protoWallets,
+    required String? newActiveId,
+    required bool newHasWalletOnDisk,
+  }) {
     final previousActiveId = activeWalletId;
-    final newActiveId = resp.activeWalletId.isEmpty ? null : resp.activeWalletId as String;
     if (previousActiveId != newActiveId) {
       _logger.i(
         'WalletReaderProvider: activeWalletId $previousActiveId -> $newActiveId '
-        '(wallets=${resp.wallets.length})',
+        '(wallets=${protoWallets.length})',
       );
     }
     activeWalletId = newActiveId;
 
     final previousHasWallet = hasWalletOnDisk;
-    hasWalletOnDisk = resp.hasWallet as bool;
+    hasWalletOnDisk = newHasWalletOnDisk;
     if (previousHasWallet != hasWalletOnDisk) {
       _logger.i('WalletReaderProvider: hasWalletOnDisk $previousHasWallet -> $hasWalletOnDisk');
     }
 
-    wallets = resp.wallets.map<WalletData>((protoWallet) {
+    wallets = protoWallets.map<WalletData>((protoWallet) {
       WalletGradient gradient = WalletGradient.fromWalletId(protoWallet.id);
       if (protoWallet.gradientJson.isNotEmpty) {
         try {
@@ -161,7 +172,32 @@ class WalletReaderProvider extends ChangeNotifier {
   }
 
   Future<void> init() async {
-    // Stream will deliver initial state; nothing extra needed.
+    if (Environment.isInTest) return;
+    // Seed state synchronously instead of waiting for the WatchWalletData
+    // stream. The stream races UI mount on cold start, and a slow/broken
+    // stream leaves the wallet dropdown, BIP47 card and starters tab empty
+    // even when the orchestrator already has the wallet on disk.
+    // listWallets + getWalletStatus return the same fields the stream
+    // would push, so we can populate the provider directly.
+    if (wallets.isNotEmpty) return;
+    try {
+      final results = await Future.wait([
+        _client.listWallets(),
+        _client.getWalletStatus(),
+      ]).timeout(const Duration(seconds: 3));
+      // Stream may have delivered while we awaited — let it win.
+      if (wallets.isNotEmpty) return;
+      final list = results[0] as dynamic;
+      final status = results[1] as dynamic;
+      if (list.wallets.isEmpty) return;
+      _applyState(
+        protoWallets: list.wallets,
+        newActiveId: list.activeWalletId.isEmpty ? null : list.activeWalletId as String,
+        newHasWalletOnDisk: status.hasWallet as bool,
+      );
+    } catch (e) {
+      _logger.w('WalletReaderProvider: init seed failed: $e');
+    }
   }
 
   Future<bool> hasWallet() async {

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.206
+version: 1.0.207
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.77
+version: 1.0.78
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.204
+version: 1.0.205
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
## Summary
- `WalletReaderProvider.init()` now seeds wallets/activeWalletId via `listWallets` + `getWalletStatus` instead of waiting for the `WatchWalletData` stream.
- `bootBitwindowBackend` re-runs `init()` once the orchestrator is confirmed ready, since the boot-time call in `setupBitwindow` fires before any backend exists.

## Why
The stream races UI mount on cold start: the first push fires into a provider whose listeners aren't attached yet, then the next fallback tick is up to 5s away. The dropdown, BIP47 card and starters tab all read straight off the provider, so they render empty against a wallet that's already loaded — `TransactionProvider` already self-heals via direct `getWalletStatus`, but the reader did not.

## Test plan
- [ ] Cold-boot bitwindow with an existing `wallet.json` — wallet dropdown shows the wallet immediately, BIP47 receive card populates, starters tab is non-empty.
- [ ] Generate a new wallet — dropdown updates as before via the writer's `init()` call.
- [ ] sail_ui tests pass (`flutter test test/wallet_reader_provider_test.dart`).