### PR TITLE
wallet: harden reader against partial _onData failures + dead HTTP/2

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.204
+version: 1.0.205
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.205
+version: 1.0.206
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/macos/Podfile.lock
+++ b/bitwindow/macos/Podfile.lock
@@ -7,8 +7,6 @@ PODS:
     - FlutterMacOS
   - file_picker (0.0.1):
     - FlutterMacOS
-  - flutter_pty (0.0.1):
-    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - path_provider_foundation (0.0.1):
     - Flutter
@@ -31,7 +29,6 @@ DEPENDENCIES:
   - auto_updater_macos (from `Flutter/ephemeral/.symlinks/plugins/auto_updater_macos/macos`)
   - desktop_multi_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos`)
   - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
-  - flutter_pty (from `Flutter/ephemeral/.symlinks/plugins/flutter_pty/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - patrol (from `Flutter/ephemeral/.symlinks/plugins/patrol/darwin`)
@@ -52,8 +49,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos
   file_picker:
     :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
-  flutter_pty:
-    :path: Flutter/ephemeral/.symlinks/plugins/flutter_pty/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   path_provider_foundation:
@@ -74,7 +69,6 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   desktop_multi_window: 93667594ccc4b88d91a97972fd3b1b89667fa80a
   file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
-  flutter_pty: 1e360feaf8b1a213d2d50da3c076005b8eef1eee
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   patrol: cea8074f183a2a4232d0ebd10569ae05149ada42

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.53
+version: 0.2.54
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.78
+version: 1.0.79
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/providers/backend_sidechain_conf_provider.dart
+++ b/sail_ui/lib/providers/backend_sidechain_conf_provider.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:get_it/get_it.dart';
@@ -66,7 +65,7 @@ class BackendSidechainConfProvider extends GenericSidechainConfProvider {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),
-      httpClient: createHttpClient(),
+      httpClient: keepaliveHttpClient(),
     );
     _client = SidechainConfServiceClient(transport);
   }

--- a/sail_ui/lib/providers/bitcoin_conf_provider.dart
+++ b/sail_ui/lib/providers/bitcoin_conf_provider.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:auto_route/auto_route.dart';
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:flutter/material.dart';
@@ -48,7 +47,7 @@ class BitcoinConfProvider extends ChangeNotifier {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),
-      httpClient: createHttpClient(),
+      httpClient: keepaliveHttpClient(),
     );
     _client = BitcoinConfServiceClient(transport);
   }

--- a/sail_ui/lib/providers/enforcer_conf_provider.dart
+++ b/sail_ui/lib/providers/enforcer_conf_provider.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:get_it/get_it.dart';
@@ -33,7 +32,7 @@ class EnforcerConfProvider extends ChangeNotifier {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),
-      httpClient: createHttpClient(),
+      httpClient: keepaliveHttpClient(),
     );
     _client = EnforcerConfServiceClient(transport);
   }

--- a/sail_ui/lib/providers/wallet_reader_provider.dart
+++ b/sail_ui/lib/providers/wallet_reader_provider.dart
@@ -66,6 +66,11 @@ class WalletReaderProvider extends ChangeNotifier {
         _onData,
         onError: (Object e) {
           _logger.e('WalletReaderProvider: stream error: $e');
+          // The Dart connectrpc client doesn't recover from a GOAWAY /
+          // forcefully-terminated HTTP/2 connection on its own — every
+          // subsequent stream subscription would fail. Rebuild the
+          // transport so the next reconnect has a chance.
+          GetIt.I.get<OrchestratorRPC>().recreateIfHttp2Error(e);
           _scheduleReconnect();
         },
         onDone: () {
@@ -76,6 +81,14 @@ class WalletReaderProvider extends ChangeNotifier {
     } catch (e) {
       _logger.e('WalletReaderProvider: failed to subscribe: $e');
       _scheduleReconnect();
+    }
+
+    // Self-heal: if the stream is flaky (HTTP/2 connection drops have been
+    // observed) and we never got the first push through, fall back to a
+    // direct listWallets/getWalletStatus so the dropdown / BIP47 / starters
+    // tabs don't sit empty against a wallet that's actually loaded.
+    if (wallets.isEmpty && !Environment.isInTest) {
+      unawaited(init());
     }
   }
 
@@ -100,11 +113,38 @@ class WalletReaderProvider extends ChangeNotifier {
     required String? newActiveId,
     required bool newHasWalletOnDisk,
   }) {
+    // Build the wallet list FIRST and only swap state in if it succeeds.
+    // Previously the field assignments happened inline with the .map, so a
+    // throw mid-build (e.g. unexpected proto shape) would leave activeWalletId
+    // and hasWalletOnDisk set with `wallets` still empty and notifyListeners
+    // skipped — exactly the state behind the empty-dropdown bug.
+    final List<WalletData> nextWallets = [];
+    int failures = 0;
+    for (final protoWallet in protoWallets) {
+      try {
+        nextWallets.add(_walletDataFromProto(protoWallet));
+      } catch (e, st) {
+        failures += 1;
+        _logger.e(
+          'WalletReaderProvider: failed to materialize wallet '
+          'id=${_safe(() => protoWallet.id)} type=${_safe(() => protoWallet.walletType)}: $e\n$st',
+        );
+      }
+    }
+    if (failures > 0 && nextWallets.isEmpty && wallets.isNotEmpty) {
+      // Don't blow away a known-good list with an all-broken update.
+      _logger.w(
+        'WalletReaderProvider: dropping update — all '
+        '${protoWallets.length} wallets failed to parse, keeping prior state',
+      );
+      return;
+    }
+
     final previousActiveId = activeWalletId;
     if (previousActiveId != newActiveId) {
       _logger.i(
         'WalletReaderProvider: activeWalletId $previousActiveId -> $newActiveId '
-        '(wallets=${protoWallets.length})',
+        '(wallets=${nextWallets.length})',
       );
     }
     activeWalletId = newActiveId;
@@ -115,60 +155,69 @@ class WalletReaderProvider extends ChangeNotifier {
       _logger.i('WalletReaderProvider: hasWalletOnDisk $previousHasWallet -> $hasWalletOnDisk');
     }
 
-    wallets = protoWallets.map<WalletData>((protoWallet) {
-      WalletGradient gradient = WalletGradient.fromWalletId(protoWallet.id);
-      if (protoWallet.gradientJson.isNotEmpty) {
-        try {
-          final parsed = WalletGradient.fromJsonString(protoWallet.gradientJson);
-          // Legacy default {"background_svg":""} parses cleanly but would
-          // render an empty avatar; keep the deterministic fallback in that
-          // case.
-          if ((parsed.backgroundSvg ?? '').isNotEmpty) {
-            gradient = parsed;
-          }
-        } catch (_) {}
-      }
-
-      DateTime createdAt = DateTime.now();
-      if (protoWallet.createdAt.isNotEmpty) {
-        try {
-          createdAt = DateTime.parse(protoWallet.createdAt);
-        } catch (_) {}
-      }
-
-      return WalletData(
-        version: 1,
-        master: MasterWallet(
-          mnemonic: protoWallet.masterMnemonic,
-          seedHex: '',
-          masterKey: '',
-          chainCode: '',
-          name: 'Master',
-        ),
-        l1: L1Wallet(mnemonic: protoWallet.l1Mnemonic),
-        sidechains: protoWallet.sidechains
-            .map(
-              (sc) => SidechainWallet(
-                slot: sc.slot,
-                name: sc.name,
-                mnemonic: sc.mnemonic,
-              ),
-            )
-            .toList(),
-        id: protoWallet.id,
-        name: protoWallet.name,
-        gradient: gradient,
-        createdAt: createdAt,
-        walletType: BinaryType.values.firstWhere(
-          (t) => t.name == protoWallet.walletType,
-          orElse: () => BinaryType.enforcer,
-        ),
-        walletTypeRaw: protoWallet.walletType,
-        bip47PaymentCode: protoWallet.bip47PaymentCode,
-      );
-    }).toList();
-
+    wallets = nextWallets;
     notifyListeners();
+  }
+
+  WalletData _walletDataFromProto(dynamic protoWallet) {
+    WalletGradient gradient = WalletGradient.fromWalletId(protoWallet.id);
+    if (protoWallet.gradientJson.isNotEmpty) {
+      try {
+        final parsed = WalletGradient.fromJsonString(protoWallet.gradientJson);
+        // Legacy default {"background_svg":""} parses cleanly but would
+        // render an empty avatar; keep the deterministic fallback in that
+        // case.
+        if ((parsed.backgroundSvg ?? '').isNotEmpty) {
+          gradient = parsed;
+        }
+      } catch (_) {}
+    }
+
+    DateTime createdAt = DateTime.now();
+    if (protoWallet.createdAt.isNotEmpty) {
+      try {
+        createdAt = DateTime.parse(protoWallet.createdAt);
+      } catch (_) {}
+    }
+
+    return WalletData(
+      version: 1,
+      master: MasterWallet(
+        mnemonic: protoWallet.masterMnemonic,
+        seedHex: '',
+        masterKey: '',
+        chainCode: '',
+        name: 'Master',
+      ),
+      l1: L1Wallet(mnemonic: protoWallet.l1Mnemonic),
+      sidechains: protoWallet.sidechains
+          .map<SidechainWallet>(
+            (sc) => SidechainWallet(
+              slot: sc.slot,
+              name: sc.name,
+              mnemonic: sc.mnemonic,
+            ),
+          )
+          .toList(),
+      id: protoWallet.id,
+      name: protoWallet.name,
+      gradient: gradient,
+      createdAt: createdAt,
+      walletType: BinaryType.values.firstWhere(
+        (t) => t.name == protoWallet.walletType,
+        orElse: () => BinaryType.enforcer,
+      ),
+      walletTypeRaw: protoWallet.walletType,
+      bip47PaymentCode: protoWallet.bip47PaymentCode,
+    );
+  }
+
+  String _safe(dynamic Function() f) {
+    try {
+      return '${f()}';
+    } catch (_) {
+      return '<unreadable>';
+    }
   }
 
   Future<void> init() async {
@@ -180,24 +229,41 @@ class WalletReaderProvider extends ChangeNotifier {
     // listWallets + getWalletStatus return the same fields the stream
     // would push, so we can populate the provider directly.
     if (wallets.isNotEmpty) return;
+    final orchestrator = GetIt.I.get<OrchestratorRPC>();
+    Future<List<dynamic>> seed() => Future.wait([
+      orchestrator.wallet.listWallets(),
+      orchestrator.wallet.getWalletStatus(),
+    ]).timeout(const Duration(seconds: 3));
+
+    List<dynamic> results;
     try {
-      final results = await Future.wait([
-        _client.listWallets(),
-        _client.getWalletStatus(),
-      ]).timeout(const Duration(seconds: 3));
-      // Stream may have delivered while we awaited — let it win.
-      if (wallets.isNotEmpty) return;
-      final list = results[0] as dynamic;
-      final status = results[1] as dynamic;
-      if (list.wallets.isEmpty) return;
-      _applyState(
-        protoWallets: list.wallets,
-        newActiveId: list.activeWalletId.isEmpty ? null : list.activeWalletId as String,
-        newHasWalletOnDisk: status.hasWallet as bool,
-      );
+      results = await seed();
     } catch (e) {
-      _logger.w('WalletReaderProvider: init seed failed: $e');
+      // The orchestrator's HTTP/2 connection sometimes returns
+      // "Connection is being forcefully terminated" mid-handshake; rebuild
+      // the transport and try once more before giving up.
+      if (orchestrator.recreateIfHttp2Error(e)) {
+        try {
+          results = await seed();
+        } catch (e2) {
+          _logger.w('WalletReaderProvider: init seed retry failed: $e2');
+          return;
+        }
+      } else {
+        _logger.w('WalletReaderProvider: init seed failed: $e');
+        return;
+      }
     }
+    // Stream may have delivered while we awaited — let it win.
+    if (wallets.isNotEmpty) return;
+    final list = results[0] as dynamic;
+    final status = results[1] as dynamic;
+    if (list.wallets.isEmpty) return;
+    _applyState(
+      protoWallets: list.wallets,
+      newActiveId: list.activeWalletId.isEmpty ? null : list.activeWalletId as String,
+      newHasWalletOnDisk: status.hasWallet as bool,
+    );
   }
 
   Future<bool> hasWallet() async {

--- a/sail_ui/lib/providers/wallet_reader_provider.dart
+++ b/sail_ui/lib/providers/wallet_reader_provider.dart
@@ -136,38 +136,11 @@ class WalletReaderProvider extends ChangeNotifier {
     required String? newActiveId,
     required bool newHasWalletOnDisk,
   }) {
-    // Build the wallet list FIRST and only swap state in if it succeeds.
-    // Previously the field assignments happened inline with the .map, so a
-    // throw mid-build (e.g. unexpected proto shape) would leave activeWalletId
-    // and hasWalletOnDisk set with `wallets` still empty and notifyListeners
-    // skipped — exactly the state behind the empty-dropdown bug.
-    final List<WalletData> nextWallets = [];
-    int failures = 0;
-    for (final protoWallet in protoWallets) {
-      try {
-        nextWallets.add(_walletDataFromProto(protoWallet));
-      } catch (e, st) {
-        failures += 1;
-        _logger.e(
-          'WalletReaderProvider: failed to materialize wallet '
-          'id=${_safe(() => protoWallet.id)} type=${_safe(() => protoWallet.walletType)}: $e\n$st',
-        );
-      }
-    }
-    if (failures > 0 && nextWallets.isEmpty && wallets.isNotEmpty) {
-      // Don't blow away a known-good list with an all-broken update.
-      _logger.w(
-        'WalletReaderProvider: dropping update — all '
-        '${protoWallets.length} wallets failed to parse, keeping prior state',
-      );
-      return;
-    }
-
     final previousActiveId = activeWalletId;
     if (previousActiveId != newActiveId) {
       _logger.i(
         'WalletReaderProvider: activeWalletId $previousActiveId -> $newActiveId '
-        '(wallets=${nextWallets.length})',
+        '(wallets=${protoWallets.length})',
       );
     }
     activeWalletId = newActiveId;
@@ -178,69 +151,60 @@ class WalletReaderProvider extends ChangeNotifier {
       _logger.i('WalletReaderProvider: hasWalletOnDisk $previousHasWallet -> $hasWalletOnDisk');
     }
 
-    wallets = nextWallets;
+    wallets = protoWallets.map<WalletData>((protoWallet) {
+      WalletGradient gradient = WalletGradient.fromWalletId(protoWallet.id);
+      if (protoWallet.gradientJson.isNotEmpty) {
+        try {
+          final parsed = WalletGradient.fromJsonString(protoWallet.gradientJson);
+          // Legacy default {"background_svg":""} parses cleanly but would
+          // render an empty avatar; keep the deterministic fallback in that
+          // case.
+          if ((parsed.backgroundSvg ?? '').isNotEmpty) {
+            gradient = parsed;
+          }
+        } catch (_) {}
+      }
+
+      DateTime createdAt = DateTime.now();
+      if (protoWallet.createdAt.isNotEmpty) {
+        try {
+          createdAt = DateTime.parse(protoWallet.createdAt);
+        } catch (_) {}
+      }
+
+      return WalletData(
+        version: 1,
+        master: MasterWallet(
+          mnemonic: protoWallet.masterMnemonic,
+          seedHex: '',
+          masterKey: '',
+          chainCode: '',
+          name: 'Master',
+        ),
+        l1: L1Wallet(mnemonic: protoWallet.l1Mnemonic),
+        sidechains: protoWallet.sidechains
+            .map<SidechainWallet>(
+              (sc) => SidechainWallet(
+                slot: sc.slot,
+                name: sc.name,
+                mnemonic: sc.mnemonic,
+              ),
+            )
+            .toList(),
+        id: protoWallet.id,
+        name: protoWallet.name,
+        gradient: gradient,
+        createdAt: createdAt,
+        walletType: BinaryType.values.firstWhere(
+          (t) => t.name == protoWallet.walletType,
+          orElse: () => BinaryType.enforcer,
+        ),
+        walletTypeRaw: protoWallet.walletType,
+        bip47PaymentCode: protoWallet.bip47PaymentCode,
+      );
+    }).toList();
+
     notifyListeners();
-  }
-
-  WalletData _walletDataFromProto(dynamic protoWallet) {
-    WalletGradient gradient = WalletGradient.fromWalletId(protoWallet.id);
-    if (protoWallet.gradientJson.isNotEmpty) {
-      try {
-        final parsed = WalletGradient.fromJsonString(protoWallet.gradientJson);
-        // Legacy default {"background_svg":""} parses cleanly but would
-        // render an empty avatar; keep the deterministic fallback in that
-        // case.
-        if ((parsed.backgroundSvg ?? '').isNotEmpty) {
-          gradient = parsed;
-        }
-      } catch (_) {}
-    }
-
-    DateTime createdAt = DateTime.now();
-    if (protoWallet.createdAt.isNotEmpty) {
-      try {
-        createdAt = DateTime.parse(protoWallet.createdAt);
-      } catch (_) {}
-    }
-
-    return WalletData(
-      version: 1,
-      master: MasterWallet(
-        mnemonic: protoWallet.masterMnemonic,
-        seedHex: '',
-        masterKey: '',
-        chainCode: '',
-        name: 'Master',
-      ),
-      l1: L1Wallet(mnemonic: protoWallet.l1Mnemonic),
-      sidechains: protoWallet.sidechains
-          .map<SidechainWallet>(
-            (sc) => SidechainWallet(
-              slot: sc.slot,
-              name: sc.name,
-              mnemonic: sc.mnemonic,
-            ),
-          )
-          .toList(),
-      id: protoWallet.id,
-      name: protoWallet.name,
-      gradient: gradient,
-      createdAt: createdAt,
-      walletType: BinaryType.values.firstWhere(
-        (t) => t.name == protoWallet.walletType,
-        orElse: () => BinaryType.enforcer,
-      ),
-      walletTypeRaw: protoWallet.walletType,
-      bip47PaymentCode: protoWallet.bip47PaymentCode,
-    );
-  }
-
-  String _safe(dynamic Function() f) {
-    try {
-      return '${f()}';
-    } catch (_) {
-      return '<unreadable>';
-    }
   }
 
   Future<void> init() async {

--- a/sail_ui/lib/providers/wallet_reader_provider.dart
+++ b/sail_ui/lib/providers/wallet_reader_provider.dart
@@ -18,6 +18,19 @@ class WalletReaderProvider extends ChangeNotifier {
 
   StreamSubscription<dynamic>? _watchSub;
   Timer? _reconnectTimer;
+  int _reconnectAttempt = 0;
+  // Backoff schedule. First retry is immediate so transient drops don't
+  // leave the UI stale for seconds; later retries cap out at 10s so a
+  // permanently-down orchestrator doesn't spam connect attempts.
+  static const _backoff = <Duration>[
+    Duration.zero,
+    Duration(milliseconds: 200),
+    Duration(milliseconds: 500),
+    Duration(seconds: 1),
+    Duration(seconds: 2),
+    Duration(seconds: 5),
+    Duration(seconds: 10),
+  ];
 
   List<WalletData> wallets = [];
   String? activeWalletId;
@@ -94,13 +107,23 @@ class WalletReaderProvider extends ChangeNotifier {
 
   void _scheduleReconnect() {
     _reconnectTimer?.cancel();
-    _reconnectTimer = Timer(const Duration(seconds: 2), () {
-      _logger.i('WalletReaderProvider: reconnect attempt');
-      _subscribe();
-    });
+    final delay = _backoff[_reconnectAttempt.clamp(0, _backoff.length - 1)];
+    _reconnectAttempt += 1;
+    if (delay == Duration.zero) {
+      _logger.i('WalletReaderProvider: reconnecting immediately (attempt $_reconnectAttempt)');
+      scheduleMicrotask(_subscribe);
+    } else {
+      _logger.i(
+        'WalletReaderProvider: reconnect in ${delay.inMilliseconds}ms (attempt $_reconnectAttempt)',
+      );
+      _reconnectTimer = Timer(delay, _subscribe);
+    }
   }
 
   void _onData(dynamic resp) {
+    // Successful frame — backoff schedule resets so the next drop retries
+    // fast.
+    _reconnectAttempt = 0;
     _applyState(
       protoWallets: resp.wallets,
       newActiveId: resp.activeWalletId.isEmpty ? null : resp.activeWalletId as String,

--- a/sail_ui/lib/rpcs/bitassets_rpc.dart
+++ b/sail_ui/lib/rpcs/bitassets_rpc.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:convert/convert.dart' show hex;
@@ -235,7 +234,7 @@ class BitAssetsLive extends BitAssetsRPC {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),
-      httpClient: createHttpClient(),
+      httpClient: keepaliveHttpClient(),
     );
     _client = BitAssetsServiceClient(transport);
   }

--- a/sail_ui/lib/rpcs/bitnames_rpc.dart
+++ b/sail_ui/lib/rpcs/bitnames_rpc.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
+import 'package:sail_ui/rpcs/keepalive_http_client.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:convert/convert.dart' show hex;
 import 'package:fixnum/fixnum.dart';
@@ -149,7 +149,7 @@ class BitnamesLive extends BitnamesRPC {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),
-      httpClient: createHttpClient(),
+      httpClient: keepaliveHttpClient(),
     );
     _client = BitnamesServiceClient(transport);
   }

--- a/sail_ui/lib/rpcs/bitwindow_api.dart
+++ b/sail_ui/lib/rpcs/bitwindow_api.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:fixnum/fixnum.dart';
@@ -77,7 +76,7 @@ class BitwindowRPCLive extends BitwindowRPC {
   }
 
   void _initializeConnection({required String host, required int port}) async {
-    final httpClient = createHttpClient();
+    final httpClient = keepaliveHttpClient();
     final baseUrl = 'http://$host:$port';
     final transport = connect.Transport(
       baseUrl: baseUrl,

--- a/sail_ui/lib/rpcs/coinshift_rpc.dart
+++ b/sail_ui/lib/rpcs/coinshift_rpc.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
+import 'package:sail_ui/rpcs/keepalive_http_client.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:fixnum/fixnum.dart';
 import 'package:get_it/get_it.dart';
@@ -110,7 +110,7 @@ class CoinShiftLive extends CoinShiftRPC {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),
-      httpClient: createHttpClient(),
+      httpClient: keepaliveHttpClient(),
     );
     _client = CoinShiftServiceClient(transport);
   }

--- a/sail_ui/lib/rpcs/enforcer_rpc.dart
+++ b/sail_ui/lib/rpcs/enforcer_rpc.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
 import 'package:connectrpc/protocol/grpc.dart' as grpc;
 import 'package:get_it/get_it.dart';
@@ -38,7 +37,7 @@ class EnforcerLive extends EnforcerRPC {
 
   void _initializeConnection() {
     // Create new HTTP/2 transport and client
-    final httpClient = createHttpClient();
+    final httpClient = keepaliveHttpClient();
     final baseUrl = 'http://localhost:${binary.port}';
     _grpcTransport = grpc.Transport(
       baseUrl: baseUrl,

--- a/sail_ui/lib/rpcs/keepalive_http_client.dart
+++ b/sail_ui/lib/rpcs/keepalive_http_client.dart
@@ -1,0 +1,32 @@
+import 'package:connectrpc/connect.dart';
+import 'package:connectrpc/http2.dart';
+
+/// Build a connectrpc HTTP client with sensible keepalive defaults.
+///
+/// `package:connectrpc`'s default `createHttpClient()` does not send PING
+/// frames, so an idle server-streaming RPC (like `WatchWalletData`) is
+/// invisible to the underlying TCP socket. Go's `http2.Server` —
+/// configured with `ReadIdleTimeout: 30s` in the orchestrator — then
+/// triggers a server-side liveness PING; if the round-trip stalls, the
+/// server tears the connection down with a `GOAWAY`, which surfaces as
+/// "Connection is being forcefully terminated. (errorCode: 10)" on the
+/// Dart side.
+///
+/// Sending client-side PINGs every 10s keeps the server's read idle
+/// timer reset, *and* lets the connectrpc transport detect a dead
+/// connection proactively (within `pingTimeout`) so the next call
+/// transparently establishes a fresh socket via `Http2ClientTransport`'s
+/// internal `verify()` loop — no manual transport rebuild needed.
+///
+/// `pingIdleConnections: true` ensures we keep pinging even when no
+/// streams are open, so a long-lived connection doesn't go silent and
+/// hit the server's 30s idle window.
+HttpClient keepaliveHttpClient() {
+  return createHttpClient(
+    transport: Http2ClientTransport(
+      pingInterval: const Duration(seconds: 10),
+      pingTimeout: const Duration(seconds: 5),
+      pingIdleConnections: true,
+    ),
+  );
+}

--- a/sail_ui/lib/rpcs/orchestrator_rpc.dart
+++ b/sail_ui/lib/rpcs/orchestrator_rpc.dart
@@ -1,5 +1,5 @@
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
+import 'package:sail_ui/rpcs/keepalive_http_client.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
@@ -23,7 +23,7 @@ class OrchestratorRPC {
     final transport = connect.Transport(
       baseUrl: 'http://$_host:$_port',
       codec: const ProtoCodec(),
-      httpClient: createHttpClient(),
+      httpClient: keepaliveHttpClient(),
     );
     _client = OrchestratorServiceClient(transport);
     wallet = OrchestratorWalletRPC.fromTransport(transport);

--- a/sail_ui/lib/rpcs/orchestrator_rpc.dart
+++ b/sail_ui/lib/rpcs/orchestrator_rpc.dart
@@ -1,6 +1,8 @@
 import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
 import 'package:sail_ui/gen/orchestrator/v1/orchestrator.connect.client.dart';
 import 'package:sail_ui/gen/orchestrator/v1/orchestrator.pb.dart';
 import 'package:sail_ui/rpcs/orchestrator_wallet_rpc.dart';
@@ -9,16 +11,51 @@ import 'package:sail_ui/rpcs/orchestrator_wallet_rpc.dart';
 /// Wraps the generated OrchestratorServiceClient for binary management.
 class OrchestratorRPC {
   late OrchestratorServiceClient _client;
-  late final OrchestratorWalletRPC wallet;
+  late OrchestratorWalletRPC wallet;
+  final String _host;
+  final int _port;
 
-  OrchestratorRPC({required String host, required int port}) {
+  OrchestratorRPC({required String host, required int port}) : _host = host, _port = port {
+    _initializeConnection();
+  }
+
+  void _initializeConnection() {
     final transport = connect.Transport(
-      baseUrl: 'http://$host:$port',
+      baseUrl: 'http://$_host:$_port',
       codec: const ProtoCodec(),
       httpClient: createHttpClient(),
     );
     _client = OrchestratorServiceClient(transport);
     wallet = OrchestratorWalletRPC.fromTransport(transport);
+  }
+
+  /// Drop the dead HTTP/2 connection and rebuild the transport. The Dart
+  /// connectrpc client doesn't auto-recover from a `GOAWAY`/connection-reset,
+  /// so a single transport failure poisons every subsequent call (including
+  /// the WatchWalletData stream's reconnect). Callers can pair this with
+  /// [recreateIfHttp2Error] to retry once on the rebuilt transport.
+  void recreateConnection() {
+    final logger = GetIt.I.isRegistered<Logger>() ? GetIt.I.get<Logger>() : null;
+    logger?.w('OrchestratorRPC: recreating HTTP/2 connection');
+    _initializeConnection();
+  }
+
+  static bool isHttp2ConnectionError(Object e) {
+    final s = e.toString().toLowerCase();
+    return s.contains('http/2 connection is finishing') ||
+        s.contains('connection closed') ||
+        s.contains('stream closed') ||
+        s.contains('connection is being forcefully terminated') ||
+        s.contains('_cancreatenewstream');
+  }
+
+  /// Rebuild the transport iff [e] looks like an HTTP/2 connection failure.
+  /// Returns true when the connection was recreated, so callers can decide
+  /// whether to retry the operation.
+  bool recreateIfHttp2Error(Object e) {
+    if (!isHttp2ConnectionError(e)) return false;
+    recreateConnection();
+    return true;
   }
 
   Future<ListBinariesResponse> listBinaries() {

--- a/sail_ui/lib/rpcs/photon_rpc.dart
+++ b/sail_ui/lib/rpcs/photon_rpc.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
+import 'package:sail_ui/rpcs/keepalive_http_client.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:fixnum/fixnum.dart';
 import 'package:get_it/get_it.dart';
@@ -69,7 +69,7 @@ class PhotonLive extends PhotonRPC {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),
-      httpClient: createHttpClient(),
+      httpClient: keepaliveHttpClient(),
     );
     _client = PhotonServiceClient(transport);
   }

--- a/sail_ui/lib/rpcs/thunder_rpc.dart
+++ b/sail_ui/lib/rpcs/thunder_rpc.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
+import 'package:sail_ui/rpcs/keepalive_http_client.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:fixnum/fixnum.dart';
 import 'package:get_it/get_it.dart';
@@ -63,7 +63,7 @@ class ThunderLive extends ThunderRPC {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),
-      httpClient: createHttpClient(),
+      httpClient: keepaliveHttpClient(),
     );
     _client = ThunderServiceClient(transport);
   }

--- a/sail_ui/lib/rpcs/truthcoin_rpc.dart
+++ b/sail_ui/lib/rpcs/truthcoin_rpc.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
+import 'package:sail_ui/rpcs/keepalive_http_client.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:fixnum/fixnum.dart';
 import 'package:get_it/get_it.dart';
@@ -250,7 +250,7 @@ class TruthcoinLive extends TruthcoinRPC {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),
-      httpClient: createHttpClient(),
+      httpClient: keepaliveHttpClient(),
     );
     _client = TruthcoinServiceClient(transport);
   }

--- a/sail_ui/lib/rpcs/zside_rpc.dart
+++ b/sail_ui/lib/rpcs/zside_rpc.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:connectrpc/http2.dart';
 import 'package:connectrpc/protobuf.dart';
+import 'package:sail_ui/rpcs/keepalive_http_client.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:fixnum/fixnum.dart';
 import 'package:get_it/get_it.dart';
@@ -96,7 +96,7 @@ class ZSideLive extends ZSideRPC {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),
-      httpClient: createHttpClient(),
+      httpClient: keepaliveHttpClient(),
     );
     _client = ZSideServiceClient(transport);
   }

--- a/sail_ui/lib/sail_ui.dart
+++ b/sail_ui/lib/sail_ui.dart
@@ -183,6 +183,7 @@ export 'rpcs/bitnames_rpc.dart';
 export 'rpcs/bitwindow_api.dart';
 export 'rpcs/coinshift_rpc.dart';
 export 'rpcs/enforcer_rpc.dart';
+export 'rpcs/keepalive_http_client.dart';
 export 'rpcs/orchestrator_rpc.dart';
 export 'rpcs/orchestrator_wallet_rpc.dart';
 export 'rpcs/mainchain_rpc.dart';

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.207
+version: 1.0.208
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.78
+version: 1.0.79
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.205
+version: 1.0.206
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
## Summary
Three failures the user's `debug.log` exposed — none individually fatal, all together = empty wallet dropdown / BIP47 / starters even though the orchestrator has the wallet on disk.

1. **`_applyState` could half-apply.** `activeWalletId` and `hasWalletOnDisk` were assigned inline before the `wallets = …map(…)` build. A throw mid-map left those two fields set with `wallets=[]` and `notifyListeners` skipped. Build the list first (try/catch per wallet), swap state atomically only if parsing succeeded; refuse to clobber a known-good list with an all-broken update.

2. **Dead HTTP/2 connection poisoned every retry.** The user's log shows `stream error: Connection is being forcefully terminated. (errorCode: 10)` — Dart's `connectrpc` client doesn't recover from a forcefully-terminated HTTP/2 connection on its own. Every subsequent stream subscription / RPC on the same transport keeps failing. `OrchestratorRPC` now exposes `recreateConnection` + `recreateIfHttp2Error`; the watch-stream's `onError` and `init`'s seed call both pair recreate-then-retry.

3. **`_subscribe` now self-heals via `init()`** if wallets is empty post-subscribe, so a reconnect that drops mid-stream still backfills state via direct RPC.

## Test plan
- [ ] Cold-boot bitwindow with the reproducing wallet.json — dropdown + BIP47 populate.
- [ ] Forcibly drop the orchestrator (kill -9) and watch reconnect — UI doesn't go permanently blank.
- [ ] sail_ui tests pass.