### PR TITLE
orchestrator: extract test sidechains as Flutter app trees

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.206
+version: 1.0.207
 
 environment:
   sdk: 3.11.4

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.205
+version: 1.0.206
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.206
+version: 1.0.207
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.207
+version: 1.0.208
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/lib/pages/root_page.dart
+++ b/bitwindow/lib/pages/root_page.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:auto_route/auto_route.dart';
 import 'package:bitwindow/dialogs/base58_decoder_dialog.dart';
 import 'package:bitwindow/dialogs/command_palette_dialog.dart';
+import 'package:bitwindow/pages/settings/settings_network.dart';
 import 'package:bitwindow/pages/settings_page.dart';
 import 'package:bitwindow/pages/wallet/wallet_page.dart';
 import 'package:bitwindow/services/code_search_service.dart';
@@ -1096,7 +1097,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
                               ],
                               onChanged: (BitcoinNetwork? network) async {
                                 if (network == null || _confProvider.hasPrivateBitcoinConf) return;
-                                await _confProvider.swapNetwork(context, network);
+                                await swapNetworkWithDatadirPrompt(context, _confProvider, network);
                               },
                             ),
                             SailButton(

--- a/bitwindow/lib/pages/settings/settings_network.dart
+++ b/bitwindow/lib/pages/settings/settings_network.dart
@@ -57,8 +57,7 @@ class _SettingsNetworkState extends State<SettingsNetwork> {
       return;
     }
 
-    // swapNetwork() handles everything: datadir check, dialogs, service restart
-    await _confProvider.swapNetwork(context, network);
+    await swapNetworkWithDatadirPrompt(context, _confProvider, network);
   }
 
   Future<void> _selectDataDirectory() async {
@@ -290,8 +289,32 @@ class _SettingsNetworkState extends State<SettingsNetwork> {
   }
 }
 
+/// Wraps a network swap with a datadir prompt. If the backend rejects the
+/// swap because the target network has no datadir configured, this opens
+/// [DataDirSelectionDialog], persists the chosen path, then retries the swap.
+Future<void> swapNetworkWithDatadirPrompt(
+  BuildContext context,
+  BitcoinConfProvider provider,
+  BitcoinNetwork network,
+) async {
+  try {
+    await provider.swapNetwork(context, network);
+  } on MissingDatadirException catch (e) {
+    if (!context.mounted) return;
+    final selected = await showDialog<String>(
+      context: context,
+      builder: (_) => DataDirSelectionDialog(network: e.network),
+    );
+    if (selected == null || selected.isEmpty) return;
+    await provider.updateDataDir(selected, forNetwork: e.network);
+    if (!context.mounted) return;
+    await provider.swapNetwork(context, network);
+  }
+}
+
 class DataDirSelectionDialog extends StatefulWidget {
-  const DataDirSelectionDialog({super.key});
+  final BitcoinNetwork? network;
+  const DataDirSelectionDialog({super.key, this.network});
 
   @override
   State<DataDirSelectionDialog> createState() => _DataDirSelectionDialogState();
@@ -331,6 +354,17 @@ class _DataDirSelectionDialogState extends State<DataDirSelectionDialog> {
     }
   }
 
+  String _subtitle() {
+    switch (widget.network) {
+      case BitcoinNetwork.BITCOIN_NETWORK_MAINNET:
+        return 'Mainnet needs a Bitcoin Core data directory with the blockchain data (2.5TB+). Pick a directory that contains the blocks folder.';
+      case BitcoinNetwork.BITCOIN_NETWORK_FORKNET:
+        return 'Forknet needs a data directory to store the chain. Pick an empty directory or one already used for forknet.';
+      default:
+        return 'Pick a directory for Bitcoin Core to store its data.';
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = SailTheme.of(context);
@@ -341,8 +375,7 @@ class _DataDirSelectionDialogState extends State<DataDirSelectionDialog> {
         constraints: const BoxConstraints(maxWidth: 500),
         child: SailCard(
           title: 'Select Bitcoin Data Directory',
-          subtitle:
-              'Mainnet requires a Bitcoin Core data directory with the blockchain data (2.5TB+). Select a directory that contains the blocks folder.',
+          subtitle: _subtitle(),
           child: SailColumn(
             spacing: SailStyleValues.padding16,
             crossAxisAlignment: CrossAxisAlignment.start,

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.55
+version: 0.2.56
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.54
+version: 0.2.55
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.79
+version: 1.0.80
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.80
+version: 1.0.81
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/providers/bitcoin_conf_provider.dart
+++ b/sail_ui/lib/providers/bitcoin_conf_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:auto_route/auto_route.dart';
+import 'package:connectrpc/connect.dart' as crpc;
 import 'package:connectrpc/protobuf.dart';
 import 'package:connectrpc/protocol/connect.dart' as connect;
 import 'package:flutter/material.dart';
@@ -8,6 +9,17 @@ import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:sail_ui/env.dart';
 import 'package:sail_ui/sail_ui.dart';
+
+/// Thrown when the user tries to switch to a network that requires a datadir
+/// (mainnet/forknet) but none is configured. Callers should prompt for a
+/// directory, persist it via [BitcoinConfProvider.updateDataDir], then retry.
+class MissingDatadirException implements Exception {
+  final BitcoinNetwork network;
+  MissingDatadirException(this.network);
+
+  @override
+  String toString() => 'datadir not configured for $network';
+}
 
 /// Bitcoin Core configuration provider backed by orchestrator's BitcoinConfService.
 /// All reads/writes go through the backend — no local file access.
@@ -111,8 +123,15 @@ class BitcoinConfProvider extends ChangeNotifier {
         SetBitcoinConfigNetworkRequest(network: _networkToString(newNetwork)),
       );
       await loadConfig();
+    } on crpc.ConnectException catch (e) {
+      if (e.code == crpc.Code.failedPrecondition && e.message.contains('datadir not configured')) {
+        throw MissingDatadirException(newNetwork);
+      }
+      log.e('BitcoinConfProvider: failed to update network: $e');
+      rethrow;
     } catch (e) {
       log.e('BitcoinConfProvider: failed to update network: $e');
+      rethrow;
     }
   }
 

--- a/sail_ui/lib/viewmodels/bitcoin_config_editor_viewmodel.dart
+++ b/sail_ui/lib/viewmodels/bitcoin_config_editor_viewmodel.dart
@@ -31,6 +31,9 @@ class BitcoinConfigEditorViewModel extends ChangeNotifier {
 
   void _onConfProviderChanged() {
     if (_isDisposed) return;
+    // Don't clobber the editor while the user is mid-edit — the conf
+    // provider polls every 5s and would otherwise wipe in-progress changes.
+    if (hasUnsavedChanges) return;
     _rawConfigText = null;
     currentPreset = ConfigPreset.custom;
     loadConfig();

--- a/sidechain-orchestrator/api/bitcoin_conf_handler.go
+++ b/sidechain-orchestrator/api/bitcoin_conf_handler.go
@@ -68,6 +68,16 @@ func (h *BitcoinConfHandler) SetBitcoinConfigNetwork(ctx context.Context, req *c
 	}
 
 	network := config.NetworkFromString(networkStr)
+
+	// Guard: mainnet/forknet need a datadir set up before we switch. Surface
+	// a FailedPrecondition so the frontend can prompt the user to pick one.
+	if !h.conf.HasDatadirForNetwork(network) {
+		return nil, connect.NewError(
+			connect.CodeFailedPrecondition,
+			fmt.Errorf("datadir not configured for %s", network),
+		)
+	}
+
 	if err := h.conf.UpdateNetwork(network); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("update network: %w", err))
 	}

--- a/sidechain-orchestrator/config.go
+++ b/sidechain-orchestrator/config.go
@@ -2,8 +2,10 @@ package orchestrator
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 )
@@ -190,13 +192,44 @@ func CoreBinaryPath(dataDir string, variant CoreVariantSpec, binaryName string) 
 // doesn't trash the cached download.
 const testSidechainSubfolder = "test"
 
-// TestSidechainBinaryPath returns the on-disk path for a layer-2 test build.
+// TestSidechainDir returns the per-binary directory that test/alternative
+// sidechain builds extract into. Test builds are full Flutter app bundles
+// with sibling lib/data trees (Linux) or `.app` packages (macOS); each
+// sidechain therefore needs its own subfolder so libraries don't collide.
+func TestSidechainDir(dataDir, binaryName string) string {
+	return filepath.Join(BinDir(dataDir), testSidechainSubfolder, binaryName)
+}
+
+// TestSidechainBinaryPath resolves the launchable binary inside a test build's
+// directory. Three shapes are supported:
+//
+//   - Linux: `<dir>/<binaryName>` next to `lib/`+`data/`.
+//   - macOS: `<dir>/<TitleCase>.app/Contents/MacOS/<TitleCase>` (Flutter
+//     bundle). We walk the directory once to find the `.app` so the spec
+//     doesn't need to encode TitleCase mappings (`thunder` → `Thunder`,
+//     `bitassets` → `BitAssets`, etc.).
+//   - Windows: `<dir>/<binaryName>.exe` — single self-contained .exe.
 func TestSidechainBinaryPath(dataDir, binaryName string) string {
-	name := binaryName
-	if runtime.GOOS == "windows" {
-		name += ".exe"
+	dir := TestSidechainDir(dataDir, binaryName)
+	switch runtime.GOOS {
+	case "windows":
+		return filepath.Join(dir, binaryName+".exe")
+	case "darwin":
+		// Look for the .app bundle. Single pass is fine — the dir holds
+		// exactly one app per sidechain.
+		entries, _ := os.ReadDir(dir)
+		for _, e := range entries {
+			if e.IsDir() && strings.HasSuffix(e.Name(), ".app") {
+				inner := strings.TrimSuffix(e.Name(), ".app")
+				return filepath.Join(dir, e.Name(), "Contents", "MacOS", inner)
+			}
+		}
+		// Fallback so callers always get a path; nonexistent stat is the
+		// "not downloaded yet" signal.
+		return filepath.Join(dir, binaryName)
+	default:
+		return filepath.Join(dir, binaryName)
 	}
-	return filepath.Join(BinDir(dataDir), testSidechainSubfolder, name)
 }
 
 // PidDir returns the directory where PID files are stored.

--- a/sidechain-orchestrator/config/bitcoin_config.go
+++ b/sidechain-orchestrator/config/bitcoin_config.go
@@ -9,21 +9,34 @@ import (
 const bitcoinConfVersionCommentPrefix = "# bitwindow-bitcoin-conf-version="
 
 // BitcoinConfig represents a parsed Bitcoin Core configuration file.
-// 1:1 port of sail_ui/lib/models/bitcoin_config.dart
+//
+// Order matters: the conf editor and the user expect the on-disk order to be
+// preserved across read/write round-trips. Go maps don't preserve insertion
+// order, so we keep a parallel `*Order` slice for each settings map and walk
+// it in Serialize.
 type BitcoinConfig struct {
 	GlobalSettings  map[string]string
+	GlobalOrder     []string
 	NetworkSettings map[string]map[string]string // "main", "test", "signet", "regtest"
+	NetworkOrder    map[string][]string
 	ConfigVersion   int
 }
 
 func NewBitcoinConfig() *BitcoinConfig {
 	return &BitcoinConfig{
 		GlobalSettings: make(map[string]string),
+		GlobalOrder:    nil,
 		NetworkSettings: map[string]map[string]string{
 			"main":    {},
 			"test":    {},
 			"signet":  {},
 			"regtest": {},
+		},
+		NetworkOrder: map[string][]string{
+			"main":    nil,
+			"test":    nil,
+			"signet":  nil,
+			"regtest": nil,
 		},
 		ConfigVersion: 0,
 	}
@@ -66,19 +79,16 @@ func ParseBitcoinConfig(content string) *BitcoinConfig {
 		if eqIdx > 0 {
 			key := strings.TrimSpace(trimmed[:eqIdx])
 			value := strings.TrimSpace(trimmed[eqIdx+1:])
-
-			if currentSection != "" {
-				config.NetworkSettings[currentSection][key] = value
-			} else {
-				config.GlobalSettings[key] = value
-			}
+			config.SetSetting(key, value, currentSection)
 		}
 	}
 
 	return config
 }
 
-// Serialize writes the config back to file format.
+// Serialize writes the config back to file format, preserving the order in
+// which keys were inserted (i.e. the order they appeared on disk for parsed
+// configs, or insertion order for programmatically built configs).
 func (c *BitcoinConfig) Serialize() string {
 	var b strings.Builder
 
@@ -92,8 +102,8 @@ func (c *BitcoinConfig) Serialize() string {
 	// Write global settings
 	if len(c.GlobalSettings) > 0 {
 		b.WriteString("# [common settings]\n")
-		for key, value := range c.GlobalSettings {
-			fmt.Fprintf(&b, "%s=%s\n", key, value)
+		for _, key := range c.orderedKeys("") {
+			fmt.Fprintf(&b, "%s=%s\n", key, c.GlobalSettings[key])
 		}
 		b.WriteString("\n")
 	}
@@ -116,14 +126,45 @@ func (c *BitcoinConfig) Serialize() string {
 			}
 			fmt.Fprintf(&b, "# Options for %s only\n", label)
 			fmt.Fprintf(&b, "%s\n", sectionNames[network])
-			for key, value := range settings {
-				fmt.Fprintf(&b, "%s=%s\n", key, value)
+			for _, key := range c.orderedKeys(network) {
+				fmt.Fprintf(&b, "%s=%s\n", key, settings[key])
 			}
 			b.WriteString("\n")
 		}
 	}
 
 	return b.String()
+}
+
+// orderedKeys returns keys for a section (or globals if section == ""), using
+// the tracked insertion order. Any keys present in the map but missing from
+// the order list (defensive: e.g. a caller wrote directly to the map) are
+// appended in map-iteration order at the end.
+func (c *BitcoinConfig) orderedKeys(section string) []string {
+	var order []string
+	var settings map[string]string
+	if section == "" {
+		order = c.GlobalOrder
+		settings = c.GlobalSettings
+	} else {
+		order = c.NetworkOrder[section]
+		settings = c.NetworkSettings[section]
+	}
+
+	seen := make(map[string]struct{}, len(order))
+	out := make([]string, 0, len(settings))
+	for _, k := range order {
+		if _, ok := settings[k]; ok {
+			out = append(out, k)
+			seen[k] = struct{}{}
+		}
+	}
+	for k := range settings {
+		if _, ok := seen[k]; !ok {
+			out = append(out, k)
+		}
+	}
+	return out
 }
 
 func (c *BitcoinConfig) GetSetting(key string, section ...string) string {
@@ -148,22 +189,43 @@ func (c *BitcoinConfig) GetEffectiveSetting(key, network string) string {
 
 func (c *BitcoinConfig) SetSetting(key, value string, section ...string) {
 	if len(section) > 0 && section[0] != "" {
-		if s, ok := c.NetworkSettings[section[0]]; ok {
-			s[key] = value
+		s := section[0]
+		if _, ok := c.NetworkSettings[s]; !ok {
+			c.NetworkSettings[s] = make(map[string]string)
 		}
+		if _, exists := c.NetworkSettings[s][key]; !exists {
+			c.NetworkOrder[s] = append(c.NetworkOrder[s], key)
+		}
+		c.NetworkSettings[s][key] = value
 	} else {
+		if _, exists := c.GlobalSettings[key]; !exists {
+			c.GlobalOrder = append(c.GlobalOrder, key)
+		}
 		c.GlobalSettings[key] = value
 	}
 }
 
 func (c *BitcoinConfig) RemoveSetting(key string, section ...string) {
 	if len(section) > 0 && section[0] != "" {
-		if s, ok := c.NetworkSettings[section[0]]; ok {
-			delete(s, key)
+		s := section[0]
+		if settings, ok := c.NetworkSettings[s]; ok {
+			delete(settings, key)
+			c.NetworkOrder[s] = removeFromOrder(c.NetworkOrder[s], key)
 		}
 	} else {
 		delete(c.GlobalSettings, key)
+		c.GlobalOrder = removeFromOrder(c.GlobalOrder, key)
 	}
+}
+
+// ReplaceSection swaps in a new map+order pair for a section, used when a
+// per-network [main] backup file is loaded.
+func (c *BitcoinConfig) ReplaceSection(section string, settings map[string]string, order []string) {
+	if _, ok := c.NetworkSettings[section]; !ok {
+		return
+	}
+	c.NetworkSettings[section] = settings
+	c.NetworkOrder[section] = order
 }
 
 func (c *BitcoinConfig) HasSetting(key string, section ...string) bool {
@@ -176,4 +238,13 @@ func (c *BitcoinConfig) HasSetting(key string, section ...string) bool {
 	}
 	_, exists := c.GlobalSettings[key]
 	return exists
+}
+
+func removeFromOrder(order []string, key string) []string {
+	for i, k := range order {
+		if k == key {
+			return append(order[:i], order[i+1:]...)
+		}
+	}
+	return order
 }

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -21,8 +21,12 @@ const kMainnetConfVersionCommentPrefix = "# bitwindow-mainnet-conf-version="
 
 // ForknetConfig stores [main] section settings when network is forknet.
 // Stored in bitwindow-forknet.conf alongside the master bitcoin config.
+//
+// Order matters: Set/Parse track insertion order so Serialize emits keys in
+// the same order they appeared on disk.
 type ForknetConfig struct {
 	Settings map[string]string
+	Order    []string
 	Version  int
 }
 
@@ -30,6 +34,18 @@ func NewForknetConfig() *ForknetConfig {
 	return &ForknetConfig{
 		Settings: make(map[string]string),
 	}
+}
+
+func (c *ForknetConfig) Set(key, value string) {
+	if _, exists := c.Settings[key]; !exists {
+		c.Order = append(c.Order, key)
+	}
+	c.Settings[key] = value
+}
+
+func (c *ForknetConfig) Delete(key string) {
+	delete(c.Settings, key)
+	c.Order = removeFromOrder(c.Order, key)
 }
 
 func ParseForknetConfig(content string) *ForknetConfig {
@@ -49,7 +65,7 @@ func ParseForknetConfig(content string) *ForknetConfig {
 		if eqIdx := strings.Index(trimmed, "="); eqIdx > 0 {
 			key := strings.TrimSpace(trimmed[:eqIdx])
 			value := strings.TrimSpace(trimmed[eqIdx+1:])
-			c.Settings[key] = value
+			c.Set(key, value)
 		}
 	}
 	return c
@@ -58,8 +74,8 @@ func ParseForknetConfig(content string) *ForknetConfig {
 func (c *ForknetConfig) Serialize() string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s%d\n", kForknetConfVersionCommentPrefix, c.Version)
-	for key, value := range c.Settings {
-		fmt.Fprintf(&b, "%s=%s\n", key, value)
+	for _, key := range orderedKeys(c.Order, c.Settings) {
+		fmt.Fprintf(&b, "%s=%s\n", key, c.Settings[key])
 	}
 	return b.String()
 }
@@ -68,6 +84,7 @@ func (c *ForknetConfig) Serialize() string {
 // Stored in bitwindow-mainnet.conf alongside the master bitcoin config.
 type MainnetConfig struct {
 	Settings map[string]string
+	Order    []string
 	Version  int
 }
 
@@ -75,6 +92,18 @@ func NewMainnetConfig() *MainnetConfig {
 	return &MainnetConfig{
 		Settings: make(map[string]string),
 	}
+}
+
+func (c *MainnetConfig) Set(key, value string) {
+	if _, exists := c.Settings[key]; !exists {
+		c.Order = append(c.Order, key)
+	}
+	c.Settings[key] = value
+}
+
+func (c *MainnetConfig) Delete(key string) {
+	delete(c.Settings, key)
+	c.Order = removeFromOrder(c.Order, key)
 }
 
 func ParseMainnetConfig(content string) *MainnetConfig {
@@ -94,7 +123,7 @@ func ParseMainnetConfig(content string) *MainnetConfig {
 		if eqIdx := strings.Index(trimmed, "="); eqIdx > 0 {
 			key := strings.TrimSpace(trimmed[:eqIdx])
 			value := strings.TrimSpace(trimmed[eqIdx+1:])
-			c.Settings[key] = value
+			c.Set(key, value)
 		}
 	}
 	return c
@@ -103,10 +132,29 @@ func ParseMainnetConfig(content string) *MainnetConfig {
 func (c *MainnetConfig) Serialize() string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s%d\n", kMainnetConfVersionCommentPrefix, c.Version)
-	for key, value := range c.Settings {
-		fmt.Fprintf(&b, "%s=%s\n", key, value)
+	for _, key := range orderedKeys(c.Order, c.Settings) {
+		fmt.Fprintf(&b, "%s=%s\n", key, c.Settings[key])
 	}
 	return b.String()
+}
+
+// orderedKeys returns keys from settings using the tracked order, with any
+// stray keys (set via direct map writes) appended at the end.
+func orderedKeys(order []string, settings map[string]string) []string {
+	seen := make(map[string]struct{}, len(order))
+	out := make([]string, 0, len(settings))
+	for _, k := range order {
+		if _, ok := settings[k]; ok {
+			out = append(out, k)
+			seen[k] = struct{}{}
+		}
+	}
+	for k := range settings {
+		if _, ok := seen[k]; !ok {
+			out = append(out, k)
+		}
+	}
+	return out
 }
 
 // ---------------------------------------------------------------------------
@@ -138,9 +186,9 @@ var bitcoinConfMigrations = []BitcoinConfMigration{
 		Version: 2,
 		Changes: map[string]map[string]string{
 			"signet": {
-				"addnode":          "172.105.148.135:38333",
-				"signetblocktime":  "60",
-				"signetchallenge":  "00141551188e5153533b4fdd555449e640d9cc129456",
+				"addnode":         "172.105.148.135:38333",
+				"signetblocktime": "60",
+				"signetchallenge": "00141551188e5153533b4fdd555449e640d9cc129456",
 				"acceptnonstdtxn": "1",
 			},
 		},
@@ -194,14 +242,7 @@ func RunBitcoinConfMigrations(config *BitcoinConfig, isForknet bool) bool {
 			}
 
 			for key, value := range settings {
-				if targetSection == "" {
-					config.GlobalSettings[key] = value
-				} else {
-					if _, ok := config.NetworkSettings[targetSection]; !ok {
-						config.NetworkSettings[targetSection] = make(map[string]string)
-					}
-					config.NetworkSettings[targetSection][key] = value
-				}
+				config.SetSetting(key, value, targetSection)
 			}
 		}
 		config.ConfigVersion = m.Version
@@ -219,7 +260,7 @@ func RunForknetConfMigrations(config *ForknetConfig) bool {
 		}
 		if forknetChanges, ok := m.Changes["forknet"]; ok {
 			for key, value := range forknetChanges {
-				config.Settings[key] = value
+				config.Set(key, value)
 			}
 		}
 		config.Version = m.Version
@@ -237,7 +278,7 @@ func RunMainnetConfMigrations(config *MainnetConfig) bool {
 		}
 		if mainnetChanges, ok := m.Changes["mainnet"]; ok {
 			for key, value := range mainnetChanges {
-				config.Settings[key] = value
+				config.Set(key, value)
 			}
 		}
 		config.Version = m.Version
@@ -445,13 +486,29 @@ func (m *BitcoinConfManager) getMainSectionPath(n Network) string {
 	return filepath.Join(m.BitwindowDir, name)
 }
 
-// getDefaultMainSection returns the default [main] section settings for a network.
-func getDefaultMainSection(n Network) map[string]string {
+// getDefaultMainSection returns the default [main] section settings for a
+// network, plus a stable key order so Serialize emits keys in a predictable
+// sequence on first creation.
+func getDefaultMainSection(n Network) (map[string]string, []string) {
 	if n == NetworkForknet {
-		return map[string]string{
-			"port":              "8300",
-			"rpcport":           "18301",
-			"rpcbind":           "127.0.0.1",
+		order := []string{
+			"port",
+			"rpcport",
+			"rpcbind",
+			"rpcallowip",
+			"zmqpubhashblock",
+			"zmqpubhashtx",
+			"zmqpubrawblock",
+			"zmqpubrawtx",
+			"assumevalid",
+			"minimumchainwork",
+			"listenonion",
+			"drivechain",
+		}
+		settings := map[string]string{
+			"port":             "8300",
+			"rpcport":          "18301",
+			"rpcbind":          "127.0.0.1",
 			"rpcallowip":       "0.0.0.0/0",
 			"zmqpubhashblock":  "tcp://127.0.0.1:29001",
 			"zmqpubhashtx":     "tcp://127.0.0.1:29002",
@@ -462,8 +519,9 @@ func getDefaultMainSection(n Network) map[string]string {
 			"listenonion":      "0",
 			"drivechain":       "1",
 		}
+		return settings, order
 	}
-	return map[string]string{}
+	return map[string]string{}, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -483,9 +541,7 @@ func (m *BitcoinConfManager) SaveMainSectionForNetwork(n Network) error {
 	}
 
 	mainSettings := m.Config.NetworkSettings["main"]
-	if mainSettings == nil {
-		mainSettings = map[string]string{}
-	}
+	mainOrder := m.Config.NetworkOrder["main"]
 
 	if n == NetworkForknet {
 		fc := NewForknetConfig()
@@ -496,8 +552,8 @@ func (m *BitcoinConfManager) SaveMainSectionForNetwork(n Network) error {
 			fc.Version = ParseForknetConfig(string(data)).Version
 		}
 
-		for k, v := range mainSettings {
-			fc.Settings[k] = v
+		for _, k := range orderedKeys(mainOrder, mainSettings) {
+			fc.Set(k, mainSettings[k])
 		}
 		return os.WriteFile(confPath, []byte(fc.Serialize()), 0644)
 	}
@@ -510,8 +566,8 @@ func (m *BitcoinConfManager) SaveMainSectionForNetwork(n Network) error {
 		mc.Version = ParseMainnetConfig(string(data)).Version
 	}
 
-	for k, v := range mainSettings {
-		mc.Settings[k] = v
+	for _, k := range orderedKeys(mainOrder, mainSettings) {
+		mc.Set(k, mainSettings[k])
 	}
 	return os.WriteFile(confPath, []byte(mc.Serialize()), 0644)
 }
@@ -528,7 +584,8 @@ func (m *BitcoinConfManager) LoadMainSectionForNetwork(n Network) error {
 	if err != nil {
 		if os.IsNotExist(err) {
 			m.log.Info().Str("network", string(n)).Msg("no saved [main] section, using defaults")
-			m.Config.NetworkSettings["main"] = getDefaultMainSection(n)
+			settings, order := getDefaultMainSection(n)
+			m.Config.ReplaceSection("main", settings, order)
 			return nil
 		}
 		return fmt.Errorf("read main section: %w", err)
@@ -536,18 +593,18 @@ func (m *BitcoinConfManager) LoadMainSectionForNetwork(n Network) error {
 
 	if n == NetworkForknet {
 		fc := ParseForknetConfig(string(data))
-		newMain := make(map[string]string)
+		newMain := make(map[string]string, len(fc.Settings))
 		for k, v := range fc.Settings {
 			newMain[k] = v
 		}
-		m.Config.NetworkSettings["main"] = newMain
+		m.Config.ReplaceSection("main", newMain, append([]string(nil), fc.Order...))
 	} else {
 		mc := ParseMainnetConfig(string(data))
-		newMain := make(map[string]string)
+		newMain := make(map[string]string, len(mc.Settings))
 		for k, v := range mc.Settings {
 			newMain[k] = v
 		}
-		m.Config.NetworkSettings["main"] = newMain
+		m.Config.ReplaceSection("main", newMain, append([]string(nil), mc.Order...))
 	}
 
 	m.log.Info().Str("network", string(n)).Str("path", confPath).Msg("loaded [main] section")
@@ -567,8 +624,9 @@ func (m *BitcoinConfManager) migrateForknetConfig() error {
 		fc = ParseForknetConfig(string(data))
 	} else {
 		fc = NewForknetConfig()
-		for k, v := range getDefaultMainSection(NetworkForknet) {
-			fc.Settings[k] = v
+		settings, order := getDefaultMainSection(NetworkForknet)
+		for _, k := range orderedKeys(order, settings) {
+			fc.Set(k, settings[k])
 		}
 	}
 
@@ -593,8 +651,9 @@ func (m *BitcoinConfManager) migrateMainnetConfig() error {
 		mc = ParseMainnetConfig(string(data))
 	} else {
 		mc = NewMainnetConfig()
-		for k, v := range getDefaultMainSection(NetworkMainnet) {
-			mc.Settings[k] = v
+		settings, order := getDefaultMainSection(NetworkMainnet)
+		for _, k := range orderedKeys(order, settings) {
+			mc.Set(k, settings[k])
 		}
 	}
 
@@ -661,8 +720,16 @@ func (m *BitcoinConfManager) CopyConfigDownstream() error {
 // ---------------------------------------------------------------------------
 
 // UpdateDataDir sets the datadir for the specified (or current) network.
-// If updating for a DIFFERENT mainnet/forknet network, saves the [main]
-// section to that network's file first so it persists across network switches.
+//
+// For the current network: writes to master's [main] section AND mirrors to
+// the per-network backup (bitwindow-mainnet.conf / bitwindow-forknet.conf).
+// The mirror is essential — on every network switch, LoadMainSectionForNetwork
+// replaces [main] with the backup file's contents, so without a backup the
+// datadir vanishes the next time the user switches and switches back.
+//
+// For a different network (e.g. configuring mainnet datadir while on signet):
+// writes only to the per-network backup. Master's [main] belongs to the
+// currently-active network, so we don't touch it.
 func (m *BitcoinConfManager) UpdateDataDir(dataDir string, forNetwork Network) error {
 	if m.HasPrivateConf || m.Config == nil {
 		return nil
@@ -672,21 +739,26 @@ func (m *BitcoinConfManager) UpdateDataDir(dataDir string, forNetwork Network) e
 	if targetNetwork == "" {
 		targetNetwork = m.Network
 	}
-	section := CoreSectionForNetwork(targetNetwork)
 
-	dataDir = strings.TrimSpace(dataDir)
-	if dataDir == "" {
+	cleanDataDir := strings.ReplaceAll(strings.TrimSpace(dataDir), "\\ ", " ")
+
+	if targetNetwork != m.Network {
+		if !isMainnetOrForknet(targetNetwork) {
+			return nil
+		}
+		return m.updateDatadirInBackup(targetNetwork, cleanDataDir)
+	}
+
+	section := CoreSectionForNetwork(targetNetwork)
+	if cleanDataDir == "" {
 		m.Config.RemoveSetting("datadir", section)
 	} else {
-		cleanDataDir := strings.ReplaceAll(dataDir, "\\ ", " ")
 		m.Config.SetSetting("datadir", cleanDataDir, section)
 	}
 
-	// Cross-network save: if updating datadir for a DIFFERENT mainnet/forknet
-	// network, save [main] to that network's file so it persists when switched.
-	if isMainnetOrForknet(targetNetwork) && targetNetwork != m.Network {
+	if isMainnetOrForknet(targetNetwork) {
 		if err := m.SaveMainSectionForNetwork(targetNetwork); err != nil {
-			m.log.Error().Err(err).Msg("cross-network datadir save failed")
+			m.log.Error().Err(err).Msg("save per-network backup")
 		}
 	}
 
@@ -694,6 +766,50 @@ func (m *BitcoinConfManager) UpdateDataDir(dataDir string, forNetwork Network) e
 		return err
 	}
 	return m.LoadConfig(false)
+}
+
+// updateDatadirInBackup writes a datadir change directly to the per-network
+// backup file, without touching master. Used when the target network differs
+// from the currently-active network.
+func (m *BitcoinConfManager) updateDatadirInBackup(n Network, dataDir string) error {
+	confPath := m.getMainSectionPath(n)
+	if err := os.MkdirAll(filepath.Dir(confPath), 0755); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+
+	if n == NetworkForknet {
+		var fc *ForknetConfig
+		if data, err := os.ReadFile(confPath); err == nil {
+			fc = ParseForknetConfig(string(data))
+		} else {
+			fc = NewForknetConfig()
+			fc.Version = BitcoinConfMigrationsVersion
+			settings, order := getDefaultMainSection(n)
+			for _, k := range orderedKeys(order, settings) {
+				fc.Set(k, settings[k])
+			}
+		}
+		if dataDir == "" {
+			fc.Delete("datadir")
+		} else {
+			fc.Set("datadir", dataDir)
+		}
+		return os.WriteFile(confPath, []byte(fc.Serialize()), 0644)
+	}
+
+	var mc *MainnetConfig
+	if data, err := os.ReadFile(confPath); err == nil {
+		mc = ParseMainnetConfig(string(data))
+	} else {
+		mc = NewMainnetConfig()
+		mc.Version = BitcoinConfMigrationsVersion
+	}
+	if dataDir == "" {
+		mc.Delete("datadir")
+	} else {
+		mc.Set("datadir", dataDir)
+	}
+	return os.WriteFile(confPath, []byte(mc.Serialize()), 0644)
 }
 
 // ---------------------------------------------------------------------------

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -231,20 +231,23 @@ func TestGetMainSectionPath(t *testing.T) {
 }
 
 func TestGetDefaultMainSection(t *testing.T) {
-	forknet := getDefaultMainSection(NetworkForknet)
+	forknet, forknetOrder := getDefaultMainSection(NetworkForknet)
 	if forknet["drivechain"] != "1" {
 		t.Error("forknet should have drivechain=1")
 	}
 	if forknet["rpcport"] != "18301" {
 		t.Errorf("forknet rpcport = %q, want 18301", forknet["rpcport"])
 	}
+	if len(forknetOrder) != len(forknet) {
+		t.Errorf("forknet order len %d != settings len %d", len(forknetOrder), len(forknet))
+	}
 
-	mainnet := getDefaultMainSection(NetworkMainnet)
+	mainnet, _ := getDefaultMainSection(NetworkMainnet)
 	if len(mainnet) != 0 {
 		t.Errorf("mainnet defaults should be empty, got %v", mainnet)
 	}
 
-	signet := getDefaultMainSection(NetworkSignet)
+	signet, _ := getDefaultMainSection(NetworkSignet)
 	if len(signet) != 0 {
 		t.Errorf("signet defaults should be empty, got %v", signet)
 	}

--- a/sidechain-orchestrator/download.go
+++ b/sidechain-orchestrator/download.go
@@ -142,8 +142,18 @@ func (d *DownloadManager) Download(ctx context.Context, config BinaryConfig, net
 		defer d.inFlight.Delete(inFlightKey)
 		defer close(ch)
 
+		// Test sidechain alt URLs are always served directly from
+		// releases.drivechain.info; the prod-side DownloadSourceGitHub flag
+		// (used by zside/thunder-orchard for the production builds) doesn't
+		// apply to them. Falling through to resolveGitHubURL would try to
+		// JSON-parse an HTML 404 and abort the download with a confusing
+		// "decode response: invalid character '<'" error.
 		var downloadURL string
-		switch config.DownloadSource {
+		source := config.DownloadSource
+		if hasSCVariant {
+			source = DownloadSourceDirect
+		}
+		switch source {
 		case DownloadSourceGitHub:
 			url, err := d.resolveGitHubURL(ctx, baseURL, fileName)
 			if err != nil {
@@ -363,10 +373,11 @@ func (d *DownloadManager) extractBinary(archivePath string, config BinaryConfig,
 		// builds (untouched / touched / knots) can coexist on disk.
 		destDir = filepath.Join(destDir, variant.Subfolder)
 	case hasSCVariant:
-		// Test sidechain builds live under bin/test/ so the production
-		// binary in bin/ stays intact and the user can flip back without
-		// redownloading.
-		destDir = filepath.Join(destDir, testSidechainSubfolder)
+		// Test sidechain builds live under bin/test/<binary>/ — Flutter app
+		// archives bring their own runtime layout (`Thunder.app/...` on
+		// macOS, `<name>/<bin>+lib/+data/` on Linux) and need a private
+		// directory so multiple sidechains' lib/data trees don't collide.
+		destDir = filepath.Join(destDir, testSidechainSubfolder, config.BinaryName)
 	case !config.IsBitcoinCore:
 		// Non-Core binaries keep the legacy network-driven extract subfolder
 		// (forknet zips ship a top-level directory we have to peel off).
@@ -382,12 +393,126 @@ func (d *DownloadManager) extractBinary(archivePath string, config BinaryConfig,
 	lower := strings.ToLower(archivePath)
 	switch {
 	case strings.HasSuffix(lower, ".zip"):
+		// Test sidechain archives ship as Flutter app bundles — the
+		// flatten-by-basename move would destroy the bundle structure
+		// (collapsing 1800+ Info.plist + framework files into one
+		// directory), so we preserve the layout for them.
+		if hasSCVariant {
+			return d.extractZipPreservingTree(archivePath, destDir, config.ExtractSubfolder[currentOS()])
+		}
 		return d.extractZip(archivePath, destDir, config.BinaryName)
 	case strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tgz"):
 		return d.extractTarGz(archivePath, destDir, config.BinaryName)
 	default:
+		// For test sidechains the raw payload is a single Windows .exe; we
+		// land it at `bin/test/<binary>.exe` (where binary already includes
+		// the `.exe` suffix on Windows via Files[currentOS()]) so the
+		// resolver finds it without further plumbing.
+		if hasSCVariant {
+			return d.processRawBinary(archivePath, destDir, config.BinaryName+exeSuffix())
+		}
 		return d.processRawBinary(archivePath, destDir, config.BinaryName)
 	}
+}
+
+// exeSuffix is ".exe" on Windows and "" elsewhere — used to land raw-binary
+// test sidechain payloads (Flutter Windows builds ship as a single .exe) at
+// a path the launcher can find without further heuristics.
+func exeSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
+}
+
+// extractZipPreservingTree extracts a zip preserving its directory layout.
+// Used for test sidechain Flutter app bundles, where the `Foo.app/` (macOS)
+// or `foo/lib/...` (Linux) tree must remain intact for the runtime to
+// find frameworks, plugins, and assets at the expected relative paths. If
+// stripPrefix is non-empty, that path prefix is removed from each archive
+// entry so the archive's top-level namespace doesn't double up against
+// destDir's per-binary subfolder (e.g. without stripping "thunder/", the
+// Linux extract would land at `bin/test/thunder/thunder/thunder`).
+func (d *DownloadManager) extractZipPreservingTree(archivePath, destDir, stripPrefix string) (bool, error) {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return false, fmt.Errorf("open zip: %w", err)
+	}
+	defer r.Close() //nolint:errcheck // cleanup
+
+	if stripPrefix != "" && !strings.HasSuffix(stripPrefix, "/") {
+		stripPrefix += "/"
+	}
+
+	moved := 0
+	hasCLI := false
+	for _, f := range r.File {
+		name := f.Name
+		if stripPrefix != "" {
+			if !strings.HasPrefix(name, stripPrefix) {
+				// Anything outside the expected top-level dir is metadata
+				// we don't want polluting the bin tree (LICENSE, README,
+				// stray sibling files). Skip silently.
+				continue
+			}
+			name = strings.TrimPrefix(name, stripPrefix)
+			if name == "" {
+				continue
+			}
+		}
+
+		destPath := filepath.Join(destDir, name)
+
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(destPath, 0o755); err != nil {
+				return false, fmt.Errorf("create dir: %w", err)
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+			return false, fmt.Errorf("create dir: %w", err)
+		}
+
+		// Symlinks (`Versions/Current` -> `A`, `framework_name` ->
+		// `Versions/A/framework_name`) are essential to macOS framework
+		// resolution; the framework's main binary is reached through them
+		// and code-signing fails to verify if they're rewritten as files.
+		if f.Mode()&os.ModeSymlink != 0 {
+			rc, err := f.Open()
+			if err != nil {
+				return false, fmt.Errorf("open symlink %s: %w", f.Name, err)
+			}
+			target, err := io.ReadAll(rc)
+			_ = rc.Close()
+			if err != nil {
+				return false, fmt.Errorf("read symlink %s: %w", f.Name, err)
+			}
+			_ = os.Remove(destPath)
+			if err := os.Symlink(string(target), destPath); err != nil {
+				return false, fmt.Errorf("create symlink %s -> %s: %w", destPath, string(target), err)
+			}
+			moved++
+			continue
+		}
+
+		if err := extractZipFile(f, destPath); err != nil {
+			return false, err
+		}
+		if err := chmod(destPath); err != nil {
+			d.log.Warn().Err(err).Str("file", destPath).Msg("chmod")
+		}
+		if strings.Contains(strings.ToLower(strings.TrimSuffix(filepath.Base(destPath), ".exe")), "-cli") {
+			hasCLI = true
+		}
+		moved++
+	}
+
+	if moved == 0 {
+		return false, fmt.Errorf("no files extracted from %s (stripPrefix=%q)", archivePath, stripPrefix)
+	}
+
+	return hasCLI, nil
 }
 
 // extractZip extracts a zip archive, flattening single-directory archives.

--- a/sidechain-orchestrator/download.go
+++ b/sidechain-orchestrator/download.go
@@ -197,28 +197,25 @@ func (d *DownloadManager) Download(ctx context.Context, config BinaryConfig, net
 
 		ch <- DownloadProgress{Message: "extracting..."}
 
-		extractCfg := config
+		extractName := config.BinaryName
+		stripPrefix := ""
 		if hasSCVariant {
-			extractCfg.BinaryName = scVariant.BinaryName
-			if scVariant.ExtractSubfolder != "" {
-				extractCfg.ExtractSubfolder = map[string]string{currentOS(): scVariant.ExtractSubfolder}
-			} else {
-				extractCfg.ExtractSubfolder = nil
-			}
+			extractName = scVariant.BinaryName
+			stripPrefix = scVariant.ExtractSubfolder
 		}
-		hasCLI, err := d.extractBinary(savePath, extractCfg, d.dataDir, network, variant, hasVariant, hasSCVariant)
+		hasCLI, err := d.extractBinary(savePath, config, extractName, stripPrefix, d.dataDir, network, variant, hasVariant, hasSCVariant)
 		if err != nil {
 			ch <- DownloadProgress{Error: fmt.Errorf("extract: %w", err)}
 			return
 		}
-		d.log.Info().Bool("has_cli", hasCLI).Str("binary", extractCfg.BinaryName).Msg("extraction complete")
+		d.log.Info().Bool("has_cli", hasCLI).Str("binary", extractName).Msg("extraction complete")
 
-		finalPath := BinaryPath(d.dataDir, extractCfg.BinaryName)
+		finalPath := BinaryPath(d.dataDir, extractName)
 		switch {
 		case hasVariant:
 			finalPath = CoreBinaryPath(d.dataDir, variant, config.BinaryName)
 		case hasSCVariant:
-			finalPath = TestSidechainBinaryPath(d.dataDir, extractCfg.BinaryName)
+			finalPath = TestSidechainBinaryPath(d.dataDir, extractName)
 		}
 		ch <- DownloadProgress{Message: finalPath, Done: true}
 	}()
@@ -364,7 +361,7 @@ func (d *DownloadManager) downloadFile(ctx context.Context, url, savePath string
 // extractBinary extracts a downloaded archive to the bin directory.
 // Returns hasCLI=true iff a companion CLI binary (name contains "-cli") was
 // extracted alongside the main binary. Raw binaries never have a CLI.
-func (d *DownloadManager) extractBinary(archivePath string, config BinaryConfig, dataDir, network string, variant CoreVariantSpec, hasVariant, hasSCVariant bool) (bool, error) {
+func (d *DownloadManager) extractBinary(archivePath string, config BinaryConfig, extractName, stripPrefix, dataDir, network string, variant CoreVariantSpec, hasVariant, hasSCVariant bool) (bool, error) {
 	destDir := BinDir(dataDir)
 
 	switch {
@@ -373,14 +370,11 @@ func (d *DownloadManager) extractBinary(archivePath string, config BinaryConfig,
 		// builds (untouched / touched / knots) can coexist on disk.
 		destDir = filepath.Join(destDir, variant.Subfolder)
 	case hasSCVariant:
-		// Test sidechain builds live under bin/test/<binary>/ — Flutter app
-		// archives bring their own runtime layout (`Thunder.app/...` on
-		// macOS, `<name>/<bin>+lib/+data/` on Linux) and need a private
-		// directory so multiple sidechains' lib/data trees don't collide.
-		destDir = filepath.Join(destDir, testSidechainSubfolder, config.BinaryName)
+		// Test sidechain builds need a private dir so per-binary lib/data
+		// trees don't collide.
+		destDir = filepath.Join(destDir, testSidechainSubfolder, extractName)
 	case !config.IsBitcoinCore:
-		// Non-Core binaries keep the legacy network-driven extract subfolder
-		// (forknet zips ship a top-level directory we have to peel off).
+		// Forknet zips ship a top-level directory we have to peel off.
 		if subfolder, ok := config.ExtractSubfolder[currentOS()]; ok && subfolder != "" {
 			if network == "forknet" && len(config.ForknetFiles) > 0 {
 				destDir = filepath.Join(destDir, subfolder)
@@ -393,36 +387,22 @@ func (d *DownloadManager) extractBinary(archivePath string, config BinaryConfig,
 	lower := strings.ToLower(archivePath)
 	switch {
 	case strings.HasSuffix(lower, ".zip"):
-		// Test sidechain archives ship as Flutter app bundles — the
-		// flatten-by-basename move would destroy the bundle structure
-		// (collapsing 1800+ Info.plist + framework files into one
-		// directory), so we preserve the layout for them.
+		// Test sidechain archives ship as Flutter app bundles — flatten-by-
+		// basename would destroy the bundle, so preserve the tree.
 		if hasSCVariant {
-			return d.extractZipPreservingTree(archivePath, destDir, config.ExtractSubfolder[currentOS()])
+			return d.extractZipPreservingTree(archivePath, destDir, stripPrefix)
 		}
-		return d.extractZip(archivePath, destDir, config.BinaryName)
+		return d.extractZip(archivePath, destDir, extractName)
 	case strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tgz"):
-		return d.extractTarGz(archivePath, destDir, config.BinaryName)
+		return d.extractTarGz(archivePath, destDir, extractName)
 	default:
-		// For test sidechains the raw payload is a single Windows .exe; we
-		// land it at `bin/test/<binary>.exe` (where binary already includes
-		// the `.exe` suffix on Windows via Files[currentOS()]) so the
-		// resolver finds it without further plumbing.
-		if hasSCVariant {
-			return d.processRawBinary(archivePath, destDir, config.BinaryName+exeSuffix())
+		// Raw test-sidechain payload on Windows lands at <name>.exe.
+		name := extractName
+		if hasSCVariant && runtime.GOOS == "windows" {
+			name += ".exe"
 		}
-		return d.processRawBinary(archivePath, destDir, config.BinaryName)
+		return d.processRawBinary(archivePath, destDir, name)
 	}
-}
-
-// exeSuffix is ".exe" on Windows and "" elsewhere — used to land raw-binary
-// test sidechain payloads (Flutter Windows builds ship as a single .exe) at
-// a path the launcher can find without further heuristics.
-func exeSuffix() string {
-	if runtime.GOOS == "windows" {
-		return ".exe"
-	}
-	return ""
 }
 
 // extractZipPreservingTree extracts a zip preserving its directory layout.

--- a/sidechain-orchestrator/sidechain_test_download_live_test.go
+++ b/sidechain-orchestrator/sidechain_test_download_live_test.go
@@ -1,0 +1,113 @@
+//go:build integration_live
+
+package orchestrator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegrationLive_TestSidechains_DownloadAlt downloads every layer-2
+// sidechain's alt build from releases.drivechain.info and asserts the
+// extracted artifact is launchable. Run with:
+//
+//	go test -tags integration_live -run TestIntegrationLive_TestSidechains_DownloadAlt ./...
+//
+// The default test path is broken: archives ship as Flutter app bundles
+// (`.app` on macOS, `<name>/` directory on Linux with sibling lib/+data/),
+// not flat binaries. extractBinary's flatten-by-basename logic destroys the
+// bundle structure, so the binary either isn't recognisable on disk or is
+// missing its runtime dependencies. This test surfaces that failure
+// against the real archives served by releases.drivechain.info.
+func TestIntegrationLive_TestSidechains_DownloadAlt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live download in short mode")
+	}
+
+	dataDir := t.TempDir()
+	bwDir := t.TempDir()
+	cfgs := AllDefaults()
+	o := New(dataDir, "signet", bwDir, cfgs, testLogger(t))
+
+	require.NoError(t, o.SetTestSidechains(context.Background(), true))
+	require.True(t, o.UseTestSidechains())
+
+	for _, cfg := range cfgs {
+		cfg := cfg
+		if cfg.ChainLayer != 2 || cfg.AltBinaryName == "" {
+			continue
+		}
+		if cfg.AltFiles[currentOS()] == "" {
+			t.Logf("skip %s: no alt file for %s", cfg.Name, currentOS())
+			continue
+		}
+		t.Run(cfg.Name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			progress, err := o.Download(ctx, cfg.Name, true)
+			require.NoError(t, err, "Download(%s)", cfg.Name)
+
+			var last DownloadProgress
+			for p := range progress {
+				if p.Error != nil {
+					t.Fatalf("download error for %s: %v", cfg.Name, p.Error)
+				}
+				last = p
+			}
+			require.True(t, last.Done, "download for %s never completed", cfg.Name)
+
+			binPath := TestSidechainBinaryPath(dataDir, cfg.AltBinaryName)
+			info, err := os.Stat(binPath)
+			require.NoError(t, err, "expected %s binary at %s", cfg.AltBinaryName, binPath)
+			require.False(t, info.IsDir(), "%s should be a regular file, got dir at %s", cfg.AltBinaryName, binPath)
+			require.NotZero(t, info.Size(), "%s at %s is empty", cfg.AltBinaryName, binPath)
+
+			// Flutter app bundles ship as either:
+			//   - macOS: `Foo.app/Contents/MacOS/Foo` — bundle layout must
+			//     stay intact (Frameworks dir + symlinks + plist) for
+			//     macOS to load the binary.
+			//   - Linux: `<name>` binary with `lib/`+`data/` siblings.
+			//
+			// Resolution returning a sane path is necessary but not
+			// sufficient — also confirm the surrounding structure survived.
+			scDir := TestSidechainDir(dataDir, cfg.AltBinaryName)
+			switch runtime.GOOS {
+			case "darwin":
+				entries, err := os.ReadDir(scDir)
+				require.NoError(t, err)
+				var app string
+				for _, e := range entries {
+					if e.IsDir() && filepathHasSuffix(e.Name(), ".app") {
+						app = filepath.Join(scDir, e.Name())
+						break
+					}
+				}
+				require.NotEmpty(t, app, "macOS test build for %s must extract an .app bundle in %s", cfg.Name, scDir)
+				_, err = os.Stat(filepath.Join(app, "Contents", "Info.plist"))
+				assert.NoError(t, err, "%s missing bundle Info.plist", app)
+				_, err = os.Stat(filepath.Join(app, "Contents", "Frameworks"))
+				assert.NoError(t, err, "%s missing Frameworks/ — extraction flattened the bundle", app)
+			case "linux":
+				_, err := os.Stat(filepath.Join(scDir, "lib"))
+				assert.NoError(t, err, "linux test build for %s missing sibling lib/", cfg.Name)
+				_, err = os.Stat(filepath.Join(scDir, "data"))
+				assert.NoError(t, err, "linux test build for %s missing sibling data/", cfg.Name)
+			}
+		})
+	}
+}
+
+func filepathHasSuffix(name, suffix string) bool {
+	if len(name) < len(suffix) {
+		return false
+	}
+	return name[len(name)-len(suffix):] == suffix
+}

--- a/sidechain-orchestrator/sidechain_variant_test.go
+++ b/sidechain-orchestrator/sidechain_variant_test.go
@@ -76,8 +76,11 @@ func TestDownload_SidechainVariant_HitsAltURL(t *testing.T) {
 	assert.True(t, last.Done)
 	assert.Equal(t, "/thunder-test.zip", requested)
 
-	// Test build lands under bin/test/, prod path stays empty.
-	expected := filepath.Join(BinDir(dir), "test", binName)
+	// Test build lands under bin/test/<binary>/<binary> — Flutter app
+	// archives need a per-binary namespace for their lib/data trees, so
+	// every test sidechain extracts into its own subdirectory and the
+	// resolver finds the binary inside.
+	expected := TestSidechainBinaryPath(dir, "thunder")
 	got, err := os.ReadFile(expected)
 	require.NoError(t, err)
 	assert.Equal(t, "test-bin", string(got))
@@ -167,7 +170,7 @@ func TestDownload_SidechainVariant_CoexistsWithProd(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "prod-bin", string(prod))
 
-	test, err := os.ReadFile(filepath.Join(BinDir(dir), "test", binName))
+	test, err := os.ReadFile(TestSidechainBinaryPath(dir, "thunder"))
 	require.NoError(t, err)
 	assert.Equal(t, "test-bin", string(test))
 }
@@ -298,10 +301,14 @@ func TestIntegration_TestSidechains_FreshSwitchHitsAltURL(t *testing.T) {
 	assert.Contains(t, requested, "/test/thunder.zip", "must hit alt URL when toggle is on")
 	assert.NotContains(t, requested, "/prod/thunder.zip")
 
-	// Test build lives under bin/test/.
+	// Test build lives under bin/test/<binary>/<binary>.
 	got, err := os.ReadFile(TestSidechainBinaryPath(dataDir, "thunder"))
 	require.NoError(t, err)
 	assert.Equal(t, "test-bin", string(got))
+	// Per-binary directory exists.
+	scDir, err := os.Stat(TestSidechainDir(dataDir, "thunder"))
+	require.NoError(t, err)
+	assert.True(t, scDir.IsDir())
 
 	// Status reports Downloaded=true via the test path.
 	status := o.Status("thunder")

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.209
+version: 1.0.210
 
 environment:
   sdk: 3.11.4

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.208
+version: 1.0.209
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.80
+version: 1.0.81
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.79
+version: 1.0.80
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.206
+version: 1.0.207
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.207
+version: 1.0.208
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
Test sidechain archives ship as Flutter app bundles (.app on macOS, <name>/+lib/+data/ on Linux); flatten-by-basename extraction destroyed the bundle so the Download button bounced back. Lands each archive under bin/test/<binary>/ preserving structure, strips the alt extract_subfolder prefix on Linux, forces DownloadSourceDirect for the alt URL, and resolves the macOS .app inner Mach-O.

Live integration test under `//go:build integration_live` covers every layer-2 sidechain against releases.drivechain.info — verified locally on macOS.