### PR TITLE
orchestrator: presync detection + mainnet rest=1

### DIFF
--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -23,6 +23,7 @@
         "Verification: No coin database inconsistencies",
         "Loading block index",
         "Done loading",
+        "Pre-synchronizing blockheaders",
         "Synchronizing blockheaders",
         "Rescan completed in",
         "Rescan started from block"

--- a/sail_ui/test/widgets/daemon_connection_card_test.dart
+++ b/sail_ui/test/widgets/daemon_connection_card_test.dart
@@ -71,6 +71,21 @@ void main() {
       );
     });
 
+    // BIP324 headers-presync: BitcoindHealthCheck on the orchestrator
+    // synthesises a startup error containing the peer-reported height when
+    // getblockchaininfo still reports 0/0. The UI must treat this exactly
+    // like the -28 warmup phase: amber dot, !connected — not green/connected
+    // with a frozen-looking 0/0 progress bar (the bug this guards against).
+    test('amber for presync — synthetic startupError carrying header height', () {
+      expect(
+        call(
+          startupError: 'Pre-synchronizing blockheaders, height: 226000',
+          connected: false,
+        ),
+        theme.colors.orangeLight,
+      );
+    });
+
     test('amber while initializing', () {
       expect(
         call(initializingBinary: true, connected: false),

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -23,6 +23,7 @@
         "Verification: No coin database inconsistencies",
         "Loading block index",
         "Done loading",
+        "Pre-synchronizing blockheaders",
         "Synchronizing blockheaders",
         "Rescan completed in",
         "Rescan started from block"

--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -102,7 +102,10 @@ func (m *BitcoinConfManager) GetRPCPort() int {
 func (m *BitcoinConfManager) GetDefaultConfig() string {
 	currentNetwork := CoreSectionForNetwork(m.Network)
 
-	// Real mainnet gets minimal standard Bitcoin Core config
+	// Real mainnet gets minimal standard Bitcoin Core config.
+	// rest=1 is required by the enforcer on every network, including mainnet —
+	// without it the enforcer crashes at boot with "Bitcoin Core REST server is
+	// not enabled" and the UI's enforcer-derived chain state goes blank.
 	if m.Network == NetworkMainnet {
 		mainnetDatadir := m.rootDirNetwork(NetworkMainnet)
 		return fmt.Sprintf(`# Generated code. Any changes to this file *will* get overwritten.
@@ -115,6 +118,7 @@ rpcpassword=password
 server=1
 listen=1
 txindex=1
+rest=1
 chain=main
 `, mainnetDatadir)
 	}

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -163,10 +163,22 @@ var bitcoinConfMigrations = []BitcoinConfMigration{
 			},
 		},
 	},
+	{
+		// Mainnet support shipped with a "minimal" mainnet template that
+		// dropped rest=1. The enforcer requires REST on every network, so
+		// without this the enforcer dies at boot. Backfill it for existing
+		// configs that predate the fixed default.
+		Version: 5,
+		Changes: map[string]map[string]string{
+			"": {
+				"rest": "1",
+			},
+		},
+	},
 }
 
 // BitcoinConfMigrationsVersion is the highest migration version.
-var BitcoinConfMigrationsVersion = 4
+var BitcoinConfMigrationsVersion = 5
 
 // RunBitcoinConfMigrations applies pending migrations to a BitcoinConfig.
 // isForknet controls whether "forknet" or "mainnet" section data applies to [main].

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -144,10 +145,10 @@ func TestRunBitcoinConfMigrationsPartial(t *testing.T) {
 
 	migrated := RunBitcoinConfMigrations(config, false)
 	if !migrated {
-		t.Fatal("expected migrations 3+4 to run")
+		t.Fatal("expected migrations 3+ to run")
 	}
-	if config.ConfigVersion != 4 {
-		t.Errorf("version = %d, want 4", config.ConfigVersion)
+	if config.ConfigVersion != BitcoinConfMigrationsVersion {
+		t.Errorf("version = %d, want %d", config.ConfigVersion, BitcoinConfMigrationsVersion)
 	}
 
 	// Migration 3 should have updated signet
@@ -155,6 +156,34 @@ func TestRunBitcoinConfMigrationsPartial(t *testing.T) {
 		t.Errorf("signetblocktime = %q, want 600", config.NetworkSettings["signet"]["signetblocktime"])
 	}
 }
+
+// Existing mainnet/signet/regtest configs that predate migration 5 must get
+// rest=1 added to their global settings — the enforcer requires it on every
+// network. Regression guard for the bug where mainnet conf shipped without
+// rest=1, the enforcer crashed at boot, and the UI lost its enforcer chain
+// tip.
+func TestRunBitcoinConfMigrationsBackfillsRest(t *testing.T) {
+	config := NewBitcoinConfig()
+	config.ConfigVersion = 4
+	// User's existing mainnet conf at the time migration 5 lands.
+	config.GlobalSettings["rpcuser"] = "user"
+	config.GlobalSettings["rpcpassword"] = "password"
+	config.GlobalSettings["server"] = "1"
+	config.GlobalSettings["txindex"] = "1"
+	config.GlobalSettings["chain"] = "main"
+
+	migrated := RunBitcoinConfMigrations(config, false)
+	if !migrated {
+		t.Fatal("expected migration 5 to run on a v4 config")
+	}
+	if got := config.GlobalSettings["rest"]; got != "1" {
+		t.Errorf("rest = %q, want 1", got)
+	}
+	if config.ConfigVersion != BitcoinConfMigrationsVersion {
+		t.Errorf("version = %d, want %d", config.ConfigVersion, BitcoinConfMigrationsVersion)
+	}
+}
+
 
 func TestRunBitcoinConfMigrationsForknetConditional(t *testing.T) {
 	// Currently no forknet-specific migration data, but test the mechanism
@@ -202,13 +231,25 @@ func TestGetDefaultConfigHasVersionPrefix(t *testing.T) {
 	m := &BitcoinConfManager{Network: NetworkSignet}
 	conf := m.GetDefaultConfig()
 
-	prefix := "# bitwindow-bitcoin-conf-version=4"
+	prefix := fmt.Sprintf("# bitwindow-bitcoin-conf-version=%d", BitcoinConfMigrationsVersion)
 	if !strings.HasPrefix(conf, prefix) {
 		first := conf
 		if len(first) > 80 {
 			first = first[:80]
 		}
 		t.Errorf("default config should start with %q, got %q...", prefix, first)
+	}
+}
+
+// The mainnet template ships rest=1 — without it the enforcer crashes at
+// boot. Regression guard for the bug where mainnet was carved out into a
+// "minimal" template that dropped the setting.
+func TestGetDefaultConfigMainnetIncludesRest(t *testing.T) {
+	m := &BitcoinConfManager{Network: NetworkMainnet}
+	conf := m.GetDefaultConfig()
+
+	if !strings.Contains(conf, "\nrest=1\n") {
+		t.Errorf("mainnet default config must include rest=1, got:\n%s", conf)
 	}
 }
 

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -23,6 +23,7 @@
         "Verification: No coin database inconsistencies",
         "Loading block index",
         "Done loading",
+        "Pre-synchronizing blockheaders",
         "Synchronizing blockheaders",
         "Rescan completed in",
         "Rescan started from block"

--- a/sidechain-orchestrator/connection_monitor.go
+++ b/sidechain-orchestrator/connection_monitor.go
@@ -124,6 +124,10 @@ var bitcoindStartupPatterns = []string{
 	"Creating work queue",
 	"RPC warming up",
 	"Done loading",
+	// BitcoindHealthCheck synthesises this when getpeerinfo reports a
+	// non-zero presynced_headers but getblockchaininfo still reports 0/0
+	// (BIP324 headers presync — RPC is responsive, chain isn't visible yet).
+	PresyncMessagePrefix,
 }
 
 // Enforcer startup messages.

--- a/sidechain-orchestrator/health.go
+++ b/sidechain-orchestrator/health.go
@@ -159,6 +159,19 @@ func NewHealthChecker(config BinaryConfig, opts ...HealthCheckOpts) HealthChecke
 
 	switch config.HealthCheckType {
 	case HealthCheckJSONRPC:
+		// Bitcoin Core needs presync detection on top of the basic ping —
+		// during BIP324 headers-presync, getblockcount returns 0 cleanly, so
+		// the regular check would flip connected=true with blocks=0/headers=0
+		// and the UI would look frozen. BitcoindHealthCheck synthesises a
+		// startup error containing the presync height instead.
+		if config.IsBitcoinCore {
+			return &BitcoindHealthCheck{
+				URL:      fmt.Sprintf("http://%s:%d", host, config.Port),
+				User:     opt.User,
+				Password: opt.Password,
+				Timeout:  timeout,
+			}
+		}
 		method := config.HealthCheckRPC
 		if method == "" {
 			method = "getblockcount"

--- a/sidechain-orchestrator/health_bitcoind.go
+++ b/sidechain-orchestrator/health_bitcoind.go
@@ -1,0 +1,146 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// BitcoindHealthCheck wraps the regular RPC ping with detection for the
+// "Pre-synchronizing blockheaders" phase. During that phase, Bitcoin Core
+// (BIP324, 22.0+) responds normally to RPC calls, but `getblockchaininfo`
+// returns blocks=0 and headers=0 — so the UI sees no progress and looks
+// frozen even though the daemon is actively downloading headers.
+//
+// We surface presync as a synthetic startup error containing the highest
+// `presynced_headers` value across `getpeerinfo`, which the connection
+// monitor's bitcoind startup-pattern list catches and routes into
+// BinaryStatus.StartupError. The Dart side already renders that field.
+type BitcoindHealthCheck struct {
+	URL      string
+	User     string
+	Password string
+	Timeout  time.Duration
+}
+
+// PresyncMessagePrefix is the prefix used in synthetic startup errors when
+// bitcoind is in the headers-presync phase. The connection monitor's
+// startup-pattern list includes this prefix so the message is classified
+// as startupError rather than connectionError.
+const PresyncMessagePrefix = "Pre-synchronizing blockheaders"
+
+func (h *BitcoindHealthCheck) Check(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, h.Timeout)
+	defer cancel()
+
+	info, err := h.callBlockchainInfo(ctx)
+	if err != nil {
+		return err
+	}
+
+	if info.Headers > 0 || info.Blocks > 0 {
+		return nil
+	}
+
+	height, ok, err := h.maxPresyncedHeaders(ctx)
+	if err != nil || !ok {
+		return nil
+	}
+	return fmt.Errorf("%s, height: %d", PresyncMessagePrefix, height)
+}
+
+type bitcoindBlockchainInfo struct {
+	Blocks  int64 `json:"blocks"`
+	Headers int64 `json:"headers"`
+}
+
+func (h *BitcoindHealthCheck) callBlockchainInfo(ctx context.Context) (bitcoindBlockchainInfo, error) {
+	var info bitcoindBlockchainInfo
+	raw, err := h.rpcCall(ctx, "getblockchaininfo", nil)
+	if err != nil {
+		return info, err
+	}
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return info, fmt.Errorf("decode getblockchaininfo: %w", err)
+	}
+	return info, nil
+}
+
+// maxPresyncedHeaders returns the highest `presynced_headers` reported by any
+// connected peer. ok=false means no peer is currently in the headers-presync
+// phase (either bitcoind has no peers yet, or it's already past presync).
+func (h *BitcoindHealthCheck) maxPresyncedHeaders(ctx context.Context) (int64, bool, error) {
+	raw, err := h.rpcCall(ctx, "getpeerinfo", nil)
+	if err != nil {
+		return 0, false, err
+	}
+	var peers []struct {
+		PresyncedHeaders int64 `json:"presynced_headers"`
+	}
+	if err := json.Unmarshal(raw, &peers); err != nil {
+		return 0, false, fmt.Errorf("decode getpeerinfo: %w", err)
+	}
+	var maxHeight int64
+	found := false
+	for _, p := range peers {
+		if p.PresyncedHeaders > maxHeight {
+			maxHeight = p.PresyncedHeaders
+			found = true
+		}
+	}
+	return maxHeight, found, nil
+}
+
+func (h *BitcoindHealthCheck) rpcCall(ctx context.Context, method string, params []interface{}) (json.RawMessage, error) {
+	if params == nil {
+		params = []interface{}{}
+	}
+	body, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "1.0",
+		"id":      "health",
+		"method":  method,
+		"params":  params,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s: %w", method, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.URL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build %s request: %w", method, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if h.User != "" {
+		req.SetBasicAuth(h.User, h.Password)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", method, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // cleanup
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read %s response: %w", method, err)
+	}
+
+	var rpcResp jsonRPCResponse
+	if jerr := json.Unmarshal(respBody, &rpcResp); jerr != nil {
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("%s: HTTP %d", method, resp.StatusCode)
+		}
+		return nil, fmt.Errorf("decode %s: %w", method, jerr)
+	}
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("%s: %s", method, rpcResp.Error.Message)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: HTTP %d", method, resp.StatusCode)
+	}
+	return rpcResp.Result, nil
+}

--- a/sidechain-orchestrator/health_bitcoind_test.go
+++ b/sidechain-orchestrator/health_bitcoind_test.go
@@ -1,0 +1,268 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rpcStub turns httptest.NewServer into a tiny JSON-RPC fake. The Method field
+// of every incoming request is dispatched to the supplied handlers — anything
+// unknown returns an error so a test that forgets to register a method fails
+// loudly instead of silently looking healthy.
+type rpcStub struct {
+	getblockchaininfo func() (interface{}, *jsonRPCErrorBody)
+	getpeerinfo       func() (interface{}, *jsonRPCErrorBody)
+
+	getblockchaininfoCalls atomic.Int32
+	getpeerinfoCalls       atomic.Int32
+}
+
+type jsonRPCErrorBody struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (s *rpcStub) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var req struct {
+			Method string `json:"method"`
+		}
+		require.NoError(t, json.Unmarshal(body, &req))
+
+		var (
+			result interface{}
+			rpcErr *jsonRPCErrorBody
+		)
+		switch req.Method {
+		case "getblockchaininfo":
+			s.getblockchaininfoCalls.Add(1)
+			require.NotNil(t, s.getblockchaininfo, "test forgot to stub getblockchaininfo")
+			result, rpcErr = s.getblockchaininfo()
+		case "getpeerinfo":
+			s.getpeerinfoCalls.Add(1)
+			require.NotNil(t, s.getpeerinfo, "test forgot to stub getpeerinfo")
+			result, rpcErr = s.getpeerinfo()
+		default:
+			t.Fatalf("unexpected RPC method: %s", req.Method)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":     "health",
+			"result": result,
+			"error":  rpcErr,
+		})
+	}
+}
+
+func newBitcoindHealthCheck(url string) *BitcoindHealthCheck {
+	return &BitcoindHealthCheck{
+		URL:     url,
+		Timeout: 2 * time.Second,
+	}
+}
+
+// Past presync, blocks > 0 — the daemon is healthy and getpeerinfo must not
+// be polled (avoids extra RPC traffic on every 1s tick).
+func TestBitcoindHealthCheck_HealthyWhenBlocksAdvanced(t *testing.T) {
+	stub := &rpcStub{
+		getblockchaininfo: func() (interface{}, *jsonRPCErrorBody) {
+			return map[string]interface{}{"blocks": 100, "headers": 100}, nil
+		},
+	}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	err := newBitcoindHealthCheck(srv.URL).Check(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), stub.getpeerinfoCalls.Load(), "getpeerinfo must not be called when blocks > 0")
+}
+
+// During the regular header-sync phase headers > 0 even if blocks == 0.
+// We're past presync so no startup error should be raised.
+func TestBitcoindHealthCheck_HealthyWhenHeadersAdvanced(t *testing.T) {
+	stub := &rpcStub{
+		getblockchaininfo: func() (interface{}, *jsonRPCErrorBody) {
+			return map[string]interface{}{"blocks": 0, "headers": 500}, nil
+		},
+	}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	err := newBitcoindHealthCheck(srv.URL).Check(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), stub.getpeerinfoCalls.Load())
+}
+
+// The headline fix: getblockchaininfo reports 0/0 but a peer is feeding us
+// headers via the BIP324 presync mechanism. The check must surface that as
+// an error message containing "Pre-synchronizing blockheaders" and the peer's
+// reported height so the connection monitor can route it to startupError.
+func TestBitcoindHealthCheck_PresyncDetected(t *testing.T) {
+	stub := &rpcStub{
+		getblockchaininfo: func() (interface{}, *jsonRPCErrorBody) {
+			return map[string]interface{}{"blocks": 0, "headers": 0}, nil
+		},
+		getpeerinfo: func() (interface{}, *jsonRPCErrorBody) {
+			return []map[string]interface{}{
+				{"presynced_headers": 226000},
+				{"presynced_headers": -1},
+			}, nil
+		},
+	}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	err := newBitcoindHealthCheck(srv.URL).Check(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Pre-synchronizing blockheaders")
+	assert.Contains(t, err.Error(), "226000")
+}
+
+// When several peers are mid-presync we report the highest height — that's
+// the one closest to the actual chain tip.
+func TestBitcoindHealthCheck_PresyncMaxAcrossPeers(t *testing.T) {
+	stub := &rpcStub{
+		getblockchaininfo: func() (interface{}, *jsonRPCErrorBody) {
+			return map[string]interface{}{"blocks": 0, "headers": 0}, nil
+		},
+		getpeerinfo: func() (interface{}, *jsonRPCErrorBody) {
+			return []map[string]interface{}{
+				{"presynced_headers": 100000},
+				{"presynced_headers": 226000},
+				{"presynced_headers": 50000},
+			}, nil
+		},
+	}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	err := newBitcoindHealthCheck(srv.URL).Check(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "226000")
+	assert.NotContains(t, err.Error(), "100000")
+}
+
+// Brand-new node, RPC up, no peers yet. We must NOT raise a fake startup
+// error here — that would mark the daemon as still booting indefinitely if
+// the user has no internet. Returning nil keeps connected=true and lets the
+// existing flow play out naturally.
+func TestBitcoindHealthCheck_NoPeersIsHealthy(t *testing.T) {
+	stub := &rpcStub{
+		getblockchaininfo: func() (interface{}, *jsonRPCErrorBody) {
+			return map[string]interface{}{"blocks": 0, "headers": 0}, nil
+		},
+		getpeerinfo: func() (interface{}, *jsonRPCErrorBody) {
+			return []map[string]interface{}{}, nil
+		},
+	}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	err := newBitcoindHealthCheck(srv.URL).Check(context.Background())
+	require.NoError(t, err)
+}
+
+// Peers connected but none of them are mid-presync (presynced_headers == -1
+// is Bitcoin Core's "not in presync" sentinel). Same outcome as no peers:
+// don't synthesise a startup error from nothing.
+func TestBitcoindHealthCheck_PeersNotInPresyncIsHealthy(t *testing.T) {
+	stub := &rpcStub{
+		getblockchaininfo: func() (interface{}, *jsonRPCErrorBody) {
+			return map[string]interface{}{"blocks": 0, "headers": 0}, nil
+		},
+		getpeerinfo: func() (interface{}, *jsonRPCErrorBody) {
+			return []map[string]interface{}{
+				{"presynced_headers": -1},
+				{"presynced_headers": -1},
+			}, nil
+		},
+	}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	err := newBitcoindHealthCheck(srv.URL).Check(context.Background())
+	require.NoError(t, err)
+}
+
+// Bitcoin Core's RPC warmup phase (-28) must keep the existing flow: the
+// monitor's extractStartupError pulls the message after " - " and routes it
+// to startupError. We must not swallow that error in the new check.
+func TestBitcoindHealthCheck_WarmupErrorPropagates(t *testing.T) {
+	stub := &rpcStub{
+		getblockchaininfo: func() (interface{}, *jsonRPCErrorBody) {
+			return nil, &jsonRPCErrorBody{Code: -28, Message: "Loading block index..."}
+		},
+	}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	err := newBitcoindHealthCheck(srv.URL).Check(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Loading block index")
+}
+
+// If getpeerinfo errors out (e.g. an older bitcoind that doesn't expose the
+// field) we must not crash the health check — fall through and report the
+// daemon as connected. Worse to break sync detection than to miss presync.
+func TestBitcoindHealthCheck_PeerinfoErrorIsHealthy(t *testing.T) {
+	stub := &rpcStub{
+		getblockchaininfo: func() (interface{}, *jsonRPCErrorBody) {
+			return map[string]interface{}{"blocks": 0, "headers": 0}, nil
+		},
+		getpeerinfo: func() (interface{}, *jsonRPCErrorBody) {
+			return nil, &jsonRPCErrorBody{Code: -32601, Message: "method not found"}
+		},
+	}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	err := newBitcoindHealthCheck(srv.URL).Check(context.Background())
+	require.NoError(t, err)
+}
+
+// The presync message must be on bitcoind's startup-pattern list so the
+// connection monitor classifies it as startupError, not connectionError.
+// This guards the contract between BitcoindHealthCheck and ConnectionMonitor.
+func TestBitcoindStartupPatterns_MatchesSyntheticPresyncMessage(t *testing.T) {
+	msg := "Pre-synchronizing blockheaders, height: 226000"
+	matched := false
+	for _, p := range bitcoindStartupPatterns {
+		if strings.Contains(msg, p) {
+			matched = true
+			break
+		}
+	}
+	assert.True(t, matched, "bitcoindStartupPatterns must contain a substring that matches %q", msg)
+}
+
+// End-to-end through the connection monitor: a checker that returns the
+// presync error must land in startupError, not connectionError, and the
+// monitor must report connected=false (the daemon isn't actually usable
+// yet — same semantics as -28 warmup).
+func TestConnectionMonitor_PresyncFlowsToStartupError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	checker := &startupErrorChecker{errMsg: "Pre-synchronizing blockheaders, height: 226000"}
+	mon := NewConnectionMonitor("bitcoind", checker, bitcoindStartupPatterns, testLogger(t))
+	mon.testConnection(ctx)
+
+	assert.False(t, mon.Connected(), "presync means RPC is up but chain isn't")
+	assert.Empty(t, mon.ConnectionError(), "presync must not be classified as a connection error")
+	assert.Contains(t, mon.StartupError(), "Pre-synchronizing blockheaders")
+	assert.Contains(t, mon.StartupError(), "226000")
+}


### PR DESCRIPTION
- BitcoindHealthCheck surfaces BIP324 headers-presync as startupError so bitwindow stops looking frozen during it.
- Backfill `rest=1` for mainnet — the carve-out in 9c4f335b dropped it and the enforcer crashes at boot without REST.