### PR TITLE
orchestrator: trust persisted bitcoin.conf network

### DIFF
--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -36,10 +36,16 @@ type BitcoinConfManager struct {
 }
 
 // NewBitcoinConfManager creates a new BitcoinConfManager and loads config.
-func NewBitcoinConfManager(bitwindowDir string, log zerolog.Logger) (*BitcoinConfManager, error) {
+// defaultNetwork seeds the network used to generate the conf on first boot
+// (when no bitwindow-bitcoin.conf exists yet); once the conf exists, its
+// chain= setting drives the manager and the seed is ignored.
+func NewBitcoinConfManager(bitwindowDir string, defaultNetwork Network, log zerolog.Logger) (*BitcoinConfManager, error) {
+	if defaultNetwork == "" {
+		defaultNetwork = NetworkSignet
+	}
 	m := &BitcoinConfManager{
 		BitwindowDir: bitwindowDir,
-		Network:      NetworkSignet, // default before config is loaded
+		Network:      defaultNetwork,
 		log:          log.With().Str("component", "bitcoin-conf").Logger(),
 	}
 	if err := m.LoadConfig(true); err != nil {

--- a/sidechain-orchestrator/config/bitcoin_config.go
+++ b/sidechain-orchestrator/config/bitcoin_config.go
@@ -79,6 +79,11 @@ func ParseBitcoinConfig(content string) *BitcoinConfig {
 		if eqIdx > 0 {
 			key := strings.TrimSpace(trimmed[:eqIdx])
 			value := strings.TrimSpace(trimmed[eqIdx+1:])
+			// Strip inline `# comment` so values like `chain=main # current
+			// network` round-trip as just `main`.
+			if hashIdx := strings.Index(value, "#"); hashIdx >= 0 {
+				value = strings.TrimSpace(value[:hashIdx])
+			}
 			config.SetSetting(key, value, currentSection)
 		}
 	}

--- a/sidechain-orchestrator/core_variants_integration_test.go
+++ b/sidechain-orchestrator/core_variants_integration_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 )
 
 // variantArchive is the fake archive served by the mock server for a given
@@ -223,14 +225,20 @@ func TestIntegration_VariantResolver_ClampsOnNetworkSwap(t *testing.T) {
 	first := newIntegrationOrchestrator(t, "signet", srv.URL+"/", dataDir, bwDir)
 	require.NoError(t, first.SetCoreVariant(context.Background(), "knots"))
 
-	// Same data dirs, different network. Settings still say knots.
-	second := newIntegrationOrchestrator(t, "forknet", srv.URL+"/", dataDir, bwDir)
+	// Persist the network swap to disk the way the UI does — bitwindow-
+	// bitcoin.conf is the source of truth on subsequent boots, the CLI
+	// flag only seeds first-boot defaults.
+	require.NoError(t, first.BitcoinConf.UpdateNetwork(config.NetworkForknet))
+
+	// Same data dirs; the new orchestrator picks up the persisted forknet.
+	second := newIntegrationOrchestrator(t, "signet", srv.URL+"/", dataDir, bwDir)
 
 	v, ok := second.download.CoreVariant()
 	require.True(t, ok, "resolver must produce a variant on forknet")
 	assert.Equal(t, "touched", v.ID, "persisted knots is not forknet-compatible; must clamp to touched")
 
-	// On a network where knots IS available, the persisted choice still wins.
+	// Swap back to signet via the conf, then knots becomes valid again.
+	require.NoError(t, second.BitcoinConf.UpdateNetwork(config.NetworkSignet))
 	third := newIntegrationOrchestrator(t, "signet", srv.URL+"/", dataDir, bwDir)
 	v, ok = third.download.CoreVariant()
 	require.True(t, ok)

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -247,20 +247,19 @@ func New(dataDir, network, bitwindowDir string, configs []BinaryConfig, log zero
 	}
 
 	// Initialize config managers for auto-building args
-	bitcoinConf, err := config.NewBitcoinConfManager(bitwindowDir, log)
+	bitcoinConf, err := config.NewBitcoinConfManager(bitwindowDir, config.Network(network), log)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to initialize bitcoin config manager, args must be passed explicitly")
 	} else {
-		// Sync the bitcoin conf network with the CLI --network flag
-		cliNetwork := config.Network(network)
-		if bitcoinConf.Network != cliNetwork {
+		// bitwindow-bitcoin.conf on disk wins. The CLI --network flag only
+		// seeds the first-boot default inside NewBitcoinConfManager — once
+		// the conf exists, persisted state drives the orchestrator.
+		if string(bitcoinConf.Network) != orch.Network {
 			log.Info().
 				Str("conf_network", string(bitcoinConf.Network)).
 				Str("cli_network", network).
-				Msg("overriding bitcoin conf network to match CLI flag")
-			if err := bitcoinConf.UpdateNetwork(cliNetwork); err != nil {
-				log.Warn().Err(err).Msg("failed to update bitcoin conf network")
-			}
+				Msg("using persisted network from bitwindow-bitcoin.conf")
+			orch.Network = string(bitcoinConf.Network)
 		}
 		orch.BitcoinConf = bitcoinConf
 


### PR DESCRIPTION
Fixes bitwindow booting on the wrong network: persisted chain= now wins over the CLI --network flag, and the parser strips inline # comments so values round-trip correctly.