### PR TITLE
bitwindow: trust persisted bitcoin.conf network

### DIFF
--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.56
+version: 0.2.57
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/server/config/config.go
+++ b/bitwindow/server/config/config.go
@@ -72,27 +72,6 @@ func Parse() (Config, error) {
 		conf.BitcoinCoreRpcPassword = password
 	}
 
-	// Handle network/URL derivation
-	switch {
-	case conf.BitcoinCoreNetwork != "" && conf.BitcoinCoreURL != "":
-		// Both set - use as provided
-	case conf.BitcoinCoreNetwork != "" && conf.BitcoinCoreURL == "":
-		// Network set, derive URL
-		conf.BitcoinCoreURL = deriveURLFromNetwork(conf.BitcoinCoreNetwork)
-		if conf.BitcoinCoreURL == "" {
-			return Config{}, fmt.Errorf("could not derive URL from network %q", conf.BitcoinCoreNetwork)
-		}
-	case conf.BitcoinCoreNetwork == "" && conf.BitcoinCoreURL != "":
-		// URL set, derive network
-		conf.BitcoinCoreNetwork = deriveNetworkFromURL(conf.BitcoinCoreURL)
-		if conf.BitcoinCoreNetwork == "" {
-			return Config{}, fmt.Errorf("could not derive network from URL %q: please specify --bitcoincore.network flag", conf.BitcoinCoreURL)
-		}
-	default:
-		// Neither set
-		return Config{}, errors.New("either --bitcoincore.network or --bitcoincore.url must be specified")
-	}
-
 	if conf.Datadir == "" {
 		datadir, err := dir.DefaultDataDir()
 		if err != nil {
@@ -101,20 +80,56 @@ func Parse() (Config, error) {
 		conf.Datadir = datadir
 	}
 
-	// Append network subdirectory
-	conf.Datadir = filepath.Join(conf.Datadir, string(conf.BitcoinCoreNetwork))
-
-	if conf.LogPath == "" {
-		conf.LogPath = filepath.Join(conf.Datadir, "server.log")
-	}
-
-	// Ensure the data directory exists
-	err := os.MkdirAll(conf.Datadir, 0755)
-	if err != nil && !os.IsExist(err) {
-		return Config{}, fmt.Errorf("create data directory: %w", err)
-	}
-
 	return conf, nil
+}
+
+// BitwindowDir returns the parent dir before the per-network suffix is
+// appended in Finalize. bitwindow-bitcoin.conf and wallet.json live here.
+func (c *Config) BitwindowDir() string {
+	return c.Datadir
+}
+
+// Finalize resolves the network/URL/auth and appends the per-network suffix
+// to Datadir. Call exactly once after Parse, before opening the log file or
+// using any path/URL fields. The two args come from BitcoinConfManager when
+// it is available; pass empty values to fall back to the CLI flags.
+func (c *Config) Finalize(confNetwork Network, confRPCPort int) error {
+	switch {
+	case confNetwork != "":
+		// bitwindow-bitcoin.conf wins. CLI --bitcoincore.network was just a seed.
+		c.BitcoinCoreNetwork = confNetwork
+		if confRPCPort > 0 {
+			c.BitcoinCoreURL = fmt.Sprintf("http://localhost:%d", confRPCPort)
+		} else {
+			c.BitcoinCoreURL = deriveURLFromNetwork(confNetwork)
+		}
+	case c.BitcoinCoreNetwork != "" && c.BitcoinCoreURL != "":
+		// Flags set explicitly, no conf manager — used by integration tests.
+	case c.BitcoinCoreNetwork != "" && c.BitcoinCoreURL == "":
+		c.BitcoinCoreURL = deriveURLFromNetwork(c.BitcoinCoreNetwork)
+		if c.BitcoinCoreURL == "" {
+			return fmt.Errorf("could not derive URL from network %q", c.BitcoinCoreNetwork)
+		}
+	case c.BitcoinCoreNetwork == "" && c.BitcoinCoreURL != "":
+		c.BitcoinCoreNetwork = deriveNetworkFromURL(c.BitcoinCoreURL)
+		if c.BitcoinCoreNetwork == "" {
+			return fmt.Errorf("could not derive network from URL %q: please specify --bitcoincore.network flag", c.BitcoinCoreURL)
+		}
+	default:
+		return errors.New("either --bitcoincore.network or --bitcoincore.url must be specified")
+	}
+
+	c.Datadir = filepath.Join(c.Datadir, string(c.BitcoinCoreNetwork))
+
+	if c.LogPath == "" {
+		c.LogPath = filepath.Join(c.Datadir, "server.log")
+	}
+
+	if err := os.MkdirAll(c.Datadir, 0755); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("create data directory: %w", err)
+	}
+
+	return nil
 }
 
 func deriveURLFromNetwork(network Network) string {

--- a/bitwindow/server/main.go
+++ b/bitwindow/server/main.go
@@ -25,6 +25,7 @@ import (
 	dial "github.com/LayerTwo-Labs/sidesail/bitwindow/server/dial"
 	engines "github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/version"
+	orchconfig "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 	cryptorpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/crypto/v1/cryptov1connect"
 	rpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
@@ -85,6 +86,44 @@ func realMain(ctx context.Context, cancelCtx context.CancelFunc) error {
 		return nil
 	}
 
+	// Resolve the network from bitwindow-bitcoin.conf (when present) before
+	// finalizing paths/URLs. The CLI --bitcoincore.network flag is only the
+	// first-boot seed; once the conf exists, its chain= setting wins. This
+	// matches the orchestrator policy so a network switch in the frontend
+	// flows to bitwindowd too — see OnNetworkChanged below.
+	bootLogger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	bitcoinConf, confErr := orchconfig.NewBitcoinConfManager(
+		conf.BitwindowDir(),
+		orchconfig.Network(conf.BitcoinCoreNetwork),
+		bootLogger,
+	)
+	var (
+		confNetwork orchconfig.Network
+		confRPCPort int
+	)
+	if confErr != nil {
+		bootLogger.Warn().Err(confErr).Msg("could not load bitwindow-bitcoin.conf; falling back to CLI flags")
+	} else {
+		confNetwork = bitcoinConf.Network
+		confRPCPort = bitcoinConf.GetRPCPort()
+		// Pull rpcuser/rpcpassword from the conf when available so bitwindowd
+		// always matches whatever bitcoind is running with. CLI flag values
+		// are kept as fallbacks for tests / cookie-auth setups.
+		if bitcoinConf.Config != nil && conf.BitcoinCoreCookie == "" {
+			section := bitcoinConf.Network.CoreSection()
+			if u := bitcoinConf.Config.GetEffectiveSetting("rpcuser", section); u != "" {
+				conf.BitcoinCoreRpcUser = u
+			}
+			if p := bitcoinConf.Config.GetEffectiveSetting("rpcpassword", section); p != "" {
+				conf.BitcoinCoreRpcPassword = p
+			}
+		}
+	}
+
+	if err := conf.Finalize(config.Network(confNetwork), confRPCPort); err != nil {
+		return fmt.Errorf("finalize config: %w", err)
+	}
+
 	logFile, err := os.OpenFile(conf.LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		return fmt.Errorf("open log file: %w", err)
@@ -100,6 +139,26 @@ func realMain(ctx context.Context, cancelCtx context.CancelFunc) error {
 	// Now that the logger is initialized, we can use zerolog.Ctx(ctx) safely
 	log := zerolog.Ctx(ctx)
 	log.Info().Msgf("logger initialized successfully with file %q", conf.LogPath)
+	log.Info().
+		Str("network", string(conf.BitcoinCoreNetwork)).
+		Str("bitcoind_rpc", conf.BitcoinCoreURL).
+		Msg("resolved Bitcoin Core network from bitwindow-bitcoin.conf")
+
+	// Watch the conf for runtime network switches. When the user flips the
+	// network in the frontend, the conf is rewritten; we exit so the parent
+	// (BitWindow.app process manager) relaunches us against the new chain.
+	// bitcoind itself is restarted by the orchestrator's matching watcher.
+	if bitcoinConf != nil {
+		bitcoinConf.OnNetworkChanged = func() {
+			log.Warn().Msg("bitwindow-bitcoin.conf network changed; shutting down so the parent process manager restarts bitwindowd against the fresh chain")
+			cancelCtx()
+		}
+		if err := bitcoinConf.StartWatching(); err != nil {
+			log.Warn().Err(err).Msg("could not watch bitwindow-bitcoin.conf for network changes")
+		} else {
+			defer bitcoinConf.StopWatching()
+		}
+	}
 
 	log.Debug().
 		Msgf("initiating database")

--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -36,10 +36,16 @@ type BitcoinConfManager struct {
 }
 
 // NewBitcoinConfManager creates a new BitcoinConfManager and loads config.
-func NewBitcoinConfManager(bitwindowDir string, log zerolog.Logger) (*BitcoinConfManager, error) {
+// defaultNetwork seeds the network used to generate the conf on first boot
+// (when no bitwindow-bitcoin.conf exists yet); once the conf exists, its
+// chain= setting drives the manager and the seed is ignored.
+func NewBitcoinConfManager(bitwindowDir string, defaultNetwork Network, log zerolog.Logger) (*BitcoinConfManager, error) {
+	if defaultNetwork == "" {
+		defaultNetwork = NetworkSignet
+	}
 	m := &BitcoinConfManager{
 		BitwindowDir: bitwindowDir,
-		Network:      NetworkSignet, // default before config is loaded
+		Network:      defaultNetwork,
 		log:          log.With().Str("component", "bitcoin-conf").Logger(),
 	}
 	if err := m.LoadConfig(true); err != nil {

--- a/sidechain-orchestrator/config/bitcoin_config.go
+++ b/sidechain-orchestrator/config/bitcoin_config.go
@@ -79,6 +79,11 @@ func ParseBitcoinConfig(content string) *BitcoinConfig {
 		if eqIdx > 0 {
 			key := strings.TrimSpace(trimmed[:eqIdx])
 			value := strings.TrimSpace(trimmed[eqIdx+1:])
+			// Strip inline `# comment` so values like `chain=main # current
+			// network` round-trip as just `main`.
+			if hashIdx := strings.Index(value, "#"); hashIdx >= 0 {
+				value = strings.TrimSpace(value[:hashIdx])
+			}
 			config.SetSetting(key, value, currentSection)
 		}
 	}

--- a/sidechain-orchestrator/core_variants_integration_test.go
+++ b/sidechain-orchestrator/core_variants_integration_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 )
 
 // variantArchive is the fake archive served by the mock server for a given
@@ -223,14 +225,20 @@ func TestIntegration_VariantResolver_ClampsOnNetworkSwap(t *testing.T) {
 	first := newIntegrationOrchestrator(t, "signet", srv.URL+"/", dataDir, bwDir)
 	require.NoError(t, first.SetCoreVariant(context.Background(), "knots"))
 
-	// Same data dirs, different network. Settings still say knots.
-	second := newIntegrationOrchestrator(t, "forknet", srv.URL+"/", dataDir, bwDir)
+	// Persist the network swap to disk the way the UI does — bitwindow-
+	// bitcoin.conf is the source of truth on subsequent boots, the CLI
+	// flag only seeds first-boot defaults.
+	require.NoError(t, first.BitcoinConf.UpdateNetwork(config.NetworkForknet))
+
+	// Same data dirs; the new orchestrator picks up the persisted forknet.
+	second := newIntegrationOrchestrator(t, "signet", srv.URL+"/", dataDir, bwDir)
 
 	v, ok := second.download.CoreVariant()
 	require.True(t, ok, "resolver must produce a variant on forknet")
 	assert.Equal(t, "touched", v.ID, "persisted knots is not forknet-compatible; must clamp to touched")
 
-	// On a network where knots IS available, the persisted choice still wins.
+	// Swap back to signet via the conf, then knots becomes valid again.
+	require.NoError(t, second.BitcoinConf.UpdateNetwork(config.NetworkSignet))
 	third := newIntegrationOrchestrator(t, "signet", srv.URL+"/", dataDir, bwDir)
 	v, ok = third.download.CoreVariant()
 	require.True(t, ok)

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -247,20 +247,19 @@ func New(dataDir, network, bitwindowDir string, configs []BinaryConfig, log zero
 	}
 
 	// Initialize config managers for auto-building args
-	bitcoinConf, err := config.NewBitcoinConfManager(bitwindowDir, log)
+	bitcoinConf, err := config.NewBitcoinConfManager(bitwindowDir, config.Network(network), log)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to initialize bitcoin config manager, args must be passed explicitly")
 	} else {
-		// Sync the bitcoin conf network with the CLI --network flag
-		cliNetwork := config.Network(network)
-		if bitcoinConf.Network != cliNetwork {
+		// bitwindow-bitcoin.conf on disk wins. The CLI --network flag only
+		// seeds the first-boot default inside NewBitcoinConfManager — once
+		// the conf exists, persisted state drives the orchestrator.
+		if string(bitcoinConf.Network) != orch.Network {
 			log.Info().
 				Str("conf_network", string(bitcoinConf.Network)).
 				Str("cli_network", network).
-				Msg("overriding bitcoin conf network to match CLI flag")
-			if err := bitcoinConf.UpdateNetwork(cliNetwork); err != nil {
-				log.Warn().Err(err).Msg("failed to update bitcoin conf network")
-			}
+				Msg("using persisted network from bitwindow-bitcoin.conf")
+			orch.Network = string(bitcoinConf.Network)
 		}
 		orch.BitcoinConf = bitcoinConf
 


### PR DESCRIPTION
bitwindowd now sources its network/RPC port from bitwindow-bitcoin.conf via the orchestrator's BitcoinConfManager, and exits on OnNetworkChanged so the parent process manager relaunches it against the fresh chain — matching the orchestrator's recent policy flip in 8d941ee6.