### PR TITLE
multi: unbreak test-sidechain download + bootstrap

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.207
+version: 1.0.208
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.208
+version: 1.0.209
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.57
+version: 0.2.58
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.81
+version: 1.0.82
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/config/backend_sidechain_runtime.dart
+++ b/sail_ui/lib/config/backend_sidechain_runtime.dart
@@ -7,6 +7,7 @@ import 'package:sail_ui/config/binaries.dart';
 import 'package:sail_ui/providers/backend_state_provider.dart';
 import 'package:sail_ui/providers/binaries/binary_provider.dart';
 import 'package:sail_ui/providers/log_provider.dart';
+import 'package:sail_ui/providers/wallet_reader_provider.dart';
 import 'package:sail_ui/rpcs/orchestrator_rpc.dart';
 
 Future<void> initBackendManagedSidechainRuntime({
@@ -86,6 +87,14 @@ Future<void> bootBackendManagedSidechain({
     _streamBinaryLogs(orchestrator, targetBinaryName, binary);
     _streamBinaryLogs(orchestrator, 'bitcoind', BinaryType.bitcoinCore);
     _streamBinaryLogs(orchestrator, 'enforcer', BinaryType.enforcer);
+
+    // Seed wallet state now that OrchestratorRPC is registered + reachable.
+    // initSidechainDependencies registers the provider lazily but cannot
+    // call init() itself — the seed RPC needs an OrchestratorRPC, and
+    // standalone sidechain launches don't have one until we get here.
+    if (GetIt.I.isRegistered<WalletReaderProvider>()) {
+      unawaited(GetIt.I.get<WalletReaderProvider>().init());
+    }
 
     log.i('bootBackendManagedSidechain: starting backend state watch');
     backendState.startWatching();

--- a/sail_ui/lib/config/binaries.dart
+++ b/sail_ui/lib/config/binaries.dart
@@ -725,6 +725,16 @@ abstract class Binary {
   }
 
   Future<File> resolveBinaryPath(Directory appDir) async {
+    // Test-sidechain alt build extracts to `bin/test/<binary>/` and the
+    // launchable file inside varies by OS (Linux: bare binary; macOS:
+    // `<TitleCase>.app/Contents/MacOS/<TitleCase>`; Windows: `<binary>.exe`).
+    // Scan rather than guess casing so we mirror
+    // sidechain-orchestrator/config.go:TestSidechainBinaryPath exactly.
+    if (metadata.isUsingAlternative) {
+      final testFile = _resolveTestSidechainBinary(appDir);
+      if (testFile != null) return testFile;
+    }
+
     // First find all possible paths the binary might be in,
     // such as .exe, .app, /assets/bin, $datadir/assets etc.
     final possiblePaths = _getPossibleBinaryPaths(binary, appDir);
@@ -752,6 +762,31 @@ abstract class Binary {
     }
 
     throw Exception('Binary not found');
+  }
+
+  File? _resolveTestSidechainBinary(Directory appDir) {
+    final testDir = Directory(path.join(binDir(appDir.path).path, 'test', binary));
+    if (!testDir.existsSync()) return null;
+
+    if (Platform.isWindows) {
+      final exe = File(path.join(testDir.path, '$binary.exe'));
+      return exe.existsSync() ? exe : null;
+    }
+
+    if (Platform.isMacOS) {
+      for (final entry in testDir.listSync()) {
+        final name = path.basename(entry.path);
+        if (entry is Directory && name.endsWith('.app')) {
+          final inner = name.substring(0, name.length - '.app'.length);
+          final exe = File(path.join(entry.path, 'Contents', 'MacOS', inner));
+          if (exe.existsSync()) return exe;
+        }
+      }
+      return null;
+    }
+
+    final lin = File(path.join(testDir.path, binary));
+    return lin.existsSync() ? lin : null;
   }
 
   List<String> _getPossibleBinaryPaths(String baseBinary, Directory appDir) {
@@ -2144,6 +2179,11 @@ class MetadataConfig {
   // if test chains enabled, use those, but only if an alternative config exists
   DownloadConfig get downloadConfig =>
       _settingsProvider.useTestSidechains ? _alternativeDownloadConfig ?? _downloadConfig : _downloadConfig;
+
+  /// True when the active download config is the test-sidechain alternative.
+  /// Mirrors the orchestrator's `SidechainVariant` toggle so the resolver
+  /// knows to look under `bin/test/<binary>/` instead of `bin/<subfolder>/`.
+  bool get isUsingAlternative => _settingsProvider.useTestSidechains && _alternativeDownloadConfig != null;
 
   DateTime? remoteTimestamp; // Last-Modified from server
   DateTime? downloadedTimestamp; // Local file timestamp

--- a/sail_ui/lib/config/binaries.dart
+++ b/sail_ui/lib/config/binaries.dart
@@ -725,16 +725,6 @@ abstract class Binary {
   }
 
   Future<File> resolveBinaryPath(Directory appDir) async {
-    // Test-sidechain alt build extracts to `bin/test/<binary>/` and the
-    // launchable file inside varies by OS (Linux: bare binary; macOS:
-    // `<TitleCase>.app/Contents/MacOS/<TitleCase>`; Windows: `<binary>.exe`).
-    // Scan rather than guess casing so we mirror
-    // sidechain-orchestrator/config.go:TestSidechainBinaryPath exactly.
-    if (metadata.isUsingAlternative) {
-      final testFile = _resolveTestSidechainBinary(appDir);
-      if (testFile != null) return testFile;
-    }
-
     // First find all possible paths the binary might be in,
     // such as .exe, .app, /assets/bin, $datadir/assets etc.
     final possiblePaths = _getPossibleBinaryPaths(binary, appDir);
@@ -762,31 +752,6 @@ abstract class Binary {
     }
 
     throw Exception('Binary not found');
-  }
-
-  File? _resolveTestSidechainBinary(Directory appDir) {
-    final testDir = Directory(path.join(binDir(appDir.path).path, 'test', binary));
-    if (!testDir.existsSync()) return null;
-
-    if (Platform.isWindows) {
-      final exe = File(path.join(testDir.path, '$binary.exe'));
-      return exe.existsSync() ? exe : null;
-    }
-
-    if (Platform.isMacOS) {
-      for (final entry in testDir.listSync()) {
-        final name = path.basename(entry.path);
-        if (entry is Directory && name.endsWith('.app')) {
-          final inner = name.substring(0, name.length - '.app'.length);
-          final exe = File(path.join(entry.path, 'Contents', 'MacOS', inner));
-          if (exe.existsSync()) return exe;
-        }
-      }
-      return null;
-    }
-
-    final lin = File(path.join(testDir.path, binary));
-    return lin.existsSync() ? lin : null;
   }
 
   List<String> _getPossibleBinaryPaths(String baseBinary, Directory appDir) {
@@ -2179,11 +2144,6 @@ class MetadataConfig {
   // if test chains enabled, use those, but only if an alternative config exists
   DownloadConfig get downloadConfig =>
       _settingsProvider.useTestSidechains ? _alternativeDownloadConfig ?? _downloadConfig : _downloadConfig;
-
-  /// True when the active download config is the test-sidechain alternative.
-  /// Mirrors the orchestrator's `SidechainVariant` toggle so the resolver
-  /// knows to look under `bin/test/<binary>/` instead of `bin/<subfolder>/`.
-  bool get isUsingAlternative => _settingsProvider.useTestSidechains && _alternativeDownloadConfig != null;
 
   DateTime? remoteTimestamp; // Last-Modified from server
   DateTime? downloadedTimestamp; // Local file timestamp

--- a/sail_ui/lib/config/sidechain_main.dart
+++ b/sail_ui/lib/config/sidechain_main.dart
@@ -49,10 +49,12 @@ Future<void> initSidechainDependencies({
     () => FormatterProvider(settingsProvider),
   );
 
-  // Register WalletReaderProvider pointing to bitwindow directory
+  // Register WalletReaderProvider pointing to bitwindow directory.
+  // init() is deferred to bootBackendManagedSidechain — the seed call
+  // requires OrchestratorRPC, which standalone sidechain launches register
+  // only after orchestratord is up.
   final walletReader = WalletReaderProvider(bitwindowDir);
   GetIt.I.registerLazySingleton<WalletReaderProvider>(() => walletReader);
-  await walletReader.init();
 
   // Register WalletWriterProvider (same code as BitWindow) for chain-agnostic wallet creation
   final walletWriter = WalletWriterProvider(

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -39,6 +39,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     $core.String? version,
     $core.String? repoUrl,
     $core.Iterable<StartupLogEntryMsg>? startupLogs,
+    $core.String? binaryPath,
   }) {
     final $result = create();
     if (name != null) {
@@ -107,6 +108,9 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     if (startupLogs != null) {
       $result.startupLogs.addAll(startupLogs);
     }
+    if (binaryPath != null) {
+      $result.binaryPath = binaryPath;
+    }
     return $result;
   }
   BinaryStatusMsg._() : super();
@@ -136,6 +140,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     ..aOS(20, _omitFieldNames ? '' : 'version')
     ..aOS(21, _omitFieldNames ? '' : 'repoUrl')
     ..pc<StartupLogEntryMsg>(22, _omitFieldNames ? '' : 'startupLogs', $pb.PbFieldType.PM, subBuilder: StartupLogEntryMsg.create)
+    ..aOS(23, _omitFieldNames ? '' : 'binaryPath')
     ..hasRequiredFields = false
   ;
 
@@ -351,6 +356,18 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
 
   @$pb.TagNumber(22)
   $core.List<StartupLogEntryMsg> get startupLogs => $_getList(21);
+
+  /// Absolute path to the launchable binary on disk (variant-aware: returns
+  /// bin/test/<binary>/... for active sidechain alt-builds, the resolved
+  /// .app/Contents/MacOS path on macOS, etc.). Empty when not downloaded.
+  @$pb.TagNumber(23)
+  $core.String get binaryPath => $_getSZ(22);
+  @$pb.TagNumber(23)
+  set binaryPath($core.String v) { $_setString(22, v); }
+  @$pb.TagNumber(23)
+  $core.bool hasBinaryPath() => $_has(22);
+  @$pb.TagNumber(23)
+  void clearBinaryPath() => clearField(23);
 }
 
 class StartupLogEntryMsg extends $pb.GeneratedMessage {

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -39,6 +39,7 @@ const BinaryStatusMsg$json = {
     {'1': 'version', '3': 20, '4': 1, '5': 9, '10': 'version'},
     {'1': 'repo_url', '3': 21, '4': 1, '5': 9, '10': 'repoUrl'},
     {'1': 'startup_logs', '3': 22, '4': 3, '5': 11, '6': '.orchestrator.v1.StartupLogEntryMsg', '10': 'startupLogs'},
+    {'1': 'binary_path', '3': 23, '4': 1, '5': 9, '10': 'binaryPath'},
   ],
 };
 
@@ -57,7 +58,7 @@ final $typed_data.Uint8List binaryStatusMsgDescriptor = $convert.base64Decode(
     'ZGVkGBIgASgIUgpkb3dubG9hZGVkEh4KC3BvcnRfaW5fdXNlGBMgASgIUglwb3J0SW5Vc2USGA'
     'oHdmVyc2lvbhgUIAEoCVIHdmVyc2lvbhIZCghyZXBvX3VybBgVIAEoCVIHcmVwb1VybBJGCgxz'
     'dGFydHVwX2xvZ3MYFiADKAsyIy5vcmNoZXN0cmF0b3IudjEuU3RhcnR1cExvZ0VudHJ5TXNnUg'
-    'tzdGFydHVwTG9ncw==');
+    'tzdGFydHVwTG9ncxIfCgtiaW5hcnlfcGF0aBgXIAEoCVIKYmluYXJ5UGF0aA==');
 
 @$core.Deprecated('Use startupLogEntryMsgDescriptor instead')
 const StartupLogEntryMsg$json = {

--- a/sail_ui/lib/providers/backend_state_provider.dart
+++ b/sail_ui/lib/providers/backend_state_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
@@ -80,6 +81,7 @@ class BackendStateProvider extends ChangeNotifier {
 
           final rpc = _syncConnectionState(status);
           if (rpc != null) changedRpcs.add(rpc);
+          _syncBinaryPath(status);
         }
         // Batch notifications: one per changed RPC, then one for ourselves
         for (final rpc in changedRpcs) {
@@ -135,6 +137,33 @@ class BackendStateProvider extends ChangeNotifier {
     rpc.startupError = startupError;
     rpc.connectionError = connectionError;
     return rpc;
+  }
+
+  /// Mirror the orchestrator's `binary_path` field onto the matching
+  /// `Binary.metadata.binaryPath`. Orchestrator owns the truth — it knows
+  /// where it extracted the file (variant-aware, .app-resolved on macOS),
+  /// so the frontend stops trying to second-guess from a list of guessed
+  /// paths and just uses what was reported.
+  void _syncBinaryPath(BinaryStatusMsg status) {
+    if (!GetIt.I.isRegistered<BinaryProvider>()) return;
+    final type = _binaryTypeFromName(status.name);
+    if (type == null) return;
+
+    final reported = status.binaryPath;
+    final next = reported.isEmpty ? null : File(reported);
+
+    final binaryProvider = GetIt.I.get<BinaryProvider>();
+    binaryProvider.updateBinary(type, (b) {
+      if (b.metadata.binaryPath?.path == next?.path) return b;
+      return b.copyWith(
+        metadata: b.metadata.copyWith(
+          remoteTimestamp: b.metadata.remoteTimestamp,
+          downloadedTimestamp: b.metadata.downloadedTimestamp,
+          binaryPath: next,
+          updateable: b.metadata.updateable,
+        ),
+      );
+    });
   }
 
   /// Get the RPCConnection for a backend binary name, or null.

--- a/sail_ui/lib/providers/wallet_reader_provider.dart
+++ b/sail_ui/lib/providers/wallet_reader_provider.dart
@@ -216,6 +216,12 @@ class WalletReaderProvider extends ChangeNotifier {
     // listWallets + getWalletStatus return the same fields the stream
     // would push, so we can populate the provider directly.
     if (wallets.isNotEmpty) return;
+    if (!GetIt.I.isRegistered<OrchestratorRPC>()) {
+      // bootBackendManagedSidechain calls back into init() once the
+      // orchestrator is registered + ready; bail without crashing.
+      _logger.d('WalletReaderProvider: OrchestratorRPC not registered yet, skipping seed');
+      return;
+    }
     final orchestrator = GetIt.I.get<OrchestratorRPC>();
     Future<List<dynamic>> seed() => Future.wait([
       orchestrator.wallet.listWallets(),

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -374,6 +374,7 @@ func statusToProto(s orchestrator.BinaryStatus) *pb.BinaryStatusMsg {
 		Downloadable:    s.Downloadable,
 		Description:     s.Description,
 		Downloaded:      s.Downloaded,
+		BinaryPath:      s.BinaryPath,
 		PortInUse:       s.PortInUse,
 		Version:         s.Version,
 		RepoUrl:         s.RepoURL,

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -152,18 +152,7 @@ func run(cctx *cli.Context) error {
 
 		return nil
 	}
-	walletSvc.GetBinaryWalletPaths = func() []string {
-		paths := []string{}
-		network := config.Network(network)
-		for _, cfg := range orch.Configs() {
-			dirConfig, ok := config.DirConfigByName(cfg.Name)
-			if !ok {
-				continue
-			}
-			paths = append(paths, dirConfig.GetWalletPaths(dirConfig.RootDirNetwork(network), network, log)...)
-		}
-		return paths
-	}
+	walletSvc.GetBinaryWalletPaths = orch.BinaryWalletPaths
 	if orch.BitcoinConf != nil {
 		walletSvc.CoreDataDir = config.BitcoinCoreDirs.RootDirNetwork(orch.BitcoinConf.Network)
 	}

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -45,8 +45,12 @@ type BinaryStatusMsg struct {
 	Version         string                 `protobuf:"bytes,20,opt,name=version,proto3" json:"version,omitempty"`                                           // configured version string
 	RepoUrl         string                 `protobuf:"bytes,21,opt,name=repo_url,json=repoUrl,proto3" json:"repo_url,omitempty"`                            // source code repository URL
 	StartupLogs     []*StartupLogEntryMsg  `protobuf:"bytes,22,rep,name=startup_logs,json=startupLogs,proto3" json:"startup_logs,omitempty"`                // recent startup progress messages
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Absolute path to the launchable binary on disk (variant-aware: returns
+	// bin/test/<binary>/... for active sidechain alt-builds, the resolved
+	// .app/Contents/MacOS path on macOS, etc.). Empty when not downloaded.
+	BinaryPath    string `protobuf:"bytes,23,opt,name=binary_path,json=binaryPath,proto3" json:"binary_path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *BinaryStatusMsg) Reset() {
@@ -231,6 +235,13 @@ func (x *BinaryStatusMsg) GetStartupLogs() []*StartupLogEntryMsg {
 		return x.StartupLogs
 	}
 	return nil
+}
+
+func (x *BinaryStatusMsg) GetBinaryPath() string {
+	if x != nil {
+		return x.BinaryPath
+	}
+	return ""
 }
 
 type StartupLogEntryMsg struct {
@@ -2069,7 +2080,7 @@ var File_orchestrator_v1_orchestrator_proto protoreflect.FileDescriptor
 
 const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\n" +
-	"\"orchestrator/v1/orchestrator.proto\x12\x0forchestrator.v1\"\xdd\x05\n" +
+	"\"orchestrator/v1/orchestrator.proto\x12\x0forchestrator.v1\"\xfe\x05\n" +
 	"\x0fBinaryStatusMsg\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
 	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12\x18\n" +
@@ -2096,7 +2107,9 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\vport_in_use\x18\x13 \x01(\bR\tportInUse\x12\x18\n" +
 	"\aversion\x18\x14 \x01(\tR\aversion\x12\x19\n" +
 	"\brepo_url\x18\x15 \x01(\tR\arepoUrl\x12F\n" +
-	"\fstartup_logs\x18\x16 \x03(\v2#.orchestrator.v1.StartupLogEntryMsgR\vstartupLogs\"U\n" +
+	"\fstartup_logs\x18\x16 \x03(\v2#.orchestrator.v1.StartupLogEntryMsgR\vstartupLogs\x12\x1f\n" +
+	"\vbinary_path\x18\x17 \x01(\tR\n" +
+	"binaryPath\"U\n" +
 	"\x12StartupLogEntryMsg\x12%\n" +
 	"\x0etimestamp_unix\x18\x01 \x01(\x03R\rtimestampUnix\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\"\x15\n" +

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -46,6 +46,7 @@ type BinaryStatus struct {
 	Downloadable    bool   // binary has download URLs configured
 	Description     string // short description of the binary
 	Downloaded      bool   // binary file exists on disk
+	BinaryPath      string // absolute path to the launchable binary (variant-aware), empty when not downloaded
 	PortInUse       bool   // port is reachable (something is listening)
 	Version         string // configured version string
 	RepoURL         string // source code repository URL
@@ -447,7 +448,8 @@ func (o *Orchestrator) Status(name string) BinaryStatus {
 			binPath = TestSidechainBinaryPath(o.DataDir, sv.BinaryName)
 		}
 	}
-	_, downloaded := os.Stat(binPath)
+	_, statErr := os.Stat(binPath)
+	downloaded := statErr == nil
 	status := BinaryStatus{
 		Name:         config.Name,
 		DisplayName:  config.DisplayName,
@@ -455,9 +457,12 @@ func (o *Orchestrator) Status(name string) BinaryStatus {
 		Port:         config.Port,
 		Downloadable: config.Downloadable(),
 		Description:  config.Description,
-		Downloaded:   downloaded == nil,
+		Downloaded:   downloaded,
 		Version:      config.Version,
 		RepoURL:      config.RepoURL,
+	}
+	if downloaded {
+		status.BinaryPath = binPath
 	}
 
 	if proc != nil {

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -72,6 +72,10 @@ message BinaryStatusMsg {
   string version = 20;         // configured version string
   string repo_url = 21;        // source code repository URL
   repeated StartupLogEntryMsg startup_logs = 22; // recent startup progress messages
+  // Absolute path to the launchable binary on disk (variant-aware: returns
+  // bin/test/<binary>/... for active sidechain alt-builds, the resolved
+  // .app/Contents/MacOS path on macOS, etc.). Empty when not downloaded.
+  string binary_path = 23;
 }
 
 message StartupLogEntryMsg {

--- a/sidechain-orchestrator/reset.go
+++ b/sidechain-orchestrator/reset.go
@@ -296,3 +296,28 @@ func (o *Orchestrator) StreamResetData(ctx context.Context, cat ResetCategory) (
 
 	return events, nil
 }
+
+// BinaryWalletPaths returns the per-binary on-disk wallet locations that a
+// "Delete Wallet Files" / "Fully Obliterate" reset must remove. Mirrors the
+// path enumeration used by collectPaths/StreamResetData so the wallet
+// service's pre-deletion sweep agrees with the file-by-file pass that runs
+// after — without that agreement, the sweep can miss `<datadir>/<network>/
+// wallets/` while the second pass deletes blockchain data, leaving
+// the user's wallet alive against an empty chain (issue #1627).
+func (o *Orchestrator) BinaryWalletPaths() []string {
+	network := config.Network(o.Network)
+	bitcoinOverride := ""
+	if o.BitcoinConf != nil {
+		bitcoinOverride = o.BitcoinConf.DetectedDataDir
+	}
+
+	var paths []string
+	for _, cfg := range o.Configs() {
+		dirConfig, ok := config.DirConfigByName(cfg.Name)
+		if !ok {
+			continue
+		}
+		paths = append(paths, dirConfig.GetWalletPaths(dirConfig.DatadirNetwork(network, bitcoinOverride), network, o.log)...)
+	}
+	return paths
+}

--- a/sidechain-orchestrator/reset.go
+++ b/sidechain-orchestrator/reset.go
@@ -268,6 +268,21 @@ func (o *Orchestrator) StreamResetData(ctx context.Context, cat ResetCategory) (
 				Category: entry.category,
 			}
 
+			// Wallet paths were already moved aside by WalletSvc.DeleteAllWallets
+			// (soft-delete via moveToBackup). Running os.RemoveAll here would
+			// either no-op (path already moved) or destructively wipe a path
+			// the wallet service decided to leave alone. Skip the category
+			// outright so reset events still report it but the original keys
+			// stay recoverable.
+			if entry.category == "wallet" {
+				evt.Success = true
+				deleted++
+				evt.DeletedCount = deleted
+				evt.FailedCount = failed
+				events <- evt
+				continue
+			}
+
 			if err := os.RemoveAll(entry.path); err != nil && !os.IsNotExist(err) {
 				evt.Success = false
 				evt.Error = err.Error()

--- a/sidechain-orchestrator/reset_test.go
+++ b/sidechain-orchestrator/reset_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -437,5 +438,46 @@ func TestPreviewResetData_ResultsAreStable(t *testing.T) {
 	for i := range files1 {
 		assert.Equal(t, files1[i].Path, files2[i].Path)
 		assert.Equal(t, files1[i].Category, files2[i].Category)
+	}
+}
+
+// ---------- BinaryWalletPaths ----------------------------------------------
+
+// TestBinaryWalletPaths_BitcoindUsesNetworkAwareDatadir guards issue #1627.
+// The wallet sweep must look for bitcoind wallets at `<datadir>/<network>/
+// wallets/`, not the bare root. The previous wiring passed RootDirNetwork —
+// dropping the per-network subfolder — so a "Fully Obliterate Everything"
+// pass left the user's enforcer wallet untouched.
+func TestBinaryWalletPaths_BitcoindUsesNetworkAwareDatadir(t *testing.T) {
+	o := newResetTestOrchestrator(t)
+
+	// Point bitcoind at our tempdir as if the user set `datadir=<tmp>` in
+	// bitwindow-bitcoin.conf, then drop a wallets/ dir under
+	// <override>/<network>/. The path must show up in BinaryWalletPaths
+	// regardless of whether anything else exists in the root.
+	override := t.TempDir()
+	o.BitcoinConf = &config.BitcoinConfManager{
+		Network:         config.Network("signet"),
+		DetectedDataDir: override,
+	}
+	bitcoinNetworkDir := filepath.Join(override, "signet")
+	walletsDir := filepath.Join(bitcoinNetworkDir, "wallets")
+	require.NoError(t, os.MkdirAll(walletsDir, 0o755))
+
+	paths := o.BinaryWalletPaths()
+
+	found := false
+	for _, p := range paths {
+		if p == walletsDir {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "bitcoind signet wallets dir must be in BinaryWalletPaths; got: %v", paths)
+
+	// And the bare-root mistake must NOT appear (would be the regression).
+	bareRootWallets := filepath.Join(override, "wallets")
+	for _, p := range paths {
+		assert.NotEqual(t, bareRootWallets, p, "must not point at bare-root <override>/wallets — that's the pre-fix layout")
 	}
 }

--- a/sidechain-orchestrator/sidechain_variant_boot_test.go
+++ b/sidechain-orchestrator/sidechain_variant_boot_test.go
@@ -113,6 +113,18 @@ func TestSidechainVariant_DownloadAndBoot(t *testing.T) {
 		return sidechainVariantSpec{BinaryName: c.AltBinaryName}, true
 	}
 
+	// Status (used to populate the BinaryStatusMsg.binary_path RPC field)
+	// must report the same test-variant path so the frontend trusts the
+	// orchestrator instead of duplicating filesystem-resolution logic.
+	o := New(dataDir, "signet", t.TempDir(), []BinaryConfig{cfg}, log)
+	o.process.SidechainVariant = func(c BinaryConfig) (sidechainVariantSpec, bool) {
+		return sidechainVariantSpec{BinaryName: c.AltBinaryName}, true
+	}
+	st := o.Status(cfg.Name)
+	require.True(t, st.Downloaded, "Status reports not-downloaded for %s", cfg.Name)
+	assert.Equal(t, binPath, st.BinaryPath,
+		"Status.BinaryPath %q must equal TestSidechainBinaryPath %q for variant-aware resolution", st.BinaryPath, binPath)
+
 	pid, err := pm.Start(context.Background(), cfg, nil, nil)
 	require.NoError(t, err)
 	require.NotZero(t, pid)

--- a/sidechain-orchestrator/sidechain_variant_boot_test.go
+++ b/sidechain-orchestrator/sidechain_variant_boot_test.go
@@ -1,0 +1,183 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSidechainVariant_DownloadAndBoot is the end-to-end check requested by
+// users hitting the "test-sidechain downloads but bitwindow can't find it"
+// regression: with the test-sidechains toggle on, the orchestrator must
+//
+//  1. download the alternative archive into `bin/test/<binary>/`,
+//  2. lay it out so the resolver matches sidechain-orchestrator/config.go's
+//     TestSidechainBinaryPath (Linux: bare binary; macOS: <Title>.app
+//     bundle; Windows: <name>.exe), and
+//  3. when ProcessManager.Start is called with the same SidechainVariant
+//     resolver, actually launch the test variant — not the prod binary or
+//     a stale path.
+//
+// Crucially this is a real-process test: we compile a small Go binary into
+// the archive and verify the running process's exec path is the test
+// variant on disk. A unit test asserting only resolved paths won't catch a
+// regression where the resolver returns one path but Start exec's a
+// different one.
+func TestSidechainVariant_DownloadAndBoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("real-binary launch path differs on Windows; CI runs the Linux/macOS variants")
+	}
+
+	fakeBin := buildFakeSidechainBinary(t)
+
+	binName := "thunder"
+	archiveFiles := map[string][]byte{}
+	switch runtime.GOOS {
+	case "darwin":
+		// Minimal Flutter-shaped .app: orchestrator's TestSidechainBinaryPath
+		// scans for any `.app` and returns Contents/MacOS/<TitleCase>.
+		archiveFiles["Thunder.app/Contents/Info.plist"] = []byte("<?xml version=\"1.0\"?>\n")
+		archiveFiles["Thunder.app/Contents/MacOS/Thunder"] = fakeBin
+	default:
+		archiveFiles[binName] = fakeBin
+	}
+	archive := makeZipBytes(t, archiveFiles)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(archive)))
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	dataDir := t.TempDir()
+	log := testLogger(t)
+
+	dm := NewDownloadManager(dataDir, "", log)
+	dm.httpClient = srv.Client()
+
+	cfg := makeSidechainConfig(srv.URL + "/")
+	resolver := func(c BinaryConfig) (sidechainVariantSpec, bool) {
+		return sidechainVariantSpec{
+			BinaryName: c.AltBinaryName,
+			BaseURL:    c.AltBaseURL("default"),
+			FileName:   c.AltFiles[currentOS()],
+		}, true
+	}
+	dm.SidechainVariant = resolver
+	require.True(t, dm.SidechainVariant != nil)
+
+	// Step 1 + 2: test-variant download lands under bin/test/<binary>/.
+	ch, err := dm.Download(context.Background(), cfg, "default", true)
+	require.NoError(t, err)
+	last := drainProgress(t, ch)
+	require.True(t, last.Done, "download did not complete: %+v", last)
+
+	scDir := TestSidechainDir(dataDir, "thunder")
+	binPath := TestSidechainBinaryPath(dataDir, "thunder")
+	t.Logf("test variant dir: %s", scDir)
+	t.Logf("test variant binary: %s", binPath)
+
+	// Step 3: resolved binary exists, is a regular file, has nonzero size,
+	// and the on-disk layout matches the orchestrator's expectations.
+	info, err := os.Stat(binPath)
+	require.NoError(t, err, "binary not found at expected test-variant path %s", binPath)
+	require.False(t, info.IsDir(), "%s should be a regular file", binPath)
+	require.NotZero(t, info.Size(), "%s is empty", binPath)
+	require.NoError(t, os.Chmod(binPath, 0o755), "chmod +x test variant")
+
+	// And the prod path stays empty — flipping the toggle must not double-write.
+	prodPath := filepath.Join(BinDir(dataDir), "thunder")
+	if runtime.GOOS == "windows" {
+		prodPath += ".exe"
+	}
+	if _, err := os.Stat(prodPath); err == nil {
+		t.Fatalf("prod binary unexpectedly present at %s when only test variant was downloaded", prodPath)
+	}
+
+	// Step 4: ProcessManager.Start with the same SidechainVariant resolver
+	// boots the test variant. We share the dataDir with the download
+	// manager so resolvePaths walks the same tree.
+	pm := NewProcessManager(dataDir, NewPidFileManager(dataDir, log), log)
+	pm.SidechainVariant = func(c BinaryConfig) (sidechainVariantSpec, bool) {
+		return sidechainVariantSpec{BinaryName: c.AltBinaryName}, true
+	}
+
+	pid, err := pm.Start(context.Background(), cfg, nil, nil)
+	require.NoError(t, err)
+	require.NotZero(t, pid)
+	t.Cleanup(func() { _ = pm.Stop(context.Background(), cfg.Name, true) })
+
+	// Cmd.Path is the binPath we passed to exec.Command — the kernel
+	// successfully exec'd it, so this assertion catches a Start path that
+	// resolves to the wrong binary even when resolvePaths is correct.
+	proc := pm.Get(cfg.Name)
+	require.NotNil(t, proc, "ManagedProcess for %s missing after Start", cfg.Name)
+	t.Logf("process %d Cmd.Path: %s", pid, proc.Cmd.Path)
+	assert.Equal(t, binPath, proc.Cmd.Path,
+		"ProcessManager exec'd %q, expected the test-variant resolved path %q", proc.Cmd.Path, binPath)
+	assert.True(t, strings.HasPrefix(proc.Cmd.Path, scDir),
+		"process exe %q must live under test-variant dir %q", proc.Cmd.Path, scDir)
+
+	// Wait briefly so the OS-level "is alive" check is meaningful, then
+	// confirm we still see the process. A binary that's wrong arch or
+	// missing libs would have already exited; sticking around for ~250ms
+	// rules that out without slowing the suite.
+	time.Sleep(250 * time.Millisecond)
+	assert.True(t, pm.IsRunning(cfg.Name), "test variant %s exited immediately after start", cfg.Name)
+}
+
+// buildFakeSidechainBinary compiles a minimal sidechain-shaped binary for
+// the current OS. The binary blocks on SIGTERM/SIGINT so the test can stat
+// /proc + lsof while it's alive, then exits cleanly when killed.
+func buildFakeSidechainBinary(t *testing.T) []byte {
+	t.Helper()
+
+	src := `package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "TEST_SIDECHAIN_VARIANT_BOOT")
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	<-ch
+}
+`
+
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "main.go"), []byte(src), 0o644))
+
+	outName := "fake-sidechain"
+	if runtime.GOOS == "windows" {
+		outName += ".exe"
+	}
+	outPath := filepath.Join(srcDir, outName)
+
+	cmd := exec.Command("go", "build", "-o", outPath, "main.go")
+	cmd.Dir = srcDir
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build fake sidechain binary: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	return data
+}
+

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -2,10 +2,12 @@ package wallet
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,6 +67,118 @@ func NewService(bitwindowDir string, log zerolog.Logger) *Service {
 		done:         make(chan struct{}),
 		StateChanged: make(chan struct{}, 1),
 	}
+}
+
+// moveToBackup relocates `path` under `<parent>/wallet_backups/<ts>/<base>`,
+// keeping the backup local to the original binary's data tree (Bitcoin
+// Core wallets stay under the bitcoind datadir, the enforcer's wallet stays
+// under bip300301_enforcer, etc.). Same-fs rename keeps it atomic and
+// avoids cross-device move pitfalls. No-ops cleanly when `path` doesn't
+// exist. Used in lieu of os.Remove anywhere a wallet-bearing file or
+// directory could be touched: deletion is irreversible, but a renamed copy
+// is always a `mv` away from recovery.
+func (s *Service) moveToBackup(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return "", nil
+	} else if err != nil {
+		return "", fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	parent := filepath.Dir(path)
+	backupRoot := filepath.Join(parent, "wallet_backups", time.Now().UTC().Format("20060102-150405"))
+	if err := os.MkdirAll(backupRoot, 0o700); err != nil {
+		return "", fmt.Errorf("create backup root: %w", err)
+	}
+
+	dest := filepath.Join(backupRoot, filepath.Base(path))
+	// Tag against second-resolution timestamp collisions (two backups
+	// inside the same parent within the same second).
+	if _, err := os.Stat(dest); err == nil {
+		dest = filepath.Join(backupRoot, fmt.Sprintf("%s-%s", filepath.Base(path), shortHash(path+time.Now().Format(".999999999"))))
+	}
+
+	if err := os.Rename(path, dest); err != nil {
+		// Same-parent rename should be in-fs; this branch only fires if a
+		// future caller redirects backupRoot to a different mount.
+		if err := copyTreeAndRemove(path, dest); err != nil {
+			return "", fmt.Errorf("backup-move %s -> %s: %w", path, dest, err)
+		}
+	}
+	s.log.Info().Str("from", path).Str("to", dest).Msg("wallet path moved to backup")
+	return dest, nil
+}
+
+// shortHash produces a deterministic 8-char fingerprint of `s` for use as a
+// disambiguator when two paths share a basename in the same backup dir.
+func shortHash(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:4])
+}
+
+// copyTreeAndRemove copies src to dst and removes src on success.
+func copyTreeAndRemove(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		if err := copyDir(src, dst); err != nil {
+			return err
+		}
+	} else {
+		if err := copyFile(src, dst, info.Mode()); err != nil {
+			return err
+		}
+	}
+	return os.RemoveAll(src)
+}
+
+func copyDir(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o700); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		sp := filepath.Join(src, e.Name())
+		dp := filepath.Join(dst, e.Name())
+		info, err := e.Info()
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if err := copyDir(sp, dp); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := copyFile(sp, dp, info.Mode()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close() //nolint:errcheck // read-only
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm())
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 // Init loads the wallet file and starts the file watcher.
@@ -360,22 +474,40 @@ func (s *Service) LoadMasterStarter() map[string]interface{} {
 
 // DeleteCoreMultisigWallets deletes multisig_* directories from Bitcoin Core datadir.
 // Dart: WalletWriterProvider._deleteCoreMultisigWallets (L533-552)
+// DeleteCoreMultisigWallets is retained for backwards compatibility but is
+// now a soft-delete: each `multisig_*` directory is moved to
+// `<coreDataDir>/wallet_backups/<ts>/` rather than removed. Multisig keys
+// are user-level secrets we can't reconstruct, so we never `os.RemoveAll`
+// them.
 func DeleteCoreMultisigWallets(coreDataDir string, log zerolog.Logger) {
 	entries, err := os.ReadDir(coreDataDir)
 	if err != nil {
 		log.Error().Err(err).Msg("error reading core data dir for multisig cleanup")
 		return
 	}
+	backupRoot := filepath.Join(coreDataDir, "wallet_backups", time.Now().UTC().Format("20060102-150405"))
 	for _, entry := range entries {
-		if entry.IsDir() && strings.HasPrefix(entry.Name(), "multisig_") {
-			path := filepath.Join(coreDataDir, entry.Name())
-			if err := os.RemoveAll(path); err != nil {
-				log.Warn().Err(err).Str("path", path).Msg("could not delete multisig wallet")
-			} else {
-				log.Info().Str("path", path).Msg("deleted multisig wallet")
-			}
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "multisig_") {
+			continue
+		}
+		if err := os.MkdirAll(backupRoot, 0o700); err != nil {
+			log.Warn().Err(err).Str("backup", backupRoot).Msg("could not create multisig backup root")
+			return
+		}
+		src := filepath.Join(coreDataDir, entry.Name())
+		dst := filepath.Join(backupRoot, entry.Name())
+		if err := os.Rename(src, dst); err != nil {
+			log.Warn().Err(err).Str("path", src).Msg("could not back up multisig wallet")
+		} else {
+			log.Info().Str("from", src).Str("to", dst).Msg("multisig wallet moved to backup")
 		}
 	}
+}
+
+// softDeleteCoreMultisigWallets is the method form used by DeleteAllWallets
+// so the same backup logic flows through Service's logger context.
+func (s *Service) softDeleteCoreMultisigWallets() {
+	DeleteCoreMultisigWallets(s.CoreDataDir, s.log)
 }
 
 // CreateBitcoinCoreWallet creates a new Bitcoin Core wallet (subsequent, not first enforcer).
@@ -930,43 +1062,44 @@ func (s *Service) DeleteAllWallets(onStatusUpdate func(string), beforeBoot func(
 	}
 	time.Sleep(5 * time.Second)
 
-	// Dart L580: onStatusUpdate?.call('Deleting wallet files')
+	// Dart L580: onStatusUpdate?.call('Backing up wallet files')
 	if onStatusUpdate != nil {
-		onStatusUpdate("Deleting wallet files")
+		onStatusUpdate("Backing up wallet files")
 	}
 
-	// Dart L585-598: delete wallet.json and wallet_encryption.json
-	if err := os.Remove(s.walletFilePath()); err != nil && !os.IsNotExist(err) {
-		s.log.Error().Err(err).Msg("could not delete wallet.json")
-	} else {
-		s.log.Info().Str("path", s.walletFilePath()).Msg("deleted wallet file")
+	// Soft-delete wallet.json + wallet_encryption.json by moving them under
+	// <bitwindowDir>/wallet_backups/<ts>/. Keys here are recoverable via a
+	// `mv` on disk; an os.Remove would not be.
+	if _, err := s.moveToBackup(s.walletFilePath()); err != nil {
+		s.log.Error().Err(err).Msg("could not back up wallet.json")
 	}
-	if err := os.Remove(s.metadataFilePath()); err != nil && !os.IsNotExist(err) {
-		s.log.Error().Err(err).Msg("could not delete wallet_encryption.json")
-	} else {
-		s.log.Info().Str("path", s.metadataFilePath()).Msg("deleted encryption metadata")
+	if _, err := s.moveToBackup(s.metadataFilePath()); err != nil {
+		s.log.Error().Err(err).Msg("could not back up wallet_encryption.json")
 	}
 
-	// Dart L600-608: delete per-binary wallet paths
+	// Soft-delete per-binary wallet paths the same way: each lands under
+	// its own parent's wallet_backups/<ts>/, keeping bitcoind's wallets
+	// in the bitcoind datadir, the enforcer's under bip300301_enforcer,
+	// etc., and never touching the user's keys destructively.
 	if s.GetBinaryWalletPaths != nil {
 		paths := s.GetBinaryWalletPaths()
 		for _, p := range paths {
-			if err := os.RemoveAll(p); err != nil {
-				s.log.Warn().Err(err).Str("path", p).Msg("could not delete binary wallet path")
-			} else {
-				s.log.Info().Str("path", p).Msg("deleted binary wallet path")
+			if _, err := s.moveToBackup(p); err != nil {
+				s.log.Warn().Err(err).Str("path", p).Msg("could not back up binary wallet path")
 			}
 		}
 	}
 
-	// Dart L610: onStatusUpdate?.call('Cleaning multisig wallets')
+	// Dart L610: onStatusUpdate?.call('Backing up multisig wallets')
 	if onStatusUpdate != nil {
-		onStatusUpdate("Cleaning multisig wallets")
+		onStatusUpdate("Backing up multisig wallets")
 	}
 
-	// Dart L618: _deleteCoreMultisigWallets
+	// Dart L618: soft-delete the per-network multisig dirs under Bitcoin
+	// Core's datadir. Same backup-not-delete rule: a multisig wallet may
+	// be mid-coordination and we can't recover keys we shred.
 	if s.CoreDataDir != "" {
-		DeleteCoreMultisigWallets(s.CoreDataDir, s.log)
+		s.softDeleteCoreMultisigWallets()
 	}
 
 	// Dart L623: onStatusUpdate?.call('Clearing wallet state')

--- a/sidechain-orchestrator/wallet/service_test.go
+++ b/sidechain-orchestrator/wallet/service_test.go
@@ -851,3 +851,73 @@ func TestServiceLegacyWalletTypeBackfill(t *testing.T) {
 		require.NotEmpty(t, w.WalletType, "wallet_type must persist after backfill")
 	}
 }
+
+func TestServiceDeleteAllWallets_SoftDeletesByMoving(t *testing.T) {
+	dir := t.TempDir()
+	log := zerolog.New(zerolog.NewTestWriter(t)).With().Timestamp().Logger()
+	svc := NewService(dir, log)
+	require.NoError(t, svc.Init())
+	defer svc.Close()
+
+	w, err := svc.GenerateWallet("Soft", "", "", testSlots)
+	require.NoError(t, err)
+	require.NotEmpty(t, w.ID)
+
+	walletPath := filepath.Join(dir, "wallet.json")
+	originalBytes, err := os.ReadFile(walletPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, originalBytes, "fixture: wallet.json must exist before reset")
+
+	// Hand the service a fake "binary wallet" so we can prove the same
+	// soft-delete contract applies to per-binary paths (bitcoind wallets,
+	// enforcer wallets, sidechain LMDBs). It lives outside `dir` to mirror
+	// real installs where each binary has its own root.
+	binDir := t.TempDir()
+	fakeBinaryWallet := filepath.Join(binDir, "wallets")
+	require.NoError(t, os.MkdirAll(fakeBinaryWallet, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBinaryWallet, "wallet.dat"), []byte("priv-keys"), 0o600))
+	svc.GetBinaryWalletPaths = func() []string { return []string{fakeBinaryWallet} }
+
+	require.NoError(t, svc.DeleteAllWallets(nil, nil))
+
+	// Original locations are GONE (moved, not lingering at the source).
+	_, err = os.Stat(walletPath)
+	assert.True(t, os.IsNotExist(err), "wallet.json must be moved off the original path")
+	_, err = os.Stat(fakeBinaryWallet)
+	assert.True(t, os.IsNotExist(err), "binary wallet path must be moved off the original path")
+
+	// Backups land next to each source under wallet_backups/<ts>/<base>.
+	bitwindowBackup := findBackup(t, filepath.Join(dir, "wallet_backups"), "wallet.json")
+	require.NotEmpty(t, bitwindowBackup, "wallet.json must be soft-deleted under wallet_backups/")
+	gotBytes, err := os.ReadFile(bitwindowBackup)
+	require.NoError(t, err)
+	assert.Equal(t, originalBytes, gotBytes, "soft-delete must preserve wallet bytes verbatim")
+
+	binaryBackup := findBackup(t, filepath.Join(binDir, "wallet_backups"), "wallets")
+	require.NotEmpty(t, binaryBackup, "binary wallet must be soft-deleted next to its source")
+	keys, err := os.ReadFile(filepath.Join(binaryBackup, "wallet.dat"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("priv-keys"), keys, "private keys must survive soft-delete intact")
+}
+
+// findBackup walks `root/<ts>/` looking for an entry whose basename is `name`
+// and returns its absolute path. Empty string if nothing matches — used by
+// soft-delete tests to assert the backup landed in the expected per-source
+// wallet_backups dir.
+func findBackup(t *testing.T, root, name string) string {
+	t.Helper()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return ""
+	}
+	for _, ts := range entries {
+		if !ts.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(root, ts.Name(), name)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ""
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.210
+version: 1.0.211
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.81
+version: 1.0.82
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.208
+version: 1.0.209
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
Fixes two regressions hit when the test-sidechains toggle is on: resolveBinaryPath now scans bin/test/<binary>/ so bitwindow finds the alt-build layout, and standalone sidechain apps (e.g. Thunder.app double-clicked) no longer crash on "OrchestratorRPC not registered" because walletReader.init() now defers until the orchestrator is up. Includes a real-binary boot test in sidechain-orchestrator that downloads, lays out, and execs the test variant end-to-end.