### PR TITLE
bitwindow: minimize instead of hide on macOS

### DIFF
--- a/bitwindow/lib/pages/root_page.dart
+++ b/bitwindow/lib/pages/root_page.dart
@@ -422,7 +422,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
                   ],
                 ),
                 PlatformMenuItemGroup(
-                  members: buildVisibilityMenuItems(isMacOS: Platform.isMacOS),
+                  members: buildVisibilityMenuItems(),
                 ),
                 PlatformMenuItemGroup(
                   members: [
@@ -1328,27 +1328,13 @@ extension on Block {
   }
 }
 
-List<PlatformMenuItem> buildVisibilityMenuItems({required bool isMacOS}) {
-  if (isMacOS) {
-    return [
-      PlatformMenuItem(
-        label: 'Hide bitwindow',
-        shortcut: const SingleActivator(LogicalKeyboardKey.keyH, meta: true),
-        onSelected: () async {
-          await windowManager.hide();
-        },
-      ),
-      PlatformMenuItem(
-        label: 'Show All',
-        onSelected: () async {
-          await windowManager.show();
-        },
-      ),
-    ];
-  }
-  // Linux/Windows have no dock or default tray, so a hidden window has no
-  // taskbar entry to bring back. Minimize keeps the taskbar/Alt-Tab entry
-  // alive.
+List<PlatformMenuItem> buildVisibilityMenuItems() {
+  // Minimize on every platform — `windowManager.hide()` removes the window
+  // from the dock/taskbar with no first-party way to bring it back (issue
+  // #1657: "process is still running but no way to bring the window back
+  // after that"). Minimize keeps the dock icon and Alt-Tab entry, so a
+  // single click restores the window. Cmd/Ctrl+M is the standard system
+  // shortcut for window minimize.
   return [
     PlatformMenuItem(
       label: 'Minimize bitwindow',

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.58
+version: 0.2.59
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/test/about_dialog_and_menu_test.dart
+++ b/bitwindow/test/about_dialog_and_menu_test.dart
@@ -25,20 +25,12 @@ void main() {
   });
 
   group('buildVisibilityMenuItems', () {
-    test('macOS exposes Hide and Show All', () {
-      final items = buildVisibilityMenuItems(isMacOS: true);
-      expect(items, hasLength(2));
-      expect(items[0].label, 'Hide bitwindow');
-      expect(
-        items[0].shortcut,
-        const SingleActivator(LogicalKeyboardKey.keyH, meta: true),
-      );
-      expect(items[1].label, 'Show All');
-      expect(items[1].shortcut, isNull);
-    });
-
-    test('non-macOS exposes Minimize with Ctrl+M shortcut', () {
-      final items = buildVisibilityMenuItems(isMacOS: false);
+    test('exposes Minimize with Cmd/Ctrl+M on every platform', () {
+      // Issue #1657: macOS used to call windowManager.hide(), which strips
+      // the dock icon and leaves users with no first-party way back into
+      // the app. Minimize is the only path now — keep the menu surface
+      // identical across platforms so the shortcut and label match.
+      final items = buildVisibilityMenuItems();
       expect(items, hasLength(1));
       expect(items.single.label, 'Minimize bitwindow');
       expect(
@@ -49,6 +41,8 @@ void main() {
       expect(
         items.where((m) => m.label == 'Hide bitwindow' || m.label == 'Show All'),
         isEmpty,
+        reason:
+            'hide/show-all must not return as menu items — bringing the window back relied on a dock icon that hide() removed',
       );
     });
   });


### PR DESCRIPTION
macOS windowManager.hide() removed the dock icon, leaving the process alive with no first-party way back into the app. Minimize on every platform — dock/taskbar entry stays, single click restores.

Fixes #1657.