### PR TITLE
coinnews: indexer + cn_* tables

### DIFF
--- a/bitwindow/server/coinnews/codec_test.go
+++ b/bitwindow/server/coinnews/codec_test.go
@@ -60,9 +60,9 @@ func TestItemIDDeterministic(t *testing.T) {
 	assert.Equal(t, id1, parsed)
 }
 
-// --- BIP test vectors ------------------------------------------------------
+// --- Spec test vectors ------------------------------------------------------
 
-// TestVector_TopicCreation matches the worked example in the BIP's
+// TestVector_TopicCreation matches the worked example in the spec's
 // "Test Vectors" section.
 func TestVector_TopicCreation(t *testing.T) {
 	tc := TopicCreation{
@@ -84,7 +84,7 @@ func TestVector_TopicCreation(t *testing.T) {
 	assert.Equal(t, tc, *roundTripped)
 }
 
-// TestVector_VoteEnvelopeIs111Bytes pins the BIP §8 invariant: a Vote
+// TestVector_VoteEnvelopeIs111Bytes pins the spec §8 invariant: a Vote
 // envelope is exactly 111 bytes regardless of pubkey or sig contents.
 // A regression here means the on-chain footprint of every vote
 // changes — strictly observable to anyone scanning blocks.
@@ -107,7 +107,7 @@ func TestVector_VoteEnvelopeIs111Bytes(t *testing.T) {
 
 	encoded, err := EncodeVote(v)
 	require.NoError(t, err)
-	assert.Equal(t, 111, len(encoded), "Vote envelope must be exactly 111 B per BIP §8")
+	assert.Equal(t, 111, len(encoded), "Vote envelope must be exactly 111 B per spec §8")
 }
 
 // TestStoryRoundTripWithTLV proves the TLV section survives encode →
@@ -189,7 +189,7 @@ func TestCommentSignatureRoundTrip(t *testing.T) {
 
 // TestVoteSignatureRoundTrip mirrors the comment test and additionally
 // proves the typetag is part of the digest — flipping up→down without
-// re-signing must fail (BIP §8 first-wins replay protection).
+// re-signing must fail (spec §8 first-wins replay protection).
 func TestVoteSignatureRoundTrip(t *testing.T) {
 	priv, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
@@ -220,21 +220,30 @@ func TestVoteSignatureRoundTrip(t *testing.T) {
 }
 
 // TestNotCoinNewsTraffic proves the dispatcher's classification: any
-// payload that doesn't start with "CN" must report ErrNotCoinNews so
-// the indexer's "skip" path fires instead of erroring out.
+// payload that doesn't start with "CN" reports ErrNotCoinNews so the
+// indexer's "skip" path fires instead of erroring out.
 func TestNotCoinNewsTraffic(t *testing.T) {
 	for _, p := range [][]byte{
 		nil,
 		{},
-		{'C'},                         // half-magic
-		{'C', 'X', 0x01},              // wrong magic
-		{'C', 'N'},                    // magic but no type
-		{'C', 'N', 0xff, 0x00, 0x00},  // unknown type
-		{'X', 'X', 0x01, 0x00, 0x00},  // some other protocol
+		{'C'},                        // half-magic
+		{'C', 'X', 0x01},             // wrong magic
+		{'C', 'N'},                   // magic but no type
+		{'X', 'X', 0x01, 0x00, 0x00}, // some other protocol
 	} {
 		_, _, err := DecodeMessage(p)
 		assert.ErrorIs(t, err, ErrNotCoinNews, "payload %x", p)
 	}
+}
+
+// TestUnknownTypeTagDistinct proves an unknown TypeTag (magic matched
+// but the byte after isn't a known type) returns ErrUnknownTypeTag,
+// NOT ErrNotCoinNews — telemetry distinguishes "future protocol
+// version" from "wrong protocol entirely."
+func TestUnknownTypeTagDistinct(t *testing.T) {
+	_, _, err := DecodeMessage([]byte{'C', 'N', 0xff, 0x00, 0x00})
+	assert.ErrorIs(t, err, ErrUnknownTypeTag, "unknown TypeTag must surface as ErrUnknownTypeTag")
+	assert.NotErrorIs(t, err, ErrNotCoinNews, "ErrUnknownTypeTag must be distinct from ErrNotCoinNews")
 }
 
 // TestContinuationChunkBound rejects oversize chunks: §9 caps a single

--- a/bitwindow/server/coinnews/constants.go
+++ b/bitwindow/server/coinnews/constants.go
@@ -1,11 +1,11 @@
 package coinnews
 
 // Magic is the 2-byte prefix every CoinNews payload starts with — see
-// BIP §1. Lets indexers reject non-CoinNews OP_RETURN traffic with a
+// spec §1. Lets indexers reject non-CoinNews OP_RETURN traffic with a
 // 2-byte prefix scan.
 var Magic = [2]byte{'C', 'N'}
 
-// TypeTag identifies the payload that follows Magic. See BIP §1.
+// TypeTag identifies the payload that follows Magic. See spec §1.
 type TypeTag byte
 
 const (
@@ -40,7 +40,7 @@ const (
 	HeadlineMaxLen = 252
 )
 
-// TLVTag values defined in BIP §10. Tags 0x80–0xef are reserved for the
+// TLVTag values defined in spec §10. Tags 0x80–0xef are reserved for the
 // out-of-band metadata registry; 0xf0–0xff for application-private
 // extensions.
 type TLVTag byte

--- a/bitwindow/server/coinnews/decode.go
+++ b/bitwindow/server/coinnews/decode.go
@@ -6,10 +6,16 @@ import (
 )
 
 // ErrNotCoinNews indicates the payload's leading bytes don't match the
-// "CN" magic or the TypeTag is unknown — i.e. this OP_RETURN belongs
-// to some other application. Indexers SHOULD treat this as "skip,
-// not error".
+// "CN" magic — this OP_RETURN belongs to some other application.
+// Indexers SHOULD treat this as "skip, not error".
 var ErrNotCoinNews = errors.New("coinnews: payload is not a CoinNews message")
+
+// ErrUnknownTypeTag indicates the magic matched but the TypeTag isn't
+// one this codec knows about. Per spec §1 a future protocol revision
+// may define new tags — current indexers MUST drop the message, but
+// keeping the error distinct from ErrNotCoinNews preserves telemetry
+// (a sudden uptick in unknown tags ⇒ a newer publisher is on chain).
+var ErrUnknownTypeTag = errors.New("coinnews: unknown type tag")
 
 // DecodeMessage classifies the payload and returns one of:
 //
@@ -47,10 +53,10 @@ func DecodeMessage(payload []byte) (TypeTag, any, error) {
 	default:
 		// Unknown TypeTag: the magic matched, so the publisher
 		// intended this as a CoinNews message, but we don't know how
-		// to parse it. Per BIP §1, indexers MUST drop unknown tags —
-		// reflect that as ErrNotCoinNews so the caller's "skip" path
-		// fires.
-		return 0, nil, ErrNotCoinNews
+		// to parse it. Per spec §1, indexers MUST drop unknown tags —
+		// callers treat this as a skip, but the distinct error keeps
+		// telemetry useful.
+		return 0, nil, ErrUnknownTypeTag
 	}
 }
 
@@ -158,8 +164,10 @@ func VerifyVote(v *Vote) error {
 }
 
 func decodeContinuation(b []byte) (*Continuation, error) {
-	if len(b) < ItemIDLen+1 {
-		return nil, fmt.Errorf("coinnews: continuation truncated")
+	if len(b) <= ItemIDLen+1 {
+		// Header-only continuations are meaningless — they let a
+		// publisher pad block space without contributing payload.
+		return nil, fmt.Errorf("coinnews: continuation chunk must be non-empty")
 	}
 	if len(b) > ItemIDLen+1+ContinuationChunk {
 		return nil, fmt.Errorf("coinnews: continuation chunk %d > %d", len(b)-ItemIDLen-1, ContinuationChunk)

--- a/bitwindow/server/coinnews/encode.go
+++ b/bitwindow/server/coinnews/encode.go
@@ -6,7 +6,7 @@ import (
 )
 
 // EncodeTopicCreation produces the wire bytes for a Topic Creation
-// (BIP §5):
+// (spec §5):
 //
 //	"CN" ‖ 0x01 ‖ topic(4) ‖ retention(1) ‖ name(varint+UTF-8)
 func EncodeTopicCreation(t TopicCreation) ([]byte, error) {
@@ -25,17 +25,12 @@ func EncodeTopicCreation(t TopicCreation) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// EncodeStory (BIP §6):
+// EncodeStory (spec §6):
 //
 //	"CN" ‖ 0x02 ‖ topic(4) ‖ headline(varint+UTF-8) ‖ tlv*
+//
+// Long headlines are legal; the varint just costs more bytes.
 func EncodeStory(s Story) ([]byte, error) {
-	if len(s.Headline) > HeadlineMaxLen {
-		// Not a hard error — long headlines are legal — but we want
-		// callers to be aware they're paying a 3-byte varint instead
-		// of 1 byte. Returning the headline anyway lets ranking land
-		// the post; refusing here would force every wallet to
-		// pre-truncate.
-	}
 	var buf bytes.Buffer
 	buf.Write(Magic[:])
 	buf.WriteByte(byte(TypeStory))
@@ -50,7 +45,7 @@ func EncodeStory(s Story) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// EncodeComment (BIP §7). Caller is responsible for producing a sig
+// EncodeComment (spec §7). Caller is responsible for producing a sig
 // that covers CommentSigHash(Parent, SerialiseTLVs(TLVs)) — the
 // encoder does not re-sign on the fly because callers may want to
 // build the bytes once (e.g. for fee preview) before signing.
@@ -67,7 +62,7 @@ func EncodeComment(c Comment) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// EncodeVote (BIP §8). Always 111 B — the only CoinNews payload with
+// EncodeVote (spec §8). Always 111 B — the only CoinNews payload with
 // no variable-length section.
 func EncodeVote(v Vote) ([]byte, error) {
 	if v.Kind != TypeUpvote && v.Kind != TypeDownvote {
@@ -85,8 +80,13 @@ func EncodeVote(v Vote) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// EncodeContinuation (BIP §9).
+// EncodeContinuation (spec §9). Empty chunks are rejected — they let
+// a publisher pad block space without contributing to the reassembled
+// payload, so we refuse to produce or accept them.
 func EncodeContinuation(c Continuation) ([]byte, error) {
+	if len(c.Chunk) == 0 {
+		return nil, fmt.Errorf("coinnews: continuation chunk must be non-empty")
+	}
 	if len(c.Chunk) > ContinuationChunk {
 		return nil, fmt.Errorf("coinnews: continuation chunk %d > %d", len(c.Chunk), ContinuationChunk)
 	}

--- a/bitwindow/server/coinnews/itemid.go
+++ b/bitwindow/server/coinnews/itemid.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ItemID is the 12-byte truncated SHA-256 of a CoinNews Item's outpoint
-// (BIP §4). 96 bits of collision space — at any plausible CoinNews
+// (spec §4). 96 bits of collision space — at any plausible CoinNews
 // volume the chance of any collision is < 10⁻¹³.
 type ItemID [ItemIDLen]byte
 

--- a/bitwindow/server/coinnews/message.go
+++ b/bitwindow/server/coinnews/message.go
@@ -10,7 +10,7 @@ type XOnlyPubKey [XOnlyPubKeyLen]byte
 type SchnorrSig [SchnorrSigLen]byte
 
 // TopicCreation announces a topic. Earliest confirmed creation per
-// TopicID wins (BIP §5).
+// TopicID wins (spec §5).
 type TopicCreation struct {
 	Topic          Topic
 	RetentionDays  byte
@@ -18,14 +18,14 @@ type TopicCreation struct {
 }
 
 // Story is a Topic-scoped post. Headline is required; everything else
-// rides in the TLV section (BIP §6).
+// rides in the TLV section (spec §6).
 type Story struct {
 	Topic    Topic
 	Headline string
 	TLVs     []TLV
 }
 
-// Comment is a signed reply to another Item (BIP §7). Sig MUST cover
+// Comment is a signed reply to another Item (spec §7). Sig MUST cover
 // CommentSigHash(Parent, SerialiseTLVs(TLVs)).
 type Comment struct {
 	Parent    ItemID
@@ -34,7 +34,7 @@ type Comment struct {
 	TLVs      []TLV
 }
 
-// Vote is a signed +1 (Up) or −1 (Down) directed at one Item (BIP §8).
+// Vote is a signed +1 (Up) or −1 (Down) directed at one Item (spec §8).
 type Vote struct {
 	Kind      TypeTag // TypeUpvote or TypeDownvote
 	Target    ItemID
@@ -42,7 +42,7 @@ type Vote struct {
 	Sig       SchnorrSig
 }
 
-// Continuation extends a head Message that didn't fit in 80 B (BIP §9).
+// Continuation extends a head Message that didn't fit in 80 B (spec §9).
 type Continuation struct {
 	Head  ItemID
 	Seq   byte

--- a/bitwindow/server/coinnews/sign.go
+++ b/bitwindow/server/coinnews/sign.go
@@ -31,12 +31,12 @@ func taggedHash(tag [32]byte, msg ...[]byte) [32]byte {
 }
 
 // CommentSigHash is the 32-byte digest a Comment's signature MUST cover
-// per BIP §7.
+// per spec §7.
 func CommentSigHash(parent ItemID, tlvBlob []byte) [32]byte {
 	return taggedHash(tagCommentHash, parent[:], tlvBlob)
 }
 
-// VoteSigHash is the digest a Vote's signature MUST cover per BIP §8.
+// VoteSigHash is the digest a Vote's signature MUST cover per spec §8.
 // Includes the type tag byte so an upvote and a downvote signed against
 // the same target produce different digests — protects against trivial
 // up-to-down replay.

--- a/bitwindow/server/coinnews/tlv.go
+++ b/bitwindow/server/coinnews/tlv.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// TLV is one Tag-Length-Value tuple (BIP §10). Length is implied by
+// TLV is one Tag-Length-Value tuple (spec §10). Length is implied by
 // len(Value) on encode and recovered from the wire on decode.
 type TLV struct {
 	Tag   TLVTag
@@ -14,7 +14,7 @@ type TLV struct {
 
 // EncodeTLVs writes the concatenation of (tag ‖ varint-length ‖ value)
 // for every entry in `tlvs`, preserving caller order. Order is
-// significant for first-wins duplicate semantics (BIP §10).
+// significant for first-wins duplicate semantics (spec §10).
 func EncodeTLVs(w writer, tlvs []TLV) error {
 	for _, t := range tlvs {
 		if err := w.WriteByte(byte(t.Tag)); err != nil {
@@ -55,7 +55,7 @@ func DecodeTLVs(b []byte) ([]TLV, error) {
 }
 
 // FindFirst returns the first TLV with the given tag, or nil if absent.
-// Encodes the BIP §10 first-wins rule for single-value tags.
+// Encodes the spec §10 first-wins rule for single-value tags.
 func FindFirst(tlvs []TLV, tag TLVTag) *TLV {
 	for i := range tlvs {
 		if tlvs[i].Tag == tag {

--- a/bitwindow/server/coinnews/varint.go
+++ b/bitwindow/server/coinnews/varint.go
@@ -6,7 +6,7 @@ import (
 	"io"
 )
 
-// CompactSize encodes Bitcoin's compact-size varint per BIP §2:
+// CompactSize encodes Bitcoin's compact-size varint per spec §2:
 //
 //	0x00..0xfc       -> 1 byte
 //	0xfd + uint16 LE -> 3 bytes
@@ -36,7 +36,7 @@ func encodeCompactSize(w writer, n uint64) error {
 		_, err := w.Write(buf[:])
 		return err
 	default:
-		return fmt.Errorf("coinnews: length %d exceeds compact-size 0xfe budget", n)
+		return fmt.Errorf("coinnews: length %d exceeds uint32 (>2^32-1); the 0xff varint form is reserved", n)
 	}
 }
 

--- a/bitwindow/server/database/migrations/035_coinnews.sql
+++ b/bitwindow/server/database/migrations/035_coinnews.sql
@@ -1,0 +1,99 @@
+-- CoinNews v2 (BIP-coinnews) tables.
+--
+-- The legacy `coin_news_topics` + `op_returns` tables continue to serve
+-- the v1 (pre-BIP) wire format. v2 lives in its own `cn_*` namespace so
+-- the two indexers don't fight over rows; queries that want a unified
+-- view UNION across both.
+--
+-- All `BLOB(N)` columns store raw bytes — ItemIDs are 12 B truncated
+-- SHA-256 (spec §4), topic IDs 4 B, x-only pubkeys 32 B, media hashes
+-- 32 B, schnorr sigs 64 B. SQLite ignores the size hint but it is
+-- documentation against schema drift.
+
+-- Universal index of every accepted CoinNews v2 Item, addressed by
+-- ItemID. Anything keyed by ItemID elsewhere has a foreign key here.
+-- The `(block_height, tx_index, vout_index)` triple matches the
+-- canonical scan order in spec §4.2.
+CREATE TABLE cn_items (
+    item_id      BLOB(12) PRIMARY KEY,
+    txid         TEXT     NOT NULL,
+    vout         INTEGER  NOT NULL,
+    block_height INTEGER  NOT NULL,
+    tx_index     INTEGER  NOT NULL,
+    vout_index   INTEGER  NOT NULL,
+    type_tag     INTEGER  NOT NULL,
+    block_time   TIMESTAMP NOT NULL,
+    UNIQUE (txid, vout)
+);
+CREATE INDEX idx_cn_items_order ON cn_items (block_height, tx_index, vout_index);
+CREATE INDEX idx_cn_items_type  ON cn_items (type_tag, block_height DESC);
+
+-- Topic registry. Earliest confirmed creation per topic_id wins; we
+-- enforce that with the PRIMARY KEY (later inserts hit the conflict
+-- and the indexer ignores them).
+CREATE TABLE cn_topics (
+    topic          BLOB(4) PRIMARY KEY,
+    name           TEXT     NOT NULL,
+    retention_days INTEGER  NOT NULL DEFAULT 0,
+    created_height INTEGER  NOT NULL,
+    txid           TEXT     NOT NULL
+);
+
+-- One row per Story. Common fields hoisted to columns for fast feed
+-- queries; the full TLV blob is preserved in `raw_tlv` so an indexer
+-- upgrade can re-derive new metadata without re-scanning chain.
+CREATE TABLE cn_stories (
+    item_id    BLOB(12) PRIMARY KEY REFERENCES cn_items(item_id),
+    topic      BLOB(4)  NOT NULL,
+    headline   TEXT     NOT NULL,
+    subtype    INTEGER  NOT NULL DEFAULT 0,
+    url        TEXT,
+    body       TEXT,
+    lang       TEXT,
+    nsfw       BOOLEAN  NOT NULL DEFAULT FALSE,
+    media_hash BLOB(32),
+    raw_tlv    BLOB
+);
+CREATE INDEX idx_cn_stories_topic   ON cn_stories (topic);
+CREATE INDEX idx_cn_stories_subtype ON cn_stories (subtype);
+
+-- One row per Comment. Signature has already been verified at insert
+-- time; rows here are by definition from the claimed `author_xpk`.
+CREATE TABLE cn_comments (
+    item_id     BLOB(12) PRIMARY KEY REFERENCES cn_items(item_id),
+    parent_id   BLOB(12) NOT NULL,
+    author_xpk  BLOB(32) NOT NULL,
+    body        TEXT,
+    url         TEXT,
+    lang        TEXT,
+    reply_quote TEXT,
+    raw_tlv     BLOB
+);
+CREATE INDEX idx_cn_comments_parent ON cn_comments (parent_id);
+CREATE INDEX idx_cn_comments_author ON cn_comments (author_xpk);
+
+-- Vote tally. The PRIMARY KEY enforces spec §8 dedup: a given
+-- (target_id, author_xpk) is at most one row. Inserts that race
+-- against an existing row on the same key MUST be ignored by the
+-- caller (engine uses INSERT OR IGNORE).
+CREATE TABLE cn_votes (
+    target_id    BLOB(12) NOT NULL,
+    author_xpk   BLOB(32) NOT NULL,
+    kind         INTEGER  NOT NULL,           -- 4 = up, 5 = down
+    block_height INTEGER  NOT NULL,
+    tx_index     INTEGER  NOT NULL,
+    vout_index   INTEGER  NOT NULL,
+    block_time   TIMESTAMP NOT NULL,
+    PRIMARY KEY (target_id, author_xpk)
+);
+CREATE INDEX idx_cn_votes_target ON cn_votes (target_id);
+
+-- Continuation chunks for a head Item. `(head_id, seq)` is unique;
+-- gaps or out-of-order inserts are caught at scan time per spec §9.
+CREATE TABLE cn_continuations (
+    head_id      BLOB(12) NOT NULL,
+    seq          INTEGER  NOT NULL,
+    chunk        BLOB     NOT NULL,
+    block_height INTEGER  NOT NULL,
+    PRIMARY KEY (head_id, seq)
+);

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -173,6 +173,13 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 		lastProcessedHeight -= 20
 		zerolog.Ctx(ctx).Trace().
 			Msgf("bitcoind_engine/parser: detected reorg, processing last 20 blocks")
+
+		// Wipe the CoinNews rows that came from blocks we're about to
+		// replay; otherwise the canonical first-wins rules see stale
+		// orphans from the pre-reorg chain and ignore the new winners.
+		if err := p.purgeCoinNewsAtOrAbove(ctx, lastProcessedHeight+1); err != nil {
+			return fmt.Errorf("purge coinnews on reorg: %w", err)
+		}
 	}
 
 	const batchSize = 30
@@ -265,6 +272,14 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 // and marks the block as processed.
 func (p *Parser) processBlocks(ctx context.Context, coreBlocks []lo.Tuple2[uint32, *wire.MsgBlock]) error {
 
+	// CoinNews indexing must commit BEFORE the block is marked processed:
+	// if it fails, we want the next sync attempt to retry, not skip the
+	// block as already-done. Sequential, canonical-order pass — see
+	// indexCoinNewsBlocks for the spec rationale.
+	if err := p.indexCoinNewsBlocks(ctx, coreBlocks); err != nil {
+		return fmt.Errorf("index coinnews: %w", err)
+	}
+
 	// Insert the processed blocks
 	if err := blocks.MarkBlocksProcessed(ctx, p.db, lo.Map(coreBlocks, func(t lo.Tuple2[uint32, *wire.MsgBlock], _ int) blocks.ProcessedBlock {
 		height, block := t.Unpack()
@@ -311,7 +326,9 @@ func (p *Parser) HandleNewRawTransaction(
 	return nil
 }
 
-// Nil height means unconfirmed. Nil time means we don't know the TX time
+// Nil height means unconfirmed. Nil time means we don't know the TX time.
+// CoinNews indexing runs separately, in canonical scan order, after all
+// blocks in a batch are fetched (see processBlocks).
 func (p *Parser) opReturnForTXID(
 	ctx context.Context, tx *wire.MsgTx,
 	height *uint32, createdAt *time.Time,
@@ -606,6 +623,12 @@ func (p *Parser) handleOpReturns(
 			Msgf("bitcoind_engine/parser: found OP_RETURN")
 
 		p.logCoinnews(txid, vout, data, height)
+
+		// CoinNews indexing happens elsewhere — we cannot do it here
+		// because handleOpReturns runs concurrently across blocks in
+		// a batch, and the spec's first-wins/last-wins rules require
+		// canonical (height, tx_index, vout_index) order. See
+		// processBlocks → indexCoinNewsBlocks.
 
 		// Always fetch fee for OP_RETURN transactions. This avoids a race
 		// condition where blocks are processed in parallel and a topic

--- a/bitwindow/server/engines/coinnews.go
+++ b/bitwindow/server/engines/coinnews.go
@@ -1,0 +1,152 @@
+package engines
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/rs/zerolog"
+	"github.com/samber/lo"
+
+	codec "github.com/LayerTwo-Labs/sidesail/bitwindow/server/coinnews"
+	cnstore "github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/coinnews"
+)
+
+// indexCoinNewsBlocks runs the CoinNews indexing pass over a batch of
+// already-fetched blocks. Blocks are processed in canonical scan order
+// (`block_height ASC, tx_index ASC, vout_index ASC`) — that ordering is
+// load-bearing for the spec's first-wins / last-wins semantics, so we
+// run sequentially even though block fetching above us is parallel.
+//
+// Errors bubble — a failed cn_* insert MUST NOT mark its block as
+// processed, otherwise resync can't heal the gap.
+func (p *Parser) indexCoinNewsBlocks(ctx context.Context, blocks []lo.Tuple2[uint32, *wire.MsgBlock]) error {
+	sorted := append([]lo.Tuple2[uint32, *wire.MsgBlock]{}, blocks...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].A < sorted[j].A })
+
+	for _, t := range sorted {
+		height, block := t.Unpack()
+		if err := p.indexCoinNewsForBlock(ctx, height, block); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// indexCoinNewsForBlock walks one block's transactions and OP_RETURN
+// outputs in canonical order, dispatching each CoinNews payload to
+// the persistence layer. Transactions that aren't CoinNews are
+// skipped silently; signed messages whose sigs don't verify are
+// dropped (logged at debug, never persisted).
+func (p *Parser) indexCoinNewsForBlock(ctx context.Context, height uint32, block *wire.MsgBlock) error {
+	for txIdx, tx := range block.Transactions {
+		txid := tx.TxID()
+		for vout, txout := range tx.TxOut {
+			data, ok := coinNewsPayload(txout.PkScript)
+			if !ok {
+				continue
+			}
+			pos := cnstore.BlockPos{
+				BlockHeight: height,
+				TxIndex:     uint32(txIdx),
+				VoutIndex:   uint32(vout),
+				BlockTime:   block.Header.Timestamp,
+				TxID:        txid,
+			}
+			if err := p.indexCoinNewsPayload(ctx, data, pos); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// indexCoinNewsPayload classifies one OP_RETURN payload and persists
+// it. Returns nil for non-CoinNews bytes (silent skip), nil for
+// dropped messages (bad sig, malformed envelope), and a non-nil
+// error only on persistence failure — the caller surfaces that.
+func (p *Parser) indexCoinNewsPayload(ctx context.Context, data []byte, pos cnstore.BlockPos) error {
+	tag, msg, err := codec.DecodeMessage(data)
+	if err != nil {
+		if errors.Is(err, codec.ErrNotCoinNews) || errors.Is(err, codec.ErrUnknownTypeTag) {
+			return nil
+		}
+		// Magic matched but parsing failed — malformed CoinNews payload.
+		// Drop with a debug log so test runs surface it.
+		dropMsg(ctx, pos, "malformed payload", err)
+		return nil
+	}
+
+	switch m := msg.(type) {
+	case *codec.Comment:
+		if err := codec.VerifyComment(m); err != nil {
+			dropMsg(ctx, pos, "comment sig invalid", err)
+			return nil
+		}
+	case *codec.Vote:
+		if err := codec.VerifyVote(m); err != nil {
+			dropMsg(ctx, pos, "vote sig invalid", err)
+			return nil
+		}
+	}
+
+	return cnstore.Index(ctx, p.db, cnstore.IndexEnv{Pos: pos, TypeTag: tag, Msg: msg})
+}
+
+// coinNewsPayload extracts the bytes pushed by a single-push OP_RETURN
+// script. Returns ok=false for anything else (not OP_RETURN, multi-
+// push, OP_DRIVECHAIN, coinbase carrier).
+func coinNewsPayload(pkScript []byte) ([]byte, bool) {
+	if len(pkScript) < 2 || pkScript[0] != txscript.OP_RETURN {
+		return nil, false
+	}
+	if pkScript[1] == txscript.OP_DATA_36 {
+		return nil, false
+	}
+	if shouldSkip(pkScript) {
+		return nil, false
+	}
+	return parseOPReturnData(pkScript)
+}
+
+// dropMsg emits the "decoded but rejected" log line, used for both
+// malformed payloads and failed-sig drops. Single helper keeps the
+// log format consistent across decode-failure paths.
+func dropMsg(ctx context.Context, pos cnstore.BlockPos, reason string, err error) {
+	zerolog.Ctx(ctx).Debug().Err(err).
+		Str("txid", pos.TxID).
+		Uint32("vout", pos.VoutIndex).
+		Uint32("height", pos.BlockHeight).
+		Msg("coinnews: " + reason + ", dropping")
+}
+
+// purgeCoinNewsAtOrAbove deletes every cn_* row originating from a
+// block at or above `fromHeight`. Called when the engine detects a
+// reorg and replays a height range — without it, `INSERT OR IGNORE`
+// during the replay would silently keep orphaned rows from the
+// pre-reorg chain, breaking the determinism budget.
+func (p *Parser) purgeCoinNewsAtOrAbove(ctx context.Context, fromHeight uint32) error {
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // committed on success
+
+	stmts := []string{
+		`DELETE FROM cn_stories       WHERE item_id IN (SELECT item_id FROM cn_items WHERE block_height >= ?)`,
+		`DELETE FROM cn_comments      WHERE item_id IN (SELECT item_id FROM cn_items WHERE block_height >= ?)`,
+		`DELETE FROM cn_votes         WHERE block_height >= ?`,
+		`DELETE FROM cn_continuations WHERE block_height >= ?`,
+		`DELETE FROM cn_topics        WHERE created_height >= ?`,
+		`DELETE FROM cn_items         WHERE block_height >= ?`,
+	}
+	for _, q := range stmts {
+		if _, err := tx.ExecContext(ctx, q, fromHeight); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+

--- a/bitwindow/server/engines/coinnews_test.go
+++ b/bitwindow/server/engines/coinnews_test.go
@@ -1,0 +1,271 @@
+package engines
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	codec "github.com/LayerTwo-Labs/sidesail/bitwindow/server/coinnews"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	service "github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+)
+
+// newCoinNewsParser builds a Parser with a fresh in-memory database
+// for direct calls into indexCoinNewsBlocks / indexCoinNewsForBlock.
+func newCoinNewsParser(t *testing.T) *Parser {
+	t.Helper()
+	core := mocks.NewMockBitcoinServiceClient(gomock.NewController(t))
+	core.EXPECT().GetRawTransaction(gomock.Any(), gomock.Any()).
+		Return(connect.NewResponse(&corepb.GetRawTransactionResponse{Fee: 0.0001}), nil).
+		AnyTimes()
+	return &Parser{
+		db: database.Test(t),
+		bitcoind: service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+			return core, nil
+		}),
+	}
+}
+
+// TestCoinNewsIndexer_StoryAndVoteAcrossBlocks: a Story in block N,
+// a signed Vote in block N+1, both land in cn_*. Replaying the Vote
+// (same author, same target) leaves cn_votes at exactly one row —
+// the spec §8 dedup invariant.
+func TestCoinNewsIndexer_StoryAndVoteAcrossBlocks(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	p := newCoinNewsParser(t)
+
+	// Story (block N).
+	storyBytes, err := codec.EncodeStory(codec.Story{
+		Topic:    codec.Topic{0x48, 0x4e, 0x53, 0x21},
+		Headline: "Hello CoinNews",
+		TLVs: []codec.TLV{
+			{Tag: codec.TLVURL, Value: []byte("https://example.com/story")},
+			{Tag: codec.TLVSubtype, Value: []byte{byte(codec.SubtypeLink)}},
+		},
+	})
+	require.NoError(t, err)
+	storyBlock := blockOf(t, [][]byte{storyBytes}, time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC))
+	storyTxHash := storyBlock.Transactions[0].TxHash()
+	var storyTxidNatural [32]byte
+	copy(storyTxidNatural[:], storyTxHash[:])
+	storyItem := codec.ComputeItemID(storyTxidNatural, 0)
+
+	// Vote (block N+1).
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	digest := codec.VoteSigHash(codec.TypeUpvote, storyItem)
+	sig, err := schnorr.Sign(priv, digest[:])
+	require.NoError(t, err)
+
+	var v codec.Vote
+	v.Kind = codec.TypeUpvote
+	v.Target = storyItem
+	copy(v.AuthorXPK[:], schnorr.SerializePubKey(priv.PubKey()))
+	copy(v.Sig[:], sig.Serialize())
+	voteBytes, err := codec.EncodeVote(v)
+	require.NoError(t, err)
+	voteBlock := blockOfWithPrevHash(t, [][]byte{voteBytes},
+		time.Date(2026, 4, 27, 12, 10, 0, 0, time.UTC),
+		chainhash.Hash{99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99},
+	)
+
+	require.NoError(t, p.indexCoinNewsBlocks(ctx, []lo.Tuple2[uint32, *wire.MsgBlock]{
+		lo.T2(uint32(800_000), storyBlock),
+		lo.T2(uint32(800_001), voteBlock),
+	}))
+
+	var rowCount int
+	require.NoError(t, p.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM cn_items`).Scan(&rowCount))
+	assert.Equal(t, 2, rowCount, "Story + Vote both in cn_items")
+
+	var headline, url string
+	var subtype int
+	require.NoError(t, p.db.QueryRowContext(ctx,
+		`SELECT headline, subtype, COALESCE(url, '') FROM cn_stories WHERE item_id = ?`, storyItem[:]).
+		Scan(&headline, &subtype, &url))
+	assert.Equal(t, "Hello CoinNews", headline)
+	assert.Equal(t, int(codec.SubtypeLink), subtype)
+	assert.Equal(t, "https://example.com/story", url)
+
+	require.NoError(t, p.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM cn_votes WHERE target_id = ?`, storyItem[:]).Scan(&rowCount))
+	assert.Equal(t, 1, rowCount, "Vote with valid sig persists exactly once")
+
+	// Replay the Vote — dedup MUST hold.
+	require.NoError(t, p.indexCoinNewsBlocks(ctx, []lo.Tuple2[uint32, *wire.MsgBlock]{
+		lo.T2(uint32(800_001), voteBlock),
+	}))
+	require.NoError(t, p.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM cn_votes WHERE target_id = ?`, storyItem[:]).Scan(&rowCount))
+	assert.Equal(t, 1, rowCount, "(author, target) dedup MUST hold across replays")
+}
+
+// TestCoinNewsIndexer_SortsBatchByHeight proves that even when blocks
+// arrive in non-sorted order (the parallel fetcher above us doesn't
+// promise ordering), indexCoinNewsBlocks reorders to canonical
+// height-ascending. Two TopicCreations at the same TopicID land in
+// blocks N and N+1; whichever block is "first" by height MUST win the
+// row regardless of input ordering.
+func TestCoinNewsIndexer_SortsBatchByHeight(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	p := newCoinNewsParser(t)
+
+	topic := codec.Topic{0xaa, 0xaa, 0xaa, 0xaa}
+	earlyBytes, _ := codec.EncodeTopicCreation(codec.TopicCreation{Topic: topic, RetentionDays: 7, Name: "early"})
+	lateBytes, _ := codec.EncodeTopicCreation(codec.TopicCreation{Topic: topic, RetentionDays: 30, Name: "late"})
+	early := blockOf(t, [][]byte{earlyBytes}, time.Now().UTC())
+	late := blockOfWithPrevHash(t, [][]byte{lateBytes}, time.Now().UTC().Add(time.Hour),
+		chainhash.Hash{0xfe, 0xed, 0xfa, 0xce, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28},
+	)
+
+	// Hand them in REVERSE order.
+	require.NoError(t, p.indexCoinNewsBlocks(ctx, []lo.Tuple2[uint32, *wire.MsgBlock]{
+		lo.T2(uint32(900_001), late),
+		lo.T2(uint32(900_000), early),
+	}))
+
+	var name string
+	require.NoError(t, p.db.QueryRowContext(ctx, `SELECT name FROM cn_topics WHERE topic = ?`, topic[:]).Scan(&name))
+	assert.Equal(t, "early", name, "earliest-by-height TopicCreation MUST win even when batch input is unordered")
+}
+
+// TestCoinNewsIndexer_DropsBadSignature: a forged-sig Vote MUST NOT
+// land in cn_votes, and there must be NO cn_items row for it either —
+// signature verification gates persistence end to end.
+func TestCoinNewsIndexer_DropsBadSignature(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	p := newCoinNewsParser(t)
+
+	var target codec.ItemID
+	_, _ = rand.Read(target[:])
+
+	var v codec.Vote
+	v.Kind = codec.TypeUpvote
+	v.Target = target
+	_, _ = rand.Read(v.AuthorXPK[:])
+	_, _ = rand.Read(v.Sig[:])
+	voteBytes, err := codec.EncodeVote(v)
+	require.NoError(t, err)
+
+	block := blockOf(t, [][]byte{voteBytes}, time.Now().UTC())
+	require.NoError(t, p.indexCoinNewsBlocks(ctx, []lo.Tuple2[uint32, *wire.MsgBlock]{
+		lo.T2(uint32(900_002), block),
+	}))
+
+	var rowCount int
+	require.NoError(t, p.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM cn_votes`).Scan(&rowCount))
+	assert.Zero(t, rowCount, "forged-sig Vote MUST NOT persist")
+	require.NoError(t, p.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM cn_items`).Scan(&rowCount))
+	assert.Zero(t, rowCount, "no cn_items row for a dropped Vote")
+}
+
+// TestCoinNewsIndexer_SkipsNonCoinNewsTraffic: random OP_RETURN bytes
+// don't pollute cn_*; the legacy News Message path keeps working.
+func TestCoinNewsIndexer_SkipsNonCoinNewsTraffic(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	p := newCoinNewsParser(t)
+
+	junk := make([]byte, 20)
+	_, _ = rand.Read(junk)
+	block := blockOf(t, [][]byte{junk}, time.Now().UTC())
+	require.NoError(t, p.indexCoinNewsBlocks(ctx, []lo.Tuple2[uint32, *wire.MsgBlock]{
+		lo.T2(uint32(900_003), block),
+	}))
+
+	var rowCount int
+	require.NoError(t, p.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM cn_items`).Scan(&rowCount))
+	assert.Zero(t, rowCount, "non-CoinNews OP_RETURN must not pollute cn_items")
+}
+
+// TestCoinNewsIndexer_PurgeAtOrAbove proves the reorg purge wipes
+// rows from blocks at or above the rewind target — without this,
+// orphaned rows from the pre-reorg chain block first-wins inserts on
+// the replayed range.
+func TestCoinNewsIndexer_PurgeAtOrAbove(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	p := newCoinNewsParser(t)
+
+	keepTopic := codec.Topic{0x11, 0x11, 0x11, 0x11}
+	purgeTopic := codec.Topic{0x22, 0x22, 0x22, 0x22}
+	keepBytes, _ := codec.EncodeTopicCreation(codec.TopicCreation{Topic: keepTopic, RetentionDays: 7, Name: "keep"})
+	purgeBytes, _ := codec.EncodeTopicCreation(codec.TopicCreation{Topic: purgeTopic, RetentionDays: 7, Name: "purge"})
+	keepBlock := blockOf(t, [][]byte{keepBytes}, time.Now().UTC())
+	purgeBlock := blockOfWithPrevHash(t, [][]byte{purgeBytes}, time.Now().UTC(),
+		chainhash.Hash{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 99},
+	)
+
+	require.NoError(t, p.indexCoinNewsBlocks(ctx, []lo.Tuple2[uint32, *wire.MsgBlock]{
+		lo.T2(uint32(100), keepBlock),
+		lo.T2(uint32(200), purgeBlock),
+	}))
+
+	require.NoError(t, p.purgeCoinNewsAtOrAbove(ctx, 200))
+
+	var rowCount int
+	require.NoError(t, p.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM cn_topics WHERE topic = ?`, keepTopic[:]).Scan(&rowCount))
+	assert.Equal(t, 1, rowCount, "rows below rewind target survive")
+	require.NoError(t, p.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM cn_topics WHERE topic = ?`, purgeTopic[:]).Scan(&rowCount))
+	assert.Zero(t, rowCount, "rows at-or-above rewind target are wiped")
+}
+
+// TestCoinNewsIndexer_ErrorsBubble verifies that a hard persistence
+// failure (e.g. a malformed payload that survives to the SQL layer)
+// surfaces as a non-nil error rather than being logged-and-dropped.
+// We trigger one by closing the DB before indexing — every subsequent
+// transaction fails to begin, and that error must reach the caller.
+func TestCoinNewsIndexer_ErrorsBubble(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	p := newCoinNewsParser(t)
+
+	storyBytes, err := codec.EncodeStory(codec.Story{Topic: codec.Topic{1, 2, 3, 4}, Headline: "h"})
+	require.NoError(t, err)
+	block := blockOf(t, [][]byte{storyBytes}, time.Now().UTC())
+
+	require.NoError(t, p.db.Close())
+	err = p.indexCoinNewsBlocks(ctx, []lo.Tuple2[uint32, *wire.MsgBlock]{
+		lo.T2(uint32(900_004), block),
+	})
+	require.Error(t, err, "persistence failures MUST surface, not log-and-continue")
+}
+
+// blockOf wraps one or more OP_RETURN payloads into a wire.MsgBlock
+// suitable for the indexer. Single-tx blocks are skipped by the
+// parser (treated as coinbase-only), so we always include a stub
+// non-coinbase tx alongside.
+func blockOf(t *testing.T, datas [][]byte, blockTime time.Time) *wire.MsgBlock {
+	return blockOfWithPrevHash(t, datas, blockTime, chainhash.Hash{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32})
+}
+
+func blockOfWithPrevHash(t *testing.T, datas [][]byte, blockTime time.Time, prevHash chainhash.Hash) *wire.MsgBlock {
+	t.Helper()
+	tx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{Hash: prevHash, Index: 0},
+		}},
+	}
+	for _, d := range datas {
+		tx.TxOut = append(tx.TxOut, &wire.TxOut{Value: 0, PkScript: pkScript(t, d)})
+	}
+	return &wire.MsgBlock{
+		Header:       wire.BlockHeader{Timestamp: blockTime},
+		Transactions: []*wire.MsgTx{tx},
+	}
+}

--- a/bitwindow/server/models/coinnews/store.go
+++ b/bitwindow/server/models/coinnews/store.go
@@ -1,0 +1,244 @@
+// Package coinnews persists CoinNews messages decoded by the
+// `bitwindow/server/coinnews` codec. The two packages are deliberately
+// split: the codec is pure bytes, the store is database/SQL only. The
+// engine's parser glues them together (see `bitwindow/server/engines`).
+package coinnews
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"time"
+
+	codec "github.com/LayerTwo-Labs/sidesail/bitwindow/server/coinnews"
+)
+
+// BlockPos locates an Item in canonical scan order (spec §4.2). Always
+// fully populated when an Item is being indexed — making this a value
+// type (not a pointer) prevents the partial-nil bug classes the
+// previous shape was vulnerable to.
+type BlockPos struct {
+	BlockHeight uint32
+	TxIndex     uint32
+	VoutIndex   uint32
+	BlockTime   time.Time
+	TxID        string
+}
+
+// IndexEnv is everything the persistence layer needs about a single
+// decoded Message: where it lives on chain (BlockPos) plus the typed
+// payload returned by codec.DecodeMessage.
+type IndexEnv struct {
+	Pos     BlockPos
+	TypeTag codec.TypeTag
+	Msg     any // *codec.TopicCreation | *codec.Story | *codec.Comment | *codec.Vote | *codec.Continuation
+}
+
+// Index dispatches one decoded CoinNews Message into the right
+// table(s). Idempotent on `(txid, vout)` collisions: re-running over
+// the same block leaves the DB unchanged (engine resync safety).
+//
+// Caller MUST have already verified Comment and Vote signatures via
+// codec.VerifyComment / codec.VerifyVote — Index trusts what it gets.
+func Index(ctx context.Context, db *sql.DB, env IndexEnv) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("coinnews: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // committed on success path
+
+	itemID, err := registerItem(ctx, tx, env)
+	if err != nil {
+		return err
+	}
+
+	switch m := env.Msg.(type) {
+	case *codec.TopicCreation:
+		if err := indexTopic(ctx, tx, env.Pos, m); err != nil {
+			return err
+		}
+	case *codec.Story:
+		if err := indexStory(ctx, tx, itemID, m); err != nil {
+			return err
+		}
+	case *codec.Comment:
+		if err := indexComment(ctx, tx, itemID, m); err != nil {
+			return err
+		}
+	case *codec.Vote:
+		if err := indexVote(ctx, tx, env.Pos, m); err != nil {
+			return err
+		}
+	case *codec.Continuation:
+		if err := indexContinuation(ctx, tx, env.Pos, m); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("coinnews: unhandled message type %T", env.Msg)
+	}
+
+	return tx.Commit()
+}
+
+// registerItem inserts the row in cn_items and returns the ItemID it
+// was indexed by. Every confirmed CoinNews Message — including Topic
+// Creations — gets a row here so the determinism budget (spec §4.2)
+// can hash a stable items_by_id tuple.
+func registerItem(ctx context.Context, tx *sql.Tx, env IndexEnv) (codec.ItemID, error) {
+	var txidBytes [32]byte
+	raw, err := hex.DecodeString(env.Pos.TxID)
+	if err != nil || len(raw) != 32 {
+		return codec.ItemID{}, fmt.Errorf("coinnews: invalid txid %q: %w", env.Pos.TxID, err)
+	}
+	// Bitcoin Core gives us txids in display (reversed) hex; reverse
+	// to natural byte order for the SHA-256 input the spec defines.
+	slices.Reverse(raw)
+	copy(txidBytes[:], raw)
+	id := codec.ComputeItemID(txidBytes, env.Pos.VoutIndex)
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO cn_items
+			(item_id, txid, vout, block_height, tx_index, vout_index, type_tag, block_time)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, id[:], env.Pos.TxID, env.Pos.VoutIndex, env.Pos.BlockHeight, env.Pos.TxIndex, env.Pos.VoutIndex, byte(env.TypeTag), env.Pos.BlockTime)
+	if err != nil {
+		return codec.ItemID{}, fmt.Errorf("coinnews: insert cn_items: %w", err)
+	}
+	return id, nil
+}
+
+func indexTopic(ctx context.Context, tx *sql.Tx, pos BlockPos, t *codec.TopicCreation) error {
+	// Earliest confirmed creation per topic wins. PRIMARY KEY conflict
+	// ⇒ silently ignored — exactly the spec §5 semantics.
+	_, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO cn_topics
+			(topic, name, retention_days, created_height, txid)
+		VALUES (?, ?, ?, ?, ?)
+	`, t.Topic[:], t.Name, t.RetentionDays, pos.BlockHeight, pos.TxID)
+	if err != nil {
+		return fmt.Errorf("coinnews: insert cn_topics: %w", err)
+	}
+	return nil
+}
+
+func indexStory(ctx context.Context, tx *sql.Tx, id codec.ItemID, s *codec.Story) error {
+	url, body, lang, nsfw, mediaHash, subtype := extractStoryTLV(s.TLVs)
+	rawTLV, err := codec.SerialiseTLVs(s.TLVs)
+	if err != nil {
+		return fmt.Errorf("coinnews: serialise story tlvs: %w", err)
+	}
+	_, err = tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO cn_stories
+			(item_id, topic, headline, subtype, url, body, lang, nsfw, media_hash, raw_tlv)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id[:], s.Topic[:], s.Headline, byte(subtype),
+		nullableString(url), nullableString(body), nullableString(lang),
+		nsfw, nullableBytes(mediaHash), rawTLV)
+	if err != nil {
+		return fmt.Errorf("coinnews: insert cn_stories: %w", err)
+	}
+	return nil
+}
+
+func indexComment(ctx context.Context, tx *sql.Tx, id codec.ItemID, c *codec.Comment) error {
+	url, body, lang, replyQuote := extractCommentTLV(c.TLVs)
+	rawTLV, err := codec.SerialiseTLVs(c.TLVs)
+	if err != nil {
+		return fmt.Errorf("coinnews: serialise comment tlvs: %w", err)
+	}
+	_, err = tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO cn_comments
+			(item_id, parent_id, author_xpk, body, url, lang, reply_quote, raw_tlv)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, id[:], c.Parent[:], c.AuthorXPK[:],
+		nullableString(body), nullableString(url), nullableString(lang),
+		nullableString(replyQuote), rawTLV)
+	if err != nil {
+		return fmt.Errorf("coinnews: insert cn_comments: %w", err)
+	}
+	return nil
+}
+
+func indexVote(ctx context.Context, tx *sql.Tx, pos BlockPos, v *codec.Vote) error {
+	// First-vote-wins: PRIMARY KEY (target_id, author_xpk) makes
+	// the conflict path an ignored insert.
+	_, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO cn_votes
+			(target_id, author_xpk, kind, block_height, tx_index, vout_index, block_time)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, v.Target[:], v.AuthorXPK[:], byte(v.Kind),
+		pos.BlockHeight, pos.TxIndex, pos.VoutIndex, pos.BlockTime)
+	if err != nil {
+		return fmt.Errorf("coinnews: insert cn_votes: %w", err)
+	}
+	return nil
+}
+
+func indexContinuation(ctx context.Context, tx *sql.Tx, pos BlockPos, c *codec.Continuation) error {
+	_, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO cn_continuations
+			(head_id, seq, chunk, block_height)
+		VALUES (?, ?, ?, ?)
+	`, c.Head[:], c.Seq, c.Chunk, pos.BlockHeight)
+	if err != nil {
+		return fmt.Errorf("coinnews: insert cn_continuations: %w", err)
+	}
+	return nil
+}
+
+// extractStoryTLV pulls the columns we hoist out of the Story TLV blob
+// for fast feed queries. Anything we don't hoist remains in raw_tlv so
+// schema upgrades can re-derive without re-scanning the chain.
+func extractStoryTLV(tlvs []codec.TLV) (url, body, lang string, nsfw bool, mediaHash []byte, subtype codec.Subtype) {
+	if t := codec.FindFirst(tlvs, codec.TLVURL); t != nil {
+		url = string(t.Value)
+	}
+	if t := codec.FindFirst(tlvs, codec.TLVBody); t != nil {
+		body = string(t.Value)
+	}
+	if t := codec.FindFirst(tlvs, codec.TLVLang); t != nil {
+		lang = string(t.Value)
+	}
+	if t := codec.FindFirst(tlvs, codec.TLVNSFW); t != nil {
+		nsfw = len(t.Value) > 0 && t.Value[0] != 0
+	}
+	if t := codec.FindFirst(tlvs, codec.TLVMediaHash); t != nil && len(t.Value) == 32 {
+		mediaHash = append([]byte{}, t.Value...)
+	}
+	if t := codec.FindFirst(tlvs, codec.TLVSubtype); t != nil && len(t.Value) > 0 {
+		subtype = codec.Subtype(t.Value[0])
+	}
+	return
+}
+
+func extractCommentTLV(tlvs []codec.TLV) (url, body, lang, replyQuote string) {
+	if t := codec.FindFirst(tlvs, codec.TLVURL); t != nil {
+		url = string(t.Value)
+	}
+	if t := codec.FindFirst(tlvs, codec.TLVBody); t != nil {
+		body = string(t.Value)
+	}
+	if t := codec.FindFirst(tlvs, codec.TLVLang); t != nil {
+		lang = string(t.Value)
+	}
+	if t := codec.FindFirst(tlvs, codec.TLVReplyQuote); t != nil {
+		replyQuote = string(t.Value)
+	}
+	return
+}
+
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func nullableBytes(b []byte) any {
+	if len(b) == 0 {
+		return nil
+	}
+	return b
+}

--- a/bitwindow/server/models/coinnews/store_test.go
+++ b/bitwindow/server/models/coinnews/store_test.go
@@ -1,0 +1,283 @@
+package coinnews
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	codec "github.com/LayerTwo-Labs/sidesail/bitwindow/server/coinnews"
+)
+
+// pos returns a BlockPos seeded for tests. Callers tweak fields they
+// care about (height, tx_index, vout_index) so per-test ordering is
+// explicit.
+func pos(height, txIdx, voutIdx uint32) BlockPos {
+	return BlockPos{
+		BlockHeight: height,
+		TxIndex:     txIdx,
+		VoutIndex:   voutIdx,
+		BlockTime:   time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC),
+		TxID:        "1111111111111111111111111111111111111111111111111111111111111111",
+	}
+}
+
+// TestStore_TopicCreation_EarliestWins guards spec §5: when two
+// creations race for the same TopicID, only the first confirmed one
+// keeps the name. The second insert is silently ignored — exactly
+// what `INSERT OR IGNORE` against the PRIMARY KEY gives us.
+func TestStore_TopicCreation_EarliestWins(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	first := &codec.TopicCreation{
+		Topic:         codec.Topic{0xa1, 0xa2, 0xa3, 0xa4},
+		RetentionDays: 7,
+		Name:          "First Wins",
+	}
+	require.NoError(t, Index(ctx, db, IndexEnv{
+		Pos: pos(100, 0, 0), TypeTag: codec.TypeTopicCreation, Msg: first,
+	}))
+
+	second := &codec.TopicCreation{
+		Topic:         codec.Topic{0xa1, 0xa2, 0xa3, 0xa4}, // same TopicID
+		RetentionDays: 30,
+		Name:          "Second Loses",
+	}
+	require.NoError(t, Index(ctx, db, IndexEnv{
+		Pos: pos(101, 0, 0), TypeTag: codec.TypeTopicCreation, Msg: second,
+	}))
+
+	var name string
+	var ret int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT name, retention_days FROM cn_topics WHERE topic = ?`,
+		first.Topic[:],
+	).Scan(&name, &ret))
+	assert.Equal(t, "First Wins", name, "first confirmed Topic Creation must win the name")
+	assert.Equal(t, 7, ret, "retention from first creation must persist")
+}
+
+// TestStore_Story_HoistsCommonTLVs proves the TLV-to-column extraction:
+// a Story carrying url/body/lang/nsfw/subtype lands them in their hot
+// columns AND keeps a verbatim copy in raw_tlv (so future schema
+// upgrades can re-derive new fields without a chain rescan).
+func TestStore_Story_HoistsCommonTLVs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	// Topic must exist in cn_topics first; while the spec doesn't
+	// mandate this for Stories (only for indexer presentation), we
+	// register it so a UI rendering the row can resolve the topic.
+	require.NoError(t, Index(ctx, db, IndexEnv{
+		Pos: pos(50, 0, 0), TypeTag: codec.TypeTopicCreation,
+		Msg: &codec.TopicCreation{Topic: codec.Topic{1, 2, 3, 4}, Name: "T", RetentionDays: 7},
+	}))
+
+	story := &codec.Story{
+		Topic:    codec.Topic{1, 2, 3, 4},
+		Headline: "the headline",
+		TLVs: []codec.TLV{
+			{Tag: codec.TLVURL, Value: []byte("https://example.com/a")},
+			{Tag: codec.TLVBody, Value: []byte("the body text")},
+			{Tag: codec.TLVLang, Value: []byte("en")},
+			{Tag: codec.TLVNSFW, Value: []byte{0x01}},
+			{Tag: codec.TLVSubtype, Value: []byte{byte(codec.SubtypeShow)}},
+		},
+	}
+	require.NoError(t, Index(ctx, db, IndexEnv{
+		Pos: pos(100, 0, 0), TypeTag: codec.TypeStory, Msg: story,
+	}))
+
+	// Compute the ItemID we expect.
+	var txid [32]byte
+	for i := range txid {
+		txid[31-i] = 0x11 // mirror reversed→natural step
+	}
+	id := codec.ComputeItemID(txid, 0)
+
+	var (
+		headline, url, body, lang string
+		subtype                   int
+		nsfw                      bool
+		mediaHash                 []byte
+		rawTLV                    []byte
+	)
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT headline, COALESCE(url, ''), COALESCE(body, ''), COALESCE(lang, ''),
+		       subtype, nsfw, COALESCE(media_hash, X''), raw_tlv
+		FROM cn_stories WHERE item_id = ?
+	`, id[:]).Scan(&headline, &url, &body, &lang, &subtype, &nsfw, &mediaHash, &rawTLV))
+
+	assert.Equal(t, "the headline", headline)
+	assert.Equal(t, "https://example.com/a", url)
+	assert.Equal(t, "the body text", body)
+	assert.Equal(t, "en", lang)
+	assert.Equal(t, int(codec.SubtypeShow), subtype)
+	assert.True(t, nsfw, "nsfw flag must survive the TLV roundtrip")
+	assert.Empty(t, mediaHash, "media_hash absent ⇒ NULL/empty")
+
+	// raw_tlv preserves the full payload for schema upgrades.
+	expectedRaw, err := codec.SerialiseTLVs(story.TLVs)
+	require.NoError(t, err)
+	assert.Equal(t, expectedRaw, rawTLV, "raw_tlv must be a verbatim copy of the encoded TLVs")
+}
+
+// TestStore_Vote_DedupByAuthorAndTarget pins the §8 invariant:
+// (author_xpk, target_id) is unique. Re-indexing the same Vote at a
+// later block, or a flipped (up→down) Vote from the same author,
+// MUST leave the original row untouched.
+func TestStore_Vote_DedupByAuthorAndTarget(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	var target codec.ItemID
+	_, _ = rand.Read(target[:])
+	var xpk codec.XOnlyPubKey
+	_, _ = rand.Read(xpk[:])
+
+	upvote := &codec.Vote{Kind: codec.TypeUpvote, Target: target, AuthorXPK: xpk}
+	require.NoError(t, Index(ctx, db, IndexEnv{
+		Pos: pos(100, 0, 0), TypeTag: codec.TypeUpvote, Msg: upvote,
+	}))
+
+	// Same author, same target, but downvote in a later block —
+	// MUST be ignored.
+	downvote := &codec.Vote{Kind: codec.TypeDownvote, Target: target, AuthorXPK: xpk}
+	require.NoError(t, Index(ctx, db, IndexEnv{
+		Pos: pos(101, 0, 0), TypeTag: codec.TypeDownvote, Msg: downvote,
+	}))
+
+	var rowCount int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM cn_votes WHERE target_id = ?`, target[:]).Scan(&rowCount))
+	assert.Equal(t, 1, rowCount, "vote dedup MUST hold across (author, target)")
+
+	var kind int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT kind FROM cn_votes WHERE target_id = ?`, target[:]).Scan(&kind))
+	assert.Equal(t, int(codec.TypeUpvote), kind, "first vote (upvote) must persist; flip is dropped")
+}
+
+// TestStore_Comment_PersistsAllExtractedFields hoists each TLV onto
+// its own column and keeps the raw blob. Acceptance test for a thread-
+// rendering query that fetches a comment by item_id.
+func TestStore_Comment_PersistsAllExtractedFields(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	var parent codec.ItemID
+	_, _ = rand.Read(parent[:])
+	var xpk codec.XOnlyPubKey
+	_, _ = rand.Read(xpk[:])
+
+	comment := &codec.Comment{
+		Parent:    parent,
+		AuthorXPK: xpk,
+		TLVs: []codec.TLV{
+			{Tag: codec.TLVBody, Value: []byte("body text")},
+			{Tag: codec.TLVURL, Value: []byte("https://reply.example/x")},
+			{Tag: codec.TLVLang, Value: []byte("en")},
+			{Tag: codec.TLVReplyQuote, Value: []byte("> the parent's words")},
+		},
+	}
+	require.NoError(t, Index(ctx, db, IndexEnv{
+		Pos: pos(200, 1, 0), TypeTag: codec.TypeComment, Msg: comment,
+	}))
+
+	// Recompute ItemID for the comment.
+	var txid [32]byte
+	for i := range txid {
+		txid[31-i] = 0x11
+	}
+	id := codec.ComputeItemID(txid, 0)
+
+	var body, url, lang, replyQuote string
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT COALESCE(body, ''), COALESCE(url, ''), COALESCE(lang, ''), COALESCE(reply_quote, '')
+		FROM cn_comments WHERE item_id = ?
+	`, id[:]).Scan(&body, &url, &lang, &replyQuote))
+	assert.Equal(t, "body text", body)
+	assert.Equal(t, "https://reply.example/x", url)
+	assert.Equal(t, "en", lang)
+	assert.Equal(t, "> the parent's words", replyQuote)
+}
+
+// TestStore_Continuation_StoresChunksByHeadAndSeq locks down the
+// (head_id, seq) PRIMARY KEY: inserting two chunks at the same seq
+// for the same head MUST leave the original chunk in place.
+func TestStore_Continuation_StoresChunksByHeadAndSeq(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	var head codec.ItemID
+	_, _ = rand.Read(head[:])
+
+	require.NoError(t, Index(ctx, db, IndexEnv{
+		Pos: pos(300, 0, 1), TypeTag: codec.TypeContinuation,
+		Msg: &codec.Continuation{Head: head, Seq: 0, Chunk: []byte("chunk-zero")},
+	}))
+	require.NoError(t, Index(ctx, db, IndexEnv{
+		Pos: pos(300, 0, 2), TypeTag: codec.TypeContinuation,
+		Msg: &codec.Continuation{Head: head, Seq: 1, Chunk: []byte("chunk-one")},
+	}))
+	// Re-insert seq 0 with different bytes — must be ignored.
+	require.NoError(t, Index(ctx, db, IndexEnv{
+		Pos: pos(301, 0, 0), TypeTag: codec.TypeContinuation,
+		Msg: &codec.Continuation{Head: head, Seq: 0, Chunk: []byte("REPLAY")},
+	}))
+
+	var rowCount int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM cn_continuations WHERE head_id = ?`, head[:]).Scan(&rowCount))
+	assert.Equal(t, 2, rowCount, "two chunks expected; replay at seq 0 dropped")
+
+	var chunk0 []byte
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT chunk FROM cn_continuations WHERE head_id = ? AND seq = 0`, head[:]).Scan(&chunk0))
+	assert.Equal(t, []byte("chunk-zero"), chunk0, "first-write-wins on (head, seq)")
+}
+
+// TestStore_Item_RegistersTxidVoutWithCanonicalOrder asserts that
+// every non-Topic insert ALSO registers a row in cn_items with the
+// canonical (height, tx_index, vout_index) triple — that's the index
+// every feed query depends on for stable ordering across indexers.
+func TestStore_Item_RegistersTxidVoutWithCanonicalOrder(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	story := &codec.Story{Topic: codec.Topic{1, 2, 3, 4}, Headline: "h"}
+	require.NoError(t, Index(ctx, db, IndexEnv{
+		Pos:     BlockPos{BlockHeight: 9, TxIndex: 3, VoutIndex: 2, BlockTime: time.Now().UTC(), TxID: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+		TypeTag: codec.TypeStory,
+		Msg:     story,
+	}))
+
+	var (
+		gotTxid               string
+		gotVout               int
+		gotHeight             int
+		gotTxIndex, gotVoutIx int
+		gotType               int
+	)
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT txid, vout, block_height, tx_index, vout_index, type_tag
+		FROM cn_items LIMIT 1
+	`).Scan(&gotTxid, &gotVout, &gotHeight, &gotTxIndex, &gotVoutIx, &gotType))
+
+	assert.Equal(t, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", gotTxid)
+	assert.Equal(t, 2, gotVout)
+	assert.Equal(t, 9, gotHeight)
+	assert.Equal(t, 3, gotTxIndex)
+	assert.Equal(t, 2, gotVoutIx)
+	assert.Equal(t, int(codec.TypeStory), gotType)
+}
+

--- a/docs/coinnews-protocol.md
+++ b/docs/coinnews-protocol.md
@@ -6,7 +6,7 @@ CoinNews encodes a topic-scoped bulletin board — stories, threaded
 comments, signed votes — inside Bitcoin `OP_RETURN` outputs.
 Indexers reach the same view by scanning blocks; no trusted server.
 Wire format is engineered for byte-efficiency (Vote = 111 B,
-headline-only Story = 6 B + headline) so on-chain footprint per
+headline-only Story = 8 B + headline) so on-chain footprint per
 message stays close to the irreducible signature + reference cost.
 
 ## Definitions
@@ -185,7 +185,8 @@ TopicID wins; later collisions are silently ignored.
 
 Headline is a varint-prefixed UTF-8 string. The trailing TLV section
 (§10) carries optional `url`, `body`, `subtype`, etc. A
-headline-only Story is 7 + headline bytes.
+headline-only Story is 8 + headline bytes (`magic 2 + tag 1 + topic 4
++ headline-length varint 1 + headline`).
 
 Stories are unsigned: attribution falls to the spending transaction's
 first input address. Implementations wanting cryptographic authorship


### PR DESCRIPTION
Stacks on #1686. Hooks the codec into the bitcoind block parser; cn_* tables follow the layout the encoder/decoder produces.

**Migration 035** — `cn_items` (universal index by ItemID, including TopicCreations), `cn_topics`, `cn_stories`, `cn_comments`, `cn_votes` (PRIMARY KEY enforces `(target, author)` dedup), `cn_continuations`.

**Engine architecture (post-codex review):**
- CoinNews indexing runs **sequentially** in a post-fetch pass, sorted by `(block_height, tx_index, vout_index)`. The block-fetch pool above stays parallel; canonical scan order (spec §4.2) is preserved at the indexing layer.
- Persistence errors **bubble** — a failed cn_* insert means the block is NOT marked processed, so the next sync attempt retries instead of skipping.
- Reorg detection now **purges** cn_* rows at-or-above the rewind target before replay, so first-wins inserts on the new chain do not collide with stale orphans.
- `BlockPos` is value-typed; no partial-nil bug class.
- Signature verification gates persistence end-to-end.

**Tests** (12 total across two packages):
- engine: Story+Vote across blocks with (author, target) dedup on replay; out-of-order batch input sorts to canonical order; forged-sig drop; non-CoinNews skip; reorg purge wipes at-or-above; persistence errors surface (DB closed mid-batch).
- store: TopicCreation earliest-wins, Story TLV column hoisting + raw_tlv preservation, Vote dedup, Comment field extraction, Continuation `(head, seq)` PK enforcement, cn_items canonical-order registration.

Full server suite stays green.