### PR TITLE
scripts: pre-commit hook also runs gofmt

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.208
+version: 1.0.209
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.209
+version: 1.0.210
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.59
+version: 0.2.60
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.82
+version: 1.0.83
 
 environment:
   sdk: 3.11.4

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,12 +1,39 @@
 #!/usr/bin/env bash
-# Block commits that CI would reject. Two gates:
-#   1. dart format on staged Dart files; re-stage if reformatted.
-#   2. flutter analyze on every Dart project that has staged changes.
-# Skips generated (lib/gen/**) and tooling (.dart_tool/**) paths.
+# Block commits that CI would reject. Three gates:
+#   1. gofmt on staged Go files; re-stage if reformatted (CI's
+#      golangci-lint runs gofmt and rejects on style; failing on push
+#      after a clean local `go test` is wasted CI time).
+#   2. dart format on staged Dart files; re-stage if reformatted.
+#   3. flutter analyze on every Dart project that has staged changes.
+# Skips generated paths.
 # Install: bash scripts/install-hooks.sh
 
 set -euo pipefail
 
+# ----- Go: gofmt -----------------------------------------------------------
+go_files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.go' \
+  | grep -vE '(^|/)gen/' \
+  | grep -vE '(^|/)vendor/' \
+  | grep -vE '\.pb\.go$' \
+  || true)
+
+if [ -n "$go_files" ]; then
+  if command -v gofmt >/dev/null 2>&1; then
+    bad=$(gofmt -l $go_files 2>/dev/null || true)
+    if [ -n "$bad" ]; then
+      echo "pre-commit: gofmt rewrote: $bad" >&2
+      while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        gofmt -w -- "$f"
+        git add -- "$f"
+      done <<<"$bad"
+    fi
+  else
+    echo "pre-commit: gofmt not found on PATH, skipping Go format" >&2
+  fi
+fi
+
+# ----- Dart: format + analyze ----------------------------------------------
 files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.dart' \
   | grep -vE '(^|/)lib/gen/' \
   | grep -vE '(^|/)\.dart_tool/' \

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.211
+version: 1.0.212
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.82
+version: 1.0.83
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.209
+version: 1.0.210
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
CI runs golangci-lint (gofmt included); local `go test` does not enforce style, so style breakage went undetected pre-push. The existing pre-commit hook already runs dart format + flutter analyze; this adds the equivalent gofmt step for staged `.go` files (skipping generated/vendor/.pb.go). Auto-restages reformatted files.