### PR TITLE
sail_ui: fix null check crash opening Daemon Status pre-init

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.209
+version: 1.0.210
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.210
+version: 1.0.211
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.60
+version: 0.2.61
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.83
+version: 1.0.84
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/config/binaries.dart
+++ b/sail_ui/lib/config/binaries.dart
@@ -85,6 +85,7 @@ abstract class Binary {
   bool get updateAvailable =>
       isDownloaded &&
       metadata.remoteTimestamp != null &&
+      metadata.downloadedTimestamp != null &&
       metadata.remoteTimestamp!.isAfter(metadata.downloadedTimestamp!);
 
   // Process log storage (in-memory, session-based)

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.212
+version: 1.0.213
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.83
+version: 1.0.84
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.210
+version: 1.0.211
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
Opening Daemon Status before a binary's `downloadedTimestamp` was populated crashed in `Binary.updateAvailable` — `remoteTimestamp` was null-checked but `downloadedTimestamp` was force-unwrapped.

Null-check both.