### PR TITLE
bitwindow: page-based network switch flow

### DIFF
--- a/bitwindow/lib/pages/settings/datadir_select_page.dart
+++ b/bitwindow/lib/pages/settings/datadir_select_page.dart
@@ -1,0 +1,139 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+/// Full-page picker for the Bitcoin Core data directory. Pushed when a
+/// network switch needs a datadir but none is configured.
+class DataDirSelectPage extends StatefulWidget {
+  final BitcoinNetwork? network;
+
+  const DataDirSelectPage({super.key, this.network});
+
+  @override
+  State<DataDirSelectPage> createState() => _DataDirSelectPageState();
+}
+
+class _DataDirSelectPageState extends State<DataDirSelectPage> {
+  String? _selectedPath;
+  bool _isPicking = false;
+
+  Future<void> _pickDirectory() async {
+    setState(() => _isPicking = true);
+    try {
+      final result = await FilePicker.getDirectoryPath();
+      if (result != null && mounted) {
+        setState(() => _selectedPath = result);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error selecting directory: $e'),
+            backgroundColor: SailTheme.of(context).colors.error,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isPicking = false);
+      }
+    }
+  }
+
+  String _subtitle() {
+    switch (widget.network) {
+      case BitcoinNetwork.BITCOIN_NETWORK_MAINNET:
+        return 'Mainnet needs a Bitcoin Core data directory with the blockchain data (2.5TB+). Pick a directory that contains the blocks folder.';
+      case BitcoinNetwork.BITCOIN_NETWORK_FORKNET:
+        return 'Forknet needs a data directory to store the chain. Pick an empty directory or one already used for forknet.';
+      default:
+        return 'Pick a directory for Bitcoin Core to store its data.';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+    final networkName = widget.network?.toDisplayName() ?? 'Bitcoin Core';
+
+    return Scaffold(
+      backgroundColor: theme.colors.background,
+      appBar: AppBar(
+        backgroundColor: theme.colors.background,
+        foregroundColor: theme.colors.text,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: SafeArea(
+        child: Stack(
+          children: [
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 32.0),
+                child: SizedBox(
+                  width: 800,
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.only(bottom: 100),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        const SizedBox(height: 30),
+                        SailText.primary24(
+                          'Select $networkName Data Directory',
+                          bold: true,
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 16),
+                        SailText.secondary13(
+                          _subtitle(),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 32),
+                        Container(
+                          padding: const EdgeInsets.all(SailStyleValues.padding12),
+                          decoration: BoxDecoration(
+                            border: Border.all(color: theme.colors.border),
+                            borderRadius: SailStyleValues.borderRadiusSmall,
+                            color: theme.colors.backgroundSecondary,
+                          ),
+                          child: SailText.secondary13(
+                            _selectedPath ?? 'No directory selected',
+                            monospace: true,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        SailButton(
+                          label: 'Browse',
+                          loading: _isPicking,
+                          onPressed: () async => await _pickDirectory(),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            BottomActionBar(
+              children: [
+                SailButton(
+                  label: 'Cancel',
+                  variant: ButtonVariant.secondary,
+                  onPressed: () async => Navigator.of(context).pop(),
+                ),
+                const SizedBox(width: SailStyleValues.padding12),
+                SailButton(
+                  label: 'Confirm',
+                  variant: ButtonVariant.primary,
+                  disabled: _selectedPath == null,
+                  onPressed: () async => Navigator.of(context).pop(_selectedPath),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/bitwindow/lib/pages/settings/network_swap_page.dart
+++ b/bitwindow/lib/pages/settings/network_swap_page.dart
@@ -1,0 +1,243 @@
+import 'package:bitwindow/main.dart' show bootBitwindowBackend;
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+/// Confirms a Bitcoin network change, then runs the swap as
+/// "shut down → save → boot back up", mirroring the reset flow.
+class NetworkSwapPage extends StatefulWidget {
+  final BitcoinNetwork fromNetwork;
+  final BitcoinNetwork toNetwork;
+
+  const NetworkSwapPage({
+    super.key,
+    required this.fromNetwork,
+    required this.toNetwork,
+  });
+
+  @override
+  State<NetworkSwapPage> createState() => _NetworkSwapPageState();
+}
+
+class _NetworkSwapPageState extends State<NetworkSwapPage> {
+  Logger get _log => GetIt.I.get<Logger>();
+  BitcoinConfProvider get _conf => GetIt.I.get<BitcoinConfProvider>();
+  BinaryProvider get _binaries => GetIt.I.get<BinaryProvider>();
+
+  final List<_SwapStep> _steps = [
+    _SwapStep('Stopping binaries'),
+    _SwapStep('Saving network configuration'),
+    _SwapStep('Starting binaries'),
+  ];
+
+  bool _isSwapping = false;
+  bool _swapComplete = false;
+  int _currentStepIndex = -1;
+  String? _error;
+
+  Future<void> _startSwap() async {
+    setState(() {
+      _isSwapping = true;
+      _error = null;
+    });
+
+    try {
+      await _runStep(0, () async {
+        await _binaries.stop(BitWindow());
+        await Future.delayed(const Duration(seconds: 2));
+      });
+      await _runStep(1, () => _conf.updateNetwork(widget.toNetwork));
+      await _runStep(2, () => bootBitwindowBackend(_log));
+
+      if (mounted) {
+        setState(() => _swapComplete = true);
+      }
+    } catch (e) {
+      _log.e('NetworkSwapPage: swap failed: $e');
+      if (mounted) {
+        setState(() {
+          _error = e.toString();
+          if (_currentStepIndex >= 0 && _currentStepIndex < _steps.length) {
+            _steps[_currentStepIndex].endTime = DateTime.now();
+          }
+        });
+      }
+    }
+  }
+
+  Future<void> _runStep(int idx, Future<void> Function() action) async {
+    if (!mounted) return;
+    setState(() {
+      _currentStepIndex = idx;
+      _steps[idx].startTime = DateTime.now();
+    });
+    await action();
+    if (!mounted) return;
+    setState(() {
+      _steps[idx].endTime = DateTime.now();
+    });
+  }
+
+  void _handleBack() {
+    Navigator.of(context).pop(_isSwapping);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+    final fromName = widget.fromNetwork.toDisplayName();
+    final toName = widget.toNetwork.toDisplayName();
+
+    return PopScope(
+      canPop: !_isSwapping || _swapComplete || _error != null,
+      onPopInvokedWithResult: (didPop, result) {
+        if (!didPop && (_swapComplete || _error != null)) {
+          Navigator.of(context).pop(_swapComplete);
+        }
+      },
+      child: Scaffold(
+        backgroundColor: theme.colors.background,
+        appBar: AppBar(
+          backgroundColor: theme.colors.background,
+          foregroundColor: theme.colors.text,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: _isSwapping && !_swapComplete && _error == null ? null : _handleBack,
+          ),
+        ),
+        body: SafeArea(
+          child: Stack(
+            children: [
+              Center(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 32.0),
+                  child: SizedBox(
+                    width: 800,
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.only(bottom: 100),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          const SizedBox(height: 30),
+                          SailRow(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            spacing: SailStyleValues.padding12,
+                            children: [
+                              if (_swapComplete)
+                                Icon(
+                                  Icons.check_circle,
+                                  color: theme.colors.success,
+                                  size: 32,
+                                )
+                              else if (_error != null)
+                                Icon(
+                                  Icons.error,
+                                  color: theme.colors.error,
+                                  size: 32,
+                                )
+                              else
+                                SailSVG.fromAsset(
+                                  SailSVGAsset.iconRestart,
+                                  color: theme.colors.primary,
+                                  width: 32,
+                                  height: 32,
+                                ),
+                              SailText.primary24(
+                                _swapComplete
+                                    ? 'Network Switch Complete'
+                                    : _error != null
+                                    ? 'Network Switch Failed'
+                                    : 'Switch Bitcoin Network',
+                                bold: true,
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 16),
+                          SailText.secondary13(
+                            _swapComplete
+                                ? 'Switched from $fromName to $toName.'
+                                : _error != null
+                                ? _error!
+                                : _isSwapping
+                                ? 'Switching from $fromName to $toName...'
+                                : 'BitWindow will stop, save the new network, and boot back up. Switching from $fromName to $toName.',
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 24),
+                          if (_isSwapping || _swapComplete || _error != null)
+                            DecoratedBox(
+                              decoration: BoxDecoration(
+                                color: theme.colors.backgroundSecondary,
+                                borderRadius: SailStyleValues.borderRadiusSmall,
+                              ),
+                              child: Padding(
+                                padding: const EdgeInsets.all(SailStyleValues.padding12),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    for (var i = 0; i < _steps.length; i++)
+                                      Padding(
+                                        padding: const EdgeInsets.symmetric(vertical: 2),
+                                        child: ProgressStepTile(
+                                          name: _steps[i].name,
+                                          isCompleted: _steps[i].isCompleted,
+                                          duration: _steps[i].duration,
+                                          isActive: i == _currentStepIndex && !_steps[i].isCompleted,
+                                        ),
+                                      ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              BottomActionBar(
+                children: [
+                  if (!_isSwapping) ...[
+                    SailButton(
+                      label: 'Cancel',
+                      onPressed: () async => Navigator.of(context).pop(false),
+                    ),
+                    const SizedBox(width: SailStyleValues.padding12),
+                    SailButton(
+                      label: 'Switch to $toName',
+                      variant: ButtonVariant.primary,
+                      onPressed: () async => await _startSwap(),
+                    ),
+                  ] else if (_swapComplete)
+                    SailButton(
+                      label: 'Continue',
+                      variant: ButtonVariant.primary,
+                      onPressed: () async => _handleBack(),
+                    )
+                  else if (_error != null)
+                    SailButton(
+                      label: 'Close',
+                      variant: ButtonVariant.secondary,
+                      onPressed: () async => _handleBack(),
+                    ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SwapStep {
+  final String name;
+  DateTime? startTime;
+  DateTime? endTime;
+
+  _SwapStep(this.name);
+
+  bool get isCompleted => endTime != null;
+  Duration? get duration => (startTime != null && endTime != null) ? endTime!.difference(startTime!) : null;
+}

--- a/bitwindow/lib/pages/settings/settings_network.dart
+++ b/bitwindow/lib/pages/settings/settings_network.dart
@@ -1,3 +1,5 @@
+import 'package:bitwindow/pages/settings/datadir_select_page.dart';
+import 'package:bitwindow/pages/settings/network_swap_page.dart';
 import 'package:bitwindow/routing/router.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
@@ -289,132 +291,37 @@ class _SettingsNetworkState extends State<SettingsNetwork> {
   }
 }
 
-/// Wraps a network swap with a datadir prompt. If the backend rejects the
-/// swap because the target network has no datadir configured, this opens
-/// [DataDirSelectionDialog], persists the chosen path, then retries the swap.
+/// Pushes the full-page network swap flow. When the target network has no
+/// datadir configured yet, this first pushes [DataDirSelectPage] to capture
+/// one (mirroring the wallet-guard full-page pattern), then pushes
+/// [NetworkSwapPage] which performs "shut down → save → boot back up" with
+/// progress UI matching the reset flow.
 Future<void> swapNetworkWithDatadirPrompt(
   BuildContext context,
   BitcoinConfProvider provider,
   BitcoinNetwork network,
 ) async {
-  try {
-    await provider.swapNetwork(context, network);
-  } on MissingDatadirException catch (e) {
-    if (!context.mounted) return;
-    final selected = await showDialog<String>(
-      context: context,
-      builder: (_) => DataDirSelectionDialog(network: e.network),
+  if (provider.network == network) return;
+
+  if (_networkNeedsDatadir(network) && provider.detectedDataDir == null) {
+    final selected = await Navigator.of(context).push<String>(
+      MaterialPageRoute(builder: (_) => DataDirSelectPage(network: network)),
     );
     if (selected == null || selected.isEmpty) return;
-    await provider.updateDataDir(selected, forNetwork: e.network);
     if (!context.mounted) return;
-    await provider.swapNetwork(context, network);
-  }
-}
-
-class DataDirSelectionDialog extends StatefulWidget {
-  final BitcoinNetwork? network;
-  const DataDirSelectionDialog({super.key, this.network});
-
-  @override
-  State<DataDirSelectionDialog> createState() => _DataDirSelectionDialogState();
-}
-
-class _DataDirSelectionDialogState extends State<DataDirSelectionDialog> {
-  String? selectedPath;
-  bool isSelecting = false;
-
-  Future<void> _selectDirectory() async {
-    setState(() {
-      isSelecting = true;
-    });
-
-    try {
-      final result = await FilePicker.getDirectoryPath();
-      if (result != null) {
-        setState(() {
-          selectedPath = result;
-        });
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Error selecting directory: $e'),
-            backgroundColor: SailTheme.of(context).colors.error,
-          ),
-        );
-      }
-    } finally {
-      if (mounted) {
-        setState(() {
-          isSelecting = false;
-        });
-      }
-    }
+    await provider.updateDataDir(selected, forNetwork: network);
   }
 
-  String _subtitle() {
-    switch (widget.network) {
-      case BitcoinNetwork.BITCOIN_NETWORK_MAINNET:
-        return 'Mainnet needs a Bitcoin Core data directory with the blockchain data (2.5TB+). Pick a directory that contains the blocks folder.';
-      case BitcoinNetwork.BITCOIN_NETWORK_FORKNET:
-        return 'Forknet needs a data directory to store the chain. Pick an empty directory or one already used for forknet.';
-      default:
-        return 'Pick a directory for Bitcoin Core to store its data.';
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = SailTheme.of(context);
-
-    return Dialog(
-      backgroundColor: Colors.transparent,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 500),
-        child: SailCard(
-          title: 'Select Bitcoin Data Directory',
-          subtitle: _subtitle(),
-          child: SailColumn(
-            spacing: SailStyleValues.padding16,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                padding: const EdgeInsets.all(SailStyleValues.padding12),
-                decoration: BoxDecoration(
-                  border: Border.all(color: theme.colors.border),
-                  borderRadius: SailStyleValues.borderRadiusSmall,
-                ),
-                child: SailText.secondary13(
-                  selectedPath ?? 'No directory selected',
-                ),
-              ),
-              SailButton(
-                label: 'Browse',
-                loading: isSelecting,
-                onPressed: () async => await _selectDirectory(),
-              ),
-              SailRow(
-                mainAxisAlignment: MainAxisAlignment.end,
-                spacing: SailStyleValues.padding08,
-                children: [
-                  SailButton(
-                    label: 'Cancel',
-                    variant: ButtonVariant.secondary,
-                    onPressed: () async => Navigator.of(context).pop(),
-                  ),
-                  SailButton(
-                    label: 'Confirm',
-                    disabled: selectedPath == null,
-                    onPressed: () async => Navigator.of(context).pop(selectedPath),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
+  if (!context.mounted) return;
+  await Navigator.of(context).push<bool>(
+    MaterialPageRoute(
+      builder: (_) => NetworkSwapPage(
+        fromNetwork: provider.network,
+        toNetwork: network,
       ),
-    );
-  }
+    ),
+  );
 }
+
+bool _networkNeedsDatadir(BitcoinNetwork network) =>
+    network == BitcoinNetwork.BITCOIN_NETWORK_MAINNET || network == BitcoinNetwork.BITCOIN_NETWORK_FORKNET;

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.61
+version: 0.2.62
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION

Switching networks now pushes a NetworkSwapPage that mirrors the reset
flow: stop binaries → save new network → boot back up, with per-step
progress UI. When the target network needs a datadir but none is
configured, push DataDirSelectPage first (full page like the wallet
guard) instead of the old modal dialog.
