### PR TITLE
orchestrator, sail_ui: stream L1 sync state to frontend

### DIFF
--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.client.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "orchestrator.pb.dart" as orchestratorv1orchestrator;
 import "orchestrator.connect.spec.dart" as specs;
 
-extension type OrchestratorServiceClient (connect.Transport _transport) {
+extension type OrchestratorServiceClient(connect.Transport _transport) {
   /// List all configured binaries and their status.
   Future<orchestratorv1orchestrator.ListBinariesResponse> listBinaries(
     orchestratorv1orchestrator.ListBinariesRequest input, {

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -40,6 +40,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     $core.String? repoUrl,
     $core.Iterable<StartupLogEntryMsg>? startupLogs,
     $core.String? binaryPath,
+    BlockchainSyncMsg? blockchainSync,
   }) {
     final $result = create();
     if (name != null) {
@@ -111,13 +112,20 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     if (binaryPath != null) {
       $result.binaryPath = binaryPath;
     }
+    if (blockchainSync != null) {
+      $result.blockchainSync = blockchainSync;
+    }
     return $result;
   }
   BinaryStatusMsg._() : super();
-  factory BinaryStatusMsg.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory BinaryStatusMsg.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory BinaryStatusMsg.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory BinaryStatusMsg.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinaryStatusMsg', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinaryStatusMsg',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOS(2, _omitFieldNames ? '' : 'displayName')
     ..aOB(3, _omitFieldNames ? '' : 'running')
@@ -139,21 +147,21 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     ..aOB(19, _omitFieldNames ? '' : 'portInUse')
     ..aOS(20, _omitFieldNames ? '' : 'version')
     ..aOS(21, _omitFieldNames ? '' : 'repoUrl')
-    ..pc<StartupLogEntryMsg>(22, _omitFieldNames ? '' : 'startupLogs', $pb.PbFieldType.PM, subBuilder: StartupLogEntryMsg.create)
+    ..pc<StartupLogEntryMsg>(22, _omitFieldNames ? '' : 'startupLogs', $pb.PbFieldType.PM,
+        subBuilder: StartupLogEntryMsg.create)
     ..aOS(23, _omitFieldNames ? '' : 'binaryPath')
-    ..hasRequiredFields = false
-  ;
+    ..aOM<BlockchainSyncMsg>(24, _omitFieldNames ? '' : 'blockchainSync', subBuilder: BlockchainSyncMsg.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   BinaryStatusMsg clone() => BinaryStatusMsg()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  BinaryStatusMsg copyWith(void Function(BinaryStatusMsg) updates) => super.copyWith((message) => updates(message as BinaryStatusMsg)) as BinaryStatusMsg;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  BinaryStatusMsg copyWith(void Function(BinaryStatusMsg) updates) =>
+      super.copyWith((message) => updates(message as BinaryStatusMsg)) as BinaryStatusMsg;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -162,13 +170,17 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   BinaryStatusMsg createEmptyInstance() => create();
   static $pb.PbList<BinaryStatusMsg> createRepeated() => $pb.PbList<BinaryStatusMsg>();
   @$core.pragma('dart2js:noInline')
-  static BinaryStatusMsg getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinaryStatusMsg>(create);
+  static BinaryStatusMsg getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinaryStatusMsg>(create);
   static BinaryStatusMsg? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -177,7 +189,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get displayName => $_getSZ(1);
   @$pb.TagNumber(2)
-  set displayName($core.String v) { $_setString(1, v); }
+  set displayName($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasDisplayName() => $_has(1);
   @$pb.TagNumber(2)
@@ -186,7 +201,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get running => $_getBF(2);
   @$pb.TagNumber(3)
-  set running($core.bool v) { $_setBool(2, v); }
+  set running($core.bool v) {
+    $_setBool(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasRunning() => $_has(2);
   @$pb.TagNumber(3)
@@ -195,7 +213,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get healthy => $_getBF(3);
   @$pb.TagNumber(4)
-  set healthy($core.bool v) { $_setBool(3, v); }
+  set healthy($core.bool v) {
+    $_setBool(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasHealthy() => $_has(3);
   @$pb.TagNumber(4)
@@ -204,7 +225,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.int get pid => $_getIZ(4);
   @$pb.TagNumber(5)
-  set pid($core.int v) { $_setSignedInt32(4, v); }
+  set pid($core.int v) {
+    $_setSignedInt32(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasPid() => $_has(4);
   @$pb.TagNumber(5)
@@ -213,7 +237,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get uptimeSeconds => $_getI64(5);
   @$pb.TagNumber(6)
-  set uptimeSeconds($fixnum.Int64 v) { $_setInt64(5, v); }
+  set uptimeSeconds($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasUptimeSeconds() => $_has(5);
   @$pb.TagNumber(6)
@@ -222,7 +249,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.int get chainLayer => $_getIZ(6);
   @$pb.TagNumber(7)
-  set chainLayer($core.int v) { $_setSignedInt32(6, v); }
+  set chainLayer($core.int v) {
+    $_setSignedInt32(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasChainLayer() => $_has(6);
   @$pb.TagNumber(7)
@@ -231,7 +261,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.int get port => $_getIZ(7);
   @$pb.TagNumber(8)
-  set port($core.int v) { $_setSignedInt32(7, v); }
+  set port($core.int v) {
+    $_setSignedInt32(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasPort() => $_has(7);
   @$pb.TagNumber(8)
@@ -240,7 +273,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.String get error => $_getSZ(8);
   @$pb.TagNumber(9)
-  set error($core.String v) { $_setString(8, v); }
+  set error($core.String v) {
+    $_setString(8, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasError() => $_has(8);
   @$pb.TagNumber(9)
@@ -249,7 +285,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.bool get connected => $_getBF(9);
   @$pb.TagNumber(10)
-  set connected($core.bool v) { $_setBool(9, v); }
+  set connected($core.bool v) {
+    $_setBool(9, v);
+  }
+
   @$pb.TagNumber(10)
   $core.bool hasConnected() => $_has(9);
   @$pb.TagNumber(10)
@@ -258,7 +297,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $core.String get startupError => $_getSZ(10);
   @$pb.TagNumber(11)
-  set startupError($core.String v) { $_setString(10, v); }
+  set startupError($core.String v) {
+    $_setString(10, v);
+  }
+
   @$pb.TagNumber(11)
   $core.bool hasStartupError() => $_has(10);
   @$pb.TagNumber(11)
@@ -267,7 +309,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $core.String get connectionError => $_getSZ(11);
   @$pb.TagNumber(12)
-  set connectionError($core.String v) { $_setString(11, v); }
+  set connectionError($core.String v) {
+    $_setString(11, v);
+  }
+
   @$pb.TagNumber(12)
   $core.bool hasConnectionError() => $_has(11);
   @$pb.TagNumber(12)
@@ -276,7 +321,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(13)
   $core.bool get stopping => $_getBF(12);
   @$pb.TagNumber(13)
-  set stopping($core.bool v) { $_setBool(12, v); }
+  set stopping($core.bool v) {
+    $_setBool(12, v);
+  }
+
   @$pb.TagNumber(13)
   $core.bool hasStopping() => $_has(12);
   @$pb.TagNumber(13)
@@ -285,7 +333,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(14)
   $core.bool get initializing => $_getBF(13);
   @$pb.TagNumber(14)
-  set initializing($core.bool v) { $_setBool(13, v); }
+  set initializing($core.bool v) {
+    $_setBool(13, v);
+  }
+
   @$pb.TagNumber(14)
   $core.bool hasInitializing() => $_has(13);
   @$pb.TagNumber(14)
@@ -294,7 +345,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(15)
   $core.bool get connectModeOnly => $_getBF(14);
   @$pb.TagNumber(15)
-  set connectModeOnly($core.bool v) { $_setBool(14, v); }
+  set connectModeOnly($core.bool v) {
+    $_setBool(14, v);
+  }
+
   @$pb.TagNumber(15)
   $core.bool hasConnectModeOnly() => $_has(14);
   @$pb.TagNumber(15)
@@ -303,7 +357,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(16)
   $core.bool get downloadable => $_getBF(15);
   @$pb.TagNumber(16)
-  set downloadable($core.bool v) { $_setBool(15, v); }
+  set downloadable($core.bool v) {
+    $_setBool(15, v);
+  }
+
   @$pb.TagNumber(16)
   $core.bool hasDownloadable() => $_has(15);
   @$pb.TagNumber(16)
@@ -312,7 +369,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(17)
   $core.String get description => $_getSZ(16);
   @$pb.TagNumber(17)
-  set description($core.String v) { $_setString(16, v); }
+  set description($core.String v) {
+    $_setString(16, v);
+  }
+
   @$pb.TagNumber(17)
   $core.bool hasDescription() => $_has(16);
   @$pb.TagNumber(17)
@@ -321,7 +381,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(18)
   $core.bool get downloaded => $_getBF(17);
   @$pb.TagNumber(18)
-  set downloaded($core.bool v) { $_setBool(17, v); }
+  set downloaded($core.bool v) {
+    $_setBool(17, v);
+  }
+
   @$pb.TagNumber(18)
   $core.bool hasDownloaded() => $_has(17);
   @$pb.TagNumber(18)
@@ -330,7 +393,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(19)
   $core.bool get portInUse => $_getBF(18);
   @$pb.TagNumber(19)
-  set portInUse($core.bool v) { $_setBool(18, v); }
+  set portInUse($core.bool v) {
+    $_setBool(18, v);
+  }
+
   @$pb.TagNumber(19)
   $core.bool hasPortInUse() => $_has(18);
   @$pb.TagNumber(19)
@@ -339,7 +405,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(20)
   $core.String get version => $_getSZ(19);
   @$pb.TagNumber(20)
-  set version($core.String v) { $_setString(19, v); }
+  set version($core.String v) {
+    $_setString(19, v);
+  }
+
   @$pb.TagNumber(20)
   $core.bool hasVersion() => $_has(19);
   @$pb.TagNumber(20)
@@ -348,7 +417,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(21)
   $core.String get repoUrl => $_getSZ(20);
   @$pb.TagNumber(21)
-  set repoUrl($core.String v) { $_setString(20, v); }
+  set repoUrl($core.String v) {
+    $_setString(20, v);
+  }
+
   @$pb.TagNumber(21)
   $core.bool hasRepoUrl() => $_has(20);
   @$pb.TagNumber(21)
@@ -363,11 +435,198 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(23)
   $core.String get binaryPath => $_getSZ(22);
   @$pb.TagNumber(23)
-  set binaryPath($core.String v) { $_setString(22, v); }
+  set binaryPath($core.String v) {
+    $_setString(22, v);
+  }
+
   @$pb.TagNumber(23)
   $core.bool hasBinaryPath() => $_has(22);
   @$pb.TagNumber(23)
   void clearBinaryPath() => clearField(23);
+
+  /// Live blockchain sync state for chain-layer 1 binaries (bitcoind, enforcer).
+  /// Populated from the orchestrator's existing health-check getblockchaininfo
+  /// poll, so the frontend never has to make its own RPC call to read sync
+  /// state. Nil/zero for non-L1 binaries or before the first successful poll.
+  @$pb.TagNumber(24)
+  BlockchainSyncMsg get blockchainSync => $_getN(23);
+  @$pb.TagNumber(24)
+  set blockchainSync(BlockchainSyncMsg v) {
+    setField(24, v);
+  }
+
+  @$pb.TagNumber(24)
+  $core.bool hasBlockchainSync() => $_has(23);
+  @$pb.TagNumber(24)
+  void clearBlockchainSync() => clearField(24);
+  @$pb.TagNumber(24)
+  BlockchainSyncMsg ensureBlockchainSync() => $_ensure(23);
+}
+
+/// BlockchainSyncMsg snapshots the chain tip + IBD state for an L1 binary.
+/// Filled in by the orchestrator after each successful getblockchaininfo poll
+/// and pushed to the frontend via WatchBinaries.
+class BlockchainSyncMsg extends $pb.GeneratedMessage {
+  factory BlockchainSyncMsg({
+    $core.int? blocks,
+    $core.int? headers,
+    $core.double? verificationProgress,
+    $core.bool? initialBlockDownload,
+    $core.bool? inHeaderSync,
+    $fixnum.Int64? time,
+    $core.String? bestBlockHash,
+  }) {
+    final $result = create();
+    if (blocks != null) {
+      $result.blocks = blocks;
+    }
+    if (headers != null) {
+      $result.headers = headers;
+    }
+    if (verificationProgress != null) {
+      $result.verificationProgress = verificationProgress;
+    }
+    if (initialBlockDownload != null) {
+      $result.initialBlockDownload = initialBlockDownload;
+    }
+    if (inHeaderSync != null) {
+      $result.inHeaderSync = inHeaderSync;
+    }
+    if (time != null) {
+      $result.time = time;
+    }
+    if (bestBlockHash != null) {
+      $result.bestBlockHash = bestBlockHash;
+    }
+    return $result;
+  }
+  BlockchainSyncMsg._() : super();
+  factory BlockchainSyncMsg.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory BlockchainSyncMsg.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BlockchainSyncMsg',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'blocks', $pb.PbFieldType.O3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'headers', $pb.PbFieldType.O3)
+    ..a<$core.double>(3, _omitFieldNames ? '' : 'verificationProgress', $pb.PbFieldType.OD)
+    ..aOB(4, _omitFieldNames ? '' : 'initialBlockDownload')
+    ..aOB(5, _omitFieldNames ? '' : 'inHeaderSync')
+    ..aInt64(6, _omitFieldNames ? '' : 'time')
+    ..aOS(7, _omitFieldNames ? '' : 'bestBlockHash')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  BlockchainSyncMsg clone() => BlockchainSyncMsg()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  BlockchainSyncMsg copyWith(void Function(BlockchainSyncMsg) updates) =>
+      super.copyWith((message) => updates(message as BlockchainSyncMsg)) as BlockchainSyncMsg;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BlockchainSyncMsg create() => BlockchainSyncMsg._();
+  BlockchainSyncMsg createEmptyInstance() => create();
+  static $pb.PbList<BlockchainSyncMsg> createRepeated() => $pb.PbList<BlockchainSyncMsg>();
+  @$core.pragma('dart2js:noInline')
+  static BlockchainSyncMsg getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BlockchainSyncMsg>(create);
+  static BlockchainSyncMsg? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get blocks => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set blocks($core.int v) {
+    $_setSignedInt32(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasBlocks() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearBlocks() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get headers => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set headers($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasHeaders() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearHeaders() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.double get verificationProgress => $_getN(2);
+  @$pb.TagNumber(3)
+  set verificationProgress($core.double v) {
+    $_setDouble(2, v);
+  }
+
+  @$pb.TagNumber(3)
+  $core.bool hasVerificationProgress() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearVerificationProgress() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.bool get initialBlockDownload => $_getBF(3);
+  @$pb.TagNumber(4)
+  set initialBlockDownload($core.bool v) {
+    $_setBool(3, v);
+  }
+
+  @$pb.TagNumber(4)
+  $core.bool hasInitialBlockDownload() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearInitialBlockDownload() => clearField(4);
+
+  /// True while the node is still bootstrapping headers (headers count too low
+  /// to have meaningful sync info). Frontend uses this to gate "waiting for
+  /// headers" UI without doing its own threshold math.
+  @$pb.TagNumber(5)
+  $core.bool get inHeaderSync => $_getBF(4);
+  @$pb.TagNumber(5)
+  set inHeaderSync($core.bool v) {
+    $_setBool(4, v);
+  }
+
+  @$pb.TagNumber(5)
+  $core.bool hasInHeaderSync() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearInHeaderSync() => clearField(5);
+
+  /// Block tip timestamp (unix seconds), 0 when no tip yet.
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get time => $_getI64(5);
+  @$pb.TagNumber(6)
+  set time($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
+  @$pb.TagNumber(6)
+  $core.bool hasTime() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearTime() => clearField(6);
+
+  /// Best block hash at the tip — empty before the first poll.
+  @$pb.TagNumber(7)
+  $core.String get bestBlockHash => $_getSZ(6);
+  @$pb.TagNumber(7)
+  set bestBlockHash($core.String v) {
+    $_setString(6, v);
+  }
+
+  @$pb.TagNumber(7)
+  $core.bool hasBestBlockHash() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearBestBlockHash() => clearField(7);
 }
 
 class StartupLogEntryMsg extends $pb.GeneratedMessage {
@@ -385,25 +644,27 @@ class StartupLogEntryMsg extends $pb.GeneratedMessage {
     return $result;
   }
   StartupLogEntryMsg._() : super();
-  factory StartupLogEntryMsg.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StartupLogEntryMsg.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory StartupLogEntryMsg.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StartupLogEntryMsg.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartupLogEntryMsg', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartupLogEntryMsg',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'timestampUnix')
     ..aOS(2, _omitFieldNames ? '' : 'message')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   StartupLogEntryMsg clone() => StartupLogEntryMsg()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StartupLogEntryMsg copyWith(void Function(StartupLogEntryMsg) updates) => super.copyWith((message) => updates(message as StartupLogEntryMsg)) as StartupLogEntryMsg;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StartupLogEntryMsg copyWith(void Function(StartupLogEntryMsg) updates) =>
+      super.copyWith((message) => updates(message as StartupLogEntryMsg)) as StartupLogEntryMsg;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -412,13 +673,17 @@ class StartupLogEntryMsg extends $pb.GeneratedMessage {
   StartupLogEntryMsg createEmptyInstance() => create();
   static $pb.PbList<StartupLogEntryMsg> createRepeated() => $pb.PbList<StartupLogEntryMsg>();
   @$core.pragma('dart2js:noInline')
-  static StartupLogEntryMsg getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartupLogEntryMsg>(create);
+  static StartupLogEntryMsg getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartupLogEntryMsg>(create);
   static StartupLogEntryMsg? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get timestampUnix => $_getI64(0);
   @$pb.TagNumber(1)
-  set timestampUnix($fixnum.Int64 v) { $_setInt64(0, v); }
+  set timestampUnix($fixnum.Int64 v) {
+    $_setInt64(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasTimestampUnix() => $_has(0);
   @$pb.TagNumber(1)
@@ -427,7 +692,10 @@ class StartupLogEntryMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get message => $_getSZ(1);
   @$pb.TagNumber(2)
-  set message($core.String v) { $_setString(1, v); }
+  set message($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasMessage() => $_has(1);
   @$pb.TagNumber(2)
@@ -437,23 +705,25 @@ class StartupLogEntryMsg extends $pb.GeneratedMessage {
 class ListBinariesRequest extends $pb.GeneratedMessage {
   factory ListBinariesRequest() => create();
   ListBinariesRequest._() : super();
-  factory ListBinariesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ListBinariesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory ListBinariesRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ListBinariesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBinariesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBinariesRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ListBinariesRequest clone() => ListBinariesRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ListBinariesRequest copyWith(void Function(ListBinariesRequest) updates) => super.copyWith((message) => updates(message as ListBinariesRequest)) as ListBinariesRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ListBinariesRequest copyWith(void Function(ListBinariesRequest) updates) =>
+      super.copyWith((message) => updates(message as ListBinariesRequest)) as ListBinariesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -462,7 +732,8 @@ class ListBinariesRequest extends $pb.GeneratedMessage {
   ListBinariesRequest createEmptyInstance() => create();
   static $pb.PbList<ListBinariesRequest> createRepeated() => $pb.PbList<ListBinariesRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListBinariesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBinariesRequest>(create);
+  static ListBinariesRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBinariesRequest>(create);
   static ListBinariesRequest? _defaultInstance;
 }
 
@@ -477,24 +748,26 @@ class ListBinariesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListBinariesResponse._() : super();
-  factory ListBinariesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ListBinariesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory ListBinariesResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ListBinariesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBinariesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBinariesResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..pc<BinaryStatusMsg>(1, _omitFieldNames ? '' : 'binaries', $pb.PbFieldType.PM, subBuilder: BinaryStatusMsg.create)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ListBinariesResponse clone() => ListBinariesResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ListBinariesResponse copyWith(void Function(ListBinariesResponse) updates) => super.copyWith((message) => updates(message as ListBinariesResponse)) as ListBinariesResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ListBinariesResponse copyWith(void Function(ListBinariesResponse) updates) =>
+      super.copyWith((message) => updates(message as ListBinariesResponse)) as ListBinariesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -503,7 +776,8 @@ class ListBinariesResponse extends $pb.GeneratedMessage {
   ListBinariesResponse createEmptyInstance() => create();
   static $pb.PbList<ListBinariesResponse> createRepeated() => $pb.PbList<ListBinariesResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListBinariesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBinariesResponse>(create);
+  static ListBinariesResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBinariesResponse>(create);
   static ListBinariesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -521,24 +795,26 @@ class GetBinaryStatusRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBinaryStatusRequest._() : super();
-  factory GetBinaryStatusRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetBinaryStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GetBinaryStatusRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetBinaryStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBinaryStatusRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBinaryStatusRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetBinaryStatusRequest clone() => GetBinaryStatusRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetBinaryStatusRequest copyWith(void Function(GetBinaryStatusRequest) updates) => super.copyWith((message) => updates(message as GetBinaryStatusRequest)) as GetBinaryStatusRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetBinaryStatusRequest copyWith(void Function(GetBinaryStatusRequest) updates) =>
+      super.copyWith((message) => updates(message as GetBinaryStatusRequest)) as GetBinaryStatusRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -547,13 +823,17 @@ class GetBinaryStatusRequest extends $pb.GeneratedMessage {
   GetBinaryStatusRequest createEmptyInstance() => create();
   static $pb.PbList<GetBinaryStatusRequest> createRepeated() => $pb.PbList<GetBinaryStatusRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBinaryStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBinaryStatusRequest>(create);
+  static GetBinaryStatusRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBinaryStatusRequest>(create);
   static GetBinaryStatusRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -571,24 +851,26 @@ class GetBinaryStatusResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBinaryStatusResponse._() : super();
-  factory GetBinaryStatusResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetBinaryStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GetBinaryStatusResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetBinaryStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBinaryStatusResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBinaryStatusResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOM<BinaryStatusMsg>(1, _omitFieldNames ? '' : 'status', subBuilder: BinaryStatusMsg.create)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetBinaryStatusResponse clone() => GetBinaryStatusResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetBinaryStatusResponse copyWith(void Function(GetBinaryStatusResponse) updates) => super.copyWith((message) => updates(message as GetBinaryStatusResponse)) as GetBinaryStatusResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetBinaryStatusResponse copyWith(void Function(GetBinaryStatusResponse) updates) =>
+      super.copyWith((message) => updates(message as GetBinaryStatusResponse)) as GetBinaryStatusResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -597,13 +879,17 @@ class GetBinaryStatusResponse extends $pb.GeneratedMessage {
   GetBinaryStatusResponse createEmptyInstance() => create();
   static $pb.PbList<GetBinaryStatusResponse> createRepeated() => $pb.PbList<GetBinaryStatusResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBinaryStatusResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBinaryStatusResponse>(create);
+  static GetBinaryStatusResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBinaryStatusResponse>(create);
   static GetBinaryStatusResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   BinaryStatusMsg get status => $_getN(0);
   @$pb.TagNumber(1)
-  set status(BinaryStatusMsg v) { setField(1, v); }
+  set status(BinaryStatusMsg v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasStatus() => $_has(0);
   @$pb.TagNumber(1)
@@ -627,25 +913,27 @@ class DownloadBinaryRequest extends $pb.GeneratedMessage {
     return $result;
   }
   DownloadBinaryRequest._() : super();
-  factory DownloadBinaryRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory DownloadBinaryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory DownloadBinaryRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory DownloadBinaryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DownloadBinaryRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DownloadBinaryRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOB(2, _omitFieldNames ? '' : 'force')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   DownloadBinaryRequest clone() => DownloadBinaryRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  DownloadBinaryRequest copyWith(void Function(DownloadBinaryRequest) updates) => super.copyWith((message) => updates(message as DownloadBinaryRequest)) as DownloadBinaryRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  DownloadBinaryRequest copyWith(void Function(DownloadBinaryRequest) updates) =>
+      super.copyWith((message) => updates(message as DownloadBinaryRequest)) as DownloadBinaryRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -654,13 +942,17 @@ class DownloadBinaryRequest extends $pb.GeneratedMessage {
   DownloadBinaryRequest createEmptyInstance() => create();
   static $pb.PbList<DownloadBinaryRequest> createRepeated() => $pb.PbList<DownloadBinaryRequest>();
   @$core.pragma('dart2js:noInline')
-  static DownloadBinaryRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DownloadBinaryRequest>(create);
+  static DownloadBinaryRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DownloadBinaryRequest>(create);
   static DownloadBinaryRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -669,7 +961,10 @@ class DownloadBinaryRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get force => $_getBF(1);
   @$pb.TagNumber(2)
-  set force($core.bool v) { $_setBool(1, v); }
+  set force($core.bool v) {
+    $_setBool(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasForce() => $_has(1);
   @$pb.TagNumber(2)
@@ -703,28 +998,30 @@ class DownloadBinaryResponse extends $pb.GeneratedMessage {
     return $result;
   }
   DownloadBinaryResponse._() : super();
-  factory DownloadBinaryResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory DownloadBinaryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory DownloadBinaryResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory DownloadBinaryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DownloadBinaryResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DownloadBinaryResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'bytesDownloaded')
     ..aInt64(2, _omitFieldNames ? '' : 'totalBytes')
     ..aOS(3, _omitFieldNames ? '' : 'message')
     ..aOB(4, _omitFieldNames ? '' : 'done')
     ..aOS(5, _omitFieldNames ? '' : 'error')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   DownloadBinaryResponse clone() => DownloadBinaryResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  DownloadBinaryResponse copyWith(void Function(DownloadBinaryResponse) updates) => super.copyWith((message) => updates(message as DownloadBinaryResponse)) as DownloadBinaryResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  DownloadBinaryResponse copyWith(void Function(DownloadBinaryResponse) updates) =>
+      super.copyWith((message) => updates(message as DownloadBinaryResponse)) as DownloadBinaryResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -733,13 +1030,17 @@ class DownloadBinaryResponse extends $pb.GeneratedMessage {
   DownloadBinaryResponse createEmptyInstance() => create();
   static $pb.PbList<DownloadBinaryResponse> createRepeated() => $pb.PbList<DownloadBinaryResponse>();
   @$core.pragma('dart2js:noInline')
-  static DownloadBinaryResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DownloadBinaryResponse>(create);
+  static DownloadBinaryResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DownloadBinaryResponse>(create);
   static DownloadBinaryResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get bytesDownloaded => $_getI64(0);
   @$pb.TagNumber(1)
-  set bytesDownloaded($fixnum.Int64 v) { $_setInt64(0, v); }
+  set bytesDownloaded($fixnum.Int64 v) {
+    $_setInt64(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasBytesDownloaded() => $_has(0);
   @$pb.TagNumber(1)
@@ -748,7 +1049,10 @@ class DownloadBinaryResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get totalBytes => $_getI64(1);
   @$pb.TagNumber(2)
-  set totalBytes($fixnum.Int64 v) { $_setInt64(1, v); }
+  set totalBytes($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasTotalBytes() => $_has(1);
   @$pb.TagNumber(2)
@@ -757,7 +1061,10 @@ class DownloadBinaryResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get message => $_getSZ(2);
   @$pb.TagNumber(3)
-  set message($core.String v) { $_setString(2, v); }
+  set message($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasMessage() => $_has(2);
   @$pb.TagNumber(3)
@@ -766,7 +1073,10 @@ class DownloadBinaryResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get done => $_getBF(3);
   @$pb.TagNumber(4)
-  set done($core.bool v) { $_setBool(3, v); }
+  set done($core.bool v) {
+    $_setBool(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasDone() => $_has(3);
   @$pb.TagNumber(4)
@@ -775,7 +1085,10 @@ class DownloadBinaryResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get error => $_getSZ(4);
   @$pb.TagNumber(5)
-  set error($core.String v) { $_setString(4, v); }
+  set error($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasError() => $_has(4);
   @$pb.TagNumber(5)
@@ -801,26 +1114,32 @@ class StartBinaryRequest extends $pb.GeneratedMessage {
     return $result;
   }
   StartBinaryRequest._() : super();
-  factory StartBinaryRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StartBinaryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory StartBinaryRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StartBinaryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartBinaryRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartBinaryRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..pPS(2, _omitFieldNames ? '' : 'extraArgs')
-    ..m<$core.String, $core.String>(3, _omitFieldNames ? '' : 'env', entryClassName: 'StartBinaryRequest.EnvEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS, packageName: const $pb.PackageName('orchestrator.v1'))
-    ..hasRequiredFields = false
-  ;
+    ..m<$core.String, $core.String>(3, _omitFieldNames ? '' : 'env',
+        entryClassName: 'StartBinaryRequest.EnvEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OS,
+        packageName: const $pb.PackageName('orchestrator.v1'))
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   StartBinaryRequest clone() => StartBinaryRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StartBinaryRequest copyWith(void Function(StartBinaryRequest) updates) => super.copyWith((message) => updates(message as StartBinaryRequest)) as StartBinaryRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StartBinaryRequest copyWith(void Function(StartBinaryRequest) updates) =>
+      super.copyWith((message) => updates(message as StartBinaryRequest)) as StartBinaryRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -829,13 +1148,17 @@ class StartBinaryRequest extends $pb.GeneratedMessage {
   StartBinaryRequest createEmptyInstance() => create();
   static $pb.PbList<StartBinaryRequest> createRepeated() => $pb.PbList<StartBinaryRequest>();
   @$core.pragma('dart2js:noInline')
-  static StartBinaryRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartBinaryRequest>(create);
+  static StartBinaryRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartBinaryRequest>(create);
   static StartBinaryRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -859,24 +1182,26 @@ class StartBinaryResponse extends $pb.GeneratedMessage {
     return $result;
   }
   StartBinaryResponse._() : super();
-  factory StartBinaryResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StartBinaryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory StartBinaryResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StartBinaryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartBinaryResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartBinaryResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'pid', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   StartBinaryResponse clone() => StartBinaryResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StartBinaryResponse copyWith(void Function(StartBinaryResponse) updates) => super.copyWith((message) => updates(message as StartBinaryResponse)) as StartBinaryResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StartBinaryResponse copyWith(void Function(StartBinaryResponse) updates) =>
+      super.copyWith((message) => updates(message as StartBinaryResponse)) as StartBinaryResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -885,13 +1210,17 @@ class StartBinaryResponse extends $pb.GeneratedMessage {
   StartBinaryResponse createEmptyInstance() => create();
   static $pb.PbList<StartBinaryResponse> createRepeated() => $pb.PbList<StartBinaryResponse>();
   @$core.pragma('dart2js:noInline')
-  static StartBinaryResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartBinaryResponse>(create);
+  static StartBinaryResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartBinaryResponse>(create);
   static StartBinaryResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get pid => $_getIZ(0);
   @$pb.TagNumber(1)
-  set pid($core.int v) { $_setSignedInt32(0, v); }
+  set pid($core.int v) {
+    $_setSignedInt32(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPid() => $_has(0);
   @$pb.TagNumber(1)
@@ -913,25 +1242,27 @@ class StopBinaryRequest extends $pb.GeneratedMessage {
     return $result;
   }
   StopBinaryRequest._() : super();
-  factory StopBinaryRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StopBinaryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory StopBinaryRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StopBinaryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopBinaryRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopBinaryRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOB(2, _omitFieldNames ? '' : 'force')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   StopBinaryRequest clone() => StopBinaryRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StopBinaryRequest copyWith(void Function(StopBinaryRequest) updates) => super.copyWith((message) => updates(message as StopBinaryRequest)) as StopBinaryRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StopBinaryRequest copyWith(void Function(StopBinaryRequest) updates) =>
+      super.copyWith((message) => updates(message as StopBinaryRequest)) as StopBinaryRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -940,13 +1271,17 @@ class StopBinaryRequest extends $pb.GeneratedMessage {
   StopBinaryRequest createEmptyInstance() => create();
   static $pb.PbList<StopBinaryRequest> createRepeated() => $pb.PbList<StopBinaryRequest>();
   @$core.pragma('dart2js:noInline')
-  static StopBinaryRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StopBinaryRequest>(create);
+  static StopBinaryRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StopBinaryRequest>(create);
   static StopBinaryRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -955,7 +1290,10 @@ class StopBinaryRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get force => $_getBF(1);
   @$pb.TagNumber(2)
-  set force($core.bool v) { $_setBool(1, v); }
+  set force($core.bool v) {
+    $_setBool(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasForce() => $_has(1);
   @$pb.TagNumber(2)
@@ -965,23 +1303,25 @@ class StopBinaryRequest extends $pb.GeneratedMessage {
 class StopBinaryResponse extends $pb.GeneratedMessage {
   factory StopBinaryResponse() => create();
   StopBinaryResponse._() : super();
-  factory StopBinaryResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StopBinaryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory StopBinaryResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StopBinaryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopBinaryResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopBinaryResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   StopBinaryResponse clone() => StopBinaryResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StopBinaryResponse copyWith(void Function(StopBinaryResponse) updates) => super.copyWith((message) => updates(message as StopBinaryResponse)) as StopBinaryResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StopBinaryResponse copyWith(void Function(StopBinaryResponse) updates) =>
+      super.copyWith((message) => updates(message as StopBinaryResponse)) as StopBinaryResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -990,30 +1330,33 @@ class StopBinaryResponse extends $pb.GeneratedMessage {
   StopBinaryResponse createEmptyInstance() => create();
   static $pb.PbList<StopBinaryResponse> createRepeated() => $pb.PbList<StopBinaryResponse>();
   @$core.pragma('dart2js:noInline')
-  static StopBinaryResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StopBinaryResponse>(create);
+  static StopBinaryResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StopBinaryResponse>(create);
   static StopBinaryResponse? _defaultInstance;
 }
 
 class WatchBinariesRequest extends $pb.GeneratedMessage {
   factory WatchBinariesRequest() => create();
   WatchBinariesRequest._() : super();
-  factory WatchBinariesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory WatchBinariesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory WatchBinariesRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory WatchBinariesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WatchBinariesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WatchBinariesRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   WatchBinariesRequest clone() => WatchBinariesRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  WatchBinariesRequest copyWith(void Function(WatchBinariesRequest) updates) => super.copyWith((message) => updates(message as WatchBinariesRequest)) as WatchBinariesRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  WatchBinariesRequest copyWith(void Function(WatchBinariesRequest) updates) =>
+      super.copyWith((message) => updates(message as WatchBinariesRequest)) as WatchBinariesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1022,7 +1365,8 @@ class WatchBinariesRequest extends $pb.GeneratedMessage {
   WatchBinariesRequest createEmptyInstance() => create();
   static $pb.PbList<WatchBinariesRequest> createRepeated() => $pb.PbList<WatchBinariesRequest>();
   @$core.pragma('dart2js:noInline')
-  static WatchBinariesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WatchBinariesRequest>(create);
+  static WatchBinariesRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WatchBinariesRequest>(create);
   static WatchBinariesRequest? _defaultInstance;
 }
 
@@ -1037,24 +1381,26 @@ class WatchBinariesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   WatchBinariesResponse._() : super();
-  factory WatchBinariesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory WatchBinariesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory WatchBinariesResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory WatchBinariesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WatchBinariesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WatchBinariesResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..pc<BinaryStatusMsg>(1, _omitFieldNames ? '' : 'binaries', $pb.PbFieldType.PM, subBuilder: BinaryStatusMsg.create)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   WatchBinariesResponse clone() => WatchBinariesResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  WatchBinariesResponse copyWith(void Function(WatchBinariesResponse) updates) => super.copyWith((message) => updates(message as WatchBinariesResponse)) as WatchBinariesResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  WatchBinariesResponse copyWith(void Function(WatchBinariesResponse) updates) =>
+      super.copyWith((message) => updates(message as WatchBinariesResponse)) as WatchBinariesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1063,7 +1409,8 @@ class WatchBinariesResponse extends $pb.GeneratedMessage {
   WatchBinariesResponse createEmptyInstance() => create();
   static $pb.PbList<WatchBinariesResponse> createRepeated() => $pb.PbList<WatchBinariesResponse>();
   @$core.pragma('dart2js:noInline')
-  static WatchBinariesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WatchBinariesResponse>(create);
+  static WatchBinariesResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WatchBinariesResponse>(create);
   static WatchBinariesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -1085,25 +1432,27 @@ class StreamLogsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   StreamLogsRequest._() : super();
-  factory StreamLogsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StreamLogsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory StreamLogsRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StreamLogsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamLogsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamLogsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'tail', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   StreamLogsRequest clone() => StreamLogsRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StreamLogsRequest copyWith(void Function(StreamLogsRequest) updates) => super.copyWith((message) => updates(message as StreamLogsRequest)) as StreamLogsRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StreamLogsRequest copyWith(void Function(StreamLogsRequest) updates) =>
+      super.copyWith((message) => updates(message as StreamLogsRequest)) as StreamLogsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1112,13 +1461,17 @@ class StreamLogsRequest extends $pb.GeneratedMessage {
   StreamLogsRequest createEmptyInstance() => create();
   static $pb.PbList<StreamLogsRequest> createRepeated() => $pb.PbList<StreamLogsRequest>();
   @$core.pragma('dart2js:noInline')
-  static StreamLogsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamLogsRequest>(create);
+  static StreamLogsRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamLogsRequest>(create);
   static StreamLogsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -1127,7 +1480,10 @@ class StreamLogsRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get tail => $_getIZ(1);
   @$pb.TagNumber(2)
-  set tail($core.int v) { $_setSignedInt32(1, v); }
+  set tail($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasTail() => $_has(1);
   @$pb.TagNumber(2)
@@ -1153,26 +1509,28 @@ class StreamLogsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   StreamLogsResponse._() : super();
-  factory StreamLogsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StreamLogsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory StreamLogsResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StreamLogsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamLogsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamLogsResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'stream')
     ..aOS(2, _omitFieldNames ? '' : 'line')
     ..aInt64(3, _omitFieldNames ? '' : 'timestampUnix')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   StreamLogsResponse clone() => StreamLogsResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StreamLogsResponse copyWith(void Function(StreamLogsResponse) updates) => super.copyWith((message) => updates(message as StreamLogsResponse)) as StreamLogsResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StreamLogsResponse copyWith(void Function(StreamLogsResponse) updates) =>
+      super.copyWith((message) => updates(message as StreamLogsResponse)) as StreamLogsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1181,13 +1539,17 @@ class StreamLogsResponse extends $pb.GeneratedMessage {
   StreamLogsResponse createEmptyInstance() => create();
   static $pb.PbList<StreamLogsResponse> createRepeated() => $pb.PbList<StreamLogsResponse>();
   @$core.pragma('dart2js:noInline')
-  static StreamLogsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamLogsResponse>(create);
+  static StreamLogsResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamLogsResponse>(create);
   static StreamLogsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get stream => $_getSZ(0);
   @$pb.TagNumber(1)
-  set stream($core.String v) { $_setString(0, v); }
+  set stream($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasStream() => $_has(0);
   @$pb.TagNumber(1)
@@ -1196,7 +1558,10 @@ class StreamLogsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get line => $_getSZ(1);
   @$pb.TagNumber(2)
-  set line($core.String v) { $_setString(1, v); }
+  set line($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLine() => $_has(1);
   @$pb.TagNumber(2)
@@ -1205,7 +1570,10 @@ class StreamLogsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get timestampUnix => $_getI64(2);
   @$pb.TagNumber(3)
-  set timestampUnix($fixnum.Int64 v) { $_setInt64(2, v); }
+  set timestampUnix($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasTimestampUnix() => $_has(2);
   @$pb.TagNumber(3)
@@ -1243,29 +1611,35 @@ class StartWithL1Request extends $pb.GeneratedMessage {
     return $result;
   }
   StartWithL1Request._() : super();
-  factory StartWithL1Request.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StartWithL1Request.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory StartWithL1Request.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StartWithL1Request.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartWithL1Request', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartWithL1Request',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'target')
     ..pPS(2, _omitFieldNames ? '' : 'targetArgs')
-    ..m<$core.String, $core.String>(3, _omitFieldNames ? '' : 'targetEnv', entryClassName: 'StartWithL1Request.TargetEnvEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS, packageName: const $pb.PackageName('orchestrator.v1'))
+    ..m<$core.String, $core.String>(3, _omitFieldNames ? '' : 'targetEnv',
+        entryClassName: 'StartWithL1Request.TargetEnvEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OS,
+        packageName: const $pb.PackageName('orchestrator.v1'))
     ..pPS(4, _omitFieldNames ? '' : 'coreArgs')
     ..pPS(5, _omitFieldNames ? '' : 'enforcerArgs')
     ..aOB(6, _omitFieldNames ? '' : 'immediate')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   StartWithL1Request clone() => StartWithL1Request()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StartWithL1Request copyWith(void Function(StartWithL1Request) updates) => super.copyWith((message) => updates(message as StartWithL1Request)) as StartWithL1Request;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StartWithL1Request copyWith(void Function(StartWithL1Request) updates) =>
+      super.copyWith((message) => updates(message as StartWithL1Request)) as StartWithL1Request;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1274,13 +1648,17 @@ class StartWithL1Request extends $pb.GeneratedMessage {
   StartWithL1Request createEmptyInstance() => create();
   static $pb.PbList<StartWithL1Request> createRepeated() => $pb.PbList<StartWithL1Request>();
   @$core.pragma('dart2js:noInline')
-  static StartWithL1Request getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartWithL1Request>(create);
+  static StartWithL1Request getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartWithL1Request>(create);
   static StartWithL1Request? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get target => $_getSZ(0);
   @$pb.TagNumber(1)
-  set target($core.String v) { $_setString(0, v); }
+  set target($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasTarget() => $_has(0);
   @$pb.TagNumber(1)
@@ -1301,7 +1679,10 @@ class StartWithL1Request extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.bool get immediate => $_getBF(5);
   @$pb.TagNumber(6)
-  set immediate($core.bool v) { $_setBool(5, v); }
+  set immediate($core.bool v) {
+    $_setBool(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasImmediate() => $_has(5);
   @$pb.TagNumber(6)
@@ -1339,29 +1720,31 @@ class StartWithL1Response extends $pb.GeneratedMessage {
     return $result;
   }
   StartWithL1Response._() : super();
-  factory StartWithL1Response.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StartWithL1Response.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory StartWithL1Response.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StartWithL1Response.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartWithL1Response', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartWithL1Response',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'stage')
     ..aOS(2, _omitFieldNames ? '' : 'message')
     ..aOB(3, _omitFieldNames ? '' : 'done')
     ..aOS(4, _omitFieldNames ? '' : 'error')
     ..aInt64(5, _omitFieldNames ? '' : 'bytesDownloaded')
     ..aInt64(6, _omitFieldNames ? '' : 'totalBytes')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   StartWithL1Response clone() => StartWithL1Response()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StartWithL1Response copyWith(void Function(StartWithL1Response) updates) => super.copyWith((message) => updates(message as StartWithL1Response)) as StartWithL1Response;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StartWithL1Response copyWith(void Function(StartWithL1Response) updates) =>
+      super.copyWith((message) => updates(message as StartWithL1Response)) as StartWithL1Response;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1370,13 +1753,17 @@ class StartWithL1Response extends $pb.GeneratedMessage {
   StartWithL1Response createEmptyInstance() => create();
   static $pb.PbList<StartWithL1Response> createRepeated() => $pb.PbList<StartWithL1Response>();
   @$core.pragma('dart2js:noInline')
-  static StartWithL1Response getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartWithL1Response>(create);
+  static StartWithL1Response getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartWithL1Response>(create);
   static StartWithL1Response? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get stage => $_getSZ(0);
   @$pb.TagNumber(1)
-  set stage($core.String v) { $_setString(0, v); }
+  set stage($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasStage() => $_has(0);
   @$pb.TagNumber(1)
@@ -1385,7 +1772,10 @@ class StartWithL1Response extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get message => $_getSZ(1);
   @$pb.TagNumber(2)
-  set message($core.String v) { $_setString(1, v); }
+  set message($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasMessage() => $_has(1);
   @$pb.TagNumber(2)
@@ -1394,7 +1784,10 @@ class StartWithL1Response extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get done => $_getBF(2);
   @$pb.TagNumber(3)
-  set done($core.bool v) { $_setBool(2, v); }
+  set done($core.bool v) {
+    $_setBool(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasDone() => $_has(2);
   @$pb.TagNumber(3)
@@ -1403,7 +1796,10 @@ class StartWithL1Response extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get error => $_getSZ(3);
   @$pb.TagNumber(4)
-  set error($core.String v) { $_setString(3, v); }
+  set error($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasError() => $_has(3);
   @$pb.TagNumber(4)
@@ -1412,7 +1808,10 @@ class StartWithL1Response extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get bytesDownloaded => $_getI64(4);
   @$pb.TagNumber(5)
-  set bytesDownloaded($fixnum.Int64 v) { $_setInt64(4, v); }
+  set bytesDownloaded($fixnum.Int64 v) {
+    $_setInt64(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasBytesDownloaded() => $_has(4);
   @$pb.TagNumber(5)
@@ -1421,7 +1820,10 @@ class StartWithL1Response extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get totalBytes => $_getI64(5);
   @$pb.TagNumber(6)
-  set totalBytes($fixnum.Int64 v) { $_setInt64(5, v); }
+  set totalBytes($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasTotalBytes() => $_has(5);
   @$pb.TagNumber(6)
@@ -1439,24 +1841,26 @@ class ShutdownAllRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ShutdownAllRequest._() : super();
-  factory ShutdownAllRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ShutdownAllRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory ShutdownAllRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ShutdownAllRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShutdownAllRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShutdownAllRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'force')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ShutdownAllRequest clone() => ShutdownAllRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ShutdownAllRequest copyWith(void Function(ShutdownAllRequest) updates) => super.copyWith((message) => updates(message as ShutdownAllRequest)) as ShutdownAllRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ShutdownAllRequest copyWith(void Function(ShutdownAllRequest) updates) =>
+      super.copyWith((message) => updates(message as ShutdownAllRequest)) as ShutdownAllRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1465,13 +1869,17 @@ class ShutdownAllRequest extends $pb.GeneratedMessage {
   ShutdownAllRequest createEmptyInstance() => create();
   static $pb.PbList<ShutdownAllRequest> createRepeated() => $pb.PbList<ShutdownAllRequest>();
   @$core.pragma('dart2js:noInline')
-  static ShutdownAllRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShutdownAllRequest>(create);
+  static ShutdownAllRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShutdownAllRequest>(create);
   static ShutdownAllRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get force => $_getBF(0);
   @$pb.TagNumber(1)
-  set force($core.bool v) { $_setBool(0, v); }
+  set force($core.bool v) {
+    $_setBool(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasForce() => $_has(0);
   @$pb.TagNumber(1)
@@ -1505,28 +1913,30 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ShutdownAllResponse._() : super();
-  factory ShutdownAllResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ShutdownAllResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory ShutdownAllResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ShutdownAllResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShutdownAllResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShutdownAllResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'totalCount', $pb.PbFieldType.O3)
     ..a<$core.int>(2, _omitFieldNames ? '' : 'completedCount', $pb.PbFieldType.O3)
     ..aOS(3, _omitFieldNames ? '' : 'currentBinary')
     ..aOB(4, _omitFieldNames ? '' : 'done')
     ..aOS(5, _omitFieldNames ? '' : 'error')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ShutdownAllResponse clone() => ShutdownAllResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ShutdownAllResponse copyWith(void Function(ShutdownAllResponse) updates) => super.copyWith((message) => updates(message as ShutdownAllResponse)) as ShutdownAllResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ShutdownAllResponse copyWith(void Function(ShutdownAllResponse) updates) =>
+      super.copyWith((message) => updates(message as ShutdownAllResponse)) as ShutdownAllResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1535,13 +1945,17 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
   ShutdownAllResponse createEmptyInstance() => create();
   static $pb.PbList<ShutdownAllResponse> createRepeated() => $pb.PbList<ShutdownAllResponse>();
   @$core.pragma('dart2js:noInline')
-  static ShutdownAllResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShutdownAllResponse>(create);
+  static ShutdownAllResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShutdownAllResponse>(create);
   static ShutdownAllResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get totalCount => $_getIZ(0);
   @$pb.TagNumber(1)
-  set totalCount($core.int v) { $_setSignedInt32(0, v); }
+  set totalCount($core.int v) {
+    $_setSignedInt32(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasTotalCount() => $_has(0);
   @$pb.TagNumber(1)
@@ -1550,7 +1964,10 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get completedCount => $_getIZ(1);
   @$pb.TagNumber(2)
-  set completedCount($core.int v) { $_setSignedInt32(1, v); }
+  set completedCount($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasCompletedCount() => $_has(1);
   @$pb.TagNumber(2)
@@ -1559,7 +1976,10 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get currentBinary => $_getSZ(2);
   @$pb.TagNumber(3)
-  set currentBinary($core.String v) { $_setString(2, v); }
+  set currentBinary($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasCurrentBinary() => $_has(2);
   @$pb.TagNumber(3)
@@ -1568,7 +1988,10 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get done => $_getBF(3);
   @$pb.TagNumber(4)
-  set done($core.bool v) { $_setBool(3, v); }
+  set done($core.bool v) {
+    $_setBool(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasDone() => $_has(3);
   @$pb.TagNumber(4)
@@ -1577,7 +2000,10 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get error => $_getSZ(4);
   @$pb.TagNumber(5)
-  set error($core.String v) { $_setString(4, v); }
+  set error($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasError() => $_has(4);
   @$pb.TagNumber(5)
@@ -1587,23 +2013,25 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
 class GetBTCPriceRequest extends $pb.GeneratedMessage {
   factory GetBTCPriceRequest() => create();
   GetBTCPriceRequest._() : super();
-  factory GetBTCPriceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetBTCPriceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GetBTCPriceRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetBTCPriceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBTCPriceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBTCPriceRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetBTCPriceRequest clone() => GetBTCPriceRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetBTCPriceRequest copyWith(void Function(GetBTCPriceRequest) updates) => super.copyWith((message) => updates(message as GetBTCPriceRequest)) as GetBTCPriceRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetBTCPriceRequest copyWith(void Function(GetBTCPriceRequest) updates) =>
+      super.copyWith((message) => updates(message as GetBTCPriceRequest)) as GetBTCPriceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1612,7 +2040,8 @@ class GetBTCPriceRequest extends $pb.GeneratedMessage {
   GetBTCPriceRequest createEmptyInstance() => create();
   static $pb.PbList<GetBTCPriceRequest> createRepeated() => $pb.PbList<GetBTCPriceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBTCPriceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBTCPriceRequest>(create);
+  static GetBTCPriceRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBTCPriceRequest>(create);
   static GetBTCPriceRequest? _defaultInstance;
 }
 
@@ -1631,25 +2060,27 @@ class GetBTCPriceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBTCPriceResponse._() : super();
-  factory GetBTCPriceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetBTCPriceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GetBTCPriceResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetBTCPriceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBTCPriceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBTCPriceResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.double>(1, _omitFieldNames ? '' : 'btcusd', $pb.PbFieldType.OD)
     ..aInt64(2, _omitFieldNames ? '' : 'lastUpdatedUnix')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetBTCPriceResponse clone() => GetBTCPriceResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetBTCPriceResponse copyWith(void Function(GetBTCPriceResponse) updates) => super.copyWith((message) => updates(message as GetBTCPriceResponse)) as GetBTCPriceResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetBTCPriceResponse copyWith(void Function(GetBTCPriceResponse) updates) =>
+      super.copyWith((message) => updates(message as GetBTCPriceResponse)) as GetBTCPriceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1658,13 +2089,17 @@ class GetBTCPriceResponse extends $pb.GeneratedMessage {
   GetBTCPriceResponse createEmptyInstance() => create();
   static $pb.PbList<GetBTCPriceResponse> createRepeated() => $pb.PbList<GetBTCPriceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBTCPriceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBTCPriceResponse>(create);
+  static GetBTCPriceResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBTCPriceResponse>(create);
   static GetBTCPriceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.double get btcusd => $_getN(0);
   @$pb.TagNumber(1)
-  set btcusd($core.double v) { $_setDouble(0, v); }
+  set btcusd($core.double v) {
+    $_setDouble(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasBtcusd() => $_has(0);
   @$pb.TagNumber(1)
@@ -1673,7 +2108,10 @@ class GetBTCPriceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get lastUpdatedUnix => $_getI64(1);
   @$pb.TagNumber(2)
-  set lastUpdatedUnix($fixnum.Int64 v) { $_setInt64(1, v); }
+  set lastUpdatedUnix($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLastUpdatedUnix() => $_has(1);
   @$pb.TagNumber(2)
@@ -1683,32 +2121,38 @@ class GetBTCPriceResponse extends $pb.GeneratedMessage {
 class GetMainchainBlockchainInfoRequest extends $pb.GeneratedMessage {
   factory GetMainchainBlockchainInfoRequest() => create();
   GetMainchainBlockchainInfoRequest._() : super();
-  factory GetMainchainBlockchainInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetMainchainBlockchainInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GetMainchainBlockchainInfoRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetMainchainBlockchainInfoRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBlockchainInfoRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBlockchainInfoRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetMainchainBlockchainInfoRequest clone() => GetMainchainBlockchainInfoRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetMainchainBlockchainInfoRequest copyWith(void Function(GetMainchainBlockchainInfoRequest) updates) => super.copyWith((message) => updates(message as GetMainchainBlockchainInfoRequest)) as GetMainchainBlockchainInfoRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetMainchainBlockchainInfoRequest copyWith(void Function(GetMainchainBlockchainInfoRequest) updates) =>
+      super.copyWith((message) => updates(message as GetMainchainBlockchainInfoRequest))
+          as GetMainchainBlockchainInfoRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetMainchainBlockchainInfoRequest create() => GetMainchainBlockchainInfoRequest._();
   GetMainchainBlockchainInfoRequest createEmptyInstance() => create();
-  static $pb.PbList<GetMainchainBlockchainInfoRequest> createRepeated() => $pb.PbList<GetMainchainBlockchainInfoRequest>();
+  static $pb.PbList<GetMainchainBlockchainInfoRequest> createRepeated() =>
+      $pb.PbList<GetMainchainBlockchainInfoRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetMainchainBlockchainInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBlockchainInfoRequest>(create);
+  static GetMainchainBlockchainInfoRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBlockchainInfoRequest>(create);
   static GetMainchainBlockchainInfoRequest? _defaultInstance;
 }
 
@@ -1767,10 +2211,15 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetMainchainBlockchainInfoResponse._() : super();
-  factory GetMainchainBlockchainInfoResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetMainchainBlockchainInfoResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GetMainchainBlockchainInfoResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetMainchainBlockchainInfoResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBlockchainInfoResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBlockchainInfoResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'chain')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'blocks', $pb.PbFieldType.O3)
     ..a<$core.int>(3, _omitFieldNames ? '' : 'headers', $pb.PbFieldType.O3)
@@ -1783,34 +2232,38 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
     ..aOS(10, _omitFieldNames ? '' : 'chainWork')
     ..aInt64(11, _omitFieldNames ? '' : 'sizeOnDisk')
     ..aOB(12, _omitFieldNames ? '' : 'pruned')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetMainchainBlockchainInfoResponse clone() => GetMainchainBlockchainInfoResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetMainchainBlockchainInfoResponse copyWith(void Function(GetMainchainBlockchainInfoResponse) updates) => super.copyWith((message) => updates(message as GetMainchainBlockchainInfoResponse)) as GetMainchainBlockchainInfoResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetMainchainBlockchainInfoResponse copyWith(void Function(GetMainchainBlockchainInfoResponse) updates) =>
+      super.copyWith((message) => updates(message as GetMainchainBlockchainInfoResponse))
+          as GetMainchainBlockchainInfoResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetMainchainBlockchainInfoResponse create() => GetMainchainBlockchainInfoResponse._();
   GetMainchainBlockchainInfoResponse createEmptyInstance() => create();
-  static $pb.PbList<GetMainchainBlockchainInfoResponse> createRepeated() => $pb.PbList<GetMainchainBlockchainInfoResponse>();
+  static $pb.PbList<GetMainchainBlockchainInfoResponse> createRepeated() =>
+      $pb.PbList<GetMainchainBlockchainInfoResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetMainchainBlockchainInfoResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBlockchainInfoResponse>(create);
+  static GetMainchainBlockchainInfoResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBlockchainInfoResponse>(create);
   static GetMainchainBlockchainInfoResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get chain => $_getSZ(0);
   @$pb.TagNumber(1)
-  set chain($core.String v) { $_setString(0, v); }
+  set chain($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasChain() => $_has(0);
   @$pb.TagNumber(1)
@@ -1819,7 +2272,10 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get blocks => $_getIZ(1);
   @$pb.TagNumber(2)
-  set blocks($core.int v) { $_setSignedInt32(1, v); }
+  set blocks($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasBlocks() => $_has(1);
   @$pb.TagNumber(2)
@@ -1828,7 +2284,10 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get headers => $_getIZ(2);
   @$pb.TagNumber(3)
-  set headers($core.int v) { $_setSignedInt32(2, v); }
+  set headers($core.int v) {
+    $_setSignedInt32(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasHeaders() => $_has(2);
   @$pb.TagNumber(3)
@@ -1837,7 +2296,10 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get bestBlockHash => $_getSZ(3);
   @$pb.TagNumber(4)
-  set bestBlockHash($core.String v) { $_setString(3, v); }
+  set bestBlockHash($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasBestBlockHash() => $_has(3);
   @$pb.TagNumber(4)
@@ -1846,7 +2308,10 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.double get difficulty => $_getN(4);
   @$pb.TagNumber(5)
-  set difficulty($core.double v) { $_setDouble(4, v); }
+  set difficulty($core.double v) {
+    $_setDouble(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasDifficulty() => $_has(4);
   @$pb.TagNumber(5)
@@ -1855,7 +2320,10 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get time => $_getI64(5);
   @$pb.TagNumber(6)
-  set time($fixnum.Int64 v) { $_setInt64(5, v); }
+  set time($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasTime() => $_has(5);
   @$pb.TagNumber(6)
@@ -1864,7 +2332,10 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get medianTime => $_getI64(6);
   @$pb.TagNumber(7)
-  set medianTime($fixnum.Int64 v) { $_setInt64(6, v); }
+  set medianTime($fixnum.Int64 v) {
+    $_setInt64(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasMedianTime() => $_has(6);
   @$pb.TagNumber(7)
@@ -1873,7 +2344,10 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.double get verificationProgress => $_getN(7);
   @$pb.TagNumber(8)
-  set verificationProgress($core.double v) { $_setDouble(7, v); }
+  set verificationProgress($core.double v) {
+    $_setDouble(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasVerificationProgress() => $_has(7);
   @$pb.TagNumber(8)
@@ -1882,7 +2356,10 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.bool get initialBlockDownload => $_getBF(8);
   @$pb.TagNumber(9)
-  set initialBlockDownload($core.bool v) { $_setBool(8, v); }
+  set initialBlockDownload($core.bool v) {
+    $_setBool(8, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasInitialBlockDownload() => $_has(8);
   @$pb.TagNumber(9)
@@ -1891,7 +2368,10 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.String get chainWork => $_getSZ(9);
   @$pb.TagNumber(10)
-  set chainWork($core.String v) { $_setString(9, v); }
+  set chainWork($core.String v) {
+    $_setString(9, v);
+  }
+
   @$pb.TagNumber(10)
   $core.bool hasChainWork() => $_has(9);
   @$pb.TagNumber(10)
@@ -1900,7 +2380,10 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $fixnum.Int64 get sizeOnDisk => $_getI64(10);
   @$pb.TagNumber(11)
-  set sizeOnDisk($fixnum.Int64 v) { $_setInt64(10, v); }
+  set sizeOnDisk($fixnum.Int64 v) {
+    $_setInt64(10, v);
+  }
+
   @$pb.TagNumber(11)
   $core.bool hasSizeOnDisk() => $_has(10);
   @$pb.TagNumber(11)
@@ -1909,7 +2392,10 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $core.bool get pruned => $_getBF(11);
   @$pb.TagNumber(12)
-  set pruned($core.bool v) { $_setBool(11, v); }
+  set pruned($core.bool v) {
+    $_setBool(11, v);
+  }
+
   @$pb.TagNumber(12)
   $core.bool hasPruned() => $_has(11);
   @$pb.TagNumber(12)
@@ -1919,32 +2405,38 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
 class GetEnforcerBlockchainInfoRequest extends $pb.GeneratedMessage {
   factory GetEnforcerBlockchainInfoRequest() => create();
   GetEnforcerBlockchainInfoRequest._() : super();
-  factory GetEnforcerBlockchainInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetEnforcerBlockchainInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GetEnforcerBlockchainInfoRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetEnforcerBlockchainInfoRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEnforcerBlockchainInfoRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEnforcerBlockchainInfoRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetEnforcerBlockchainInfoRequest clone() => GetEnforcerBlockchainInfoRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetEnforcerBlockchainInfoRequest copyWith(void Function(GetEnforcerBlockchainInfoRequest) updates) => super.copyWith((message) => updates(message as GetEnforcerBlockchainInfoRequest)) as GetEnforcerBlockchainInfoRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetEnforcerBlockchainInfoRequest copyWith(void Function(GetEnforcerBlockchainInfoRequest) updates) =>
+      super.copyWith((message) => updates(message as GetEnforcerBlockchainInfoRequest))
+          as GetEnforcerBlockchainInfoRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetEnforcerBlockchainInfoRequest create() => GetEnforcerBlockchainInfoRequest._();
   GetEnforcerBlockchainInfoRequest createEmptyInstance() => create();
-  static $pb.PbList<GetEnforcerBlockchainInfoRequest> createRepeated() => $pb.PbList<GetEnforcerBlockchainInfoRequest>();
+  static $pb.PbList<GetEnforcerBlockchainInfoRequest> createRepeated() =>
+      $pb.PbList<GetEnforcerBlockchainInfoRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetEnforcerBlockchainInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEnforcerBlockchainInfoRequest>(create);
+  static GetEnforcerBlockchainInfoRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEnforcerBlockchainInfoRequest>(create);
   static GetEnforcerBlockchainInfoRequest? _defaultInstance;
 }
 
@@ -1967,41 +2459,50 @@ class GetEnforcerBlockchainInfoResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetEnforcerBlockchainInfoResponse._() : super();
-  factory GetEnforcerBlockchainInfoResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetEnforcerBlockchainInfoResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GetEnforcerBlockchainInfoResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetEnforcerBlockchainInfoResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEnforcerBlockchainInfoResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEnforcerBlockchainInfoResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'blocks', $pb.PbFieldType.O3)
     ..a<$core.int>(2, _omitFieldNames ? '' : 'headers', $pb.PbFieldType.O3)
     ..aInt64(3, _omitFieldNames ? '' : 'time')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetEnforcerBlockchainInfoResponse clone() => GetEnforcerBlockchainInfoResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetEnforcerBlockchainInfoResponse copyWith(void Function(GetEnforcerBlockchainInfoResponse) updates) => super.copyWith((message) => updates(message as GetEnforcerBlockchainInfoResponse)) as GetEnforcerBlockchainInfoResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetEnforcerBlockchainInfoResponse copyWith(void Function(GetEnforcerBlockchainInfoResponse) updates) =>
+      super.copyWith((message) => updates(message as GetEnforcerBlockchainInfoResponse))
+          as GetEnforcerBlockchainInfoResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetEnforcerBlockchainInfoResponse create() => GetEnforcerBlockchainInfoResponse._();
   GetEnforcerBlockchainInfoResponse createEmptyInstance() => create();
-  static $pb.PbList<GetEnforcerBlockchainInfoResponse> createRepeated() => $pb.PbList<GetEnforcerBlockchainInfoResponse>();
+  static $pb.PbList<GetEnforcerBlockchainInfoResponse> createRepeated() =>
+      $pb.PbList<GetEnforcerBlockchainInfoResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetEnforcerBlockchainInfoResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEnforcerBlockchainInfoResponse>(create);
+  static GetEnforcerBlockchainInfoResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEnforcerBlockchainInfoResponse>(create);
   static GetEnforcerBlockchainInfoResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get blocks => $_getIZ(0);
   @$pb.TagNumber(1)
-  set blocks($core.int v) { $_setSignedInt32(0, v); }
+  set blocks($core.int v) {
+    $_setSignedInt32(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasBlocks() => $_has(0);
   @$pb.TagNumber(1)
@@ -2010,7 +2511,10 @@ class GetEnforcerBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get headers => $_getIZ(1);
   @$pb.TagNumber(2)
-  set headers($core.int v) { $_setSignedInt32(1, v); }
+  set headers($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasHeaders() => $_has(1);
   @$pb.TagNumber(2)
@@ -2019,7 +2523,10 @@ class GetEnforcerBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get time => $_getI64(2);
   @$pb.TagNumber(3)
-  set time($fixnum.Int64 v) { $_setInt64(2, v); }
+  set time($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasTime() => $_has(2);
   @$pb.TagNumber(3)
@@ -2029,23 +2536,26 @@ class GetEnforcerBlockchainInfoResponse extends $pb.GeneratedMessage {
 class GetMainchainBalanceRequest extends $pb.GeneratedMessage {
   factory GetMainchainBalanceRequest() => create();
   GetMainchainBalanceRequest._() : super();
-  factory GetMainchainBalanceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetMainchainBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GetMainchainBalanceRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetMainchainBalanceRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBalanceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBalanceRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetMainchainBalanceRequest clone() => GetMainchainBalanceRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetMainchainBalanceRequest copyWith(void Function(GetMainchainBalanceRequest) updates) => super.copyWith((message) => updates(message as GetMainchainBalanceRequest)) as GetMainchainBalanceRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetMainchainBalanceRequest copyWith(void Function(GetMainchainBalanceRequest) updates) =>
+      super.copyWith((message) => updates(message as GetMainchainBalanceRequest)) as GetMainchainBalanceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2054,7 +2564,8 @@ class GetMainchainBalanceRequest extends $pb.GeneratedMessage {
   GetMainchainBalanceRequest createEmptyInstance() => create();
   static $pb.PbList<GetMainchainBalanceRequest> createRepeated() => $pb.PbList<GetMainchainBalanceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetMainchainBalanceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBalanceRequest>(create);
+  static GetMainchainBalanceRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBalanceRequest>(create);
   static GetMainchainBalanceRequest? _defaultInstance;
 }
 
@@ -2073,25 +2584,28 @@ class GetMainchainBalanceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetMainchainBalanceResponse._() : super();
-  factory GetMainchainBalanceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetMainchainBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GetMainchainBalanceResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetMainchainBalanceResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBalanceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBalanceResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.double>(1, _omitFieldNames ? '' : 'confirmed', $pb.PbFieldType.OD)
     ..a<$core.double>(2, _omitFieldNames ? '' : 'unconfirmed', $pb.PbFieldType.OD)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetMainchainBalanceResponse clone() => GetMainchainBalanceResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetMainchainBalanceResponse copyWith(void Function(GetMainchainBalanceResponse) updates) => super.copyWith((message) => updates(message as GetMainchainBalanceResponse)) as GetMainchainBalanceResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetMainchainBalanceResponse copyWith(void Function(GetMainchainBalanceResponse) updates) =>
+      super.copyWith((message) => updates(message as GetMainchainBalanceResponse)) as GetMainchainBalanceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2100,13 +2614,17 @@ class GetMainchainBalanceResponse extends $pb.GeneratedMessage {
   GetMainchainBalanceResponse createEmptyInstance() => create();
   static $pb.PbList<GetMainchainBalanceResponse> createRepeated() => $pb.PbList<GetMainchainBalanceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetMainchainBalanceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBalanceResponse>(create);
+  static GetMainchainBalanceResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBalanceResponse>(create);
   static GetMainchainBalanceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.double get confirmed => $_getN(0);
   @$pb.TagNumber(1)
-  set confirmed($core.double v) { $_setDouble(0, v); }
+  set confirmed($core.double v) {
+    $_setDouble(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasConfirmed() => $_has(0);
   @$pb.TagNumber(1)
@@ -2115,7 +2633,10 @@ class GetMainchainBalanceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.double get unconfirmed => $_getN(1);
   @$pb.TagNumber(2)
-  set unconfirmed($core.double v) { $_setDouble(1, v); }
+  set unconfirmed($core.double v) {
+    $_setDouble(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasUnconfirmed() => $_has(1);
   @$pb.TagNumber(2)
@@ -2153,29 +2674,31 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
     return $result;
   }
   PreviewResetDataRequest._() : super();
-  factory PreviewResetDataRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PreviewResetDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory PreviewResetDataRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PreviewResetDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PreviewResetDataRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PreviewResetDataRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'deleteBlockchainData')
     ..aOB(2, _omitFieldNames ? '' : 'deleteNodeSoftware')
     ..aOB(3, _omitFieldNames ? '' : 'deleteLogs')
     ..aOB(4, _omitFieldNames ? '' : 'deleteSettings')
     ..aOB(5, _omitFieldNames ? '' : 'deleteWalletFiles')
     ..aOB(6, _omitFieldNames ? '' : 'alsoResetSidechains')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PreviewResetDataRequest clone() => PreviewResetDataRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PreviewResetDataRequest copyWith(void Function(PreviewResetDataRequest) updates) => super.copyWith((message) => updates(message as PreviewResetDataRequest)) as PreviewResetDataRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PreviewResetDataRequest copyWith(void Function(PreviewResetDataRequest) updates) =>
+      super.copyWith((message) => updates(message as PreviewResetDataRequest)) as PreviewResetDataRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2184,13 +2707,17 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
   PreviewResetDataRequest createEmptyInstance() => create();
   static $pb.PbList<PreviewResetDataRequest> createRepeated() => $pb.PbList<PreviewResetDataRequest>();
   @$core.pragma('dart2js:noInline')
-  static PreviewResetDataRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PreviewResetDataRequest>(create);
+  static PreviewResetDataRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PreviewResetDataRequest>(create);
   static PreviewResetDataRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get deleteBlockchainData => $_getBF(0);
   @$pb.TagNumber(1)
-  set deleteBlockchainData($core.bool v) { $_setBool(0, v); }
+  set deleteBlockchainData($core.bool v) {
+    $_setBool(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasDeleteBlockchainData() => $_has(0);
   @$pb.TagNumber(1)
@@ -2199,7 +2726,10 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get deleteNodeSoftware => $_getBF(1);
   @$pb.TagNumber(2)
-  set deleteNodeSoftware($core.bool v) { $_setBool(1, v); }
+  set deleteNodeSoftware($core.bool v) {
+    $_setBool(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasDeleteNodeSoftware() => $_has(1);
   @$pb.TagNumber(2)
@@ -2208,7 +2738,10 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get deleteLogs => $_getBF(2);
   @$pb.TagNumber(3)
-  set deleteLogs($core.bool v) { $_setBool(2, v); }
+  set deleteLogs($core.bool v) {
+    $_setBool(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasDeleteLogs() => $_has(2);
   @$pb.TagNumber(3)
@@ -2217,7 +2750,10 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get deleteSettings => $_getBF(3);
   @$pb.TagNumber(4)
-  set deleteSettings($core.bool v) { $_setBool(3, v); }
+  set deleteSettings($core.bool v) {
+    $_setBool(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasDeleteSettings() => $_has(3);
   @$pb.TagNumber(4)
@@ -2226,7 +2762,10 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.bool get deleteWalletFiles => $_getBF(4);
   @$pb.TagNumber(5)
-  set deleteWalletFiles($core.bool v) { $_setBool(4, v); }
+  set deleteWalletFiles($core.bool v) {
+    $_setBool(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasDeleteWalletFiles() => $_has(4);
   @$pb.TagNumber(5)
@@ -2235,7 +2774,10 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.bool get alsoResetSidechains => $_getBF(5);
   @$pb.TagNumber(6)
-  set alsoResetSidechains($core.bool v) { $_setBool(5, v); }
+  set alsoResetSidechains($core.bool v) {
+    $_setBool(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasAlsoResetSidechains() => $_has(5);
   @$pb.TagNumber(6)
@@ -2253,24 +2795,26 @@ class PreviewResetDataResponse extends $pb.GeneratedMessage {
     return $result;
   }
   PreviewResetDataResponse._() : super();
-  factory PreviewResetDataResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PreviewResetDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory PreviewResetDataResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PreviewResetDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PreviewResetDataResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PreviewResetDataResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..pc<ResetFileInfo>(1, _omitFieldNames ? '' : 'files', $pb.PbFieldType.PM, subBuilder: ResetFileInfo.create)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PreviewResetDataResponse clone() => PreviewResetDataResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PreviewResetDataResponse copyWith(void Function(PreviewResetDataResponse) updates) => super.copyWith((message) => updates(message as PreviewResetDataResponse)) as PreviewResetDataResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PreviewResetDataResponse copyWith(void Function(PreviewResetDataResponse) updates) =>
+      super.copyWith((message) => updates(message as PreviewResetDataResponse)) as PreviewResetDataResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2279,7 +2823,8 @@ class PreviewResetDataResponse extends $pb.GeneratedMessage {
   PreviewResetDataResponse createEmptyInstance() => create();
   static $pb.PbList<PreviewResetDataResponse> createRepeated() => $pb.PbList<PreviewResetDataResponse>();
   @$core.pragma('dart2js:noInline')
-  static PreviewResetDataResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PreviewResetDataResponse>(create);
+  static PreviewResetDataResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PreviewResetDataResponse>(create);
   static PreviewResetDataResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -2309,27 +2854,28 @@ class ResetFileInfo extends $pb.GeneratedMessage {
     return $result;
   }
   ResetFileInfo._() : super();
-  factory ResetFileInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ResetFileInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory ResetFileInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ResetFileInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResetFileInfo', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResetFileInfo',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'path')
     ..aOS(2, _omitFieldNames ? '' : 'category')
     ..aInt64(3, _omitFieldNames ? '' : 'sizeBytes')
     ..aOB(4, _omitFieldNames ? '' : 'isDirectory')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ResetFileInfo clone() => ResetFileInfo()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ResetFileInfo copyWith(void Function(ResetFileInfo) updates) => super.copyWith((message) => updates(message as ResetFileInfo)) as ResetFileInfo;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ResetFileInfo copyWith(void Function(ResetFileInfo) updates) =>
+      super.copyWith((message) => updates(message as ResetFileInfo)) as ResetFileInfo;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2344,7 +2890,10 @@ class ResetFileInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get path => $_getSZ(0);
   @$pb.TagNumber(1)
-  set path($core.String v) { $_setString(0, v); }
+  set path($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPath() => $_has(0);
   @$pb.TagNumber(1)
@@ -2353,7 +2902,10 @@ class ResetFileInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get category => $_getSZ(1);
   @$pb.TagNumber(2)
-  set category($core.String v) { $_setString(1, v); }
+  set category($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasCategory() => $_has(1);
   @$pb.TagNumber(2)
@@ -2362,7 +2914,10 @@ class ResetFileInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get sizeBytes => $_getI64(2);
   @$pb.TagNumber(3)
-  set sizeBytes($fixnum.Int64 v) { $_setInt64(2, v); }
+  set sizeBytes($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasSizeBytes() => $_has(2);
   @$pb.TagNumber(3)
@@ -2371,7 +2926,10 @@ class ResetFileInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get isDirectory => $_getBF(3);
   @$pb.TagNumber(4)
-  set isDirectory($core.bool v) { $_setBool(3, v); }
+  set isDirectory($core.bool v) {
+    $_setBool(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasIsDirectory() => $_has(3);
   @$pb.TagNumber(4)
@@ -2409,29 +2967,31 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
     return $result;
   }
   StreamResetDataRequest._() : super();
-  factory StreamResetDataRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StreamResetDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory StreamResetDataRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StreamResetDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamResetDataRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamResetDataRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'deleteBlockchainData')
     ..aOB(2, _omitFieldNames ? '' : 'deleteNodeSoftware')
     ..aOB(3, _omitFieldNames ? '' : 'deleteLogs')
     ..aOB(4, _omitFieldNames ? '' : 'deleteSettings')
     ..aOB(5, _omitFieldNames ? '' : 'deleteWalletFiles')
     ..aOB(6, _omitFieldNames ? '' : 'alsoResetSidechains')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   StreamResetDataRequest clone() => StreamResetDataRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StreamResetDataRequest copyWith(void Function(StreamResetDataRequest) updates) => super.copyWith((message) => updates(message as StreamResetDataRequest)) as StreamResetDataRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StreamResetDataRequest copyWith(void Function(StreamResetDataRequest) updates) =>
+      super.copyWith((message) => updates(message as StreamResetDataRequest)) as StreamResetDataRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2440,13 +3000,17 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
   StreamResetDataRequest createEmptyInstance() => create();
   static $pb.PbList<StreamResetDataRequest> createRepeated() => $pb.PbList<StreamResetDataRequest>();
   @$core.pragma('dart2js:noInline')
-  static StreamResetDataRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamResetDataRequest>(create);
+  static StreamResetDataRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamResetDataRequest>(create);
   static StreamResetDataRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get deleteBlockchainData => $_getBF(0);
   @$pb.TagNumber(1)
-  set deleteBlockchainData($core.bool v) { $_setBool(0, v); }
+  set deleteBlockchainData($core.bool v) {
+    $_setBool(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasDeleteBlockchainData() => $_has(0);
   @$pb.TagNumber(1)
@@ -2455,7 +3019,10 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get deleteNodeSoftware => $_getBF(1);
   @$pb.TagNumber(2)
-  set deleteNodeSoftware($core.bool v) { $_setBool(1, v); }
+  set deleteNodeSoftware($core.bool v) {
+    $_setBool(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasDeleteNodeSoftware() => $_has(1);
   @$pb.TagNumber(2)
@@ -2464,7 +3031,10 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get deleteLogs => $_getBF(2);
   @$pb.TagNumber(3)
-  set deleteLogs($core.bool v) { $_setBool(2, v); }
+  set deleteLogs($core.bool v) {
+    $_setBool(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasDeleteLogs() => $_has(2);
   @$pb.TagNumber(3)
@@ -2473,7 +3043,10 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get deleteSettings => $_getBF(3);
   @$pb.TagNumber(4)
-  set deleteSettings($core.bool v) { $_setBool(3, v); }
+  set deleteSettings($core.bool v) {
+    $_setBool(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasDeleteSettings() => $_has(3);
   @$pb.TagNumber(4)
@@ -2482,7 +3055,10 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.bool get deleteWalletFiles => $_getBF(4);
   @$pb.TagNumber(5)
-  set deleteWalletFiles($core.bool v) { $_setBool(4, v); }
+  set deleteWalletFiles($core.bool v) {
+    $_setBool(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasDeleteWalletFiles() => $_has(4);
   @$pb.TagNumber(5)
@@ -2491,7 +3067,10 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.bool get alsoResetSidechains => $_getBF(5);
   @$pb.TagNumber(6)
-  set alsoResetSidechains($core.bool v) { $_setBool(5, v); }
+  set alsoResetSidechains($core.bool v) {
+    $_setBool(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasAlsoResetSidechains() => $_has(5);
   @$pb.TagNumber(6)
@@ -2533,10 +3112,14 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
     return $result;
   }
   StreamResetDataResponse._() : super();
-  factory StreamResetDataResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StreamResetDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory StreamResetDataResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StreamResetDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamResetDataResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamResetDataResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'path')
     ..aOS(2, _omitFieldNames ? '' : 'category')
     ..aOB(3, _omitFieldNames ? '' : 'success')
@@ -2544,19 +3127,17 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
     ..aOB(5, _omitFieldNames ? '' : 'done')
     ..a<$core.int>(6, _omitFieldNames ? '' : 'deletedCount', $pb.PbFieldType.O3)
     ..a<$core.int>(7, _omitFieldNames ? '' : 'failedCount', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   StreamResetDataResponse clone() => StreamResetDataResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StreamResetDataResponse copyWith(void Function(StreamResetDataResponse) updates) => super.copyWith((message) => updates(message as StreamResetDataResponse)) as StreamResetDataResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StreamResetDataResponse copyWith(void Function(StreamResetDataResponse) updates) =>
+      super.copyWith((message) => updates(message as StreamResetDataResponse)) as StreamResetDataResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2565,13 +3146,17 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   StreamResetDataResponse createEmptyInstance() => create();
   static $pb.PbList<StreamResetDataResponse> createRepeated() => $pb.PbList<StreamResetDataResponse>();
   @$core.pragma('dart2js:noInline')
-  static StreamResetDataResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamResetDataResponse>(create);
+  static StreamResetDataResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamResetDataResponse>(create);
   static StreamResetDataResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get path => $_getSZ(0);
   @$pb.TagNumber(1)
-  set path($core.String v) { $_setString(0, v); }
+  set path($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPath() => $_has(0);
   @$pb.TagNumber(1)
@@ -2580,7 +3165,10 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get category => $_getSZ(1);
   @$pb.TagNumber(2)
-  set category($core.String v) { $_setString(1, v); }
+  set category($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasCategory() => $_has(1);
   @$pb.TagNumber(2)
@@ -2589,7 +3177,10 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get success => $_getBF(2);
   @$pb.TagNumber(3)
-  set success($core.bool v) { $_setBool(2, v); }
+  set success($core.bool v) {
+    $_setBool(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasSuccess() => $_has(2);
   @$pb.TagNumber(3)
@@ -2598,7 +3189,10 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get error => $_getSZ(3);
   @$pb.TagNumber(4)
-  set error($core.String v) { $_setString(3, v); }
+  set error($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasError() => $_has(3);
   @$pb.TagNumber(4)
@@ -2607,7 +3201,10 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.bool get done => $_getBF(4);
   @$pb.TagNumber(5)
-  set done($core.bool v) { $_setBool(4, v); }
+  set done($core.bool v) {
+    $_setBool(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasDone() => $_has(4);
   @$pb.TagNumber(5)
@@ -2616,7 +3213,10 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get deletedCount => $_getIZ(5);
   @$pb.TagNumber(6)
-  set deletedCount($core.int v) { $_setSignedInt32(5, v); }
+  set deletedCount($core.int v) {
+    $_setSignedInt32(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasDeletedCount() => $_has(5);
   @$pb.TagNumber(6)
@@ -2625,7 +3225,10 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.int get failedCount => $_getIZ(6);
   @$pb.TagNumber(7)
-  set failedCount($core.int v) { $_setSignedInt32(6, v); }
+  set failedCount($core.int v) {
+    $_setSignedInt32(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasFailedCount() => $_has(6);
   @$pb.TagNumber(7)
@@ -2637,52 +3240,45 @@ class OrchestratorServiceApi {
   OrchestratorServiceApi(this._client);
 
   $async.Future<ListBinariesResponse> listBinaries($pb.ClientContext? ctx, ListBinariesRequest request) =>
-    _client.invoke<ListBinariesResponse>(ctx, 'OrchestratorService', 'ListBinaries', request, ListBinariesResponse())
-  ;
+      _client.invoke<ListBinariesResponse>(ctx, 'OrchestratorService', 'ListBinaries', request, ListBinariesResponse());
   $async.Future<GetBinaryStatusResponse> getBinaryStatus($pb.ClientContext? ctx, GetBinaryStatusRequest request) =>
-    _client.invoke<GetBinaryStatusResponse>(ctx, 'OrchestratorService', 'GetBinaryStatus', request, GetBinaryStatusResponse())
-  ;
-  $async.Future<DownloadBinaryResponse> downloadBinary($pb.ClientContext? ctx, DownloadBinaryRequest request) =>
-    _client.invoke<DownloadBinaryResponse>(ctx, 'OrchestratorService', 'DownloadBinary', request, DownloadBinaryResponse())
-  ;
+      _client.invoke<GetBinaryStatusResponse>(
+          ctx, 'OrchestratorService', 'GetBinaryStatus', request, GetBinaryStatusResponse());
+  $async.Future<DownloadBinaryResponse> downloadBinary($pb.ClientContext? ctx, DownloadBinaryRequest request) => _client
+      .invoke<DownloadBinaryResponse>(ctx, 'OrchestratorService', 'DownloadBinary', request, DownloadBinaryResponse());
   $async.Future<StartBinaryResponse> startBinary($pb.ClientContext? ctx, StartBinaryRequest request) =>
-    _client.invoke<StartBinaryResponse>(ctx, 'OrchestratorService', 'StartBinary', request, StartBinaryResponse())
-  ;
+      _client.invoke<StartBinaryResponse>(ctx, 'OrchestratorService', 'StartBinary', request, StartBinaryResponse());
   $async.Future<StopBinaryResponse> stopBinary($pb.ClientContext? ctx, StopBinaryRequest request) =>
-    _client.invoke<StopBinaryResponse>(ctx, 'OrchestratorService', 'StopBinary', request, StopBinaryResponse())
-  ;
-  $async.Future<WatchBinariesResponse> watchBinaries($pb.ClientContext? ctx, WatchBinariesRequest request) =>
-    _client.invoke<WatchBinariesResponse>(ctx, 'OrchestratorService', 'WatchBinaries', request, WatchBinariesResponse())
-  ;
+      _client.invoke<StopBinaryResponse>(ctx, 'OrchestratorService', 'StopBinary', request, StopBinaryResponse());
+  $async.Future<WatchBinariesResponse> watchBinaries($pb.ClientContext? ctx, WatchBinariesRequest request) => _client
+      .invoke<WatchBinariesResponse>(ctx, 'OrchestratorService', 'WatchBinaries', request, WatchBinariesResponse());
   $async.Future<StreamLogsResponse> streamLogs($pb.ClientContext? ctx, StreamLogsRequest request) =>
-    _client.invoke<StreamLogsResponse>(ctx, 'OrchestratorService', 'StreamLogs', request, StreamLogsResponse())
-  ;
+      _client.invoke<StreamLogsResponse>(ctx, 'OrchestratorService', 'StreamLogs', request, StreamLogsResponse());
   $async.Future<StartWithL1Response> startWithL1($pb.ClientContext? ctx, StartWithL1Request request) =>
-    _client.invoke<StartWithL1Response>(ctx, 'OrchestratorService', 'StartWithL1', request, StartWithL1Response())
-  ;
+      _client.invoke<StartWithL1Response>(ctx, 'OrchestratorService', 'StartWithL1', request, StartWithL1Response());
   $async.Future<ShutdownAllResponse> shutdownAll($pb.ClientContext? ctx, ShutdownAllRequest request) =>
-    _client.invoke<ShutdownAllResponse>(ctx, 'OrchestratorService', 'ShutdownAll', request, ShutdownAllResponse())
-  ;
+      _client.invoke<ShutdownAllResponse>(ctx, 'OrchestratorService', 'ShutdownAll', request, ShutdownAllResponse());
   $async.Future<GetBTCPriceResponse> getBTCPrice($pb.ClientContext? ctx, GetBTCPriceRequest request) =>
-    _client.invoke<GetBTCPriceResponse>(ctx, 'OrchestratorService', 'GetBTCPrice', request, GetBTCPriceResponse())
-  ;
-  $async.Future<GetMainchainBlockchainInfoResponse> getMainchainBlockchainInfo($pb.ClientContext? ctx, GetMainchainBlockchainInfoRequest request) =>
-    _client.invoke<GetMainchainBlockchainInfoResponse>(ctx, 'OrchestratorService', 'GetMainchainBlockchainInfo', request, GetMainchainBlockchainInfoResponse())
-  ;
-  $async.Future<GetEnforcerBlockchainInfoResponse> getEnforcerBlockchainInfo($pb.ClientContext? ctx, GetEnforcerBlockchainInfoRequest request) =>
-    _client.invoke<GetEnforcerBlockchainInfoResponse>(ctx, 'OrchestratorService', 'GetEnforcerBlockchainInfo', request, GetEnforcerBlockchainInfoResponse())
-  ;
-  $async.Future<GetMainchainBalanceResponse> getMainchainBalance($pb.ClientContext? ctx, GetMainchainBalanceRequest request) =>
-    _client.invoke<GetMainchainBalanceResponse>(ctx, 'OrchestratorService', 'GetMainchainBalance', request, GetMainchainBalanceResponse())
-  ;
+      _client.invoke<GetBTCPriceResponse>(ctx, 'OrchestratorService', 'GetBTCPrice', request, GetBTCPriceResponse());
+  $async.Future<GetMainchainBlockchainInfoResponse> getMainchainBlockchainInfo(
+          $pb.ClientContext? ctx, GetMainchainBlockchainInfoRequest request) =>
+      _client.invoke<GetMainchainBlockchainInfoResponse>(
+          ctx, 'OrchestratorService', 'GetMainchainBlockchainInfo', request, GetMainchainBlockchainInfoResponse());
+  $async.Future<GetEnforcerBlockchainInfoResponse> getEnforcerBlockchainInfo(
+          $pb.ClientContext? ctx, GetEnforcerBlockchainInfoRequest request) =>
+      _client.invoke<GetEnforcerBlockchainInfoResponse>(
+          ctx, 'OrchestratorService', 'GetEnforcerBlockchainInfo', request, GetEnforcerBlockchainInfoResponse());
+  $async.Future<GetMainchainBalanceResponse> getMainchainBalance(
+          $pb.ClientContext? ctx, GetMainchainBalanceRequest request) =>
+      _client.invoke<GetMainchainBalanceResponse>(
+          ctx, 'OrchestratorService', 'GetMainchainBalance', request, GetMainchainBalanceResponse());
   $async.Future<PreviewResetDataResponse> previewResetData($pb.ClientContext? ctx, PreviewResetDataRequest request) =>
-    _client.invoke<PreviewResetDataResponse>(ctx, 'OrchestratorService', 'PreviewResetData', request, PreviewResetDataResponse())
-  ;
+      _client.invoke<PreviewResetDataResponse>(
+          ctx, 'OrchestratorService', 'PreviewResetData', request, PreviewResetDataResponse());
   $async.Future<StreamResetDataResponse> streamResetData($pb.ClientContext? ctx, StreamResetDataRequest request) =>
-    _client.invoke<StreamResetDataResponse>(ctx, 'OrchestratorService', 'StreamResetData', request, StreamResetDataResponse())
-  ;
+      _client.invoke<StreamResetDataResponse>(
+          ctx, 'OrchestratorService', 'StreamResetData', request, StreamResetDataResponse());
 }
-
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbenum.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbenum.dart
@@ -8,4 +8,3 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -40,25 +40,57 @@ const BinaryStatusMsg$json = {
     {'1': 'repo_url', '3': 21, '4': 1, '5': 9, '10': 'repoUrl'},
     {'1': 'startup_logs', '3': 22, '4': 3, '5': 11, '6': '.orchestrator.v1.StartupLogEntryMsg', '10': 'startupLogs'},
     {'1': 'binary_path', '3': 23, '4': 1, '5': 9, '10': 'binaryPath'},
+    {
+      '1': 'blockchain_sync',
+      '3': 24,
+      '4': 1,
+      '5': 11,
+      '6': '.orchestrator.v1.BlockchainSyncMsg',
+      '10': 'blockchainSync'
+    },
   ],
 };
 
 /// Descriptor for `BinaryStatusMsg`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List binaryStatusMsgDescriptor = $convert.base64Decode(
-    'Cg9CaW5hcnlTdGF0dXNNc2cSEgoEbmFtZRgBIAEoCVIEbmFtZRIhCgxkaXNwbGF5X25hbWUYAi'
-    'ABKAlSC2Rpc3BsYXlOYW1lEhgKB3J1bm5pbmcYAyABKAhSB3J1bm5pbmcSGAoHaGVhbHRoeRgE'
-    'IAEoCFIHaGVhbHRoeRIQCgNwaWQYBSABKAVSA3BpZBIlCg51cHRpbWVfc2Vjb25kcxgGIAEoA1'
-    'INdXB0aW1lU2Vjb25kcxIfCgtjaGFpbl9sYXllchgHIAEoBVIKY2hhaW5MYXllchISCgRwb3J0'
-    'GAggASgFUgRwb3J0EhQKBWVycm9yGAkgASgJUgVlcnJvchIcCgljb25uZWN0ZWQYCiABKAhSCW'
-    'Nvbm5lY3RlZBIjCg1zdGFydHVwX2Vycm9yGAsgASgJUgxzdGFydHVwRXJyb3ISKQoQY29ubmVj'
-    'dGlvbl9lcnJvchgMIAEoCVIPY29ubmVjdGlvbkVycm9yEhoKCHN0b3BwaW5nGA0gASgIUghzdG'
-    '9wcGluZxIiCgxpbml0aWFsaXppbmcYDiABKAhSDGluaXRpYWxpemluZxIqChFjb25uZWN0X21v'
-    'ZGVfb25seRgPIAEoCFIPY29ubmVjdE1vZGVPbmx5EiIKDGRvd25sb2FkYWJsZRgQIAEoCFIMZG'
-    '93bmxvYWRhYmxlEiAKC2Rlc2NyaXB0aW9uGBEgASgJUgtkZXNjcmlwdGlvbhIeCgpkb3dubG9h'
-    'ZGVkGBIgASgIUgpkb3dubG9hZGVkEh4KC3BvcnRfaW5fdXNlGBMgASgIUglwb3J0SW5Vc2USGA'
-    'oHdmVyc2lvbhgUIAEoCVIHdmVyc2lvbhIZCghyZXBvX3VybBgVIAEoCVIHcmVwb1VybBJGCgxz'
-    'dGFydHVwX2xvZ3MYFiADKAsyIy5vcmNoZXN0cmF0b3IudjEuU3RhcnR1cExvZ0VudHJ5TXNnUg'
-    'tzdGFydHVwTG9ncxIfCgtiaW5hcnlfcGF0aBgXIAEoCVIKYmluYXJ5UGF0aA==');
+final $typed_data.Uint8List binaryStatusMsgDescriptor =
+    $convert.base64Decode('Cg9CaW5hcnlTdGF0dXNNc2cSEgoEbmFtZRgBIAEoCVIEbmFtZRIhCgxkaXNwbGF5X25hbWUYAi'
+        'ABKAlSC2Rpc3BsYXlOYW1lEhgKB3J1bm5pbmcYAyABKAhSB3J1bm5pbmcSGAoHaGVhbHRoeRgE'
+        'IAEoCFIHaGVhbHRoeRIQCgNwaWQYBSABKAVSA3BpZBIlCg51cHRpbWVfc2Vjb25kcxgGIAEoA1'
+        'INdXB0aW1lU2Vjb25kcxIfCgtjaGFpbl9sYXllchgHIAEoBVIKY2hhaW5MYXllchISCgRwb3J0'
+        'GAggASgFUgRwb3J0EhQKBWVycm9yGAkgASgJUgVlcnJvchIcCgljb25uZWN0ZWQYCiABKAhSCW'
+        'Nvbm5lY3RlZBIjCg1zdGFydHVwX2Vycm9yGAsgASgJUgxzdGFydHVwRXJyb3ISKQoQY29ubmVj'
+        'dGlvbl9lcnJvchgMIAEoCVIPY29ubmVjdGlvbkVycm9yEhoKCHN0b3BwaW5nGA0gASgIUghzdG'
+        '9wcGluZxIiCgxpbml0aWFsaXppbmcYDiABKAhSDGluaXRpYWxpemluZxIqChFjb25uZWN0X21v'
+        'ZGVfb25seRgPIAEoCFIPY29ubmVjdE1vZGVPbmx5EiIKDGRvd25sb2FkYWJsZRgQIAEoCFIMZG'
+        '93bmxvYWRhYmxlEiAKC2Rlc2NyaXB0aW9uGBEgASgJUgtkZXNjcmlwdGlvbhIeCgpkb3dubG9h'
+        'ZGVkGBIgASgIUgpkb3dubG9hZGVkEh4KC3BvcnRfaW5fdXNlGBMgASgIUglwb3J0SW5Vc2USGA'
+        'oHdmVyc2lvbhgUIAEoCVIHdmVyc2lvbhIZCghyZXBvX3VybBgVIAEoCVIHcmVwb1VybBJGCgxz'
+        'dGFydHVwX2xvZ3MYFiADKAsyIy5vcmNoZXN0cmF0b3IudjEuU3RhcnR1cExvZ0VudHJ5TXNnUg'
+        'tzdGFydHVwTG9ncxIfCgtiaW5hcnlfcGF0aBgXIAEoCVIKYmluYXJ5UGF0aBJLCg9ibG9ja2No'
+        'YWluX3N5bmMYGCABKAsyIi5vcmNoZXN0cmF0b3IudjEuQmxvY2tjaGFpblN5bmNNc2dSDmJsb2'
+        'NrY2hhaW5TeW5j');
+
+@$core.Deprecated('Use blockchainSyncMsgDescriptor instead')
+const BlockchainSyncMsg$json = {
+  '1': 'BlockchainSyncMsg',
+  '2': [
+    {'1': 'blocks', '3': 1, '4': 1, '5': 5, '10': 'blocks'},
+    {'1': 'headers', '3': 2, '4': 1, '5': 5, '10': 'headers'},
+    {'1': 'verification_progress', '3': 3, '4': 1, '5': 1, '10': 'verificationProgress'},
+    {'1': 'initial_block_download', '3': 4, '4': 1, '5': 8, '10': 'initialBlockDownload'},
+    {'1': 'in_header_sync', '3': 5, '4': 1, '5': 8, '10': 'inHeaderSync'},
+    {'1': 'time', '3': 6, '4': 1, '5': 3, '10': 'time'},
+    {'1': 'best_block_hash', '3': 7, '4': 1, '5': 9, '10': 'bestBlockHash'},
+  ],
+};
+
+/// Descriptor for `BlockchainSyncMsg`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List blockchainSyncMsgDescriptor =
+    $convert.base64Decode('ChFCbG9ja2NoYWluU3luY01zZxIWCgZibG9ja3MYASABKAVSBmJsb2NrcxIYCgdoZWFkZXJzGA'
+        'IgASgFUgdoZWFkZXJzEjMKFXZlcmlmaWNhdGlvbl9wcm9ncmVzcxgDIAEoAVIUdmVyaWZpY2F0'
+        'aW9uUHJvZ3Jlc3MSNAoWaW5pdGlhbF9ibG9ja19kb3dubG9hZBgEIAEoCFIUaW5pdGlhbEJsb2'
+        'NrRG93bmxvYWQSJAoOaW5faGVhZGVyX3N5bmMYBSABKAhSDGluSGVhZGVyU3luYxISCgR0aW1l'
+        'GAYgASgDUgR0aW1lEiYKD2Jlc3RfYmxvY2tfaGFzaBgHIAEoCVINYmVzdEJsb2NrSGFzaA==');
 
 @$core.Deprecated('Use startupLogEntryMsgDescriptor instead')
 const StartupLogEntryMsg$json = {
@@ -70,9 +102,9 @@ const StartupLogEntryMsg$json = {
 };
 
 /// Descriptor for `StartupLogEntryMsg`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startupLogEntryMsgDescriptor = $convert.base64Decode(
-    'ChJTdGFydHVwTG9nRW50cnlNc2cSJQoOdGltZXN0YW1wX3VuaXgYASABKANSDXRpbWVzdGFtcF'
-    'VuaXgSGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZQ==');
+final $typed_data.Uint8List startupLogEntryMsgDescriptor =
+    $convert.base64Decode('ChJTdGFydHVwTG9nRW50cnlNc2cSJQoOdGltZXN0YW1wX3VuaXgYASABKANSDXRpbWVzdGFtcF'
+        'VuaXgSGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZQ==');
 
 @$core.Deprecated('Use listBinariesRequestDescriptor instead')
 const ListBinariesRequest$json = {
@@ -80,8 +112,7 @@ const ListBinariesRequest$json = {
 };
 
 /// Descriptor for `ListBinariesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listBinariesRequestDescriptor = $convert.base64Decode(
-    'ChNMaXN0QmluYXJpZXNSZXF1ZXN0');
+final $typed_data.Uint8List listBinariesRequestDescriptor = $convert.base64Decode('ChNMaXN0QmluYXJpZXNSZXF1ZXN0');
 
 @$core.Deprecated('Use listBinariesResponseDescriptor instead')
 const ListBinariesResponse$json = {
@@ -92,9 +123,9 @@ const ListBinariesResponse$json = {
 };
 
 /// Descriptor for `ListBinariesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listBinariesResponseDescriptor = $convert.base64Decode(
-    'ChRMaXN0QmluYXJpZXNSZXNwb25zZRI8CghiaW5hcmllcxgBIAMoCzIgLm9yY2hlc3RyYXRvci'
-    '52MS5CaW5hcnlTdGF0dXNNc2dSCGJpbmFyaWVz');
+final $typed_data.Uint8List listBinariesResponseDescriptor =
+    $convert.base64Decode('ChRMaXN0QmluYXJpZXNSZXNwb25zZRI8CghiaW5hcmllcxgBIAMoCzIgLm9yY2hlc3RyYXRvci'
+        '52MS5CaW5hcnlTdGF0dXNNc2dSCGJpbmFyaWVz');
 
 @$core.Deprecated('Use getBinaryStatusRequestDescriptor instead')
 const GetBinaryStatusRequest$json = {
@@ -105,8 +136,8 @@ const GetBinaryStatusRequest$json = {
 };
 
 /// Descriptor for `GetBinaryStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBinaryStatusRequestDescriptor = $convert.base64Decode(
-    'ChZHZXRCaW5hcnlTdGF0dXNSZXF1ZXN0EhIKBG5hbWUYASABKAlSBG5hbWU=');
+final $typed_data.Uint8List getBinaryStatusRequestDescriptor =
+    $convert.base64Decode('ChZHZXRCaW5hcnlTdGF0dXNSZXF1ZXN0EhIKBG5hbWUYASABKAlSBG5hbWU=');
 
 @$core.Deprecated('Use getBinaryStatusResponseDescriptor instead')
 const GetBinaryStatusResponse$json = {
@@ -117,9 +148,9 @@ const GetBinaryStatusResponse$json = {
 };
 
 /// Descriptor for `GetBinaryStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBinaryStatusResponseDescriptor = $convert.base64Decode(
-    'ChdHZXRCaW5hcnlTdGF0dXNSZXNwb25zZRI4CgZzdGF0dXMYASABKAsyIC5vcmNoZXN0cmF0b3'
-    'IudjEuQmluYXJ5U3RhdHVzTXNnUgZzdGF0dXM=');
+final $typed_data.Uint8List getBinaryStatusResponseDescriptor =
+    $convert.base64Decode('ChdHZXRCaW5hcnlTdGF0dXNSZXNwb25zZRI4CgZzdGF0dXMYASABKAsyIC5vcmNoZXN0cmF0b3'
+        'IudjEuQmluYXJ5U3RhdHVzTXNnUgZzdGF0dXM=');
 
 @$core.Deprecated('Use downloadBinaryRequestDescriptor instead')
 const DownloadBinaryRequest$json = {
@@ -131,9 +162,9 @@ const DownloadBinaryRequest$json = {
 };
 
 /// Descriptor for `DownloadBinaryRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List downloadBinaryRequestDescriptor = $convert.base64Decode(
-    'ChVEb3dubG9hZEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIUCgVmb3JjZRgCIA'
-    'EoCFIFZm9yY2U=');
+final $typed_data.Uint8List downloadBinaryRequestDescriptor =
+    $convert.base64Decode('ChVEb3dubG9hZEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIUCgVmb3JjZRgCIA'
+        'EoCFIFZm9yY2U=');
 
 @$core.Deprecated('Use downloadBinaryResponseDescriptor instead')
 const DownloadBinaryResponse$json = {
@@ -148,11 +179,11 @@ const DownloadBinaryResponse$json = {
 };
 
 /// Descriptor for `DownloadBinaryResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List downloadBinaryResponseDescriptor = $convert.base64Decode(
-    'ChZEb3dubG9hZEJpbmFyeVJlc3BvbnNlEikKEGJ5dGVzX2Rvd25sb2FkZWQYASABKANSD2J5dG'
-    'VzRG93bmxvYWRlZBIfCgt0b3RhbF9ieXRlcxgCIAEoA1IKdG90YWxCeXRlcxIYCgdtZXNzYWdl'
-    'GAMgASgJUgdtZXNzYWdlEhIKBGRvbmUYBCABKAhSBGRvbmUSFAoFZXJyb3IYBSABKAlSBWVycm'
-    '9y');
+final $typed_data.Uint8List downloadBinaryResponseDescriptor =
+    $convert.base64Decode('ChZEb3dubG9hZEJpbmFyeVJlc3BvbnNlEikKEGJ5dGVzX2Rvd25sb2FkZWQYASABKANSD2J5dG'
+        'VzRG93bmxvYWRlZBIfCgt0b3RhbF9ieXRlcxgCIAEoA1IKdG90YWxCeXRlcxIYCgdtZXNzYWdl'
+        'GAMgASgJUgdtZXNzYWdlEhIKBGRvbmUYBCABKAhSBGRvbmUSFAoFZXJyb3IYBSABKAlSBWVycm'
+        '9y');
 
 @$core.Deprecated('Use startBinaryRequestDescriptor instead')
 const StartBinaryRequest$json = {
@@ -176,11 +207,11 @@ const StartBinaryRequest_EnvEntry$json = {
 };
 
 /// Descriptor for `StartBinaryRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startBinaryRequestDescriptor = $convert.base64Decode(
-    'ChJTdGFydEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIdCgpleHRyYV9hcmdzGA'
-    'IgAygJUglleHRyYUFyZ3MSPgoDZW52GAMgAygLMiwub3JjaGVzdHJhdG9yLnYxLlN0YXJ0Qmlu'
-    'YXJ5UmVxdWVzdC5FbnZFbnRyeVIDZW52GjYKCEVudkVudHJ5EhAKA2tleRgBIAEoCVIDa2V5Eh'
-    'QKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+final $typed_data.Uint8List startBinaryRequestDescriptor =
+    $convert.base64Decode('ChJTdGFydEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIdCgpleHRyYV9hcmdzGA'
+        'IgAygJUglleHRyYUFyZ3MSPgoDZW52GAMgAygLMiwub3JjaGVzdHJhdG9yLnYxLlN0YXJ0Qmlu'
+        'YXJ5UmVxdWVzdC5FbnZFbnRyeVIDZW52GjYKCEVudkVudHJ5EhAKA2tleRgBIAEoCVIDa2V5Eh'
+        'QKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
 
 @$core.Deprecated('Use startBinaryResponseDescriptor instead')
 const StartBinaryResponse$json = {
@@ -191,8 +222,8 @@ const StartBinaryResponse$json = {
 };
 
 /// Descriptor for `StartBinaryResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startBinaryResponseDescriptor = $convert.base64Decode(
-    'ChNTdGFydEJpbmFyeVJlc3BvbnNlEhAKA3BpZBgBIAEoBVIDcGlk');
+final $typed_data.Uint8List startBinaryResponseDescriptor =
+    $convert.base64Decode('ChNTdGFydEJpbmFyeVJlc3BvbnNlEhAKA3BpZBgBIAEoBVIDcGlk');
 
 @$core.Deprecated('Use stopBinaryRequestDescriptor instead')
 const StopBinaryRequest$json = {
@@ -204,9 +235,9 @@ const StopBinaryRequest$json = {
 };
 
 /// Descriptor for `StopBinaryRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopBinaryRequestDescriptor = $convert.base64Decode(
-    'ChFTdG9wQmluYXJ5UmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhQKBWZvcmNlGAIgASgIUg'
-    'Vmb3JjZQ==');
+final $typed_data.Uint8List stopBinaryRequestDescriptor =
+    $convert.base64Decode('ChFTdG9wQmluYXJ5UmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhQKBWZvcmNlGAIgASgIUg'
+        'Vmb3JjZQ==');
 
 @$core.Deprecated('Use stopBinaryResponseDescriptor instead')
 const StopBinaryResponse$json = {
@@ -214,8 +245,7 @@ const StopBinaryResponse$json = {
 };
 
 /// Descriptor for `StopBinaryResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopBinaryResponseDescriptor = $convert.base64Decode(
-    'ChJTdG9wQmluYXJ5UmVzcG9uc2U=');
+final $typed_data.Uint8List stopBinaryResponseDescriptor = $convert.base64Decode('ChJTdG9wQmluYXJ5UmVzcG9uc2U=');
 
 @$core.Deprecated('Use watchBinariesRequestDescriptor instead')
 const WatchBinariesRequest$json = {
@@ -223,8 +253,7 @@ const WatchBinariesRequest$json = {
 };
 
 /// Descriptor for `WatchBinariesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List watchBinariesRequestDescriptor = $convert.base64Decode(
-    'ChRXYXRjaEJpbmFyaWVzUmVxdWVzdA==');
+final $typed_data.Uint8List watchBinariesRequestDescriptor = $convert.base64Decode('ChRXYXRjaEJpbmFyaWVzUmVxdWVzdA==');
 
 @$core.Deprecated('Use watchBinariesResponseDescriptor instead')
 const WatchBinariesResponse$json = {
@@ -235,9 +264,9 @@ const WatchBinariesResponse$json = {
 };
 
 /// Descriptor for `WatchBinariesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List watchBinariesResponseDescriptor = $convert.base64Decode(
-    'ChVXYXRjaEJpbmFyaWVzUmVzcG9uc2USPAoIYmluYXJpZXMYASADKAsyIC5vcmNoZXN0cmF0b3'
-    'IudjEuQmluYXJ5U3RhdHVzTXNnUghiaW5hcmllcw==');
+final $typed_data.Uint8List watchBinariesResponseDescriptor =
+    $convert.base64Decode('ChVXYXRjaEJpbmFyaWVzUmVzcG9uc2USPAoIYmluYXJpZXMYASADKAsyIC5vcmNoZXN0cmF0b3'
+        'IudjEuQmluYXJ5U3RhdHVzTXNnUghiaW5hcmllcw==');
 
 @$core.Deprecated('Use streamLogsRequestDescriptor instead')
 const StreamLogsRequest$json = {
@@ -249,9 +278,9 @@ const StreamLogsRequest$json = {
 };
 
 /// Descriptor for `StreamLogsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List streamLogsRequestDescriptor = $convert.base64Decode(
-    'ChFTdHJlYW1Mb2dzUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhIKBHRhaWwYAiABKAVSBH'
-    'RhaWw=');
+final $typed_data.Uint8List streamLogsRequestDescriptor =
+    $convert.base64Decode('ChFTdHJlYW1Mb2dzUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhIKBHRhaWwYAiABKAVSBH'
+        'RhaWw=');
 
 @$core.Deprecated('Use streamLogsResponseDescriptor instead')
 const StreamLogsResponse$json = {
@@ -264,9 +293,9 @@ const StreamLogsResponse$json = {
 };
 
 /// Descriptor for `StreamLogsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List streamLogsResponseDescriptor = $convert.base64Decode(
-    'ChJTdHJlYW1Mb2dzUmVzcG9uc2USFgoGc3RyZWFtGAEgASgJUgZzdHJlYW0SEgoEbGluZRgCIA'
-    'EoCVIEbGluZRIlCg50aW1lc3RhbXBfdW5peBgDIAEoA1INdGltZXN0YW1wVW5peA==');
+final $typed_data.Uint8List streamLogsResponseDescriptor =
+    $convert.base64Decode('ChJTdHJlYW1Mb2dzUmVzcG9uc2USFgoGc3RyZWFtGAEgASgJUgZzdHJlYW0SEgoEbGluZRgCIA'
+        'EoCVIEbGluZRIlCg50aW1lc3RhbXBfdW5peBgDIAEoA1INdGltZXN0YW1wVW5peA==');
 
 @$core.Deprecated('Use startWithL1RequestDescriptor instead')
 const StartWithL1Request$json = {
@@ -274,7 +303,14 @@ const StartWithL1Request$json = {
   '2': [
     {'1': 'target', '3': 1, '4': 1, '5': 9, '10': 'target'},
     {'1': 'target_args', '3': 2, '4': 3, '5': 9, '10': 'targetArgs'},
-    {'1': 'target_env', '3': 3, '4': 3, '5': 11, '6': '.orchestrator.v1.StartWithL1Request.TargetEnvEntry', '10': 'targetEnv'},
+    {
+      '1': 'target_env',
+      '3': 3,
+      '4': 3,
+      '5': 11,
+      '6': '.orchestrator.v1.StartWithL1Request.TargetEnvEntry',
+      '10': 'targetEnv'
+    },
     {'1': 'core_args', '3': 4, '4': 3, '5': 9, '10': 'coreArgs'},
     {'1': 'enforcer_args', '3': 5, '4': 3, '5': 9, '10': 'enforcerArgs'},
     {'1': 'immediate', '3': 6, '4': 1, '5': 8, '10': 'immediate'},
@@ -293,13 +329,13 @@ const StartWithL1Request_TargetEnvEntry$json = {
 };
 
 /// Descriptor for `StartWithL1Request`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startWithL1RequestDescriptor = $convert.base64Decode(
-    'ChJTdGFydFdpdGhMMVJlcXVlc3QSFgoGdGFyZ2V0GAEgASgJUgZ0YXJnZXQSHwoLdGFyZ2V0X2'
-    'FyZ3MYAiADKAlSCnRhcmdldEFyZ3MSUQoKdGFyZ2V0X2VudhgDIAMoCzIyLm9yY2hlc3RyYXRv'
-    'ci52MS5TdGFydFdpdGhMMVJlcXVlc3QuVGFyZ2V0RW52RW50cnlSCXRhcmdldEVudhIbCgljb3'
-    'JlX2FyZ3MYBCADKAlSCGNvcmVBcmdzEiMKDWVuZm9yY2VyX2FyZ3MYBSADKAlSDGVuZm9yY2Vy'
-    'QXJncxIcCglpbW1lZGlhdGUYBiABKAhSCWltbWVkaWF0ZRo8Cg5UYXJnZXRFbnZFbnRyeRIQCg'
-    'NrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
+final $typed_data.Uint8List startWithL1RequestDescriptor =
+    $convert.base64Decode('ChJTdGFydFdpdGhMMVJlcXVlc3QSFgoGdGFyZ2V0GAEgASgJUgZ0YXJnZXQSHwoLdGFyZ2V0X2'
+        'FyZ3MYAiADKAlSCnRhcmdldEFyZ3MSUQoKdGFyZ2V0X2VudhgDIAMoCzIyLm9yY2hlc3RyYXRv'
+        'ci52MS5TdGFydFdpdGhMMVJlcXVlc3QuVGFyZ2V0RW52RW50cnlSCXRhcmdldEVudhIbCgljb3'
+        'JlX2FyZ3MYBCADKAlSCGNvcmVBcmdzEiMKDWVuZm9yY2VyX2FyZ3MYBSADKAlSDGVuZm9yY2Vy'
+        'QXJncxIcCglpbW1lZGlhdGUYBiABKAhSCWltbWVkaWF0ZRo8Cg5UYXJnZXRFbnZFbnRyeRIQCg'
+        'NrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
 
 @$core.Deprecated('Use startWithL1ResponseDescriptor instead')
 const StartWithL1Response$json = {
@@ -315,11 +351,11 @@ const StartWithL1Response$json = {
 };
 
 /// Descriptor for `StartWithL1Response`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startWithL1ResponseDescriptor = $convert.base64Decode(
-    'ChNTdGFydFdpdGhMMVJlc3BvbnNlEhQKBXN0YWdlGAEgASgJUgVzdGFnZRIYCgdtZXNzYWdlGA'
-    'IgASgJUgdtZXNzYWdlEhIKBGRvbmUYAyABKAhSBGRvbmUSFAoFZXJyb3IYBCABKAlSBWVycm9y'
-    'EikKEGJ5dGVzX2Rvd25sb2FkZWQYBSABKANSD2J5dGVzRG93bmxvYWRlZBIfCgt0b3RhbF9ieX'
-    'RlcxgGIAEoA1IKdG90YWxCeXRlcw==');
+final $typed_data.Uint8List startWithL1ResponseDescriptor =
+    $convert.base64Decode('ChNTdGFydFdpdGhMMVJlc3BvbnNlEhQKBXN0YWdlGAEgASgJUgVzdGFnZRIYCgdtZXNzYWdlGA'
+        'IgASgJUgdtZXNzYWdlEhIKBGRvbmUYAyABKAhSBGRvbmUSFAoFZXJyb3IYBCABKAlSBWVycm9y'
+        'EikKEGJ5dGVzX2Rvd25sb2FkZWQYBSABKANSD2J5dGVzRG93bmxvYWRlZBIfCgt0b3RhbF9ieX'
+        'RlcxgGIAEoA1IKdG90YWxCeXRlcw==');
 
 @$core.Deprecated('Use shutdownAllRequestDescriptor instead')
 const ShutdownAllRequest$json = {
@@ -330,8 +366,8 @@ const ShutdownAllRequest$json = {
 };
 
 /// Descriptor for `ShutdownAllRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List shutdownAllRequestDescriptor = $convert.base64Decode(
-    'ChJTaHV0ZG93bkFsbFJlcXVlc3QSFAoFZm9yY2UYASABKAhSBWZvcmNl');
+final $typed_data.Uint8List shutdownAllRequestDescriptor =
+    $convert.base64Decode('ChJTaHV0ZG93bkFsbFJlcXVlc3QSFAoFZm9yY2UYASABKAhSBWZvcmNl');
 
 @$core.Deprecated('Use shutdownAllResponseDescriptor instead')
 const ShutdownAllResponse$json = {
@@ -346,11 +382,11 @@ const ShutdownAllResponse$json = {
 };
 
 /// Descriptor for `ShutdownAllResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List shutdownAllResponseDescriptor = $convert.base64Decode(
-    'ChNTaHV0ZG93bkFsbFJlc3BvbnNlEh8KC3RvdGFsX2NvdW50GAEgASgFUgp0b3RhbENvdW50Ei'
-    'cKD2NvbXBsZXRlZF9jb3VudBgCIAEoBVIOY29tcGxldGVkQ291bnQSJQoOY3VycmVudF9iaW5h'
-    'cnkYAyABKAlSDWN1cnJlbnRCaW5hcnkSEgoEZG9uZRgEIAEoCFIEZG9uZRIUCgVlcnJvchgFIA'
-    'EoCVIFZXJyb3I=');
+final $typed_data.Uint8List shutdownAllResponseDescriptor =
+    $convert.base64Decode('ChNTaHV0ZG93bkFsbFJlc3BvbnNlEh8KC3RvdGFsX2NvdW50GAEgASgFUgp0b3RhbENvdW50Ei'
+        'cKD2NvbXBsZXRlZF9jb3VudBgCIAEoBVIOY29tcGxldGVkQ291bnQSJQoOY3VycmVudF9iaW5h'
+        'cnkYAyABKAlSDWN1cnJlbnRCaW5hcnkSEgoEZG9uZRgEIAEoCFIEZG9uZRIUCgVlcnJvchgFIA'
+        'EoCVIFZXJyb3I=');
 
 @$core.Deprecated('Use getBTCPriceRequestDescriptor instead')
 const GetBTCPriceRequest$json = {
@@ -358,8 +394,7 @@ const GetBTCPriceRequest$json = {
 };
 
 /// Descriptor for `GetBTCPriceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBTCPriceRequestDescriptor = $convert.base64Decode(
-    'ChJHZXRCVENQcmljZVJlcXVlc3Q=');
+final $typed_data.Uint8List getBTCPriceRequestDescriptor = $convert.base64Decode('ChJHZXRCVENQcmljZVJlcXVlc3Q=');
 
 @$core.Deprecated('Use getBTCPriceResponseDescriptor instead')
 const GetBTCPriceResponse$json = {
@@ -371,9 +406,9 @@ const GetBTCPriceResponse$json = {
 };
 
 /// Descriptor for `GetBTCPriceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBTCPriceResponseDescriptor = $convert.base64Decode(
-    'ChNHZXRCVENQcmljZVJlc3BvbnNlEhYKBmJ0Y3VzZBgBIAEoAVIGYnRjdXNkEioKEWxhc3RfdX'
-    'BkYXRlZF91bml4GAIgASgDUg9sYXN0VXBkYXRlZFVuaXg=');
+final $typed_data.Uint8List getBTCPriceResponseDescriptor =
+    $convert.base64Decode('ChNHZXRCVENQcmljZVJlc3BvbnNlEhYKBmJ0Y3VzZBgBIAEoAVIGYnRjdXNkEioKEWxhc3RfdX'
+        'BkYXRlZF91bml4GAIgASgDUg9sYXN0VXBkYXRlZFVuaXg=');
 
 @$core.Deprecated('Use getMainchainBlockchainInfoRequestDescriptor instead')
 const GetMainchainBlockchainInfoRequest$json = {
@@ -381,8 +416,8 @@ const GetMainchainBlockchainInfoRequest$json = {
 };
 
 /// Descriptor for `GetMainchainBlockchainInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getMainchainBlockchainInfoRequestDescriptor = $convert.base64Decode(
-    'CiFHZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1JlcXVlc3Q=');
+final $typed_data.Uint8List getMainchainBlockchainInfoRequestDescriptor =
+    $convert.base64Decode('CiFHZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getMainchainBlockchainInfoResponseDescriptor instead')
 const GetMainchainBlockchainInfoResponse$json = {
@@ -404,15 +439,15 @@ const GetMainchainBlockchainInfoResponse$json = {
 };
 
 /// Descriptor for `GetMainchainBlockchainInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getMainchainBlockchainInfoResponseDescriptor = $convert.base64Decode(
-    'CiJHZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1Jlc3BvbnNlEhQKBWNoYWluGAEgASgJUgVjaG'
-    'FpbhIWCgZibG9ja3MYAiABKAVSBmJsb2NrcxIYCgdoZWFkZXJzGAMgASgFUgdoZWFkZXJzEiYK'
-    'D2Jlc3RfYmxvY2tfaGFzaBgEIAEoCVINYmVzdEJsb2NrSGFzaBIeCgpkaWZmaWN1bHR5GAUgAS'
-    'gBUgpkaWZmaWN1bHR5EhIKBHRpbWUYBiABKANSBHRpbWUSHwoLbWVkaWFuX3RpbWUYByABKANS'
-    'Cm1lZGlhblRpbWUSMwoVdmVyaWZpY2F0aW9uX3Byb2dyZXNzGAggASgBUhR2ZXJpZmljYXRpb2'
-    '5Qcm9ncmVzcxI0ChZpbml0aWFsX2Jsb2NrX2Rvd25sb2FkGAkgASgIUhRpbml0aWFsQmxvY2tE'
-    'b3dubG9hZBIdCgpjaGFpbl93b3JrGAogASgJUgljaGFpbldvcmsSIAoMc2l6ZV9vbl9kaXNrGA'
-    'sgASgDUgpzaXplT25EaXNrEhYKBnBydW5lZBgMIAEoCFIGcHJ1bmVk');
+final $typed_data.Uint8List getMainchainBlockchainInfoResponseDescriptor =
+    $convert.base64Decode('CiJHZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1Jlc3BvbnNlEhQKBWNoYWluGAEgASgJUgVjaG'
+        'FpbhIWCgZibG9ja3MYAiABKAVSBmJsb2NrcxIYCgdoZWFkZXJzGAMgASgFUgdoZWFkZXJzEiYK'
+        'D2Jlc3RfYmxvY2tfaGFzaBgEIAEoCVINYmVzdEJsb2NrSGFzaBIeCgpkaWZmaWN1bHR5GAUgAS'
+        'gBUgpkaWZmaWN1bHR5EhIKBHRpbWUYBiABKANSBHRpbWUSHwoLbWVkaWFuX3RpbWUYByABKANS'
+        'Cm1lZGlhblRpbWUSMwoVdmVyaWZpY2F0aW9uX3Byb2dyZXNzGAggASgBUhR2ZXJpZmljYXRpb2'
+        '5Qcm9ncmVzcxI0ChZpbml0aWFsX2Jsb2NrX2Rvd25sb2FkGAkgASgIUhRpbml0aWFsQmxvY2tE'
+        'b3dubG9hZBIdCgpjaGFpbl93b3JrGAogASgJUgljaGFpbldvcmsSIAoMc2l6ZV9vbl9kaXNrGA'
+        'sgASgDUgpzaXplT25EaXNrEhYKBnBydW5lZBgMIAEoCFIGcHJ1bmVk');
 
 @$core.Deprecated('Use getEnforcerBlockchainInfoRequestDescriptor instead')
 const GetEnforcerBlockchainInfoRequest$json = {
@@ -420,8 +455,8 @@ const GetEnforcerBlockchainInfoRequest$json = {
 };
 
 /// Descriptor for `GetEnforcerBlockchainInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getEnforcerBlockchainInfoRequestDescriptor = $convert.base64Decode(
-    'CiBHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvUmVxdWVzdA==');
+final $typed_data.Uint8List getEnforcerBlockchainInfoRequestDescriptor =
+    $convert.base64Decode('CiBHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvUmVxdWVzdA==');
 
 @$core.Deprecated('Use getEnforcerBlockchainInfoResponseDescriptor instead')
 const GetEnforcerBlockchainInfoResponse$json = {
@@ -434,9 +469,9 @@ const GetEnforcerBlockchainInfoResponse$json = {
 };
 
 /// Descriptor for `GetEnforcerBlockchainInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getEnforcerBlockchainInfoResponseDescriptor = $convert.base64Decode(
-    'CiFHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvUmVzcG9uc2USFgoGYmxvY2tzGAEgASgFUgZibG'
-    '9ja3MSGAoHaGVhZGVycxgCIAEoBVIHaGVhZGVycxISCgR0aW1lGAMgASgDUgR0aW1l');
+final $typed_data.Uint8List getEnforcerBlockchainInfoResponseDescriptor =
+    $convert.base64Decode('CiFHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvUmVzcG9uc2USFgoGYmxvY2tzGAEgASgFUgZibG'
+        '9ja3MSGAoHaGVhZGVycxgCIAEoBVIHaGVhZGVycxISCgR0aW1lGAMgASgDUgR0aW1l');
 
 @$core.Deprecated('Use getMainchainBalanceRequestDescriptor instead')
 const GetMainchainBalanceRequest$json = {
@@ -444,8 +479,8 @@ const GetMainchainBalanceRequest$json = {
 };
 
 /// Descriptor for `GetMainchainBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getMainchainBalanceRequestDescriptor = $convert.base64Decode(
-    'ChpHZXRNYWluY2hhaW5CYWxhbmNlUmVxdWVzdA==');
+final $typed_data.Uint8List getMainchainBalanceRequestDescriptor =
+    $convert.base64Decode('ChpHZXRNYWluY2hhaW5CYWxhbmNlUmVxdWVzdA==');
 
 @$core.Deprecated('Use getMainchainBalanceResponseDescriptor instead')
 const GetMainchainBalanceResponse$json = {
@@ -457,9 +492,9 @@ const GetMainchainBalanceResponse$json = {
 };
 
 /// Descriptor for `GetMainchainBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getMainchainBalanceResponseDescriptor = $convert.base64Decode(
-    'ChtHZXRNYWluY2hhaW5CYWxhbmNlUmVzcG9uc2USHAoJY29uZmlybWVkGAEgASgBUgljb25maX'
-    'JtZWQSIAoLdW5jb25maXJtZWQYAiABKAFSC3VuY29uZmlybWVk');
+final $typed_data.Uint8List getMainchainBalanceResponseDescriptor =
+    $convert.base64Decode('ChtHZXRNYWluY2hhaW5CYWxhbmNlUmVzcG9uc2USHAoJY29uZmlybWVkGAEgASgBUgljb25maX'
+        'JtZWQSIAoLdW5jb25maXJtZWQYAiABKAFSC3VuY29uZmlybWVk');
 
 @$core.Deprecated('Use previewResetDataRequestDescriptor instead')
 const PreviewResetDataRequest$json = {
@@ -475,13 +510,13 @@ const PreviewResetDataRequest$json = {
 };
 
 /// Descriptor for `PreviewResetDataRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List previewResetDataRequestDescriptor = $convert.base64Decode(
-    'ChdQcmV2aWV3UmVzZXREYXRhUmVxdWVzdBI0ChZkZWxldGVfYmxvY2tjaGFpbl9kYXRhGAEgAS'
-    'gIUhRkZWxldGVCbG9ja2NoYWluRGF0YRIwChRkZWxldGVfbm9kZV9zb2Z0d2FyZRgCIAEoCFIS'
-    'ZGVsZXRlTm9kZVNvZnR3YXJlEh8KC2RlbGV0ZV9sb2dzGAMgASgIUgpkZWxldGVMb2dzEicKD2'
-    'RlbGV0ZV9zZXR0aW5ncxgEIAEoCFIOZGVsZXRlU2V0dGluZ3MSLgoTZGVsZXRlX3dhbGxldF9m'
-    'aWxlcxgFIAEoCFIRZGVsZXRlV2FsbGV0RmlsZXMSMgoVYWxzb19yZXNldF9zaWRlY2hhaW5zGA'
-    'YgASgIUhNhbHNvUmVzZXRTaWRlY2hhaW5z');
+final $typed_data.Uint8List previewResetDataRequestDescriptor =
+    $convert.base64Decode('ChdQcmV2aWV3UmVzZXREYXRhUmVxdWVzdBI0ChZkZWxldGVfYmxvY2tjaGFpbl9kYXRhGAEgAS'
+        'gIUhRkZWxldGVCbG9ja2NoYWluRGF0YRIwChRkZWxldGVfbm9kZV9zb2Z0d2FyZRgCIAEoCFIS'
+        'ZGVsZXRlTm9kZVNvZnR3YXJlEh8KC2RlbGV0ZV9sb2dzGAMgASgIUgpkZWxldGVMb2dzEicKD2'
+        'RlbGV0ZV9zZXR0aW5ncxgEIAEoCFIOZGVsZXRlU2V0dGluZ3MSLgoTZGVsZXRlX3dhbGxldF9m'
+        'aWxlcxgFIAEoCFIRZGVsZXRlV2FsbGV0RmlsZXMSMgoVYWxzb19yZXNldF9zaWRlY2hhaW5zGA'
+        'YgASgIUhNhbHNvUmVzZXRTaWRlY2hhaW5z');
 
 @$core.Deprecated('Use previewResetDataResponseDescriptor instead')
 const PreviewResetDataResponse$json = {
@@ -492,9 +527,9 @@ const PreviewResetDataResponse$json = {
 };
 
 /// Descriptor for `PreviewResetDataResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List previewResetDataResponseDescriptor = $convert.base64Decode(
-    'ChhQcmV2aWV3UmVzZXREYXRhUmVzcG9uc2USNAoFZmlsZXMYASADKAsyHi5vcmNoZXN0cmF0b3'
-    'IudjEuUmVzZXRGaWxlSW5mb1IFZmlsZXM=');
+final $typed_data.Uint8List previewResetDataResponseDescriptor =
+    $convert.base64Decode('ChhQcmV2aWV3UmVzZXREYXRhUmVzcG9uc2USNAoFZmlsZXMYASADKAsyHi5vcmNoZXN0cmF0b3'
+        'IudjEuUmVzZXRGaWxlSW5mb1IFZmlsZXM=');
 
 @$core.Deprecated('Use resetFileInfoDescriptor instead')
 const ResetFileInfo$json = {
@@ -508,10 +543,10 @@ const ResetFileInfo$json = {
 };
 
 /// Descriptor for `ResetFileInfo`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List resetFileInfoDescriptor = $convert.base64Decode(
-    'Cg1SZXNldEZpbGVJbmZvEhIKBHBhdGgYASABKAlSBHBhdGgSGgoIY2F0ZWdvcnkYAiABKAlSCG'
-    'NhdGVnb3J5Eh0KCnNpemVfYnl0ZXMYAyABKANSCXNpemVCeXRlcxIhCgxpc19kaXJlY3RvcnkY'
-    'BCABKAhSC2lzRGlyZWN0b3J5');
+final $typed_data.Uint8List resetFileInfoDescriptor =
+    $convert.base64Decode('Cg1SZXNldEZpbGVJbmZvEhIKBHBhdGgYASABKAlSBHBhdGgSGgoIY2F0ZWdvcnkYAiABKAlSCG'
+        'NhdGVnb3J5Eh0KCnNpemVfYnl0ZXMYAyABKANSCXNpemVCeXRlcxIhCgxpc19kaXJlY3RvcnkY'
+        'BCABKAhSC2lzRGlyZWN0b3J5');
 
 @$core.Deprecated('Use streamResetDataRequestDescriptor instead')
 const StreamResetDataRequest$json = {
@@ -527,13 +562,13 @@ const StreamResetDataRequest$json = {
 };
 
 /// Descriptor for `StreamResetDataRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List streamResetDataRequestDescriptor = $convert.base64Decode(
-    'ChZTdHJlYW1SZXNldERhdGFSZXF1ZXN0EjQKFmRlbGV0ZV9ibG9ja2NoYWluX2RhdGEYASABKA'
-    'hSFGRlbGV0ZUJsb2NrY2hhaW5EYXRhEjAKFGRlbGV0ZV9ub2RlX3NvZnR3YXJlGAIgASgIUhJk'
-    'ZWxldGVOb2RlU29mdHdhcmUSHwoLZGVsZXRlX2xvZ3MYAyABKAhSCmRlbGV0ZUxvZ3MSJwoPZG'
-    'VsZXRlX3NldHRpbmdzGAQgASgIUg5kZWxldGVTZXR0aW5ncxIuChNkZWxldGVfd2FsbGV0X2Zp'
-    'bGVzGAUgASgIUhFkZWxldGVXYWxsZXRGaWxlcxIyChVhbHNvX3Jlc2V0X3NpZGVjaGFpbnMYBi'
-    'ABKAhSE2Fsc29SZXNldFNpZGVjaGFpbnM=');
+final $typed_data.Uint8List streamResetDataRequestDescriptor =
+    $convert.base64Decode('ChZTdHJlYW1SZXNldERhdGFSZXF1ZXN0EjQKFmRlbGV0ZV9ibG9ja2NoYWluX2RhdGEYASABKA'
+        'hSFGRlbGV0ZUJsb2NrY2hhaW5EYXRhEjAKFGRlbGV0ZV9ub2RlX3NvZnR3YXJlGAIgASgIUhJk'
+        'ZWxldGVOb2RlU29mdHdhcmUSHwoLZGVsZXRlX2xvZ3MYAyABKAhSCmRlbGV0ZUxvZ3MSJwoPZG'
+        'VsZXRlX3NldHRpbmdzGAQgASgIUg5kZWxldGVTZXR0aW5ncxIuChNkZWxldGVfd2FsbGV0X2Zp'
+        'bGVzGAUgASgIUhFkZWxldGVXYWxsZXRGaWxlcxIyChVhbHNvX3Jlc2V0X3NpZGVjaGFpbnMYBi'
+        'ABKAhSE2Fsc29SZXNldFNpZGVjaGFpbnM=');
 
 @$core.Deprecated('Use streamResetDataResponseDescriptor instead')
 const StreamResetDataResponse$json = {
@@ -550,30 +585,80 @@ const StreamResetDataResponse$json = {
 };
 
 /// Descriptor for `StreamResetDataResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List streamResetDataResponseDescriptor = $convert.base64Decode(
-    'ChdTdHJlYW1SZXNldERhdGFSZXNwb25zZRISCgRwYXRoGAEgASgJUgRwYXRoEhoKCGNhdGVnb3'
-    'J5GAIgASgJUghjYXRlZ29yeRIYCgdzdWNjZXNzGAMgASgIUgdzdWNjZXNzEhQKBWVycm9yGAQg'
-    'ASgJUgVlcnJvchISCgRkb25lGAUgASgIUgRkb25lEiMKDWRlbGV0ZWRfY291bnQYBiABKAVSDG'
-    'RlbGV0ZWRDb3VudBIhCgxmYWlsZWRfY291bnQYByABKAVSC2ZhaWxlZENvdW50');
+final $typed_data.Uint8List streamResetDataResponseDescriptor =
+    $convert.base64Decode('ChdTdHJlYW1SZXNldERhdGFSZXNwb25zZRISCgRwYXRoGAEgASgJUgRwYXRoEhoKCGNhdGVnb3'
+        'J5GAIgASgJUghjYXRlZ29yeRIYCgdzdWNjZXNzGAMgASgIUgdzdWNjZXNzEhQKBWVycm9yGAQg'
+        'ASgJUgVlcnJvchISCgRkb25lGAUgASgIUgRkb25lEiMKDWRlbGV0ZWRfY291bnQYBiABKAVSDG'
+        'RlbGV0ZWRDb3VudBIhCgxmYWlsZWRfY291bnQYByABKAVSC2ZhaWxlZENvdW50');
 
 const $core.Map<$core.String, $core.dynamic> OrchestratorServiceBase$json = {
   '1': 'OrchestratorService',
   '2': [
     {'1': 'ListBinaries', '2': '.orchestrator.v1.ListBinariesRequest', '3': '.orchestrator.v1.ListBinariesResponse'},
-    {'1': 'GetBinaryStatus', '2': '.orchestrator.v1.GetBinaryStatusRequest', '3': '.orchestrator.v1.GetBinaryStatusResponse'},
-    {'1': 'DownloadBinary', '2': '.orchestrator.v1.DownloadBinaryRequest', '3': '.orchestrator.v1.DownloadBinaryResponse', '6': true},
+    {
+      '1': 'GetBinaryStatus',
+      '2': '.orchestrator.v1.GetBinaryStatusRequest',
+      '3': '.orchestrator.v1.GetBinaryStatusResponse'
+    },
+    {
+      '1': 'DownloadBinary',
+      '2': '.orchestrator.v1.DownloadBinaryRequest',
+      '3': '.orchestrator.v1.DownloadBinaryResponse',
+      '6': true
+    },
     {'1': 'StartBinary', '2': '.orchestrator.v1.StartBinaryRequest', '3': '.orchestrator.v1.StartBinaryResponse'},
     {'1': 'StopBinary', '2': '.orchestrator.v1.StopBinaryRequest', '3': '.orchestrator.v1.StopBinaryResponse'},
-    {'1': 'WatchBinaries', '2': '.orchestrator.v1.WatchBinariesRequest', '3': '.orchestrator.v1.WatchBinariesResponse', '6': true},
-    {'1': 'StreamLogs', '2': '.orchestrator.v1.StreamLogsRequest', '3': '.orchestrator.v1.StreamLogsResponse', '6': true},
-    {'1': 'StartWithL1', '2': '.orchestrator.v1.StartWithL1Request', '3': '.orchestrator.v1.StartWithL1Response', '6': true},
-    {'1': 'ShutdownAll', '2': '.orchestrator.v1.ShutdownAllRequest', '3': '.orchestrator.v1.ShutdownAllResponse', '6': true},
+    {
+      '1': 'WatchBinaries',
+      '2': '.orchestrator.v1.WatchBinariesRequest',
+      '3': '.orchestrator.v1.WatchBinariesResponse',
+      '6': true
+    },
+    {
+      '1': 'StreamLogs',
+      '2': '.orchestrator.v1.StreamLogsRequest',
+      '3': '.orchestrator.v1.StreamLogsResponse',
+      '6': true
+    },
+    {
+      '1': 'StartWithL1',
+      '2': '.orchestrator.v1.StartWithL1Request',
+      '3': '.orchestrator.v1.StartWithL1Response',
+      '6': true
+    },
+    {
+      '1': 'ShutdownAll',
+      '2': '.orchestrator.v1.ShutdownAllRequest',
+      '3': '.orchestrator.v1.ShutdownAllResponse',
+      '6': true
+    },
     {'1': 'GetBTCPrice', '2': '.orchestrator.v1.GetBTCPriceRequest', '3': '.orchestrator.v1.GetBTCPriceResponse'},
-    {'1': 'GetMainchainBlockchainInfo', '2': '.orchestrator.v1.GetMainchainBlockchainInfoRequest', '3': '.orchestrator.v1.GetMainchainBlockchainInfoResponse'},
-    {'1': 'GetEnforcerBlockchainInfo', '2': '.orchestrator.v1.GetEnforcerBlockchainInfoRequest', '3': '.orchestrator.v1.GetEnforcerBlockchainInfoResponse'},
-    {'1': 'GetMainchainBalance', '2': '.orchestrator.v1.GetMainchainBalanceRequest', '3': '.orchestrator.v1.GetMainchainBalanceResponse'},
-    {'1': 'PreviewResetData', '2': '.orchestrator.v1.PreviewResetDataRequest', '3': '.orchestrator.v1.PreviewResetDataResponse'},
-    {'1': 'StreamResetData', '2': '.orchestrator.v1.StreamResetDataRequest', '3': '.orchestrator.v1.StreamResetDataResponse', '6': true},
+    {
+      '1': 'GetMainchainBlockchainInfo',
+      '2': '.orchestrator.v1.GetMainchainBlockchainInfoRequest',
+      '3': '.orchestrator.v1.GetMainchainBlockchainInfoResponse'
+    },
+    {
+      '1': 'GetEnforcerBlockchainInfo',
+      '2': '.orchestrator.v1.GetEnforcerBlockchainInfoRequest',
+      '3': '.orchestrator.v1.GetEnforcerBlockchainInfoResponse'
+    },
+    {
+      '1': 'GetMainchainBalance',
+      '2': '.orchestrator.v1.GetMainchainBalanceRequest',
+      '3': '.orchestrator.v1.GetMainchainBalanceResponse'
+    },
+    {
+      '1': 'PreviewResetData',
+      '2': '.orchestrator.v1.PreviewResetDataRequest',
+      '3': '.orchestrator.v1.PreviewResetDataResponse'
+    },
+    {
+      '1': 'StreamResetData',
+      '2': '.orchestrator.v1.StreamResetDataRequest',
+      '3': '.orchestrator.v1.StreamResetDataResponse',
+      '6': true
+    },
   ],
 };
 
@@ -583,6 +668,7 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> Orchestrat
   '.orchestrator.v1.ListBinariesResponse': ListBinariesResponse$json,
   '.orchestrator.v1.BinaryStatusMsg': BinaryStatusMsg$json,
   '.orchestrator.v1.StartupLogEntryMsg': StartupLogEntryMsg$json,
+  '.orchestrator.v1.BlockchainSyncMsg': BlockchainSyncMsg$json,
   '.orchestrator.v1.GetBinaryStatusRequest': GetBinaryStatusRequest$json,
   '.orchestrator.v1.GetBinaryStatusResponse': GetBinaryStatusResponse$json,
   '.orchestrator.v1.DownloadBinaryRequest': DownloadBinaryRequest$json,
@@ -617,33 +703,32 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> Orchestrat
 };
 
 /// Descriptor for `OrchestratorService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List orchestratorServiceDescriptor = $convert.base64Decode(
-    'ChNPcmNoZXN0cmF0b3JTZXJ2aWNlElsKDExpc3RCaW5hcmllcxIkLm9yY2hlc3RyYXRvci52MS'
-    '5MaXN0QmluYXJpZXNSZXF1ZXN0GiUub3JjaGVzdHJhdG9yLnYxLkxpc3RCaW5hcmllc1Jlc3Bv'
-    'bnNlEmQKD0dldEJpbmFyeVN0YXR1cxInLm9yY2hlc3RyYXRvci52MS5HZXRCaW5hcnlTdGF0dX'
-    'NSZXF1ZXN0Gigub3JjaGVzdHJhdG9yLnYxLkdldEJpbmFyeVN0YXR1c1Jlc3BvbnNlEmMKDkRv'
-    'd25sb2FkQmluYXJ5EiYub3JjaGVzdHJhdG9yLnYxLkRvd25sb2FkQmluYXJ5UmVxdWVzdBonLm'
-    '9yY2hlc3RyYXRvci52MS5Eb3dubG9hZEJpbmFyeVJlc3BvbnNlMAESWAoLU3RhcnRCaW5hcnkS'
-    'Iy5vcmNoZXN0cmF0b3IudjEuU3RhcnRCaW5hcnlSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLl'
-    'N0YXJ0QmluYXJ5UmVzcG9uc2USVQoKU3RvcEJpbmFyeRIiLm9yY2hlc3RyYXRvci52MS5TdG9w'
-    'QmluYXJ5UmVxdWVzdBojLm9yY2hlc3RyYXRvci52MS5TdG9wQmluYXJ5UmVzcG9uc2USYAoNV2'
-    'F0Y2hCaW5hcmllcxIlLm9yY2hlc3RyYXRvci52MS5XYXRjaEJpbmFyaWVzUmVxdWVzdBomLm9y'
-    'Y2hlc3RyYXRvci52MS5XYXRjaEJpbmFyaWVzUmVzcG9uc2UwARJXCgpTdHJlYW1Mb2dzEiIub3'
-    'JjaGVzdHJhdG9yLnYxLlN0cmVhbUxvZ3NSZXF1ZXN0GiMub3JjaGVzdHJhdG9yLnYxLlN0cmVh'
-    'bUxvZ3NSZXNwb25zZTABEloKC1N0YXJ0V2l0aEwxEiMub3JjaGVzdHJhdG9yLnYxLlN0YXJ0V2'
-    'l0aEwxUmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5TdGFydFdpdGhMMVJlc3BvbnNlMAESWgoL'
-    'U2h1dGRvd25BbGwSIy5vcmNoZXN0cmF0b3IudjEuU2h1dGRvd25BbGxSZXF1ZXN0GiQub3JjaG'
-    'VzdHJhdG9yLnYxLlNodXRkb3duQWxsUmVzcG9uc2UwARJYCgtHZXRCVENQcmljZRIjLm9yY2hl'
-    'c3RyYXRvci52MS5HZXRCVENQcmljZVJlcXVlc3QaJC5vcmNoZXN0cmF0b3IudjEuR2V0QlRDUH'
-    'JpY2VSZXNwb25zZRKFAQoaR2V0TWFpbmNoYWluQmxvY2tjaGFpbkluZm8SMi5vcmNoZXN0cmF0'
-    'b3IudjEuR2V0TWFpbmNoYWluQmxvY2tjaGFpbkluZm9SZXF1ZXN0GjMub3JjaGVzdHJhdG9yLn'
-    'YxLkdldE1haW5jaGFpbkJsb2NrY2hhaW5JbmZvUmVzcG9uc2USggEKGUdldEVuZm9yY2VyQmxv'
-    'Y2tjaGFpbkluZm8SMS5vcmNoZXN0cmF0b3IudjEuR2V0RW5mb3JjZXJCbG9ja2NoYWluSW5mb1'
-    'JlcXVlc3QaMi5vcmNoZXN0cmF0b3IudjEuR2V0RW5mb3JjZXJCbG9ja2NoYWluSW5mb1Jlc3Bv'
-    'bnNlEnAKE0dldE1haW5jaGFpbkJhbGFuY2USKy5vcmNoZXN0cmF0b3IudjEuR2V0TWFpbmNoYW'
-    'luQmFsYW5jZVJlcXVlc3QaLC5vcmNoZXN0cmF0b3IudjEuR2V0TWFpbmNoYWluQmFsYW5jZVJl'
-    'c3BvbnNlEmcKEFByZXZpZXdSZXNldERhdGESKC5vcmNoZXN0cmF0b3IudjEuUHJldmlld1Jlc2'
-    'V0RGF0YVJlcXVlc3QaKS5vcmNoZXN0cmF0b3IudjEuUHJldmlld1Jlc2V0RGF0YVJlc3BvbnNl'
-    'EmYKD1N0cmVhbVJlc2V0RGF0YRInLm9yY2hlc3RyYXRvci52MS5TdHJlYW1SZXNldERhdGFSZX'
-    'F1ZXN0Gigub3JjaGVzdHJhdG9yLnYxLlN0cmVhbVJlc2V0RGF0YVJlc3BvbnNlMAE=');
-
+final $typed_data.Uint8List orchestratorServiceDescriptor =
+    $convert.base64Decode('ChNPcmNoZXN0cmF0b3JTZXJ2aWNlElsKDExpc3RCaW5hcmllcxIkLm9yY2hlc3RyYXRvci52MS'
+        '5MaXN0QmluYXJpZXNSZXF1ZXN0GiUub3JjaGVzdHJhdG9yLnYxLkxpc3RCaW5hcmllc1Jlc3Bv'
+        'bnNlEmQKD0dldEJpbmFyeVN0YXR1cxInLm9yY2hlc3RyYXRvci52MS5HZXRCaW5hcnlTdGF0dX'
+        'NSZXF1ZXN0Gigub3JjaGVzdHJhdG9yLnYxLkdldEJpbmFyeVN0YXR1c1Jlc3BvbnNlEmMKDkRv'
+        'd25sb2FkQmluYXJ5EiYub3JjaGVzdHJhdG9yLnYxLkRvd25sb2FkQmluYXJ5UmVxdWVzdBonLm'
+        '9yY2hlc3RyYXRvci52MS5Eb3dubG9hZEJpbmFyeVJlc3BvbnNlMAESWAoLU3RhcnRCaW5hcnkS'
+        'Iy5vcmNoZXN0cmF0b3IudjEuU3RhcnRCaW5hcnlSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLl'
+        'N0YXJ0QmluYXJ5UmVzcG9uc2USVQoKU3RvcEJpbmFyeRIiLm9yY2hlc3RyYXRvci52MS5TdG9w'
+        'QmluYXJ5UmVxdWVzdBojLm9yY2hlc3RyYXRvci52MS5TdG9wQmluYXJ5UmVzcG9uc2USYAoNV2'
+        'F0Y2hCaW5hcmllcxIlLm9yY2hlc3RyYXRvci52MS5XYXRjaEJpbmFyaWVzUmVxdWVzdBomLm9y'
+        'Y2hlc3RyYXRvci52MS5XYXRjaEJpbmFyaWVzUmVzcG9uc2UwARJXCgpTdHJlYW1Mb2dzEiIub3'
+        'JjaGVzdHJhdG9yLnYxLlN0cmVhbUxvZ3NSZXF1ZXN0GiMub3JjaGVzdHJhdG9yLnYxLlN0cmVh'
+        'bUxvZ3NSZXNwb25zZTABEloKC1N0YXJ0V2l0aEwxEiMub3JjaGVzdHJhdG9yLnYxLlN0YXJ0V2'
+        'l0aEwxUmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5TdGFydFdpdGhMMVJlc3BvbnNlMAESWgoL'
+        'U2h1dGRvd25BbGwSIy5vcmNoZXN0cmF0b3IudjEuU2h1dGRvd25BbGxSZXF1ZXN0GiQub3JjaG'
+        'VzdHJhdG9yLnYxLlNodXRkb3duQWxsUmVzcG9uc2UwARJYCgtHZXRCVENQcmljZRIjLm9yY2hl'
+        'c3RyYXRvci52MS5HZXRCVENQcmljZVJlcXVlc3QaJC5vcmNoZXN0cmF0b3IudjEuR2V0QlRDUH'
+        'JpY2VSZXNwb25zZRKFAQoaR2V0TWFpbmNoYWluQmxvY2tjaGFpbkluZm8SMi5vcmNoZXN0cmF0'
+        'b3IudjEuR2V0TWFpbmNoYWluQmxvY2tjaGFpbkluZm9SZXF1ZXN0GjMub3JjaGVzdHJhdG9yLn'
+        'YxLkdldE1haW5jaGFpbkJsb2NrY2hhaW5JbmZvUmVzcG9uc2USggEKGUdldEVuZm9yY2VyQmxv'
+        'Y2tjaGFpbkluZm8SMS5vcmNoZXN0cmF0b3IudjEuR2V0RW5mb3JjZXJCbG9ja2NoYWluSW5mb1'
+        'JlcXVlc3QaMi5vcmNoZXN0cmF0b3IudjEuR2V0RW5mb3JjZXJCbG9ja2NoYWluSW5mb1Jlc3Bv'
+        'bnNlEnAKE0dldE1haW5jaGFpbkJhbGFuY2USKy5vcmNoZXN0cmF0b3IudjEuR2V0TWFpbmNoYW'
+        'luQmFsYW5jZVJlcXVlc3QaLC5vcmNoZXN0cmF0b3IudjEuR2V0TWFpbmNoYWluQmFsYW5jZVJl'
+        'c3BvbnNlEmcKEFByZXZpZXdSZXNldERhdGESKC5vcmNoZXN0cmF0b3IudjEuUHJldmlld1Jlc2'
+        'V0RGF0YVJlcXVlc3QaKS5vcmNoZXN0cmF0b3IudjEuUHJldmlld1Jlc2V0RGF0YVJlc3BvbnNl'
+        'EmYKD1N0cmVhbVJlc2V0RGF0YRInLm9yY2hlc3RyYXRvci52MS5TdHJlYW1SZXNldERhdGFSZX'
+        'F1ZXN0Gigub3JjaGVzdHJhdG9yLnYxLlN0cmVhbVJlc2V0RGF0YVJlc3BvbnNlMAE=');

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbserver.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbserver.dart
@@ -15,71 +15,108 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-import 'orchestrator.pb.dart' as $5;
+import 'orchestrator.pb.dart' as $0;
 import 'orchestrator.pbjson.dart';
 
 export 'orchestrator.pb.dart';
 
 abstract class OrchestratorServiceBase extends $pb.GeneratedService {
-  $async.Future<$5.ListBinariesResponse> listBinaries($pb.ServerContext ctx, $5.ListBinariesRequest request);
-  $async.Future<$5.GetBinaryStatusResponse> getBinaryStatus($pb.ServerContext ctx, $5.GetBinaryStatusRequest request);
-  $async.Future<$5.DownloadBinaryResponse> downloadBinary($pb.ServerContext ctx, $5.DownloadBinaryRequest request);
-  $async.Future<$5.StartBinaryResponse> startBinary($pb.ServerContext ctx, $5.StartBinaryRequest request);
-  $async.Future<$5.StopBinaryResponse> stopBinary($pb.ServerContext ctx, $5.StopBinaryRequest request);
-  $async.Future<$5.WatchBinariesResponse> watchBinaries($pb.ServerContext ctx, $5.WatchBinariesRequest request);
-  $async.Future<$5.StreamLogsResponse> streamLogs($pb.ServerContext ctx, $5.StreamLogsRequest request);
-  $async.Future<$5.StartWithL1Response> startWithL1($pb.ServerContext ctx, $5.StartWithL1Request request);
-  $async.Future<$5.ShutdownAllResponse> shutdownAll($pb.ServerContext ctx, $5.ShutdownAllRequest request);
-  $async.Future<$5.GetBTCPriceResponse> getBTCPrice($pb.ServerContext ctx, $5.GetBTCPriceRequest request);
-  $async.Future<$5.GetMainchainBlockchainInfoResponse> getMainchainBlockchainInfo($pb.ServerContext ctx, $5.GetMainchainBlockchainInfoRequest request);
-  $async.Future<$5.GetEnforcerBlockchainInfoResponse> getEnforcerBlockchainInfo($pb.ServerContext ctx, $5.GetEnforcerBlockchainInfoRequest request);
-  $async.Future<$5.GetMainchainBalanceResponse> getMainchainBalance($pb.ServerContext ctx, $5.GetMainchainBalanceRequest request);
-  $async.Future<$5.PreviewResetDataResponse> previewResetData($pb.ServerContext ctx, $5.PreviewResetDataRequest request);
-  $async.Future<$5.StreamResetDataResponse> streamResetData($pb.ServerContext ctx, $5.StreamResetDataRequest request);
+  $async.Future<$0.ListBinariesResponse> listBinaries($pb.ServerContext ctx, $0.ListBinariesRequest request);
+  $async.Future<$0.GetBinaryStatusResponse> getBinaryStatus($pb.ServerContext ctx, $0.GetBinaryStatusRequest request);
+  $async.Future<$0.DownloadBinaryResponse> downloadBinary($pb.ServerContext ctx, $0.DownloadBinaryRequest request);
+  $async.Future<$0.StartBinaryResponse> startBinary($pb.ServerContext ctx, $0.StartBinaryRequest request);
+  $async.Future<$0.StopBinaryResponse> stopBinary($pb.ServerContext ctx, $0.StopBinaryRequest request);
+  $async.Future<$0.WatchBinariesResponse> watchBinaries($pb.ServerContext ctx, $0.WatchBinariesRequest request);
+  $async.Future<$0.StreamLogsResponse> streamLogs($pb.ServerContext ctx, $0.StreamLogsRequest request);
+  $async.Future<$0.StartWithL1Response> startWithL1($pb.ServerContext ctx, $0.StartWithL1Request request);
+  $async.Future<$0.ShutdownAllResponse> shutdownAll($pb.ServerContext ctx, $0.ShutdownAllRequest request);
+  $async.Future<$0.GetBTCPriceResponse> getBTCPrice($pb.ServerContext ctx, $0.GetBTCPriceRequest request);
+  $async.Future<$0.GetMainchainBlockchainInfoResponse> getMainchainBlockchainInfo(
+      $pb.ServerContext ctx, $0.GetMainchainBlockchainInfoRequest request);
+  $async.Future<$0.GetEnforcerBlockchainInfoResponse> getEnforcerBlockchainInfo(
+      $pb.ServerContext ctx, $0.GetEnforcerBlockchainInfoRequest request);
+  $async.Future<$0.GetMainchainBalanceResponse> getMainchainBalance(
+      $pb.ServerContext ctx, $0.GetMainchainBalanceRequest request);
+  $async.Future<$0.PreviewResetDataResponse> previewResetData(
+      $pb.ServerContext ctx, $0.PreviewResetDataRequest request);
+  $async.Future<$0.StreamResetDataResponse> streamResetData($pb.ServerContext ctx, $0.StreamResetDataRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'ListBinaries': return $5.ListBinariesRequest();
-      case 'GetBinaryStatus': return $5.GetBinaryStatusRequest();
-      case 'DownloadBinary': return $5.DownloadBinaryRequest();
-      case 'StartBinary': return $5.StartBinaryRequest();
-      case 'StopBinary': return $5.StopBinaryRequest();
-      case 'WatchBinaries': return $5.WatchBinariesRequest();
-      case 'StreamLogs': return $5.StreamLogsRequest();
-      case 'StartWithL1': return $5.StartWithL1Request();
-      case 'ShutdownAll': return $5.ShutdownAllRequest();
-      case 'GetBTCPrice': return $5.GetBTCPriceRequest();
-      case 'GetMainchainBlockchainInfo': return $5.GetMainchainBlockchainInfoRequest();
-      case 'GetEnforcerBlockchainInfo': return $5.GetEnforcerBlockchainInfoRequest();
-      case 'GetMainchainBalance': return $5.GetMainchainBalanceRequest();
-      case 'PreviewResetData': return $5.PreviewResetDataRequest();
-      case 'StreamResetData': return $5.StreamResetDataRequest();
-      default: throw $core.ArgumentError('Unknown method: $methodName');
+      case 'ListBinaries':
+        return $0.ListBinariesRequest();
+      case 'GetBinaryStatus':
+        return $0.GetBinaryStatusRequest();
+      case 'DownloadBinary':
+        return $0.DownloadBinaryRequest();
+      case 'StartBinary':
+        return $0.StartBinaryRequest();
+      case 'StopBinary':
+        return $0.StopBinaryRequest();
+      case 'WatchBinaries':
+        return $0.WatchBinariesRequest();
+      case 'StreamLogs':
+        return $0.StreamLogsRequest();
+      case 'StartWithL1':
+        return $0.StartWithL1Request();
+      case 'ShutdownAll':
+        return $0.ShutdownAllRequest();
+      case 'GetBTCPrice':
+        return $0.GetBTCPriceRequest();
+      case 'GetMainchainBlockchainInfo':
+        return $0.GetMainchainBlockchainInfoRequest();
+      case 'GetEnforcerBlockchainInfo':
+        return $0.GetEnforcerBlockchainInfoRequest();
+      case 'GetMainchainBalance':
+        return $0.GetMainchainBalanceRequest();
+      case 'PreviewResetData':
+        return $0.PreviewResetDataRequest();
+      case 'StreamResetData':
+        return $0.StreamResetDataRequest();
+      default:
+        throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall(
+      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'ListBinaries': return this.listBinaries(ctx, request as $5.ListBinariesRequest);
-      case 'GetBinaryStatus': return this.getBinaryStatus(ctx, request as $5.GetBinaryStatusRequest);
-      case 'DownloadBinary': return this.downloadBinary(ctx, request as $5.DownloadBinaryRequest);
-      case 'StartBinary': return this.startBinary(ctx, request as $5.StartBinaryRequest);
-      case 'StopBinary': return this.stopBinary(ctx, request as $5.StopBinaryRequest);
-      case 'WatchBinaries': return this.watchBinaries(ctx, request as $5.WatchBinariesRequest);
-      case 'StreamLogs': return this.streamLogs(ctx, request as $5.StreamLogsRequest);
-      case 'StartWithL1': return this.startWithL1(ctx, request as $5.StartWithL1Request);
-      case 'ShutdownAll': return this.shutdownAll(ctx, request as $5.ShutdownAllRequest);
-      case 'GetBTCPrice': return this.getBTCPrice(ctx, request as $5.GetBTCPriceRequest);
-      case 'GetMainchainBlockchainInfo': return this.getMainchainBlockchainInfo(ctx, request as $5.GetMainchainBlockchainInfoRequest);
-      case 'GetEnforcerBlockchainInfo': return this.getEnforcerBlockchainInfo(ctx, request as $5.GetEnforcerBlockchainInfoRequest);
-      case 'GetMainchainBalance': return this.getMainchainBalance(ctx, request as $5.GetMainchainBalanceRequest);
-      case 'PreviewResetData': return this.previewResetData(ctx, request as $5.PreviewResetDataRequest);
-      case 'StreamResetData': return this.streamResetData(ctx, request as $5.StreamResetDataRequest);
-      default: throw $core.ArgumentError('Unknown method: $methodName');
+      case 'ListBinaries':
+        return this.listBinaries(ctx, request as $0.ListBinariesRequest);
+      case 'GetBinaryStatus':
+        return this.getBinaryStatus(ctx, request as $0.GetBinaryStatusRequest);
+      case 'DownloadBinary':
+        return this.downloadBinary(ctx, request as $0.DownloadBinaryRequest);
+      case 'StartBinary':
+        return this.startBinary(ctx, request as $0.StartBinaryRequest);
+      case 'StopBinary':
+        return this.stopBinary(ctx, request as $0.StopBinaryRequest);
+      case 'WatchBinaries':
+        return this.watchBinaries(ctx, request as $0.WatchBinariesRequest);
+      case 'StreamLogs':
+        return this.streamLogs(ctx, request as $0.StreamLogsRequest);
+      case 'StartWithL1':
+        return this.startWithL1(ctx, request as $0.StartWithL1Request);
+      case 'ShutdownAll':
+        return this.shutdownAll(ctx, request as $0.ShutdownAllRequest);
+      case 'GetBTCPrice':
+        return this.getBTCPrice(ctx, request as $0.GetBTCPriceRequest);
+      case 'GetMainchainBlockchainInfo':
+        return this.getMainchainBlockchainInfo(ctx, request as $0.GetMainchainBlockchainInfoRequest);
+      case 'GetEnforcerBlockchainInfo':
+        return this.getEnforcerBlockchainInfo(ctx, request as $0.GetEnforcerBlockchainInfoRequest);
+      case 'GetMainchainBalance':
+        return this.getMainchainBalance(ctx, request as $0.GetMainchainBalanceRequest);
+      case 'PreviewResetData':
+        return this.previewResetData(ctx, request as $0.PreviewResetDataRequest);
+      case 'StreamResetData':
+        return this.streamResetData(ctx, request as $0.StreamResetDataRequest);
+      default:
+        throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => OrchestratorServiceBase$json;
-  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => OrchestratorServiceBase$messageJson;
+  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson =>
+      OrchestratorServiceBase$messageJson;
 }
-

--- a/sail_ui/lib/providers/backend_state_provider.dart
+++ b/sail_ui/lib/providers/backend_state_provider.dart
@@ -120,6 +120,14 @@ class BackendStateProvider extends ChangeNotifier {
     final startupError = status.startupError.isEmpty ? null : status.startupError;
     final connectionError = status.connectionError.isEmpty ? null : status.connectionError;
 
+    // Mirror the orchestrator's blockchain_sync onto MainchainRPC's IBD
+    // flags. Single source of truth: the backend already runs
+    // getblockchaininfo as part of its health-check loop, no reason for
+    // the frontend to make its own RPC call.
+    if (rpc is MainchainRPC) {
+      rpc.applyBackendSync(status.hasBlockchainSync() ? status.blockchainSync : null);
+    }
+
     // Check if anything actually changed to avoid unnecessary rebuilds
     if (rpc.connected == status.connected &&
         rpc.stoppingBinary == status.stopping &&

--- a/sail_ui/lib/providers/sync_provider.dart
+++ b/sail_ui/lib/providers/sync_provider.dart
@@ -6,6 +6,7 @@ import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:sail_ui/env.dart';
 import 'package:sail_ui/gen/google/protobuf/timestamp.pb.dart';
+import 'package:sail_ui/gen/orchestrator/v1/orchestrator.pb.dart' as orch_pb;
 import 'package:sail_ui/sail_ui.dart';
 
 /// Represents detailed information about a blockchain
@@ -61,6 +62,8 @@ class SyncProvider extends ChangeNotifier {
   MainchainRPC get mainchainRPC => GetIt.I.get<MainchainRPC>();
   EnforcerRPC get enforcerRPC => GetIt.I.get<EnforcerRPC>();
   BinaryProvider get binaryProvider => GetIt.I.get<BinaryProvider>();
+  BackendStateProvider? get _backendState =>
+      GetIt.I.isRegistered<BackendStateProvider>() ? GetIt.I.get<BackendStateProvider>() : null;
 
   SyncConnection get mainchain => SyncConnection(rpc: mainchainRPC, name: BitcoinCore().name);
   SyncConnection get enforcer => SyncConnection(rpc: enforcerRPC, name: Enforcer().name);
@@ -78,16 +81,13 @@ class SyncProvider extends ChangeNotifier {
   // Mainchain state
   SyncInfo? mainchainSyncInfo;
   String? mainchainError;
-  Timer? _mainchainTimer;
-  bool _isFetchingMainchain = false;
 
   // Enforcer state
   SyncInfo? enforcerSyncInfo;
   String? enforcerError;
-  Timer? _enforcerTimer;
-  bool _isFetchingEnforcer = false;
 
-  // Additional connection state
+  // Additional connection state (sidechain — orchestrator doesn't proxy
+  // sidechain blockchain info, so we still poll directly here).
   SyncInfo? additionalSyncInfo;
   String? additionalError;
   Timer? _additionalTimer;
@@ -95,10 +95,14 @@ class SyncProvider extends ChangeNotifier {
 
   SyncProvider({this.additionalConnection, bool startTimer = true}) {
     binaryProvider.addListener(_checkDownloadProgress);
+    _backendState?.addListener(_onBackendStateChanged);
 
     if (startTimer && !Environment.isInTest) {
-      _startAllTimers();
+      if (additionalConnection != null) {
+        _startAdditionalTimer();
+      }
     }
+    _onBackendStateChanged();
     fetch();
   }
 
@@ -107,78 +111,63 @@ class SyncProvider extends ChangeNotifier {
     binaryProvider.addListener(_checkDownloadProgress);
   }
 
-  void _startAllTimers() {
-    _startMainchainTimer();
-    _startEnforcerTimer();
-    if (additionalConnection != null) {
-      _startAdditionalTimer();
+  // Orchestrator binary names — same keys used by BackendStateProvider's
+  // `binaries` map (status.name from the proto). Don't use Binary.binaryName,
+  // which encodes the executable filename and diverges (e.g.
+  // "bip300301-enforcer" vs the orchestrator's "enforcer").
+  static const String _kMainchainBinary = 'bitcoind';
+  static const String _kEnforcerBinary = 'enforcer';
+
+  void _onBackendStateChanged() {
+    final state = _backendState;
+    if (state == null) return;
+
+    bool hasChanges = false;
+    if (_applyBackendBinary(state.binaries[_kMainchainBinary], _kMainchainBinary)) {
+      hasChanges = true;
+    }
+    if (_applyBackendBinary(state.binaries[_kEnforcerBinary], _kEnforcerBinary)) {
+      hasChanges = true;
+    }
+    if (hasChanges) {
+      notifyListeners();
     }
   }
 
-  void _startMainchainTimer() {
-    if (Environment.isInTest) {
-      return;
+  bool _applyBackendBinary(BinaryStatusMsg? status, String name) {
+    final isMainchain = name == _kMainchainBinary;
+    final isEnforcer = name == _kEnforcerBinary;
+    if (!isMainchain && !isEnforcer) return false;
+
+    final orch_pb.BlockchainSyncMsg? sync = (status?.hasBlockchainSync() ?? false) ? status!.blockchainSync : null;
+    final SyncInfo? prev = isMainchain ? mainchainSyncInfo : enforcerSyncInfo;
+
+    if (sync == null) {
+      // No backend sample yet — keep the previous SyncInfo so the UI doesn't
+      // flicker between "loading" and "synced" if a stream hiccup arrives.
+      return false;
     }
 
-    _mainchainTimer?.cancel();
-    void tick() async {
-      if (_isFetchingMainchain) return;
-      _isFetchingMainchain = true;
+    final goal = isEnforcer ? (mainchainSyncInfo?.progressGoal ?? sync.headers.toDouble()) : sync.headers.toDouble();
 
-      try {
-        bool wasSynced = mainchainSyncInfo?.isSynced ?? false;
-        await _fetchMainchain();
-        bool isSynced = mainchainSyncInfo?.isSynced ?? false;
+    final newSyncInfo = SyncInfo(
+      progressCurrent: sync.blocks.toDouble(),
+      progressGoal: goal,
+      lastBlockAt: sync.time != 0 ? Timestamp(seconds: sync.time) : null,
+      downloadInfo: prev?.downloadInfo ?? DownloadInfo(),
+    );
 
-        if (wasSynced != isSynced) {
-          // changed sync status, so we must apply the correct timer
-          _mainchainTimer?.cancel();
-          _mainchainTimer = Timer.periodic(
-            isSynced ? PASSIVE_INTERVAL : AGGRESSIVE_INTERVAL,
-            (_) => tick(),
-          );
-        }
-      } catch (e) {
-        // swallow
-      } finally {
-        _isFetchingMainchain = false;
-      }
+    if (!_syncInfoHasChanged(prev, newSyncInfo)) {
+      return false;
     }
-
-    _mainchainTimer = Timer.periodic(AGGRESSIVE_INTERVAL, (_) => tick());
-  }
-
-  void _startEnforcerTimer() {
-    if (Environment.isInTest) {
-      return;
+    if (isMainchain) {
+      mainchainSyncInfo = newSyncInfo;
+      mainchainError = null;
+    } else {
+      enforcerSyncInfo = newSyncInfo;
+      enforcerError = null;
     }
-
-    _enforcerTimer?.cancel();
-    void tick() async {
-      if (_isFetchingEnforcer) return;
-      _isFetchingEnforcer = true;
-
-      try {
-        bool wasSynced = enforcerSyncInfo?.isSynced ?? false;
-        await _fetchEnforcer();
-        bool isSynced = enforcerSyncInfo?.isSynced ?? false;
-
-        if (wasSynced != isSynced) {
-          // changed sync status, so we must apply the correct timer
-          _enforcerTimer?.cancel();
-          _enforcerTimer = Timer.periodic(
-            isSynced ? PASSIVE_INTERVAL : AGGRESSIVE_INTERVAL,
-            (_) => tick(),
-          );
-        }
-      } catch (e) {
-        // swallow
-      } finally {
-        _isFetchingEnforcer = false;
-      }
-    }
-
-    _enforcerTimer = Timer.periodic(AGGRESSIVE_INTERVAL, (_) => tick());
+    return true;
   }
 
   void _startAdditionalTimer() {
@@ -212,70 +201,6 @@ class SyncProvider extends ChangeNotifier {
     }
 
     _additionalTimer = Timer.periodic(AGGRESSIVE_INTERVAL, (_) => tick());
-  }
-
-  Future<void> _fetchMainchain() async {
-    bool hasChanges = false;
-    try {
-      if (!mainchain.rpc.connected) return;
-
-      final newBlockchainInfo = await mainchain.rpc.getBlockchainInfo();
-      final newSyncInfo = SyncInfo(
-        progressCurrent: newBlockchainInfo.blocks.toDouble(),
-        progressGoal: newBlockchainInfo.headers.toDouble(),
-        lastBlockAt: newBlockchainInfo.time != 0 ? Timestamp(seconds: Int64(newBlockchainInfo.time)) : null,
-        downloadInfo: mainchainSyncInfo?.downloadInfo ?? DownloadInfo(),
-      );
-
-      if (_syncInfoHasChanged(mainchainSyncInfo, newSyncInfo) || mainchainError != null) {
-        mainchainSyncInfo = newSyncInfo;
-        mainchainError = null;
-        hasChanges = true;
-      }
-    } catch (e) {
-      final newError = extractConnectException(e);
-      if (mainchainError != newError) {
-        mainchainError = newError;
-        hasChanges = true;
-      }
-    } finally {
-      _isFetchingMainchain = false;
-      if (hasChanges) {
-        notifyListeners();
-      }
-    }
-  }
-
-  Future<void> _fetchEnforcer() async {
-    bool hasChanges = false;
-    try {
-      if (!enforcer.rpc.connected) return;
-
-      final newBlockchainInfo = await enforcer.rpc.getBlockchainInfo();
-      final newSyncInfo = SyncInfo(
-        progressCurrent: newBlockchainInfo.blocks.toDouble(),
-        progressGoal: mainchainSyncInfo?.progressGoal ?? 0,
-        lastBlockAt: newBlockchainInfo.time != 0 ? Timestamp(seconds: Int64(newBlockchainInfo.time)) : null,
-        downloadInfo: enforcerSyncInfo?.downloadInfo ?? DownloadInfo(),
-      );
-
-      if (_syncInfoHasChanged(enforcerSyncInfo, newSyncInfo) || enforcerError != null) {
-        enforcerSyncInfo = newSyncInfo;
-        enforcerError = null;
-        hasChanges = true;
-      }
-    } catch (e) {
-      final newError = extractConnectException(e);
-      if (enforcerError != newError) {
-        enforcerError = newError;
-        hasChanges = true;
-      }
-    } finally {
-      _isFetchingEnforcer = false;
-      if (hasChanges) {
-        notifyListeners();
-      }
-    }
   }
 
   Future<void> _fetchAdditional() async {
@@ -374,13 +299,13 @@ class SyncProvider extends ChangeNotifier {
     return oldInfo != newInfo;
   }
 
-  // For manual fetching of all connections
+  // Pull state from all sources. Mainchain + enforcer come from the backend
+  // stream (no fetch needed); the sidechain still polls.
   Future<void> fetch() async {
-    await Future.wait([
-      _fetchMainchain(),
-      _fetchEnforcer(),
-      if (additionalConnection != null) _fetchAdditional(),
-    ]);
+    _onBackendStateChanged();
+    if (additionalConnection != null) {
+      await _fetchAdditional();
+    }
   }
 
   /// Clear all sync state - useful when network changes or services restart
@@ -396,10 +321,9 @@ class SyncProvider extends ChangeNotifier {
 
   @override
   void dispose() {
-    _mainchainTimer?.cancel();
-    _enforcerTimer?.cancel();
     _additionalTimer?.cancel();
     binaryProvider.removeListener(_checkDownloadProgress);
+    _backendState?.removeListener(_onBackendStateChanged);
     super.dispose();
   }
 }

--- a/sail_ui/lib/rpcs/mainchain_rpc.dart
+++ b/sail_ui/lib/rpcs/mainchain_rpc.dart
@@ -1,10 +1,9 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:dart_coin_rpc/dart_coin_rpc.dart';
 import 'package:dio/dio.dart';
 import 'package:get_it/get_it.dart';
-import 'package:sail_ui/env.dart';
+import 'package:sail_ui/gen/orchestrator/v1/orchestrator.pb.dart' as orch_pb;
 import 'package:sail_ui/sail_ui.dart';
 
 /// RPC connection to the mainchain node. Only really used
@@ -25,9 +24,42 @@ abstract class MainchainRPC extends RPCConnection {
     notifyListeners();
   }
 
+  // IBD state mirrors what the orchestrator tells us via WatchBinaries
+  // (BinaryStatusMsg.blockchain_sync). The frontend never polls bitcoind
+  // directly anymore — `applyBackendSync` is the single mutation point,
+  // called from BackendStateProvider whenever the stream pushes new state.
   bool inIBD = true;
   bool inHeaderSync = true;
+  // Misnamed historically: true while *syncing*, false when fully caught up.
   bool inSync = true;
+
+  /// Mirror the orchestrator's blockchain_sync field onto our IBD flags.
+  /// Pass null when the backend hasn't reported a sample yet — flags reset
+  /// to the initial "still syncing" state so UI shows the loading affordance
+  /// instead of falsely reporting synced.
+  void applyBackendSync(orch_pb.BlockchainSyncMsg? sync) {
+    final bool nextHeaderSync;
+    final bool nextIBD;
+    final bool nextSync;
+    if (sync == null) {
+      nextHeaderSync = true;
+      nextIBD = true;
+      nextSync = true;
+    } else {
+      nextHeaderSync = sync.inHeaderSync;
+      nextIBD = nextHeaderSync || sync.initialBlockDownload;
+      // inSync is "still syncing" — true unless headers caught up to blocks.
+      nextSync = nextIBD || sync.blocks != sync.headers;
+    }
+
+    if (nextHeaderSync == inHeaderSync && nextIBD == inIBD && nextSync == inSync) {
+      return;
+    }
+    inHeaderSync = nextHeaderSync;
+    inIBD = nextIBD;
+    inSync = nextSync;
+    notifyListeners();
+  }
 
   Future<dynamic> callRAW(String method, [List<dynamic>? params]);
   List<String> getMethods();
@@ -63,55 +95,7 @@ class MainchainRPCLive extends MainchainRPC {
     : super(
         conf: readMainchainConf(),
         binaryType: BinaryType.bitcoinCore,
-      ) {
-    if (Environment.isInTest) {
-      return;
-    }
-    pollIBDStatus();
-  }
-
-  void pollIBDStatus() {
-    // start off with the assumption that the parent chain is syncing
-    inIBD = true;
-    inHeaderSync = true;
-    inSync = true;
-    log.i('mainchain init: starting IBD status polling');
-
-    Timer.periodic(const Duration(seconds: 1), (timer) async {
-      try {
-        final info = await getBlockchainInfo();
-
-        // Update header sync status. Header download runs ahead of block
-        // validation — `info.headers` is the count Core has received from
-        // peers. A fresh node boots with 0/0 and the header count jumps to
-        // the chain tip within seconds once peers connect. Require at least
-        // 10 headers so we don't declare "header sync done" mid-bootstrap.
-        final wasInHeaderSync = inHeaderSync;
-        inHeaderSync = info.headers < 10;
-
-        // Update IBD status
-        final wasInIBD = inIBD;
-        inIBD = inHeaderSync || info.initialBlockDownload;
-
-        final wasInSync = inSync;
-        if (!inIBD && info.blocks == info.headers) {
-          // IBD is done, and block height matches header height,
-          // we're fully synced
-          inSync = false;
-        }
-
-        // Only notify if status changed
-        if (wasInHeaderSync != inHeaderSync || wasInIBD != inIBD || inSync != wasInSync) {
-          log.i(
-            'IBD status changed - inHeaderSync: $inHeaderSync, inIBD: $inIBD, inSync: $inSync',
-          );
-          notifyListeners();
-        }
-      } catch (error) {
-        // probably just cant connect, and is in bootup-phase, which is okay
-      }
-    });
-  }
+      );
 
   // cleanArgs makes sure to NOT add any cli-args that are already set in the conf file
   // any duplicates are removed

--- a/sail_ui/lib/widgets/components/daemon_connection_card.dart
+++ b/sail_ui/lib/widgets/components/daemon_connection_card.dart
@@ -161,16 +161,13 @@ class DaemonConnectionCard extends StatelessWidget {
               padding: const EdgeInsets.only(top: SailStyleValues.padding04),
               child: SailText.secondary12(
                 prettifyLogMessage(
-                  // When connected, the daemon is healthy — stale startupError and
-                  // initializingBinary are ignored. Only show this row for real trouble
-                  // (connectionError, !connected) or explicit infoMessage.
-                  infoMessage ??
-                      connection.connectionError ??
-                      connection.startupError ??
-                      (connection.initializingBinary
-                          ? (providerBinary?.startupLogs.lastOrNull?.message ?? 'Initializing...')
-                          : null) ??
-                      'Not connected',
+                  resolveDaemonStatusMessage(
+                    connectionError: connection.connectionError,
+                    startupError: connection.startupError,
+                    infoMessage: infoMessage,
+                    initializingBinary: connection.initializingBinary,
+                    initializingFallback: providerBinary?.startupLogs.lastOrNull?.message,
+                  ),
                 ),
                 monospace: true,
               ),
@@ -189,6 +186,32 @@ class DaemonConnectionCard extends StatelessWidget {
     isDownloading: syncInfo?.downloadInfo.isDownloading ?? false,
     hasInfoMessage: infoMessage != null,
   );
+}
+
+/// Pure function for the daemon-status text precedence. Exposed for testing.
+///
+/// Real failure signals beat informational hints: a fatal `connectionError`
+/// (e.g. enforcer "ZMQ address not reachable") must NOT be masked by a stale
+/// `infoMessage` like "Waiting for L1 to sync headers". Order:
+///
+///  1. connectionError      — explicit RPC/transport failure
+///  2. startupError         — warmup message ("Loading block index…")
+///  3. infoMessage          — caller-provided hint
+///  4. initializing fallback — most recent startup log line, else "Initializing..."
+///  5. "Not connected"      — last resort when no other signal exists
+@visibleForTesting
+String resolveDaemonStatusMessage({
+  required String? connectionError,
+  required String? startupError,
+  required String? infoMessage,
+  required bool initializingBinary,
+  required String? initializingFallback,
+}) {
+  if (connectionError != null) return connectionError;
+  if (startupError != null) return startupError;
+  if (infoMessage != null) return infoMessage;
+  if (initializingBinary) return initializingFallback ?? 'Initializing...';
+  return 'Not connected';
 }
 
 /// Pure function for the daemon-status color precedence. Exposed for testing.

--- a/sail_ui/test/widgets/daemon_connection_card_test.dart
+++ b/sail_ui/test/widgets/daemon_connection_card_test.dart
@@ -121,4 +121,68 @@ void main() {
       );
     });
   });
+
+  // The regression this guards against: the enforcer dies at boot with a
+  // fatal "ZMQ address for mempool sync is not reachable" connectionError,
+  // but bottom_nav.dart was passing infoMessage="Waiting for L1 to sync
+  // headers..." into the card. Old precedence (infoMessage first) hid the
+  // real error. New precedence: real failure signals win.
+  group('resolveDaemonStatusMessage', () {
+    String call({
+      String? connectionError,
+      String? startupError,
+      String? infoMessage,
+      bool initializingBinary = false,
+      String? initializingFallback,
+    }) => resolveDaemonStatusMessage(
+      connectionError: connectionError,
+      startupError: startupError,
+      infoMessage: infoMessage,
+      initializingBinary: initializingBinary,
+      initializingFallback: initializingFallback,
+    );
+
+    test('connectionError beats infoMessage', () {
+      expect(
+        call(
+          connectionError: 'ZMQ address for mempool sync is not reachable',
+          infoMessage: 'Waiting for L1 to sync headers...',
+        ),
+        'ZMQ address for mempool sync is not reachable',
+      );
+    });
+
+    test('startupError beats infoMessage', () {
+      expect(
+        call(
+          startupError: 'Loading block index…',
+          infoMessage: 'Waiting for L1 to sync headers...',
+        ),
+        'Loading block index…',
+      );
+    });
+
+    test('connectionError beats startupError', () {
+      expect(
+        call(connectionError: 'real fail', startupError: 'warming up'),
+        'real fail',
+      );
+    });
+
+    test('infoMessage shows when no error or warmup is set', () {
+      expect(call(infoMessage: 'Waiting for L1 to sync headers...'), 'Waiting for L1 to sync headers...');
+    });
+
+    test('initializing fallback used when no other signal', () {
+      expect(
+        call(initializingBinary: true, initializingFallback: 'Loading wallet…'),
+        'Loading wallet…',
+      );
+      expect(call(initializingBinary: true), 'Initializing...');
+    });
+
+    test('falls back to "Not connected" when no signal at all', () {
+      expect(call(), 'Not connected');
+    });
+  });
 }

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -219,10 +219,10 @@ func (h *Handler) ShutdownAll(ctx context.Context, req *connect.Request[pb.Shutd
 
 	for p := range ch {
 		msg := &pb.ShutdownAllResponse{
-			TotalCount:    int32(p.TotalCount),
+			TotalCount:     int32(p.TotalCount),
 			CompletedCount: int32(p.CompletedCount),
-			CurrentBinary: p.CurrentBinary,
-			Done:          p.Done,
+			CurrentBinary:  p.CurrentBinary,
+			Done:           p.Done,
 		}
 		if p.Error != nil {
 			msg.Error = p.Error.Error()
@@ -355,6 +355,19 @@ func statusToProto(s orchestrator.BinaryStatus) *pb.BinaryStatusMsg {
 		}
 	}
 
+	var sync *pb.BlockchainSyncMsg
+	if s.BlockchainSync != nil {
+		sync = &pb.BlockchainSyncMsg{
+			Blocks:               int32(s.BlockchainSync.Blocks),
+			Headers:              int32(s.BlockchainSync.Headers),
+			VerificationProgress: s.BlockchainSync.VerificationProgress,
+			InitialBlockDownload: s.BlockchainSync.InitialBlockDownload,
+			InHeaderSync:         s.BlockchainSync.InHeaderSync,
+			Time:                 s.BlockchainSync.Time,
+			BestBlockHash:        s.BlockchainSync.BestBlockHash,
+		}
+	}
+
 	return &pb.BinaryStatusMsg{
 		Name:            s.Name,
 		DisplayName:     s.DisplayName,
@@ -379,5 +392,6 @@ func statusToProto(s orchestrator.BinaryStatus) *pb.BinaryStatusMsg {
 		Version:         s.Version,
 		RepoUrl:         s.RepoURL,
 		StartupLogs:     startupLogs,
+		BlockchainSync:  sync,
 	}
 }

--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -17,13 +17,13 @@ const bitwindowBitcoinConfFilename = "bitwindow-bitcoin.conf"
 // Port of the data/config logic from sail_ui/lib/providers/bitcoin_conf_provider.dart.
 // UI-specific logic (file watching, navigation, restart) is omitted.
 type BitcoinConfManager struct {
-	BitwindowDir   string
-	Network        Network
-	Config         *BitcoinConfig
-	ConfigPath     string
+	BitwindowDir    string
+	Network         Network
+	Config          *BitcoinConfig
+	ConfigPath      string
 	DetectedDataDir string
-	HasPrivateConf bool
-	log            zerolog.Logger
+	HasPrivateConf  bool
+	log             zerolog.Logger
 
 	// OnNetworkChanged is called after a network switch completes.
 	// Set by the server to restart services (orchestrator binaries).
@@ -32,7 +32,6 @@ type BitcoinConfManager struct {
 	// File watching (managed by StartWatching/StopWatching)
 	watcher   *fsnotify.Watcher
 	watchDone chan struct{}
-
 }
 
 // NewBitcoinConfManager creates a new BitcoinConfManager and loads config.
@@ -112,9 +111,14 @@ func (m *BitcoinConfManager) GetDefaultConfig() string {
 	// rest=1 is required by the enforcer on every network, including mainnet —
 	// without it the enforcer crashes at boot with "Bitcoin Core REST server is
 	// not enabled" and the UI's enforcer-derived chain state goes blank.
+	// zmqpubsequence is also required by the enforcer's mempool sync; without
+	// it the enforcer dies at startup with "ZMQ address for mempool sync is
+	// not reachable" and never starts.
 	if m.Network == NetworkMainnet {
 		mainnetDatadir := m.rootDirNetwork(NetworkMainnet)
-		return fmt.Sprintf(`# Generated code. Any changes to this file *will* get overwritten.
+		return fmt.Sprintf(`%s%d
+
+# Generated code. Any changes to this file *will* get overwritten.
 # source: bitwindow bitcoin config settings
 
 # Standard Bitcoin Core mainnet configuration
@@ -125,8 +129,9 @@ server=1
 listen=1
 txindex=1
 rest=1
+zmqpubsequence=tcp://127.0.0.1:29000
 chain=main
-`, mainnetDatadir)
+`, bitcoinConfVersionCommentPrefix, BitcoinConfMigrationsVersion, mainnetDatadir)
 	}
 
 	// Build [main] section based on network

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -223,10 +223,23 @@ var bitcoinConfMigrations = []BitcoinConfMigration{
 			},
 		},
 	},
+	{
+		// The mainnet template also dropped zmqpubsequence. Without it the
+		// enforcer dies at boot with "ZMQ address for mempool sync is not
+		// reachable" and the L1 stack never comes up. Backfill globally
+		// (the line is harmless on signet/forknet, where the same value is
+		// already in the default template).
+		Version: 6,
+		Changes: map[string]map[string]string{
+			"": {
+				"zmqpubsequence": "tcp://127.0.0.1:29000",
+			},
+		},
+	},
 }
 
 // BitcoinConfMigrationsVersion is the highest migration version.
-var BitcoinConfMigrationsVersion = 5
+var BitcoinConfMigrationsVersion = 6
 
 // RunBitcoinConfMigrations applies pending migrations to a BitcoinConfig.
 // isForknet controls whether "forknet" or "mainnet" section data applies to [main].

--- a/sidechain-orchestrator/connection_monitor.go
+++ b/sidechain-orchestrator/connection_monitor.go
@@ -94,6 +94,12 @@ type ConnectionMonitor struct {
 	// that match the binary's startup_log_patterns. Streamed to the UI via watchBinaries.
 	// Dart: Binary.startupLogs (binaries.dart)
 	startupLogs []StartupLogLine
+
+	// blockchainSync is the most recent snapshot of L1 chain state captured
+	// by health-check pollers (BitcoindHealthCheck for bitcoind, the orchestrator's
+	// enforcer prober for the enforcer). Streamed to the UI via watchBinaries
+	// so the frontend never needs its own bitcoind RPC client.
+	blockchainSync *BlockchainSync
 }
 
 // StartupLogLine is a timestamped startup progress message.
@@ -171,6 +177,42 @@ func (m *ConnectionMonitor) StartupLogs() []StartupLogLine {
 	out := make([]StartupLogLine, len(m.startupLogs))
 	copy(out, m.startupLogs)
 	return out
+}
+
+// SetBlockchainSync stores the latest sync snapshot recorded by a poller.
+// Fires onChange so subscribers see the new tip without waiting for the
+// next status diff (sync state changes far more often than connected/error).
+func (m *ConnectionMonitor) SetBlockchainSync(s *BlockchainSync) {
+	m.mu.Lock()
+	if blockchainSyncEqual(m.blockchainSync, s) {
+		m.mu.Unlock()
+		return
+	}
+	m.blockchainSync = s
+	m.mu.Unlock()
+	m.notifyChange()
+}
+
+// BlockchainSync returns the most recent sync snapshot, or nil before the
+// first successful poll.
+func (m *ConnectionMonitor) BlockchainSync() *BlockchainSync {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.blockchainSync == nil {
+		return nil
+	}
+	c := *m.blockchainSync
+	return &c
+}
+
+func blockchainSyncEqual(a, b *BlockchainSync) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 // SetConnectionError sets the connection error from an external source (e.g. process crash).

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -48,9 +48,14 @@ type BinaryStatusMsg struct {
 	// Absolute path to the launchable binary on disk (variant-aware: returns
 	// bin/test/<binary>/... for active sidechain alt-builds, the resolved
 	// .app/Contents/MacOS path on macOS, etc.). Empty when not downloaded.
-	BinaryPath    string `protobuf:"bytes,23,opt,name=binary_path,json=binaryPath,proto3" json:"binary_path,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	BinaryPath string `protobuf:"bytes,23,opt,name=binary_path,json=binaryPath,proto3" json:"binary_path,omitempty"`
+	// Live blockchain sync state for chain-layer 1 binaries (bitcoind, enforcer).
+	// Populated from the orchestrator's existing health-check getblockchaininfo
+	// poll, so the frontend never has to make its own RPC call to read sync
+	// state. Nil/zero for non-L1 binaries or before the first successful poll.
+	BlockchainSync *BlockchainSyncMsg `protobuf:"bytes,24,opt,name=blockchain_sync,json=blockchainSync,proto3" json:"blockchain_sync,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *BinaryStatusMsg) Reset() {
@@ -244,6 +249,113 @@ func (x *BinaryStatusMsg) GetBinaryPath() string {
 	return ""
 }
 
+func (x *BinaryStatusMsg) GetBlockchainSync() *BlockchainSyncMsg {
+	if x != nil {
+		return x.BlockchainSync
+	}
+	return nil
+}
+
+// BlockchainSyncMsg snapshots the chain tip + IBD state for an L1 binary.
+// Filled in by the orchestrator after each successful getblockchaininfo poll
+// and pushed to the frontend via WatchBinaries.
+type BlockchainSyncMsg struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	Blocks               int32                  `protobuf:"varint,1,opt,name=blocks,proto3" json:"blocks,omitempty"`
+	Headers              int32                  `protobuf:"varint,2,opt,name=headers,proto3" json:"headers,omitempty"`
+	VerificationProgress float64                `protobuf:"fixed64,3,opt,name=verification_progress,json=verificationProgress,proto3" json:"verification_progress,omitempty"`
+	InitialBlockDownload bool                   `protobuf:"varint,4,opt,name=initial_block_download,json=initialBlockDownload,proto3" json:"initial_block_download,omitempty"`
+	// True while the node is still bootstrapping headers (headers count too low
+	// to have meaningful sync info). Frontend uses this to gate "waiting for
+	// headers" UI without doing its own threshold math.
+	InHeaderSync bool `protobuf:"varint,5,opt,name=in_header_sync,json=inHeaderSync,proto3" json:"in_header_sync,omitempty"`
+	// Block tip timestamp (unix seconds), 0 when no tip yet.
+	Time int64 `protobuf:"varint,6,opt,name=time,proto3" json:"time,omitempty"`
+	// Best block hash at the tip — empty before the first poll.
+	BestBlockHash string `protobuf:"bytes,7,opt,name=best_block_hash,json=bestBlockHash,proto3" json:"best_block_hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BlockchainSyncMsg) Reset() {
+	*x = BlockchainSyncMsg{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BlockchainSyncMsg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlockchainSyncMsg) ProtoMessage() {}
+
+func (x *BlockchainSyncMsg) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BlockchainSyncMsg.ProtoReflect.Descriptor instead.
+func (*BlockchainSyncMsg) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *BlockchainSyncMsg) GetBlocks() int32 {
+	if x != nil {
+		return x.Blocks
+	}
+	return 0
+}
+
+func (x *BlockchainSyncMsg) GetHeaders() int32 {
+	if x != nil {
+		return x.Headers
+	}
+	return 0
+}
+
+func (x *BlockchainSyncMsg) GetVerificationProgress() float64 {
+	if x != nil {
+		return x.VerificationProgress
+	}
+	return 0
+}
+
+func (x *BlockchainSyncMsg) GetInitialBlockDownload() bool {
+	if x != nil {
+		return x.InitialBlockDownload
+	}
+	return false
+}
+
+func (x *BlockchainSyncMsg) GetInHeaderSync() bool {
+	if x != nil {
+		return x.InHeaderSync
+	}
+	return false
+}
+
+func (x *BlockchainSyncMsg) GetTime() int64 {
+	if x != nil {
+		return x.Time
+	}
+	return 0
+}
+
+func (x *BlockchainSyncMsg) GetBestBlockHash() string {
+	if x != nil {
+		return x.BestBlockHash
+	}
+	return ""
+}
+
 type StartupLogEntryMsg struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TimestampUnix int64                  `protobuf:"varint,1,opt,name=timestamp_unix,json=timestampUnix,proto3" json:"timestamp_unix,omitempty"`
@@ -254,7 +366,7 @@ type StartupLogEntryMsg struct {
 
 func (x *StartupLogEntryMsg) Reset() {
 	*x = StartupLogEntryMsg{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[1]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -266,7 +378,7 @@ func (x *StartupLogEntryMsg) String() string {
 func (*StartupLogEntryMsg) ProtoMessage() {}
 
 func (x *StartupLogEntryMsg) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[1]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -279,7 +391,7 @@ func (x *StartupLogEntryMsg) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartupLogEntryMsg.ProtoReflect.Descriptor instead.
 func (*StartupLogEntryMsg) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{1}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *StartupLogEntryMsg) GetTimestampUnix() int64 {
@@ -304,7 +416,7 @@ type ListBinariesRequest struct {
 
 func (x *ListBinariesRequest) Reset() {
 	*x = ListBinariesRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[2]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -316,7 +428,7 @@ func (x *ListBinariesRequest) String() string {
 func (*ListBinariesRequest) ProtoMessage() {}
 
 func (x *ListBinariesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[2]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -329,7 +441,7 @@ func (x *ListBinariesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBinariesRequest.ProtoReflect.Descriptor instead.
 func (*ListBinariesRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{2}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{3}
 }
 
 type ListBinariesResponse struct {
@@ -341,7 +453,7 @@ type ListBinariesResponse struct {
 
 func (x *ListBinariesResponse) Reset() {
 	*x = ListBinariesResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[3]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -353,7 +465,7 @@ func (x *ListBinariesResponse) String() string {
 func (*ListBinariesResponse) ProtoMessage() {}
 
 func (x *ListBinariesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[3]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -366,7 +478,7 @@ func (x *ListBinariesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBinariesResponse.ProtoReflect.Descriptor instead.
 func (*ListBinariesResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{3}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ListBinariesResponse) GetBinaries() []*BinaryStatusMsg {
@@ -385,7 +497,7 @@ type GetBinaryStatusRequest struct {
 
 func (x *GetBinaryStatusRequest) Reset() {
 	*x = GetBinaryStatusRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[4]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -397,7 +509,7 @@ func (x *GetBinaryStatusRequest) String() string {
 func (*GetBinaryStatusRequest) ProtoMessage() {}
 
 func (x *GetBinaryStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[4]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -410,7 +522,7 @@ func (x *GetBinaryStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBinaryStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetBinaryStatusRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{4}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *GetBinaryStatusRequest) GetName() string {
@@ -429,7 +541,7 @@ type GetBinaryStatusResponse struct {
 
 func (x *GetBinaryStatusResponse) Reset() {
 	*x = GetBinaryStatusResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[5]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -441,7 +553,7 @@ func (x *GetBinaryStatusResponse) String() string {
 func (*GetBinaryStatusResponse) ProtoMessage() {}
 
 func (x *GetBinaryStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[5]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -454,7 +566,7 @@ func (x *GetBinaryStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBinaryStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetBinaryStatusResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{5}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *GetBinaryStatusResponse) GetStatus() *BinaryStatusMsg {
@@ -474,7 +586,7 @@ type DownloadBinaryRequest struct {
 
 func (x *DownloadBinaryRequest) Reset() {
 	*x = DownloadBinaryRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[6]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -486,7 +598,7 @@ func (x *DownloadBinaryRequest) String() string {
 func (*DownloadBinaryRequest) ProtoMessage() {}
 
 func (x *DownloadBinaryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[6]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -499,7 +611,7 @@ func (x *DownloadBinaryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadBinaryRequest.ProtoReflect.Descriptor instead.
 func (*DownloadBinaryRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{6}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *DownloadBinaryRequest) GetName() string {
@@ -529,7 +641,7 @@ type DownloadBinaryResponse struct {
 
 func (x *DownloadBinaryResponse) Reset() {
 	*x = DownloadBinaryResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[7]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -541,7 +653,7 @@ func (x *DownloadBinaryResponse) String() string {
 func (*DownloadBinaryResponse) ProtoMessage() {}
 
 func (x *DownloadBinaryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[7]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -554,7 +666,7 @@ func (x *DownloadBinaryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadBinaryResponse.ProtoReflect.Descriptor instead.
 func (*DownloadBinaryResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{7}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *DownloadBinaryResponse) GetBytesDownloaded() int64 {
@@ -603,7 +715,7 @@ type StartBinaryRequest struct {
 
 func (x *StartBinaryRequest) Reset() {
 	*x = StartBinaryRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[8]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -615,7 +727,7 @@ func (x *StartBinaryRequest) String() string {
 func (*StartBinaryRequest) ProtoMessage() {}
 
 func (x *StartBinaryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[8]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -628,7 +740,7 @@ func (x *StartBinaryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartBinaryRequest.ProtoReflect.Descriptor instead.
 func (*StartBinaryRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{8}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *StartBinaryRequest) GetName() string {
@@ -661,7 +773,7 @@ type StartBinaryResponse struct {
 
 func (x *StartBinaryResponse) Reset() {
 	*x = StartBinaryResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[9]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -673,7 +785,7 @@ func (x *StartBinaryResponse) String() string {
 func (*StartBinaryResponse) ProtoMessage() {}
 
 func (x *StartBinaryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[9]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -686,7 +798,7 @@ func (x *StartBinaryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartBinaryResponse.ProtoReflect.Descriptor instead.
 func (*StartBinaryResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{9}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *StartBinaryResponse) GetPid() int32 {
@@ -706,7 +818,7 @@ type StopBinaryRequest struct {
 
 func (x *StopBinaryRequest) Reset() {
 	*x = StopBinaryRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[10]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -718,7 +830,7 @@ func (x *StopBinaryRequest) String() string {
 func (*StopBinaryRequest) ProtoMessage() {}
 
 func (x *StopBinaryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[10]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -731,7 +843,7 @@ func (x *StopBinaryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopBinaryRequest.ProtoReflect.Descriptor instead.
 func (*StopBinaryRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{10}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *StopBinaryRequest) GetName() string {
@@ -756,7 +868,7 @@ type StopBinaryResponse struct {
 
 func (x *StopBinaryResponse) Reset() {
 	*x = StopBinaryResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[11]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -768,7 +880,7 @@ func (x *StopBinaryResponse) String() string {
 func (*StopBinaryResponse) ProtoMessage() {}
 
 func (x *StopBinaryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[11]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -781,7 +893,7 @@ func (x *StopBinaryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopBinaryResponse.ProtoReflect.Descriptor instead.
 func (*StopBinaryResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{11}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{12}
 }
 
 type WatchBinariesRequest struct {
@@ -792,7 +904,7 @@ type WatchBinariesRequest struct {
 
 func (x *WatchBinariesRequest) Reset() {
 	*x = WatchBinariesRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[12]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -804,7 +916,7 @@ func (x *WatchBinariesRequest) String() string {
 func (*WatchBinariesRequest) ProtoMessage() {}
 
 func (x *WatchBinariesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[12]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -817,7 +929,7 @@ func (x *WatchBinariesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchBinariesRequest.ProtoReflect.Descriptor instead.
 func (*WatchBinariesRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{12}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{13}
 }
 
 type WatchBinariesResponse struct {
@@ -829,7 +941,7 @@ type WatchBinariesResponse struct {
 
 func (x *WatchBinariesResponse) Reset() {
 	*x = WatchBinariesResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[13]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -841,7 +953,7 @@ func (x *WatchBinariesResponse) String() string {
 func (*WatchBinariesResponse) ProtoMessage() {}
 
 func (x *WatchBinariesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[13]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -854,7 +966,7 @@ func (x *WatchBinariesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchBinariesResponse.ProtoReflect.Descriptor instead.
 func (*WatchBinariesResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{13}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *WatchBinariesResponse) GetBinaries() []*BinaryStatusMsg {
@@ -874,7 +986,7 @@ type StreamLogsRequest struct {
 
 func (x *StreamLogsRequest) Reset() {
 	*x = StreamLogsRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[14]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -886,7 +998,7 @@ func (x *StreamLogsRequest) String() string {
 func (*StreamLogsRequest) ProtoMessage() {}
 
 func (x *StreamLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[14]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -899,7 +1011,7 @@ func (x *StreamLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamLogsRequest.ProtoReflect.Descriptor instead.
 func (*StreamLogsRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{14}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *StreamLogsRequest) GetName() string {
@@ -927,7 +1039,7 @@ type StreamLogsResponse struct {
 
 func (x *StreamLogsResponse) Reset() {
 	*x = StreamLogsResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[15]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -939,7 +1051,7 @@ func (x *StreamLogsResponse) String() string {
 func (*StreamLogsResponse) ProtoMessage() {}
 
 func (x *StreamLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[15]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -952,7 +1064,7 @@ func (x *StreamLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamLogsResponse.ProtoReflect.Descriptor instead.
 func (*StreamLogsResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{15}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *StreamLogsResponse) GetStream() string {
@@ -990,7 +1102,7 @@ type StartWithL1Request struct {
 
 func (x *StartWithL1Request) Reset() {
 	*x = StartWithL1Request{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[16]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1002,7 +1114,7 @@ func (x *StartWithL1Request) String() string {
 func (*StartWithL1Request) ProtoMessage() {}
 
 func (x *StartWithL1Request) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[16]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1015,7 +1127,7 @@ func (x *StartWithL1Request) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartWithL1Request.ProtoReflect.Descriptor instead.
 func (*StartWithL1Request) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{16}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *StartWithL1Request) GetTarget() string {
@@ -1074,7 +1186,7 @@ type StartWithL1Response struct {
 
 func (x *StartWithL1Response) Reset() {
 	*x = StartWithL1Response{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[17]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1086,7 +1198,7 @@ func (x *StartWithL1Response) String() string {
 func (*StartWithL1Response) ProtoMessage() {}
 
 func (x *StartWithL1Response) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[17]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1099,7 +1211,7 @@ func (x *StartWithL1Response) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartWithL1Response.ProtoReflect.Descriptor instead.
 func (*StartWithL1Response) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{17}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *StartWithL1Response) GetStage() string {
@@ -1153,7 +1265,7 @@ type ShutdownAllRequest struct {
 
 func (x *ShutdownAllRequest) Reset() {
 	*x = ShutdownAllRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[18]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1165,7 +1277,7 @@ func (x *ShutdownAllRequest) String() string {
 func (*ShutdownAllRequest) ProtoMessage() {}
 
 func (x *ShutdownAllRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[18]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1178,7 +1290,7 @@ func (x *ShutdownAllRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownAllRequest.ProtoReflect.Descriptor instead.
 func (*ShutdownAllRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{18}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ShutdownAllRequest) GetForce() bool {
@@ -1201,7 +1313,7 @@ type ShutdownAllResponse struct {
 
 func (x *ShutdownAllResponse) Reset() {
 	*x = ShutdownAllResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[19]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1213,7 +1325,7 @@ func (x *ShutdownAllResponse) String() string {
 func (*ShutdownAllResponse) ProtoMessage() {}
 
 func (x *ShutdownAllResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[19]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1226,7 +1338,7 @@ func (x *ShutdownAllResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownAllResponse.ProtoReflect.Descriptor instead.
 func (*ShutdownAllResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{19}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ShutdownAllResponse) GetTotalCount() int32 {
@@ -1272,7 +1384,7 @@ type GetBTCPriceRequest struct {
 
 func (x *GetBTCPriceRequest) Reset() {
 	*x = GetBTCPriceRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[20]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1284,7 +1396,7 @@ func (x *GetBTCPriceRequest) String() string {
 func (*GetBTCPriceRequest) ProtoMessage() {}
 
 func (x *GetBTCPriceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[20]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1297,7 +1409,7 @@ func (x *GetBTCPriceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBTCPriceRequest.ProtoReflect.Descriptor instead.
 func (*GetBTCPriceRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{20}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{21}
 }
 
 type GetBTCPriceResponse struct {
@@ -1310,7 +1422,7 @@ type GetBTCPriceResponse struct {
 
 func (x *GetBTCPriceResponse) Reset() {
 	*x = GetBTCPriceResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[21]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1322,7 +1434,7 @@ func (x *GetBTCPriceResponse) String() string {
 func (*GetBTCPriceResponse) ProtoMessage() {}
 
 func (x *GetBTCPriceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[21]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1335,7 +1447,7 @@ func (x *GetBTCPriceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBTCPriceResponse.ProtoReflect.Descriptor instead.
 func (*GetBTCPriceResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{21}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetBTCPriceResponse) GetBtcusd() float64 {
@@ -1360,7 +1472,7 @@ type GetMainchainBlockchainInfoRequest struct {
 
 func (x *GetMainchainBlockchainInfoRequest) Reset() {
 	*x = GetMainchainBlockchainInfoRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[22]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1372,7 +1484,7 @@ func (x *GetMainchainBlockchainInfoRequest) String() string {
 func (*GetMainchainBlockchainInfoRequest) ProtoMessage() {}
 
 func (x *GetMainchainBlockchainInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[22]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1385,7 +1497,7 @@ func (x *GetMainchainBlockchainInfoRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetMainchainBlockchainInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetMainchainBlockchainInfoRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{22}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{23}
 }
 
 type GetMainchainBlockchainInfoResponse struct {
@@ -1408,7 +1520,7 @@ type GetMainchainBlockchainInfoResponse struct {
 
 func (x *GetMainchainBlockchainInfoResponse) Reset() {
 	*x = GetMainchainBlockchainInfoResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[23]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1420,7 +1532,7 @@ func (x *GetMainchainBlockchainInfoResponse) String() string {
 func (*GetMainchainBlockchainInfoResponse) ProtoMessage() {}
 
 func (x *GetMainchainBlockchainInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[23]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1433,7 +1545,7 @@ func (x *GetMainchainBlockchainInfoResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetMainchainBlockchainInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetMainchainBlockchainInfoResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{23}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetMainchainBlockchainInfoResponse) GetChain() string {
@@ -1528,7 +1640,7 @@ type GetEnforcerBlockchainInfoRequest struct {
 
 func (x *GetEnforcerBlockchainInfoRequest) Reset() {
 	*x = GetEnforcerBlockchainInfoRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[24]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1540,7 +1652,7 @@ func (x *GetEnforcerBlockchainInfoRequest) String() string {
 func (*GetEnforcerBlockchainInfoRequest) ProtoMessage() {}
 
 func (x *GetEnforcerBlockchainInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[24]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1553,7 +1665,7 @@ func (x *GetEnforcerBlockchainInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEnforcerBlockchainInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetEnforcerBlockchainInfoRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{24}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{25}
 }
 
 type GetEnforcerBlockchainInfoResponse struct {
@@ -1567,7 +1679,7 @@ type GetEnforcerBlockchainInfoResponse struct {
 
 func (x *GetEnforcerBlockchainInfoResponse) Reset() {
 	*x = GetEnforcerBlockchainInfoResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[25]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1579,7 +1691,7 @@ func (x *GetEnforcerBlockchainInfoResponse) String() string {
 func (*GetEnforcerBlockchainInfoResponse) ProtoMessage() {}
 
 func (x *GetEnforcerBlockchainInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[25]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1592,7 +1704,7 @@ func (x *GetEnforcerBlockchainInfoResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetEnforcerBlockchainInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetEnforcerBlockchainInfoResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{25}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetEnforcerBlockchainInfoResponse) GetBlocks() int32 {
@@ -1624,7 +1736,7 @@ type GetMainchainBalanceRequest struct {
 
 func (x *GetMainchainBalanceRequest) Reset() {
 	*x = GetMainchainBalanceRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[26]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1636,7 +1748,7 @@ func (x *GetMainchainBalanceRequest) String() string {
 func (*GetMainchainBalanceRequest) ProtoMessage() {}
 
 func (x *GetMainchainBalanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[26]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1649,7 +1761,7 @@ func (x *GetMainchainBalanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMainchainBalanceRequest.ProtoReflect.Descriptor instead.
 func (*GetMainchainBalanceRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{26}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{27}
 }
 
 type GetMainchainBalanceResponse struct {
@@ -1662,7 +1774,7 @@ type GetMainchainBalanceResponse struct {
 
 func (x *GetMainchainBalanceResponse) Reset() {
 	*x = GetMainchainBalanceResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[27]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1674,7 +1786,7 @@ func (x *GetMainchainBalanceResponse) String() string {
 func (*GetMainchainBalanceResponse) ProtoMessage() {}
 
 func (x *GetMainchainBalanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[27]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1687,7 +1799,7 @@ func (x *GetMainchainBalanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMainchainBalanceResponse.ProtoReflect.Descriptor instead.
 func (*GetMainchainBalanceResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{27}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GetMainchainBalanceResponse) GetConfirmed() float64 {
@@ -1718,7 +1830,7 @@ type PreviewResetDataRequest struct {
 
 func (x *PreviewResetDataRequest) Reset() {
 	*x = PreviewResetDataRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[28]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1730,7 +1842,7 @@ func (x *PreviewResetDataRequest) String() string {
 func (*PreviewResetDataRequest) ProtoMessage() {}
 
 func (x *PreviewResetDataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[28]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1743,7 +1855,7 @@ func (x *PreviewResetDataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewResetDataRequest.ProtoReflect.Descriptor instead.
 func (*PreviewResetDataRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{28}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *PreviewResetDataRequest) GetDeleteBlockchainData() bool {
@@ -1797,7 +1909,7 @@ type PreviewResetDataResponse struct {
 
 func (x *PreviewResetDataResponse) Reset() {
 	*x = PreviewResetDataResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[29]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1809,7 +1921,7 @@ func (x *PreviewResetDataResponse) String() string {
 func (*PreviewResetDataResponse) ProtoMessage() {}
 
 func (x *PreviewResetDataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[29]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1822,7 +1934,7 @@ func (x *PreviewResetDataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewResetDataResponse.ProtoReflect.Descriptor instead.
 func (*PreviewResetDataResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{29}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *PreviewResetDataResponse) GetFiles() []*ResetFileInfo {
@@ -1844,7 +1956,7 @@ type ResetFileInfo struct {
 
 func (x *ResetFileInfo) Reset() {
 	*x = ResetFileInfo{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[30]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1856,7 +1968,7 @@ func (x *ResetFileInfo) String() string {
 func (*ResetFileInfo) ProtoMessage() {}
 
 func (x *ResetFileInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[30]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1869,7 +1981,7 @@ func (x *ResetFileInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResetFileInfo.ProtoReflect.Descriptor instead.
 func (*ResetFileInfo) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{30}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ResetFileInfo) GetPath() string {
@@ -1914,7 +2026,7 @@ type StreamResetDataRequest struct {
 
 func (x *StreamResetDataRequest) Reset() {
 	*x = StreamResetDataRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[31]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1926,7 +2038,7 @@ func (x *StreamResetDataRequest) String() string {
 func (*StreamResetDataRequest) ProtoMessage() {}
 
 func (x *StreamResetDataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[31]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1939,7 +2051,7 @@ func (x *StreamResetDataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamResetDataRequest.ProtoReflect.Descriptor instead.
 func (*StreamResetDataRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{31}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *StreamResetDataRequest) GetDeleteBlockchainData() bool {
@@ -1999,7 +2111,7 @@ type StreamResetDataResponse struct {
 
 func (x *StreamResetDataResponse) Reset() {
 	*x = StreamResetDataResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[32]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2011,7 +2123,7 @@ func (x *StreamResetDataResponse) String() string {
 func (*StreamResetDataResponse) ProtoMessage() {}
 
 func (x *StreamResetDataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[32]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2024,7 +2136,7 @@ func (x *StreamResetDataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamResetDataResponse.ProtoReflect.Descriptor instead.
 func (*StreamResetDataResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{32}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *StreamResetDataResponse) GetPath() string {
@@ -2080,7 +2192,7 @@ var File_orchestrator_v1_orchestrator_proto protoreflect.FileDescriptor
 
 const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\n" +
-	"\"orchestrator/v1/orchestrator.proto\x12\x0forchestrator.v1\"\xfe\x05\n" +
+	"\"orchestrator/v1/orchestrator.proto\x12\x0forchestrator.v1\"\xcb\x06\n" +
 	"\x0fBinaryStatusMsg\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
 	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12\x18\n" +
@@ -2109,7 +2221,16 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\brepo_url\x18\x15 \x01(\tR\arepoUrl\x12F\n" +
 	"\fstartup_logs\x18\x16 \x03(\v2#.orchestrator.v1.StartupLogEntryMsgR\vstartupLogs\x12\x1f\n" +
 	"\vbinary_path\x18\x17 \x01(\tR\n" +
-	"binaryPath\"U\n" +
+	"binaryPath\x12K\n" +
+	"\x0fblockchain_sync\x18\x18 \x01(\v2\".orchestrator.v1.BlockchainSyncMsgR\x0eblockchainSync\"\x92\x02\n" +
+	"\x11BlockchainSyncMsg\x12\x16\n" +
+	"\x06blocks\x18\x01 \x01(\x05R\x06blocks\x12\x18\n" +
+	"\aheaders\x18\x02 \x01(\x05R\aheaders\x123\n" +
+	"\x15verification_progress\x18\x03 \x01(\x01R\x14verificationProgress\x124\n" +
+	"\x16initial_block_download\x18\x04 \x01(\bR\x14initialBlockDownload\x12$\n" +
+	"\x0ein_header_sync\x18\x05 \x01(\bR\finHeaderSync\x12\x12\n" +
+	"\x04time\x18\x06 \x01(\x03R\x04time\x12&\n" +
+	"\x0fbest_block_hash\x18\a \x01(\tR\rbestBlockHash\"U\n" +
 	"\x12StartupLogEntryMsg\x12%\n" +
 	"\x0etimestamp_unix\x18\x01 \x01(\x03R\rtimestampUnix\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\"\x15\n" +
@@ -2280,87 +2401,89 @@ func file_orchestrator_v1_orchestrator_proto_rawDescGZIP() []byte {
 	return file_orchestrator_v1_orchestrator_proto_rawDescData
 }
 
-var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_orchestrator_v1_orchestrator_proto_goTypes = []any{
 	(*BinaryStatusMsg)(nil),                    // 0: orchestrator.v1.BinaryStatusMsg
-	(*StartupLogEntryMsg)(nil),                 // 1: orchestrator.v1.StartupLogEntryMsg
-	(*ListBinariesRequest)(nil),                // 2: orchestrator.v1.ListBinariesRequest
-	(*ListBinariesResponse)(nil),               // 3: orchestrator.v1.ListBinariesResponse
-	(*GetBinaryStatusRequest)(nil),             // 4: orchestrator.v1.GetBinaryStatusRequest
-	(*GetBinaryStatusResponse)(nil),            // 5: orchestrator.v1.GetBinaryStatusResponse
-	(*DownloadBinaryRequest)(nil),              // 6: orchestrator.v1.DownloadBinaryRequest
-	(*DownloadBinaryResponse)(nil),             // 7: orchestrator.v1.DownloadBinaryResponse
-	(*StartBinaryRequest)(nil),                 // 8: orchestrator.v1.StartBinaryRequest
-	(*StartBinaryResponse)(nil),                // 9: orchestrator.v1.StartBinaryResponse
-	(*StopBinaryRequest)(nil),                  // 10: orchestrator.v1.StopBinaryRequest
-	(*StopBinaryResponse)(nil),                 // 11: orchestrator.v1.StopBinaryResponse
-	(*WatchBinariesRequest)(nil),               // 12: orchestrator.v1.WatchBinariesRequest
-	(*WatchBinariesResponse)(nil),              // 13: orchestrator.v1.WatchBinariesResponse
-	(*StreamLogsRequest)(nil),                  // 14: orchestrator.v1.StreamLogsRequest
-	(*StreamLogsResponse)(nil),                 // 15: orchestrator.v1.StreamLogsResponse
-	(*StartWithL1Request)(nil),                 // 16: orchestrator.v1.StartWithL1Request
-	(*StartWithL1Response)(nil),                // 17: orchestrator.v1.StartWithL1Response
-	(*ShutdownAllRequest)(nil),                 // 18: orchestrator.v1.ShutdownAllRequest
-	(*ShutdownAllResponse)(nil),                // 19: orchestrator.v1.ShutdownAllResponse
-	(*GetBTCPriceRequest)(nil),                 // 20: orchestrator.v1.GetBTCPriceRequest
-	(*GetBTCPriceResponse)(nil),                // 21: orchestrator.v1.GetBTCPriceResponse
-	(*GetMainchainBlockchainInfoRequest)(nil),  // 22: orchestrator.v1.GetMainchainBlockchainInfoRequest
-	(*GetMainchainBlockchainInfoResponse)(nil), // 23: orchestrator.v1.GetMainchainBlockchainInfoResponse
-	(*GetEnforcerBlockchainInfoRequest)(nil),   // 24: orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	(*GetEnforcerBlockchainInfoResponse)(nil),  // 25: orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	(*GetMainchainBalanceRequest)(nil),         // 26: orchestrator.v1.GetMainchainBalanceRequest
-	(*GetMainchainBalanceResponse)(nil),        // 27: orchestrator.v1.GetMainchainBalanceResponse
-	(*PreviewResetDataRequest)(nil),            // 28: orchestrator.v1.PreviewResetDataRequest
-	(*PreviewResetDataResponse)(nil),           // 29: orchestrator.v1.PreviewResetDataResponse
-	(*ResetFileInfo)(nil),                      // 30: orchestrator.v1.ResetFileInfo
-	(*StreamResetDataRequest)(nil),             // 31: orchestrator.v1.StreamResetDataRequest
-	(*StreamResetDataResponse)(nil),            // 32: orchestrator.v1.StreamResetDataResponse
-	nil,                                        // 33: orchestrator.v1.StartBinaryRequest.EnvEntry
-	nil,                                        // 34: orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	(*BlockchainSyncMsg)(nil),                  // 1: orchestrator.v1.BlockchainSyncMsg
+	(*StartupLogEntryMsg)(nil),                 // 2: orchestrator.v1.StartupLogEntryMsg
+	(*ListBinariesRequest)(nil),                // 3: orchestrator.v1.ListBinariesRequest
+	(*ListBinariesResponse)(nil),               // 4: orchestrator.v1.ListBinariesResponse
+	(*GetBinaryStatusRequest)(nil),             // 5: orchestrator.v1.GetBinaryStatusRequest
+	(*GetBinaryStatusResponse)(nil),            // 6: orchestrator.v1.GetBinaryStatusResponse
+	(*DownloadBinaryRequest)(nil),              // 7: orchestrator.v1.DownloadBinaryRequest
+	(*DownloadBinaryResponse)(nil),             // 8: orchestrator.v1.DownloadBinaryResponse
+	(*StartBinaryRequest)(nil),                 // 9: orchestrator.v1.StartBinaryRequest
+	(*StartBinaryResponse)(nil),                // 10: orchestrator.v1.StartBinaryResponse
+	(*StopBinaryRequest)(nil),                  // 11: orchestrator.v1.StopBinaryRequest
+	(*StopBinaryResponse)(nil),                 // 12: orchestrator.v1.StopBinaryResponse
+	(*WatchBinariesRequest)(nil),               // 13: orchestrator.v1.WatchBinariesRequest
+	(*WatchBinariesResponse)(nil),              // 14: orchestrator.v1.WatchBinariesResponse
+	(*StreamLogsRequest)(nil),                  // 15: orchestrator.v1.StreamLogsRequest
+	(*StreamLogsResponse)(nil),                 // 16: orchestrator.v1.StreamLogsResponse
+	(*StartWithL1Request)(nil),                 // 17: orchestrator.v1.StartWithL1Request
+	(*StartWithL1Response)(nil),                // 18: orchestrator.v1.StartWithL1Response
+	(*ShutdownAllRequest)(nil),                 // 19: orchestrator.v1.ShutdownAllRequest
+	(*ShutdownAllResponse)(nil),                // 20: orchestrator.v1.ShutdownAllResponse
+	(*GetBTCPriceRequest)(nil),                 // 21: orchestrator.v1.GetBTCPriceRequest
+	(*GetBTCPriceResponse)(nil),                // 22: orchestrator.v1.GetBTCPriceResponse
+	(*GetMainchainBlockchainInfoRequest)(nil),  // 23: orchestrator.v1.GetMainchainBlockchainInfoRequest
+	(*GetMainchainBlockchainInfoResponse)(nil), // 24: orchestrator.v1.GetMainchainBlockchainInfoResponse
+	(*GetEnforcerBlockchainInfoRequest)(nil),   // 25: orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	(*GetEnforcerBlockchainInfoResponse)(nil),  // 26: orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	(*GetMainchainBalanceRequest)(nil),         // 27: orchestrator.v1.GetMainchainBalanceRequest
+	(*GetMainchainBalanceResponse)(nil),        // 28: orchestrator.v1.GetMainchainBalanceResponse
+	(*PreviewResetDataRequest)(nil),            // 29: orchestrator.v1.PreviewResetDataRequest
+	(*PreviewResetDataResponse)(nil),           // 30: orchestrator.v1.PreviewResetDataResponse
+	(*ResetFileInfo)(nil),                      // 31: orchestrator.v1.ResetFileInfo
+	(*StreamResetDataRequest)(nil),             // 32: orchestrator.v1.StreamResetDataRequest
+	(*StreamResetDataResponse)(nil),            // 33: orchestrator.v1.StreamResetDataResponse
+	nil,                                        // 34: orchestrator.v1.StartBinaryRequest.EnvEntry
+	nil,                                        // 35: orchestrator.v1.StartWithL1Request.TargetEnvEntry
 }
 var file_orchestrator_v1_orchestrator_proto_depIdxs = []int32{
-	1,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
-	0,  // 1: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
-	0,  // 2: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
-	33, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
-	0,  // 4: orchestrator.v1.WatchBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
-	34, // 5: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
-	30, // 6: orchestrator.v1.PreviewResetDataResponse.files:type_name -> orchestrator.v1.ResetFileInfo
-	2,  // 7: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
-	4,  // 8: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
-	6,  // 9: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
-	8,  // 10: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
-	10, // 11: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
-	12, // 12: orchestrator.v1.OrchestratorService.WatchBinaries:input_type -> orchestrator.v1.WatchBinariesRequest
-	14, // 13: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
-	16, // 14: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
-	18, // 15: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
-	20, // 16: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
-	22, // 17: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
-	24, // 18: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	26, // 19: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
-	28, // 20: orchestrator.v1.OrchestratorService.PreviewResetData:input_type -> orchestrator.v1.PreviewResetDataRequest
-	31, // 21: orchestrator.v1.OrchestratorService.StreamResetData:input_type -> orchestrator.v1.StreamResetDataRequest
-	3,  // 22: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
-	5,  // 23: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
-	7,  // 24: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
-	9,  // 25: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
-	11, // 26: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
-	13, // 27: orchestrator.v1.OrchestratorService.WatchBinaries:output_type -> orchestrator.v1.WatchBinariesResponse
-	15, // 28: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
-	17, // 29: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
-	19, // 30: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
-	21, // 31: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
-	23, // 32: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
-	25, // 33: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	27, // 34: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
-	29, // 35: orchestrator.v1.OrchestratorService.PreviewResetData:output_type -> orchestrator.v1.PreviewResetDataResponse
-	32, // 36: orchestrator.v1.OrchestratorService.StreamResetData:output_type -> orchestrator.v1.StreamResetDataResponse
-	22, // [22:37] is the sub-list for method output_type
-	7,  // [7:22] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	2,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
+	1,  // 1: orchestrator.v1.BinaryStatusMsg.blockchain_sync:type_name -> orchestrator.v1.BlockchainSyncMsg
+	0,  // 2: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
+	0,  // 3: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
+	34, // 4: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
+	0,  // 5: orchestrator.v1.WatchBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
+	35, // 6: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	31, // 7: orchestrator.v1.PreviewResetDataResponse.files:type_name -> orchestrator.v1.ResetFileInfo
+	3,  // 8: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
+	5,  // 9: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
+	7,  // 10: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
+	9,  // 11: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
+	11, // 12: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
+	13, // 13: orchestrator.v1.OrchestratorService.WatchBinaries:input_type -> orchestrator.v1.WatchBinariesRequest
+	15, // 14: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
+	17, // 15: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
+	19, // 16: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
+	21, // 17: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
+	23, // 18: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
+	25, // 19: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	27, // 20: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
+	29, // 21: orchestrator.v1.OrchestratorService.PreviewResetData:input_type -> orchestrator.v1.PreviewResetDataRequest
+	32, // 22: orchestrator.v1.OrchestratorService.StreamResetData:input_type -> orchestrator.v1.StreamResetDataRequest
+	4,  // 23: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
+	6,  // 24: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
+	8,  // 25: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
+	10, // 26: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
+	12, // 27: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
+	14, // 28: orchestrator.v1.OrchestratorService.WatchBinaries:output_type -> orchestrator.v1.WatchBinariesResponse
+	16, // 29: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
+	18, // 30: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
+	20, // 31: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
+	22, // 32: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
+	24, // 33: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
+	26, // 34: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	28, // 35: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
+	30, // 36: orchestrator.v1.OrchestratorService.PreviewResetData:output_type -> orchestrator.v1.PreviewResetDataResponse
+	33, // 37: orchestrator.v1.OrchestratorService.StreamResetData:output_type -> orchestrator.v1.StreamResetDataResponse
+	23, // [23:38] is the sub-list for method output_type
+	8,  // [8:23] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_orchestrator_v1_orchestrator_proto_init() }
@@ -2374,7 +2497,7 @@ func file_orchestrator_v1_orchestrator_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_orchestrator_v1_orchestrator_proto_rawDesc), len(file_orchestrator_v1_orchestrator_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   35,
+			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/health_bitcoind.go
+++ b/sidechain-orchestrator/health_bitcoind.go
@@ -25,6 +25,12 @@ type BitcoindHealthCheck struct {
 	User     string
 	Password string
 	Timeout  time.Duration
+
+	// OnSync is invoked after each successful getblockchaininfo call with the
+	// full blockchain state. The orchestrator wires this to the bitcoind
+	// monitor's SetBlockchainSync so the WatchBinaries stream carries the tip
+	// without a second RPC client. Optional — nil is fine.
+	OnSync func(*BlockchainSync)
 }
 
 // PresyncMessagePrefix is the prefix used in synthetic startup errors when
@@ -42,6 +48,22 @@ func (h *BitcoindHealthCheck) Check(ctx context.Context) error {
 		return err
 	}
 
+	// Headers count below 10 means we're still pre-syncing. Frontend reads
+	// this off BlockchainSync.in_header_sync to gate "waiting for headers" UI.
+	inHeaderSync := info.Headers < 10
+
+	if h.OnSync != nil {
+		h.OnSync(&BlockchainSync{
+			Blocks:               int(info.Blocks),
+			Headers:              int(info.Headers),
+			VerificationProgress: info.VerificationProgress,
+			InitialBlockDownload: info.InitialBlockDownload,
+			InHeaderSync:         inHeaderSync,
+			Time:                 info.Time,
+			BestBlockHash:        info.BestBlockHash,
+		})
+	}
+
 	if info.Headers > 0 || info.Blocks > 0 {
 		return nil
 	}
@@ -54,8 +76,12 @@ func (h *BitcoindHealthCheck) Check(ctx context.Context) error {
 }
 
 type bitcoindBlockchainInfo struct {
-	Blocks  int64 `json:"blocks"`
-	Headers int64 `json:"headers"`
+	Blocks               int64   `json:"blocks"`
+	Headers              int64   `json:"headers"`
+	VerificationProgress float64 `json:"verificationprogress"`
+	InitialBlockDownload bool    `json:"initialblockdownload"`
+	Time                 int64   `json:"time"`
+	BestBlockHash        string  `json:"bestblockhash"`
 }
 
 func (h *BitcoindHealthCheck) callBlockchainInfo(ctx context.Context) (bitcoindBlockchainInfo, error) {

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -51,6 +51,22 @@ type BinaryStatus struct {
 	Version         string // configured version string
 	RepoURL         string // source code repository URL
 	StartupLogs     []StartupLogLine
+	// BlockchainSync is populated for chainLayer=1 binaries from the
+	// orchestrator's getblockchaininfo health poll. Nil when no sample yet.
+	BlockchainSync *BlockchainSync
+}
+
+// BlockchainSync is the snapshot the connection monitor records after each
+// successful getblockchaininfo. Frontend reads this from BinaryStatusMsg
+// instead of running its own bitcoind RPC client.
+type BlockchainSync struct {
+	Blocks               int
+	Headers              int
+	VerificationProgress float64
+	InitialBlockDownload bool
+	InHeaderSync         bool
+	Time                 int64
+	BestBlockHash        string
 }
 
 // StartupProgress reports progress during StartWithL1.
@@ -308,6 +324,14 @@ func (o *Orchestrator) getOrCreateMonitor(name string, checker HealthChecker, st
 	return mon
 }
 
+// getMonitor returns the existing ConnectionMonitor for a binary, or nil if
+// none has been created yet. Read-only — does NOT create.
+func (o *Orchestrator) getMonitor(name string) *ConnectionMonitor {
+	o.monitorsMu.Lock()
+	defer o.monitorsMu.Unlock()
+	return o.monitors[name]
+}
+
 // StopAllMonitors stops all connection monitor timers.
 func (o *Orchestrator) StopAllMonitors() {
 	o.monitorsMu.Lock()
@@ -491,6 +515,7 @@ func (o *Orchestrator) Status(name string) BinaryStatus {
 		status.Initializing = mon.InitializingBinary()
 		status.ConnectModeOnly = mon.ConnectModeOnly()
 		status.StartupLogs = mon.StartupLogs()
+		status.BlockchainSync = mon.BlockchainSync()
 	}
 	o.monitorsMu.Unlock()
 
@@ -645,6 +670,22 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 		}
 		coreChecker := NewHealthChecker(coreCfg, coreHealthOpts)
 		coreMon := o.getOrCreateMonitor("bitcoind", coreChecker, bitcoindStartupPatterns)
+
+		// Push every successful getblockchaininfo into the monitor so the
+		// WatchBinaries stream carries live tip + IBD state. Frontend reads
+		// it from BinaryStatusMsg.blockchain_sync instead of running its own
+		// bitcoind RPC client. The enforcer mirrors mainchain blocks
+		// (GetEnforcerBlockchainInfo proxies to the same data) so we copy
+		// the snapshot onto its monitor while it's connected — same source
+		// of truth, one less poll for the UI to make.
+		if bc, ok := coreChecker.(*BitcoindHealthCheck); ok {
+			bc.OnSync = func(s *BlockchainSync) {
+				coreMon.SetBlockchainSync(s)
+				if enfMon := o.getMonitor("enforcer"); enfMon != nil && enfMon.Connected() {
+					enfMon.SetBlockchainSync(s)
+				}
+			}
+		}
 
 		// Dart L208: await startConnectionTimer()
 		coreMon.StartConnectionTimer(ctx)

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -76,6 +76,29 @@ message BinaryStatusMsg {
   // bin/test/<binary>/... for active sidechain alt-builds, the resolved
   // .app/Contents/MacOS path on macOS, etc.). Empty when not downloaded.
   string binary_path = 23;
+  // Live blockchain sync state for chain-layer 1 binaries (bitcoind, enforcer).
+  // Populated from the orchestrator's existing health-check getblockchaininfo
+  // poll, so the frontend never has to make its own RPC call to read sync
+  // state. Nil/zero for non-L1 binaries or before the first successful poll.
+  BlockchainSyncMsg blockchain_sync = 24;
+}
+
+// BlockchainSyncMsg snapshots the chain tip + IBD state for an L1 binary.
+// Filled in by the orchestrator after each successful getblockchaininfo poll
+// and pushed to the frontend via WatchBinaries.
+message BlockchainSyncMsg {
+  int32 blocks = 1;
+  int32 headers = 2;
+  double verification_progress = 3;
+  bool initial_block_download = 4;
+  // True while the node is still bootstrapping headers (headers count too low
+  // to have meaningful sync info). Frontend uses this to gate "waiting for
+  // headers" UI without doing its own threshold math.
+  bool in_header_sync = 5;
+  // Block tip timestamp (unix seconds), 0 when no tip yet.
+  int64 time = 6;
+  // Best block hash at the tip — empty before the first poll.
+  string best_block_hash = 7;
 }
 
 message StartupLogEntryMsg {


### PR DESCRIPTION
Makes the orchestrator the single source of truth for L1 sync state: every getblockchaininfo health-poll now feeds blocks/headers/IBD into BinaryStatusMsg.blockchain_sync, so the frontend can drop its own bitcoind RPC client (and the conf-load race that left bitwindow stuck on 'Waiting for L1 to sync headers'). Also bakes zmqpubsequence into the default bitcoin.conf and adds a v6 migration so the enforcer actually starts. Daemon-card text precedence flipped so connection/startup errors win over informational hints.