### PR TITLE
orchestrator: per-daemon restart RPC

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.214
+version: 1.0.215
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.215
+version: 1.0.216
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.66
+version: 0.2.67
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -494,11 +494,6 @@ func isBitcoinCoreStartupError(errMsg string) bool {
 	return IsBitcoinCoreStartupError(errMsg)
 }
 
-func (p *Parser) currentHeight(ctx context.Context) (uint32, chainhash.Hash, error) {
-	height, hash, _, err := p.currentChainState(ctx)
-	return height, hash, err
-}
-
 // currentChainState returns the tip plus the IBD flag in one RPC. Callers
 // that want to gate heavy work on "Core has caught up" use the inIBD
 // return so they don't pay the cost of a second getblockchaininfo.

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -62,6 +62,15 @@ func (p *Parser) SetCoinnewsLogger(logger *zerolog.Logger) {
 	p.coinnewsLog = logger
 }
 
+// isFullChainNetwork reports whether the given network has full mainnet-
+// scale block volume. The OP_RETURN scanner's per-tx GetRawTransaction
+// fan-out is cheap on small-block networks and only becomes a problem on
+// these. signet / testnet / regtest blocks are small or empty so the
+// scanner stays running there during IBD.
+func isFullChainNetwork(n config.Network) bool {
+	return n == config.NetworkMainnet || n == config.NetworkForknet
+}
+
 // Run runs the engine. It checks if a new block has been mined,
 // and if so, handles it!
 //
@@ -164,18 +173,23 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 		return fmt.Errorf("fetch current height: %w", err)
 	}
 
-	// While Core is still doing initial block download, skip the OP_RETURN
-	// scan entirely. Each scan fans out a parallel batch of blocks and
-	// issues per-tx GetRawTransaction calls (needed for fee), all of which
-	// queue behind cs_main on Core. During IBD that's enough RPC pressure
-	// to push getblockchaininfo past its client timeout, which then trips
-	// the orchestrator's connection-lost monitor — and the UI block height
-	// stops updating. Catching up to the tip will happen in one batch the
-	// first tick after IBD clears; until then, keep out of Core's way.
-	if inIBD {
+	// While Core is still doing initial block download on a *full* chain
+	// (mainnet / forknet), skip the OP_RETURN scan entirely. Each scan
+	// fans out a parallel batch of blocks and issues per-tx
+	// GetRawTransaction calls (needed for fee), all of which queue behind
+	// cs_main. During IBD on a populated chain that's enough pressure to
+	// push getblockchaininfo past its client timeout, which trips the
+	// orchestrator's connection-lost monitor and freezes the UI height.
+	// Catching up runs in one batch the first tick after IBD clears.
+	//
+	// Signet / testnet / regtest blocks are small or empty, so the scan
+	// is cheap even mid-sync — keep running there so the user sees recent
+	// OP_RETURN activity while Core finishes catching up.
+	if inIBD && isFullChainNetwork(p.conf.BitcoinCoreNetwork) {
 		zerolog.Ctx(ctx).Debug().
 			Uint32("tip", currentHeight).
 			Uint32("processed", lastProcessedHeight).
+			Str("network", string(p.conf.BitcoinCoreNetwork)).
 			Msg("bitcoind_engine/parser: skipping scan while Core is in IBD")
 		return nil
 	}

--- a/bitwindow/server/integrationtest/backend_runtime_smoke_test.go
+++ b/bitwindow/server/integrationtest/backend_runtime_smoke_test.go
@@ -186,11 +186,11 @@ func newOrchestratorOnlyNode(t *testing.T) *orchestratorOnlyNode {
 	bitcoinDataDir := filepath.Join(nodeDir, "bitcoin")
 	require.NoError(t, os.MkdirAll(bitwindowDir, 0o700))
 	require.NoError(t, os.MkdirAll(bitcoinDataDir, 0o700))
-	// Pin the orchestrator under test to the untouched variant so we can
+	// Pin the orchestrator under test to the core variant so we can
 	// drop the locally-built bitcoind into its variant subfolder.
 	require.NoError(t, os.WriteFile(
 		filepath.Join(bitwindowDir, "orchestrator_settings.json"),
-		[]byte(`{"core_variant":"untouched"}`),
+		[]byte(`{"core_variant":"core"}`),
 		0o600,
 	))
 	smokeConfigs := orchestrator.AllDefaults()
@@ -385,7 +385,7 @@ func findBitcoind(t *testing.T) string {
 	dm := orchestrator.NewDownloadManager(dataDir, configPath, log)
 	// bitcoind downloads are now variant-keyed; pick a regtest-compatible
 	// variant explicitly since we don't have a full Orchestrator here.
-	variant := bitcoindConfig.Variants["untouched"]
+	variant := bitcoindConfig.Variants["core"]
 	dm.CoreVariant = func() (orchestrator.CoreVariantSpec, bool) { return variant, true }
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.88
+version: 1.0.89
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -50,7 +50,7 @@
       "download": {
         "binary": "bitcoind",
         "variants": {
-          "untouched": {
+          "core": {
             "subfolder": "bitcoin",
             "base_url": "https://bitcoincore.org/bin/bitcoin-core-30.2/",
             "files": {
@@ -59,16 +59,6 @@
               "windows": "bitcoin-30.2-win64.zip"
             },
             "available_networks": ["signet", "testnet", "regtest"]
-          },
-          "touched": {
-            "subfolder": "drivechain",
-            "base_url": "https://releases.drivechain.info/",
-            "files": {
-              "linux": "L1-bitcoin-patched-forknet-x86_64-unknown-linux-gnu.zip",
-              "macos": "L1-bitcoin-patched-forknet-x86_64-apple-darwin.zip",
-              "windows": "L1-bitcoin-patched-forknet-x86_64-w64-msvc.zip"
-            },
-            "available_networks": ["forknet"]
           },
           "patched": {
             "subfolder": "drivechain-patched",

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.client.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.client.dart
@@ -142,6 +142,28 @@ extension type OrchestratorServiceClient(connect.Transport _transport) {
     );
   }
 
+  /// Stop the named binary and start it again, single-daemon scope. Never
+  /// touches sibling daemons: restarting "enforcer" never spawns or adopts
+  /// bitcoind. Use this for per-daemon "Restart" buttons on UI cards;
+  /// StartWithL1 stays the entry point for full-chain bootstrap. Same
+  /// fire-and-forget shape as StartWithL1.
+  Future<orchestratorv1orchestrator.RestartDaemonResponse> restartDaemon(
+    orchestratorv1orchestrator.RestartDaemonRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.OrchestratorService.restartDaemon,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
   /// Shutdown all running binaries.
   Stream<orchestratorv1orchestrator.ShutdownAllResponse> shutdownAll(
     orchestratorv1orchestrator.ShutdownAllRequest input, {

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.spec.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.spec.dart
@@ -74,6 +74,18 @@ abstract final class OrchestratorService {
     orchestratorv1orchestrator.StartWithL1Response.new,
   );
 
+  /// Stop the named binary and start it again, single-daemon scope. Never
+  /// touches sibling daemons: restarting "enforcer" never spawns or adopts
+  /// bitcoind. Use this for per-daemon "Restart" buttons on UI cards;
+  /// StartWithL1 stays the entry point for full-chain bootstrap. Same
+  /// fire-and-forget shape as StartWithL1.
+  static const restartDaemon = connect.Spec(
+    '/$name/RestartDaemon',
+    connect.StreamType.unary,
+    orchestratorv1orchestrator.RestartDaemonRequest.new,
+    orchestratorv1orchestrator.RestartDaemonResponse.new,
+  );
+
   /// Shutdown all running binaries.
   static const shutdownAll = connect.Spec(
     '/$name/ShutdownAll',

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -1368,6 +1368,97 @@ class StartWithL1Response extends $pb.GeneratedMessage {
   static StartWithL1Response? _defaultInstance;
 }
 
+class RestartDaemonRequest extends $pb.GeneratedMessage {
+  factory RestartDaemonRequest({
+    $core.String? name,
+  }) {
+    final $result = create();
+    if (name != null) {
+      $result.name = name;
+    }
+    return $result;
+  }
+  RestartDaemonRequest._() : super();
+  factory RestartDaemonRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RestartDaemonRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RestartDaemonRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  RestartDaemonRequest clone() => RestartDaemonRequest()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RestartDaemonRequest copyWith(void Function(RestartDaemonRequest) updates) =>
+      super.copyWith((message) => updates(message as RestartDaemonRequest)) as RestartDaemonRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static RestartDaemonRequest create() => RestartDaemonRequest._();
+  RestartDaemonRequest createEmptyInstance() => create();
+  static $pb.PbList<RestartDaemonRequest> createRepeated() => $pb.PbList<RestartDaemonRequest>();
+  @$core.pragma('dart2js:noInline')
+  static RestartDaemonRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RestartDaemonRequest>(create);
+  static RestartDaemonRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+}
+
+class RestartDaemonResponse extends $pb.GeneratedMessage {
+  factory RestartDaemonResponse() => create();
+  RestartDaemonResponse._() : super();
+  factory RestartDaemonResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RestartDaemonResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RestartDaemonResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  RestartDaemonResponse clone() => RestartDaemonResponse()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RestartDaemonResponse copyWith(void Function(RestartDaemonResponse) updates) =>
+      super.copyWith((message) => updates(message as RestartDaemonResponse)) as RestartDaemonResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static RestartDaemonResponse create() => RestartDaemonResponse._();
+  RestartDaemonResponse createEmptyInstance() => create();
+  static $pb.PbList<RestartDaemonResponse> createRepeated() => $pb.PbList<RestartDaemonResponse>();
+  @$core.pragma('dart2js:noInline')
+  static RestartDaemonResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RestartDaemonResponse>(create);
+  static RestartDaemonResponse? _defaultInstance;
+}
+
 class ShutdownAllRequest extends $pb.GeneratedMessage {
   factory ShutdownAllRequest({
     $core.bool? force,
@@ -3554,6 +3645,8 @@ class OrchestratorServiceApi {
       _client.invoke<StreamLogsResponse>(ctx, 'OrchestratorService', 'StreamLogs', request, StreamLogsResponse());
   $async.Future<StartWithL1Response> startWithL1($pb.ClientContext? ctx, StartWithL1Request request) =>
       _client.invoke<StartWithL1Response>(ctx, 'OrchestratorService', 'StartWithL1', request, StartWithL1Response());
+  $async.Future<RestartDaemonResponse> restartDaemon($pb.ClientContext? ctx, RestartDaemonRequest request) => _client
+      .invoke<RestartDaemonResponse>(ctx, 'OrchestratorService', 'RestartDaemon', request, RestartDaemonResponse());
   $async.Future<ShutdownAllResponse> shutdownAll($pb.ClientContext? ctx, ShutdownAllRequest request) =>
       _client.invoke<ShutdownAllResponse>(ctx, 'OrchestratorService', 'ShutdownAll', request, ShutdownAllResponse());
   $async.Future<GetBTCPriceResponse> getBTCPrice($pb.ClientContext? ctx, GetBTCPriceRequest request) =>

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -305,6 +305,26 @@ const StartWithL1Response$json = {
 /// Descriptor for `StartWithL1Response`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List startWithL1ResponseDescriptor = $convert.base64Decode('ChNTdGFydFdpdGhMMVJlc3BvbnNl');
 
+@$core.Deprecated('Use restartDaemonRequestDescriptor instead')
+const RestartDaemonRequest$json = {
+  '1': 'RestartDaemonRequest',
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+  ],
+};
+
+/// Descriptor for `RestartDaemonRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List restartDaemonRequestDescriptor =
+    $convert.base64Decode('ChRSZXN0YXJ0RGFlbW9uUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1l');
+
+@$core.Deprecated('Use restartDaemonResponseDescriptor instead')
+const RestartDaemonResponse$json = {
+  '1': 'RestartDaemonResponse',
+};
+
+/// Descriptor for `RestartDaemonResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List restartDaemonResponseDescriptor = $convert.base64Decode('ChVSZXN0YXJ0RGFlbW9uUmVzcG9uc2U=');
+
 @$core.Deprecated('Use shutdownAllRequestDescriptor instead')
 const ShutdownAllRequest$json = {
   '1': 'ShutdownAllRequest',
@@ -684,6 +704,7 @@ const $core.Map<$core.String, $core.dynamic> OrchestratorServiceBase$json = {
       '6': true
     },
     {'1': 'StartWithL1', '2': '.orchestrator.v1.StartWithL1Request', '3': '.orchestrator.v1.StartWithL1Response'},
+    {'1': 'RestartDaemon', '2': '.orchestrator.v1.RestartDaemonRequest', '3': '.orchestrator.v1.RestartDaemonResponse'},
     {
       '1': 'ShutdownAll',
       '2': '.orchestrator.v1.ShutdownAllRequest',
@@ -747,6 +768,8 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> Orchestrat
   '.orchestrator.v1.StartWithL1Request': StartWithL1Request$json,
   '.orchestrator.v1.StartWithL1Request.TargetEnvEntry': StartWithL1Request_TargetEnvEntry$json,
   '.orchestrator.v1.StartWithL1Response': StartWithL1Response$json,
+  '.orchestrator.v1.RestartDaemonRequest': RestartDaemonRequest$json,
+  '.orchestrator.v1.RestartDaemonResponse': RestartDaemonResponse$json,
   '.orchestrator.v1.ShutdownAllRequest': ShutdownAllRequest$json,
   '.orchestrator.v1.ShutdownAllResponse': ShutdownAllResponse$json,
   '.orchestrator.v1.GetBTCPriceRequest': GetBTCPriceRequest$json,
@@ -786,23 +809,25 @@ final $typed_data.Uint8List orchestratorServiceDescriptor =
         'VhbUxvZ3MSIi5vcmNoZXN0cmF0b3IudjEuU3RyZWFtTG9nc1JlcXVlc3QaIy5vcmNoZXN0cmF0'
         'b3IudjEuU3RyZWFtTG9nc1Jlc3BvbnNlMAESWAoLU3RhcnRXaXRoTDESIy5vcmNoZXN0cmF0b3'
         'IudjEuU3RhcnRXaXRoTDFSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLlN0YXJ0V2l0aEwxUmVz'
-        'cG9uc2USWgoLU2h1dGRvd25BbGwSIy5vcmNoZXN0cmF0b3IudjEuU2h1dGRvd25BbGxSZXF1ZX'
-        'N0GiQub3JjaGVzdHJhdG9yLnYxLlNodXRkb3duQWxsUmVzcG9uc2UwARJYCgtHZXRCVENQcmlj'
-        'ZRIjLm9yY2hlc3RyYXRvci52MS5HZXRCVENQcmljZVJlcXVlc3QaJC5vcmNoZXN0cmF0b3Iudj'
-        'EuR2V0QlRDUHJpY2VSZXNwb25zZRKFAQoaR2V0TWFpbmNoYWluQmxvY2tjaGFpbkluZm8SMi5v'
-        'cmNoZXN0cmF0b3IudjEuR2V0TWFpbmNoYWluQmxvY2tjaGFpbkluZm9SZXF1ZXN0GjMub3JjaG'
-        'VzdHJhdG9yLnYxLkdldE1haW5jaGFpbkJsb2NrY2hhaW5JbmZvUmVzcG9uc2USggEKGUdldEVu'
-        'Zm9yY2VyQmxvY2tjaGFpbkluZm8SMS5vcmNoZXN0cmF0b3IudjEuR2V0RW5mb3JjZXJCbG9ja2'
-        'NoYWluSW5mb1JlcXVlc3QaMi5vcmNoZXN0cmF0b3IudjEuR2V0RW5mb3JjZXJCbG9ja2NoYWlu'
-        'SW5mb1Jlc3BvbnNlEl4KDUdldFN5bmNTdGF0dXMSJS5vcmNoZXN0cmF0b3IudjEuR2V0U3luY1'
-        'N0YXR1c1JlcXVlc3QaJi5vcmNoZXN0cmF0b3IudjEuR2V0U3luY1N0YXR1c1Jlc3BvbnNlEnAK'
-        'E0dldE1haW5jaGFpbkJhbGFuY2USKy5vcmNoZXN0cmF0b3IudjEuR2V0TWFpbmNoYWluQmFsYW'
-        '5jZVJlcXVlc3QaLC5vcmNoZXN0cmF0b3IudjEuR2V0TWFpbmNoYWluQmFsYW5jZVJlc3BvbnNl'
-        'EmcKEFByZXZpZXdSZXNldERhdGESKC5vcmNoZXN0cmF0b3IudjEuUHJldmlld1Jlc2V0RGF0YV'
-        'JlcXVlc3QaKS5vcmNoZXN0cmF0b3IudjEuUHJldmlld1Jlc2V0RGF0YVJlc3BvbnNlEmYKD1N0'
-        'cmVhbVJlc2V0RGF0YRInLm9yY2hlc3RyYXRvci52MS5TdHJlYW1SZXNldERhdGFSZXF1ZXN0Gi'
-        'gub3JjaGVzdHJhdG9yLnYxLlN0cmVhbVJlc2V0RGF0YVJlc3BvbnNlMAESbQoSR2V0Q29yZU1l'
-        'bXBvb2xJbmZvEioub3JjaGVzdHJhdG9yLnYxLkdldENvcmVNZW1wb29sSW5mb1JlcXVlc3QaKy'
-        '5vcmNoZXN0cmF0b3IudjEuR2V0Q29yZU1lbXBvb2xJbmZvUmVzcG9uc2USWAoLQ29yZVJhd0Nh'
-        'bGwSIy5vcmNoZXN0cmF0b3IudjEuQ29yZVJhd0NhbGxSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLn'
-        'YxLkNvcmVSYXdDYWxsUmVzcG9uc2U=');
+        'cG9uc2USXgoNUmVzdGFydERhZW1vbhIlLm9yY2hlc3RyYXRvci52MS5SZXN0YXJ0RGFlbW9uUm'
+        'VxdWVzdBomLm9yY2hlc3RyYXRvci52MS5SZXN0YXJ0RGFlbW9uUmVzcG9uc2USWgoLU2h1dGRv'
+        'd25BbGwSIy5vcmNoZXN0cmF0b3IudjEuU2h1dGRvd25BbGxSZXF1ZXN0GiQub3JjaGVzdHJhdG'
+        '9yLnYxLlNodXRkb3duQWxsUmVzcG9uc2UwARJYCgtHZXRCVENQcmljZRIjLm9yY2hlc3RyYXRv'
+        'ci52MS5HZXRCVENQcmljZVJlcXVlc3QaJC5vcmNoZXN0cmF0b3IudjEuR2V0QlRDUHJpY2VSZX'
+        'Nwb25zZRKFAQoaR2V0TWFpbmNoYWluQmxvY2tjaGFpbkluZm8SMi5vcmNoZXN0cmF0b3IudjEu'
+        'R2V0TWFpbmNoYWluQmxvY2tjaGFpbkluZm9SZXF1ZXN0GjMub3JjaGVzdHJhdG9yLnYxLkdldE'
+        '1haW5jaGFpbkJsb2NrY2hhaW5JbmZvUmVzcG9uc2USggEKGUdldEVuZm9yY2VyQmxvY2tjaGFp'
+        'bkluZm8SMS5vcmNoZXN0cmF0b3IudjEuR2V0RW5mb3JjZXJCbG9ja2NoYWluSW5mb1JlcXVlc3'
+        'QaMi5vcmNoZXN0cmF0b3IudjEuR2V0RW5mb3JjZXJCbG9ja2NoYWluSW5mb1Jlc3BvbnNlEl4K'
+        'DUdldFN5bmNTdGF0dXMSJS5vcmNoZXN0cmF0b3IudjEuR2V0U3luY1N0YXR1c1JlcXVlc3QaJi'
+        '5vcmNoZXN0cmF0b3IudjEuR2V0U3luY1N0YXR1c1Jlc3BvbnNlEnAKE0dldE1haW5jaGFpbkJh'
+        'bGFuY2USKy5vcmNoZXN0cmF0b3IudjEuR2V0TWFpbmNoYWluQmFsYW5jZVJlcXVlc3QaLC5vcm'
+        'NoZXN0cmF0b3IudjEuR2V0TWFpbmNoYWluQmFsYW5jZVJlc3BvbnNlEmcKEFByZXZpZXdSZXNl'
+        'dERhdGESKC5vcmNoZXN0cmF0b3IudjEuUHJldmlld1Jlc2V0RGF0YVJlcXVlc3QaKS5vcmNoZX'
+        'N0cmF0b3IudjEuUHJldmlld1Jlc2V0RGF0YVJlc3BvbnNlEmYKD1N0cmVhbVJlc2V0RGF0YRIn'
+        'Lm9yY2hlc3RyYXRvci52MS5TdHJlYW1SZXNldERhdGFSZXF1ZXN0Gigub3JjaGVzdHJhdG9yLn'
+        'YxLlN0cmVhbVJlc2V0RGF0YVJlc3BvbnNlMAESbQoSR2V0Q29yZU1lbXBvb2xJbmZvEioub3Jj'
+        'aGVzdHJhdG9yLnYxLkdldENvcmVNZW1wb29sSW5mb1JlcXVlc3QaKy5vcmNoZXN0cmF0b3Iudj'
+        'EuR2V0Q29yZU1lbXBvb2xJbmZvUmVzcG9uc2USWAoLQ29yZVJhd0NhbGwSIy5vcmNoZXN0cmF0'
+        'b3IudjEuQ29yZVJhd0NhbGxSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLkNvcmVSYXdDYWxsUm'
+        'VzcG9uc2U=');

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbserver.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbserver.dart
@@ -28,6 +28,7 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
   $async.Future<$5.StopBinaryResponse> stopBinary($pb.ServerContext ctx, $5.StopBinaryRequest request);
   $async.Future<$5.StreamLogsResponse> streamLogs($pb.ServerContext ctx, $5.StreamLogsRequest request);
   $async.Future<$5.StartWithL1Response> startWithL1($pb.ServerContext ctx, $5.StartWithL1Request request);
+  $async.Future<$5.RestartDaemonResponse> restartDaemon($pb.ServerContext ctx, $5.RestartDaemonRequest request);
   $async.Future<$5.ShutdownAllResponse> shutdownAll($pb.ServerContext ctx, $5.ShutdownAllRequest request);
   $async.Future<$5.GetBTCPriceResponse> getBTCPrice($pb.ServerContext ctx, $5.GetBTCPriceRequest request);
   $async.Future<$5.GetMainchainBlockchainInfoResponse> getMainchainBlockchainInfo(
@@ -60,6 +61,8 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
         return $5.StreamLogsRequest();
       case 'StartWithL1':
         return $5.StartWithL1Request();
+      case 'RestartDaemon':
+        return $5.RestartDaemonRequest();
       case 'ShutdownAll':
         return $5.ShutdownAllRequest();
       case 'GetBTCPrice':
@@ -102,6 +105,8 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
         return this.streamLogs(ctx, request as $5.StreamLogsRequest);
       case 'StartWithL1':
         return this.startWithL1(ctx, request as $5.StartWithL1Request);
+      case 'RestartDaemon':
+        return this.restartDaemon(ctx, request as $5.RestartDaemonRequest);
       case 'ShutdownAll':
         return this.shutdownAll(ctx, request as $5.ShutdownAllRequest);
       case 'GetBTCPrice':

--- a/sail_ui/lib/providers/binaries/binary_provider.dart
+++ b/sail_ui/lib/providers/binaries/binary_provider.dart
@@ -89,6 +89,33 @@ class BinaryProvider extends ChangeNotifier {
     await _orchestrator.startWithL1(name);
   }
 
+  /// Restart a single binary in-place. Unlike [start], which routes through
+  /// the orchestrator's full L1 boot chain (Core -> Enforcer -> target),
+  /// this stops + starts only the named binary. Restarting the enforcer
+  /// never tries to spawn or adopt bitcoind — fixes the "bitcoind is already
+  /// running" phantom error that surfaced on Bitcoin Core's card whenever a
+  /// user clicked Restart on a sibling daemon.
+  ///
+  /// Use this for the per-daemon Restart buttons in daemon status cards,
+  /// chain-settings modals, the persistent status bar, and the sidechains
+  /// page. Reserve [start] for first-time chain bootstrap.
+  Future<void> restart(Binary binary) async {
+    if (_isDaemonBinary(binary)) {
+      await _stopDaemonBinary(binary);
+      await _startDaemonBinary(binary);
+      return;
+    }
+
+    final name = _orchestratorName(binary);
+    if (name == null) {
+      log.e('BinaryProvider: unknown binary ${binary.name}');
+      return;
+    }
+
+    log.i('BinaryProvider: restarting $name via orchestrator');
+    await _orchestrator.restartDaemon(name);
+  }
+
   Future<void> stop(Binary binary, {bool skipDownstream = false}) async {
     if (_isDaemonBinary(binary)) {
       await _stopDaemonBinary(binary);

--- a/sail_ui/lib/providers/sync_provider.dart
+++ b/sail_ui/lib/providers/sync_provider.dart
@@ -140,8 +140,8 @@ class SyncProvider extends ChangeNotifier {
   SyncProvider({this.additionalConnection, bool startTimer = true}) {
     if (startTimer && !Environment.isInTest) {
       _scheduleNextTick();
+      fetch();
     }
-    fetch();
   }
 
   void _scheduleNextTick() {

--- a/sail_ui/lib/rpcs/orchestrator_rpc.dart
+++ b/sail_ui/lib/rpcs/orchestrator_rpc.dart
@@ -196,6 +196,15 @@ class OrchestratorRPC {
     );
   }
 
+  /// Fire-and-forget: stops + starts the named binary on the server. Single-
+  /// daemon scope — never touches sibling daemons, so restarting "enforcer"
+  /// can't surface a phantom "bitcoind is already running" error on Bitcoin
+  /// Core's card. Use this for per-daemon Restart buttons; reserve
+  /// [startWithL1] for full-chain bootstrap.
+  Future<RestartDaemonResponse> restartDaemon(String name) {
+    return _unaryClient.restartDaemon(RestartDaemonRequest(name: name));
+  }
+
   Stream<ShutdownAllResponse> shutdownAll({bool force = false}) {
     return _streamClient.shutdownAll(ShutdownAllRequest(force: force));
   }

--- a/sail_ui/lib/widgets/components/daemon_connection_card.dart
+++ b/sail_ui/lib/widgets/components/daemon_connection_card.dart
@@ -64,10 +64,9 @@ class DaemonConnectionCard extends StatelessWidget {
                         shouldUpdate: true,
                       );
 
-                      // 2. Stop the binary
-                      await _binaryProvider.stop(providerBinary);
-
-                      // 3. Start the binary with retry logic (3 attempts, 5 second wait)
+                      // 2. Restart the binary with retry logic (3 attempts,
+                      // 5 second wait). Per-daemon scope — restarting the
+                      // enforcer here must not poke bitcoind and vice versa.
                       bool started = false;
                       int attempts = 0;
                       const maxAttempts = 3;
@@ -76,14 +75,12 @@ class DaemonConnectionCard extends StatelessWidget {
                       while (!started && attempts < maxAttempts) {
                         attempts++;
                         try {
-                          await _binaryProvider.start(providerBinary);
+                          await _binaryProvider.restart(providerBinary);
                           started = true;
                         } catch (e) {
                           if (attempts < maxAttempts) {
-                            // Wait before retry
                             await Future.delayed(retryDelay);
                           } else {
-                            // Re-throw the error on final attempt
                             rethrow;
                           }
                         }

--- a/sail_ui/lib/widgets/modals/chain_settings_modal.dart
+++ b/sail_ui/lib/widgets/modals/chain_settings_modal.dart
@@ -412,10 +412,9 @@ class ChainSettingsViewModel extends BaseViewModel {
 
       bool wasRunning = _binaryProvider.isConnected(_binary);
       if (wasRunning) {
-        // 2. Stop the binary
-        await _binaryProvider.stop(_binary);
-
-        // 3. Start the binary with retry logic (3 attempts, 5 second wait)
+        // 2. Restart the binary with retry logic (3 attempts, 5 second wait).
+        // Per-daemon scope: restarting one binary here must not poke its
+        // siblings.
         bool started = false;
         int attempts = 0;
         const maxAttempts = 3;
@@ -424,14 +423,12 @@ class ChainSettingsViewModel extends BaseViewModel {
         while (!started && attempts < maxAttempts) {
           attempts++;
           try {
-            await _binaryProvider.start(_binary);
+            await _binaryProvider.restart(_binary);
             started = true;
           } catch (e) {
             if (attempts < maxAttempts) {
-              // Wait before retry
               await Future.delayed(retryDelay);
             } else {
-              // Re-throw the error on final attempt
               rethrow;
             }
           }

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -173,7 +173,7 @@ class BottomNav extends StatelessWidget {
                     DaemonConnectionCard(
                       connection: model.mainchain,
                       syncInfo: model.syncProvider.mainchainSyncInfo,
-                      restartDaemon: () => binaryProvider.start(
+                      restartDaemon: () => binaryProvider.restart(
                         binaryProvider.binaries.firstWhere(
                           (b) => b.name == BitcoinCore().name,
                         ),
@@ -204,7 +204,7 @@ class BottomNav extends StatelessWidget {
                               : model.syncProvider.inHeaderSync
                               ? 'Waiting for L1 to sync headers...'
                               : null),
-                      restartDaemon: () => binaryProvider.start(
+                      restartDaemon: () => binaryProvider.restart(
                         binaryProvider.binaries.firstWhere(
                           (b) => b.name == Enforcer().name,
                         ),
@@ -242,7 +242,7 @@ class BottomNav extends StatelessWidget {
                         connection: additionalConnection.rpc,
                         syncInfo: coreReady ? model.additionalSyncInfo : null,
                         infoMessage: infoMessage,
-                        restartDaemon: () => binaryProvider.start(
+                        restartDaemon: () => binaryProvider.restart(
                           binaryProvider.binaries.firstWhere(
                             (b) => b.name == additionalConnection.rpc.binary.name,
                           ),

--- a/sail_ui/lib/widgets/nav/persistent_status_bar.dart
+++ b/sail_ui/lib/widgets/nav/persistent_status_bar.dart
@@ -69,7 +69,7 @@ class PersistentStatusBar extends StatelessWidget {
                       variant: ButtonVariant.ghost,
                       onPressed: () async {
                         for (final binary in broken) {
-                          await binaryProvider.start(binary);
+                          await binaryProvider.restart(binary);
                         }
                       },
                     ),

--- a/sail_ui/test/widgets/persistent_status_bar_test.dart
+++ b/sail_ui/test/widgets/persistent_status_bar_test.dart
@@ -8,13 +8,13 @@ import 'package:sail_ui/sail_ui.dart';
 
 /// BinaryProvider double that exposes setters for the exact fields the
 /// PersistentStatusBar inspects (isConnected / isInitializing / isStopping /
-/// connectionError) and records calls to [start].
+/// connectionError) and records calls to [restart].
 class _FakeBinaryProvider extends BinaryProvider {
   final Map<BinaryType, bool> _connected = {};
   final Map<BinaryType, bool> _initializing = {};
   final Map<BinaryType, bool> _stopping = {};
   final Map<BinaryType, String?> _errors = {};
-  final List<BinaryType> startedTypes = [];
+  final List<BinaryType> restartedTypes = [];
 
   _FakeBinaryProvider({required super.appDir, required super.binaries}) : super.test();
 
@@ -45,8 +45,8 @@ class _FakeBinaryProvider extends BinaryProvider {
   String? connectionError(Binary binary) => _errors[binary.type];
 
   @override
-  Future<void> start(Binary binary) async {
-    startedTypes.add(binary.type);
+  Future<void> restart(Binary binary) async {
+    restartedTypes.add(binary.type);
   }
 
   @override
@@ -152,7 +152,7 @@ void main() {
     expect(find.text('Restart'), findsWidgets);
   });
 
-  testWidgets('tapping Restart calls BinaryProvider.start for every broken daemon', (tester) async {
+  testWidgets('tapping Restart calls BinaryProvider.restart for every broken daemon', (tester) async {
     binaryProvider.setState(BinaryType.orchestratord, error: 'down');
     binaryProvider.setState(BinaryType.bitWindow, error: 'down');
 
@@ -163,7 +163,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      binaryProvider.startedTypes,
+      binaryProvider.restartedTypes,
       containsAll(<BinaryType>[BinaryType.orchestratord, BinaryType.bitWindow]),
     );
   });

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -125,6 +125,25 @@ func (h *Handler) StreamLogs(ctx context.Context, req *connect.Request[pb.Stream
 	}
 }
 
+// RestartDaemon stops + starts a single binary. Same fire-and-forget shape
+// as StartWithL1: the boot goroutine uses context.Background() so a transport
+// blip can't kill an in-flight restart. Crucially, it does NOT cascade to
+// sibling daemons — restarting "enforcer" never spawns or adopts bitcoind.
+func (h *Handler) RestartDaemon(ctx context.Context, req *connect.Request[pb.RestartDaemonRequest]) (*connect.Response[pb.RestartDaemonResponse], error) {
+	ch, err := h.orch.RestartDaemon(context.Background(), req.Msg.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		for range ch {
+			// drain
+		}
+	}()
+
+	return connect.NewResponse(&pb.RestartDaemonResponse{}), nil
+}
+
 // StartWithL1 dispatches a boot goroutine and returns immediately. The
 // goroutine uses context.Background() so that a transport blip / client
 // disconnect on this RPC can't cancel an in-flight bitcoind download or

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -810,50 +810,6 @@ func (m *BitcoinConfManager) UpdateDataDir(dataDir string, forNetwork Network) e
 	return m.LoadConfig(false)
 }
 
-// updateDatadirInBackup writes a datadir change directly to the per-network
-// backup file, without touching master. Used when the target network differs
-// from the currently-active network.
-func (m *BitcoinConfManager) updateDatadirInBackup(n Network, dataDir string) error {
-	confPath := m.getMainSectionPath(n)
-	if err := os.MkdirAll(filepath.Dir(confPath), 0755); err != nil {
-		return fmt.Errorf("create dir: %w", err)
-	}
-
-	if n == NetworkForknet {
-		var fc *ForknetConfig
-		if data, err := os.ReadFile(confPath); err == nil {
-			fc = ParseForknetConfig(string(data))
-		} else {
-			fc = NewForknetConfig()
-			fc.Version = BitcoinConfMigrationsVersion
-			settings, order := getDefaultMainSection(n)
-			for _, k := range orderedKeys(order, settings) {
-				fc.Set(k, settings[k])
-			}
-		}
-		if dataDir == "" {
-			fc.Delete("datadir")
-		} else {
-			fc.Set("datadir", dataDir)
-		}
-		return os.WriteFile(confPath, []byte(fc.Serialize()), 0644)
-	}
-
-	var mc *MainnetConfig
-	if data, err := os.ReadFile(confPath); err == nil {
-		mc = ParseMainnetConfig(string(data))
-	} else {
-		mc = NewMainnetConfig()
-		mc.Version = BitcoinConfMigrationsVersion
-	}
-	if dataDir == "" {
-		mc.Delete("datadir")
-	} else {
-		mc.Set("datadir", dataDir)
-	}
-	return os.WriteFile(confPath, []byte(mc.Serialize()), 0644)
-}
-
 // ---------------------------------------------------------------------------
 // Piece 10: HasDatadirForNetwork
 // ---------------------------------------------------------------------------

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -1044,6 +1044,86 @@ func (*StartWithL1Response) Descriptor() ([]byte, []int) {
 	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{15}
 }
 
+type RestartDaemonRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RestartDaemonRequest) Reset() {
+	*x = RestartDaemonRequest{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestartDaemonRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestartDaemonRequest) ProtoMessage() {}
+
+func (x *RestartDaemonRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestartDaemonRequest.ProtoReflect.Descriptor instead.
+func (*RestartDaemonRequest) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *RestartDaemonRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type RestartDaemonResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RestartDaemonResponse) Reset() {
+	*x = RestartDaemonResponse{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestartDaemonResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestartDaemonResponse) ProtoMessage() {}
+
+func (x *RestartDaemonResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestartDaemonResponse.ProtoReflect.Descriptor instead.
+func (*RestartDaemonResponse) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{17}
+}
+
 type ShutdownAllRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Force         bool                   `protobuf:"varint,1,opt,name=force,proto3" json:"force,omitempty"`
@@ -1053,7 +1133,7 @@ type ShutdownAllRequest struct {
 
 func (x *ShutdownAllRequest) Reset() {
 	*x = ShutdownAllRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[16]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1065,7 +1145,7 @@ func (x *ShutdownAllRequest) String() string {
 func (*ShutdownAllRequest) ProtoMessage() {}
 
 func (x *ShutdownAllRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[16]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1078,7 +1158,7 @@ func (x *ShutdownAllRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownAllRequest.ProtoReflect.Descriptor instead.
 func (*ShutdownAllRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{16}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ShutdownAllRequest) GetForce() bool {
@@ -1101,7 +1181,7 @@ type ShutdownAllResponse struct {
 
 func (x *ShutdownAllResponse) Reset() {
 	*x = ShutdownAllResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[17]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1113,7 +1193,7 @@ func (x *ShutdownAllResponse) String() string {
 func (*ShutdownAllResponse) ProtoMessage() {}
 
 func (x *ShutdownAllResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[17]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1126,7 +1206,7 @@ func (x *ShutdownAllResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownAllResponse.ProtoReflect.Descriptor instead.
 func (*ShutdownAllResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{17}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ShutdownAllResponse) GetTotalCount() int32 {
@@ -1172,7 +1252,7 @@ type GetBTCPriceRequest struct {
 
 func (x *GetBTCPriceRequest) Reset() {
 	*x = GetBTCPriceRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[18]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1184,7 +1264,7 @@ func (x *GetBTCPriceRequest) String() string {
 func (*GetBTCPriceRequest) ProtoMessage() {}
 
 func (x *GetBTCPriceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[18]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1197,7 +1277,7 @@ func (x *GetBTCPriceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBTCPriceRequest.ProtoReflect.Descriptor instead.
 func (*GetBTCPriceRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{18}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{20}
 }
 
 type GetBTCPriceResponse struct {
@@ -1210,7 +1290,7 @@ type GetBTCPriceResponse struct {
 
 func (x *GetBTCPriceResponse) Reset() {
 	*x = GetBTCPriceResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[19]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1222,7 +1302,7 @@ func (x *GetBTCPriceResponse) String() string {
 func (*GetBTCPriceResponse) ProtoMessage() {}
 
 func (x *GetBTCPriceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[19]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1235,7 +1315,7 @@ func (x *GetBTCPriceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBTCPriceResponse.ProtoReflect.Descriptor instead.
 func (*GetBTCPriceResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{19}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetBTCPriceResponse) GetBtcusd() float64 {
@@ -1260,7 +1340,7 @@ type GetMainchainBlockchainInfoRequest struct {
 
 func (x *GetMainchainBlockchainInfoRequest) Reset() {
 	*x = GetMainchainBlockchainInfoRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[20]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1272,7 +1352,7 @@ func (x *GetMainchainBlockchainInfoRequest) String() string {
 func (*GetMainchainBlockchainInfoRequest) ProtoMessage() {}
 
 func (x *GetMainchainBlockchainInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[20]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1285,7 +1365,7 @@ func (x *GetMainchainBlockchainInfoRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetMainchainBlockchainInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetMainchainBlockchainInfoRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{20}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{22}
 }
 
 type GetMainchainBlockchainInfoResponse struct {
@@ -1308,7 +1388,7 @@ type GetMainchainBlockchainInfoResponse struct {
 
 func (x *GetMainchainBlockchainInfoResponse) Reset() {
 	*x = GetMainchainBlockchainInfoResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[21]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1320,7 +1400,7 @@ func (x *GetMainchainBlockchainInfoResponse) String() string {
 func (*GetMainchainBlockchainInfoResponse) ProtoMessage() {}
 
 func (x *GetMainchainBlockchainInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[21]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1333,7 +1413,7 @@ func (x *GetMainchainBlockchainInfoResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetMainchainBlockchainInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetMainchainBlockchainInfoResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{21}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GetMainchainBlockchainInfoResponse) GetChain() string {
@@ -1428,7 +1508,7 @@ type GetEnforcerBlockchainInfoRequest struct {
 
 func (x *GetEnforcerBlockchainInfoRequest) Reset() {
 	*x = GetEnforcerBlockchainInfoRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[22]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1440,7 +1520,7 @@ func (x *GetEnforcerBlockchainInfoRequest) String() string {
 func (*GetEnforcerBlockchainInfoRequest) ProtoMessage() {}
 
 func (x *GetEnforcerBlockchainInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[22]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1453,7 +1533,7 @@ func (x *GetEnforcerBlockchainInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEnforcerBlockchainInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetEnforcerBlockchainInfoRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{22}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{24}
 }
 
 type GetEnforcerBlockchainInfoResponse struct {
@@ -1467,7 +1547,7 @@ type GetEnforcerBlockchainInfoResponse struct {
 
 func (x *GetEnforcerBlockchainInfoResponse) Reset() {
 	*x = GetEnforcerBlockchainInfoResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[23]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1479,7 +1559,7 @@ func (x *GetEnforcerBlockchainInfoResponse) String() string {
 func (*GetEnforcerBlockchainInfoResponse) ProtoMessage() {}
 
 func (x *GetEnforcerBlockchainInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[23]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1492,7 +1572,7 @@ func (x *GetEnforcerBlockchainInfoResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetEnforcerBlockchainInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetEnforcerBlockchainInfoResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{23}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetEnforcerBlockchainInfoResponse) GetBlocks() int32 {
@@ -1524,7 +1604,7 @@ type GetSyncStatusRequest struct {
 
 func (x *GetSyncStatusRequest) Reset() {
 	*x = GetSyncStatusRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[24]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1536,7 +1616,7 @@ func (x *GetSyncStatusRequest) String() string {
 func (*GetSyncStatusRequest) ProtoMessage() {}
 
 func (x *GetSyncStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[24]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1549,7 +1629,7 @@ func (x *GetSyncStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSyncStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetSyncStatusRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{24}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{26}
 }
 
 type GetSyncStatusResponse struct {
@@ -1568,7 +1648,7 @@ type GetSyncStatusResponse struct {
 
 func (x *GetSyncStatusResponse) Reset() {
 	*x = GetSyncStatusResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[25]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1580,7 +1660,7 @@ func (x *GetSyncStatusResponse) String() string {
 func (*GetSyncStatusResponse) ProtoMessage() {}
 
 func (x *GetSyncStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[25]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1593,7 +1673,7 @@ func (x *GetSyncStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSyncStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetSyncStatusResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{25}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetSyncStatusResponse) GetMainchain() *ChainSync {
@@ -1627,7 +1707,7 @@ type SidechainStatus struct {
 
 func (x *SidechainStatus) Reset() {
 	*x = SidechainStatus{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[26]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1639,7 +1719,7 @@ func (x *SidechainStatus) String() string {
 func (*SidechainStatus) ProtoMessage() {}
 
 func (x *SidechainStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[26]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1652,7 +1732,7 @@ func (x *SidechainStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SidechainStatus.ProtoReflect.Descriptor instead.
 func (*SidechainStatus) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{26}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *SidechainStatus) GetType() SidechainType {
@@ -1691,7 +1771,7 @@ type ChainSync struct {
 
 func (x *ChainSync) Reset() {
 	*x = ChainSync{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[27]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1703,7 +1783,7 @@ func (x *ChainSync) String() string {
 func (*ChainSync) ProtoMessage() {}
 
 func (x *ChainSync) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[27]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1716,7 +1796,7 @@ func (x *ChainSync) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChainSync.ProtoReflect.Descriptor instead.
 func (*ChainSync) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{27}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ChainSync) GetBlocks() int32 {
@@ -1762,7 +1842,7 @@ type GetMainchainBalanceRequest struct {
 
 func (x *GetMainchainBalanceRequest) Reset() {
 	*x = GetMainchainBalanceRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[28]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1774,7 +1854,7 @@ func (x *GetMainchainBalanceRequest) String() string {
 func (*GetMainchainBalanceRequest) ProtoMessage() {}
 
 func (x *GetMainchainBalanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[28]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1787,7 +1867,7 @@ func (x *GetMainchainBalanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMainchainBalanceRequest.ProtoReflect.Descriptor instead.
 func (*GetMainchainBalanceRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{28}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{30}
 }
 
 type GetMainchainBalanceResponse struct {
@@ -1800,7 +1880,7 @@ type GetMainchainBalanceResponse struct {
 
 func (x *GetMainchainBalanceResponse) Reset() {
 	*x = GetMainchainBalanceResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[29]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1812,7 +1892,7 @@ func (x *GetMainchainBalanceResponse) String() string {
 func (*GetMainchainBalanceResponse) ProtoMessage() {}
 
 func (x *GetMainchainBalanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[29]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1825,7 +1905,7 @@ func (x *GetMainchainBalanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMainchainBalanceResponse.ProtoReflect.Descriptor instead.
 func (*GetMainchainBalanceResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{29}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetMainchainBalanceResponse) GetConfirmed() float64 {
@@ -1856,7 +1936,7 @@ type PreviewResetDataRequest struct {
 
 func (x *PreviewResetDataRequest) Reset() {
 	*x = PreviewResetDataRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[30]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1868,7 +1948,7 @@ func (x *PreviewResetDataRequest) String() string {
 func (*PreviewResetDataRequest) ProtoMessage() {}
 
 func (x *PreviewResetDataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[30]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1881,7 +1961,7 @@ func (x *PreviewResetDataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewResetDataRequest.ProtoReflect.Descriptor instead.
 func (*PreviewResetDataRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{30}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *PreviewResetDataRequest) GetDeleteBlockchainData() bool {
@@ -1935,7 +2015,7 @@ type PreviewResetDataResponse struct {
 
 func (x *PreviewResetDataResponse) Reset() {
 	*x = PreviewResetDataResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[31]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1947,7 +2027,7 @@ func (x *PreviewResetDataResponse) String() string {
 func (*PreviewResetDataResponse) ProtoMessage() {}
 
 func (x *PreviewResetDataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[31]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1960,7 +2040,7 @@ func (x *PreviewResetDataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewResetDataResponse.ProtoReflect.Descriptor instead.
 func (*PreviewResetDataResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{31}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *PreviewResetDataResponse) GetFiles() []*ResetFileInfo {
@@ -1982,7 +2062,7 @@ type ResetFileInfo struct {
 
 func (x *ResetFileInfo) Reset() {
 	*x = ResetFileInfo{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[32]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1994,7 +2074,7 @@ func (x *ResetFileInfo) String() string {
 func (*ResetFileInfo) ProtoMessage() {}
 
 func (x *ResetFileInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[32]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2007,7 +2087,7 @@ func (x *ResetFileInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResetFileInfo.ProtoReflect.Descriptor instead.
 func (*ResetFileInfo) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{32}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ResetFileInfo) GetPath() string {
@@ -2052,7 +2132,7 @@ type StreamResetDataRequest struct {
 
 func (x *StreamResetDataRequest) Reset() {
 	*x = StreamResetDataRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[33]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2064,7 +2144,7 @@ func (x *StreamResetDataRequest) String() string {
 func (*StreamResetDataRequest) ProtoMessage() {}
 
 func (x *StreamResetDataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[33]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2077,7 +2157,7 @@ func (x *StreamResetDataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamResetDataRequest.ProtoReflect.Descriptor instead.
 func (*StreamResetDataRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{33}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *StreamResetDataRequest) GetDeleteBlockchainData() bool {
@@ -2137,7 +2217,7 @@ type StreamResetDataResponse struct {
 
 func (x *StreamResetDataResponse) Reset() {
 	*x = StreamResetDataResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[34]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2149,7 +2229,7 @@ func (x *StreamResetDataResponse) String() string {
 func (*StreamResetDataResponse) ProtoMessage() {}
 
 func (x *StreamResetDataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[34]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2162,7 +2242,7 @@ func (x *StreamResetDataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamResetDataResponse.ProtoReflect.Descriptor instead.
 func (*StreamResetDataResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{34}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *StreamResetDataResponse) GetPath() string {
@@ -2222,7 +2302,7 @@ type GetCoreMempoolInfoRequest struct {
 
 func (x *GetCoreMempoolInfoRequest) Reset() {
 	*x = GetCoreMempoolInfoRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[35]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2234,7 +2314,7 @@ func (x *GetCoreMempoolInfoRequest) String() string {
 func (*GetCoreMempoolInfoRequest) ProtoMessage() {}
 
 func (x *GetCoreMempoolInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[35]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2247,7 +2327,7 @@ func (x *GetCoreMempoolInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreMempoolInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetCoreMempoolInfoRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{35}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{37}
 }
 
 // Mirrors bitcoind's getmempoolinfo. Aggregate stats — distinct from
@@ -2280,7 +2360,7 @@ type GetCoreMempoolInfoResponse struct {
 
 func (x *GetCoreMempoolInfoResponse) Reset() {
 	*x = GetCoreMempoolInfoResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[36]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2292,7 +2372,7 @@ func (x *GetCoreMempoolInfoResponse) String() string {
 func (*GetCoreMempoolInfoResponse) ProtoMessage() {}
 
 func (x *GetCoreMempoolInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[36]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2305,7 +2385,7 @@ func (x *GetCoreMempoolInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreMempoolInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetCoreMempoolInfoResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{36}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *GetCoreMempoolInfoResponse) GetLoaded() bool {
@@ -2403,7 +2483,7 @@ type CoreRawCallRequest struct {
 
 func (x *CoreRawCallRequest) Reset() {
 	*x = CoreRawCallRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[37]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2415,7 +2495,7 @@ func (x *CoreRawCallRequest) String() string {
 func (*CoreRawCallRequest) ProtoMessage() {}
 
 func (x *CoreRawCallRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[37]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2428,7 +2508,7 @@ func (x *CoreRawCallRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoreRawCallRequest.ProtoReflect.Descriptor instead.
 func (*CoreRawCallRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{37}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *CoreRawCallRequest) GetMethod() string {
@@ -2462,7 +2542,7 @@ type CoreRawCallResponse struct {
 
 func (x *CoreRawCallResponse) Reset() {
 	*x = CoreRawCallResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[38]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2474,7 +2554,7 @@ func (x *CoreRawCallResponse) String() string {
 func (*CoreRawCallResponse) ProtoMessage() {}
 
 func (x *CoreRawCallResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[38]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2487,7 +2567,7 @@ func (x *CoreRawCallResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoreRawCallResponse.ProtoReflect.Descriptor instead.
 func (*CoreRawCallResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{38}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *CoreRawCallResponse) GetResultJson() string {
@@ -2579,6 +2659,9 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x15\n" +
 	"\x13StartWithL1Response\"*\n" +
+	"\x14RestartDaemonRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"\x17\n" +
+	"\x15RestartDaemonResponse\"*\n" +
 	"\x12ShutdownAllRequest\x12\x14\n" +
 	"\x05force\x18\x01 \x01(\bR\x05force\"\xb0\x01\n" +
 	"\x13ShutdownAllResponse\x12\x1f\n" +
@@ -2700,7 +2783,7 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x18SIDECHAIN_TYPE_BITASSETS\x10\x04\x12\x1c\n" +
 	"\x18SIDECHAIN_TYPE_TRUTHCOIN\x10\x05\x12\x19\n" +
 	"\x15SIDECHAIN_TYPE_PHOTON\x10\x06\x12\x1c\n" +
-	"\x18SIDECHAIN_TYPE_COINSHIFT\x10\a2\xce\r\n" +
+	"\x18SIDECHAIN_TYPE_COINSHIFT\x10\a2\xae\x0e\n" +
 	"\x13OrchestratorService\x12[\n" +
 	"\fListBinaries\x12$.orchestrator.v1.ListBinariesRequest\x1a%.orchestrator.v1.ListBinariesResponse\x12d\n" +
 	"\x0fGetBinaryStatus\x12'.orchestrator.v1.GetBinaryStatusRequest\x1a(.orchestrator.v1.GetBinaryStatusResponse\x12a\n" +
@@ -2710,7 +2793,8 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"StopBinary\x12\".orchestrator.v1.StopBinaryRequest\x1a#.orchestrator.v1.StopBinaryResponse\x12W\n" +
 	"\n" +
 	"StreamLogs\x12\".orchestrator.v1.StreamLogsRequest\x1a#.orchestrator.v1.StreamLogsResponse0\x01\x12X\n" +
-	"\vStartWithL1\x12#.orchestrator.v1.StartWithL1Request\x1a$.orchestrator.v1.StartWithL1Response\x12Z\n" +
+	"\vStartWithL1\x12#.orchestrator.v1.StartWithL1Request\x1a$.orchestrator.v1.StartWithL1Response\x12^\n" +
+	"\rRestartDaemon\x12%.orchestrator.v1.RestartDaemonRequest\x1a&.orchestrator.v1.RestartDaemonResponse\x12Z\n" +
 	"\vShutdownAll\x12#.orchestrator.v1.ShutdownAllRequest\x1a$.orchestrator.v1.ShutdownAllResponse0\x01\x12X\n" +
 	"\vGetBTCPrice\x12#.orchestrator.v1.GetBTCPriceRequest\x1a$.orchestrator.v1.GetBTCPriceResponse\x12\x85\x01\n" +
 	"\x1aGetMainchainBlockchainInfo\x122.orchestrator.v1.GetMainchainBlockchainInfoRequest\x1a3.orchestrator.v1.GetMainchainBlockchainInfoResponse\x12\x82\x01\n" +
@@ -2736,7 +2820,7 @@ func file_orchestrator_v1_orchestrator_proto_rawDescGZIP() []byte {
 }
 
 var file_orchestrator_v1_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
+var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
 var file_orchestrator_v1_orchestrator_proto_goTypes = []any{
 	(SidechainType)(0),                         // 0: orchestrator.v1.SidechainType
 	(*BinaryStatusMsg)(nil),                    // 1: orchestrator.v1.BinaryStatusMsg
@@ -2755,44 +2839,46 @@ var file_orchestrator_v1_orchestrator_proto_goTypes = []any{
 	(*StreamLogsResponse)(nil),                 // 14: orchestrator.v1.StreamLogsResponse
 	(*StartWithL1Request)(nil),                 // 15: orchestrator.v1.StartWithL1Request
 	(*StartWithL1Response)(nil),                // 16: orchestrator.v1.StartWithL1Response
-	(*ShutdownAllRequest)(nil),                 // 17: orchestrator.v1.ShutdownAllRequest
-	(*ShutdownAllResponse)(nil),                // 18: orchestrator.v1.ShutdownAllResponse
-	(*GetBTCPriceRequest)(nil),                 // 19: orchestrator.v1.GetBTCPriceRequest
-	(*GetBTCPriceResponse)(nil),                // 20: orchestrator.v1.GetBTCPriceResponse
-	(*GetMainchainBlockchainInfoRequest)(nil),  // 21: orchestrator.v1.GetMainchainBlockchainInfoRequest
-	(*GetMainchainBlockchainInfoResponse)(nil), // 22: orchestrator.v1.GetMainchainBlockchainInfoResponse
-	(*GetEnforcerBlockchainInfoRequest)(nil),   // 23: orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	(*GetEnforcerBlockchainInfoResponse)(nil),  // 24: orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	(*GetSyncStatusRequest)(nil),               // 25: orchestrator.v1.GetSyncStatusRequest
-	(*GetSyncStatusResponse)(nil),              // 26: orchestrator.v1.GetSyncStatusResponse
-	(*SidechainStatus)(nil),                    // 27: orchestrator.v1.SidechainStatus
-	(*ChainSync)(nil),                          // 28: orchestrator.v1.ChainSync
-	(*GetMainchainBalanceRequest)(nil),         // 29: orchestrator.v1.GetMainchainBalanceRequest
-	(*GetMainchainBalanceResponse)(nil),        // 30: orchestrator.v1.GetMainchainBalanceResponse
-	(*PreviewResetDataRequest)(nil),            // 31: orchestrator.v1.PreviewResetDataRequest
-	(*PreviewResetDataResponse)(nil),           // 32: orchestrator.v1.PreviewResetDataResponse
-	(*ResetFileInfo)(nil),                      // 33: orchestrator.v1.ResetFileInfo
-	(*StreamResetDataRequest)(nil),             // 34: orchestrator.v1.StreamResetDataRequest
-	(*StreamResetDataResponse)(nil),            // 35: orchestrator.v1.StreamResetDataResponse
-	(*GetCoreMempoolInfoRequest)(nil),          // 36: orchestrator.v1.GetCoreMempoolInfoRequest
-	(*GetCoreMempoolInfoResponse)(nil),         // 37: orchestrator.v1.GetCoreMempoolInfoResponse
-	(*CoreRawCallRequest)(nil),                 // 38: orchestrator.v1.CoreRawCallRequest
-	(*CoreRawCallResponse)(nil),                // 39: orchestrator.v1.CoreRawCallResponse
-	nil,                                        // 40: orchestrator.v1.StartBinaryRequest.EnvEntry
-	nil,                                        // 41: orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	(*RestartDaemonRequest)(nil),               // 17: orchestrator.v1.RestartDaemonRequest
+	(*RestartDaemonResponse)(nil),              // 18: orchestrator.v1.RestartDaemonResponse
+	(*ShutdownAllRequest)(nil),                 // 19: orchestrator.v1.ShutdownAllRequest
+	(*ShutdownAllResponse)(nil),                // 20: orchestrator.v1.ShutdownAllResponse
+	(*GetBTCPriceRequest)(nil),                 // 21: orchestrator.v1.GetBTCPriceRequest
+	(*GetBTCPriceResponse)(nil),                // 22: orchestrator.v1.GetBTCPriceResponse
+	(*GetMainchainBlockchainInfoRequest)(nil),  // 23: orchestrator.v1.GetMainchainBlockchainInfoRequest
+	(*GetMainchainBlockchainInfoResponse)(nil), // 24: orchestrator.v1.GetMainchainBlockchainInfoResponse
+	(*GetEnforcerBlockchainInfoRequest)(nil),   // 25: orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	(*GetEnforcerBlockchainInfoResponse)(nil),  // 26: orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	(*GetSyncStatusRequest)(nil),               // 27: orchestrator.v1.GetSyncStatusRequest
+	(*GetSyncStatusResponse)(nil),              // 28: orchestrator.v1.GetSyncStatusResponse
+	(*SidechainStatus)(nil),                    // 29: orchestrator.v1.SidechainStatus
+	(*ChainSync)(nil),                          // 30: orchestrator.v1.ChainSync
+	(*GetMainchainBalanceRequest)(nil),         // 31: orchestrator.v1.GetMainchainBalanceRequest
+	(*GetMainchainBalanceResponse)(nil),        // 32: orchestrator.v1.GetMainchainBalanceResponse
+	(*PreviewResetDataRequest)(nil),            // 33: orchestrator.v1.PreviewResetDataRequest
+	(*PreviewResetDataResponse)(nil),           // 34: orchestrator.v1.PreviewResetDataResponse
+	(*ResetFileInfo)(nil),                      // 35: orchestrator.v1.ResetFileInfo
+	(*StreamResetDataRequest)(nil),             // 36: orchestrator.v1.StreamResetDataRequest
+	(*StreamResetDataResponse)(nil),            // 37: orchestrator.v1.StreamResetDataResponse
+	(*GetCoreMempoolInfoRequest)(nil),          // 38: orchestrator.v1.GetCoreMempoolInfoRequest
+	(*GetCoreMempoolInfoResponse)(nil),         // 39: orchestrator.v1.GetCoreMempoolInfoResponse
+	(*CoreRawCallRequest)(nil),                 // 40: orchestrator.v1.CoreRawCallRequest
+	(*CoreRawCallResponse)(nil),                // 41: orchestrator.v1.CoreRawCallResponse
+	nil,                                        // 42: orchestrator.v1.StartBinaryRequest.EnvEntry
+	nil,                                        // 43: orchestrator.v1.StartWithL1Request.TargetEnvEntry
 }
 var file_orchestrator_v1_orchestrator_proto_depIdxs = []int32{
 	2,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
 	1,  // 1: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
 	1,  // 2: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
-	40, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
-	41, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
-	28, // 5: orchestrator.v1.GetSyncStatusResponse.mainchain:type_name -> orchestrator.v1.ChainSync
-	28, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
-	27, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
+	42, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
+	43, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	30, // 5: orchestrator.v1.GetSyncStatusResponse.mainchain:type_name -> orchestrator.v1.ChainSync
+	30, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
+	29, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
 	0,  // 8: orchestrator.v1.SidechainStatus.type:type_name -> orchestrator.v1.SidechainType
-	28, // 9: orchestrator.v1.SidechainStatus.sync:type_name -> orchestrator.v1.ChainSync
-	33, // 10: orchestrator.v1.PreviewResetDataResponse.files:type_name -> orchestrator.v1.ResetFileInfo
+	30, // 9: orchestrator.v1.SidechainStatus.sync:type_name -> orchestrator.v1.ChainSync
+	35, // 10: orchestrator.v1.PreviewResetDataResponse.files:type_name -> orchestrator.v1.ResetFileInfo
 	3,  // 11: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
 	5,  // 12: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
 	7,  // 13: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
@@ -2800,35 +2886,37 @@ var file_orchestrator_v1_orchestrator_proto_depIdxs = []int32{
 	11, // 15: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
 	13, // 16: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
 	15, // 17: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
-	17, // 18: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
-	19, // 19: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
-	21, // 20: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
-	23, // 21: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	25, // 22: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
-	29, // 23: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
-	31, // 24: orchestrator.v1.OrchestratorService.PreviewResetData:input_type -> orchestrator.v1.PreviewResetDataRequest
-	34, // 25: orchestrator.v1.OrchestratorService.StreamResetData:input_type -> orchestrator.v1.StreamResetDataRequest
-	36, // 26: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
-	38, // 27: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
-	4,  // 28: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
-	6,  // 29: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
-	8,  // 30: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
-	10, // 31: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
-	12, // 32: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
-	14, // 33: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
-	16, // 34: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
-	18, // 35: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
-	20, // 36: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
-	22, // 37: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
-	24, // 38: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	26, // 39: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
-	30, // 40: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
-	32, // 41: orchestrator.v1.OrchestratorService.PreviewResetData:output_type -> orchestrator.v1.PreviewResetDataResponse
-	35, // 42: orchestrator.v1.OrchestratorService.StreamResetData:output_type -> orchestrator.v1.StreamResetDataResponse
-	37, // 43: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
-	39, // 44: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
-	28, // [28:45] is the sub-list for method output_type
-	11, // [11:28] is the sub-list for method input_type
+	17, // 18: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
+	19, // 19: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
+	21, // 20: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
+	23, // 21: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
+	25, // 22: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	27, // 23: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
+	31, // 24: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
+	33, // 25: orchestrator.v1.OrchestratorService.PreviewResetData:input_type -> orchestrator.v1.PreviewResetDataRequest
+	36, // 26: orchestrator.v1.OrchestratorService.StreamResetData:input_type -> orchestrator.v1.StreamResetDataRequest
+	38, // 27: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
+	40, // 28: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
+	4,  // 29: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
+	6,  // 30: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
+	8,  // 31: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
+	10, // 32: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
+	12, // 33: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
+	14, // 34: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
+	16, // 35: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
+	18, // 36: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
+	20, // 37: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
+	22, // 38: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
+	24, // 39: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
+	26, // 40: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	28, // 41: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
+	32, // 42: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
+	34, // 43: orchestrator.v1.OrchestratorService.PreviewResetData:output_type -> orchestrator.v1.PreviewResetDataResponse
+	37, // 44: orchestrator.v1.OrchestratorService.StreamResetData:output_type -> orchestrator.v1.StreamResetDataResponse
+	39, // 45: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
+	41, // 46: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
+	29, // [29:47] is the sub-list for method output_type
+	11, // [11:29] is the sub-list for method input_type
 	11, // [11:11] is the sub-list for extension type_name
 	11, // [11:11] is the sub-list for extension extendee
 	0,  // [0:11] is the sub-list for field type_name
@@ -2845,7 +2933,7 @@ func file_orchestrator_v1_orchestrator_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_orchestrator_v1_orchestrator_proto_rawDesc), len(file_orchestrator_v1_orchestrator_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   41,
+			NumMessages:   43,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect/orchestrator.connect.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect/orchestrator.connect.go
@@ -54,6 +54,9 @@ const (
 	// OrchestratorServiceStartWithL1Procedure is the fully-qualified name of the OrchestratorService's
 	// StartWithL1 RPC.
 	OrchestratorServiceStartWithL1Procedure = "/orchestrator.v1.OrchestratorService/StartWithL1"
+	// OrchestratorServiceRestartDaemonProcedure is the fully-qualified name of the
+	// OrchestratorService's RestartDaemon RPC.
+	OrchestratorServiceRestartDaemonProcedure = "/orchestrator.v1.OrchestratorService/RestartDaemon"
 	// OrchestratorServiceShutdownAllProcedure is the fully-qualified name of the OrchestratorService's
 	// ShutdownAll RPC.
 	OrchestratorServiceShutdownAllProcedure = "/orchestrator.v1.OrchestratorService/ShutdownAll"
@@ -110,6 +113,12 @@ type OrchestratorServiceClient interface {
 	// download progress and connection state — never tied to this RPC's
 	// lifetime, so a transport blip can't kill an in-flight download.
 	StartWithL1(context.Context, *connect.Request[v1.StartWithL1Request]) (*connect.Response[v1.StartWithL1Response], error)
+	// Stop the named binary and start it again, single-daemon scope. Never
+	// touches sibling daemons: restarting "enforcer" never spawns or adopts
+	// bitcoind. Use this for per-daemon "Restart" buttons on UI cards;
+	// StartWithL1 stays the entry point for full-chain bootstrap. Same
+	// fire-and-forget shape as StartWithL1.
+	RestartDaemon(context.Context, *connect.Request[v1.RestartDaemonRequest]) (*connect.Response[v1.RestartDaemonResponse], error)
 	// Shutdown all running binaries.
 	ShutdownAll(context.Context, *connect.Request[v1.ShutdownAllRequest]) (*connect.ServerStreamForClient[v1.ShutdownAllResponse], error)
 	// Get the current BTC/USD exchange rate.
@@ -188,6 +197,12 @@ func NewOrchestratorServiceClient(httpClient connect.HTTPClient, baseURL string,
 			connect.WithSchema(orchestratorServiceMethods.ByName("StartWithL1")),
 			connect.WithClientOptions(opts...),
 		),
+		restartDaemon: connect.NewClient[v1.RestartDaemonRequest, v1.RestartDaemonResponse](
+			httpClient,
+			baseURL+OrchestratorServiceRestartDaemonProcedure,
+			connect.WithSchema(orchestratorServiceMethods.ByName("RestartDaemon")),
+			connect.WithClientOptions(opts...),
+		),
 		shutdownAll: connect.NewClient[v1.ShutdownAllRequest, v1.ShutdownAllResponse](
 			httpClient,
 			baseURL+OrchestratorServiceShutdownAllProcedure,
@@ -260,6 +275,7 @@ type orchestratorServiceClient struct {
 	stopBinary                 *connect.Client[v1.StopBinaryRequest, v1.StopBinaryResponse]
 	streamLogs                 *connect.Client[v1.StreamLogsRequest, v1.StreamLogsResponse]
 	startWithL1                *connect.Client[v1.StartWithL1Request, v1.StartWithL1Response]
+	restartDaemon              *connect.Client[v1.RestartDaemonRequest, v1.RestartDaemonResponse]
 	shutdownAll                *connect.Client[v1.ShutdownAllRequest, v1.ShutdownAllResponse]
 	getBTCPrice                *connect.Client[v1.GetBTCPriceRequest, v1.GetBTCPriceResponse]
 	getMainchainBlockchainInfo *connect.Client[v1.GetMainchainBlockchainInfoRequest, v1.GetMainchainBlockchainInfoResponse]
@@ -305,6 +321,11 @@ func (c *orchestratorServiceClient) StreamLogs(ctx context.Context, req *connect
 // StartWithL1 calls orchestrator.v1.OrchestratorService.StartWithL1.
 func (c *orchestratorServiceClient) StartWithL1(ctx context.Context, req *connect.Request[v1.StartWithL1Request]) (*connect.Response[v1.StartWithL1Response], error) {
 	return c.startWithL1.CallUnary(ctx, req)
+}
+
+// RestartDaemon calls orchestrator.v1.OrchestratorService.RestartDaemon.
+func (c *orchestratorServiceClient) RestartDaemon(ctx context.Context, req *connect.Request[v1.RestartDaemonRequest]) (*connect.Response[v1.RestartDaemonResponse], error) {
+	return c.restartDaemon.CallUnary(ctx, req)
 }
 
 // ShutdownAll calls orchestrator.v1.OrchestratorService.ShutdownAll.
@@ -382,6 +403,12 @@ type OrchestratorServiceHandler interface {
 	// download progress and connection state — never tied to this RPC's
 	// lifetime, so a transport blip can't kill an in-flight download.
 	StartWithL1(context.Context, *connect.Request[v1.StartWithL1Request]) (*connect.Response[v1.StartWithL1Response], error)
+	// Stop the named binary and start it again, single-daemon scope. Never
+	// touches sibling daemons: restarting "enforcer" never spawns or adopts
+	// bitcoind. Use this for per-daemon "Restart" buttons on UI cards;
+	// StartWithL1 stays the entry point for full-chain bootstrap. Same
+	// fire-and-forget shape as StartWithL1.
+	RestartDaemon(context.Context, *connect.Request[v1.RestartDaemonRequest]) (*connect.Response[v1.RestartDaemonResponse], error)
 	// Shutdown all running binaries.
 	ShutdownAll(context.Context, *connect.Request[v1.ShutdownAllRequest], *connect.ServerStream[v1.ShutdownAllResponse]) error
 	// Get the current BTC/USD exchange rate.
@@ -454,6 +481,12 @@ func NewOrchestratorServiceHandler(svc OrchestratorServiceHandler, opts ...conne
 		OrchestratorServiceStartWithL1Procedure,
 		svc.StartWithL1,
 		connect.WithSchema(orchestratorServiceMethods.ByName("StartWithL1")),
+		connect.WithHandlerOptions(opts...),
+	)
+	orchestratorServiceRestartDaemonHandler := connect.NewUnaryHandler(
+		OrchestratorServiceRestartDaemonProcedure,
+		svc.RestartDaemon,
+		connect.WithSchema(orchestratorServiceMethods.ByName("RestartDaemon")),
 		connect.WithHandlerOptions(opts...),
 	)
 	orchestratorServiceShutdownAllHandler := connect.NewServerStreamHandler(
@@ -532,6 +565,8 @@ func NewOrchestratorServiceHandler(svc OrchestratorServiceHandler, opts ...conne
 			orchestratorServiceStreamLogsHandler.ServeHTTP(w, r)
 		case OrchestratorServiceStartWithL1Procedure:
 			orchestratorServiceStartWithL1Handler.ServeHTTP(w, r)
+		case OrchestratorServiceRestartDaemonProcedure:
+			orchestratorServiceRestartDaemonHandler.ServeHTTP(w, r)
 		case OrchestratorServiceShutdownAllProcedure:
 			orchestratorServiceShutdownAllHandler.ServeHTTP(w, r)
 		case OrchestratorServiceGetBTCPriceProcedure:
@@ -587,6 +622,10 @@ func (UnimplementedOrchestratorServiceHandler) StreamLogs(context.Context, *conn
 
 func (UnimplementedOrchestratorServiceHandler) StartWithL1(context.Context, *connect.Request[v1.StartWithL1Request]) (*connect.Response[v1.StartWithL1Response], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("orchestrator.v1.OrchestratorService.StartWithL1 is not implemented"))
+}
+
+func (UnimplementedOrchestratorServiceHandler) RestartDaemon(context.Context, *connect.Request[v1.RestartDaemonRequest]) (*connect.Response[v1.RestartDaemonResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("orchestrator.v1.OrchestratorService.RestartDaemon is not implemented"))
 }
 
 func (UnimplementedOrchestratorServiceHandler) ShutdownAll(context.Context, *connect.Request[v1.ShutdownAllRequest], *connect.ServerStream[v1.ShutdownAllResponse]) error {

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -635,164 +635,236 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 			targetPrefetch = o.prefetchBinary(ctx, config)
 		}
 
-		// Auto-build core args if none provided and config manager is available
-		if len(opts.CoreArgs) == 0 && o.BitcoinConf != nil {
-			confPath := o.BitcoinConf.GetConfFilePath()
-			opts.CoreArgs = []string{fmt.Sprintf("-conf=%s", confPath)}
-			o.log.Info().Strs("core_args", opts.CoreArgs).Msg("auto-built core args from config")
+		o.prepareCoreArgs(&opts)
+		o.prepareEnforcerArgs(&opts)
+		o.injectSidechainStarter(config, &opts)
+
+		if !o.startBitcoindOnly(ctx, opts, ch) {
+			return
 		}
 
-		// Auto-build enforcer args if none provided and config manager is available
-		if len(opts.EnforcerArgs) == 0 && o.EnforcerConf != nil {
-			opts.EnforcerArgs = o.EnforcerConf.GetCliArgs()
-			o.log.Info().Strs("enforcer_args", opts.EnforcerArgs).Msg("auto-built enforcer args from config")
-		}
-
-		// Dart binary_provider.dart L314-326: inject sidechain seed for chainLayer==2 targets
-		// Dart: always tries for any chainLayer==2, no HasWallet/IsUnlocked guard
-		if config.ChainLayer == 2 && config.Slot > 0 && o.WalletSvc != nil {
-			// Dart L321: walletWriter.getSidechainStarter(slot) — ensure exists
-			if _, err := o.WalletSvc.GetOrDeriveSidechainStarter(config.Slot, config.DisplayName); err != nil {
-				o.log.Warn().Err(err).Int("slot", config.Slot).Msg("could not ensure sidechain starter")
-			}
-			// Dart L322: walletReader.writeSidechainStarter(slot) — write to temp file
-			scPath, err := o.WalletSvc.WriteSidechainStarter(config.Slot)
-			if err != nil {
-				o.log.Warn().Err(err).Int("slot", config.Slot).Msg("failed to write sidechain starter")
-			} else {
-				opts.TargetArgs = append(opts.TargetArgs, fmt.Sprintf("--mnemonic-seed-phrase-path=%s", scPath))
-				o.log.Info().Str("path", scPath).Int("slot", config.Slot).Msg("injected sidechain starter")
-			}
-		}
-
-		// === Bitcoin Core: initBinary pattern (rpc_connection.dart L197-232) ===
-		//
-		// Dart flow:
-		//   1. startConnectionTimer() — pings once, then starts 1s timer
-		//   2. if (connected) → "already running, not booting" → return
-		//   3. else → bootProcess() → wait for connection
-		//
-		// The connection timer keeps running persistently so that after a
-		// stop() the monitor enters connectModeOnly and can detect
-		// externally-restarted processes.
-
-		coreCfg := o.configs["bitcoind"]
-		var coreHealthOpts HealthCheckOpts
-		if o.BitcoinConf != nil {
-			if coreCfg.Port == 0 {
-				coreCfg.Port = o.BitcoinConf.GetRPCPort()
-			}
-			if o.BitcoinConf.Config != nil {
-				section := o.BitcoinConf.Network.CoreSection()
-				coreHealthOpts.User = o.BitcoinConf.Config.GetEffectiveSetting("rpcuser", section)
-				coreHealthOpts.Password = o.BitcoinConf.Config.GetEffectiveSetting("rpcpassword", section)
-			}
-		}
-		coreChecker := NewHealthChecker(coreCfg, coreHealthOpts)
-		coreMon := o.getOrCreateMonitor("bitcoind", coreChecker, bitcoindStartupPatterns)
-
-		// Dart L208: await startConnectionTimer()
-		coreMon.StartConnectionTimer(ctx)
-
-		// Dart L209-213: if (connected) { "already running, not booting"; return }
-		if coreMon.Connected() {
-			o.log.Info().Str("binary", "bitcoind").Msg("already running, not booting")
-			ch <- StartupProgress{Stage: "waiting-bitcoind", Message: "Bitcoin Core already running"}
-
-			// Adopt with real PID if possible (Dart: PidFileManager.readPidFile)
-			if !o.process.IsRunning("bitcoind") {
-				pid := o.discoverPid(coreCfg)
-				o.process.AdoptProcess(coreCfg, pid)
-				o.log.Info().Str("binary", "bitcoind").Int("pid", pid).Msg("adopted externally-running process")
-			}
-		} else {
-			// Mark as initializing BEFORE we start doing work. Covers the whole
-			// download → process.Start → wait-for-connection window so the UI
-			// shows a spinner instead of a red X. testConnection clears this on
-			// the first successful ping; error paths below clear it explicitly.
-			coreMon.SetInitializing(true)
-
-			// Dart L216-217: only start restart timer if this process starts the binary!
-			coreArgs := opts.CoreArgs // capture for closure
-			coreMon.StartRestartTimer(ctx,
-				// restartFunc: re-start bitcoind
-				// Dart binary_provider.dart L490-506: detect -reindex need before restart
-				func(restartCtx context.Context) error {
-					// Check stderr logs for reindex marker before restarting
-					// Dart L491-492: logs.any((line) => line.contains('Please restart with -reindex'))
-					proc := o.process.Get("bitcoind")
-					if proc != nil {
-						logs := proc.RecentLogs(100)
-						for _, entry := range logs {
-							if strings.Contains(entry.Line, "Please restart with -reindex") {
-								o.log.Warn().Msg("Bitcoin Core needs reindex, adding -reindex flag for next boot attempt")
-								hasReindex := false
-								for _, arg := range coreArgs {
-									if arg == "-reindex" {
-										hasReindex = true
-										break
-									}
-								}
-								if !hasReindex {
-									coreArgs = append(coreArgs, "-reindex")
-								}
-								break
-							}
-						}
-					}
-
-					_, err := o.process.Start(restartCtx, o.configs["bitcoind"], coreArgs, nil)
-					return err
-				},
-				// exitedFunc: check if bitcoind exited with non-zero code
-				func() (int, bool) {
-					proc := o.process.Get("bitcoind")
-					if proc == nil {
-						return 0, false
-					}
-					select {
-					case <-proc.ExitCh():
-						return proc.ExitCode(), true
-					default:
-						return 0, false
-					}
-				},
-			)
-
-			// Dart L219: log + bootProcess
-			ch <- StartupProgress{Stage: "starting-bitcoind", Message: "starting Bitcoin Core..."}
-
-			downloadCh, err := o.download.Download(ctx, o.configs["bitcoind"], o.Network, false)
-			if err != nil {
-				failBoot(coreMon, ch, "download bitcoind", err)
-				return
-			}
-			if err := forwardDownload(downloadCh, ch, "downloading-bitcoind"); err != nil {
-				failBoot(coreMon, ch, "download bitcoind", err)
-				return
-			}
-
-			if _, err := o.process.Start(ctx, o.configs["bitcoind"], opts.CoreArgs, nil); err != nil {
-				failBoot(coreMon, ch, "start bitcoind", err)
-				return
-			}
-			coreProc := o.process.Get("bitcoind")
-
-			// Wait for the connection timer to detect bitcoind is healthy
-			ch <- StartupProgress{Stage: "waiting-bitcoind", Message: "waiting for Bitcoin Core to accept connections..."}
-			if err := waitForConnectedOrExit(ctx, coreMon, coreProc); err != nil {
-				failBoot(coreMon, ch, "wait for bitcoind", err)
-				return
-			}
-		}
-
-		// Wait for wallet + IBD, then start enforcer.
-		if !opts.Immediate {
-			o.startEnforcerWhenReady(ctx, opts, enforcerPrefetch)
-		}
+		o.startEnforcerWhenReady(ctx, opts, enforcerPrefetch)
 
 		// Start the target after enforcer is ready.
 		o.startTargetOnly(ctx, config, opts, ch, targetPrefetch)
+	}()
+
+	return ch, nil
+}
+
+// prepareCoreArgs auto-fills opts.CoreArgs from BitcoinConf when empty.
+func (o *Orchestrator) prepareCoreArgs(opts *StartOpts) {
+	if len(opts.CoreArgs) > 0 || o.BitcoinConf == nil {
+		return
+	}
+	confPath := o.BitcoinConf.GetConfFilePath()
+	opts.CoreArgs = []string{fmt.Sprintf("-conf=%s", confPath)}
+	o.log.Info().Strs("core_args", opts.CoreArgs).Msg("auto-built core args from config")
+}
+
+// prepareEnforcerArgs auto-fills opts.EnforcerArgs from EnforcerConf when empty.
+func (o *Orchestrator) prepareEnforcerArgs(opts *StartOpts) {
+	if len(opts.EnforcerArgs) > 0 || o.EnforcerConf == nil {
+		return
+	}
+	opts.EnforcerArgs = o.EnforcerConf.GetCliArgs()
+	o.log.Info().Strs("enforcer_args", opts.EnforcerArgs).Msg("auto-built enforcer args from config")
+}
+
+// injectSidechainStarter writes the sidechain seed to a temp file and appends
+// --mnemonic-seed-phrase-path=... to opts.TargetArgs for chainLayer==2 binaries.
+// Dart binary_provider.dart L314-326.
+func (o *Orchestrator) injectSidechainStarter(config BinaryConfig, opts *StartOpts) {
+	if config.ChainLayer != 2 || config.Slot <= 0 || o.WalletSvc == nil {
+		return
+	}
+	if _, err := o.WalletSvc.GetOrDeriveSidechainStarter(config.Slot, config.DisplayName); err != nil {
+		o.log.Warn().Err(err).Int("slot", config.Slot).Msg("could not ensure sidechain starter")
+	}
+	scPath, err := o.WalletSvc.WriteSidechainStarter(config.Slot)
+	if err != nil {
+		o.log.Warn().Err(err).Int("slot", config.Slot).Msg("failed to write sidechain starter")
+		return
+	}
+	opts.TargetArgs = append(opts.TargetArgs, fmt.Sprintf("--mnemonic-seed-phrase-path=%s", scPath))
+	o.log.Info().Str("path", scPath).Int("slot", config.Slot).Msg("injected sidechain starter")
+}
+
+// startBitcoindOnly handles the bitcoind portion of a chain boot.
+// Returns true on success (or already-running), false on fatal failure
+// (failBoot has already surfaced the error to the UI in that case).
+//
+// Dart parity: rpc_connection.dart L197-232 initBinary pattern.
+//  1. startConnectionTimer() — pings once, then starts 1s timer
+//  2. if (connected) → "already running, not booting" → return
+//  3. else → bootProcess() → wait for connection
+func (o *Orchestrator) startBitcoindOnly(ctx context.Context, opts StartOpts, ch chan<- StartupProgress) bool {
+	coreCfg := o.configs["bitcoind"]
+	var coreHealthOpts HealthCheckOpts
+	if o.BitcoinConf != nil {
+		if coreCfg.Port == 0 {
+			coreCfg.Port = o.BitcoinConf.GetRPCPort()
+		}
+		if o.BitcoinConf.Config != nil {
+			section := o.BitcoinConf.Network.CoreSection()
+			coreHealthOpts.User = o.BitcoinConf.Config.GetEffectiveSetting("rpcuser", section)
+			coreHealthOpts.Password = o.BitcoinConf.Config.GetEffectiveSetting("rpcpassword", section)
+		}
+	}
+	coreChecker := NewHealthChecker(coreCfg, coreHealthOpts)
+	coreMon := o.getOrCreateMonitor("bitcoind", coreChecker, bitcoindStartupPatterns)
+
+	coreMon.StartConnectionTimer(ctx)
+
+	if coreMon.Connected() {
+		o.log.Info().Str("binary", "bitcoind").Msg("already running, not booting")
+		ch <- StartupProgress{Stage: "waiting-bitcoind", Message: "Bitcoin Core already running"}
+
+		if !o.process.IsRunning("bitcoind") {
+			pid := o.discoverPid(coreCfg)
+			o.process.AdoptProcess(coreCfg, pid)
+			o.log.Info().Str("binary", "bitcoind").Int("pid", pid).Msg("adopted externally-running process")
+		}
+		return true
+	}
+
+	coreMon.SetInitializing(true)
+
+	coreArgs := opts.CoreArgs
+	coreMon.StartRestartTimer(ctx,
+		// Dart binary_provider.dart L490-506: detect -reindex need before restart
+		func(restartCtx context.Context) error {
+			proc := o.process.Get("bitcoind")
+			if proc != nil {
+				logs := proc.RecentLogs(100)
+				for _, entry := range logs {
+					if strings.Contains(entry.Line, "Please restart with -reindex") {
+						o.log.Warn().Msg("Bitcoin Core needs reindex, adding -reindex flag for next boot attempt")
+						hasReindex := false
+						for _, arg := range coreArgs {
+							if arg == "-reindex" {
+								hasReindex = true
+								break
+							}
+						}
+						if !hasReindex {
+							coreArgs = append(coreArgs, "-reindex")
+						}
+						break
+					}
+				}
+			}
+
+			_, err := o.process.Start(restartCtx, o.configs["bitcoind"], coreArgs, nil)
+			return err
+		},
+		func() (int, bool) {
+			proc := o.process.Get("bitcoind")
+			if proc == nil {
+				return 0, false
+			}
+			select {
+			case <-proc.ExitCh():
+				return proc.ExitCode(), true
+			default:
+				return 0, false
+			}
+		},
+	)
+
+	ch <- StartupProgress{Stage: "starting-bitcoind", Message: "starting Bitcoin Core..."}
+
+	downloadCh, err := o.download.Download(ctx, o.configs["bitcoind"], o.Network, false)
+	if err != nil {
+		failBoot(coreMon, ch, "download bitcoind", err)
+		return false
+	}
+	if err := forwardDownload(downloadCh, ch, "downloading-bitcoind"); err != nil {
+		failBoot(coreMon, ch, "download bitcoind", err)
+		return false
+	}
+
+	// If the process is already in pm.processes (e.g. coreMon.Connected()
+	// briefly false during transient RPC blip but the process we own is
+	// still alive), wait for the existing process's connection to recover
+	// rather than calling Start again — Start would return "bitcoind is
+	// already running" and surface a phantom error on the bitcoind card.
+	if o.process.IsRunning("bitcoind") {
+		o.log.Info().Str("binary", "bitcoind").Msg("process already in tracking map, waiting for connection")
+		ch <- StartupProgress{Stage: "waiting-bitcoind", Message: "waiting for Bitcoin Core to accept connections..."}
+		if err := waitForConnectedOrExit(ctx, coreMon, o.process.Get("bitcoind")); err != nil {
+			failBoot(coreMon, ch, "wait for bitcoind", err)
+			return false
+		}
+		return true
+	}
+
+	if _, err := o.process.Start(ctx, o.configs["bitcoind"], opts.CoreArgs, nil); err != nil {
+		failBoot(coreMon, ch, "start bitcoind", err)
+		return false
+	}
+	coreProc := o.process.Get("bitcoind")
+
+	ch <- StartupProgress{Stage: "waiting-bitcoind", Message: "waiting for Bitcoin Core to accept connections..."}
+	if err := waitForConnectedOrExit(ctx, coreMon, coreProc); err != nil {
+		failBoot(coreMon, ch, "wait for bitcoind", err)
+		return false
+	}
+	return true
+}
+
+// RestartDaemon stops the named binary and starts it again — single-daemon
+// scope. Unlike StartWithL1, this never touches sibling daemons: restarting
+// "enforcer" only restarts the enforcer; it never tries to spawn or adopt
+// bitcoind. Use it for the "Restart" button on per-daemon UI cards.
+//
+// The returned channel emits StartupProgress events the same way StartWithL1
+// does and is closed when the restart completes (or fails).
+func (o *Orchestrator) RestartDaemon(ctx context.Context, name string) (<-chan StartupProgress, error) {
+	config, err := o.getConfig(name)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan StartupProgress, 100)
+
+	go func() {
+		defer close(ch)
+
+		// Best-effort stop. If the binary isn't running, fall straight through
+		// to start.
+		if o.process.IsRunning(name) {
+			ch <- StartupProgress{Stage: "stopping-" + name, Message: fmt.Sprintf("stopping %s...", config.DisplayName)}
+			if err := o.Stop(ctx, name, false); err != nil {
+				o.log.Warn().Err(err).Str("binary", name).Msg("graceful stop failed during restart, escalating to SIGKILL")
+				if killErr := o.Stop(ctx, name, true); killErr != nil {
+					o.log.Error().Err(killErr).Str("binary", name).Msg("force kill also failed during restart")
+					ch <- StartupProgress{Error: fmt.Errorf("stop %s: %w", name, killErr)}
+					return
+				}
+			}
+		}
+
+		opts := StartOpts{}
+
+		switch name {
+		case "bitcoind":
+			o.prepareCoreArgs(&opts)
+			if !o.startBitcoindOnly(ctx, opts, ch) {
+				return
+			}
+			ch <- StartupProgress{Stage: "done", Message: fmt.Sprintf("%s started", config.DisplayName), Done: true}
+
+		case "enforcer":
+			o.prepareEnforcerArgs(&opts)
+			o.startEnforcerWhenReady(ctx, opts, nil)
+			ch <- StartupProgress{Stage: "done", Message: fmt.Sprintf("%s started", config.DisplayName), Done: true}
+
+		default:
+			o.injectSidechainStarter(config, &opts)
+			// startTargetOnly emits its own "done" event.
+			o.startTargetOnly(ctx, config, opts, ch, nil)
+		}
 	}()
 
 	return ch, nil

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -32,6 +32,13 @@ service OrchestratorService {
   // lifetime, so a transport blip can't kill an in-flight download.
   rpc StartWithL1(StartWithL1Request) returns (StartWithL1Response);
 
+  // Stop the named binary and start it again, single-daemon scope. Never
+  // touches sibling daemons: restarting "enforcer" never spawns or adopts
+  // bitcoind. Use this for per-daemon "Restart" buttons on UI cards;
+  // StartWithL1 stays the entry point for full-chain bootstrap. Same
+  // fire-and-forget shape as StartWithL1.
+  rpc RestartDaemon(RestartDaemonRequest) returns (RestartDaemonResponse);
+
   // Shutdown all running binaries.
   rpc ShutdownAll(ShutdownAllRequest) returns (stream ShutdownAllResponse);
 
@@ -179,6 +186,14 @@ message StartWithL1Request {
 }
 
 message StartWithL1Response {}
+
+// RestartDaemon
+
+message RestartDaemonRequest {
+  string name = 1;
+}
+
+message RestartDaemonResponse {}
 
 // ShutdownAll
 

--- a/sidechain-orchestrator/restart_daemon_test.go
+++ b/sidechain-orchestrator/restart_daemon_test.go
@@ -1,0 +1,105 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRestartDaemon_UnknownBinary verifies that asking to restart an
+// unknown binary fails fast with a config error rather than silently
+// dispatching a no-op goroutine.
+func TestRestartDaemon_UnknownBinary(t *testing.T) {
+	o := newTestOrchestrator(t)
+	_, err := o.RestartDaemon(context.Background(), "nonexistent")
+	require.Error(t, err)
+}
+
+// TestRestartDaemon_EnforcerLeavesBitcoindMonitorUntouched is the regression
+// guard for the "restart enforcer surfaces 'bitcoind is already running' on
+// Bitcoin Core's card" bug.
+//
+// Before the fix, every restart went through StartWithL1's full L1 chain.
+// If coreMon briefly reported not connected (transient RPC blip after a
+// previous stop, slow first ping, etc.) the bitcoind block called
+// process.Start("bitcoind", ...). With pm.processes already holding bitcoind,
+// that returned "bitcoind is already running" — failBoot then surfaced the
+// error on the bitcoind monitor as a phantom connection error visible on
+// Bitcoin Core's card, even though the user had only clicked Restart on
+// the enforcer.
+//
+// With the dedicated RestartDaemon path, restarting "enforcer" must never
+// touch bitcoind state. This test wedges the orchestrator into the exact
+// pre-condition that triggered the old bug and asserts the bitcoind
+// monitor's ConnectionError stays clear of the phantom string.
+func TestRestartDaemon_EnforcerLeavesBitcoindMonitorUntouched(t *testing.T) {
+	o := newTestOrchestrator(t)
+
+	// Pre-populate pm.processes with bitcoind. This is the state that
+	// makes the old buggy path's process.Start("bitcoind", ...) return
+	// "bitcoind is already running".
+	bitcoindCfg, _ := o.getConfig("bitcoind")
+	o.process.AdoptProcess(bitcoindCfg, 1234)
+
+	// Materialise the bitcoind monitor with the same checker the production
+	// code would use. We deliberately do NOT call testConnection — the
+	// regression isn't about the monitor's pre-state, it's about whether
+	// RestartDaemon("enforcer") surfaces a phantom "already running" error
+	// here as a side effect.
+	coreChecker := &mockChecker{}
+	coreMon := o.getOrCreateMonitor("bitcoind", coreChecker, bitcoindStartupPatterns)
+	require.Empty(t, coreMon.ConnectionError())
+
+	// Tight timeout: the inner enforcer start path will block on download
+	// and process spawn, neither of which we want to actually exercise.
+	// Cancellation propagates and the goroutine returns.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	ch, err := o.RestartDaemon(ctx, "enforcer")
+	require.NoError(t, err)
+
+	for range ch {
+	}
+
+	// The phantom error string from process.go's "%s is already running"
+	// must never reach Bitcoin Core's monitor on a sibling-daemon restart.
+	got := coreMon.ConnectionError()
+	if strings.Contains(got, "already running") {
+		t.Errorf("bitcoind monitor.ConnectionError = %q after RestartDaemon(\"enforcer\"); restart enforcer must not surface 'already running' phantom errors on bitcoind", got)
+	}
+	if strings.Contains(got, "bitcoind") && strings.Contains(got, "start") {
+		t.Errorf("bitcoind monitor.ConnectionError = %q after RestartDaemon(\"enforcer\"); the enforcer restart path must not call into bitcoind's failBoot routing", got)
+	}
+}
+
+// TestPrepareCoreArgs_NoOpWhenAlreadySet verifies the extracted helper
+// doesn't clobber explicitly-supplied core args.
+func TestPrepareCoreArgs_NoOpWhenAlreadySet(t *testing.T) {
+	o := newTestOrchestrator(t)
+	opts := StartOpts{CoreArgs: []string{"-existing=arg"}}
+	o.prepareCoreArgs(&opts)
+	require.Equal(t, []string{"-existing=arg"}, opts.CoreArgs)
+}
+
+// TestPrepareCoreArgs_NoOpWhenBitcoinConfNil verifies the extracted helper
+// is a safe no-op when no config manager is wired.
+func TestPrepareCoreArgs_NoOpWhenBitcoinConfNil(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf = nil
+	opts := StartOpts{}
+	o.prepareCoreArgs(&opts)
+	require.Empty(t, opts.CoreArgs)
+}
+
+// TestPrepareEnforcerArgs_NoOpWhenAlreadySet ensures the enforcer-args
+// helper preserves caller-supplied args.
+func TestPrepareEnforcerArgs_NoOpWhenAlreadySet(t *testing.T) {
+	o := newTestOrchestrator(t)
+	opts := StartOpts{EnforcerArgs: []string{"--my=arg"}}
+	o.prepareEnforcerArgs(&opts)
+	require.Equal(t, []string{"--my=arg"}, opts.EnforcerArgs)
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.217
+version: 1.0.218
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.88
+version: 1.0.89
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.215
+version: 1.0.216
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
## Summary

- New `RestartDaemon` orchestrator RPC stops + starts a single binary, never cascading the L1 chain
- `BinaryProvider.restart()` wraps it; daemon status cards, status bar, chain settings modal, and daemon connection card now use `restart()` instead of `start()`
- `StartWithL1` still owns full-chain bootstrap

## Why

User reported clicking Restart on the enforcer surfaced "bitcoind is already running" on Bitcoin Core's card. Root cause: every per-daemon Restart went through `StartWithL1`, which always tries to start bitcoind first. On a transient `coreMon` disconnect, `process.Start("bitcoind", ...)` hit the ProcessManager's "already running" guard and `failBoot` routed the error onto bitcoind's monitor.

## Test plan

- [x] `go test ./...` (orchestrator + api)
- [x] `dart analyze` (sail_ui + bitwindow)
- [x] New regression test: `TestRestartDaemon_EnforcerLeavesBitcoindMonitorUntouched` wedges pm.processes with bitcoind and asserts no phantom error after `RestartDaemon("enforcer")`
- [ ] Manual: launch full chain, restart enforcer in daemon status, verify Bitcoin Core's card stays clean