### PR TITLE
bitcoin-conf: read datadir from global, not just [main]

### DIFF
--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.71
+version: 0.2.72
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/scripts/download-binaries.sh
+++ b/bitwindow/scripts/download-binaries.sh
@@ -3,60 +3,48 @@ set -o pipefail
 
 original_cwd=$(pwd)
 assets_dir=$original_cwd/assets/bin
-# Ensure the binary folder is in place. 
 mkdir -p $assets_dir
+
+# OS detection via `uname -s` — matches the pattern used in bitwindow/justfile.
+# `$OSTYPE` is unreliable on the GitHub Windows runner (sometimes empty),
+# which silently fell through to the else branch and dropped the .exe suffix.
+case "$(uname -s)" in
+    Darwin*)             os=darwin ;;
+    MINGW*|MSYS*|CYGWIN*) os=windows ;;
+    *)                   os=linux ;;
+esac
+
+exe=""
+if [[ "$os" == "windows" ]]; then
+    exe=".exe"
+fi
 
 cd server
 server_cwd=$(pwd)
 
-# Build bdk-cli and bitwindowd
 echo "Building bitwindowd in $server_cwd"
 
-# force building for x86_64 on macOS, so both new and old macs 
-# work
-if [[ "$OSTYPE" == "darwin"* ]]; then
+# Force amd64 on macOS so binaries run on both Apple Silicon (via Rosetta) and Intel.
+if [[ "$os" == "darwin" ]]; then
     echo "Forcing amd64 GOARCH"
     export GOARCH=amd64
 fi
 
 just build-go
 
-# Move the necessary binaries to the assets directory
-if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
-    echo "moved bin/bitwindowd to $assets_dir/bitwindowd.exe"
-    mv bin/bitwindowd $assets_dir/bitwindowd.exe
-else
-    echo "moved bin/bitwindowd to $assets_dir/bitwindowd"
-    mv bin/bitwindowd $assets_dir/bitwindowd
-fi
+echo "moved bin/bitwindowd to $assets_dir/bitwindowd$exe"
+mv bin/bitwindowd $assets_dir/bitwindowd$exe
 
 echo "bitwindowd has been built and moved to $assets_dir"
 
-# Build orchestratord
 cd $original_cwd/../sidechain-orchestrator
+
 echo "Building orchestratord"
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    GOARCH=amd64 go build -o "$assets_dir/orchestratord" ./cmd/orchestratord
-elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
-    go build -o "$assets_dir/orchestratord.exe" ./cmd/orchestratord
-else
-    go build -o "$assets_dir/orchestratord" ./cmd/orchestratord
-fi
-
+go build -o "$assets_dir/orchestratord$exe" ./cmd/orchestratord
 echo "orchestratord has been built and moved to $assets_dir"
 
-# Build orchestratorctl
 echo "Building orchestratorctl"
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    GOARCH=amd64 go build -o "$assets_dir/orchestratorctl" ./cmd/orchestratorctl
-elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
-    go build -o "$assets_dir/orchestratorctl.exe" ./cmd/orchestratorctl
-else
-    go build -o "$assets_dir/orchestratorctl" ./cmd/orchestratorctl
-fi
-
+go build -o "$assets_dir/orchestratorctl$exe" ./cmd/orchestratorctl
 echo "orchestratorctl has been built and moved to $assets_dir"
 
 cd $original_cwd

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -398,17 +398,18 @@ func (m *BitcoinConfManager) handleNetworkChangeIfNeeded(oldNetwork Network, isF
 // loadStateFromConfig loads network and datadir state from currentConfig.
 // Dart: _loadStateFromConfig (L595)
 //
-// DetectedDataDir reads only the per-network section (no global fallback) so
-// "user has explicitly chosen one" is the same question as "is this empty?".
-// The DataDirGuard / swap prompt rely on that. The global default still
-// reaches bitcoind via the on-disk conf file — this is purely a UI signal.
+// DetectedDataDir uses GetEffectiveSetting: per-network section first, then
+// global. This matches where UpdateDataDir writes (global, since Bitcoin Core
+// only honours top-level datadir) and where bitcoind itself reads from. A
+// user with their own bitcoin.conf may put datadir under [main] — that still
+// wins. Empty here means "no datadir is configured anywhere".
 func (m *BitcoinConfManager) loadStateFromConfig() {
 	if m.Config == nil {
 		return
 	}
 
 	m.Network = NetworkFromConfig(m.Config)
-	m.DetectedDataDir = m.Config.GetSetting("datadir", CoreSectionForNetwork(m.Network))
+	m.DetectedDataDir = m.Config.GetEffectiveSetting("datadir", CoreSectionForNetwork(m.Network))
 
 	// Ensure datadir exists — Bitcoin Core fails with a cryptic assertion error (exit code -6) if it doesn't
 	if m.DetectedDataDir != "" {

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -514,6 +514,50 @@ func TestHasDatadirForNetwork(t *testing.T) {
 	}
 }
 
+// Regression: UpdateDataDir writes datadir to the global section (Bitcoin
+// Core only honours top-level datadir), so loadStateFromConfig must read
+// the global value too. Reading only [main] left DetectedDataDir empty
+// after reload, which made DataDirGuard re-prompt and reject the resulting
+// navigation — symptom: blank white screen on mainnet boot.
+func TestDetectedDataDirSurvivesReloadAfterUpdate(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := newTestManager(tmpDir)
+	m.Network = NetworkMainnet
+	m.Config.SetSetting("chain", "main")
+
+	masterPath := m.getBitWindowConfigPath()
+	require.NoError(t, os.MkdirAll(filepath.Dir(masterPath), 0755))
+	require.NoError(t, os.WriteFile(masterPath, []byte(m.Config.Serialize()), 0644))
+
+	chosen := filepath.Join(tmpDir, "blocks")
+	require.NoError(t, m.UpdateDataDir(chosen, NetworkMainnet))
+	require.Equal(t, chosen, m.DetectedDataDir, "datadir must be visible immediately after UpdateDataDir")
+
+	// Simulate app restart — fresh manager loads the conf from disk.
+	m2 := &BitcoinConfManager{
+		BitwindowDir: tmpDir,
+		Network:      NetworkMainnet,
+		log:          zerolog.Nop(),
+	}
+	require.NoError(t, m2.LoadConfig(true))
+	require.Equal(t, chosen, m2.DetectedDataDir, "datadir written to global must be detected after reload")
+}
+
+// Per-section datadir still wins when present — covers users with their own
+// bitcoin.conf that scopes datadir under [main].
+func TestDetectedDataDirPrefersPerNetworkSection(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := newTestManager(tmpDir)
+	m.Config.SetSetting("chain", "main")
+	m.Config.SetSetting("datadir", "/global/path")
+	m.Config.SetSetting("datadir", "/main/path", "main")
+
+	m.loadStateFromConfig()
+
+	require.Equal(t, NetworkMainnet, m.Network)
+	require.Equal(t, "/main/path", m.DetectedDataDir)
+}
+
 // ---------------------------------------------------------------------------
 // Piece 8 tests: UpdateNetwork with [main] section swap
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `UpdateDataDir` writes datadir to the global section (Bitcoin Core ignores section-scoped datadir), but `loadStateFromConfig` was reading only the per-network section. On mainnet boot, `DetectedDataDir` came back empty even though the conf was saved.
- Symptom: `DataDirGuard` re-prompted for the directory, then rejected the resulting navigation — blank white screen.
- Fix: `GetEffectiveSetting` (per-section, fall back to global). Aligns with where the value is written and where bitcoind reads from.

## Test plan
- [x] `TestDetectedDataDirSurvivesReloadAfterUpdate` — fails on master, passes with fix
- [x] `TestDetectedDataDirPrefersPerNetworkSection` — covers private bitcoin.conf with `[main]`-scoped datadir
- [x] `go test ./config/...` green