### PR TITLE
bitwindow: improve backend performance

### DIFF
--- a/bitwindow/server/api/bitdrive/bitdrive.go
+++ b/bitwindow/server/api/bitdrive/bitdrive.go
@@ -127,7 +127,7 @@ func (s *Server) RetrieveContent(ctx context.Context, req *connect.Request[bitdr
 	}
 
 	// Get OP_RETURN data
-	opReturns, err := opreturns.List(ctx, s.database)
+	opReturns, err := opreturns.List(ctx, s.database, 0)
 	if err != nil {
 		return nil, fmt.Errorf("list OP_RETURNs: %w", err)
 	}
@@ -164,7 +164,7 @@ func (s *Server) ScanForFiles(ctx context.Context, req *connect.Request[emptypb.
 	log := zerolog.Ctx(ctx)
 
 	// Get all OP_RETURNs
-	allOpReturns, err := opreturns.List(ctx, s.database)
+	allOpReturns, err := opreturns.List(ctx, s.database, 0)
 	if err != nil {
 		return nil, fmt.Errorf("list OP_RETURNs: %w", err)
 	}
@@ -240,7 +240,7 @@ func (s *Server) DownloadPendingFiles(ctx context.Context, req *connect.Request[
 	var downloadedCount, failedCount uint32
 
 	// Get all OP_RETURNs
-	allOpReturns, err := opreturns.List(ctx, s.database)
+	allOpReturns, err := opreturns.List(ctx, s.database, 0)
 	if err != nil {
 		return nil, fmt.Errorf("list OP_RETURNs: %w", err)
 	}

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
@@ -79,6 +81,43 @@ type Server struct {
 	recycle          func(ctx context.Context, network config.Network) error
 
 	config config.Config
+
+	// Memoizes ListBlocks responses. Validity gated on (height, hash) —
+	// hash too, so same-height reorgs invalidate.
+	listBlocksCache sync.Map // listBlocksCacheKey -> *listBlocksCacheEntry
+	listBlocksTip   atomic.Pointer[blocksTip]
+}
+
+type listBlocksCacheKey struct {
+	startHeight uint32
+	pageSize    uint32
+}
+
+type listBlocksCacheEntry struct {
+	blocks  []*pb.Block
+	hasMore bool
+	tip     blocksTip
+}
+
+type blocksTip struct {
+	height uint32
+	hash   string
+}
+
+// observeTip records the current tip and returns true the first time we
+// see a new (height, hash) pair. Same-height reorgs are caught because
+// the hash changes.
+func (s *Server) observeTip(height uint32, hash string) (changed bool) {
+	next := blocksTip{height: height, hash: hash}
+	for {
+		prev := s.listBlocksTip.Load()
+		if prev != nil && *prev == next {
+			return false
+		}
+		if s.listBlocksTip.CompareAndSwap(prev, &next) {
+			return true
+		}
+	}
 }
 
 // UpdateNetwork swaps bitcoind to a new network and recycles bitwindowd's
@@ -603,9 +642,11 @@ func (s *Server) ListBlocks(ctx context.Context, c *connect.Request[pb.ListBlock
 	if err != nil {
 		return nil, fmt.Errorf("bitcoind: could not get blockchain info: %w", err)
 	}
+	currentTip := info.Msg.Blocks
+	currentHash := info.Msg.BestBlockHash
 
 	// Default to most recent blocks if no pagination
-	startHeight := info.Msg.Blocks
+	startHeight := currentTip
 	if c.Msg.StartHeight > 0 {
 		startHeight = c.Msg.StartHeight
 	}
@@ -614,6 +655,28 @@ func (s *Server) ListBlocks(ctx context.Context, c *connect.Request[pb.ListBlock
 	pageSize := uint32(50)
 	if c.Msg.PageSize > 0 {
 		pageSize = c.Msg.PageSize
+	}
+
+	currentValidity := blocksTip{height: currentTip, hash: currentHash}
+	if s.observeTip(currentTip, currentHash) {
+		s.listBlocksCache.Range(func(k, _ any) bool {
+			s.listBlocksCache.Delete(k)
+			return true
+		})
+	}
+	cacheKey := listBlocksCacheKey{startHeight: startHeight, pageSize: pageSize}
+	if v, ok := s.listBlocksCache.Load(cacheKey); ok {
+		entry := v.(*listBlocksCacheEntry)
+		if entry.tip == currentValidity {
+			// Slice header is freshly allocated; *pb.Block elements
+			// are shared and must be treated read-only by the caller.
+			out := make([]*pb.Block, len(entry.blocks))
+			copy(out, entry.blocks)
+			return connect.NewResponse(&pb.ListBlocksResponse{
+				RecentBlocks: out,
+				HasMore:      entry.hasMore,
+			}), nil
+		}
 	}
 
 	p := pool.NewWithResults[*pb.Block]().
@@ -678,9 +741,18 @@ func (s *Server) ListBlocks(ctx context.Context, c *connect.Request[pb.ListBlock
 		return -cmp.Compare(a.Height, b.Height)
 	})
 
+	hasMore := startHeight > uint32(len(blocks))
+	s.listBlocksCache.Store(cacheKey, &listBlocksCacheEntry{
+		blocks:  blocks,
+		hasMore: hasMore,
+		tip:     currentValidity,
+	})
+
+	out := make([]*pb.Block, len(blocks))
+	copy(out, blocks)
 	return connect.NewResponse(&pb.ListBlocksResponse{
-		RecentBlocks: blocks,
-		HasMore:      startHeight > uint32(len(blocks)),
+		RecentBlocks: out,
+		HasMore:      hasMore,
 	}), nil
 }
 

--- a/bitwindow/server/api/bitwindowd/bitwindowd_test.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd_test.go
@@ -1386,6 +1386,162 @@ func TestService_ListBlocks(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, resp.Msg.RecentBlocks, 5)
 	})
+
+	t.Run("repeat call at the same tip is served from cache", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.Test(t)
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		expectWatchWalletNoop(mockBitcoind)
+
+		// GetBlockHash + GetBlock fire 5× (= pageSize) total across both
+		// calls — the second call must come from cache.
+		mockBitcoind.EXPECT().GetBlockchainInfo(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.GetBlockchainInfoResponse]{
+				Msg: &corepb.GetBlockchainInfoResponse{Blocks: 10},
+			}, nil).Times(2)
+		mockBitcoind.EXPECT().GetBlockHash(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.GetBlockHashResponse]{
+				Msg: &corepb.GetBlockHashResponse{Hash: "h"},
+			}, nil).Times(5)
+		mockBitcoind.EXPECT().GetBlock(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.GetBlockResponse]{
+				Msg: &corepb.GetBlockResponse{Height: 10, Hash: "h", Time: timestamppb.Now()},
+			}, nil).Times(5)
+
+		cli := v1connect.NewBitwindowdServiceClient(apitests.API(t, db, apitests.WithBitcoind(mockBitcoind)))
+
+		req := connect.NewRequest(&v1.ListBlocksRequest{PageSize: 5})
+		first, err := cli.ListBlocks(context.Background(), req)
+		require.NoError(t, err)
+		require.Len(t, first.Msg.RecentBlocks, 5)
+
+		second, err := cli.ListBlocks(context.Background(), connect.NewRequest(&v1.ListBlocksRequest{PageSize: 5}))
+		require.NoError(t, err)
+		require.Len(t, second.Msg.RecentBlocks, 5)
+	})
+
+	t.Run("cache is dropped on same-height reorg (different best-block-hash)", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.Test(t)
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		expectWatchWalletNoop(mockBitcoind)
+
+		// Same height, different hash = same-height reorg. Each call
+		// must do its own fan-out (10 fetches each = 20 total).
+		gomock.InOrder(
+			mockBitcoind.EXPECT().GetBlockchainInfo(gomock.Any(), gomock.Any()).
+				Return(&connect.Response[corepb.GetBlockchainInfoResponse]{
+					Msg: &corepb.GetBlockchainInfoResponse{Blocks: 10, BestBlockHash: "hash-A"},
+				}, nil),
+			mockBitcoind.EXPECT().GetBlockchainInfo(gomock.Any(), gomock.Any()).
+				Return(&connect.Response[corepb.GetBlockchainInfoResponse]{
+					Msg: &corepb.GetBlockchainInfoResponse{Blocks: 10, BestBlockHash: "hash-B"},
+				}, nil),
+		)
+		mockBitcoind.EXPECT().GetBlockHash(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.GetBlockHashResponse]{
+				Msg: &corepb.GetBlockHashResponse{Hash: "h"},
+			}, nil).Times(10)
+		mockBitcoind.EXPECT().GetBlock(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.GetBlockResponse]{
+				Msg: &corepb.GetBlockResponse{Height: 10, Hash: "h", Time: timestamppb.Now()},
+			}, nil).Times(10)
+
+		cli := v1connect.NewBitwindowdServiceClient(apitests.API(t, db, apitests.WithBitcoind(mockBitcoind)))
+
+		_, err := cli.ListBlocks(context.Background(), connect.NewRequest(&v1.ListBlocksRequest{PageSize: 5}))
+		require.NoError(t, err)
+		_, err = cli.ListBlocks(context.Background(), connect.NewRequest(&v1.ListBlocksRequest{PageSize: 5}))
+		require.NoError(t, err)
+	})
+
+	t.Run("returned slice is decoupled from cache (caller mutation safe)", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.Test(t)
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		expectWatchWalletNoop(mockBitcoind)
+
+		mockBitcoind.EXPECT().GetBlockchainInfo(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.GetBlockchainInfoResponse]{
+				Msg: &corepb.GetBlockchainInfoResponse{Blocks: 10, BestBlockHash: "h"},
+			}, nil).Times(2)
+		mockBitcoind.EXPECT().GetBlockHash(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.GetBlockHashResponse]{
+				Msg: &corepb.GetBlockHashResponse{Hash: "h"},
+			}, nil).Times(3)
+		mockBitcoind.EXPECT().GetBlock(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.GetBlockResponse]{
+				Msg: &corepb.GetBlockResponse{Height: 10, Hash: "h", Time: timestamppb.Now()},
+			}, nil).Times(3)
+
+		cli := v1connect.NewBitwindowdServiceClient(apitests.API(t, db, apitests.WithBitcoind(mockBitcoind)))
+
+		first, err := cli.ListBlocks(context.Background(), connect.NewRequest(&v1.ListBlocksRequest{PageSize: 3}))
+		require.NoError(t, err)
+		require.Len(t, first.Msg.RecentBlocks, 3)
+
+		// Mutate the response: if the cache shared its backing array
+		// we'd corrupt the next caller.
+		first.Msg.RecentBlocks[0] = nil
+		first.Msg.RecentBlocks = append(first.Msg.RecentBlocks, nil, nil, nil, nil)
+
+		second, err := cli.ListBlocks(context.Background(), connect.NewRequest(&v1.ListBlocksRequest{PageSize: 3}))
+		require.NoError(t, err)
+		require.Len(t, second.Msg.RecentBlocks, 3, "cache must hand out a fresh slice")
+		require.NotNil(t, second.Msg.RecentBlocks[0])
+	})
+
+	t.Run("cache is dropped when tip moves", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.Test(t)
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+
+		mockBitcoind.EXPECT().ListWallets(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.ListWalletsResponse]{
+				Msg: &corepb.ListWalletsResponse{Wallets: []string{}},
+			}, nil).AnyTimes()
+		mockBitcoind.EXPECT().CreateWallet(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.CreateWalletResponse]{
+				Msg: &corepb.CreateWalletResponse{Name: "cheque_watch"},
+			}, nil).AnyTimes()
+
+		// First call: tip=10. Second call: tip=11 — must invalidate the
+		// cache and re-fetch all blocks. So GetBlockHash + GetBlock fire
+		// 5 times PER call = 10 total.
+		gomock.InOrder(
+			mockBitcoind.EXPECT().GetBlockchainInfo(gomock.Any(), gomock.Any()).
+				Return(&connect.Response[corepb.GetBlockchainInfoResponse]{
+					Msg: &corepb.GetBlockchainInfoResponse{Blocks: 10},
+				}, nil),
+			mockBitcoind.EXPECT().GetBlockchainInfo(gomock.Any(), gomock.Any()).
+				Return(&connect.Response[corepb.GetBlockchainInfoResponse]{
+					Msg: &corepb.GetBlockchainInfoResponse{Blocks: 11},
+				}, nil),
+		)
+		mockBitcoind.EXPECT().GetBlockHash(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.GetBlockHashResponse]{
+				Msg: &corepb.GetBlockHashResponse{Hash: "h"},
+			}, nil).Times(10)
+		mockBitcoind.EXPECT().GetBlock(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.GetBlockResponse]{
+				Msg: &corepb.GetBlockResponse{Height: 10, Hash: "h", Time: timestamppb.Now()},
+			}, nil).Times(10)
+
+		cli := v1connect.NewBitwindowdServiceClient(apitests.API(t, db, apitests.WithBitcoind(mockBitcoind)))
+
+		_, err := cli.ListBlocks(context.Background(), connect.NewRequest(&v1.ListBlocksRequest{PageSize: 5}))
+		require.NoError(t, err)
+		_, err = cli.ListBlocks(context.Background(), connect.NewRequest(&v1.ListBlocksRequest{PageSize: 5}))
+		require.NoError(t, err)
+	})
 }
 
 func TestService_ListRecentTransactions(t *testing.T) {
@@ -1620,4 +1776,17 @@ func TestService_GetNetworkStats(t *testing.T) {
 		assert.Equal(t, "/Satoshi:25.0.0/", resp.Msg.Subversion)
 		assert.Equal(t, 12345.67, resp.Msg.Difficulty)
 	})
+}
+
+// expectWatchWalletNoop satisfies the background ensureWatchWallet path
+// for tests that don't care about it.
+func expectWatchWalletNoop(m *mocks.MockBitcoinServiceClient) {
+	m.EXPECT().ListWallets(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[corepb.ListWalletsResponse]{
+			Msg: &corepb.ListWalletsResponse{Wallets: []string{}},
+		}, nil).AnyTimes()
+	m.EXPECT().CreateWallet(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[corepb.CreateWalletResponse]{
+			Msg: &corepb.CreateWalletResponse{Name: "cheque_watch"},
+		}, nil).AnyTimes()
 }

--- a/bitwindow/server/api/misc/misc.go
+++ b/bitwindow/server/api/misc/misc.go
@@ -53,9 +53,14 @@ type Server struct {
 	bitcoind        *service.Service[corerpc.BitcoinServiceClient]
 }
 
+// listOPReturnLimit is the cap for the gRPC ListOPReturn handler. The
+// UI is the only consumer and only renders the most-recent N; without
+// a cap each poll dragged every row in the table back through the wire.
+const listOPReturnLimit = 1000
+
 // ListOPReturn implements miscv1connect.MiscServiceHandler.
 func (s *Server) ListOPReturn(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[miscv1.ListOPReturnResponse], error) {
-	opReturns, err := opreturns.List(ctx, s.database)
+	opReturns, err := opreturns.List(ctx, s.database, listOPReturnLimit)
 	if err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not list op returns")
 		return nil, err

--- a/bitwindow/server/models/opreturns/cache_test.go
+++ b/bitwindow/server/models/opreturns/cache_test.go
@@ -1,0 +1,411 @@
+package opreturns
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// List(..., limit) must cap rows at the requested limit.
+func TestList_LimitCaps(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	const total = 50
+	const limit = 10
+	rows := make([]OPReturn, 0, total)
+	for i := 0; i < total; i++ {
+		h := uint32(i + 1)
+		now := time.Now().Add(time.Duration(i) * time.Millisecond)
+		rows = append(rows, OPReturn{
+			Height:    &h,
+			TxID:      fmt.Sprintf("tx-%d", i),
+			Vout:      0,
+			Data:      []byte("payload"),
+			CreatedAt: &now,
+		})
+	}
+	require.NoError(t, Persist(ctx, db, rows))
+
+	got, err := List(ctx, db, limit)
+	require.NoError(t, err)
+	assert.Len(t, got, limit)
+}
+
+// List(..., 0) is the explicit "full table" escape hatch (bitdrive).
+func TestList_LimitZeroIsUnbounded(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	const n = 50
+	rows := make([]OPReturn, 0, n)
+	for i := 0; i < n; i++ {
+		h := uint32(i + 1)
+		now := time.Now().Add(time.Duration(i) * time.Millisecond)
+		rows = append(rows, OPReturn{
+			Height:    &h,
+			TxID:      fmt.Sprintf("tx-%d", i),
+			Vout:      0,
+			Data:      []byte("payload"),
+			CreatedAt: &now,
+		})
+	}
+	require.NoError(t, Persist(ctx, db, rows))
+
+	got, err := List(ctx, db, 0)
+	require.NoError(t, err)
+	assert.Len(t, got, n)
+}
+
+// Closing the DB after the first call proves the second read is served
+// purely from cache (a real query would fail).
+func TestListCache_HitAfterMiss(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	h := uint32(1)
+	now := time.Now()
+	require.NoError(t, Persist(ctx, db, []OPReturn{{
+		Height: &h, TxID: "tx", Vout: 0, Data: []byte("hi"), CreatedAt: &now,
+	}}))
+
+	first, err := List(ctx, db, 100)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	require.NoError(t, db.Close())
+
+	// If the cache wasn't honored, this would error with "sql: database is closed".
+	second, err := List(ctx, db, 100)
+	require.NoError(t, err, "second call must hit the cache, not the closed DB")
+	assert.Equal(t, first, second)
+}
+
+// Persist must drop the cache so the next read sees the new row.
+func TestListCache_InvalidatedByPersist(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	first, err := List(ctx, db, 100)
+	require.NoError(t, err)
+	require.Empty(t, first, "fresh DB must list empty")
+
+	h := uint32(1)
+	now := time.Now()
+	require.NoError(t, Persist(ctx, db, []OPReturn{{
+		Height: &h, TxID: "tx", Vout: 0, Data: []byte("hi"), CreatedAt: &now,
+	}}))
+
+	second, err := List(ctx, db, 100)
+	require.NoError(t, err)
+	assert.Len(t, second, 1, "Persist must invalidate the cached empty result")
+}
+
+// Cache must not bleed entries across DBs.
+func TestListCache_PerDBIsolation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbA := database.Test(t)
+	dbB := database.Test(t)
+
+	h := uint32(1)
+	now := time.Now()
+	require.NoError(t, Persist(ctx, dbA, []OPReturn{{
+		Height: &h, TxID: "in-a", Vout: 0, Data: []byte("a"), CreatedAt: &now,
+	}}))
+
+	gotA, err := List(ctx, dbA, 100)
+	require.NoError(t, err)
+	require.Len(t, gotA, 1)
+
+	gotB, err := List(ctx, dbB, 100)
+	require.NoError(t, err)
+	assert.Empty(t, gotB, "dbB must not see dbA's rows via shared cache")
+}
+
+// Only rows whose topic prefix matches a known topic are returned.
+func TestListCoinNews_TopicSQLJoin(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	known := mustTopicID(t, "a1a1a1a1")
+	unknown := mustTopicID(t, "deadbeef")
+	require.NoError(t, CreateTopic(ctx, db, known, "Known", "topic_txid", true, 0))
+
+	now := time.Now()
+	h := uint32(1)
+	require.NoError(t, Persist(ctx, db, []OPReturn{
+		{
+			Height: &h, TxID: "matching", Vout: 0,
+			Data:      EncodeNewsMessage(known, "headline", "body"),
+			CreatedAt: &now,
+		},
+		{
+			Height: &h, TxID: "non-matching", Vout: 1,
+			Data:      EncodeNewsMessage(unknown, "headline", "body"),
+			CreatedAt: &now,
+		},
+	}))
+
+	got, err := ListCoinNews(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "only the known-topic row should come back")
+	assert.Equal(t, "headline", got[0].Headline)
+	assert.Equal(t, "body", got[0].Content)
+}
+
+// Per-topic retention is applied at SQL time; rows past the cutoff drop.
+func TestListCoinNews_RetentionFilteredAtSQL(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	topic := mustTopicID(t, "b2b2b2b2")
+	// 7-day retention.
+	require.NoError(t, CreateTopic(ctx, db, topic, "Weekly", "topic_txid", true, 7))
+
+	old := time.Now().AddDate(0, 0, -30) // way past the 7-day cutoff
+	fresh := time.Now()
+	h := uint32(1)
+	require.NoError(t, Persist(ctx, db, []OPReturn{
+		{
+			Height: &h, TxID: "old-news", Vout: 0,
+			Data:      EncodeNewsMessage(topic, "stale", "stale"),
+			CreatedAt: &old,
+		},
+		{
+			Height: &h, TxID: "fresh-news", Vout: 1,
+			Data:      EncodeNewsMessage(topic, "fresh", "fresh"),
+			CreatedAt: &fresh,
+		},
+	}))
+
+	got, err := ListCoinNews(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "fresh", got[0].Headline)
+}
+
+// A caller mutating the returned slice must not corrupt the cache.
+func TestList_CallerCannotPoisonCache(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	h := uint32(1)
+	now := time.Now()
+	require.NoError(t, Persist(ctx, db, []OPReturn{{
+		Height: &h, TxID: "real", Vout: 0, Data: []byte("real"), CreatedAt: &now,
+	}}))
+
+	first, err := List(ctx, db, 100)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	// Mutate the returned slice — clobber the row, then append junk.
+	first[0] = OPReturn{TxID: "POISONED"}
+	_ = append(first, OPReturn{TxID: "EXTRA"})
+
+	second, err := List(ctx, db, 100)
+	require.NoError(t, err)
+	require.Len(t, second, 1, "cache must not absorb caller's append")
+	assert.Equal(t, "real", second[0].TxID, "cache must not absorb caller's mutation")
+}
+
+// Same mutation guard for the ListCoinNews path.
+func TestListCoinNews_CallerCannotPoisonCache(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	topic := mustTopicID(t, "d4d4d4d4")
+	require.NoError(t, CreateTopic(ctx, db, topic, "T", "topic_txid", true, 0))
+
+	h := uint32(1)
+	now := time.Now()
+	require.NoError(t, Persist(ctx, db, []OPReturn{{
+		Height: &h, TxID: "tx", Vout: 0,
+		Data:      EncodeNewsMessage(topic, "real-headline", "real-body"),
+		CreatedAt: &now,
+	}}))
+
+	first, err := ListCoinNews(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	first[0] = CoinNews{Headline: "POISONED"}
+	_ = append(first, CoinNews{Headline: "EXTRA"})
+
+	second, err := ListCoinNews(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	assert.Equal(t, "real-headline", second[0].Headline)
+}
+
+// A topic-creation OP_RETURN matches the topic prefix in SQL (it starts
+// with the same 4 bytes) but isn't news — it's the announcement of the
+// topic itself. The Go pass strips these via IsCreateTopic; without
+// that filter a brand-new topic would surface as its own first item.
+func TestListCoinNews_TopicCreationRowFiltered(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	topic := mustTopicID(t, "e5e5e5e5")
+	require.NoError(t, CreateTopic(ctx, db, topic, "T", "topic_txid", true, 0))
+
+	now := time.Now()
+	h := uint32(1)
+	require.NoError(t, Persist(ctx, db, []OPReturn{
+		// Topic-creation message: <topic><"new"><retention><name>.
+		{
+			Height: &h, TxID: "create-row", Vout: 0,
+			Data:      EncodeTopicCreationMessage(topic, "T", 0),
+			CreatedAt: &now,
+		},
+		// Real news under the same topic.
+		{
+			Height: &h, TxID: "news-row", Vout: 1,
+			Data:      EncodeNewsMessage(topic, "real", "real"),
+			CreatedAt: &now,
+		},
+	}))
+
+	got, err := ListCoinNews(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "topic-creation row must not surface as news")
+	assert.Equal(t, "real", got[0].Headline)
+}
+
+// retention_days = 0 means "keep forever" — even years-old rows must
+// come back. The SQL WHERE clause uses an OR for this case; if it
+// regressed to a strict cutoff the row would silently drop.
+func TestListCoinNews_ZeroRetentionKeepsForever(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	topic := mustTopicID(t, "f6f6f6f6")
+	require.NoError(t, CreateTopic(ctx, db, topic, "Forever", "topic_txid", true, 0))
+
+	ancient := time.Now().AddDate(-5, 0, 0)
+	h := uint32(1)
+	require.NoError(t, Persist(ctx, db, []OPReturn{{
+		Height: &h, TxID: "ancient", Vout: 0,
+		Data:      EncodeNewsMessage(topic, "old", "old"),
+		CreatedAt: &ancient,
+	}}))
+
+	got, err := ListCoinNews(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "retention_days=0 must keep ancient rows")
+	assert.Equal(t, "old", got[0].Headline)
+}
+
+// Junk rows where headline + content are both blank-or-padding-only
+// must not surface — they pass the SQL filter (right topic prefix,
+// within retention) but the Go pass drops them.
+func TestListCoinNews_EmptyPayloadFiltered(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	topic := mustTopicID(t, "07070707")
+	require.NoError(t, CreateTopic(ctx, db, topic, "T", "topic_txid", true, 0))
+
+	now := time.Now()
+	h := uint32(1)
+	require.NoError(t, Persist(ctx, db, []OPReturn{
+		// All padding — no real headline, no real content.
+		{
+			Height: &h, TxID: "junk", Vout: 0,
+			Data:      EncodeNewsMessage(topic, "", ""),
+			CreatedAt: &now,
+		},
+		// Real entry for contrast.
+		{
+			Height: &h, TxID: "real", Vout: 1,
+			Data:      EncodeNewsMessage(topic, "real", "real"),
+			CreatedAt: &now,
+		},
+	}))
+
+	got, err := ListCoinNews(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "empty-payload row must not surface")
+	assert.Equal(t, "real", got[0].Headline)
+}
+
+// Multi-topic, multi-row check that the JOIN populates TopicName
+// correctly per row (rather than e.g. carrying over the previous row's
+// topic). Catches a class of JOIN-mapping bug.
+func TestListCoinNews_TopicNameMatchesEachRow(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	topicA := mustTopicID(t, "aaaaaaaa")
+	topicB := mustTopicID(t, "bbbbbbbb")
+	require.NoError(t, CreateTopic(ctx, db, topicA, "A name", "atxid", true, 0))
+	require.NoError(t, CreateTopic(ctx, db, topicB, "B name", "btxid", true, 0))
+
+	now := time.Now()
+	h := uint32(1)
+	require.NoError(t, Persist(ctx, db, []OPReturn{
+		{Height: &h, TxID: "txA", Vout: 0, Data: EncodeNewsMessage(topicA, "ha", "ba"), CreatedAt: &now},
+		{Height: &h, TxID: "txB", Vout: 1, Data: EncodeNewsMessage(topicB, "hb", "bb"), CreatedAt: &now},
+	}))
+
+	got, err := ListCoinNews(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	byHeadline := map[string]CoinNews{}
+	for _, n := range got {
+		byHeadline[n.Headline] = n
+	}
+	assert.Equal(t, "A name", byHeadline["ha"].TopicName)
+	assert.Equal(t, "B name", byHeadline["hb"].TopicName)
+	assert.Equal(t, topicA, byHeadline["ha"].Topic)
+	assert.Equal(t, topicB, byHeadline["hb"].Topic)
+}
+
+// CreateTopic must invalidate ListCoinNews — without that, an op_return
+// inserted before its topic existed would stay invisible after the topic
+// is added.
+func TestListCoinNews_CreateTopicInvalidatesCache(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	topic := mustTopicID(t, "c3c3c3c3")
+	now := time.Now()
+	h := uint32(1)
+	// Op_return inserted before the topic exists — first ListCoinNews
+	// will see no match, populate the cache with empty.
+	require.NoError(t, Persist(ctx, db, []OPReturn{{
+		Height: &h, TxID: "tx", Vout: 0,
+		Data:      EncodeNewsMessage(topic, "headline", "body"),
+		CreatedAt: &now,
+	}}))
+
+	first, err := ListCoinNews(ctx, db)
+	require.NoError(t, err)
+	require.Empty(t, first)
+
+	// Creating the topic must drop the empty-result cache.
+	require.NoError(t, CreateTopic(ctx, db, topic, "T", "topic_txid", true, 0))
+
+	second, err := ListCoinNews(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, second, 1, "CreateTopic must invalidate ListCoinNews cache")
+}

--- a/bitwindow/server/models/opreturns/opreturns.go
+++ b/bitwindow/server/models/opreturns/opreturns.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -16,6 +17,45 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/rs/zerolog"
 )
+
+// Backstop TTL for cached List / ListCoinNews — the contract is that
+// Persist and CreateTopic invalidate; TTL only matters if a query
+// races a write.
+const listCacheTTL = 2 * time.Second
+
+// Caches are keyed by *sql.DB so parallel tests with their own DBs
+// don't share entries. Production has one *sql.DB per network so this
+// is effectively a singleton.
+
+type listCacheEntry struct {
+	rows []OPReturn
+	at   time.Time
+}
+
+type coinNewsCacheEntry struct {
+	rows []CoinNews
+	at   time.Time
+}
+
+var (
+	listCacheMu      sync.RWMutex
+	listCacheEntries = map[*sql.DB]map[int]listCacheEntry{}
+
+	coinNewsCacheMu      sync.RWMutex
+	coinNewsCacheEntries = map[*sql.DB]coinNewsCacheEntry{}
+)
+
+// invalidateCaches drops cached List / ListCoinNews entries for db.
+// Called from Persist and CreateTopic.
+func invalidateCaches(db *sql.DB) {
+	listCacheMu.Lock()
+	delete(listCacheEntries, db)
+	listCacheMu.Unlock()
+
+	coinNewsCacheMu.Lock()
+	delete(coinNewsCacheEntries, db)
+	coinNewsCacheMu.Unlock()
+}
 
 func Persist(
 	ctx context.Context, db *sql.DB, values []OPReturn,
@@ -55,6 +95,8 @@ func Persist(
 		return fmt.Errorf("persist %d OP_RETURN(s): %w", len(values), err)
 	}
 
+	invalidateCaches(db)
+
 	zerolog.Ctx(ctx).Debug().
 		Msgf("opreturns: persisted %d OP_RETURN(s) in %s", len(values), time.Since(start))
 
@@ -71,12 +113,34 @@ type OPReturn struct {
 	CreatedAt *time.Time
 }
 
-func List(ctx context.Context, db *sql.DB) ([]OPReturn, error) {
-	rows, err := db.QueryContext(ctx, `
+// List returns the most-recent OP_RETURNs, ordered by created_at desc,
+// capped at `limit`. Pass 0 (or any value <= 0) to skip the cap — only
+// do that when the caller genuinely needs the full table; this table
+// grows linearly with chain height. The returned slice is freshly
+// allocated; element values are shared, so OPReturn fields must be
+// treated read-only.
+func List(ctx context.Context, db *sql.DB, limit int) ([]OPReturn, error) {
+	listCacheMu.RLock()
+	cached, hit := listCacheEntries[db][limit]
+	listCacheMu.RUnlock()
+	if hit && time.Since(cached.at) < listCacheTTL {
+		out := make([]OPReturn, len(cached.rows))
+		copy(out, cached.rows)
+		return out, nil
+	}
+
+	query := `
 		SELECT id, txid, vout, unhex(op_return_data), fee_sats, height, created_at
 		FROM op_returns
 		ORDER BY created_at DESC
-	`)
+	`
+	args := []any{}
+	if limit > 0 {
+		query += "\nLIMIT ?"
+		args = append(args, limit)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list: query op_returns: %w", err)
 	}
@@ -84,9 +148,7 @@ func List(ctx context.Context, db *sql.DB) ([]OPReturn, error) {
 
 	var opReturns []OPReturn
 	for rows.Next() {
-		var (
-			opReturn OPReturn
-		)
+		var opReturn OPReturn
 		err := rows.Scan(
 			&opReturn.ID, &opReturn.TxID, &opReturn.Vout,
 			&opReturn.Data, &opReturn.Fee, &opReturn.Height, &opReturn.CreatedAt,
@@ -94,13 +156,22 @@ func List(ctx context.Context, db *sql.DB) ([]OPReturn, error) {
 		if err != nil {
 			return nil, fmt.Errorf("list: scan op_return: %w", err)
 		}
-
 		opReturns = append(opReturns, opReturn)
 	}
-
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("list: iterate op_returns: %w", err)
 	}
+
+	snapshot := make([]OPReturn, len(opReturns))
+	copy(snapshot, opReturns)
+	listCacheMu.Lock()
+	byLimit, ok := listCacheEntries[db]
+	if !ok {
+		byLimit = map[int]listCacheEntry{}
+		listCacheEntries[db] = byLimit
+	}
+	byLimit[limit] = listCacheEntry{rows: snapshot, at: time.Now()}
+	listCacheMu.Unlock()
 
 	return opReturns, nil
 }
@@ -253,6 +324,9 @@ func CreateTopic(ctx context.Context, db *sql.DB, topic TopicID, name string, tx
 		return fmt.Errorf("create topic: %w", err)
 	}
 
+	// Topic changes alter which rows the ListCoinNews JOIN matches.
+	invalidateCaches(db)
+
 	return nil
 }
 
@@ -354,48 +428,66 @@ func (t TopicID) String() string {
 	return hex.EncodeToString(t[:])
 }
 
-func extractTopic(topics []Topic, topic TopicID) (Topic, bool) {
-	for _, t := range topics {
-		if t.Topic == topic {
-			return t, true
-		}
-	}
-	return Topic{}, false
-}
-
+// ListCoinNews returns OP_RETURNs that match a known topic, with the
+// per-topic retention cutoff applied. Topic match (first 4 bytes /
+// 8 hex chars of op_return_data) and retention are done in SQL; the Go
+// pass only strips topic-creation rows and empty payloads.
 func ListCoinNews(ctx context.Context, db *sql.DB) ([]CoinNews, error) {
-	opReturns, err := List(ctx, db)
-	if err != nil {
-		return nil, err
+	coinNewsCacheMu.RLock()
+	cached, hit := coinNewsCacheEntries[db]
+	coinNewsCacheMu.RUnlock()
+	if hit && time.Since(cached.at) < listCacheTTL {
+		out := make([]CoinNews, len(cached.rows))
+		copy(out, cached.rows)
+		return out, nil
 	}
 
-	topics, err := ListTopics(ctx, db)
+	// retention_days = 0 means keep forever.
+	rows, err := db.QueryContext(ctx, `
+		SELECT
+			o.id, o.txid, o.vout, unhex(o.op_return_data), o.fee_sats, o.height, o.created_at,
+			t.id, t.topic, t.name, t.confirmed, COALESCE(t.txid, ''), COALESCE(t.retention_days, 7), t.created_at
+		FROM op_returns o
+		INNER JOIN coin_news_topics t
+			ON SUBSTR(o.op_return_data, 1, 8) = t.topic
+		WHERE
+			t.retention_days = 0
+			OR o.created_at >= datetime('now', '-' || t.retention_days || ' days')
+		ORDER BY o.created_at DESC
+	`)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list coin news: query: %w", err)
 	}
+	defer rows.Close()
 
 	var coinNews []CoinNews
-	for _, opReturn := range opReturns {
+	for rows.Next() {
+		var (
+			opReturn   OPReturn
+			topic      Topic
+			rawTopicID string
+		)
+		err := rows.Scan(
+			&opReturn.ID, &opReturn.TxID, &opReturn.Vout,
+			&opReturn.Data, &opReturn.Fee, &opReturn.Height, &opReturn.CreatedAt,
+			&topic.ID, &rawTopicID, &topic.Name, &topic.Confirmed, &topic.Txid, &topic.RetentionDays, &topic.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("list coin news: scan: %w", err)
+		}
+
+		topicID, err := ValidNewsTopicID(rawTopicID)
+		if err != nil {
+			return nil, fmt.Errorf("list coin news: invalid topic ID: %w", err)
+		}
+		topic.Topic = topicID
+
 		if len(opReturn.Data) < TopicIdLength {
 			continue
 		}
-
-		// Skip over all topic creation OP_RETURNs
+		// Topic-creation rows match the prefix but aren't news.
 		if _, ok := IsCreateTopic(opReturn.Data); ok {
 			continue
-		}
-
-		topic, ok := extractTopic(topics, TopicID(opReturn.Data[:TopicIdLength]))
-		if !ok {
-			continue
-		}
-
-		// Filter by retention days (0 = infinite retention)
-		if topic.RetentionDays > 0 {
-			cutoff := time.Now().AddDate(0, 0, -int(topic.RetentionDays))
-			if opReturn.CreatedAt.Before(cutoff) {
-				continue
-			}
 		}
 
 		var (
@@ -432,6 +524,15 @@ func ListCoinNews(ctx context.Context, db *sql.DB) ([]CoinNews, error) {
 			CreatedAt: opReturn.CreatedAt,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list coin news: iterate: %w", err)
+	}
+
+	snapshot := make([]CoinNews, len(coinNews))
+	copy(snapshot, coinNews)
+	coinNewsCacheMu.Lock()
+	coinNewsCacheEntries[db] = coinNewsCacheEntry{rows: snapshot, at: time.Now()}
+	coinNewsCacheMu.Unlock()
 
 	return coinNews, nil
 }


### PR DESCRIPTION
Be smarter about data fetching. Limit how much we fetch + do some basic caching. 

Did some testing locally with a running app package. A completely idle signet instance used around 90% CPU for the Go backend. After these improvements we're down below 15%. Note that these measurements also used #1754, so part of the reason might be that Flutter code is calling Go code less often