### PR TITLE
bitwindow: avoid polling aggressively for absent daemons in Flutter

### DIFF
--- a/bitwindow/lib/providers/blockchain_provider.dart
+++ b/bitwindow/lib/providers/blockchain_provider.dart
@@ -95,15 +95,11 @@ class BlockchainProvider extends ChangeNotifier {
     void tick() async {
       try {
         await fetch();
-        // During IBD we should be pretty spammy to get up-to-date info all the time
-        // After IBD however we can check less frequently, so as soon as IBD is done
-        // we check every 5 seconds.
-
-        // Check if we need to change the interval
-        // SyncProvider is the source of truth for "are we still catching up";
-        // ride its `isSynced` so we drop to a calmer cadence the moment all
-        // tracked daemons report synced.
-        final newInterval = syncProvider.isSynced ? const Duration(seconds: 5) : const Duration(milliseconds: 200);
+        // Mirror SyncProvider's cadence signal so absent daemons don't
+        // trap us in 200ms polling forever.
+        final newInterval = syncProvider.shouldPollAggressively
+            ? const Duration(milliseconds: 200)
+            : const Duration(seconds: 5);
         if (newInterval != _currentInterval) {
           // IBD-status changed!
           _currentInterval = newInterval;

--- a/coinshift/lib/providers/analytics_provider.dart
+++ b/coinshift/lib/providers/analytics_provider.dart
@@ -190,7 +190,7 @@ class AnalyticsProvider extends ChangeNotifier {
 
     // Filter by created height - approximate since we don't have timestamps
     // Assuming ~10 minutes per block
-    final blocksPerHour = 6;
+    const blocksPerHour = 6;
     final currentHeight = swaps.isNotEmpty ? swaps.map((s) => s.createdAtHeight).reduce((a, b) => a > b ? a : b) : 0;
 
     final blocksToInclude = switch (selectedTimeRange) {

--- a/sail_ui/lib/mocks/mocks.dart
+++ b/sail_ui/lib/mocks/mocks.dart
@@ -1722,6 +1722,9 @@ class MockSyncProvider implements SyncProvider {
   bool get isSynced => true;
 
   @override
+  bool get shouldPollAggressively => false;
+
+  @override
   bool get inHeaderSync => false;
 }
 

--- a/sail_ui/lib/providers/sync_provider.dart
+++ b/sail_ui/lib/providers/sync_provider.dart
@@ -86,19 +86,25 @@ class SyncProvider extends ChangeNotifier {
   /// daemon (read [bitwindowdSyncInfo] or [sidechains] directly).
   bool get isSynced => (mainchainSyncInfo?.isSynced ?? false) && (enforcerSyncInfo?.isSynced ?? false);
 
-  /// True when *any* tracked daemon is actively downloading. Drives the
-  /// 100 ms cadence even when mainchain + enforcer are already synced —
-  /// e.g. someone runs `orchestratorctl download thunder` from the CLI
-  /// and we want to see MB ticks immediately.
-  bool get _anyDownloading {
-    if (mainchainSyncInfo?.downloadInfo.isDownloading ?? false) return true;
-    if (enforcerSyncInfo?.downloadInfo.isDownloading ?? false) return true;
-    if (bitwindowdSyncInfo?.downloadInfo.isDownloading ?? false) return true;
-    for (final s in sidechains.values) {
-      if (s.downloadInfo.isDownloading) return true;
-    }
-    return false;
-  }
+  /// All tracked SyncInfo slots in one list — null entries mean the
+  /// daemon hasn't reported yet. Both [_anyDownloading] and
+  /// [shouldPollAggressively] iterate this so the set stays in sync.
+  List<SyncInfo?> get _trackedSyncInfos => [
+    mainchainSyncInfo,
+    enforcerSyncInfo,
+    bitwindowdSyncInfo,
+    ...sidechains.values,
+  ];
+
+  /// True if any tracked daemon is downloading binaries.
+  bool get _anyDownloading => _trackedSyncInfos.any(
+    (s) => s?.downloadInfo.isDownloading ?? false,
+  );
+
+  /// Cadence signal — true only when there's actual progress to display.
+  /// A null SyncInfo (daemon not running) does NOT count: polling fast
+  /// for something with nothing to show would just burn CPU.
+  bool get shouldPollAggressively => _anyDownloading || _trackedSyncInfos.any((s) => s != null && !s.isSynced);
 
   /// True while bitcoind is still pulling its initial header set.
   bool get inHeaderSync {
@@ -156,10 +162,7 @@ class SyncProvider extends ChangeNotifier {
     try {
       await _fetch();
 
-      // Stay aggressive while anything's downloading OR not yet synced —
-      // that covers user-triggered CLI downloads of sidechains too.
-      final aggressive = _anyDownloading || !isSynced;
-      final nextInterval = aggressive ? AGGRESSIVE_INTERVAL : PASSIVE_INTERVAL;
+      final nextInterval = shouldPollAggressively ? AGGRESSIVE_INTERVAL : PASSIVE_INTERVAL;
       if (nextInterval != _currentInterval) {
         _currentInterval = nextInterval;
         _scheduleNextTick();


### PR DESCRIPTION
This takes CPU usage of the Flutter code part of BitWindow from 37% to 3% on my machine