### PR TITLE
bump deps

### DIFF
--- a/bitassets/pubspec.lock
+++ b/bitassets/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.0"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -1335,4 +1335,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -57,7 +57,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.3.1
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   flutter_launcher_icons: ^0.14.3
 
 flutter_launcher_icons:

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.219
+version: 1.0.220
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.lock
+++ b/bitnames/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.0"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -1335,4 +1335,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.219
+version: 1.0.220
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -57,7 +57,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   flutter_launcher_icons: ^0.14.4
 
 flutter_launcher_icons:

--- a/bitwindow/pubspec.lock
+++ b/bitwindow/pubspec.lock
@@ -221,10 +221,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.0"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -1510,4 +1510,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.71
+version: 0.2.72
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -77,7 +77,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   flutter_launcher_icons: ^0.14.4
   patrol: ^4.5.0
   integration_test:

--- a/photon/pubspec.lock
+++ b/photon/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.0"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -1335,4 +1335,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -56,7 +56,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   flutter_launcher_icons: ^0.14.4
 
 flutter_launcher_icons:

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.92
+version: 1.0.93
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/pubspec.lock
+++ b/sail_ui/pubspec.lock
@@ -133,10 +133,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.0"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -1240,4 +1240,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/sail_ui/pubspec.yaml
+++ b/sail_ui/pubspec.yaml
@@ -59,7 +59,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
 
 flutter:
   assets:

--- a/thunder/pubspec.lock
+++ b/thunder/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.0"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -1335,4 +1335,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.221
+version: 1.0.222
 
 environment:
   sdk: 3.11.4

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -56,7 +56,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   flutter_launcher_icons: ^0.14.4
 
 flutter_launcher_icons:

--- a/truthcoin/pubspec.lock
+++ b/truthcoin/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.0"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -1335,4 +1335,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -56,7 +56,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   flutter_launcher_icons: ^0.14.4
 
 flutter_launcher_icons:

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.92
+version: 1.0.93
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.lock
+++ b/zside/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.0"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -1335,4 +1335,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: "3.41.6"
+  flutter: ">=3.41.6"

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.219
+version: 1.0.220
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -56,7 +56,7 @@ dev_dependencies:
   drivechain_lints:
     path: ../drivechain_lints
   auto_route_generator: ^10.4.0
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   flutter_launcher_icons: ^0.14.4
 
 flutter_launcher_icons:


### PR DESCRIPTION
- **build(deps): bump build_runner from 2.14.0 to 2.15.0 in /sail_ui**
- **build(deps): bump build_runner from 2.14.0 to 2.15.0 in /bitwindow**
- **build(deps): bump build_runner from 2.14.0 to 2.15.0 in /thunder**
- **build(deps): bump build_runner from 2.14.0 to 2.15.0 in /bitnames**
- **build(deps): bump build_runner from 2.14.0 to 2.15.0 in /bitassets**
- **build(deps): bump build_runner from 2.14.0 to 2.15.0 in /zside**
- **build(deps): bump build_runner from 2.14.0 to 2.15.0 in /photon**
- **build(deps): bump build_runner from 2.14.0 to 2.15.0 in /truthcoin**
