### PR TITLE
sail_ui: per-connection aggressive vote in SyncProvider

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.222
+version: 1.0.223
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.222
+version: 1.0.223
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.74
+version: 0.2.75
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.95
+version: 1.0.96
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/providers/sync_provider.dart
+++ b/sail_ui/lib/providers/sync_provider.dart
@@ -86,16 +86,36 @@ class SyncProvider extends ChangeNotifier {
   /// daemon (read [bitwindowdSyncInfo] or [sidechains] directly).
   bool get isSynced => (mainchainSyncInfo?.isSynced ?? false) && (enforcerSyncInfo?.isSynced ?? false);
 
-  /// True when *any* tracked daemon is actively downloading. Drives the
-  /// 100 ms cadence even when mainchain + enforcer are already synced —
-  /// e.g. someone runs `orchestratorctl download thunder` from the CLI
-  /// and we want to see MB ticks immediately.
-  bool get _anyDownloading {
-    if (mainchainSyncInfo?.downloadInfo.isDownloading ?? false) return true;
-    if (enforcerSyncInfo?.downloadInfo.isDownloading ?? false) return true;
-    if (bitwindowdSyncInfo?.downloadInfo.isDownloading ?? false) return true;
-    for (final s in sidechains.values) {
-      if (s.downloadInfo.isDownloading) return true;
+  /// Per-connection vote on whether the global poll cadence should stay at
+  /// the aggressive 100 ms interval. A connection votes yes only if it's
+  /// actively downloading or it's running but not yet synced. Absent or
+  /// errored connections vote no — otherwise an unstarted sidechain pins
+  /// the whole app at 100 ms forever and chews ~37% CPU on the Flutter
+  /// side (issue #1754).
+  static bool connectionWantsAggressivePoll(SyncInfo? info, String? error) {
+    if (info == null) return false;
+    if (error != null && error.isNotEmpty) return false;
+    if (info.downloadInfo.isDownloading) return true;
+    return !info.isSynced;
+  }
+
+  /// True when *any* tracked connection wants aggressive (100 ms) polling.
+  /// Built from the per-connection helper so an absent sidechain with
+  /// `error="not running"` doesn't drag the cadence down.
+  bool get _wantsAggressivePoll {
+    if (connectionWantsAggressivePoll(mainchainSyncInfo, mainchainError)) {
+      return true;
+    }
+    if (connectionWantsAggressivePoll(enforcerSyncInfo, enforcerError)) {
+      return true;
+    }
+    if (connectionWantsAggressivePoll(bitwindowdSyncInfo, bitwindowdError)) {
+      return true;
+    }
+    for (final entry in sidechains.entries) {
+      if (connectionWantsAggressivePoll(entry.value, sidechainErrors[entry.key])) {
+        return true;
+      }
     }
     return false;
   }
@@ -156,10 +176,11 @@ class SyncProvider extends ChangeNotifier {
     try {
       await _fetch();
 
-      // Stay aggressive while anything's downloading OR not yet synced —
-      // that covers user-triggered CLI downloads of sidechains too.
-      final aggressive = _anyDownloading || !isSynced;
-      final nextInterval = aggressive ? AGGRESSIVE_INTERVAL : PASSIVE_INTERVAL;
+      // Aggregate per-connection votes — see [connectionWantsAggressivePoll].
+      // Catches user-triggered CLI downloads of sidechains too, while
+      // ignoring absent ("not running") sidechains that should not drive
+      // the cadence.
+      final nextInterval = _wantsAggressivePoll ? AGGRESSIVE_INTERVAL : PASSIVE_INTERVAL;
       if (nextInterval != _currentInterval) {
         _currentInterval = nextInterval;
         _scheduleNextTick();

--- a/sail_ui/test/sync_provider_aggressive_poll_test.dart
+++ b/sail_ui/test/sync_provider_aggressive_poll_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+SyncInfo _info({
+  double current = 0,
+  double goal = 0,
+  bool downloading = false,
+}) => SyncInfo(
+  progressCurrent: current,
+  progressGoal: goal,
+  lastBlockAt: null,
+  downloadInfo: DownloadInfo(
+    progress: current,
+    total: goal,
+    isDownloading: downloading,
+  ),
+);
+
+void main() {
+  group('SyncProvider.connectionWantsAggressivePoll', () {
+    test('returns false when info is null', () {
+      expect(SyncProvider.connectionWantsAggressivePoll(null, null), false);
+    });
+
+    test('returns false when the connection reports an error', () {
+      // The orchestrator marks absent sidechains with error="not running".
+      // Those used to drag the global cadence down to 100ms forever.
+      expect(
+        SyncProvider.connectionWantsAggressivePoll(_info(), 'not running'),
+        false,
+      );
+      expect(
+        SyncProvider.connectionWantsAggressivePoll(
+          _info(current: 100, goal: 100),
+          'rpc unavailable',
+        ),
+        false,
+      );
+    });
+
+    test('returns true while a binary is being downloaded', () {
+      final info = _info(current: 25, goal: 100, downloading: true);
+      expect(SyncProvider.connectionWantsAggressivePoll(info, null), true);
+      // Empty error string is treated as no error.
+      expect(SyncProvider.connectionWantsAggressivePoll(info, ''), true);
+    });
+
+    test('returns true while a healthy connection is not yet synced', () {
+      final info = _info(current: 50, goal: 100);
+      expect(SyncProvider.connectionWantsAggressivePoll(info, null), true);
+    });
+
+    test('returns false once the healthy connection is fully synced', () {
+      final info = _info(current: 100, goal: 100);
+      expect(SyncProvider.connectionWantsAggressivePoll(info, null), false);
+    });
+  });
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.224
+version: 1.0.225
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.95
+version: 1.0.96
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.222
+version: 1.0.223
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
Each tracked connection now votes on whether the global poll loop should stay at the 100 ms cadence — absent sidechains (orchestrator error="not running") no longer pin the cadence and burn ~37% CPU on the Flutter side.

Fixes #1754