### PR TITLE
feat: split download tracking into its own RPC + DownloadProvider

### DIFF
--- a/bitassets/lib/main.dart
+++ b/bitassets/lib/main.dart
@@ -82,7 +82,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   late BitAssetsLive bitassetsRPC;
 
   await initSidechainDependencies(
-    sidechainType: BinaryType.bitassets,
+    sidechainType: BinaryType.BINARY_TYPE_BITASSETS,
     createSidechainConnection: (_) {
       bitassetsRPC = BitAssetsLive();
       GetIt.I.registerSingleton<BitAssetsRPC>(bitassetsRPC);
@@ -99,7 +99,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   unawaited(
     initBackendManagedSidechainRuntime(
       log: log,
-      binary: BinaryType.bitassets,
+      binary: BinaryType.BINARY_TYPE_BITASSETS,
       appRpc: bitassetsRPC,
     ),
   );
@@ -139,7 +139,7 @@ void bootBinaries(Logger log) {
   unawaited(
     bootBackendManagedSidechain(
       log: log,
-      binary: BinaryType.bitassets,
+      binary: BinaryType.BINARY_TYPE_BITASSETS,
       appRpc: GetIt.I.isRegistered<BitAssetsRPC>() ? GetIt.I.get<BitAssetsRPC>() : null,
     ),
   );

--- a/bitassets/pubspec.lock
+++ b/bitassets/pubspec.lock
@@ -1335,4 +1335,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.223
+version: 1.0.224
 
 environment:
   sdk: 3.11.4

--- a/bitassets/test/mocks/mock_binary.dart
+++ b/bitassets/test/mocks/mock_binary.dart
@@ -43,7 +43,7 @@ class MockBinary extends Binary {
       );
 
   @override
-  BinaryType get type => BinaryType.bitassets;
+  BinaryType get type => BinaryType.BINARY_TYPE_BITASSETS;
 
   @override
   Color get color => SailColorScheme.orange;

--- a/bitassets/test/mocks/rpc_mock_bitassets.dart
+++ b/bitassets/test/mocks/rpc_mock_bitassets.dart
@@ -3,7 +3,7 @@ import 'package:sail_ui/sail_ui.dart';
 class MockBitAssetsRPC extends BitAssetsRPC {
   MockBitAssetsRPC()
     : super(
-        binaryType: BinaryType.bitassets,
+        binaryType: BinaryType.BINARY_TYPE_BITASSETS,
       );
 
   @override

--- a/bitassets/test/mocks/rpc_mock_sidechain.dart
+++ b/bitassets/test/mocks/rpc_mock_sidechain.dart
@@ -3,7 +3,7 @@ import 'package:sail_ui/sail_ui.dart';
 class MockSidechainRPC extends SidechainRPC {
   MockSidechainRPC()
     : super(
-        binaryType: BinaryType.bitassets,
+        binaryType: BinaryType.BINARY_TYPE_BITASSETS,
       );
 
   @override

--- a/bitnames/lib/main.dart
+++ b/bitnames/lib/main.dart
@@ -120,7 +120,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   late BitnamesLive bitnamesRPC;
 
   await initSidechainDependencies(
-    sidechainType: BinaryType.bitnames,
+    sidechainType: BinaryType.BINARY_TYPE_BITNAMES,
     createSidechainConnection: (_) {
       bitnamesRPC = BitnamesLive();
       GetIt.I.registerSingleton<BitnamesRPC>(bitnamesRPC);
@@ -137,7 +137,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   unawaited(
     initBackendManagedSidechainRuntime(
       log: log,
-      binary: BinaryType.bitnames,
+      binary: BinaryType.BINARY_TYPE_BITNAMES,
       appRpc: bitnamesRPC,
     ),
   );
@@ -162,7 +162,7 @@ void bootBinaries(Logger log) {
   unawaited(
     bootBackendManagedSidechain(
       log: log,
-      binary: BinaryType.bitnames,
+      binary: BinaryType.BINARY_TYPE_BITNAMES,
       appRpc: GetIt.I.isRegistered<BitnamesRPC>() ? GetIt.I.get<BitnamesRPC>() : null,
     ),
   );

--- a/bitnames/pubspec.lock
+++ b/bitnames/pubspec.lock
@@ -1335,4 +1335,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.223
+version: 1.0.224
 
 environment:
   sdk: 3.11.4

--- a/bitnames/test/mocks/mock_binary.dart
+++ b/bitnames/test/mocks/mock_binary.dart
@@ -43,7 +43,7 @@ class MockBinary extends Binary {
       );
 
   @override
-  BinaryType get type => BinaryType.bitnames;
+  BinaryType get type => BinaryType.BINARY_TYPE_BITNAMES;
 
   @override
   Color get color => SailColorScheme.orange;

--- a/bitnames/test/mocks/rpc_mock_sidechain.dart
+++ b/bitnames/test/mocks/rpc_mock_sidechain.dart
@@ -3,7 +3,7 @@ import 'package:sail_ui/sail_ui.dart';
 class MockSidechainRPC extends SidechainRPC {
   MockSidechainRPC()
     : super(
-        binaryType: BinaryType.bitnames,
+        binaryType: BinaryType.BINARY_TYPE_BITNAMES,
       );
 
   @override

--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -256,7 +256,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   GetIt.I.registerSingleton<UpdateProvider>(
     UpdateProvider(
       log: log,
-      binaryType: BinaryType.bitWindow,
+      binaryType: BinaryType.BINARY_TYPE_BITWINDOWD,
       currentVersion: AppVersion.version,
       onBeforeUpdate: () async {
         final binaryProvider = GetIt.I.get<BinaryProvider>();
@@ -821,8 +821,8 @@ Future<void> bootBitwindowBackend(Logger log) async {
     bitwindowRpc.connectionError = null;
     bitwindowRpc.markStateChanged();
   }
-  binaryProvider.addStartupLogForBinary(BinaryType.orchestratord, 'Waiting for orchestratord...');
-  binaryProvider.addStartupLogForBinary(BinaryType.bitWindow, 'Waiting for orchestratord...');
+  binaryProvider.addStartupLogForBinary(BinaryType.BINARY_TYPE_ORCHESTRATORD, 'Waiting for orchestratord...');
+  binaryProvider.addStartupLogForBinary(BinaryType.BINARY_TYPE_BITWINDOWD, 'Waiting for orchestratord...');
 
   var orchestratorReady = false;
   for (var i = 0; i < 30; i++) {
@@ -859,9 +859,9 @@ Future<void> bootBitwindowBackend(Logger log) async {
   }
 
   // 4. Stream binary logs and start watching state.
-  _streamBinaryLogs(orchestrator, 'bitcoind', BinaryType.bitcoinCore, log);
-  _streamBinaryLogs(orchestrator, 'enforcer', BinaryType.enforcer, log);
-  _streamBinaryLogs(orchestrator, 'bitwindow', BinaryType.bitWindow, log);
+  _streamBinaryLogs(orchestrator, 'bitcoind', BinaryType.BINARY_TYPE_BITCOIND, log);
+  _streamBinaryLogs(orchestrator, 'enforcer', BinaryType.BINARY_TYPE_ENFORCER, log);
+  _streamBinaryLogs(orchestrator, 'bitwindow', BinaryType.BINARY_TYPE_BITWINDOWD, log);
 
   log.i('STARTUP: starting backend state watch');
   backendState.startWatching();
@@ -1021,7 +1021,7 @@ List<Binary> initalBinaries() {
   return [
     ...coreBinaries,
     ...sidechainBinaries,
-    resolveFromConfig(BinaryType.grpcurl, () => GRPCurl()),
+    resolveFromConfig(BinaryType.BINARY_TYPE_GRPCURL, () => GRPCurl()),
   ];
 }
 

--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -228,6 +228,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
       additionalConnection: SyncConnection(rpc: bitwindow, name: bitwindow.binary.name),
     ),
   );
+  GetIt.I.registerLazySingleton<DownloadProvider>(() => DownloadProvider());
   GetIt.I.registerSingleton<BlockchainProvider>(BlockchainProvider());
   GetIt.I.registerSingleton<NetworkProvider>(NetworkProvider());
   GetIt.I.registerSingleton<TransactionProvider>(TransactionProvider());

--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -707,11 +707,12 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
     _ => null,
   };
 
-  DownloadInfo _downloadInfoFor(Binary b) {
-    final type = _sidechainType(b);
-    if (type == null) return const DownloadInfo();
-    return _syncProvider.sidechains[type]?.downloadInfo ?? const DownloadInfo();
+  DownloadProgress? _downloadProgressFor(Binary b) {
+    if (!GetIt.I.isRegistered<DownloadProvider>()) return null;
+    return GetIt.I.get<DownloadProvider>().statusFor(b.type);
   }
+
+  bool _isDownloadingFor(Binary b) => _downloadProgressFor(b) != null;
 
   SyncInfo? _syncInfoFor(Binary b) {
     final type = _sidechainType(b);
@@ -752,7 +753,7 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
   bool get isUsingBitcoinCoreWallet {
     final activeWallet = _walletReader.activeWallet;
     if (activeWallet == null) return false;
-    return activeWallet.walletType != BinaryType.enforcer;
+    return activeWallet.walletType != BinaryType.BINARY_TYPE_ENFORCER;
   }
 
   List<SidechainOverview?> get sidechains => _sidechainProvider.sidechains;
@@ -852,15 +853,12 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
     final isRunning = _binaryProvider.isConnected(sidechain);
     final isInitializing = _binaryProvider.isInitializing(sidechain);
     final stopping = _binaryProvider.isStopping(sidechain);
-    final downloadInfo = _downloadInfoFor(sidechain);
-    final downloading = downloadInfo.isDownloading;
-
-    if (downloading) {
+    final progress = _downloadProgressFor(sidechain);
+    if (progress != null) {
       final syncInfo = SyncInfo(
-        progressCurrent: downloadInfo.progress,
-        progressGoal: downloadInfo.total,
+        progressCurrent: progress.mbDownloaded.toDouble(),
+        progressGoal: progress.mbTotal > 0 ? progress.mbTotal.toDouble() : 0,
         lastBlockAt: null,
-        downloadInfo: downloadInfo,
       );
 
       return ChainLoader(
@@ -977,7 +975,7 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
 
     final isRunning = _binaryProvider.isConnected(sidechain);
     final isInitializing = _binaryProvider.isInitializing(sidechain);
-    final downloading = _downloadInfoFor(sidechain).isDownloading;
+    final downloading = _isDownloadingFor(sidechain);
     final error = _binaryProvider.connectionError(sidechain);
     final startupErr = rpc.startupError;
 
@@ -1274,7 +1272,7 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
       states['${key}_connected'] = _binaryProvider.isConnected(binary);
       states['${key}_initializing'] = _binaryProvider.isInitializing(binary);
       states['${key}_stopping'] = _binaryProvider.isStopping(binary);
-      states['${key}_downloading'] = _downloadInfoFor(binary).isDownloading;
+      states['${key}_downloading'] = _isDownloadingFor(binary);
       states['${key}_error'] = _binaryProvider.connectionError(binary);
       states['${key}_downloaded'] = binary.isDownloaded;
     }

--- a/bitwindow/lib/pages/wallet/wallet_overview.dart
+++ b/bitwindow/lib/pages/wallet/wallet_overview.dart
@@ -469,7 +469,7 @@ class OverviewViewModel extends BaseViewModel with ChangeTrackingMixin {
   double get balance => _balanceProvider.balance;
   double get pendingBalance => _balanceProvider.pendingBalance;
 
-  bool get isCoreWallet => _walletReader.activeWallet?.walletType != BinaryType.enforcer;
+  bool get isCoreWallet => _walletReader.activeWallet?.walletType != BinaryType.BINARY_TYPE_ENFORCER;
 
   String sortColumn = 'date';
   bool sortAscending = true;

--- a/bitwindow/lib/widgets/fast_withdrawal_tab.dart
+++ b/bitwindow/lib/widgets/fast_withdrawal_tab.dart
@@ -36,7 +36,7 @@ class FastWithdrawalForm extends StatelessWidget {
 
     final walletReader = GetIt.I.get<WalletReaderProvider>();
     final activeWallet = walletReader.activeWallet;
-    if (activeWallet != null && activeWallet.walletType != BinaryType.enforcer) {
+    if (activeWallet != null && activeWallet.walletType != BinaryType.BINARY_TYPE_ENFORCER) {
       return SailCard(
         error: 'Switch to your enforcer wallet to interact with sidechains',
         child: SizedBox(),

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.75
+version: 0.2.76
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/test/hd_wallet_provider_retry_test.dart
+++ b/bitwindow/test/hd_wallet_provider_retry_test.dart
@@ -17,7 +17,7 @@ WalletData _enforcer({String l1Mnemonic = ''}) => WalletData(
   name: 'Enforcer',
   gradient: WalletGradient.fromWalletId('enf'),
   createdAt: DateTime.utc(2026, 1, 1),
-  walletType: BinaryType.enforcer,
+  walletType: BinaryType.BINARY_TYPE_ENFORCER,
 );
 
 void main() {
@@ -76,7 +76,7 @@ void main() {
         name: 'Core',
         gradient: WalletGradient.fromWalletId('core'),
         createdAt: DateTime.utc(2026, 1, 1),
-        walletType: BinaryType.bitcoinCore,
+        walletType: BinaryType.BINARY_TYPE_BITCOIND,
       ),
     ];
     reader.activeWalletId = 'core';

--- a/bitwindow/test/test_utils.dart
+++ b/bitwindow/test/test_utils.dart
@@ -102,7 +102,7 @@ Future<void> registerTestDependencies() async {
   if (!GetIt.I.isRegistered<BitwindowRPC>()) {
     GetIt.I.registerLazySingleton<BitwindowRPC>(
       () => MockAPI(
-        binaryType: BinaryType.bitWindow,
+        binaryType: BinaryType.BINARY_TYPE_BITWINDOWD,
       ),
     );
   }
@@ -111,7 +111,7 @@ Future<void> registerTestDependencies() async {
     final balanceProvider = BalanceProvider(
       connections: [
         MockAPI(
-          binaryType: BinaryType.bitWindow,
+          binaryType: BinaryType.BINARY_TYPE_BITWINDOWD,
         ),
       ],
     );

--- a/coinshift/lib/main.dart
+++ b/coinshift/lib/main.dart
@@ -81,7 +81,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   }
 
   await initSidechainDependencies(
-    sidechainType: BinaryType.coinShift,
+    sidechainType: BinaryType.BINARY_TYPE_COINSHIFT,
     createSidechainConnection: createSidechainConnection,
     applicationDir: applicationDir,
     log: log,
@@ -94,7 +94,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   unawaited(
     initBackendManagedSidechainRuntime(
       log: log,
-      binary: BinaryType.coinShift,
+      binary: BinaryType.BINARY_TYPE_COINSHIFT,
       appRpc: GetIt.I.isRegistered<CoinShiftRPC>() ? GetIt.I.get<CoinShiftRPC>() : null,
     ),
   );
@@ -253,7 +253,7 @@ void bootBinaries(Logger log) {
   unawaited(
     bootBackendManagedSidechain(
       log: log,
-      binary: BinaryType.orchestratord,
+      binary: BinaryType.BINARY_TYPE_ORCHESTRATORD,
       appRpc: GetIt.I.isRegistered<CoinShiftRPC>() ? GetIt.I.get<CoinShiftRPC>() : null,
     ),
   );

--- a/coinshift/test/mocks/mock_binary.dart
+++ b/coinshift/test/mocks/mock_binary.dart
@@ -45,7 +45,7 @@ class MockBinary extends Binary {
       );
 
   @override
-  BinaryType get type => BinaryType.coinShift;
+  BinaryType get type => BinaryType.BINARY_TYPE_COINSHIFT;
 
   @override
   Color get color => SailColorScheme.orange;

--- a/coinshift/test/mocks/rpc_mock_sidechain.dart
+++ b/coinshift/test/mocks/rpc_mock_sidechain.dart
@@ -3,7 +3,7 @@ import 'package:sail_ui/sail_ui.dart';
 class MockSidechainRPC extends SidechainRPC {
   MockSidechainRPC()
     : super(
-        binaryType: BinaryType.zSide,
+        binaryType: BinaryType.BINARY_TYPE_ZSIDE,
       );
 
   @override

--- a/photon/lib/main.dart
+++ b/photon/lib/main.dart
@@ -79,7 +79,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   }
 
   await initSidechainDependencies(
-    sidechainType: BinaryType.photon,
+    sidechainType: BinaryType.BINARY_TYPE_PHOTON,
     createSidechainConnection: createSidechainConnection,
     applicationDir: applicationDir,
     log: log,
@@ -92,7 +92,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   unawaited(
     initBackendManagedSidechainRuntime(
       log: log,
-      binary: BinaryType.photon,
+      binary: BinaryType.BINARY_TYPE_PHOTON,
       appRpc: GetIt.I.isRegistered<PhotonRPC>() ? GetIt.I.get<PhotonRPC>() : null,
     ),
   );
@@ -243,7 +243,7 @@ void bootBinaries(Logger log) {
   unawaited(
     bootBackendManagedSidechain(
       log: log,
-      binary: BinaryType.orchestratord,
+      binary: BinaryType.BINARY_TYPE_ORCHESTRATORD,
       appRpc: GetIt.I.isRegistered<PhotonRPC>() ? GetIt.I.get<PhotonRPC>() : null,
     ),
   );

--- a/photon/pubspec.lock
+++ b/photon/pubspec.lock
@@ -1335,4 +1335,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.96
+version: 1.0.97
 
 environment:
   sdk: 3.11.4

--- a/photon/test/mocks/mock_binary.dart
+++ b/photon/test/mocks/mock_binary.dart
@@ -45,7 +45,7 @@ class MockBinary extends Binary {
       );
 
   @override
-  BinaryType get type => BinaryType.photon;
+  BinaryType get type => BinaryType.BINARY_TYPE_PHOTON;
 
   @override
   Color get color => SailColorScheme.orange;

--- a/photon/test/mocks/rpc_mock_sidechain.dart
+++ b/photon/test/mocks/rpc_mock_sidechain.dart
@@ -3,7 +3,7 @@ import 'package:sail_ui/sail_ui.dart';
 class MockSidechainRPC extends SidechainRPC {
   MockSidechainRPC()
     : super(
-        binaryType: BinaryType.zSide,
+        binaryType: BinaryType.BINARY_TYPE_ZSIDE,
       );
 
   @override

--- a/sail_ui/lib/config/backend_sidechain_runtime.dart
+++ b/sail_ui/lib/config/backend_sidechain_runtime.dart
@@ -61,10 +61,10 @@ Future<void> bootBackendManagedSidechain({
         appRpc.markStateChanged();
         binaryProvider.addStartupLogForBinary(appRpc.binaryType, 'Starting orchestratord...');
       }
-      binaryProvider.addStartupLogForBinary(BinaryType.orchestratord, 'Starting orchestratord...');
+      binaryProvider.addStartupLogForBinary(BinaryType.BINARY_TYPE_ORCHESTRATORD, 'Starting orchestratord...');
 
       // Pass --binary flag so orchestratord auto-boots the sidechain with deps
-      final orchestratord = binaryProvider.binaries.firstWhere((b) => b.type == BinaryType.orchestratord);
+      final orchestratord = binaryProvider.binaries.firstWhere((b) => b.type == BinaryType.BINARY_TYPE_ORCHESTRATORD);
       orchestratord.addBootArg('--binary=$targetBinaryName');
       log.i('bootBackendManagedSidechain: starting orchestratord with --binary=$targetBinaryName');
       await binaryProvider.start(orchestratord);
@@ -73,7 +73,7 @@ Future<void> bootBackendManagedSidechain({
       if (appRpc != null) {
         binaryProvider.addStartupLogForBinary(appRpc.binaryType, 'Waiting for orchestratord...');
       }
-      binaryProvider.addStartupLogForBinary(BinaryType.orchestratord, 'Waiting for orchestratord...');
+      binaryProvider.addStartupLogForBinary(BinaryType.BINARY_TYPE_ORCHESTRATORD, 'Waiting for orchestratord...');
       final ready = await _waitForBackendReady(orchestrator);
       if (!ready) {
         throw StateError('orchestratord did not become ready after 15s');
@@ -85,8 +85,8 @@ Future<void> bootBackendManagedSidechain({
     }
 
     _streamBinaryLogs(orchestrator, targetBinaryName, binary);
-    _streamBinaryLogs(orchestrator, 'bitcoind', BinaryType.bitcoinCore);
-    _streamBinaryLogs(orchestrator, 'enforcer', BinaryType.enforcer);
+    _streamBinaryLogs(orchestrator, 'bitcoind', BinaryType.BINARY_TYPE_BITCOIND);
+    _streamBinaryLogs(orchestrator, 'enforcer', BinaryType.BINARY_TYPE_ENFORCER);
 
     // Seed wallet state now that OrchestratorRPC is registered + reachable.
     // initSidechainDependencies registers the provider lazily but cannot

--- a/sail_ui/lib/config/binaries.dart
+++ b/sail_ui/lib/config/binaries.dart
@@ -11,41 +11,33 @@ import 'package:logger/logger.dart';
 import 'package:path/path.dart' as path;
 import 'package:sail_ui/sail_ui.dart';
 
+// Re-export BinaryType so callers that only import this file (the historical
+// home of the now-deleted Dart enum) keep working without an extra import.
+export 'package:sail_ui/gen/orchestrator/v1/orchestrator.pbenum.dart' show BinaryType;
+
 const kBitwindowBitcoinConfFilename = 'bitwindow-bitcoin.conf';
 
-enum BinaryType {
-  bitcoinCore,
-  bitWindow,
-  enforcer,
-  zSide,
-  thunder,
-  bitnames,
-  bitassets,
-  truthcoin,
-  photon,
-  coinShift,
-  grpcurl,
-  orchestratord,
-  zSided,
-}
+Never _unsupportedBinaryType(BinaryType t) => throw StateError('unsupported BinaryType: $t');
 
-extension BinaryTypeExtension on BinaryType {
-  Binary get binary => switch (this) {
-    BinaryType.bitcoinCore => BitcoinCore(),
-    BinaryType.bitWindow => BitWindow(),
-    BinaryType.enforcer => Enforcer(),
-    BinaryType.zSide => ZSide(),
-    BinaryType.thunder => Thunder(),
-    BinaryType.bitnames => BitNames(),
-    BinaryType.bitassets => BitAssets(),
-    BinaryType.truthcoin => Truthcoin(),
-    BinaryType.photon => Photon(),
-    BinaryType.coinShift => CoinShift(),
-    BinaryType.grpcurl => GRPCurl(),
-    BinaryType.orchestratord => Orchestratord(),
-    BinaryType.zSided => ZSided(),
-  };
-}
+/// Default-constructed [Binary] for a proto [BinaryType]. Throws on
+/// UNSPECIFIED — that value only ever surfaces from the wire and indicates
+/// the orchestrator named a binary the frontend doesn't recognise.
+Binary defaultBinaryFor(BinaryType type) => switch (type) {
+  BinaryType.BINARY_TYPE_BITCOIND => BitcoinCore(),
+  BinaryType.BINARY_TYPE_BITWINDOWD => BitWindow(),
+  BinaryType.BINARY_TYPE_ENFORCER => Enforcer(),
+  BinaryType.BINARY_TYPE_ZSIDE => ZSide(),
+  BinaryType.BINARY_TYPE_THUNDER => Thunder(),
+  BinaryType.BINARY_TYPE_BITNAMES => BitNames(),
+  BinaryType.BINARY_TYPE_BITASSETS => BitAssets(),
+  BinaryType.BINARY_TYPE_TRUTHCOIN => Truthcoin(),
+  BinaryType.BINARY_TYPE_PHOTON => Photon(),
+  BinaryType.BINARY_TYPE_COINSHIFT => CoinShift(),
+  BinaryType.BINARY_TYPE_GRPCURL => GRPCurl(),
+  BinaryType.BINARY_TYPE_ORCHESTRATORD => Orchestratord(),
+  BinaryType.BINARY_TYPE_ZSIDED => ZSided(),
+  _ => _unsupportedBinaryType(type),
+};
 
 abstract class Binary {
   Logger get log => GetIt.I.get<Logger>();
@@ -180,7 +172,7 @@ abstract class Binary {
 
     // then any extra files for that specific chain
     switch (type) {
-      case BinaryType.bitcoinCore:
+      case BinaryType.BINARY_TYPE_BITCOIND:
         await _deleteFilesInDir(dir, [
           'bitcoin-cli',
           'bitcoin-util',
@@ -189,14 +181,14 @@ abstract class Binary {
           'qt', // a directory!
         ]);
 
-      case BinaryType.enforcer:
+      case BinaryType.BINARY_TYPE_ENFORCER:
         // nothing extra for the enforcer itself, but also delete
         // grpcurl-stuff
         await _deleteFilesInDir(dir, ['LICENSE', 'grpcurl']);
 
         break;
 
-      case BinaryType.bitWindow:
+      case BinaryType.BINARY_TYPE_BITWINDOWD:
         await _deleteFilesInDir(dir, [
           'data',
           'lib',
@@ -208,31 +200,34 @@ abstract class Binary {
           'window_manager_plugin.dll',
         ]);
 
-      case BinaryType.bitnames:
+      case BinaryType.BINARY_TYPE_BITNAMES:
         await _deleteFilesInDir(dir, ['bitnames-cli']);
 
-      case BinaryType.bitassets:
+      case BinaryType.BINARY_TYPE_BITASSETS:
         await _deleteFilesInDir(dir, ['bitassets-cli']);
 
-      case BinaryType.thunder:
+      case BinaryType.BINARY_TYPE_THUNDER:
         await _deleteFilesInDir(dir, ['thunder-cli']);
 
-      case BinaryType.zSide:
+      case BinaryType.BINARY_TYPE_ZSIDE:
         await _deleteFilesInDir(dir, ['thunder-orchard']);
 
-      case BinaryType.truthcoin:
+      case BinaryType.BINARY_TYPE_TRUTHCOIN:
         await _deleteFilesInDir(dir, ['truthcoin-cli']);
 
-      case BinaryType.photon:
+      case BinaryType.BINARY_TYPE_PHOTON:
         await _deleteFilesInDir(dir, ['photon-cli']);
 
-      case BinaryType.coinShift:
+      case BinaryType.BINARY_TYPE_COINSHIFT:
         await _deleteFilesInDir(dir, ['coinshift-cli']);
 
-      case BinaryType.grpcurl:
-      case BinaryType.orchestratord:
-      case BinaryType.zSided:
+      case BinaryType.BINARY_TYPE_GRPCURL:
+      case BinaryType.BINARY_TYPE_ORCHESTRATORD:
+      case BinaryType.BINARY_TYPE_ZSIDED:
         break;
+
+      case BinaryType.BINARY_TYPE_UNSPECIFIED:
+        throw StateError('unsupported BinaryType: $type');
     }
   }
 
@@ -350,7 +345,7 @@ abstract class Binary {
     _log('getBlockchainDataPaths for $name: networkDir=$networkDir');
 
     switch (type) {
-      case BinaryType.bitcoinCore:
+      case BinaryType.BINARY_TYPE_BITCOIND:
         return _getExistingFilesInDir(networkDir, [
           '.lock',
           'anchors.dat',
@@ -367,7 +362,7 @@ abstract class Binary {
           'settings.json',
         ]);
 
-      case BinaryType.enforcer:
+      case BinaryType.BINARY_TYPE_ENFORCER:
         final rootdir = rootDir();
         final network = GetIt.I.get<BitcoinConfProvider>().network;
         return _getExistingFilesInDir(rootdir, [
@@ -376,26 +371,30 @@ abstract class Binary {
           network.toReadableNet().replaceAll('mainnet', 'bitcoin').replaceAll('forknet', 'bitcoin'),
         ]);
 
-      case BinaryType.bitWindow:
+      case BinaryType.BINARY_TYPE_BITWINDOWD:
         return _getExistingFilesInDir(networkDir, ['bitdrive', 'bitwindow.db']);
 
-      case BinaryType.bitnames:
-      case BinaryType.bitassets:
-      case BinaryType.thunder:
-      case BinaryType.zSide:
-      case BinaryType.truthcoin:
-      case BinaryType.photon:
-      case BinaryType.coinShift:
+      case BinaryType.BINARY_TYPE_BITNAMES:
+      case BinaryType.BINARY_TYPE_BITASSETS:
+      case BinaryType.BINARY_TYPE_THUNDER:
+      case BinaryType.BINARY_TYPE_ZSIDE:
+      case BinaryType.BINARY_TYPE_TRUTHCOIN:
+      case BinaryType.BINARY_TYPE_PHOTON:
+      case BinaryType.BINARY_TYPE_COINSHIFT:
         return _getExistingFilesInDir(networkDir, [
           'data.mdb',
           'lock.mdb',
           'logs',
         ]);
 
-      case BinaryType.grpcurl:
-      case BinaryType.orchestratord:
-      case BinaryType.zSided:
+      case BinaryType.BINARY_TYPE_GRPCURL:
+      case BinaryType.BINARY_TYPE_ORCHESTRATORD:
+      case BinaryType.BINARY_TYPE_ZSIDED:
         return [];
+
+      case BinaryType.BINARY_TYPE_UNSPECIFIED:
+      default:
+        throw StateError('unsupported BinaryType: $type');
     }
   }
 
@@ -415,7 +414,7 @@ abstract class Binary {
     }
 
     switch (type) {
-      case BinaryType.bitcoinCore:
+      case BinaryType.BINARY_TYPE_BITCOIND:
         final network = GetIt.I<BitcoinConfProvider>().network;
         paths.addAll(
           await _getExistingFilesInDir(datadirNetwork(), ['settings.json']),
@@ -429,10 +428,10 @@ abstract class Binary {
         );
         return paths;
 
-      case BinaryType.enforcer:
+      case BinaryType.BINARY_TYPE_ENFORCER:
         return [];
 
-      case BinaryType.bitWindow:
+      case BinaryType.BINARY_TYPE_BITWINDOWD:
         paths.addAll(
           await _getExistingFilesInDir(datadirNetwork(), ['server.log']),
         );
@@ -450,11 +449,11 @@ abstract class Binary {
         );
         return paths;
 
-      case BinaryType.bitnames:
-      case BinaryType.bitassets:
-      case BinaryType.zSide:
-      case BinaryType.truthcoin:
-      case BinaryType.photon:
+      case BinaryType.BINARY_TYPE_BITNAMES:
+      case BinaryType.BINARY_TYPE_BITASSETS:
+      case BinaryType.BINARY_TYPE_ZSIDE:
+      case BinaryType.BINARY_TYPE_TRUTHCOIN:
+      case BinaryType.BINARY_TYPE_PHOTON:
         paths.addAll(
           await _getExistingFilesInDir(frontendDir(), [
             'assets',
@@ -465,7 +464,7 @@ abstract class Binary {
         );
         return paths;
 
-      case BinaryType.thunder:
+      case BinaryType.BINARY_TYPE_THUNDER:
         paths.addAll(
           await _getExistingFilesInDir(rootDir(), [
             'start.sh',
@@ -484,7 +483,7 @@ abstract class Binary {
         );
         return paths;
 
-      case BinaryType.coinShift:
+      case BinaryType.BINARY_TYPE_COINSHIFT:
         paths.addAll(
           await _getExistingFilesInDir(datadirNetwork(), [
             'debug.log',
@@ -493,10 +492,14 @@ abstract class Binary {
         );
         return paths;
 
-      case BinaryType.grpcurl:
-      case BinaryType.orchestratord:
-      case BinaryType.zSided:
+      case BinaryType.BINARY_TYPE_GRPCURL:
+      case BinaryType.BINARY_TYPE_ORCHESTRATORD:
+      case BinaryType.BINARY_TYPE_ZSIDED:
         return [];
+
+      case BinaryType.BINARY_TYPE_UNSPECIFIED:
+      default:
+        throw StateError('unsupported BinaryType: $type');
     }
   }
 
@@ -507,7 +510,7 @@ abstract class Binary {
     final paths = <String>[];
 
     switch (type) {
-      case BinaryType.enforcer:
+      case BinaryType.BINARY_TYPE_ENFORCER:
         final rootdir = rootDir();
         final walletNetworkDir = path.join(
           rootdir,
@@ -518,19 +521,19 @@ abstract class Binary {
           paths.add(walletNetworkDir);
         }
 
-      case BinaryType.bitcoinCore:
+      case BinaryType.BINARY_TYPE_BITCOIND:
         paths.addAll(await _getBitcoinCoreWalletPaths(networkDir));
 
-      case BinaryType.bitnames:
-      case BinaryType.bitassets:
-      case BinaryType.thunder:
-      case BinaryType.zSide:
-      case BinaryType.truthcoin:
-      case BinaryType.photon:
-      case BinaryType.coinShift:
+      case BinaryType.BINARY_TYPE_BITNAMES:
+      case BinaryType.BINARY_TYPE_BITASSETS:
+      case BinaryType.BINARY_TYPE_THUNDER:
+      case BinaryType.BINARY_TYPE_ZSIDE:
+      case BinaryType.BINARY_TYPE_TRUTHCOIN:
+      case BinaryType.BINARY_TYPE_PHOTON:
+      case BinaryType.BINARY_TYPE_COINSHIFT:
         paths.addAll(await _getExistingFilesInDir(networkDir, ['wallet.mdb']));
 
-      case BinaryType.bitWindow:
+      case BinaryType.BINARY_TYPE_BITWINDOWD:
         paths.addAll(
           await _getExistingFilesInDir(networkDir, [
             'wallet.json',
@@ -538,10 +541,13 @@ abstract class Binary {
           ]),
         );
 
-      case BinaryType.grpcurl:
-      case BinaryType.orchestratord:
-      case BinaryType.zSided:
+      case BinaryType.BINARY_TYPE_GRPCURL:
+      case BinaryType.BINARY_TYPE_ORCHESTRATORD:
+      case BinaryType.BINARY_TYPE_ZSIDED:
         return [];
+
+      case BinaryType.BINARY_TYPE_UNSPECIFIED:
+        throw StateError('unsupported BinaryType: $type');
     }
 
     // Also include Flutter frontend app directory (getApplicationSupportDirectory())
@@ -581,12 +587,12 @@ abstract class Binary {
     final paths = <String>[];
 
     switch (type) {
-      case BinaryType.bitcoinCore:
+      case BinaryType.BINARY_TYPE_BITCOIND:
         paths.addAll(
           await _getExistingFilesInDir(datadirNetwork(), ['debug.log']),
         );
 
-      case BinaryType.enforcer:
+      case BinaryType.BINARY_TYPE_ENFORCER:
         // Individual log file + entire logs directory
         paths.addAll(
           await _getExistingFilesInDir(datadirNetwork(), [
@@ -595,25 +601,28 @@ abstract class Binary {
           ]),
         );
 
-      case BinaryType.bitWindow:
+      case BinaryType.BINARY_TYPE_BITWINDOWD:
         paths.addAll(
           await _getExistingFilesInDir(datadirNetwork(), ['server.log']),
         );
         paths.addAll(await _getExistingFilesInDir(rootDir(), ['debug.log']));
 
-      case BinaryType.thunder:
-      case BinaryType.bitnames:
-      case BinaryType.bitassets:
-      case BinaryType.zSide:
-      case BinaryType.truthcoin:
-      case BinaryType.photon:
-      case BinaryType.coinShift:
+      case BinaryType.BINARY_TYPE_THUNDER:
+      case BinaryType.BINARY_TYPE_BITNAMES:
+      case BinaryType.BINARY_TYPE_BITASSETS:
+      case BinaryType.BINARY_TYPE_ZSIDE:
+      case BinaryType.BINARY_TYPE_TRUTHCOIN:
+      case BinaryType.BINARY_TYPE_PHOTON:
+      case BinaryType.BINARY_TYPE_COINSHIFT:
         paths.addAll(await _getExistingFilesInDir(datadirNetwork(), ['logs']));
 
-      case BinaryType.grpcurl:
-      case BinaryType.orchestratord:
-      case BinaryType.zSided:
+      case BinaryType.BINARY_TYPE_GRPCURL:
+      case BinaryType.BINARY_TYPE_ORCHESTRATORD:
+      case BinaryType.BINARY_TYPE_ZSIDED:
         break;
+
+      case BinaryType.BINARY_TYPE_UNSPECIFIED:
+        throw StateError('unsupported BinaryType: $type');
     }
 
     // Also include Flutter frontend debug.log
@@ -643,7 +652,7 @@ abstract class Binary {
 
     // Extra files per chain
     switch (type) {
-      case BinaryType.bitcoinCore:
+      case BinaryType.BINARY_TYPE_BITCOIND:
         paths.addAll(
           await _getExistingFilesInDir(dir, [
             'bitcoin-cli',
@@ -654,10 +663,10 @@ abstract class Binary {
           ]),
         );
 
-      case BinaryType.enforcer:
+      case BinaryType.BINARY_TYPE_ENFORCER:
         paths.addAll(await _getExistingFilesInDir(dir, ['LICENSE', 'grpcurl']));
 
-      case BinaryType.bitWindow:
+      case BinaryType.BINARY_TYPE_BITWINDOWD:
         paths.addAll(
           await _getExistingFilesInDir(dir, [
             'data',
@@ -671,31 +680,34 @@ abstract class Binary {
           ]),
         );
 
-      case BinaryType.bitnames:
+      case BinaryType.BINARY_TYPE_BITNAMES:
         paths.addAll(await _getExistingFilesInDir(dir, ['bitnames-cli']));
 
-      case BinaryType.bitassets:
+      case BinaryType.BINARY_TYPE_BITASSETS:
         paths.addAll(await _getExistingFilesInDir(dir, ['bitassets-cli']));
 
-      case BinaryType.thunder:
+      case BinaryType.BINARY_TYPE_THUNDER:
         paths.addAll(await _getExistingFilesInDir(dir, ['thunder-cli']));
 
-      case BinaryType.zSide:
+      case BinaryType.BINARY_TYPE_ZSIDE:
         paths.addAll(await _getExistingFilesInDir(dir, ['thunder-orchard']));
 
-      case BinaryType.truthcoin:
+      case BinaryType.BINARY_TYPE_TRUTHCOIN:
         paths.addAll(await _getExistingFilesInDir(dir, ['truthcoin-cli']));
 
-      case BinaryType.photon:
+      case BinaryType.BINARY_TYPE_PHOTON:
         paths.addAll(await _getExistingFilesInDir(dir, ['photon-cli']));
 
-      case BinaryType.coinShift:
+      case BinaryType.BINARY_TYPE_COINSHIFT:
         paths.addAll(await _getExistingFilesInDir(dir, ['coinshift-cli']));
 
-      case BinaryType.grpcurl:
-      case BinaryType.orchestratord:
-      case BinaryType.zSided:
+      case BinaryType.BINARY_TYPE_GRPCURL:
+      case BinaryType.BINARY_TYPE_ORCHESTRATORD:
+      case BinaryType.BINARY_TYPE_ZSIDED:
         break;
+
+      case BinaryType.BINARY_TYPE_UNSPECIFIED:
+        throw StateError('unsupported BinaryType: $type');
     }
 
     return paths;
@@ -918,7 +930,7 @@ abstract class Binary {
   String get connectionString {
     // For BitcoinCore, get the actual port from BitcoinConfProvider which handles
     // both network defaults and user's custom rpcport setting
-    if (type == BinaryType.bitcoinCore && port == 0) {
+    if (type == BinaryType.BINARY_TYPE_BITCOIND && port == 0) {
       try {
         final confProvider = GetIt.I.get<BitcoinConfProvider>();
         // The provider should expose the actual port being used
@@ -1056,7 +1068,7 @@ class BitcoinCore extends Binary {
        );
 
   @override
-  BinaryType get type => BinaryType.bitcoinCore;
+  BinaryType get type => BinaryType.BINARY_TYPE_BITCOIND;
 
   @override
   Color get color => SailColorScheme.green;
@@ -1149,7 +1161,7 @@ class BitWindow extends Binary {
        );
 
   @override
-  BinaryType get type => BinaryType.bitWindow;
+  BinaryType get type => BinaryType.BINARY_TYPE_BITWINDOWD;
 
   @override
   Color get color => SailColorScheme.green;
@@ -1228,7 +1240,7 @@ class Orchestratord extends Binary {
        );
 
   @override
-  BinaryType get type => BinaryType.orchestratord;
+  BinaryType get type => BinaryType.BINARY_TYPE_ORCHESTRATORD;
 
   @override
   Color get color => SailColorScheme.orange;
@@ -1307,7 +1319,7 @@ class ZSided extends Binary {
        );
 
   @override
-  BinaryType get type => BinaryType.zSided;
+  BinaryType get type => BinaryType.BINARY_TYPE_ZSIDED;
 
   @override
   Color get color => SailColorScheme.blue;
@@ -1386,7 +1398,7 @@ class Enforcer extends Binary {
        );
 
   @override
-  BinaryType get type => BinaryType.enforcer;
+  BinaryType get type => BinaryType.BINARY_TYPE_ENFORCER;
 
   @override
   Color get color => SailColorScheme.green;
@@ -1494,7 +1506,7 @@ class GRPCurl extends Binary {
        );
 
   @override
-  BinaryType get type => BinaryType.grpcurl;
+  BinaryType get type => BinaryType.BINARY_TYPE_GRPCURL;
 
   @override
   Color get color => SailColorScheme.green;
@@ -1530,51 +1542,53 @@ class GRPCurl extends Binary {
 /// path mapping can be exercised without touching dart:io.
 String? flutterFrontendDirFor(BinaryType type, OS os, String home) {
   return switch (type) {
-    BinaryType.bitWindow => switch (os) {
+    BinaryType.BINARY_TYPE_BITWINDOWD => switch (os) {
       OS.macos => path.join(home, 'Library', 'Application Support', 'bitwindow'),
       OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'BitWindow'),
       OS.linux => path.join(home, '.local', 'share', 'bitwindow'),
     },
-    BinaryType.thunder => switch (os) {
+    BinaryType.BINARY_TYPE_THUNDER => switch (os) {
       OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.thunder'),
       OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'Thunder'),
       OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.thunder'),
     },
-    BinaryType.zSide => switch (os) {
+    BinaryType.BINARY_TYPE_ZSIDE => switch (os) {
       OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.zside'),
       OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'ZSide'),
       OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.zside'),
     },
-    BinaryType.bitnames => switch (os) {
+    BinaryType.BINARY_TYPE_BITNAMES => switch (os) {
       OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.bitnames'),
       OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'BitNames'),
       OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.bitnames'),
     },
-    BinaryType.bitassets => switch (os) {
+    BinaryType.BINARY_TYPE_BITASSETS => switch (os) {
       OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.bitassets'),
       OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'BitAssets'),
       OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.bitassets'),
     },
-    BinaryType.truthcoin => switch (os) {
+    BinaryType.BINARY_TYPE_TRUTHCOIN => switch (os) {
       OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.truthcoin'),
       OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'Truthcoin'),
       OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.truthcoin'),
     },
-    BinaryType.photon => switch (os) {
+    BinaryType.BINARY_TYPE_PHOTON => switch (os) {
       OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.photon'),
       OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'Photon'),
       OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.photon'),
     },
-    BinaryType.coinShift => switch (os) {
+    BinaryType.BINARY_TYPE_COINSHIFT => switch (os) {
       OS.macos => path.join(home, 'Library', 'Application Support', 'com.layertwolabs.coinshift'),
       OS.windows => path.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'Coinshift'),
       OS.linux => path.join(home, '.local', 'share', 'com.layertwolabs.coinshift'),
     },
-    BinaryType.bitcoinCore ||
-    BinaryType.enforcer ||
-    BinaryType.grpcurl ||
-    BinaryType.orchestratord ||
-    BinaryType.zSided => null,
+    BinaryType.BINARY_TYPE_BITCOIND ||
+    BinaryType.BINARY_TYPE_ENFORCER ||
+    BinaryType.BINARY_TYPE_GRPCURL ||
+    BinaryType.BINARY_TYPE_ORCHESTRATORD ||
+    BinaryType.BINARY_TYPE_ZSIDED => null,
+    BinaryType.BINARY_TYPE_UNSPECIFIED => _unsupportedBinaryType(type),
+    _ => _unsupportedBinaryType(type),
   };
 }
 
@@ -1590,7 +1604,7 @@ extension BinaryPaths on Binary {
 
   String confFile() {
     return switch (type) {
-      BinaryType.bitcoinCore => () {
+      BinaryType.BINARY_TYPE_BITCOIND => () {
         final network = GetIt.I.get<BitcoinConfProvider>().network;
         // For mainnet, use standard Bitcoin datadir; otherwise use Drivechain datadir (respects custom datadir)
         final confDir = network == BitcoinNetwork.BITCOIN_NETWORK_MAINNET
@@ -1613,20 +1627,22 @@ extension BinaryPaths on Binary {
 
   String logPath() {
     return switch (type) {
-      BinaryType.bitcoinCore => filePath([
+      BinaryType.BINARY_TYPE_BITCOIND => filePath([
         BitcoinCore().datadirNetwork(),
         'debug.log',
       ]),
-      BinaryType.bitWindow => filePath([datadirNetwork(), 'server.log']),
-      BinaryType.thunder ||
-      BinaryType.bitnames ||
-      BinaryType.bitassets ||
-      BinaryType.zSide ||
-      BinaryType.truthcoin ||
-      BinaryType.photon ||
-      BinaryType.coinShift => _findLatestDirVersionedLog(),
-      BinaryType.enforcer => _findLatestEnforcerLog(),
-      BinaryType.grpcurl || BinaryType.orchestratord || BinaryType.zSided => '',
+      BinaryType.BINARY_TYPE_BITWINDOWD => filePath([datadirNetwork(), 'server.log']),
+      BinaryType.BINARY_TYPE_THUNDER ||
+      BinaryType.BINARY_TYPE_BITNAMES ||
+      BinaryType.BINARY_TYPE_BITASSETS ||
+      BinaryType.BINARY_TYPE_ZSIDE ||
+      BinaryType.BINARY_TYPE_TRUTHCOIN ||
+      BinaryType.BINARY_TYPE_PHOTON ||
+      BinaryType.BINARY_TYPE_COINSHIFT => _findLatestDirVersionedLog(),
+      BinaryType.BINARY_TYPE_ENFORCER => _findLatestEnforcerLog(),
+      BinaryType.BINARY_TYPE_GRPCURL || BinaryType.BINARY_TYPE_ORCHESTRATORD || BinaryType.BINARY_TYPE_ZSIDED => '',
+      BinaryType.BINARY_TYPE_UNSPECIFIED => _unsupportedBinaryType(type),
+      _ => _unsupportedBinaryType(type),
     };
   }
 
@@ -1761,7 +1777,7 @@ extension BinaryPaths on Binary {
 
     switch (OS.current) {
       case OS.linux:
-        if (type == BinaryType.bitcoinCore) {
+        if (type == BinaryType.BINARY_TYPE_BITCOIND) {
           // in good style, this is different than all the others
           return filePath([home]);
         }
@@ -1801,22 +1817,22 @@ extension BinaryPaths on Binary {
     final network = GetIt.I<BitcoinConfProvider>().network;
 
     switch (type) {
-      case BinaryType.bitcoinCore:
+      case BinaryType.BINARY_TYPE_BITCOIND:
         final provider = GetIt.I<BitcoinConfProvider>();
         return (provider.detectedDataDir?.isNotEmpty == true) ? provider.detectedDataDir! : rootDirNetwork(network);
 
-      case BinaryType.enforcer:
+      case BinaryType.BINARY_TYPE_ENFORCER:
         final provider = GetIt.I<EnforcerConfProvider>();
         final customDir = provider.currentConfig?.getSetting('datadir');
         return customDir ?? rootDir();
 
-      case BinaryType.thunder:
-      case BinaryType.bitnames:
-      case BinaryType.bitassets:
-      case BinaryType.zSide:
-      case BinaryType.truthcoin:
-      case BinaryType.photon:
-      case BinaryType.coinShift:
+      case BinaryType.BINARY_TYPE_THUNDER:
+      case BinaryType.BINARY_TYPE_BITNAMES:
+      case BinaryType.BINARY_TYPE_BITASSETS:
+      case BinaryType.BINARY_TYPE_ZSIDE:
+      case BinaryType.BINARY_TYPE_TRUTHCOIN:
+      case BinaryType.BINARY_TYPE_PHOTON:
+      case BinaryType.BINARY_TYPE_COINSHIFT:
         if (GetIt.I.isRegistered<GenericSidechainConfProvider>()) {
           final provider = GetIt.I<GenericSidechainConfProvider>();
           final customDir = provider.currentConfig?.getSetting('datadir');
@@ -1824,13 +1840,17 @@ extension BinaryPaths on Binary {
         }
         return rootDir();
 
-      case BinaryType.bitWindow:
+      case BinaryType.BINARY_TYPE_BITWINDOWD:
         return rootDir();
 
-      case BinaryType.grpcurl:
-      case BinaryType.orchestratord:
-      case BinaryType.zSided:
+      case BinaryType.BINARY_TYPE_GRPCURL:
+      case BinaryType.BINARY_TYPE_ORCHESTRATORD:
+      case BinaryType.BINARY_TYPE_ZSIDED:
         return rootDir();
+
+      case BinaryType.BINARY_TYPE_UNSPECIFIED:
+      default:
+        throw StateError('unsupported BinaryType: $type');
     }
   }
 
@@ -1840,27 +1860,31 @@ extension BinaryPaths on Binary {
     final baseDir = datadir();
 
     switch (type) {
-      case BinaryType.bitcoinCore:
+      case BinaryType.BINARY_TYPE_BITCOIND:
         if (network == BitcoinNetwork.BITCOIN_NETWORK_MAINNET || network == BitcoinNetwork.BITCOIN_NETWORK_FORKNET) {
           return baseDir;
         }
         return path.join(baseDir, network.toReadableNet());
 
-      case BinaryType.bitWindow:
+      case BinaryType.BINARY_TYPE_BITWINDOWD:
         return path.join(baseDir, network.toReadableNet());
 
-      case BinaryType.enforcer:
-      case BinaryType.thunder:
-      case BinaryType.bitnames:
-      case BinaryType.bitassets:
-      case BinaryType.zSide:
-      case BinaryType.truthcoin:
-      case BinaryType.photon:
-      case BinaryType.coinShift:
-      case BinaryType.grpcurl:
-      case BinaryType.orchestratord:
-      case BinaryType.zSided:
+      case BinaryType.BINARY_TYPE_ENFORCER:
+      case BinaryType.BINARY_TYPE_THUNDER:
+      case BinaryType.BINARY_TYPE_BITNAMES:
+      case BinaryType.BINARY_TYPE_BITASSETS:
+      case BinaryType.BINARY_TYPE_ZSIDE:
+      case BinaryType.BINARY_TYPE_TRUTHCOIN:
+      case BinaryType.BINARY_TYPE_PHOTON:
+      case BinaryType.BINARY_TYPE_COINSHIFT:
+      case BinaryType.BINARY_TYPE_GRPCURL:
+      case BinaryType.BINARY_TYPE_ORCHESTRATORD:
+      case BinaryType.BINARY_TYPE_ZSIDED:
         return baseDir;
+
+      case BinaryType.BINARY_TYPE_UNSPECIFIED:
+      default:
+        throw StateError('unsupported BinaryType: $type');
     }
   }
 
@@ -1905,7 +1929,7 @@ extension BinaryPaths on Binary {
         return 'Unknown';
       }
 
-      if (type == BinaryType.enforcer) {
+      if (type == BinaryType.BINARY_TYPE_ENFORCER) {
         final versionLine = lines.firstWhere(
           (line) => line.contains('bip300301_enforcer_lib'),
           orElse: () => '',
@@ -2474,38 +2498,40 @@ Map<BitcoinNetwork, String> _baseUrlsFromFilesJson(
 
 BinaryType _binaryTypeFromJsonKey(String key) {
   return switch (key) {
-    'bitcoincore' => BinaryType.bitcoinCore,
-    'bitwindow' => BinaryType.bitWindow,
-    'enforcer' => BinaryType.enforcer,
-    'grpcurl' => BinaryType.grpcurl,
-    'orchestratord' => BinaryType.orchestratord,
-    'zsided' => BinaryType.zSided,
-    'thunder' => BinaryType.thunder,
-    'bitnames' => BinaryType.bitnames,
-    'bitassets' => BinaryType.bitassets,
-    'truthcoin' => BinaryType.truthcoin,
-    'photon' => BinaryType.photon,
-    'coinshift' => BinaryType.coinShift,
-    'zside' => BinaryType.zSide,
+    'bitcoincore' => BinaryType.BINARY_TYPE_BITCOIND,
+    'bitwindow' => BinaryType.BINARY_TYPE_BITWINDOWD,
+    'enforcer' => BinaryType.BINARY_TYPE_ENFORCER,
+    'grpcurl' => BinaryType.BINARY_TYPE_GRPCURL,
+    'orchestratord' => BinaryType.BINARY_TYPE_ORCHESTRATORD,
+    'zsided' => BinaryType.BINARY_TYPE_ZSIDED,
+    'thunder' => BinaryType.BINARY_TYPE_THUNDER,
+    'bitnames' => BinaryType.BINARY_TYPE_BITNAMES,
+    'bitassets' => BinaryType.BINARY_TYPE_BITASSETS,
+    'truthcoin' => BinaryType.BINARY_TYPE_TRUTHCOIN,
+    'photon' => BinaryType.BINARY_TYPE_PHOTON,
+    'coinshift' => BinaryType.BINARY_TYPE_COINSHIFT,
+    'zside' => BinaryType.BINARY_TYPE_ZSIDE,
     _ => throw ArgumentError('Unknown binary key: $key'),
   };
 }
 
 String binaryTypeToJsonKey(BinaryType type) {
   return switch (type) {
-    BinaryType.bitcoinCore => 'bitcoincore',
-    BinaryType.bitWindow => 'bitwindow',
-    BinaryType.enforcer => 'enforcer',
-    BinaryType.grpcurl => 'grpcurl',
-    BinaryType.orchestratord => 'orchestratord',
-    BinaryType.zSided => 'zsided',
-    BinaryType.thunder => 'thunder',
-    BinaryType.bitnames => 'bitnames',
-    BinaryType.bitassets => 'bitassets',
-    BinaryType.truthcoin => 'truthcoin',
-    BinaryType.photon => 'photon',
-    BinaryType.coinShift => 'coinshift',
-    BinaryType.zSide => 'zside',
+    BinaryType.BINARY_TYPE_BITCOIND => 'bitcoincore',
+    BinaryType.BINARY_TYPE_BITWINDOWD => 'bitwindow',
+    BinaryType.BINARY_TYPE_ENFORCER => 'enforcer',
+    BinaryType.BINARY_TYPE_GRPCURL => 'grpcurl',
+    BinaryType.BINARY_TYPE_ORCHESTRATORD => 'orchestratord',
+    BinaryType.BINARY_TYPE_ZSIDED => 'zsided',
+    BinaryType.BINARY_TYPE_THUNDER => 'thunder',
+    BinaryType.BINARY_TYPE_BITNAMES => 'bitnames',
+    BinaryType.BINARY_TYPE_BITASSETS => 'bitassets',
+    BinaryType.BINARY_TYPE_TRUTHCOIN => 'truthcoin',
+    BinaryType.BINARY_TYPE_PHOTON => 'photon',
+    BinaryType.BINARY_TYPE_COINSHIFT => 'coinshift',
+    BinaryType.BINARY_TYPE_ZSIDE => 'zside',
+    BinaryType.BINARY_TYPE_UNSPECIFIED => _unsupportedBinaryType(type),
+    _ => _unsupportedBinaryType(type),
   };
 }
 
@@ -2545,7 +2571,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
 
   // Dispatch to correct subclass
   return switch (binaryType) {
-    BinaryType.bitcoinCore => BitcoinCore(
+    BinaryType.BINARY_TYPE_BITCOIND => BitcoinCore(
       name: name,
       version: version,
       description: description,
@@ -2555,7 +2581,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
-    BinaryType.bitWindow => BitWindow(
+    BinaryType.BINARY_TYPE_BITWINDOWD => BitWindow(
       name: name,
       version: version,
       description: description,
@@ -2565,7 +2591,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
-    BinaryType.enforcer => Enforcer(
+    BinaryType.BINARY_TYPE_ENFORCER => Enforcer(
       name: name,
       version: version,
       description: description,
@@ -2575,7 +2601,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
-    BinaryType.grpcurl => GRPCurl(
+    BinaryType.BINARY_TYPE_GRPCURL => GRPCurl(
       name: name,
       version: version,
       description: description,
@@ -2585,7 +2611,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
-    BinaryType.orchestratord => Orchestratord(
+    BinaryType.BINARY_TYPE_ORCHESTRATORD => Orchestratord(
       name: name,
       version: version,
       description: description,
@@ -2595,7 +2621,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
-    BinaryType.zSided => ZSided(
+    BinaryType.BINARY_TYPE_ZSIDED => ZSided(
       name: name,
       version: version,
       description: description,
@@ -2605,7 +2631,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
-    BinaryType.thunder => Thunder(
+    BinaryType.BINARY_TYPE_THUNDER => Thunder(
       name: name,
       version: version,
       description: description,
@@ -2615,7 +2641,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
-    BinaryType.bitnames => BitNames(
+    BinaryType.BINARY_TYPE_BITNAMES => BitNames(
       name: name,
       version: version,
       description: description,
@@ -2625,7 +2651,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
-    BinaryType.bitassets => BitAssets(
+    BinaryType.BINARY_TYPE_BITASSETS => BitAssets(
       name: name,
       version: version,
       description: description,
@@ -2635,7 +2661,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
-    BinaryType.truthcoin => Truthcoin(
+    BinaryType.BINARY_TYPE_TRUTHCOIN => Truthcoin(
       name: name,
       version: version,
       description: description,
@@ -2645,7 +2671,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
-    BinaryType.photon => Photon(
+    BinaryType.BINARY_TYPE_PHOTON => Photon(
       name: name,
       version: version,
       description: description,
@@ -2655,7 +2681,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
-    BinaryType.coinShift => CoinShift(
+    BinaryType.BINARY_TYPE_COINSHIFT => CoinShift(
       name: name,
       version: version,
       description: description,
@@ -2665,7 +2691,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
-    BinaryType.zSide => ZSide(
+    BinaryType.BINARY_TYPE_ZSIDE => ZSide(
       name: name,
       version: version,
       description: description,
@@ -2675,5 +2701,7 @@ Binary binaryFromJson(String key, Map<String, dynamic> json) {
       port: port,
       chainLayer: chainLayer,
     ),
+    BinaryType.BINARY_TYPE_UNSPECIFIED => _unsupportedBinaryType(binaryType),
+    _ => _unsupportedBinaryType(binaryType),
   };
 }

--- a/sail_ui/lib/config/sidechain_main.dart
+++ b/sail_ui/lib/config/sidechain_main.dart
@@ -132,6 +132,7 @@ Future<void> initSidechainDependencies({
   );
   GetIt.I.registerLazySingleton<SyncProvider>(() => syncProvider);
   unawaited(syncProvider.fetch());
+  GetIt.I.registerLazySingleton<DownloadProvider>(() => DownloadProvider());
   GetIt.I.registerLazySingleton<SidechainTransactionsProvider>(
     () => SidechainTransactionsProvider(),
   );

--- a/sail_ui/lib/config/sidechain_main.dart
+++ b/sail_ui/lib/config/sidechain_main.dart
@@ -176,15 +176,15 @@ List<Binary> _initialBinaries(
   Binary resolve(BinaryType type) {
     return configBinaries.firstWhere(
       (b) => b.type == type,
-      orElse: () => type.binary, // fall back to hardcoded defaults
+      orElse: () => defaultBinaryFor(type),
     );
   }
 
   final sidechain = resolve(sidechainType);
   var binaries = [
-    resolve(BinaryType.bitcoinCore),
-    resolve(BinaryType.enforcer),
-    resolve(BinaryType.grpcurl),
+    resolve(BinaryType.BINARY_TYPE_BITCOIND),
+    resolve(BinaryType.BINARY_TYPE_ENFORCER),
+    resolve(BinaryType.BINARY_TYPE_GRPCURL),
     sidechain,
     ...additional,
   ];
@@ -243,25 +243,25 @@ Future<void> copyBinariesFromAssets(Logger log, Directory appDir) async {
 List<Binary> get allBinaries => [
   ...coreBinaries,
   ...sidechainBinaries,
-  resolveFromConfig(BinaryType.orchestratord, () => Orchestratord()),
-  resolveFromConfig(BinaryType.zSided, () => ZSided()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_ORCHESTRATORD, () => Orchestratord()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_ZSIDED, () => ZSided()),
 ];
 
 List<Binary> get coreBinaries => [
-  resolveFromConfig(BinaryType.bitcoinCore, () => BitcoinCore()),
-  resolveFromConfig(BinaryType.enforcer, () => Enforcer()),
-  resolveFromConfig(BinaryType.bitWindow, () => BitWindow()),
-  resolveFromConfig(BinaryType.orchestratord, () => Orchestratord()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_BITCOIND, () => BitcoinCore()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_ENFORCER, () => Enforcer()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_BITWINDOWD, () => BitWindow()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_ORCHESTRATORD, () => Orchestratord()),
 ];
 
 List<Binary> get sidechainBinaries => [
-  resolveFromConfig(BinaryType.thunder, () => Thunder()),
-  resolveFromConfig(BinaryType.truthcoin, () => Truthcoin()),
-  resolveFromConfig(BinaryType.photon, () => Photon()),
-  resolveFromConfig(BinaryType.bitnames, () => BitNames()),
-  resolveFromConfig(BinaryType.bitassets, () => BitAssets()),
-  resolveFromConfig(BinaryType.coinShift, () => CoinShift()),
-  resolveFromConfig(BinaryType.zSide, () => ZSide()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_THUNDER, () => Thunder()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_TRUTHCOIN, () => Truthcoin()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_PHOTON, () => Photon()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_BITNAMES, () => BitNames()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_BITASSETS, () => BitAssets()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_COINSHIFT, () => CoinShift()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_ZSIDE, () => ZSide()),
 ];
 
 Binary resolveFromConfig(BinaryType type, Binary Function() fallback) {

--- a/sail_ui/lib/config/sidechains.dart
+++ b/sail_ui/lib/config/sidechains.dart
@@ -221,7 +221,7 @@ class ZSide extends Sidechain {
   final int slot = 98;
 
   @override
-  BinaryType get type => BinaryType.zSide;
+  BinaryType get type => BinaryType.BINARY_TYPE_ZSIDE;
 
   @override
   Color color = SailColorScheme.blue;
@@ -320,7 +320,7 @@ class Thunder extends Sidechain {
   final int slot = 9;
 
   @override
-  BinaryType get type => BinaryType.thunder;
+  BinaryType get type => BinaryType.BINARY_TYPE_THUNDER;
 
   @override
   Color color = SailColorScheme.purple;
@@ -419,7 +419,7 @@ class BitNames extends Sidechain {
   final int slot = 2;
 
   @override
-  BinaryType get type => BinaryType.bitnames;
+  BinaryType get type => BinaryType.BINARY_TYPE_BITNAMES;
 
   @override
   Color color = SailColorScheme.green;
@@ -518,7 +518,7 @@ class BitAssets extends Sidechain {
   final int slot = 4;
 
   @override
-  BinaryType get type => BinaryType.bitassets;
+  BinaryType get type => BinaryType.BINARY_TYPE_BITASSETS;
 
   @override
   Color color = SailColorScheme.blue;
@@ -617,7 +617,7 @@ class Truthcoin extends Sidechain {
   final int slot = 13;
 
   @override
-  BinaryType get type => BinaryType.truthcoin;
+  BinaryType get type => BinaryType.BINARY_TYPE_TRUTHCOIN;
 
   @override
   Color color = SailColorScheme.orange;
@@ -716,7 +716,7 @@ class Photon extends Sidechain {
   final int slot = 99;
 
   @override
-  BinaryType get type => BinaryType.photon;
+  BinaryType get type => BinaryType.BINARY_TYPE_PHOTON;
 
   @override
   Color color = SailColorScheme.purple;
@@ -815,7 +815,7 @@ class CoinShift extends Sidechain {
   final int slot = 255;
 
   @override
-  BinaryType get type => BinaryType.coinShift;
+  BinaryType get type => BinaryType.BINARY_TYPE_COINSHIFT;
 
   @override
   Color color = SailColorScheme.orange;

--- a/sail_ui/lib/gen/bitassets/v1/bitassets.connect.client.dart
+++ b/sail_ui/lib/gen/bitassets/v1/bitassets.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "bitassets.pb.dart" as bitassetsv1bitassets;
 import "bitassets.connect.spec.dart" as specs;
 
-extension type BitAssetsServiceClient(connect.Transport _transport) {
+extension type BitAssetsServiceClient (connect.Transport _transport) {
   /// Get wallet balance (total and available).
   Future<bitassetsv1bitassets.GetBalanceResponse> getBalance(
     bitassetsv1bitassets.GetBalanceRequest input, {

--- a/sail_ui/lib/gen/bitassets/v1/bitassets.pb.dart
+++ b/sail_ui/lib/gen/bitassets/v1/bitassets.pb.dart
@@ -18,25 +18,23 @@ import 'package:protobuf/protobuf.dart' as $pb;
 class GetBalanceRequest extends $pb.GeneratedMessage {
   factory GetBalanceRequest() => create();
   GetBalanceRequest._() : super();
-  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceRequest clone() => GetBalanceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) => super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -45,8 +43,7 @@ class GetBalanceRequest extends $pb.GeneratedMessage {
   GetBalanceRequest createEmptyInstance() => create();
   static $pb.PbList<GetBalanceRequest> createRepeated() => $pb.PbList<GetBalanceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
+  static GetBalanceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
   static GetBalanceRequest? _defaultInstance;
 }
 
@@ -65,27 +62,25 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBalanceResponse._() : super();
-  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'totalSats')
     ..aInt64(2, _omitFieldNames ? '' : 'availableSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceResponse clone() => GetBalanceResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) => super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -94,17 +89,13 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   GetBalanceResponse createEmptyInstance() => create();
   static $pb.PbList<GetBalanceResponse> createRepeated() => $pb.PbList<GetBalanceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
+  static GetBalanceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
   static GetBalanceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get totalSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set totalSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set totalSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTotalSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -113,10 +104,7 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get availableSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set availableSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set availableSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAvailableSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -126,25 +114,23 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
 class GetBlockCountRequest extends $pb.GeneratedMessage {
   factory GetBlockCountRequest() => create();
   GetBlockCountRequest._() : super();
-  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountRequest clone() => GetBlockCountRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) => super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -153,8 +139,7 @@ class GetBlockCountRequest extends $pb.GeneratedMessage {
   GetBlockCountRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountRequest> createRepeated() => $pb.PbList<GetBlockCountRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
+  static GetBlockCountRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
   static GetBlockCountRequest? _defaultInstance;
 }
 
@@ -169,26 +154,24 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockCountResponse._() : super();
-  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'count')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountResponse clone() => GetBlockCountResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) => super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -197,17 +180,13 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
   GetBlockCountResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountResponse> createRepeated() => $pb.PbList<GetBlockCountResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
+  static GetBlockCountResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
   static GetBlockCountResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get count => $_getI64(0);
   @$pb.TagNumber(1)
-  set count($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set count($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCount() => $_has(0);
   @$pb.TagNumber(1)
@@ -217,24 +196,23 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
 class StopRequest extends $pb.GeneratedMessage {
   factory StopRequest() => create();
   StopRequest._() : super();
-  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopRequest clone() => StopRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopRequest copyWith(void Function(StopRequest) updates) =>
-      super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopRequest copyWith(void Function(StopRequest) updates) => super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -250,24 +228,23 @@ class StopRequest extends $pb.GeneratedMessage {
 class StopResponse extends $pb.GeneratedMessage {
   factory StopResponse() => create();
   StopResponse._() : super();
-  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopResponse clone() => StopResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopResponse copyWith(void Function(StopResponse) updates) =>
-      super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopResponse copyWith(void Function(StopResponse) updates) => super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -283,25 +260,23 @@ class StopResponse extends $pb.GeneratedMessage {
 class GetNewAddressRequest extends $pb.GeneratedMessage {
   factory GetNewAddressRequest() => create();
   GetNewAddressRequest._() : super();
-  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressRequest clone() => GetNewAddressRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) => super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -310,8 +285,7 @@ class GetNewAddressRequest extends $pb.GeneratedMessage {
   GetNewAddressRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressRequest> createRepeated() => $pb.PbList<GetNewAddressRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
+  static GetNewAddressRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
   static GetNewAddressRequest? _defaultInstance;
 }
 
@@ -326,26 +300,24 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewAddressResponse._() : super();
-  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressResponse clone() => GetNewAddressResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) => super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -354,17 +326,13 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
   GetNewAddressResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressResponse> createRepeated() => $pb.PbList<GetNewAddressResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
+  static GetNewAddressResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
   static GetNewAddressResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -394,29 +362,27 @@ class WithdrawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawRequest._() : super();
-  factory WithdrawRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'sideFeeSats')
     ..aInt64(4, _omitFieldNames ? '' : 'mainFeeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawRequest clone() => WithdrawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) =>
-      super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) => super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -425,17 +391,13 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   WithdrawRequest createEmptyInstance() => create();
   static $pb.PbList<WithdrawRequest> createRepeated() => $pb.PbList<WithdrawRequest>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
+  static WithdrawRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
   static WithdrawRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -444,10 +406,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -456,10 +415,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get sideFeeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set sideFeeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set sideFeeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSideFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -468,10 +424,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get mainFeeSats => $_getI64(3);
   @$pb.TagNumber(4)
-  set mainFeeSats($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set mainFeeSats($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasMainFeeSats() => $_has(3);
   @$pb.TagNumber(4)
@@ -489,26 +442,24 @@ class WithdrawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawResponse._() : super();
-  factory WithdrawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawResponse clone() => WithdrawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) =>
-      super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) => super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -517,17 +468,13 @@ class WithdrawResponse extends $pb.GeneratedMessage {
   WithdrawResponse createEmptyInstance() => create();
   static $pb.PbList<WithdrawResponse> createRepeated() => $pb.PbList<WithdrawResponse>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
+  static WithdrawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
   static WithdrawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -557,29 +504,27 @@ class TransferRequest extends $pb.GeneratedMessage {
     return $result;
   }
   TransferRequest._() : super();
-  factory TransferRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
     ..aOS(4, _omitFieldNames ? '' : 'memo')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferRequest clone() => TransferRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferRequest copyWith(void Function(TransferRequest) updates) =>
-      super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferRequest copyWith(void Function(TransferRequest) updates) => super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -588,17 +533,13 @@ class TransferRequest extends $pb.GeneratedMessage {
   TransferRequest createEmptyInstance() => create();
   static $pb.PbList<TransferRequest> createRepeated() => $pb.PbList<TransferRequest>();
   @$core.pragma('dart2js:noInline')
-  static TransferRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
+  static TransferRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
   static TransferRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -607,10 +548,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -619,10 +557,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -631,10 +566,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get memo => $_getSZ(3);
   @$pb.TagNumber(4)
-  set memo($core.String v) {
-    $_setString(3, v);
-  }
-
+  set memo($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasMemo() => $_has(3);
   @$pb.TagNumber(4)
@@ -652,26 +584,24 @@ class TransferResponse extends $pb.GeneratedMessage {
     return $result;
   }
   TransferResponse._() : super();
-  factory TransferResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferResponse clone() => TransferResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferResponse copyWith(void Function(TransferResponse) updates) =>
-      super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferResponse copyWith(void Function(TransferResponse) updates) => super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -680,17 +610,13 @@ class TransferResponse extends $pb.GeneratedMessage {
   TransferResponse createEmptyInstance() => create();
   static $pb.PbList<TransferResponse> createRepeated() => $pb.PbList<TransferResponse>();
   @$core.pragma('dart2js:noInline')
-  static TransferResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
+  static TransferResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
   static TransferResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -700,25 +626,23 @@ class TransferResponse extends $pb.GeneratedMessage {
 class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   factory GetSidechainWealthRequest() => create();
   GetSidechainWealthRequest._() : super();
-  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthRequest clone() => GetSidechainWealthRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) => super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -727,8 +651,7 @@ class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   GetSidechainWealthRequest createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthRequest> createRepeated() => $pb.PbList<GetSidechainWealthRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
+  static GetSidechainWealthRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
   static GetSidechainWealthRequest? _defaultInstance;
 }
 
@@ -743,27 +666,24 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetSidechainWealthResponse._() : super();
-  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'sats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthResponse clone() => GetSidechainWealthResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) => super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -772,17 +692,13 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
   GetSidechainWealthResponse createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthResponse> createRepeated() => $pb.PbList<GetSidechainWealthResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
+  static GetSidechainWealthResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
   static GetSidechainWealthResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get sats => $_getI64(0);
   @$pb.TagNumber(1)
-  set sats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set sats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -808,28 +724,26 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositRequest._() : super();
-  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'valueSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositRequest clone() => CreateDepositRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) => super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -838,17 +752,13 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   CreateDepositRequest createEmptyInstance() => create();
   static $pb.PbList<CreateDepositRequest> createRepeated() => $pb.PbList<CreateDepositRequest>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
+  static CreateDepositRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
   static CreateDepositRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -857,10 +767,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get valueSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set valueSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set valueSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasValueSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -869,10 +776,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -890,26 +794,24 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositResponse._() : super();
-  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositResponse clone() => CreateDepositResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) => super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -918,17 +820,13 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
   CreateDepositResponse createEmptyInstance() => create();
   static $pb.PbList<CreateDepositResponse> createRepeated() => $pb.PbList<CreateDepositResponse>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
+  static CreateDepositResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
   static CreateDepositResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -938,38 +836,32 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
 class GetPendingWithdrawalBundleRequest extends $pb.GeneratedMessage {
   factory GetPendingWithdrawalBundleRequest() => create();
   GetPendingWithdrawalBundleRequest._() : super();
-  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleRequest clone() => GetPendingWithdrawalBundleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest))
-          as GetPendingWithdrawalBundleRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest)) as GetPendingWithdrawalBundleRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleRequest create() => GetPendingWithdrawalBundleRequest._();
   GetPendingWithdrawalBundleRequest createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleRequest>();
+  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
+  static GetPendingWithdrawalBundleRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
   static GetPendingWithdrawalBundleRequest? _defaultInstance;
 }
 
@@ -984,49 +876,40 @@ class GetPendingWithdrawalBundleResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetPendingWithdrawalBundleResponse._() : super();
-  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bundleJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleResponse clone() => GetPendingWithdrawalBundleResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse))
-          as GetPendingWithdrawalBundleResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse)) as GetPendingWithdrawalBundleResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleResponse create() => GetPendingWithdrawalBundleResponse._();
   GetPendingWithdrawalBundleResponse createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleResponse>();
+  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
+  static GetPendingWithdrawalBundleResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
   static GetPendingWithdrawalBundleResponse? _defaultInstance;
 
   /// JSON string of the bundle, empty if none.
   @$pb.TagNumber(1)
   $core.String get bundleJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bundleJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bundleJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBundleJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1044,26 +927,24 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ConnectPeerRequest._() : super();
-  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerRequest clone() => ConnectPeerRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) => super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1072,17 +953,13 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
   ConnectPeerRequest createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerRequest> createRepeated() => $pb.PbList<ConnectPeerRequest>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
+  static ConnectPeerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
   static ConnectPeerRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1092,25 +969,23 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
 class ConnectPeerResponse extends $pb.GeneratedMessage {
   factory ConnectPeerResponse() => create();
   ConnectPeerResponse._() : super();
-  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerResponse clone() => ConnectPeerResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) => super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1119,8 +994,7 @@ class ConnectPeerResponse extends $pb.GeneratedMessage {
   ConnectPeerResponse createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerResponse> createRepeated() => $pb.PbList<ConnectPeerResponse>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
+  static ConnectPeerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
   static ConnectPeerResponse? _defaultInstance;
 }
 
@@ -1135,26 +1009,24 @@ class ForgetPeerRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ForgetPeerRequest._() : super();
-  factory ForgetPeerRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ForgetPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ForgetPeerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ForgetPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForgetPeerRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForgetPeerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ForgetPeerRequest clone() => ForgetPeerRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ForgetPeerRequest copyWith(void Function(ForgetPeerRequest) updates) =>
-      super.copyWith((message) => updates(message as ForgetPeerRequest)) as ForgetPeerRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ForgetPeerRequest copyWith(void Function(ForgetPeerRequest) updates) => super.copyWith((message) => updates(message as ForgetPeerRequest)) as ForgetPeerRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1163,17 +1035,13 @@ class ForgetPeerRequest extends $pb.GeneratedMessage {
   ForgetPeerRequest createEmptyInstance() => create();
   static $pb.PbList<ForgetPeerRequest> createRepeated() => $pb.PbList<ForgetPeerRequest>();
   @$core.pragma('dart2js:noInline')
-  static ForgetPeerRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForgetPeerRequest>(create);
+  static ForgetPeerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForgetPeerRequest>(create);
   static ForgetPeerRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1183,25 +1051,23 @@ class ForgetPeerRequest extends $pb.GeneratedMessage {
 class ForgetPeerResponse extends $pb.GeneratedMessage {
   factory ForgetPeerResponse() => create();
   ForgetPeerResponse._() : super();
-  factory ForgetPeerResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ForgetPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ForgetPeerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ForgetPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForgetPeerResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForgetPeerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ForgetPeerResponse clone() => ForgetPeerResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ForgetPeerResponse copyWith(void Function(ForgetPeerResponse) updates) =>
-      super.copyWith((message) => updates(message as ForgetPeerResponse)) as ForgetPeerResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ForgetPeerResponse copyWith(void Function(ForgetPeerResponse) updates) => super.copyWith((message) => updates(message as ForgetPeerResponse)) as ForgetPeerResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1210,33 +1076,30 @@ class ForgetPeerResponse extends $pb.GeneratedMessage {
   ForgetPeerResponse createEmptyInstance() => create();
   static $pb.PbList<ForgetPeerResponse> createRepeated() => $pb.PbList<ForgetPeerResponse>();
   @$core.pragma('dart2js:noInline')
-  static ForgetPeerResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForgetPeerResponse>(create);
+  static ForgetPeerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForgetPeerResponse>(create);
   static ForgetPeerResponse? _defaultInstance;
 }
 
 class ListPeersRequest extends $pb.GeneratedMessage {
   factory ListPeersRequest() => create();
   ListPeersRequest._() : super();
-  factory ListPeersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersRequest clone() => ListPeersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) =>
-      super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) => super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1245,8 +1108,7 @@ class ListPeersRequest extends $pb.GeneratedMessage {
   ListPeersRequest createEmptyInstance() => create();
   static $pb.PbList<ListPeersRequest> createRepeated() => $pb.PbList<ListPeersRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
+  static ListPeersRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
   static ListPeersRequest? _defaultInstance;
 }
 
@@ -1261,26 +1123,24 @@ class ListPeersResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListPeersResponse._() : super();
-  factory ListPeersResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'peersJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersResponse clone() => ListPeersResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) =>
-      super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) => super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1289,17 +1149,13 @@ class ListPeersResponse extends $pb.GeneratedMessage {
   ListPeersResponse createEmptyInstance() => create();
   static $pb.PbList<ListPeersResponse> createRepeated() => $pb.PbList<ListPeersResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
+  static ListPeersResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
   static ListPeersResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get peersJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set peersJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set peersJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPeersJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1317,25 +1173,24 @@ class MineRequest extends $pb.GeneratedMessage {
     return $result;
   }
   MineRequest._() : super();
-  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineRequest clone() => MineRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineRequest copyWith(void Function(MineRequest) updates) =>
-      super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineRequest copyWith(void Function(MineRequest) updates) => super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1350,10 +1205,7 @@ class MineRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $fixnum.Int64 get feeSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasFeeSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -1371,25 +1223,24 @@ class MineResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MineResponse._() : super();
-  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bmmResultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineResponse clone() => MineResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineResponse copyWith(void Function(MineResponse) updates) =>
-      super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineResponse copyWith(void Function(MineResponse) updates) => super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1404,10 +1255,7 @@ class MineResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get bmmResultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bmmResultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bmmResultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBmmResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1425,26 +1273,24 @@ class GetBlockRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockRequest._() : super();
-  factory GetBlockRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockRequest clone() => GetBlockRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) => super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1453,17 +1299,13 @@ class GetBlockRequest extends $pb.GeneratedMessage {
   GetBlockRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockRequest> createRepeated() => $pb.PbList<GetBlockRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
+  static GetBlockRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
   static GetBlockRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1481,26 +1323,24 @@ class GetBlockResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockResponse._() : super();
-  factory GetBlockResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockResponse clone() => GetBlockResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) => super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1509,17 +1349,13 @@ class GetBlockResponse extends $pb.GeneratedMessage {
   GetBlockResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockResponse> createRepeated() => $pb.PbList<GetBlockResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
+  static GetBlockResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
   static GetBlockResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1529,38 +1365,32 @@ class GetBlockResponse extends $pb.GeneratedMessage {
 class GetBestMainchainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestMainchainBlockHashRequest() => create();
   GetBestMainchainBlockHashRequest._() : super();
-  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashRequest clone() => GetBestMainchainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest))
-          as GetBestMainchainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest)) as GetBestMainchainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashRequest create() => GetBestMainchainBlockHashRequest._();
   GetBestMainchainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashRequest>();
+  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() => $pb.PbList<GetBestMainchainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
+  static GetBestMainchainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
   static GetBestMainchainBlockHashRequest? _defaultInstance;
 }
 
@@ -1575,48 +1405,39 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestMainchainBlockHashResponse._() : super();
-  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashResponse clone() => GetBestMainchainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse))
-          as GetBestMainchainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse)) as GetBestMainchainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashResponse create() => GetBestMainchainBlockHashResponse._();
   GetBestMainchainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashResponse>();
+  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() => $pb.PbList<GetBestMainchainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
+  static GetBestMainchainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
   static GetBestMainchainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1626,38 +1447,32 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
 class GetBestSidechainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestSidechainBlockHashRequest() => create();
   GetBestSidechainBlockHashRequest._() : super();
-  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashRequest clone() => GetBestSidechainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest))
-          as GetBestSidechainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest)) as GetBestSidechainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashRequest create() => GetBestSidechainBlockHashRequest._();
   GetBestSidechainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashRequest>();
+  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() => $pb.PbList<GetBestSidechainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
+  static GetBestSidechainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
   static GetBestSidechainBlockHashRequest? _defaultInstance;
 }
 
@@ -1672,48 +1487,39 @@ class GetBestSidechainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestSidechainBlockHashResponse._() : super();
-  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashResponse clone() => GetBestSidechainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse))
-          as GetBestSidechainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse)) as GetBestSidechainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashResponse create() => GetBestSidechainBlockHashResponse._();
   GetBestSidechainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashResponse>();
+  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() => $pb.PbList<GetBestSidechainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
+  static GetBestSidechainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
   static GetBestSidechainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1731,26 +1537,24 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsRequest._() : super();
-  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockHash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsRequest clone() => GetBmmInclusionsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1759,17 +1563,13 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
   GetBmmInclusionsRequest createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsRequest> createRepeated() => $pb.PbList<GetBmmInclusionsRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
+  static GetBmmInclusionsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
   static GetBmmInclusionsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockHash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockHash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockHash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1787,26 +1587,24 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsResponse._() : super();
-  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'inclusions')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsResponse clone() => GetBmmInclusionsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1815,17 +1613,13 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
   GetBmmInclusionsResponse createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsResponse> createRepeated() => $pb.PbList<GetBmmInclusionsResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
+  static GetBmmInclusionsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
   static GetBmmInclusionsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get inclusions => $_getSZ(0);
   @$pb.TagNumber(1)
-  set inclusions($core.String v) {
-    $_setString(0, v);
-  }
-
+  set inclusions($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasInclusions() => $_has(0);
   @$pb.TagNumber(1)
@@ -1835,25 +1629,23 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
 class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   factory GetWalletUtxosRequest() => create();
   GetWalletUtxosRequest._() : super();
-  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosRequest clone() => GetWalletUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) => super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1862,8 +1654,7 @@ class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   GetWalletUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosRequest> createRepeated() => $pb.PbList<GetWalletUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
+  static GetWalletUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
   static GetWalletUtxosRequest? _defaultInstance;
 }
 
@@ -1878,26 +1669,24 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletUtxosResponse._() : super();
-  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosResponse clone() => GetWalletUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) => super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1906,17 +1695,13 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
   GetWalletUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosResponse> createRepeated() => $pb.PbList<GetWalletUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
+  static GetWalletUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
   static GetWalletUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1926,25 +1711,23 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
 class ListUtxosRequest extends $pb.GeneratedMessage {
   factory ListUtxosRequest() => create();
   ListUtxosRequest._() : super();
-  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosRequest clone() => ListUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) => super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1953,8 +1736,7 @@ class ListUtxosRequest extends $pb.GeneratedMessage {
   ListUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<ListUtxosRequest> createRepeated() => $pb.PbList<ListUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
+  static ListUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
   static ListUtxosRequest? _defaultInstance;
 }
 
@@ -1969,26 +1751,24 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListUtxosResponse._() : super();
-  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosResponse clone() => ListUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) => super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1997,17 +1777,13 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
   ListUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<ListUtxosResponse> createRepeated() => $pb.PbList<ListUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
+  static ListUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
   static ListUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2025,26 +1801,24 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
     return $result;
   }
   RemoveFromMempoolRequest._() : super();
-  factory RemoveFromMempoolRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFromMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFromMempoolRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFromMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveFromMempoolRequest clone() => RemoveFromMempoolRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveFromMempoolRequest copyWith(void Function(RemoveFromMempoolRequest) updates) =>
-      super.copyWith((message) => updates(message as RemoveFromMempoolRequest)) as RemoveFromMempoolRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveFromMempoolRequest copyWith(void Function(RemoveFromMempoolRequest) updates) => super.copyWith((message) => updates(message as RemoveFromMempoolRequest)) as RemoveFromMempoolRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2053,17 +1827,13 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
   RemoveFromMempoolRequest createEmptyInstance() => create();
   static $pb.PbList<RemoveFromMempoolRequest> createRepeated() => $pb.PbList<RemoveFromMempoolRequest>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFromMempoolRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolRequest>(create);
+  static RemoveFromMempoolRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolRequest>(create);
   static RemoveFromMempoolRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2073,25 +1843,23 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
 class RemoveFromMempoolResponse extends $pb.GeneratedMessage {
   factory RemoveFromMempoolResponse() => create();
   RemoveFromMempoolResponse._() : super();
-  factory RemoveFromMempoolResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFromMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFromMempoolResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFromMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveFromMempoolResponse clone() => RemoveFromMempoolResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveFromMempoolResponse copyWith(void Function(RemoveFromMempoolResponse) updates) =>
-      super.copyWith((message) => updates(message as RemoveFromMempoolResponse)) as RemoveFromMempoolResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveFromMempoolResponse copyWith(void Function(RemoveFromMempoolResponse) updates) => super.copyWith((message) => updates(message as RemoveFromMempoolResponse)) as RemoveFromMempoolResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2100,50 +1868,39 @@ class RemoveFromMempoolResponse extends $pb.GeneratedMessage {
   RemoveFromMempoolResponse createEmptyInstance() => create();
   static $pb.PbList<RemoveFromMempoolResponse> createRepeated() => $pb.PbList<RemoveFromMempoolResponse>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFromMempoolResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolResponse>(create);
+  static RemoveFromMempoolResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolResponse>(create);
   static RemoveFromMempoolResponse? _defaultInstance;
 }
 
 class GetLatestFailedWithdrawalBundleHeightRequest extends $pb.GeneratedMessage {
   factory GetLatestFailedWithdrawalBundleHeightRequest() => create();
   GetLatestFailedWithdrawalBundleHeightRequest._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'),
-      createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest clone() =>
-      GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest))
-          as GetLatestFailedWithdrawalBundleHeightRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest clone() => GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest copyWith(void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest)) as GetLatestFailedWithdrawalBundleHeightRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightRequest create() => GetLatestFailedWithdrawalBundleHeightRequest._();
   GetLatestFailedWithdrawalBundleHeightRequest createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
+  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
   static GetLatestFailedWithdrawalBundleHeightRequest? _defaultInstance;
 }
 
@@ -2158,53 +1915,40 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
     return $result;
   }
   GetLatestFailedWithdrawalBundleHeightResponse._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'height')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse clone() =>
-      GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse))
-          as GetLatestFailedWithdrawalBundleHeightResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse clone() => GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse copyWith(void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse)) as GetLatestFailedWithdrawalBundleHeightResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightResponse create() => GetLatestFailedWithdrawalBundleHeightResponse._();
   GetLatestFailedWithdrawalBundleHeightResponse createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
+  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
   static GetLatestFailedWithdrawalBundleHeightResponse? _defaultInstance;
 
   /// 0 means no failed bundle.
   @$pb.TagNumber(1)
   $fixnum.Int64 get height => $_getI64(0);
   @$pb.TagNumber(1)
-  set height($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set height($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHeight() => $_has(0);
   @$pb.TagNumber(1)
@@ -2214,25 +1958,23 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
 class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   factory GenerateMnemonicRequest() => create();
   GenerateMnemonicRequest._() : super();
-  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicRequest clone() => GenerateMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) => super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2241,8 +1983,7 @@ class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   GenerateMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicRequest> createRepeated() => $pb.PbList<GenerateMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
+  static GenerateMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
   static GenerateMnemonicRequest? _defaultInstance;
 }
 
@@ -2257,26 +1998,24 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GenerateMnemonicResponse._() : super();
-  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicResponse clone() => GenerateMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) => super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2285,17 +2024,13 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
   GenerateMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicResponse> createRepeated() => $pb.PbList<GenerateMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
+  static GenerateMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
   static GenerateMnemonicResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2313,27 +2048,24 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SetSeedFromMnemonicRequest._() : super();
-  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicRequest clone() => SetSeedFromMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2342,17 +2074,13 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
   SetSeedFromMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicRequest> createRepeated() => $pb.PbList<SetSeedFromMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
+  static SetSeedFromMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
   static SetSeedFromMnemonicRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2362,26 +2090,23 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
 class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   factory SetSeedFromMnemonicResponse() => create();
   SetSeedFromMnemonicResponse._() : super();
-  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicResponse clone() => SetSeedFromMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2390,8 +2115,7 @@ class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   SetSeedFromMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicResponse> createRepeated() => $pb.PbList<SetSeedFromMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
+  static SetSeedFromMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
   static SetSeedFromMnemonicResponse? _defaultInstance;
 }
 
@@ -2410,26 +2134,25 @@ class CallRawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawRequest._() : super();
-  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'method')
     ..aOS(2, _omitFieldNames ? '' : 'paramsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawRequest clone() => CallRawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawRequest copyWith(void Function(CallRawRequest) updates) =>
-      super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawRequest copyWith(void Function(CallRawRequest) updates) => super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2444,10 +2167,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get method => $_getSZ(0);
   @$pb.TagNumber(1)
-  set method($core.String v) {
-    $_setString(0, v);
-  }
-
+  set method($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMethod() => $_has(0);
   @$pb.TagNumber(1)
@@ -2456,10 +2176,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get paramsJson => $_getSZ(1);
   @$pb.TagNumber(2)
-  set paramsJson($core.String v) {
-    $_setString(1, v);
-  }
-
+  set paramsJson($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasParamsJson() => $_has(1);
   @$pb.TagNumber(2)
@@ -2477,26 +2194,24 @@ class CallRawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawResponse._() : super();
-  factory CallRawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'resultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawResponse clone() => CallRawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawResponse copyWith(void Function(CallRawResponse) updates) =>
-      super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawResponse copyWith(void Function(CallRawResponse) updates) => super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2505,17 +2220,13 @@ class CallRawResponse extends $pb.GeneratedMessage {
   CallRawResponse createEmptyInstance() => create();
   static $pb.PbList<CallRawResponse> createRepeated() => $pb.PbList<CallRawResponse>();
   @$core.pragma('dart2js:noInline')
-  static CallRawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
+  static CallRawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
   static CallRawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get resultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set resultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set resultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2533,26 +2244,24 @@ class GetBitAssetDataRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBitAssetDataRequest._() : super();
-  factory GetBitAssetDataRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBitAssetDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBitAssetDataRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBitAssetDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitAssetDataRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitAssetDataRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'assetId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBitAssetDataRequest clone() => GetBitAssetDataRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBitAssetDataRequest copyWith(void Function(GetBitAssetDataRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBitAssetDataRequest)) as GetBitAssetDataRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBitAssetDataRequest copyWith(void Function(GetBitAssetDataRequest) updates) => super.copyWith((message) => updates(message as GetBitAssetDataRequest)) as GetBitAssetDataRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2561,17 +2270,13 @@ class GetBitAssetDataRequest extends $pb.GeneratedMessage {
   GetBitAssetDataRequest createEmptyInstance() => create();
   static $pb.PbList<GetBitAssetDataRequest> createRepeated() => $pb.PbList<GetBitAssetDataRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBitAssetDataRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitAssetDataRequest>(create);
+  static GetBitAssetDataRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitAssetDataRequest>(create);
   static GetBitAssetDataRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get assetId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set assetId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set assetId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAssetId() => $_has(0);
   @$pb.TagNumber(1)
@@ -2589,26 +2294,24 @@ class GetBitAssetDataResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBitAssetDataResponse._() : super();
-  factory GetBitAssetDataResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBitAssetDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBitAssetDataResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBitAssetDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitAssetDataResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitAssetDataResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'dataJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBitAssetDataResponse clone() => GetBitAssetDataResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBitAssetDataResponse copyWith(void Function(GetBitAssetDataResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBitAssetDataResponse)) as GetBitAssetDataResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBitAssetDataResponse copyWith(void Function(GetBitAssetDataResponse) updates) => super.copyWith((message) => updates(message as GetBitAssetDataResponse)) as GetBitAssetDataResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2617,17 +2320,13 @@ class GetBitAssetDataResponse extends $pb.GeneratedMessage {
   GetBitAssetDataResponse createEmptyInstance() => create();
   static $pb.PbList<GetBitAssetDataResponse> createRepeated() => $pb.PbList<GetBitAssetDataResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBitAssetDataResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitAssetDataResponse>(create);
+  static GetBitAssetDataResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitAssetDataResponse>(create);
   static GetBitAssetDataResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get dataJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set dataJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set dataJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDataJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2637,25 +2336,23 @@ class GetBitAssetDataResponse extends $pb.GeneratedMessage {
 class ListBitAssetsRequest extends $pb.GeneratedMessage {
   factory ListBitAssetsRequest() => create();
   ListBitAssetsRequest._() : super();
-  factory ListBitAssetsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListBitAssetsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListBitAssetsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListBitAssetsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBitAssetsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBitAssetsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListBitAssetsRequest clone() => ListBitAssetsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListBitAssetsRequest copyWith(void Function(ListBitAssetsRequest) updates) =>
-      super.copyWith((message) => updates(message as ListBitAssetsRequest)) as ListBitAssetsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListBitAssetsRequest copyWith(void Function(ListBitAssetsRequest) updates) => super.copyWith((message) => updates(message as ListBitAssetsRequest)) as ListBitAssetsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2664,8 +2361,7 @@ class ListBitAssetsRequest extends $pb.GeneratedMessage {
   ListBitAssetsRequest createEmptyInstance() => create();
   static $pb.PbList<ListBitAssetsRequest> createRepeated() => $pb.PbList<ListBitAssetsRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListBitAssetsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBitAssetsRequest>(create);
+  static ListBitAssetsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBitAssetsRequest>(create);
   static ListBitAssetsRequest? _defaultInstance;
 }
 
@@ -2680,26 +2376,24 @@ class ListBitAssetsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListBitAssetsResponse._() : super();
-  factory ListBitAssetsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListBitAssetsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListBitAssetsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListBitAssetsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBitAssetsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBitAssetsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bitassetsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListBitAssetsResponse clone() => ListBitAssetsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListBitAssetsResponse copyWith(void Function(ListBitAssetsResponse) updates) =>
-      super.copyWith((message) => updates(message as ListBitAssetsResponse)) as ListBitAssetsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListBitAssetsResponse copyWith(void Function(ListBitAssetsResponse) updates) => super.copyWith((message) => updates(message as ListBitAssetsResponse)) as ListBitAssetsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2708,17 +2402,13 @@ class ListBitAssetsResponse extends $pb.GeneratedMessage {
   ListBitAssetsResponse createEmptyInstance() => create();
   static $pb.PbList<ListBitAssetsResponse> createRepeated() => $pb.PbList<ListBitAssetsResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListBitAssetsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBitAssetsResponse>(create);
+  static ListBitAssetsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBitAssetsResponse>(create);
   static ListBitAssetsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get bitassetsJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bitassetsJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bitassetsJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBitassetsJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2744,28 +2434,26 @@ class RegisterBitAssetRequest extends $pb.GeneratedMessage {
     return $result;
   }
   RegisterBitAssetRequest._() : super();
-  factory RegisterBitAssetRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RegisterBitAssetRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RegisterBitAssetRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RegisterBitAssetRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RegisterBitAssetRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RegisterBitAssetRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'plaintextName')
     ..aInt64(2, _omitFieldNames ? '' : 'initialSupply')
     ..aOS(3, _omitFieldNames ? '' : 'dataJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RegisterBitAssetRequest clone() => RegisterBitAssetRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RegisterBitAssetRequest copyWith(void Function(RegisterBitAssetRequest) updates) =>
-      super.copyWith((message) => updates(message as RegisterBitAssetRequest)) as RegisterBitAssetRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RegisterBitAssetRequest copyWith(void Function(RegisterBitAssetRequest) updates) => super.copyWith((message) => updates(message as RegisterBitAssetRequest)) as RegisterBitAssetRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2774,17 +2462,13 @@ class RegisterBitAssetRequest extends $pb.GeneratedMessage {
   RegisterBitAssetRequest createEmptyInstance() => create();
   static $pb.PbList<RegisterBitAssetRequest> createRepeated() => $pb.PbList<RegisterBitAssetRequest>();
   @$core.pragma('dart2js:noInline')
-  static RegisterBitAssetRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterBitAssetRequest>(create);
+  static RegisterBitAssetRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterBitAssetRequest>(create);
   static RegisterBitAssetRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get plaintextName => $_getSZ(0);
   @$pb.TagNumber(1)
-  set plaintextName($core.String v) {
-    $_setString(0, v);
-  }
-
+  set plaintextName($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPlaintextName() => $_has(0);
   @$pb.TagNumber(1)
@@ -2793,10 +2477,7 @@ class RegisterBitAssetRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get initialSupply => $_getI64(1);
   @$pb.TagNumber(2)
-  set initialSupply($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set initialSupply($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasInitialSupply() => $_has(1);
   @$pb.TagNumber(2)
@@ -2805,10 +2486,7 @@ class RegisterBitAssetRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get dataJson => $_getSZ(2);
   @$pb.TagNumber(3)
-  set dataJson($core.String v) {
-    $_setString(2, v);
-  }
-
+  set dataJson($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasDataJson() => $_has(2);
   @$pb.TagNumber(3)
@@ -2826,26 +2504,24 @@ class RegisterBitAssetResponse extends $pb.GeneratedMessage {
     return $result;
   }
   RegisterBitAssetResponse._() : super();
-  factory RegisterBitAssetResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RegisterBitAssetResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RegisterBitAssetResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RegisterBitAssetResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RegisterBitAssetResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RegisterBitAssetResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RegisterBitAssetResponse clone() => RegisterBitAssetResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RegisterBitAssetResponse copyWith(void Function(RegisterBitAssetResponse) updates) =>
-      super.copyWith((message) => updates(message as RegisterBitAssetResponse)) as RegisterBitAssetResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RegisterBitAssetResponse copyWith(void Function(RegisterBitAssetResponse) updates) => super.copyWith((message) => updates(message as RegisterBitAssetResponse)) as RegisterBitAssetResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2854,17 +2530,13 @@ class RegisterBitAssetResponse extends $pb.GeneratedMessage {
   RegisterBitAssetResponse createEmptyInstance() => create();
   static $pb.PbList<RegisterBitAssetResponse> createRepeated() => $pb.PbList<RegisterBitAssetResponse>();
   @$core.pragma('dart2js:noInline')
-  static RegisterBitAssetResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterBitAssetResponse>(create);
+  static RegisterBitAssetResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterBitAssetResponse>(create);
   static RegisterBitAssetResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2882,26 +2554,24 @@ class ReserveBitAssetRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ReserveBitAssetRequest._() : super();
-  factory ReserveBitAssetRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReserveBitAssetRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ReserveBitAssetRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReserveBitAssetRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReserveBitAssetRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReserveBitAssetRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ReserveBitAssetRequest clone() => ReserveBitAssetRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ReserveBitAssetRequest copyWith(void Function(ReserveBitAssetRequest) updates) =>
-      super.copyWith((message) => updates(message as ReserveBitAssetRequest)) as ReserveBitAssetRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ReserveBitAssetRequest copyWith(void Function(ReserveBitAssetRequest) updates) => super.copyWith((message) => updates(message as ReserveBitAssetRequest)) as ReserveBitAssetRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2910,17 +2580,13 @@ class ReserveBitAssetRequest extends $pb.GeneratedMessage {
   ReserveBitAssetRequest createEmptyInstance() => create();
   static $pb.PbList<ReserveBitAssetRequest> createRepeated() => $pb.PbList<ReserveBitAssetRequest>();
   @$core.pragma('dart2js:noInline')
-  static ReserveBitAssetRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReserveBitAssetRequest>(create);
+  static ReserveBitAssetRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReserveBitAssetRequest>(create);
   static ReserveBitAssetRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -2938,26 +2604,24 @@ class ReserveBitAssetResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ReserveBitAssetResponse._() : super();
-  factory ReserveBitAssetResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReserveBitAssetResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ReserveBitAssetResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReserveBitAssetResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReserveBitAssetResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReserveBitAssetResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ReserveBitAssetResponse clone() => ReserveBitAssetResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ReserveBitAssetResponse copyWith(void Function(ReserveBitAssetResponse) updates) =>
-      super.copyWith((message) => updates(message as ReserveBitAssetResponse)) as ReserveBitAssetResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ReserveBitAssetResponse copyWith(void Function(ReserveBitAssetResponse) updates) => super.copyWith((message) => updates(message as ReserveBitAssetResponse)) as ReserveBitAssetResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2966,17 +2630,13 @@ class ReserveBitAssetResponse extends $pb.GeneratedMessage {
   ReserveBitAssetResponse createEmptyInstance() => create();
   static $pb.PbList<ReserveBitAssetResponse> createRepeated() => $pb.PbList<ReserveBitAssetResponse>();
   @$core.pragma('dart2js:noInline')
-  static ReserveBitAssetResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReserveBitAssetResponse>(create);
+  static ReserveBitAssetResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReserveBitAssetResponse>(create);
   static ReserveBitAssetResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -3006,29 +2666,27 @@ class TransferBitAssetRequest extends $pb.GeneratedMessage {
     return $result;
   }
   TransferBitAssetRequest._() : super();
-  factory TransferBitAssetRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferBitAssetRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferBitAssetRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferBitAssetRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferBitAssetRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferBitAssetRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'assetId')
     ..aOS(2, _omitFieldNames ? '' : 'dest')
     ..aInt64(3, _omitFieldNames ? '' : 'amount')
     ..aInt64(4, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferBitAssetRequest clone() => TransferBitAssetRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferBitAssetRequest copyWith(void Function(TransferBitAssetRequest) updates) =>
-      super.copyWith((message) => updates(message as TransferBitAssetRequest)) as TransferBitAssetRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferBitAssetRequest copyWith(void Function(TransferBitAssetRequest) updates) => super.copyWith((message) => updates(message as TransferBitAssetRequest)) as TransferBitAssetRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3037,17 +2695,13 @@ class TransferBitAssetRequest extends $pb.GeneratedMessage {
   TransferBitAssetRequest createEmptyInstance() => create();
   static $pb.PbList<TransferBitAssetRequest> createRepeated() => $pb.PbList<TransferBitAssetRequest>();
   @$core.pragma('dart2js:noInline')
-  static TransferBitAssetRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferBitAssetRequest>(create);
+  static TransferBitAssetRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferBitAssetRequest>(create);
   static TransferBitAssetRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get assetId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set assetId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set assetId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAssetId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3056,10 +2710,7 @@ class TransferBitAssetRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get dest => $_getSZ(1);
   @$pb.TagNumber(2)
-  set dest($core.String v) {
-    $_setString(1, v);
-  }
-
+  set dest($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasDest() => $_has(1);
   @$pb.TagNumber(2)
@@ -3068,10 +2719,7 @@ class TransferBitAssetRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get amount => $_getI64(2);
   @$pb.TagNumber(3)
-  set amount($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set amount($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasAmount() => $_has(2);
   @$pb.TagNumber(3)
@@ -3080,10 +2728,7 @@ class TransferBitAssetRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get feeSats => $_getI64(3);
   @$pb.TagNumber(4)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasFeeSats() => $_has(3);
   @$pb.TagNumber(4)
@@ -3101,26 +2746,24 @@ class TransferBitAssetResponse extends $pb.GeneratedMessage {
     return $result;
   }
   TransferBitAssetResponse._() : super();
-  factory TransferBitAssetResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferBitAssetResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferBitAssetResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferBitAssetResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferBitAssetResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferBitAssetResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferBitAssetResponse clone() => TransferBitAssetResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferBitAssetResponse copyWith(void Function(TransferBitAssetResponse) updates) =>
-      super.copyWith((message) => updates(message as TransferBitAssetResponse)) as TransferBitAssetResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferBitAssetResponse copyWith(void Function(TransferBitAssetResponse) updates) => super.copyWith((message) => updates(message as TransferBitAssetResponse)) as TransferBitAssetResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3129,17 +2772,13 @@ class TransferBitAssetResponse extends $pb.GeneratedMessage {
   TransferBitAssetResponse createEmptyInstance() => create();
   static $pb.PbList<TransferBitAssetResponse> createRepeated() => $pb.PbList<TransferBitAssetResponse>();
   @$core.pragma('dart2js:noInline')
-  static TransferBitAssetResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferBitAssetResponse>(create);
+  static TransferBitAssetResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferBitAssetResponse>(create);
   static TransferBitAssetResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -3149,26 +2788,23 @@ class TransferBitAssetResponse extends $pb.GeneratedMessage {
 class GetNewEncryptionKeyRequest extends $pb.GeneratedMessage {
   factory GetNewEncryptionKeyRequest() => create();
   GetNewEncryptionKeyRequest._() : super();
-  factory GetNewEncryptionKeyRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewEncryptionKeyRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewEncryptionKeyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewEncryptionKeyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewEncryptionKeyRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewEncryptionKeyRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewEncryptionKeyRequest clone() => GetNewEncryptionKeyRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewEncryptionKeyRequest copyWith(void Function(GetNewEncryptionKeyRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewEncryptionKeyRequest)) as GetNewEncryptionKeyRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewEncryptionKeyRequest copyWith(void Function(GetNewEncryptionKeyRequest) updates) => super.copyWith((message) => updates(message as GetNewEncryptionKeyRequest)) as GetNewEncryptionKeyRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3177,8 +2813,7 @@ class GetNewEncryptionKeyRequest extends $pb.GeneratedMessage {
   GetNewEncryptionKeyRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewEncryptionKeyRequest> createRepeated() => $pb.PbList<GetNewEncryptionKeyRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewEncryptionKeyRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewEncryptionKeyRequest>(create);
+  static GetNewEncryptionKeyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewEncryptionKeyRequest>(create);
   static GetNewEncryptionKeyRequest? _defaultInstance;
 }
 
@@ -3193,27 +2828,24 @@ class GetNewEncryptionKeyResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewEncryptionKeyResponse._() : super();
-  factory GetNewEncryptionKeyResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewEncryptionKeyResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewEncryptionKeyResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewEncryptionKeyResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewEncryptionKeyResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewEncryptionKeyResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'key')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewEncryptionKeyResponse clone() => GetNewEncryptionKeyResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewEncryptionKeyResponse copyWith(void Function(GetNewEncryptionKeyResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewEncryptionKeyResponse)) as GetNewEncryptionKeyResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewEncryptionKeyResponse copyWith(void Function(GetNewEncryptionKeyResponse) updates) => super.copyWith((message) => updates(message as GetNewEncryptionKeyResponse)) as GetNewEncryptionKeyResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3222,17 +2854,13 @@ class GetNewEncryptionKeyResponse extends $pb.GeneratedMessage {
   GetNewEncryptionKeyResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewEncryptionKeyResponse> createRepeated() => $pb.PbList<GetNewEncryptionKeyResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewEncryptionKeyResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewEncryptionKeyResponse>(create);
+  static GetNewEncryptionKeyResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewEncryptionKeyResponse>(create);
   static GetNewEncryptionKeyResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get key => $_getSZ(0);
   @$pb.TagNumber(1)
-  set key($core.String v) {
-    $_setString(0, v);
-  }
-
+  set key($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasKey() => $_has(0);
   @$pb.TagNumber(1)
@@ -3242,25 +2870,23 @@ class GetNewEncryptionKeyResponse extends $pb.GeneratedMessage {
 class GetNewVerifyingKeyRequest extends $pb.GeneratedMessage {
   factory GetNewVerifyingKeyRequest() => create();
   GetNewVerifyingKeyRequest._() : super();
-  factory GetNewVerifyingKeyRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewVerifyingKeyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewVerifyingKeyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewVerifyingKeyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewVerifyingKeyRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewVerifyingKeyRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewVerifyingKeyRequest clone() => GetNewVerifyingKeyRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewVerifyingKeyRequest copyWith(void Function(GetNewVerifyingKeyRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewVerifyingKeyRequest)) as GetNewVerifyingKeyRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewVerifyingKeyRequest copyWith(void Function(GetNewVerifyingKeyRequest) updates) => super.copyWith((message) => updates(message as GetNewVerifyingKeyRequest)) as GetNewVerifyingKeyRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3269,8 +2895,7 @@ class GetNewVerifyingKeyRequest extends $pb.GeneratedMessage {
   GetNewVerifyingKeyRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewVerifyingKeyRequest> createRepeated() => $pb.PbList<GetNewVerifyingKeyRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewVerifyingKeyRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewVerifyingKeyRequest>(create);
+  static GetNewVerifyingKeyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewVerifyingKeyRequest>(create);
   static GetNewVerifyingKeyRequest? _defaultInstance;
 }
 
@@ -3285,27 +2910,24 @@ class GetNewVerifyingKeyResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewVerifyingKeyResponse._() : super();
-  factory GetNewVerifyingKeyResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewVerifyingKeyResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewVerifyingKeyResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewVerifyingKeyResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewVerifyingKeyResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewVerifyingKeyResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'key')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewVerifyingKeyResponse clone() => GetNewVerifyingKeyResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewVerifyingKeyResponse copyWith(void Function(GetNewVerifyingKeyResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewVerifyingKeyResponse)) as GetNewVerifyingKeyResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewVerifyingKeyResponse copyWith(void Function(GetNewVerifyingKeyResponse) updates) => super.copyWith((message) => updates(message as GetNewVerifyingKeyResponse)) as GetNewVerifyingKeyResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3314,17 +2936,13 @@ class GetNewVerifyingKeyResponse extends $pb.GeneratedMessage {
   GetNewVerifyingKeyResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewVerifyingKeyResponse> createRepeated() => $pb.PbList<GetNewVerifyingKeyResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewVerifyingKeyResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewVerifyingKeyResponse>(create);
+  static GetNewVerifyingKeyResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewVerifyingKeyResponse>(create);
   static GetNewVerifyingKeyResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get key => $_getSZ(0);
   @$pb.TagNumber(1)
-  set key($core.String v) {
-    $_setString(0, v);
-  }
-
+  set key($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasKey() => $_has(0);
   @$pb.TagNumber(1)
@@ -3346,27 +2964,25 @@ class DecryptMsgRequest extends $pb.GeneratedMessage {
     return $result;
   }
   DecryptMsgRequest._() : super();
-  factory DecryptMsgRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DecryptMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DecryptMsgRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DecryptMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecryptMsgRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecryptMsgRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'ciphertext')
     ..aOS(2, _omitFieldNames ? '' : 'encryptionPubkey')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DecryptMsgRequest clone() => DecryptMsgRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DecryptMsgRequest copyWith(void Function(DecryptMsgRequest) updates) =>
-      super.copyWith((message) => updates(message as DecryptMsgRequest)) as DecryptMsgRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DecryptMsgRequest copyWith(void Function(DecryptMsgRequest) updates) => super.copyWith((message) => updates(message as DecryptMsgRequest)) as DecryptMsgRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3375,17 +2991,13 @@ class DecryptMsgRequest extends $pb.GeneratedMessage {
   DecryptMsgRequest createEmptyInstance() => create();
   static $pb.PbList<DecryptMsgRequest> createRepeated() => $pb.PbList<DecryptMsgRequest>();
   @$core.pragma('dart2js:noInline')
-  static DecryptMsgRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecryptMsgRequest>(create);
+  static DecryptMsgRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecryptMsgRequest>(create);
   static DecryptMsgRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get ciphertext => $_getSZ(0);
   @$pb.TagNumber(1)
-  set ciphertext($core.String v) {
-    $_setString(0, v);
-  }
-
+  set ciphertext($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCiphertext() => $_has(0);
   @$pb.TagNumber(1)
@@ -3394,10 +3006,7 @@ class DecryptMsgRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get encryptionPubkey => $_getSZ(1);
   @$pb.TagNumber(2)
-  set encryptionPubkey($core.String v) {
-    $_setString(1, v);
-  }
-
+  set encryptionPubkey($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasEncryptionPubkey() => $_has(1);
   @$pb.TagNumber(2)
@@ -3415,26 +3024,24 @@ class DecryptMsgResponse extends $pb.GeneratedMessage {
     return $result;
   }
   DecryptMsgResponse._() : super();
-  factory DecryptMsgResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DecryptMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DecryptMsgResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DecryptMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecryptMsgResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecryptMsgResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'plaintext')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DecryptMsgResponse clone() => DecryptMsgResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DecryptMsgResponse copyWith(void Function(DecryptMsgResponse) updates) =>
-      super.copyWith((message) => updates(message as DecryptMsgResponse)) as DecryptMsgResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DecryptMsgResponse copyWith(void Function(DecryptMsgResponse) updates) => super.copyWith((message) => updates(message as DecryptMsgResponse)) as DecryptMsgResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3443,17 +3050,13 @@ class DecryptMsgResponse extends $pb.GeneratedMessage {
   DecryptMsgResponse createEmptyInstance() => create();
   static $pb.PbList<DecryptMsgResponse> createRepeated() => $pb.PbList<DecryptMsgResponse>();
   @$core.pragma('dart2js:noInline')
-  static DecryptMsgResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecryptMsgResponse>(create);
+  static DecryptMsgResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecryptMsgResponse>(create);
   static DecryptMsgResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get plaintext => $_getSZ(0);
   @$pb.TagNumber(1)
-  set plaintext($core.String v) {
-    $_setString(0, v);
-  }
-
+  set plaintext($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPlaintext() => $_has(0);
   @$pb.TagNumber(1)
@@ -3475,27 +3078,25 @@ class EncryptMsgRequest extends $pb.GeneratedMessage {
     return $result;
   }
   EncryptMsgRequest._() : super();
-  factory EncryptMsgRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory EncryptMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory EncryptMsgRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EncryptMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptMsgRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptMsgRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'msg')
     ..aOS(2, _omitFieldNames ? '' : 'encryptionPubkey')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   EncryptMsgRequest clone() => EncryptMsgRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  EncryptMsgRequest copyWith(void Function(EncryptMsgRequest) updates) =>
-      super.copyWith((message) => updates(message as EncryptMsgRequest)) as EncryptMsgRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EncryptMsgRequest copyWith(void Function(EncryptMsgRequest) updates) => super.copyWith((message) => updates(message as EncryptMsgRequest)) as EncryptMsgRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3504,17 +3105,13 @@ class EncryptMsgRequest extends $pb.GeneratedMessage {
   EncryptMsgRequest createEmptyInstance() => create();
   static $pb.PbList<EncryptMsgRequest> createRepeated() => $pb.PbList<EncryptMsgRequest>();
   @$core.pragma('dart2js:noInline')
-  static EncryptMsgRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptMsgRequest>(create);
+  static EncryptMsgRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptMsgRequest>(create);
   static EncryptMsgRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get msg => $_getSZ(0);
   @$pb.TagNumber(1)
-  set msg($core.String v) {
-    $_setString(0, v);
-  }
-
+  set msg($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMsg() => $_has(0);
   @$pb.TagNumber(1)
@@ -3523,10 +3120,7 @@ class EncryptMsgRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get encryptionPubkey => $_getSZ(1);
   @$pb.TagNumber(2)
-  set encryptionPubkey($core.String v) {
-    $_setString(1, v);
-  }
-
+  set encryptionPubkey($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasEncryptionPubkey() => $_has(1);
   @$pb.TagNumber(2)
@@ -3544,26 +3138,24 @@ class EncryptMsgResponse extends $pb.GeneratedMessage {
     return $result;
   }
   EncryptMsgResponse._() : super();
-  factory EncryptMsgResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory EncryptMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory EncryptMsgResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EncryptMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptMsgResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptMsgResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'ciphertext')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   EncryptMsgResponse clone() => EncryptMsgResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  EncryptMsgResponse copyWith(void Function(EncryptMsgResponse) updates) =>
-      super.copyWith((message) => updates(message as EncryptMsgResponse)) as EncryptMsgResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EncryptMsgResponse copyWith(void Function(EncryptMsgResponse) updates) => super.copyWith((message) => updates(message as EncryptMsgResponse)) as EncryptMsgResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3572,17 +3164,13 @@ class EncryptMsgResponse extends $pb.GeneratedMessage {
   EncryptMsgResponse createEmptyInstance() => create();
   static $pb.PbList<EncryptMsgResponse> createRepeated() => $pb.PbList<EncryptMsgResponse>();
   @$core.pragma('dart2js:noInline')
-  static EncryptMsgResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptMsgResponse>(create);
+  static EncryptMsgResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptMsgResponse>(create);
   static EncryptMsgResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get ciphertext => $_getSZ(0);
   @$pb.TagNumber(1)
-  set ciphertext($core.String v) {
-    $_setString(0, v);
-  }
-
+  set ciphertext($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCiphertext() => $_has(0);
   @$pb.TagNumber(1)
@@ -3604,27 +3192,25 @@ class SignArbitraryMsgRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SignArbitraryMsgRequest._() : super();
-  factory SignArbitraryMsgRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SignArbitraryMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SignArbitraryMsgRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignArbitraryMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'msg')
     ..aOS(2, _omitFieldNames ? '' : 'verifyingKey')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SignArbitraryMsgRequest clone() => SignArbitraryMsgRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SignArbitraryMsgRequest copyWith(void Function(SignArbitraryMsgRequest) updates) =>
-      super.copyWith((message) => updates(message as SignArbitraryMsgRequest)) as SignArbitraryMsgRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignArbitraryMsgRequest copyWith(void Function(SignArbitraryMsgRequest) updates) => super.copyWith((message) => updates(message as SignArbitraryMsgRequest)) as SignArbitraryMsgRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3633,17 +3219,13 @@ class SignArbitraryMsgRequest extends $pb.GeneratedMessage {
   SignArbitraryMsgRequest createEmptyInstance() => create();
   static $pb.PbList<SignArbitraryMsgRequest> createRepeated() => $pb.PbList<SignArbitraryMsgRequest>();
   @$core.pragma('dart2js:noInline')
-  static SignArbitraryMsgRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgRequest>(create);
+  static SignArbitraryMsgRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgRequest>(create);
   static SignArbitraryMsgRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get msg => $_getSZ(0);
   @$pb.TagNumber(1)
-  set msg($core.String v) {
-    $_setString(0, v);
-  }
-
+  set msg($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMsg() => $_has(0);
   @$pb.TagNumber(1)
@@ -3652,10 +3234,7 @@ class SignArbitraryMsgRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get verifyingKey => $_getSZ(1);
   @$pb.TagNumber(2)
-  set verifyingKey($core.String v) {
-    $_setString(1, v);
-  }
-
+  set verifyingKey($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasVerifyingKey() => $_has(1);
   @$pb.TagNumber(2)
@@ -3673,26 +3252,24 @@ class SignArbitraryMsgResponse extends $pb.GeneratedMessage {
     return $result;
   }
   SignArbitraryMsgResponse._() : super();
-  factory SignArbitraryMsgResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SignArbitraryMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SignArbitraryMsgResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignArbitraryMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'signature')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SignArbitraryMsgResponse clone() => SignArbitraryMsgResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SignArbitraryMsgResponse copyWith(void Function(SignArbitraryMsgResponse) updates) =>
-      super.copyWith((message) => updates(message as SignArbitraryMsgResponse)) as SignArbitraryMsgResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignArbitraryMsgResponse copyWith(void Function(SignArbitraryMsgResponse) updates) => super.copyWith((message) => updates(message as SignArbitraryMsgResponse)) as SignArbitraryMsgResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3701,17 +3278,13 @@ class SignArbitraryMsgResponse extends $pb.GeneratedMessage {
   SignArbitraryMsgResponse createEmptyInstance() => create();
   static $pb.PbList<SignArbitraryMsgResponse> createRepeated() => $pb.PbList<SignArbitraryMsgResponse>();
   @$core.pragma('dart2js:noInline')
-  static SignArbitraryMsgResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgResponse>(create);
+  static SignArbitraryMsgResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgResponse>(create);
   static SignArbitraryMsgResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get signature => $_getSZ(0);
   @$pb.TagNumber(1)
-  set signature($core.String v) {
-    $_setString(0, v);
-  }
-
+  set signature($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSignature() => $_has(0);
   @$pb.TagNumber(1)
@@ -3733,28 +3306,25 @@ class SignArbitraryMsgAsAddrRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SignArbitraryMsgAsAddrRequest._() : super();
-  factory SignArbitraryMsgAsAddrRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SignArbitraryMsgAsAddrRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SignArbitraryMsgAsAddrRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignArbitraryMsgAsAddrRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgAsAddrRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgAsAddrRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'msg')
     ..aOS(2, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SignArbitraryMsgAsAddrRequest clone() => SignArbitraryMsgAsAddrRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SignArbitraryMsgAsAddrRequest copyWith(void Function(SignArbitraryMsgAsAddrRequest) updates) =>
-      super.copyWith((message) => updates(message as SignArbitraryMsgAsAddrRequest)) as SignArbitraryMsgAsAddrRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignArbitraryMsgAsAddrRequest copyWith(void Function(SignArbitraryMsgAsAddrRequest) updates) => super.copyWith((message) => updates(message as SignArbitraryMsgAsAddrRequest)) as SignArbitraryMsgAsAddrRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3763,17 +3333,13 @@ class SignArbitraryMsgAsAddrRequest extends $pb.GeneratedMessage {
   SignArbitraryMsgAsAddrRequest createEmptyInstance() => create();
   static $pb.PbList<SignArbitraryMsgAsAddrRequest> createRepeated() => $pb.PbList<SignArbitraryMsgAsAddrRequest>();
   @$core.pragma('dart2js:noInline')
-  static SignArbitraryMsgAsAddrRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgAsAddrRequest>(create);
+  static SignArbitraryMsgAsAddrRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgAsAddrRequest>(create);
   static SignArbitraryMsgAsAddrRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get msg => $_getSZ(0);
   @$pb.TagNumber(1)
-  set msg($core.String v) {
-    $_setString(0, v);
-  }
-
+  set msg($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMsg() => $_has(0);
   @$pb.TagNumber(1)
@@ -3782,10 +3348,7 @@ class SignArbitraryMsgAsAddrRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get address => $_getSZ(1);
   @$pb.TagNumber(2)
-  set address($core.String v) {
-    $_setString(1, v);
-  }
-
+  set address($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAddress() => $_has(1);
   @$pb.TagNumber(2)
@@ -3807,28 +3370,25 @@ class SignArbitraryMsgAsAddrResponse extends $pb.GeneratedMessage {
     return $result;
   }
   SignArbitraryMsgAsAddrResponse._() : super();
-  factory SignArbitraryMsgAsAddrResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SignArbitraryMsgAsAddrResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SignArbitraryMsgAsAddrResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignArbitraryMsgAsAddrResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgAsAddrResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgAsAddrResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'verifyingKey')
     ..aOS(2, _omitFieldNames ? '' : 'signature')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SignArbitraryMsgAsAddrResponse clone() => SignArbitraryMsgAsAddrResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SignArbitraryMsgAsAddrResponse copyWith(void Function(SignArbitraryMsgAsAddrResponse) updates) =>
-      super.copyWith((message) => updates(message as SignArbitraryMsgAsAddrResponse)) as SignArbitraryMsgAsAddrResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignArbitraryMsgAsAddrResponse copyWith(void Function(SignArbitraryMsgAsAddrResponse) updates) => super.copyWith((message) => updates(message as SignArbitraryMsgAsAddrResponse)) as SignArbitraryMsgAsAddrResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3837,17 +3397,13 @@ class SignArbitraryMsgAsAddrResponse extends $pb.GeneratedMessage {
   SignArbitraryMsgAsAddrResponse createEmptyInstance() => create();
   static $pb.PbList<SignArbitraryMsgAsAddrResponse> createRepeated() => $pb.PbList<SignArbitraryMsgAsAddrResponse>();
   @$core.pragma('dart2js:noInline')
-  static SignArbitraryMsgAsAddrResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgAsAddrResponse>(create);
+  static SignArbitraryMsgAsAddrResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgAsAddrResponse>(create);
   static SignArbitraryMsgAsAddrResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get verifyingKey => $_getSZ(0);
   @$pb.TagNumber(1)
-  set verifyingKey($core.String v) {
-    $_setString(0, v);
-  }
-
+  set verifyingKey($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasVerifyingKey() => $_has(0);
   @$pb.TagNumber(1)
@@ -3856,10 +3412,7 @@ class SignArbitraryMsgAsAddrResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get signature => $_getSZ(1);
   @$pb.TagNumber(2)
-  set signature($core.String v) {
-    $_setString(1, v);
-  }
-
+  set signature($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasSignature() => $_has(1);
   @$pb.TagNumber(2)
@@ -3885,28 +3438,26 @@ class VerifySignatureRequest extends $pb.GeneratedMessage {
     return $result;
   }
   VerifySignatureRequest._() : super();
-  factory VerifySignatureRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VerifySignatureRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VerifySignatureRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VerifySignatureRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VerifySignatureRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VerifySignatureRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'msg')
     ..aOS(2, _omitFieldNames ? '' : 'signature')
     ..aOS(3, _omitFieldNames ? '' : 'verifyingKey')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VerifySignatureRequest clone() => VerifySignatureRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VerifySignatureRequest copyWith(void Function(VerifySignatureRequest) updates) =>
-      super.copyWith((message) => updates(message as VerifySignatureRequest)) as VerifySignatureRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VerifySignatureRequest copyWith(void Function(VerifySignatureRequest) updates) => super.copyWith((message) => updates(message as VerifySignatureRequest)) as VerifySignatureRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3915,17 +3466,13 @@ class VerifySignatureRequest extends $pb.GeneratedMessage {
   VerifySignatureRequest createEmptyInstance() => create();
   static $pb.PbList<VerifySignatureRequest> createRepeated() => $pb.PbList<VerifySignatureRequest>();
   @$core.pragma('dart2js:noInline')
-  static VerifySignatureRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VerifySignatureRequest>(create);
+  static VerifySignatureRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VerifySignatureRequest>(create);
   static VerifySignatureRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get msg => $_getSZ(0);
   @$pb.TagNumber(1)
-  set msg($core.String v) {
-    $_setString(0, v);
-  }
-
+  set msg($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMsg() => $_has(0);
   @$pb.TagNumber(1)
@@ -3934,10 +3481,7 @@ class VerifySignatureRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get signature => $_getSZ(1);
   @$pb.TagNumber(2)
-  set signature($core.String v) {
-    $_setString(1, v);
-  }
-
+  set signature($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasSignature() => $_has(1);
   @$pb.TagNumber(2)
@@ -3946,10 +3490,7 @@ class VerifySignatureRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get verifyingKey => $_getSZ(2);
   @$pb.TagNumber(3)
-  set verifyingKey($core.String v) {
-    $_setString(2, v);
-  }
-
+  set verifyingKey($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasVerifyingKey() => $_has(2);
   @$pb.TagNumber(3)
@@ -3967,26 +3508,24 @@ class VerifySignatureResponse extends $pb.GeneratedMessage {
     return $result;
   }
   VerifySignatureResponse._() : super();
-  factory VerifySignatureResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VerifySignatureResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VerifySignatureResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VerifySignatureResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VerifySignatureResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VerifySignatureResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'valid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VerifySignatureResponse clone() => VerifySignatureResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VerifySignatureResponse copyWith(void Function(VerifySignatureResponse) updates) =>
-      super.copyWith((message) => updates(message as VerifySignatureResponse)) as VerifySignatureResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VerifySignatureResponse copyWith(void Function(VerifySignatureResponse) updates) => super.copyWith((message) => updates(message as VerifySignatureResponse)) as VerifySignatureResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3995,17 +3534,13 @@ class VerifySignatureResponse extends $pb.GeneratedMessage {
   VerifySignatureResponse createEmptyInstance() => create();
   static $pb.PbList<VerifySignatureResponse> createRepeated() => $pb.PbList<VerifySignatureResponse>();
   @$core.pragma('dart2js:noInline')
-  static VerifySignatureResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VerifySignatureResponse>(create);
+  static VerifySignatureResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VerifySignatureResponse>(create);
   static VerifySignatureResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get valid => $_getBF(0);
   @$pb.TagNumber(1)
-  set valid($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set valid($core.bool v) { $_setBool(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasValid() => $_has(0);
   @$pb.TagNumber(1)
@@ -4015,25 +3550,23 @@ class VerifySignatureResponse extends $pb.GeneratedMessage {
 class GetWalletAddressesRequest extends $pb.GeneratedMessage {
   factory GetWalletAddressesRequest() => create();
   GetWalletAddressesRequest._() : super();
-  factory GetWalletAddressesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletAddressesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletAddressesRequest clone() => GetWalletAddressesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletAddressesRequest copyWith(void Function(GetWalletAddressesRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletAddressesRequest)) as GetWalletAddressesRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletAddressesRequest copyWith(void Function(GetWalletAddressesRequest) updates) => super.copyWith((message) => updates(message as GetWalletAddressesRequest)) as GetWalletAddressesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4042,8 +3575,7 @@ class GetWalletAddressesRequest extends $pb.GeneratedMessage {
   GetWalletAddressesRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletAddressesRequest> createRepeated() => $pb.PbList<GetWalletAddressesRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletAddressesRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesRequest>(create);
+  static GetWalletAddressesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesRequest>(create);
   static GetWalletAddressesRequest? _defaultInstance;
 }
 
@@ -4058,27 +3590,24 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletAddressesResponse._() : super();
-  factory GetWalletAddressesResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletAddressesResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletAddressesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletAddressesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..pPS(1, _omitFieldNames ? '' : 'addresses')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletAddressesResponse clone() => GetWalletAddressesResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletAddressesResponse copyWith(void Function(GetWalletAddressesResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletAddressesResponse)) as GetWalletAddressesResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletAddressesResponse copyWith(void Function(GetWalletAddressesResponse) updates) => super.copyWith((message) => updates(message as GetWalletAddressesResponse)) as GetWalletAddressesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4087,8 +3616,7 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
   GetWalletAddressesResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletAddressesResponse> createRepeated() => $pb.PbList<GetWalletAddressesResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletAddressesResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesResponse>(create);
+  static GetWalletAddressesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesResponse>(create);
   static GetWalletAddressesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -4098,25 +3626,23 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
 class MyUnconfirmedUtxosRequest extends $pb.GeneratedMessage {
   factory MyUnconfirmedUtxosRequest() => create();
   MyUnconfirmedUtxosRequest._() : super();
-  factory MyUnconfirmedUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MyUnconfirmedUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MyUnconfirmedUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MyUnconfirmedUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUnconfirmedUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUnconfirmedUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MyUnconfirmedUtxosRequest clone() => MyUnconfirmedUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MyUnconfirmedUtxosRequest copyWith(void Function(MyUnconfirmedUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as MyUnconfirmedUtxosRequest)) as MyUnconfirmedUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MyUnconfirmedUtxosRequest copyWith(void Function(MyUnconfirmedUtxosRequest) updates) => super.copyWith((message) => updates(message as MyUnconfirmedUtxosRequest)) as MyUnconfirmedUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4125,8 +3651,7 @@ class MyUnconfirmedUtxosRequest extends $pb.GeneratedMessage {
   MyUnconfirmedUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<MyUnconfirmedUtxosRequest> createRepeated() => $pb.PbList<MyUnconfirmedUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static MyUnconfirmedUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MyUnconfirmedUtxosRequest>(create);
+  static MyUnconfirmedUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MyUnconfirmedUtxosRequest>(create);
   static MyUnconfirmedUtxosRequest? _defaultInstance;
 }
 
@@ -4141,27 +3666,24 @@ class MyUnconfirmedUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MyUnconfirmedUtxosResponse._() : super();
-  factory MyUnconfirmedUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MyUnconfirmedUtxosResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MyUnconfirmedUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MyUnconfirmedUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUnconfirmedUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUnconfirmedUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MyUnconfirmedUtxosResponse clone() => MyUnconfirmedUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MyUnconfirmedUtxosResponse copyWith(void Function(MyUnconfirmedUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as MyUnconfirmedUtxosResponse)) as MyUnconfirmedUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MyUnconfirmedUtxosResponse copyWith(void Function(MyUnconfirmedUtxosResponse) updates) => super.copyWith((message) => updates(message as MyUnconfirmedUtxosResponse)) as MyUnconfirmedUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4170,17 +3692,13 @@ class MyUnconfirmedUtxosResponse extends $pb.GeneratedMessage {
   MyUnconfirmedUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<MyUnconfirmedUtxosResponse> createRepeated() => $pb.PbList<MyUnconfirmedUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static MyUnconfirmedUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MyUnconfirmedUtxosResponse>(create);
+  static MyUnconfirmedUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MyUnconfirmedUtxosResponse>(create);
   static MyUnconfirmedUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -4190,25 +3708,23 @@ class MyUnconfirmedUtxosResponse extends $pb.GeneratedMessage {
 class OpenapiSchemaRequest extends $pb.GeneratedMessage {
   factory OpenapiSchemaRequest() => create();
   OpenapiSchemaRequest._() : super();
-  factory OpenapiSchemaRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory OpenapiSchemaRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory OpenapiSchemaRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory OpenapiSchemaRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OpenapiSchemaRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OpenapiSchemaRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   OpenapiSchemaRequest clone() => OpenapiSchemaRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  OpenapiSchemaRequest copyWith(void Function(OpenapiSchemaRequest) updates) =>
-      super.copyWith((message) => updates(message as OpenapiSchemaRequest)) as OpenapiSchemaRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  OpenapiSchemaRequest copyWith(void Function(OpenapiSchemaRequest) updates) => super.copyWith((message) => updates(message as OpenapiSchemaRequest)) as OpenapiSchemaRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4217,8 +3733,7 @@ class OpenapiSchemaRequest extends $pb.GeneratedMessage {
   OpenapiSchemaRequest createEmptyInstance() => create();
   static $pb.PbList<OpenapiSchemaRequest> createRepeated() => $pb.PbList<OpenapiSchemaRequest>();
   @$core.pragma('dart2js:noInline')
-  static OpenapiSchemaRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpenapiSchemaRequest>(create);
+  static OpenapiSchemaRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpenapiSchemaRequest>(create);
   static OpenapiSchemaRequest? _defaultInstance;
 }
 
@@ -4233,26 +3748,24 @@ class OpenapiSchemaResponse extends $pb.GeneratedMessage {
     return $result;
   }
   OpenapiSchemaResponse._() : super();
-  factory OpenapiSchemaResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory OpenapiSchemaResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory OpenapiSchemaResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory OpenapiSchemaResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OpenapiSchemaResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OpenapiSchemaResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'schemaJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   OpenapiSchemaResponse clone() => OpenapiSchemaResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  OpenapiSchemaResponse copyWith(void Function(OpenapiSchemaResponse) updates) =>
-      super.copyWith((message) => updates(message as OpenapiSchemaResponse)) as OpenapiSchemaResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  OpenapiSchemaResponse copyWith(void Function(OpenapiSchemaResponse) updates) => super.copyWith((message) => updates(message as OpenapiSchemaResponse)) as OpenapiSchemaResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4261,17 +3774,13 @@ class OpenapiSchemaResponse extends $pb.GeneratedMessage {
   OpenapiSchemaResponse createEmptyInstance() => create();
   static $pb.PbList<OpenapiSchemaResponse> createRepeated() => $pb.PbList<OpenapiSchemaResponse>();
   @$core.pragma('dart2js:noInline')
-  static OpenapiSchemaResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpenapiSchemaResponse>(create);
+  static OpenapiSchemaResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpenapiSchemaResponse>(create);
   static OpenapiSchemaResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get schemaJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set schemaJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set schemaJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSchemaJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -4297,27 +3806,26 @@ class AmmBurnRequest extends $pb.GeneratedMessage {
     return $result;
   }
   AmmBurnRequest._() : super();
-  factory AmmBurnRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AmmBurnRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory AmmBurnRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AmmBurnRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AmmBurnRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AmmBurnRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'asset0')
     ..aOS(2, _omitFieldNames ? '' : 'asset1')
     ..aInt64(3, _omitFieldNames ? '' : 'lpTokenAmount')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   AmmBurnRequest clone() => AmmBurnRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  AmmBurnRequest copyWith(void Function(AmmBurnRequest) updates) =>
-      super.copyWith((message) => updates(message as AmmBurnRequest)) as AmmBurnRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AmmBurnRequest copyWith(void Function(AmmBurnRequest) updates) => super.copyWith((message) => updates(message as AmmBurnRequest)) as AmmBurnRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4332,10 +3840,7 @@ class AmmBurnRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get asset0 => $_getSZ(0);
   @$pb.TagNumber(1)
-  set asset0($core.String v) {
-    $_setString(0, v);
-  }
-
+  set asset0($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAsset0() => $_has(0);
   @$pb.TagNumber(1)
@@ -4344,10 +3849,7 @@ class AmmBurnRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get asset1 => $_getSZ(1);
   @$pb.TagNumber(2)
-  set asset1($core.String v) {
-    $_setString(1, v);
-  }
-
+  set asset1($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAsset1() => $_has(1);
   @$pb.TagNumber(2)
@@ -4356,10 +3858,7 @@ class AmmBurnRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get lpTokenAmount => $_getI64(2);
   @$pb.TagNumber(3)
-  set lpTokenAmount($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set lpTokenAmount($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasLpTokenAmount() => $_has(2);
   @$pb.TagNumber(3)
@@ -4377,26 +3876,24 @@ class AmmBurnResponse extends $pb.GeneratedMessage {
     return $result;
   }
   AmmBurnResponse._() : super();
-  factory AmmBurnResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AmmBurnResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory AmmBurnResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AmmBurnResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AmmBurnResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AmmBurnResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   AmmBurnResponse clone() => AmmBurnResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  AmmBurnResponse copyWith(void Function(AmmBurnResponse) updates) =>
-      super.copyWith((message) => updates(message as AmmBurnResponse)) as AmmBurnResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AmmBurnResponse copyWith(void Function(AmmBurnResponse) updates) => super.copyWith((message) => updates(message as AmmBurnResponse)) as AmmBurnResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4405,17 +3902,13 @@ class AmmBurnResponse extends $pb.GeneratedMessage {
   AmmBurnResponse createEmptyInstance() => create();
   static $pb.PbList<AmmBurnResponse> createRepeated() => $pb.PbList<AmmBurnResponse>();
   @$core.pragma('dart2js:noInline')
-  static AmmBurnResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AmmBurnResponse>(create);
+  static AmmBurnResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AmmBurnResponse>(create);
   static AmmBurnResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -4445,28 +3938,27 @@ class AmmMintRequest extends $pb.GeneratedMessage {
     return $result;
   }
   AmmMintRequest._() : super();
-  factory AmmMintRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AmmMintRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory AmmMintRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AmmMintRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AmmMintRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AmmMintRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'asset0')
     ..aOS(2, _omitFieldNames ? '' : 'asset1')
     ..aInt64(3, _omitFieldNames ? '' : 'amount0')
     ..aInt64(4, _omitFieldNames ? '' : 'amount1')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   AmmMintRequest clone() => AmmMintRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  AmmMintRequest copyWith(void Function(AmmMintRequest) updates) =>
-      super.copyWith((message) => updates(message as AmmMintRequest)) as AmmMintRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AmmMintRequest copyWith(void Function(AmmMintRequest) updates) => super.copyWith((message) => updates(message as AmmMintRequest)) as AmmMintRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4481,10 +3973,7 @@ class AmmMintRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get asset0 => $_getSZ(0);
   @$pb.TagNumber(1)
-  set asset0($core.String v) {
-    $_setString(0, v);
-  }
-
+  set asset0($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAsset0() => $_has(0);
   @$pb.TagNumber(1)
@@ -4493,10 +3982,7 @@ class AmmMintRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get asset1 => $_getSZ(1);
   @$pb.TagNumber(2)
-  set asset1($core.String v) {
-    $_setString(1, v);
-  }
-
+  set asset1($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAsset1() => $_has(1);
   @$pb.TagNumber(2)
@@ -4505,10 +3991,7 @@ class AmmMintRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get amount0 => $_getI64(2);
   @$pb.TagNumber(3)
-  set amount0($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set amount0($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasAmount0() => $_has(2);
   @$pb.TagNumber(3)
@@ -4517,10 +4000,7 @@ class AmmMintRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get amount1 => $_getI64(3);
   @$pb.TagNumber(4)
-  set amount1($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set amount1($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasAmount1() => $_has(3);
   @$pb.TagNumber(4)
@@ -4538,26 +4018,24 @@ class AmmMintResponse extends $pb.GeneratedMessage {
     return $result;
   }
   AmmMintResponse._() : super();
-  factory AmmMintResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AmmMintResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory AmmMintResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AmmMintResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AmmMintResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AmmMintResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   AmmMintResponse clone() => AmmMintResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  AmmMintResponse copyWith(void Function(AmmMintResponse) updates) =>
-      super.copyWith((message) => updates(message as AmmMintResponse)) as AmmMintResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AmmMintResponse copyWith(void Function(AmmMintResponse) updates) => super.copyWith((message) => updates(message as AmmMintResponse)) as AmmMintResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4566,17 +4044,13 @@ class AmmMintResponse extends $pb.GeneratedMessage {
   AmmMintResponse createEmptyInstance() => create();
   static $pb.PbList<AmmMintResponse> createRepeated() => $pb.PbList<AmmMintResponse>();
   @$core.pragma('dart2js:noInline')
-  static AmmMintResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AmmMintResponse>(create);
+  static AmmMintResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AmmMintResponse>(create);
   static AmmMintResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -4602,27 +4076,26 @@ class AmmSwapRequest extends $pb.GeneratedMessage {
     return $result;
   }
   AmmSwapRequest._() : super();
-  factory AmmSwapRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AmmSwapRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory AmmSwapRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AmmSwapRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AmmSwapRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AmmSwapRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'assetSpend')
     ..aOS(2, _omitFieldNames ? '' : 'assetReceive')
     ..aInt64(3, _omitFieldNames ? '' : 'amountSpend')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   AmmSwapRequest clone() => AmmSwapRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  AmmSwapRequest copyWith(void Function(AmmSwapRequest) updates) =>
-      super.copyWith((message) => updates(message as AmmSwapRequest)) as AmmSwapRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AmmSwapRequest copyWith(void Function(AmmSwapRequest) updates) => super.copyWith((message) => updates(message as AmmSwapRequest)) as AmmSwapRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4637,10 +4110,7 @@ class AmmSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get assetSpend => $_getSZ(0);
   @$pb.TagNumber(1)
-  set assetSpend($core.String v) {
-    $_setString(0, v);
-  }
-
+  set assetSpend($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAssetSpend() => $_has(0);
   @$pb.TagNumber(1)
@@ -4649,10 +4119,7 @@ class AmmSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get assetReceive => $_getSZ(1);
   @$pb.TagNumber(2)
-  set assetReceive($core.String v) {
-    $_setString(1, v);
-  }
-
+  set assetReceive($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAssetReceive() => $_has(1);
   @$pb.TagNumber(2)
@@ -4661,10 +4128,7 @@ class AmmSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get amountSpend => $_getI64(2);
   @$pb.TagNumber(3)
-  set amountSpend($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set amountSpend($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasAmountSpend() => $_has(2);
   @$pb.TagNumber(3)
@@ -4682,26 +4146,24 @@ class AmmSwapResponse extends $pb.GeneratedMessage {
     return $result;
   }
   AmmSwapResponse._() : super();
-  factory AmmSwapResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AmmSwapResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory AmmSwapResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AmmSwapResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AmmSwapResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AmmSwapResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'amountReceive')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   AmmSwapResponse clone() => AmmSwapResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  AmmSwapResponse copyWith(void Function(AmmSwapResponse) updates) =>
-      super.copyWith((message) => updates(message as AmmSwapResponse)) as AmmSwapResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AmmSwapResponse copyWith(void Function(AmmSwapResponse) updates) => super.copyWith((message) => updates(message as AmmSwapResponse)) as AmmSwapResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4710,17 +4172,13 @@ class AmmSwapResponse extends $pb.GeneratedMessage {
   AmmSwapResponse createEmptyInstance() => create();
   static $pb.PbList<AmmSwapResponse> createRepeated() => $pb.PbList<AmmSwapResponse>();
   @$core.pragma('dart2js:noInline')
-  static AmmSwapResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AmmSwapResponse>(create);
+  static AmmSwapResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AmmSwapResponse>(create);
   static AmmSwapResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get amountReceive => $_getI64(0);
   @$pb.TagNumber(1)
-  set amountReceive($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set amountReceive($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAmountReceive() => $_has(0);
   @$pb.TagNumber(1)
@@ -4742,27 +4200,25 @@ class GetAmmPoolStateRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetAmmPoolStateRequest._() : super();
-  factory GetAmmPoolStateRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetAmmPoolStateRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetAmmPoolStateRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetAmmPoolStateRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetAmmPoolStateRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetAmmPoolStateRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'asset0')
     ..aOS(2, _omitFieldNames ? '' : 'asset1')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetAmmPoolStateRequest clone() => GetAmmPoolStateRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetAmmPoolStateRequest copyWith(void Function(GetAmmPoolStateRequest) updates) =>
-      super.copyWith((message) => updates(message as GetAmmPoolStateRequest)) as GetAmmPoolStateRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetAmmPoolStateRequest copyWith(void Function(GetAmmPoolStateRequest) updates) => super.copyWith((message) => updates(message as GetAmmPoolStateRequest)) as GetAmmPoolStateRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4771,17 +4227,13 @@ class GetAmmPoolStateRequest extends $pb.GeneratedMessage {
   GetAmmPoolStateRequest createEmptyInstance() => create();
   static $pb.PbList<GetAmmPoolStateRequest> createRepeated() => $pb.PbList<GetAmmPoolStateRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetAmmPoolStateRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetAmmPoolStateRequest>(create);
+  static GetAmmPoolStateRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetAmmPoolStateRequest>(create);
   static GetAmmPoolStateRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get asset0 => $_getSZ(0);
   @$pb.TagNumber(1)
-  set asset0($core.String v) {
-    $_setString(0, v);
-  }
-
+  set asset0($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAsset0() => $_has(0);
   @$pb.TagNumber(1)
@@ -4790,10 +4242,7 @@ class GetAmmPoolStateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get asset1 => $_getSZ(1);
   @$pb.TagNumber(2)
-  set asset1($core.String v) {
-    $_setString(1, v);
-  }
-
+  set asset1($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAsset1() => $_has(1);
   @$pb.TagNumber(2)
@@ -4811,26 +4260,24 @@ class GetAmmPoolStateResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetAmmPoolStateResponse._() : super();
-  factory GetAmmPoolStateResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetAmmPoolStateResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetAmmPoolStateResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetAmmPoolStateResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetAmmPoolStateResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetAmmPoolStateResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'poolStateJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetAmmPoolStateResponse clone() => GetAmmPoolStateResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetAmmPoolStateResponse copyWith(void Function(GetAmmPoolStateResponse) updates) =>
-      super.copyWith((message) => updates(message as GetAmmPoolStateResponse)) as GetAmmPoolStateResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetAmmPoolStateResponse copyWith(void Function(GetAmmPoolStateResponse) updates) => super.copyWith((message) => updates(message as GetAmmPoolStateResponse)) as GetAmmPoolStateResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4839,17 +4286,13 @@ class GetAmmPoolStateResponse extends $pb.GeneratedMessage {
   GetAmmPoolStateResponse createEmptyInstance() => create();
   static $pb.PbList<GetAmmPoolStateResponse> createRepeated() => $pb.PbList<GetAmmPoolStateResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetAmmPoolStateResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetAmmPoolStateResponse>(create);
+  static GetAmmPoolStateResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetAmmPoolStateResponse>(create);
   static GetAmmPoolStateResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get poolStateJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set poolStateJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set poolStateJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPoolStateJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -4871,27 +4314,25 @@ class GetAmmPriceRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetAmmPriceRequest._() : super();
-  factory GetAmmPriceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetAmmPriceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetAmmPriceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetAmmPriceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetAmmPriceRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetAmmPriceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'base')
     ..aOS(2, _omitFieldNames ? '' : 'quote')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetAmmPriceRequest clone() => GetAmmPriceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetAmmPriceRequest copyWith(void Function(GetAmmPriceRequest) updates) =>
-      super.copyWith((message) => updates(message as GetAmmPriceRequest)) as GetAmmPriceRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetAmmPriceRequest copyWith(void Function(GetAmmPriceRequest) updates) => super.copyWith((message) => updates(message as GetAmmPriceRequest)) as GetAmmPriceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4900,17 +4341,13 @@ class GetAmmPriceRequest extends $pb.GeneratedMessage {
   GetAmmPriceRequest createEmptyInstance() => create();
   static $pb.PbList<GetAmmPriceRequest> createRepeated() => $pb.PbList<GetAmmPriceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetAmmPriceRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetAmmPriceRequest>(create);
+  static GetAmmPriceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetAmmPriceRequest>(create);
   static GetAmmPriceRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get base => $_getSZ(0);
   @$pb.TagNumber(1)
-  set base($core.String v) {
-    $_setString(0, v);
-  }
-
+  set base($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBase() => $_has(0);
   @$pb.TagNumber(1)
@@ -4919,10 +4356,7 @@ class GetAmmPriceRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get quote => $_getSZ(1);
   @$pb.TagNumber(2)
-  set quote($core.String v) {
-    $_setString(1, v);
-  }
-
+  set quote($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasQuote() => $_has(1);
   @$pb.TagNumber(2)
@@ -4940,26 +4374,24 @@ class GetAmmPriceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetAmmPriceResponse._() : super();
-  factory GetAmmPriceResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetAmmPriceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetAmmPriceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetAmmPriceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetAmmPriceResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetAmmPriceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'priceJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetAmmPriceResponse clone() => GetAmmPriceResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetAmmPriceResponse copyWith(void Function(GetAmmPriceResponse) updates) =>
-      super.copyWith((message) => updates(message as GetAmmPriceResponse)) as GetAmmPriceResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetAmmPriceResponse copyWith(void Function(GetAmmPriceResponse) updates) => super.copyWith((message) => updates(message as GetAmmPriceResponse)) as GetAmmPriceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4968,17 +4400,13 @@ class GetAmmPriceResponse extends $pb.GeneratedMessage {
   GetAmmPriceResponse createEmptyInstance() => create();
   static $pb.PbList<GetAmmPriceResponse> createRepeated() => $pb.PbList<GetAmmPriceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetAmmPriceResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetAmmPriceResponse>(create);
+  static GetAmmPriceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetAmmPriceResponse>(create);
   static GetAmmPriceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get priceJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set priceJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set priceJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPriceJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -5000,27 +4428,25 @@ class DutchAuctionBidRequest extends $pb.GeneratedMessage {
     return $result;
   }
   DutchAuctionBidRequest._() : super();
-  factory DutchAuctionBidRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DutchAuctionBidRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DutchAuctionBidRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DutchAuctionBidRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionBidRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionBidRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'dutchAuctionId')
     ..aInt64(2, _omitFieldNames ? '' : 'bidSize')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DutchAuctionBidRequest clone() => DutchAuctionBidRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DutchAuctionBidRequest copyWith(void Function(DutchAuctionBidRequest) updates) =>
-      super.copyWith((message) => updates(message as DutchAuctionBidRequest)) as DutchAuctionBidRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DutchAuctionBidRequest copyWith(void Function(DutchAuctionBidRequest) updates) => super.copyWith((message) => updates(message as DutchAuctionBidRequest)) as DutchAuctionBidRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5029,17 +4455,13 @@ class DutchAuctionBidRequest extends $pb.GeneratedMessage {
   DutchAuctionBidRequest createEmptyInstance() => create();
   static $pb.PbList<DutchAuctionBidRequest> createRepeated() => $pb.PbList<DutchAuctionBidRequest>();
   @$core.pragma('dart2js:noInline')
-  static DutchAuctionBidRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionBidRequest>(create);
+  static DutchAuctionBidRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionBidRequest>(create);
   static DutchAuctionBidRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get dutchAuctionId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set dutchAuctionId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set dutchAuctionId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDutchAuctionId() => $_has(0);
   @$pb.TagNumber(1)
@@ -5048,10 +4470,7 @@ class DutchAuctionBidRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get bidSize => $_getI64(1);
   @$pb.TagNumber(2)
-  set bidSize($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set bidSize($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasBidSize() => $_has(1);
   @$pb.TagNumber(2)
@@ -5069,26 +4488,24 @@ class DutchAuctionBidResponse extends $pb.GeneratedMessage {
     return $result;
   }
   DutchAuctionBidResponse._() : super();
-  factory DutchAuctionBidResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DutchAuctionBidResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DutchAuctionBidResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DutchAuctionBidResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionBidResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionBidResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'baseAmount')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DutchAuctionBidResponse clone() => DutchAuctionBidResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DutchAuctionBidResponse copyWith(void Function(DutchAuctionBidResponse) updates) =>
-      super.copyWith((message) => updates(message as DutchAuctionBidResponse)) as DutchAuctionBidResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DutchAuctionBidResponse copyWith(void Function(DutchAuctionBidResponse) updates) => super.copyWith((message) => updates(message as DutchAuctionBidResponse)) as DutchAuctionBidResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5097,17 +4514,13 @@ class DutchAuctionBidResponse extends $pb.GeneratedMessage {
   DutchAuctionBidResponse createEmptyInstance() => create();
   static $pb.PbList<DutchAuctionBidResponse> createRepeated() => $pb.PbList<DutchAuctionBidResponse>();
   @$core.pragma('dart2js:noInline')
-  static DutchAuctionBidResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionBidResponse>(create);
+  static DutchAuctionBidResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionBidResponse>(create);
   static DutchAuctionBidResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get baseAmount => $_getI64(0);
   @$pb.TagNumber(1)
-  set baseAmount($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set baseAmount($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBaseAmount() => $_has(0);
   @$pb.TagNumber(1)
@@ -5125,27 +4538,24 @@ class DutchAuctionCollectRequest extends $pb.GeneratedMessage {
     return $result;
   }
   DutchAuctionCollectRequest._() : super();
-  factory DutchAuctionCollectRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DutchAuctionCollectRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DutchAuctionCollectRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DutchAuctionCollectRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionCollectRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionCollectRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'dutchAuctionId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DutchAuctionCollectRequest clone() => DutchAuctionCollectRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DutchAuctionCollectRequest copyWith(void Function(DutchAuctionCollectRequest) updates) =>
-      super.copyWith((message) => updates(message as DutchAuctionCollectRequest)) as DutchAuctionCollectRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DutchAuctionCollectRequest copyWith(void Function(DutchAuctionCollectRequest) updates) => super.copyWith((message) => updates(message as DutchAuctionCollectRequest)) as DutchAuctionCollectRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5154,17 +4564,13 @@ class DutchAuctionCollectRequest extends $pb.GeneratedMessage {
   DutchAuctionCollectRequest createEmptyInstance() => create();
   static $pb.PbList<DutchAuctionCollectRequest> createRepeated() => $pb.PbList<DutchAuctionCollectRequest>();
   @$core.pragma('dart2js:noInline')
-  static DutchAuctionCollectRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionCollectRequest>(create);
+  static DutchAuctionCollectRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionCollectRequest>(create);
   static DutchAuctionCollectRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get dutchAuctionId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set dutchAuctionId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set dutchAuctionId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDutchAuctionId() => $_has(0);
   @$pb.TagNumber(1)
@@ -5186,28 +4592,25 @@ class DutchAuctionCollectResponse extends $pb.GeneratedMessage {
     return $result;
   }
   DutchAuctionCollectResponse._() : super();
-  factory DutchAuctionCollectResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DutchAuctionCollectResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DutchAuctionCollectResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DutchAuctionCollectResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionCollectResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionCollectResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'baseAmount')
     ..aInt64(2, _omitFieldNames ? '' : 'quoteAmount')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DutchAuctionCollectResponse clone() => DutchAuctionCollectResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DutchAuctionCollectResponse copyWith(void Function(DutchAuctionCollectResponse) updates) =>
-      super.copyWith((message) => updates(message as DutchAuctionCollectResponse)) as DutchAuctionCollectResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DutchAuctionCollectResponse copyWith(void Function(DutchAuctionCollectResponse) updates) => super.copyWith((message) => updates(message as DutchAuctionCollectResponse)) as DutchAuctionCollectResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5216,17 +4619,13 @@ class DutchAuctionCollectResponse extends $pb.GeneratedMessage {
   DutchAuctionCollectResponse createEmptyInstance() => create();
   static $pb.PbList<DutchAuctionCollectResponse> createRepeated() => $pb.PbList<DutchAuctionCollectResponse>();
   @$core.pragma('dart2js:noInline')
-  static DutchAuctionCollectResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionCollectResponse>(create);
+  static DutchAuctionCollectResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionCollectResponse>(create);
   static DutchAuctionCollectResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get baseAmount => $_getI64(0);
   @$pb.TagNumber(1)
-  set baseAmount($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set baseAmount($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBaseAmount() => $_has(0);
   @$pb.TagNumber(1)
@@ -5235,10 +4634,7 @@ class DutchAuctionCollectResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get quoteAmount => $_getI64(1);
   @$pb.TagNumber(2)
-  set quoteAmount($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set quoteAmount($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasQuoteAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -5280,14 +4676,10 @@ class DutchAuctionCreateRequest extends $pb.GeneratedMessage {
     return $result;
   }
   DutchAuctionCreateRequest._() : super();
-  factory DutchAuctionCreateRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DutchAuctionCreateRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DutchAuctionCreateRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DutchAuctionCreateRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionCreateRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionCreateRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'startBlock')
     ..aInt64(2, _omitFieldNames ? '' : 'duration')
     ..aOS(3, _omitFieldNames ? '' : 'baseAsset')
@@ -5295,17 +4687,19 @@ class DutchAuctionCreateRequest extends $pb.GeneratedMessage {
     ..aOS(5, _omitFieldNames ? '' : 'quoteAsset')
     ..aInt64(6, _omitFieldNames ? '' : 'initialPrice')
     ..aInt64(7, _omitFieldNames ? '' : 'finalPrice')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DutchAuctionCreateRequest clone() => DutchAuctionCreateRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DutchAuctionCreateRequest copyWith(void Function(DutchAuctionCreateRequest) updates) =>
-      super.copyWith((message) => updates(message as DutchAuctionCreateRequest)) as DutchAuctionCreateRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DutchAuctionCreateRequest copyWith(void Function(DutchAuctionCreateRequest) updates) => super.copyWith((message) => updates(message as DutchAuctionCreateRequest)) as DutchAuctionCreateRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5314,17 +4708,13 @@ class DutchAuctionCreateRequest extends $pb.GeneratedMessage {
   DutchAuctionCreateRequest createEmptyInstance() => create();
   static $pb.PbList<DutchAuctionCreateRequest> createRepeated() => $pb.PbList<DutchAuctionCreateRequest>();
   @$core.pragma('dart2js:noInline')
-  static DutchAuctionCreateRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionCreateRequest>(create);
+  static DutchAuctionCreateRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionCreateRequest>(create);
   static DutchAuctionCreateRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get startBlock => $_getI64(0);
   @$pb.TagNumber(1)
-  set startBlock($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set startBlock($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasStartBlock() => $_has(0);
   @$pb.TagNumber(1)
@@ -5333,10 +4723,7 @@ class DutchAuctionCreateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get duration => $_getI64(1);
   @$pb.TagNumber(2)
-  set duration($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set duration($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasDuration() => $_has(1);
   @$pb.TagNumber(2)
@@ -5345,10 +4732,7 @@ class DutchAuctionCreateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get baseAsset => $_getSZ(2);
   @$pb.TagNumber(3)
-  set baseAsset($core.String v) {
-    $_setString(2, v);
-  }
-
+  set baseAsset($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasBaseAsset() => $_has(2);
   @$pb.TagNumber(3)
@@ -5357,10 +4741,7 @@ class DutchAuctionCreateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get baseAmount => $_getI64(3);
   @$pb.TagNumber(4)
-  set baseAmount($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set baseAmount($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasBaseAmount() => $_has(3);
   @$pb.TagNumber(4)
@@ -5369,10 +4750,7 @@ class DutchAuctionCreateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get quoteAsset => $_getSZ(4);
   @$pb.TagNumber(5)
-  set quoteAsset($core.String v) {
-    $_setString(4, v);
-  }
-
+  set quoteAsset($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasQuoteAsset() => $_has(4);
   @$pb.TagNumber(5)
@@ -5381,10 +4759,7 @@ class DutchAuctionCreateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get initialPrice => $_getI64(5);
   @$pb.TagNumber(6)
-  set initialPrice($fixnum.Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set initialPrice($fixnum.Int64 v) { $_setInt64(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasInitialPrice() => $_has(5);
   @$pb.TagNumber(6)
@@ -5393,10 +4768,7 @@ class DutchAuctionCreateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get finalPrice => $_getI64(6);
   @$pb.TagNumber(7)
-  set finalPrice($fixnum.Int64 v) {
-    $_setInt64(6, v);
-  }
-
+  set finalPrice($fixnum.Int64 v) { $_setInt64(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasFinalPrice() => $_has(6);
   @$pb.TagNumber(7)
@@ -5414,27 +4786,24 @@ class DutchAuctionCreateResponse extends $pb.GeneratedMessage {
     return $result;
   }
   DutchAuctionCreateResponse._() : super();
-  factory DutchAuctionCreateResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DutchAuctionCreateResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DutchAuctionCreateResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DutchAuctionCreateResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionCreateResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionCreateResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DutchAuctionCreateResponse clone() => DutchAuctionCreateResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DutchAuctionCreateResponse copyWith(void Function(DutchAuctionCreateResponse) updates) =>
-      super.copyWith((message) => updates(message as DutchAuctionCreateResponse)) as DutchAuctionCreateResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DutchAuctionCreateResponse copyWith(void Function(DutchAuctionCreateResponse) updates) => super.copyWith((message) => updates(message as DutchAuctionCreateResponse)) as DutchAuctionCreateResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5443,17 +4812,13 @@ class DutchAuctionCreateResponse extends $pb.GeneratedMessage {
   DutchAuctionCreateResponse createEmptyInstance() => create();
   static $pb.PbList<DutchAuctionCreateResponse> createRepeated() => $pb.PbList<DutchAuctionCreateResponse>();
   @$core.pragma('dart2js:noInline')
-  static DutchAuctionCreateResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionCreateResponse>(create);
+  static DutchAuctionCreateResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionCreateResponse>(create);
   static DutchAuctionCreateResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -5463,25 +4828,23 @@ class DutchAuctionCreateResponse extends $pb.GeneratedMessage {
 class DutchAuctionsRequest extends $pb.GeneratedMessage {
   factory DutchAuctionsRequest() => create();
   DutchAuctionsRequest._() : super();
-  factory DutchAuctionsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DutchAuctionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DutchAuctionsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DutchAuctionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DutchAuctionsRequest clone() => DutchAuctionsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DutchAuctionsRequest copyWith(void Function(DutchAuctionsRequest) updates) =>
-      super.copyWith((message) => updates(message as DutchAuctionsRequest)) as DutchAuctionsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DutchAuctionsRequest copyWith(void Function(DutchAuctionsRequest) updates) => super.copyWith((message) => updates(message as DutchAuctionsRequest)) as DutchAuctionsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5490,8 +4853,7 @@ class DutchAuctionsRequest extends $pb.GeneratedMessage {
   DutchAuctionsRequest createEmptyInstance() => create();
   static $pb.PbList<DutchAuctionsRequest> createRepeated() => $pb.PbList<DutchAuctionsRequest>();
   @$core.pragma('dart2js:noInline')
-  static DutchAuctionsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionsRequest>(create);
+  static DutchAuctionsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionsRequest>(create);
   static DutchAuctionsRequest? _defaultInstance;
 }
 
@@ -5506,26 +4868,24 @@ class DutchAuctionsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   DutchAuctionsResponse._() : super();
-  factory DutchAuctionsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DutchAuctionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DutchAuctionsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DutchAuctionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DutchAuctionsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitassets.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'auctionsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DutchAuctionsResponse clone() => DutchAuctionsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DutchAuctionsResponse copyWith(void Function(DutchAuctionsResponse) updates) =>
-      super.copyWith((message) => updates(message as DutchAuctionsResponse)) as DutchAuctionsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DutchAuctionsResponse copyWith(void Function(DutchAuctionsResponse) updates) => super.copyWith((message) => updates(message as DutchAuctionsResponse)) as DutchAuctionsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5534,17 +4894,13 @@ class DutchAuctionsResponse extends $pb.GeneratedMessage {
   DutchAuctionsResponse createEmptyInstance() => create();
   static $pb.PbList<DutchAuctionsResponse> createRepeated() => $pb.PbList<DutchAuctionsResponse>();
   @$core.pragma('dart2js:noInline')
-  static DutchAuctionsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionsResponse>(create);
+  static DutchAuctionsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DutchAuctionsResponse>(create);
   static DutchAuctionsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get auctionsJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set auctionsJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set auctionsJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAuctionsJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -5556,140 +4912,151 @@ class BitAssetsServiceApi {
   BitAssetsServiceApi(this._client);
 
   $async.Future<GetBalanceResponse> getBalance($pb.ClientContext? ctx, GetBalanceRequest request) =>
-      _client.invoke<GetBalanceResponse>(ctx, 'BitAssetsService', 'GetBalance', request, GetBalanceResponse());
+    _client.invoke<GetBalanceResponse>(ctx, 'BitAssetsService', 'GetBalance', request, GetBalanceResponse())
+  ;
   $async.Future<GetBlockCountResponse> getBlockCount($pb.ClientContext? ctx, GetBlockCountRequest request) =>
-      _client.invoke<GetBlockCountResponse>(ctx, 'BitAssetsService', 'GetBlockCount', request, GetBlockCountResponse());
+    _client.invoke<GetBlockCountResponse>(ctx, 'BitAssetsService', 'GetBlockCount', request, GetBlockCountResponse())
+  ;
   $async.Future<StopResponse> stop($pb.ClientContext? ctx, StopRequest request) =>
-      _client.invoke<StopResponse>(ctx, 'BitAssetsService', 'Stop', request, StopResponse());
+    _client.invoke<StopResponse>(ctx, 'BitAssetsService', 'Stop', request, StopResponse())
+  ;
   $async.Future<GetNewAddressResponse> getNewAddress($pb.ClientContext? ctx, GetNewAddressRequest request) =>
-      _client.invoke<GetNewAddressResponse>(ctx, 'BitAssetsService', 'GetNewAddress', request, GetNewAddressResponse());
+    _client.invoke<GetNewAddressResponse>(ctx, 'BitAssetsService', 'GetNewAddress', request, GetNewAddressResponse())
+  ;
   $async.Future<WithdrawResponse> withdraw($pb.ClientContext? ctx, WithdrawRequest request) =>
-      _client.invoke<WithdrawResponse>(ctx, 'BitAssetsService', 'Withdraw', request, WithdrawResponse());
+    _client.invoke<WithdrawResponse>(ctx, 'BitAssetsService', 'Withdraw', request, WithdrawResponse())
+  ;
   $async.Future<TransferResponse> transfer($pb.ClientContext? ctx, TransferRequest request) =>
-      _client.invoke<TransferResponse>(ctx, 'BitAssetsService', 'Transfer', request, TransferResponse());
-  $async.Future<GetSidechainWealthResponse> getSidechainWealth(
-          $pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
-      _client.invoke<GetSidechainWealthResponse>(
-          ctx, 'BitAssetsService', 'GetSidechainWealth', request, GetSidechainWealthResponse());
+    _client.invoke<TransferResponse>(ctx, 'BitAssetsService', 'Transfer', request, TransferResponse())
+  ;
+  $async.Future<GetSidechainWealthResponse> getSidechainWealth($pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
+    _client.invoke<GetSidechainWealthResponse>(ctx, 'BitAssetsService', 'GetSidechainWealth', request, GetSidechainWealthResponse())
+  ;
   $async.Future<CreateDepositResponse> createDeposit($pb.ClientContext? ctx, CreateDepositRequest request) =>
-      _client.invoke<CreateDepositResponse>(ctx, 'BitAssetsService', 'CreateDeposit', request, CreateDepositResponse());
-  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-          $pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
-      _client.invoke<GetPendingWithdrawalBundleResponse>(
-          ctx, 'BitAssetsService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse());
+    _client.invoke<CreateDepositResponse>(ctx, 'BitAssetsService', 'CreateDeposit', request, CreateDepositResponse())
+  ;
+  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
+    _client.invoke<GetPendingWithdrawalBundleResponse>(ctx, 'BitAssetsService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse())
+  ;
   $async.Future<ConnectPeerResponse> connectPeer($pb.ClientContext? ctx, ConnectPeerRequest request) =>
-      _client.invoke<ConnectPeerResponse>(ctx, 'BitAssetsService', 'ConnectPeer', request, ConnectPeerResponse());
+    _client.invoke<ConnectPeerResponse>(ctx, 'BitAssetsService', 'ConnectPeer', request, ConnectPeerResponse())
+  ;
   $async.Future<ForgetPeerResponse> forgetPeer($pb.ClientContext? ctx, ForgetPeerRequest request) =>
-      _client.invoke<ForgetPeerResponse>(ctx, 'BitAssetsService', 'ForgetPeer', request, ForgetPeerResponse());
+    _client.invoke<ForgetPeerResponse>(ctx, 'BitAssetsService', 'ForgetPeer', request, ForgetPeerResponse())
+  ;
   $async.Future<ListPeersResponse> listPeers($pb.ClientContext? ctx, ListPeersRequest request) =>
-      _client.invoke<ListPeersResponse>(ctx, 'BitAssetsService', 'ListPeers', request, ListPeersResponse());
+    _client.invoke<ListPeersResponse>(ctx, 'BitAssetsService', 'ListPeers', request, ListPeersResponse())
+  ;
   $async.Future<MineResponse> mine($pb.ClientContext? ctx, MineRequest request) =>
-      _client.invoke<MineResponse>(ctx, 'BitAssetsService', 'Mine', request, MineResponse());
+    _client.invoke<MineResponse>(ctx, 'BitAssetsService', 'Mine', request, MineResponse())
+  ;
   $async.Future<GetBlockResponse> getBlock($pb.ClientContext? ctx, GetBlockRequest request) =>
-      _client.invoke<GetBlockResponse>(ctx, 'BitAssetsService', 'GetBlock', request, GetBlockResponse());
-  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-          $pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
-      _client.invoke<GetBestMainchainBlockHashResponse>(
-          ctx, 'BitAssetsService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse());
-  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-          $pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
-      _client.invoke<GetBestSidechainBlockHashResponse>(
-          ctx, 'BitAssetsService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse());
+    _client.invoke<GetBlockResponse>(ctx, 'BitAssetsService', 'GetBlock', request, GetBlockResponse())
+  ;
+  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
+    _client.invoke<GetBestMainchainBlockHashResponse>(ctx, 'BitAssetsService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse())
+  ;
+  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
+    _client.invoke<GetBestSidechainBlockHashResponse>(ctx, 'BitAssetsService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse())
+  ;
   $async.Future<GetBmmInclusionsResponse> getBmmInclusions($pb.ClientContext? ctx, GetBmmInclusionsRequest request) =>
-      _client.invoke<GetBmmInclusionsResponse>(
-          ctx, 'BitAssetsService', 'GetBmmInclusions', request, GetBmmInclusionsResponse());
-  $async.Future<GetWalletUtxosResponse> getWalletUtxos($pb.ClientContext? ctx, GetWalletUtxosRequest request) => _client
-      .invoke<GetWalletUtxosResponse>(ctx, 'BitAssetsService', 'GetWalletUtxos', request, GetWalletUtxosResponse());
+    _client.invoke<GetBmmInclusionsResponse>(ctx, 'BitAssetsService', 'GetBmmInclusions', request, GetBmmInclusionsResponse())
+  ;
+  $async.Future<GetWalletUtxosResponse> getWalletUtxos($pb.ClientContext? ctx, GetWalletUtxosRequest request) =>
+    _client.invoke<GetWalletUtxosResponse>(ctx, 'BitAssetsService', 'GetWalletUtxos', request, GetWalletUtxosResponse())
+  ;
   $async.Future<ListUtxosResponse> listUtxos($pb.ClientContext? ctx, ListUtxosRequest request) =>
-      _client.invoke<ListUtxosResponse>(ctx, 'BitAssetsService', 'ListUtxos', request, ListUtxosResponse());
-  $async.Future<RemoveFromMempoolResponse> removeFromMempool(
-          $pb.ClientContext? ctx, RemoveFromMempoolRequest request) =>
-      _client.invoke<RemoveFromMempoolResponse>(
-          ctx, 'BitAssetsService', 'RemoveFromMempool', request, RemoveFromMempoolResponse());
-  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-          $pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
-      _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'BitAssetsService',
-          'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse());
+    _client.invoke<ListUtxosResponse>(ctx, 'BitAssetsService', 'ListUtxos', request, ListUtxosResponse())
+  ;
+  $async.Future<RemoveFromMempoolResponse> removeFromMempool($pb.ClientContext? ctx, RemoveFromMempoolRequest request) =>
+    _client.invoke<RemoveFromMempoolResponse>(ctx, 'BitAssetsService', 'RemoveFromMempool', request, RemoveFromMempoolResponse())
+  ;
+  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
+    _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'BitAssetsService', 'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse())
+  ;
   $async.Future<GenerateMnemonicResponse> generateMnemonic($pb.ClientContext? ctx, GenerateMnemonicRequest request) =>
-      _client.invoke<GenerateMnemonicResponse>(
-          ctx, 'BitAssetsService', 'GenerateMnemonic', request, GenerateMnemonicResponse());
-  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-          $pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
-      _client.invoke<SetSeedFromMnemonicResponse>(
-          ctx, 'BitAssetsService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse());
+    _client.invoke<GenerateMnemonicResponse>(ctx, 'BitAssetsService', 'GenerateMnemonic', request, GenerateMnemonicResponse())
+  ;
+  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
+    _client.invoke<SetSeedFromMnemonicResponse>(ctx, 'BitAssetsService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse())
+  ;
   $async.Future<CallRawResponse> callRaw($pb.ClientContext? ctx, CallRawRequest request) =>
-      _client.invoke<CallRawResponse>(ctx, 'BitAssetsService', 'CallRaw', request, CallRawResponse());
+    _client.invoke<CallRawResponse>(ctx, 'BitAssetsService', 'CallRaw', request, CallRawResponse())
+  ;
   $async.Future<GetBitAssetDataResponse> getBitAssetData($pb.ClientContext? ctx, GetBitAssetDataRequest request) =>
-      _client.invoke<GetBitAssetDataResponse>(
-          ctx, 'BitAssetsService', 'GetBitAssetData', request, GetBitAssetDataResponse());
+    _client.invoke<GetBitAssetDataResponse>(ctx, 'BitAssetsService', 'GetBitAssetData', request, GetBitAssetDataResponse())
+  ;
   $async.Future<ListBitAssetsResponse> listBitAssets($pb.ClientContext? ctx, ListBitAssetsRequest request) =>
-      _client.invoke<ListBitAssetsResponse>(ctx, 'BitAssetsService', 'ListBitAssets', request, ListBitAssetsResponse());
+    _client.invoke<ListBitAssetsResponse>(ctx, 'BitAssetsService', 'ListBitAssets', request, ListBitAssetsResponse())
+  ;
   $async.Future<RegisterBitAssetResponse> registerBitAsset($pb.ClientContext? ctx, RegisterBitAssetRequest request) =>
-      _client.invoke<RegisterBitAssetResponse>(
-          ctx, 'BitAssetsService', 'RegisterBitAsset', request, RegisterBitAssetResponse());
+    _client.invoke<RegisterBitAssetResponse>(ctx, 'BitAssetsService', 'RegisterBitAsset', request, RegisterBitAssetResponse())
+  ;
   $async.Future<ReserveBitAssetResponse> reserveBitAsset($pb.ClientContext? ctx, ReserveBitAssetRequest request) =>
-      _client.invoke<ReserveBitAssetResponse>(
-          ctx, 'BitAssetsService', 'ReserveBitAsset', request, ReserveBitAssetResponse());
+    _client.invoke<ReserveBitAssetResponse>(ctx, 'BitAssetsService', 'ReserveBitAsset', request, ReserveBitAssetResponse())
+  ;
   $async.Future<TransferBitAssetResponse> transferBitAsset($pb.ClientContext? ctx, TransferBitAssetRequest request) =>
-      _client.invoke<TransferBitAssetResponse>(
-          ctx, 'BitAssetsService', 'TransferBitAsset', request, TransferBitAssetResponse());
-  $async.Future<GetNewEncryptionKeyResponse> getNewEncryptionKey(
-          $pb.ClientContext? ctx, GetNewEncryptionKeyRequest request) =>
-      _client.invoke<GetNewEncryptionKeyResponse>(
-          ctx, 'BitAssetsService', 'GetNewEncryptionKey', request, GetNewEncryptionKeyResponse());
-  $async.Future<GetNewVerifyingKeyResponse> getNewVerifyingKey(
-          $pb.ClientContext? ctx, GetNewVerifyingKeyRequest request) =>
-      _client.invoke<GetNewVerifyingKeyResponse>(
-          ctx, 'BitAssetsService', 'GetNewVerifyingKey', request, GetNewVerifyingKeyResponse());
+    _client.invoke<TransferBitAssetResponse>(ctx, 'BitAssetsService', 'TransferBitAsset', request, TransferBitAssetResponse())
+  ;
+  $async.Future<GetNewEncryptionKeyResponse> getNewEncryptionKey($pb.ClientContext? ctx, GetNewEncryptionKeyRequest request) =>
+    _client.invoke<GetNewEncryptionKeyResponse>(ctx, 'BitAssetsService', 'GetNewEncryptionKey', request, GetNewEncryptionKeyResponse())
+  ;
+  $async.Future<GetNewVerifyingKeyResponse> getNewVerifyingKey($pb.ClientContext? ctx, GetNewVerifyingKeyRequest request) =>
+    _client.invoke<GetNewVerifyingKeyResponse>(ctx, 'BitAssetsService', 'GetNewVerifyingKey', request, GetNewVerifyingKeyResponse())
+  ;
   $async.Future<DecryptMsgResponse> decryptMsg($pb.ClientContext? ctx, DecryptMsgRequest request) =>
-      _client.invoke<DecryptMsgResponse>(ctx, 'BitAssetsService', 'DecryptMsg', request, DecryptMsgResponse());
+    _client.invoke<DecryptMsgResponse>(ctx, 'BitAssetsService', 'DecryptMsg', request, DecryptMsgResponse())
+  ;
   $async.Future<EncryptMsgResponse> encryptMsg($pb.ClientContext? ctx, EncryptMsgRequest request) =>
-      _client.invoke<EncryptMsgResponse>(ctx, 'BitAssetsService', 'EncryptMsg', request, EncryptMsgResponse());
+    _client.invoke<EncryptMsgResponse>(ctx, 'BitAssetsService', 'EncryptMsg', request, EncryptMsgResponse())
+  ;
   $async.Future<SignArbitraryMsgResponse> signArbitraryMsg($pb.ClientContext? ctx, SignArbitraryMsgRequest request) =>
-      _client.invoke<SignArbitraryMsgResponse>(
-          ctx, 'BitAssetsService', 'SignArbitraryMsg', request, SignArbitraryMsgResponse());
-  $async.Future<SignArbitraryMsgAsAddrResponse> signArbitraryMsgAsAddr(
-          $pb.ClientContext? ctx, SignArbitraryMsgAsAddrRequest request) =>
-      _client.invoke<SignArbitraryMsgAsAddrResponse>(
-          ctx, 'BitAssetsService', 'SignArbitraryMsgAsAddr', request, SignArbitraryMsgAsAddrResponse());
+    _client.invoke<SignArbitraryMsgResponse>(ctx, 'BitAssetsService', 'SignArbitraryMsg', request, SignArbitraryMsgResponse())
+  ;
+  $async.Future<SignArbitraryMsgAsAddrResponse> signArbitraryMsgAsAddr($pb.ClientContext? ctx, SignArbitraryMsgAsAddrRequest request) =>
+    _client.invoke<SignArbitraryMsgAsAddrResponse>(ctx, 'BitAssetsService', 'SignArbitraryMsgAsAddr', request, SignArbitraryMsgAsAddrResponse())
+  ;
   $async.Future<VerifySignatureResponse> verifySignature($pb.ClientContext? ctx, VerifySignatureRequest request) =>
-      _client.invoke<VerifySignatureResponse>(
-          ctx, 'BitAssetsService', 'VerifySignature', request, VerifySignatureResponse());
-  $async.Future<GetWalletAddressesResponse> getWalletAddresses(
-          $pb.ClientContext? ctx, GetWalletAddressesRequest request) =>
-      _client.invoke<GetWalletAddressesResponse>(
-          ctx, 'BitAssetsService', 'GetWalletAddresses', request, GetWalletAddressesResponse());
-  $async.Future<MyUnconfirmedUtxosResponse> myUnconfirmedUtxos(
-          $pb.ClientContext? ctx, MyUnconfirmedUtxosRequest request) =>
-      _client.invoke<MyUnconfirmedUtxosResponse>(
-          ctx, 'BitAssetsService', 'MyUnconfirmedUtxos', request, MyUnconfirmedUtxosResponse());
+    _client.invoke<VerifySignatureResponse>(ctx, 'BitAssetsService', 'VerifySignature', request, VerifySignatureResponse())
+  ;
+  $async.Future<GetWalletAddressesResponse> getWalletAddresses($pb.ClientContext? ctx, GetWalletAddressesRequest request) =>
+    _client.invoke<GetWalletAddressesResponse>(ctx, 'BitAssetsService', 'GetWalletAddresses', request, GetWalletAddressesResponse())
+  ;
+  $async.Future<MyUnconfirmedUtxosResponse> myUnconfirmedUtxos($pb.ClientContext? ctx, MyUnconfirmedUtxosRequest request) =>
+    _client.invoke<MyUnconfirmedUtxosResponse>(ctx, 'BitAssetsService', 'MyUnconfirmedUtxos', request, MyUnconfirmedUtxosResponse())
+  ;
   $async.Future<OpenapiSchemaResponse> openapiSchema($pb.ClientContext? ctx, OpenapiSchemaRequest request) =>
-      _client.invoke<OpenapiSchemaResponse>(ctx, 'BitAssetsService', 'OpenapiSchema', request, OpenapiSchemaResponse());
+    _client.invoke<OpenapiSchemaResponse>(ctx, 'BitAssetsService', 'OpenapiSchema', request, OpenapiSchemaResponse())
+  ;
   $async.Future<AmmBurnResponse> ammBurn($pb.ClientContext? ctx, AmmBurnRequest request) =>
-      _client.invoke<AmmBurnResponse>(ctx, 'BitAssetsService', 'AmmBurn', request, AmmBurnResponse());
+    _client.invoke<AmmBurnResponse>(ctx, 'BitAssetsService', 'AmmBurn', request, AmmBurnResponse())
+  ;
   $async.Future<AmmMintResponse> ammMint($pb.ClientContext? ctx, AmmMintRequest request) =>
-      _client.invoke<AmmMintResponse>(ctx, 'BitAssetsService', 'AmmMint', request, AmmMintResponse());
+    _client.invoke<AmmMintResponse>(ctx, 'BitAssetsService', 'AmmMint', request, AmmMintResponse())
+  ;
   $async.Future<AmmSwapResponse> ammSwap($pb.ClientContext? ctx, AmmSwapRequest request) =>
-      _client.invoke<AmmSwapResponse>(ctx, 'BitAssetsService', 'AmmSwap', request, AmmSwapResponse());
+    _client.invoke<AmmSwapResponse>(ctx, 'BitAssetsService', 'AmmSwap', request, AmmSwapResponse())
+  ;
   $async.Future<GetAmmPoolStateResponse> getAmmPoolState($pb.ClientContext? ctx, GetAmmPoolStateRequest request) =>
-      _client.invoke<GetAmmPoolStateResponse>(
-          ctx, 'BitAssetsService', 'GetAmmPoolState', request, GetAmmPoolStateResponse());
+    _client.invoke<GetAmmPoolStateResponse>(ctx, 'BitAssetsService', 'GetAmmPoolState', request, GetAmmPoolStateResponse())
+  ;
   $async.Future<GetAmmPriceResponse> getAmmPrice($pb.ClientContext? ctx, GetAmmPriceRequest request) =>
-      _client.invoke<GetAmmPriceResponse>(ctx, 'BitAssetsService', 'GetAmmPrice', request, GetAmmPriceResponse());
+    _client.invoke<GetAmmPriceResponse>(ctx, 'BitAssetsService', 'GetAmmPrice', request, GetAmmPriceResponse())
+  ;
   $async.Future<DutchAuctionBidResponse> dutchAuctionBid($pb.ClientContext? ctx, DutchAuctionBidRequest request) =>
-      _client.invoke<DutchAuctionBidResponse>(
-          ctx, 'BitAssetsService', 'DutchAuctionBid', request, DutchAuctionBidResponse());
-  $async.Future<DutchAuctionCollectResponse> dutchAuctionCollect(
-          $pb.ClientContext? ctx, DutchAuctionCollectRequest request) =>
-      _client.invoke<DutchAuctionCollectResponse>(
-          ctx, 'BitAssetsService', 'DutchAuctionCollect', request, DutchAuctionCollectResponse());
-  $async.Future<DutchAuctionCreateResponse> dutchAuctionCreate(
-          $pb.ClientContext? ctx, DutchAuctionCreateRequest request) =>
-      _client.invoke<DutchAuctionCreateResponse>(
-          ctx, 'BitAssetsService', 'DutchAuctionCreate', request, DutchAuctionCreateResponse());
+    _client.invoke<DutchAuctionBidResponse>(ctx, 'BitAssetsService', 'DutchAuctionBid', request, DutchAuctionBidResponse())
+  ;
+  $async.Future<DutchAuctionCollectResponse> dutchAuctionCollect($pb.ClientContext? ctx, DutchAuctionCollectRequest request) =>
+    _client.invoke<DutchAuctionCollectResponse>(ctx, 'BitAssetsService', 'DutchAuctionCollect', request, DutchAuctionCollectResponse())
+  ;
+  $async.Future<DutchAuctionCreateResponse> dutchAuctionCreate($pb.ClientContext? ctx, DutchAuctionCreateRequest request) =>
+    _client.invoke<DutchAuctionCreateResponse>(ctx, 'BitAssetsService', 'DutchAuctionCreate', request, DutchAuctionCreateResponse())
+  ;
   $async.Future<DutchAuctionsResponse> dutchAuctions($pb.ClientContext? ctx, DutchAuctionsRequest request) =>
-      _client.invoke<DutchAuctionsResponse>(ctx, 'BitAssetsService', 'DutchAuctions', request, DutchAuctionsResponse());
+    _client.invoke<DutchAuctionsResponse>(ctx, 'BitAssetsService', 'DutchAuctions', request, DutchAuctionsResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/bitassets/v1/bitassets.pbenum.dart
+++ b/sail_ui/lib/gen/bitassets/v1/bitassets.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/bitassets/v1/bitassets.pbjson.dart
+++ b/sail_ui/lib/gen/bitassets/v1/bitassets.pbjson.dart
@@ -19,7 +19,8 @@ const GetBalanceRequest$json = {
 };
 
 /// Descriptor for `GetBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode('ChFHZXRCYWxhbmNlUmVxdWVzdA==');
+final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode(
+    'ChFHZXRCYWxhbmNlUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBalanceResponseDescriptor instead')
 const GetBalanceResponse$json = {
@@ -31,9 +32,9 @@ const GetBalanceResponse$json = {
 };
 
 /// Descriptor for `GetBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceResponseDescriptor =
-    $convert.base64Decode('ChJHZXRCYWxhbmNlUmVzcG9uc2USHQoKdG90YWxfc2F0cxgBIAEoA1IJdG90YWxTYXRzEiUKDm'
-        'F2YWlsYWJsZV9zYXRzGAIgASgDUg1hdmFpbGFibGVTYXRz');
+final $typed_data.Uint8List getBalanceResponseDescriptor = $convert.base64Decode(
+    'ChJHZXRCYWxhbmNlUmVzcG9uc2USHQoKdG90YWxfc2F0cxgBIAEoA1IJdG90YWxTYXRzEiUKDm'
+    'F2YWlsYWJsZV9zYXRzGAIgASgDUg1hdmFpbGFibGVTYXRz');
 
 @$core.Deprecated('Use getBlockCountRequestDescriptor instead')
 const GetBlockCountRequest$json = {
@@ -41,7 +42,8 @@ const GetBlockCountRequest$json = {
 };
 
 /// Descriptor for `GetBlockCountRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode('ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
+final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
 
 @$core.Deprecated('Use getBlockCountResponseDescriptor instead')
 const GetBlockCountResponse$json = {
@@ -52,8 +54,8 @@ const GetBlockCountResponse$json = {
 };
 
 /// Descriptor for `GetBlockCountResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountResponseDescriptor =
-    $convert.base64Decode('ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
+final $typed_data.Uint8List getBlockCountResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
 
 @$core.Deprecated('Use stopRequestDescriptor instead')
 const StopRequest$json = {
@@ -61,7 +63,8 @@ const StopRequest$json = {
 };
 
 /// Descriptor for `StopRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode('CgtTdG9wUmVxdWVzdA==');
+final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode(
+    'CgtTdG9wUmVxdWVzdA==');
 
 @$core.Deprecated('Use stopResponseDescriptor instead')
 const StopResponse$json = {
@@ -69,7 +72,8 @@ const StopResponse$json = {
 };
 
 /// Descriptor for `StopResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode('CgxTdG9wUmVzcG9uc2U=');
+final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode(
+    'CgxTdG9wUmVzcG9uc2U=');
 
 @$core.Deprecated('Use getNewAddressRequestDescriptor instead')
 const GetNewAddressRequest$json = {
@@ -77,7 +81,8 @@ const GetNewAddressRequest$json = {
 };
 
 /// Descriptor for `GetNewAddressRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode('ChRHZXROZXdBZGRyZXNzUmVxdWVzdA==');
+final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode(
+    'ChRHZXROZXdBZGRyZXNzUmVxdWVzdA==');
 
 @$core.Deprecated('Use getNewAddressResponseDescriptor instead')
 const GetNewAddressResponse$json = {
@@ -88,8 +93,8 @@ const GetNewAddressResponse$json = {
 };
 
 /// Descriptor for `GetNewAddressResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressResponseDescriptor =
-    $convert.base64Decode('ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List getNewAddressResponseDescriptor = $convert.base64Decode(
+    'ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use withdrawRequestDescriptor instead')
 const WithdrawRequest$json = {
@@ -103,10 +108,10 @@ const WithdrawRequest$json = {
 };
 
 /// Descriptor for `WithdrawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawRequestDescriptor =
-    $convert.base64Decode('Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
-        'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
+final $typed_data.Uint8List withdrawRequestDescriptor = $convert.base64Decode(
+    'Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
+    'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
 
 @$core.Deprecated('Use withdrawResponseDescriptor instead')
 const WithdrawResponse$json = {
@@ -117,8 +122,8 @@ const WithdrawResponse$json = {
 };
 
 /// Descriptor for `WithdrawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawResponseDescriptor =
-    $convert.base64Decode('ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List withdrawResponseDescriptor = $convert.base64Decode(
+    'ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use transferRequestDescriptor instead')
 const TransferRequest$json = {
@@ -135,10 +140,10 @@ const TransferRequest$json = {
 };
 
 /// Descriptor for `TransferRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferRequestDescriptor =
-    $convert.base64Decode('Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cxIXCgRtZW1v'
-        'GAQgASgJSABSBG1lbW+IAQFCBwoFX21lbW8=');
+final $typed_data.Uint8List transferRequestDescriptor = $convert.base64Decode(
+    'Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cxIXCgRtZW1v'
+    'GAQgASgJSABSBG1lbW+IAQFCBwoFX21lbW8=');
 
 @$core.Deprecated('Use transferResponseDescriptor instead')
 const TransferResponse$json = {
@@ -149,8 +154,8 @@ const TransferResponse$json = {
 };
 
 /// Descriptor for `TransferResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferResponseDescriptor =
-    $convert.base64Decode('ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List transferResponseDescriptor = $convert.base64Decode(
+    'ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use getSidechainWealthRequestDescriptor instead')
 const GetSidechainWealthRequest$json = {
@@ -158,8 +163,8 @@ const GetSidechainWealthRequest$json = {
 };
 
 /// Descriptor for `GetSidechainWealthRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthRequestDescriptor =
-    $convert.base64Decode('ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
+final $typed_data.Uint8List getSidechainWealthRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
 
 @$core.Deprecated('Use getSidechainWealthResponseDescriptor instead')
 const GetSidechainWealthResponse$json = {
@@ -170,8 +175,8 @@ const GetSidechainWealthResponse$json = {
 };
 
 /// Descriptor for `GetSidechainWealthResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthResponseDescriptor =
-    $convert.base64Decode('ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
+final $typed_data.Uint8List getSidechainWealthResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
 
 @$core.Deprecated('Use createDepositRequestDescriptor instead')
 const CreateDepositRequest$json = {
@@ -184,9 +189,9 @@ const CreateDepositRequest$json = {
 };
 
 /// Descriptor for `CreateDepositRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositRequestDescriptor =
-    $convert.base64Decode('ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
-        'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List createDepositRequestDescriptor = $convert.base64Decode(
+    'ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
+    'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use createDepositResponseDescriptor instead')
 const CreateDepositResponse$json = {
@@ -197,8 +202,8 @@ const CreateDepositResponse$json = {
 };
 
 /// Descriptor for `CreateDepositResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositResponseDescriptor =
-    $convert.base64Decode('ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List createDepositResponseDescriptor = $convert.base64Decode(
+    'ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleRequestDescriptor instead')
 const GetPendingWithdrawalBundleRequest$json = {
@@ -206,8 +211,8 @@ const GetPendingWithdrawalBundleRequest$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor =
-    $convert.base64Decode('CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
+final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor = $convert.base64Decode(
+    'CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleResponseDescriptor instead')
 const GetPendingWithdrawalBundleResponse$json = {
@@ -218,9 +223,9 @@ const GetPendingWithdrawalBundleResponse$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor =
-    $convert.base64Decode('CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
-        'gJUgpidW5kbGVKc29u');
+final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor = $convert.base64Decode(
+    'CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
+    'gJUgpidW5kbGVKc29u');
 
 @$core.Deprecated('Use connectPeerRequestDescriptor instead')
 const ConnectPeerRequest$json = {
@@ -231,8 +236,8 @@ const ConnectPeerRequest$json = {
 };
 
 /// Descriptor for `ConnectPeerRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerRequestDescriptor =
-    $convert.base64Decode('ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List connectPeerRequestDescriptor = $convert.base64Decode(
+    'ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use connectPeerResponseDescriptor instead')
 const ConnectPeerResponse$json = {
@@ -240,7 +245,8 @@ const ConnectPeerResponse$json = {
 };
 
 /// Descriptor for `ConnectPeerResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode('ChNDb25uZWN0UGVlclJlc3BvbnNl');
+final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode(
+    'ChNDb25uZWN0UGVlclJlc3BvbnNl');
 
 @$core.Deprecated('Use forgetPeerRequestDescriptor instead')
 const ForgetPeerRequest$json = {
@@ -251,8 +257,8 @@ const ForgetPeerRequest$json = {
 };
 
 /// Descriptor for `ForgetPeerRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List forgetPeerRequestDescriptor =
-    $convert.base64Decode('ChFGb3JnZXRQZWVyUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNz');
+final $typed_data.Uint8List forgetPeerRequestDescriptor = $convert.base64Decode(
+    'ChFGb3JnZXRQZWVyUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNz');
 
 @$core.Deprecated('Use forgetPeerResponseDescriptor instead')
 const ForgetPeerResponse$json = {
@@ -260,7 +266,8 @@ const ForgetPeerResponse$json = {
 };
 
 /// Descriptor for `ForgetPeerResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List forgetPeerResponseDescriptor = $convert.base64Decode('ChJGb3JnZXRQZWVyUmVzcG9uc2U=');
+final $typed_data.Uint8List forgetPeerResponseDescriptor = $convert.base64Decode(
+    'ChJGb3JnZXRQZWVyUmVzcG9uc2U=');
 
 @$core.Deprecated('Use listPeersRequestDescriptor instead')
 const ListPeersRequest$json = {
@@ -268,7 +275,8 @@ const ListPeersRequest$json = {
 };
 
 /// Descriptor for `ListPeersRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode('ChBMaXN0UGVlcnNSZXF1ZXN0');
+final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0UGVlcnNSZXF1ZXN0');
 
 @$core.Deprecated('Use listPeersResponseDescriptor instead')
 const ListPeersResponse$json = {
@@ -279,8 +287,8 @@ const ListPeersResponse$json = {
 };
 
 /// Descriptor for `ListPeersResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
+final $typed_data.Uint8List listPeersResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
 
 @$core.Deprecated('Use mineRequestDescriptor instead')
 const MineRequest$json = {
@@ -291,8 +299,8 @@ const MineRequest$json = {
 };
 
 /// Descriptor for `MineRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineRequestDescriptor =
-    $convert.base64Decode('CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List mineRequestDescriptor = $convert.base64Decode(
+    'CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use mineResponseDescriptor instead')
 const MineResponse$json = {
@@ -303,8 +311,8 @@ const MineResponse$json = {
 };
 
 /// Descriptor for `MineResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineResponseDescriptor =
-    $convert.base64Decode('CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
+final $typed_data.Uint8List mineResponseDescriptor = $convert.base64Decode(
+    'CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
 
 @$core.Deprecated('Use getBlockRequestDescriptor instead')
 const GetBlockRequest$json = {
@@ -315,8 +323,8 @@ const GetBlockRequest$json = {
 };
 
 /// Descriptor for `GetBlockRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockRequestDescriptor =
-    $convert.base64Decode('Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
+final $typed_data.Uint8List getBlockRequestDescriptor = $convert.base64Decode(
+    'Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
 
 @$core.Deprecated('Use getBlockResponseDescriptor instead')
 const GetBlockResponse$json = {
@@ -327,8 +335,8 @@ const GetBlockResponse$json = {
 };
 
 /// Descriptor for `GetBlockResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockResponseDescriptor =
-    $convert.base64Decode('ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
+final $typed_data.Uint8List getBlockResponseDescriptor = $convert.base64Decode(
+    'ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashRequestDescriptor instead')
 const GetBestMainchainBlockHashRequest$json = {
@@ -336,8 +344,8 @@ const GetBestMainchainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashResponseDescriptor instead')
 const GetBestMainchainBlockHashResponse$json = {
@@ -348,9 +356,9 @@ const GetBestMainchainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashRequestDescriptor instead')
 const GetBestSidechainBlockHashRequest$json = {
@@ -358,8 +366,8 @@ const GetBestSidechainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashResponseDescriptor instead')
 const GetBestSidechainBlockHashResponse$json = {
@@ -370,9 +378,9 @@ const GetBestSidechainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBmmInclusionsRequestDescriptor instead')
 const GetBmmInclusionsRequest$json = {
@@ -383,9 +391,9 @@ const GetBmmInclusionsRequest$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsRequestDescriptor =
-    $convert.base64Decode('ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
-        'g=');
+final $typed_data.Uint8List getBmmInclusionsRequestDescriptor = $convert.base64Decode(
+    'ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
+    'g=');
 
 @$core.Deprecated('Use getBmmInclusionsResponseDescriptor instead')
 const GetBmmInclusionsResponse$json = {
@@ -396,9 +404,9 @@ const GetBmmInclusionsResponse$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsResponseDescriptor =
-    $convert.base64Decode('ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
-        '9ucw==');
+final $typed_data.Uint8List getBmmInclusionsResponseDescriptor = $convert.base64Decode(
+    'ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
+    '9ucw==');
 
 @$core.Deprecated('Use getWalletUtxosRequestDescriptor instead')
 const GetWalletUtxosRequest$json = {
@@ -406,7 +414,8 @@ const GetWalletUtxosRequest$json = {
 };
 
 /// Descriptor for `GetWalletUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode('ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
+final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode(
+    'ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getWalletUtxosResponseDescriptor instead')
 const GetWalletUtxosResponse$json = {
@@ -417,9 +426,9 @@ const GetWalletUtxosResponse$json = {
 };
 
 /// Descriptor for `GetWalletUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosResponseDescriptor =
-    $convert.base64Decode('ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
-        '==');
+final $typed_data.Uint8List getWalletUtxosResponseDescriptor = $convert.base64Decode(
+    'ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
+    '==');
 
 @$core.Deprecated('Use listUtxosRequestDescriptor instead')
 const ListUtxosRequest$json = {
@@ -427,7 +436,8 @@ const ListUtxosRequest$json = {
 };
 
 /// Descriptor for `ListUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode('ChBMaXN0VXR4b3NSZXF1ZXN0');
+final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0VXR4b3NSZXF1ZXN0');
 
 @$core.Deprecated('Use listUtxosResponseDescriptor instead')
 const ListUtxosResponse$json = {
@@ -438,8 +448,8 @@ const ListUtxosResponse$json = {
 };
 
 /// Descriptor for `ListUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
+final $typed_data.Uint8List listUtxosResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
 
 @$core.Deprecated('Use removeFromMempoolRequestDescriptor instead')
 const RemoveFromMempoolRequest$json = {
@@ -450,8 +460,8 @@ const RemoveFromMempoolRequest$json = {
 };
 
 /// Descriptor for `RemoveFromMempoolRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFromMempoolRequestDescriptor =
-    $convert.base64Decode('ChhSZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List removeFromMempoolRequestDescriptor = $convert.base64Decode(
+    'ChhSZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use removeFromMempoolResponseDescriptor instead')
 const RemoveFromMempoolResponse$json = {
@@ -459,8 +469,8 @@ const RemoveFromMempoolResponse$json = {
 };
 
 /// Descriptor for `RemoveFromMempoolResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFromMempoolResponseDescriptor =
-    $convert.base64Decode('ChlSZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNl');
+final $typed_data.Uint8List removeFromMempoolResponseDescriptor = $convert.base64Decode(
+    'ChlSZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNl');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightRequestDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightRequest$json = {
@@ -468,8 +478,8 @@ const GetLatestFailedWithdrawalBundleHeightRequest$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor =
-    $convert.base64Decode('CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor = $convert.base64Decode(
+    'CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightResponseDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightResponse$json = {
@@ -480,9 +490,9 @@ const GetLatestFailedWithdrawalBundleHeightResponse$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor =
-    $convert.base64Decode('Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
-        'h0GAEgASgDUgZoZWlnaHQ=');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor = $convert.base64Decode(
+    'Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
+    'h0GAEgASgDUgZoZWlnaHQ=');
 
 @$core.Deprecated('Use generateMnemonicRequestDescriptor instead')
 const GenerateMnemonicRequest$json = {
@@ -490,8 +500,8 @@ const GenerateMnemonicRequest$json = {
 };
 
 /// Descriptor for `GenerateMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicRequestDescriptor =
-    $convert.base64Decode('ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
+final $typed_data.Uint8List generateMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
 
 @$core.Deprecated('Use generateMnemonicResponseDescriptor instead')
 const GenerateMnemonicResponse$json = {
@@ -502,8 +512,8 @@ const GenerateMnemonicResponse$json = {
 };
 
 /// Descriptor for `GenerateMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicResponseDescriptor =
-    $convert.base64Decode('ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
+final $typed_data.Uint8List generateMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
 
 @$core.Deprecated('Use setSeedFromMnemonicRequestDescriptor instead')
 const SetSeedFromMnemonicRequest$json = {
@@ -514,9 +524,9 @@ const SetSeedFromMnemonicRequest$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor =
-    $convert.base64Decode('ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
-        'M=');
+final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
+    'M=');
 
 @$core.Deprecated('Use setSeedFromMnemonicResponseDescriptor instead')
 const SetSeedFromMnemonicResponse$json = {
@@ -524,8 +534,8 @@ const SetSeedFromMnemonicResponse$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor =
-    $convert.base64Decode('ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
+final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
 
 @$core.Deprecated('Use callRawRequestDescriptor instead')
 const CallRawRequest$json = {
@@ -537,9 +547,9 @@ const CallRawRequest$json = {
 };
 
 /// Descriptor for `CallRawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawRequestDescriptor =
-    $convert.base64Decode('Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
-        'gCIAEoCVIKcGFyYW1zSnNvbg==');
+final $typed_data.Uint8List callRawRequestDescriptor = $convert.base64Decode(
+    'Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
+    'gCIAEoCVIKcGFyYW1zSnNvbg==');
 
 @$core.Deprecated('Use callRawResponseDescriptor instead')
 const CallRawResponse$json = {
@@ -550,8 +560,8 @@ const CallRawResponse$json = {
 };
 
 /// Descriptor for `CallRawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawResponseDescriptor =
-    $convert.base64Decode('Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
+final $typed_data.Uint8List callRawResponseDescriptor = $convert.base64Decode(
+    'Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
 
 @$core.Deprecated('Use getBitAssetDataRequestDescriptor instead')
 const GetBitAssetDataRequest$json = {
@@ -562,8 +572,8 @@ const GetBitAssetDataRequest$json = {
 };
 
 /// Descriptor for `GetBitAssetDataRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBitAssetDataRequestDescriptor =
-    $convert.base64Decode('ChZHZXRCaXRBc3NldERhdGFSZXF1ZXN0EhkKCGFzc2V0X2lkGAEgASgJUgdhc3NldElk');
+final $typed_data.Uint8List getBitAssetDataRequestDescriptor = $convert.base64Decode(
+    'ChZHZXRCaXRBc3NldERhdGFSZXF1ZXN0EhkKCGFzc2V0X2lkGAEgASgJUgdhc3NldElk');
 
 @$core.Deprecated('Use getBitAssetDataResponseDescriptor instead')
 const GetBitAssetDataResponse$json = {
@@ -574,8 +584,8 @@ const GetBitAssetDataResponse$json = {
 };
 
 /// Descriptor for `GetBitAssetDataResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBitAssetDataResponseDescriptor =
-    $convert.base64Decode('ChdHZXRCaXRBc3NldERhdGFSZXNwb25zZRIbCglkYXRhX2pzb24YASABKAlSCGRhdGFKc29u');
+final $typed_data.Uint8List getBitAssetDataResponseDescriptor = $convert.base64Decode(
+    'ChdHZXRCaXRBc3NldERhdGFSZXNwb25zZRIbCglkYXRhX2pzb24YASABKAlSCGRhdGFKc29u');
 
 @$core.Deprecated('Use listBitAssetsRequestDescriptor instead')
 const ListBitAssetsRequest$json = {
@@ -583,7 +593,8 @@ const ListBitAssetsRequest$json = {
 };
 
 /// Descriptor for `ListBitAssetsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listBitAssetsRequestDescriptor = $convert.base64Decode('ChRMaXN0Qml0QXNzZXRzUmVxdWVzdA==');
+final $typed_data.Uint8List listBitAssetsRequestDescriptor = $convert.base64Decode(
+    'ChRMaXN0Qml0QXNzZXRzUmVxdWVzdA==');
 
 @$core.Deprecated('Use listBitAssetsResponseDescriptor instead')
 const ListBitAssetsResponse$json = {
@@ -594,9 +605,9 @@ const ListBitAssetsResponse$json = {
 };
 
 /// Descriptor for `ListBitAssetsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listBitAssetsResponseDescriptor =
-    $convert.base64Decode('ChVMaXN0Qml0QXNzZXRzUmVzcG9uc2USJQoOYml0YXNzZXRzX2pzb24YASABKAlSDWJpdGFzc2'
-        'V0c0pzb24=');
+final $typed_data.Uint8List listBitAssetsResponseDescriptor = $convert.base64Decode(
+    'ChVMaXN0Qml0QXNzZXRzUmVzcG9uc2USJQoOYml0YXNzZXRzX2pzb24YASABKAlSDWJpdGFzc2'
+    'V0c0pzb24=');
 
 @$core.Deprecated('Use registerBitAssetRequestDescriptor instead')
 const RegisterBitAssetRequest$json = {
@@ -609,10 +620,10 @@ const RegisterBitAssetRequest$json = {
 };
 
 /// Descriptor for `RegisterBitAssetRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerBitAssetRequestDescriptor =
-    $convert.base64Decode('ChdSZWdpc3RlckJpdEFzc2V0UmVxdWVzdBIlCg5wbGFpbnRleHRfbmFtZRgBIAEoCVINcGxhaW'
-        '50ZXh0TmFtZRIlCg5pbml0aWFsX3N1cHBseRgCIAEoA1INaW5pdGlhbFN1cHBseRIbCglkYXRh'
-        'X2pzb24YAyABKAlSCGRhdGFKc29u');
+final $typed_data.Uint8List registerBitAssetRequestDescriptor = $convert.base64Decode(
+    'ChdSZWdpc3RlckJpdEFzc2V0UmVxdWVzdBIlCg5wbGFpbnRleHRfbmFtZRgBIAEoCVINcGxhaW'
+    '50ZXh0TmFtZRIlCg5pbml0aWFsX3N1cHBseRgCIAEoA1INaW5pdGlhbFN1cHBseRIbCglkYXRh'
+    'X2pzb24YAyABKAlSCGRhdGFKc29u');
 
 @$core.Deprecated('Use registerBitAssetResponseDescriptor instead')
 const RegisterBitAssetResponse$json = {
@@ -623,8 +634,8 @@ const RegisterBitAssetResponse$json = {
 };
 
 /// Descriptor for `RegisterBitAssetResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerBitAssetResponseDescriptor =
-    $convert.base64Decode('ChhSZWdpc3RlckJpdEFzc2V0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List registerBitAssetResponseDescriptor = $convert.base64Decode(
+    'ChhSZWdpc3RlckJpdEFzc2V0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use reserveBitAssetRequestDescriptor instead')
 const ReserveBitAssetRequest$json = {
@@ -635,8 +646,8 @@ const ReserveBitAssetRequest$json = {
 };
 
 /// Descriptor for `ReserveBitAssetRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reserveBitAssetRequestDescriptor =
-    $convert.base64Decode('ChZSZXNlcnZlQml0QXNzZXRSZXF1ZXN0EhIKBG5hbWUYASABKAlSBG5hbWU=');
+final $typed_data.Uint8List reserveBitAssetRequestDescriptor = $convert.base64Decode(
+    'ChZSZXNlcnZlQml0QXNzZXRSZXF1ZXN0EhIKBG5hbWUYASABKAlSBG5hbWU=');
 
 @$core.Deprecated('Use reserveBitAssetResponseDescriptor instead')
 const ReserveBitAssetResponse$json = {
@@ -647,8 +658,8 @@ const ReserveBitAssetResponse$json = {
 };
 
 /// Descriptor for `ReserveBitAssetResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reserveBitAssetResponseDescriptor =
-    $convert.base64Decode('ChdSZXNlcnZlQml0QXNzZXRSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
+final $typed_data.Uint8List reserveBitAssetResponseDescriptor = $convert.base64Decode(
+    'ChdSZXNlcnZlQml0QXNzZXRSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
 
 @$core.Deprecated('Use transferBitAssetRequestDescriptor instead')
 const TransferBitAssetRequest$json = {
@@ -662,10 +673,10 @@ const TransferBitAssetRequest$json = {
 };
 
 /// Descriptor for `TransferBitAssetRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferBitAssetRequestDescriptor =
-    $convert.base64Decode('ChdUcmFuc2ZlckJpdEFzc2V0UmVxdWVzdBIZCghhc3NldF9pZBgBIAEoCVIHYXNzZXRJZBISCg'
-        'RkZXN0GAIgASgJUgRkZXN0EhYKBmFtb3VudBgDIAEoA1IGYW1vdW50EhkKCGZlZV9zYXRzGAQg'
-        'ASgDUgdmZWVTYXRz');
+final $typed_data.Uint8List transferBitAssetRequestDescriptor = $convert.base64Decode(
+    'ChdUcmFuc2ZlckJpdEFzc2V0UmVxdWVzdBIZCghhc3NldF9pZBgBIAEoCVIHYXNzZXRJZBISCg'
+    'RkZXN0GAIgASgJUgRkZXN0EhYKBmFtb3VudBgDIAEoA1IGYW1vdW50EhkKCGZlZV9zYXRzGAQg'
+    'ASgDUgdmZWVTYXRz');
 
 @$core.Deprecated('Use transferBitAssetResponseDescriptor instead')
 const TransferBitAssetResponse$json = {
@@ -676,8 +687,8 @@ const TransferBitAssetResponse$json = {
 };
 
 /// Descriptor for `TransferBitAssetResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferBitAssetResponseDescriptor =
-    $convert.base64Decode('ChhUcmFuc2ZlckJpdEFzc2V0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List transferBitAssetResponseDescriptor = $convert.base64Decode(
+    'ChhUcmFuc2ZlckJpdEFzc2V0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use getNewEncryptionKeyRequestDescriptor instead')
 const GetNewEncryptionKeyRequest$json = {
@@ -685,8 +696,8 @@ const GetNewEncryptionKeyRequest$json = {
 };
 
 /// Descriptor for `GetNewEncryptionKeyRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewEncryptionKeyRequestDescriptor =
-    $convert.base64Decode('ChpHZXROZXdFbmNyeXB0aW9uS2V5UmVxdWVzdA==');
+final $typed_data.Uint8List getNewEncryptionKeyRequestDescriptor = $convert.base64Decode(
+    'ChpHZXROZXdFbmNyeXB0aW9uS2V5UmVxdWVzdA==');
 
 @$core.Deprecated('Use getNewEncryptionKeyResponseDescriptor instead')
 const GetNewEncryptionKeyResponse$json = {
@@ -697,8 +708,8 @@ const GetNewEncryptionKeyResponse$json = {
 };
 
 /// Descriptor for `GetNewEncryptionKeyResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewEncryptionKeyResponseDescriptor =
-    $convert.base64Decode('ChtHZXROZXdFbmNyeXB0aW9uS2V5UmVzcG9uc2USEAoDa2V5GAEgASgJUgNrZXk=');
+final $typed_data.Uint8List getNewEncryptionKeyResponseDescriptor = $convert.base64Decode(
+    'ChtHZXROZXdFbmNyeXB0aW9uS2V5UmVzcG9uc2USEAoDa2V5GAEgASgJUgNrZXk=');
 
 @$core.Deprecated('Use getNewVerifyingKeyRequestDescriptor instead')
 const GetNewVerifyingKeyRequest$json = {
@@ -706,8 +717,8 @@ const GetNewVerifyingKeyRequest$json = {
 };
 
 /// Descriptor for `GetNewVerifyingKeyRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewVerifyingKeyRequestDescriptor =
-    $convert.base64Decode('ChlHZXROZXdWZXJpZnlpbmdLZXlSZXF1ZXN0');
+final $typed_data.Uint8List getNewVerifyingKeyRequestDescriptor = $convert.base64Decode(
+    'ChlHZXROZXdWZXJpZnlpbmdLZXlSZXF1ZXN0');
 
 @$core.Deprecated('Use getNewVerifyingKeyResponseDescriptor instead')
 const GetNewVerifyingKeyResponse$json = {
@@ -718,8 +729,8 @@ const GetNewVerifyingKeyResponse$json = {
 };
 
 /// Descriptor for `GetNewVerifyingKeyResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewVerifyingKeyResponseDescriptor =
-    $convert.base64Decode('ChpHZXROZXdWZXJpZnlpbmdLZXlSZXNwb25zZRIQCgNrZXkYASABKAlSA2tleQ==');
+final $typed_data.Uint8List getNewVerifyingKeyResponseDescriptor = $convert.base64Decode(
+    'ChpHZXROZXdWZXJpZnlpbmdLZXlSZXNwb25zZRIQCgNrZXkYASABKAlSA2tleQ==');
 
 @$core.Deprecated('Use decryptMsgRequestDescriptor instead')
 const DecryptMsgRequest$json = {
@@ -731,9 +742,9 @@ const DecryptMsgRequest$json = {
 };
 
 /// Descriptor for `DecryptMsgRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List decryptMsgRequestDescriptor =
-    $convert.base64Decode('ChFEZWNyeXB0TXNnUmVxdWVzdBIeCgpjaXBoZXJ0ZXh0GAEgASgJUgpjaXBoZXJ0ZXh0EisKEW'
-        'VuY3J5cHRpb25fcHVia2V5GAIgASgJUhBlbmNyeXB0aW9uUHVia2V5');
+final $typed_data.Uint8List decryptMsgRequestDescriptor = $convert.base64Decode(
+    'ChFEZWNyeXB0TXNnUmVxdWVzdBIeCgpjaXBoZXJ0ZXh0GAEgASgJUgpjaXBoZXJ0ZXh0EisKEW'
+    'VuY3J5cHRpb25fcHVia2V5GAIgASgJUhBlbmNyeXB0aW9uUHVia2V5');
 
 @$core.Deprecated('Use decryptMsgResponseDescriptor instead')
 const DecryptMsgResponse$json = {
@@ -744,8 +755,8 @@ const DecryptMsgResponse$json = {
 };
 
 /// Descriptor for `DecryptMsgResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List decryptMsgResponseDescriptor =
-    $convert.base64Decode('ChJEZWNyeXB0TXNnUmVzcG9uc2USHAoJcGxhaW50ZXh0GAEgASgJUglwbGFpbnRleHQ=');
+final $typed_data.Uint8List decryptMsgResponseDescriptor = $convert.base64Decode(
+    'ChJEZWNyeXB0TXNnUmVzcG9uc2USHAoJcGxhaW50ZXh0GAEgASgJUglwbGFpbnRleHQ=');
 
 @$core.Deprecated('Use encryptMsgRequestDescriptor instead')
 const EncryptMsgRequest$json = {
@@ -757,9 +768,9 @@ const EncryptMsgRequest$json = {
 };
 
 /// Descriptor for `EncryptMsgRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List encryptMsgRequestDescriptor =
-    $convert.base64Decode('ChFFbmNyeXB0TXNnUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIrChFlbmNyeXB0aW9uX3B1Ym'
-        'tleRgCIAEoCVIQZW5jcnlwdGlvblB1YmtleQ==');
+final $typed_data.Uint8List encryptMsgRequestDescriptor = $convert.base64Decode(
+    'ChFFbmNyeXB0TXNnUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIrChFlbmNyeXB0aW9uX3B1Ym'
+    'tleRgCIAEoCVIQZW5jcnlwdGlvblB1YmtleQ==');
 
 @$core.Deprecated('Use encryptMsgResponseDescriptor instead')
 const EncryptMsgResponse$json = {
@@ -770,8 +781,8 @@ const EncryptMsgResponse$json = {
 };
 
 /// Descriptor for `EncryptMsgResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List encryptMsgResponseDescriptor =
-    $convert.base64Decode('ChJFbmNyeXB0TXNnUmVzcG9uc2USHgoKY2lwaGVydGV4dBgBIAEoCVIKY2lwaGVydGV4dA==');
+final $typed_data.Uint8List encryptMsgResponseDescriptor = $convert.base64Decode(
+    'ChJFbmNyeXB0TXNnUmVzcG9uc2USHgoKY2lwaGVydGV4dBgBIAEoCVIKY2lwaGVydGV4dA==');
 
 @$core.Deprecated('Use signArbitraryMsgRequestDescriptor instead')
 const SignArbitraryMsgRequest$json = {
@@ -783,9 +794,9 @@ const SignArbitraryMsgRequest$json = {
 };
 
 /// Descriptor for `SignArbitraryMsgRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signArbitraryMsgRequestDescriptor =
-    $convert.base64Decode('ChdTaWduQXJiaXRyYXJ5TXNnUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIjCg12ZXJpZnlpbm'
-        'dfa2V5GAIgASgJUgx2ZXJpZnlpbmdLZXk=');
+final $typed_data.Uint8List signArbitraryMsgRequestDescriptor = $convert.base64Decode(
+    'ChdTaWduQXJiaXRyYXJ5TXNnUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIjCg12ZXJpZnlpbm'
+    'dfa2V5GAIgASgJUgx2ZXJpZnlpbmdLZXk=');
 
 @$core.Deprecated('Use signArbitraryMsgResponseDescriptor instead')
 const SignArbitraryMsgResponse$json = {
@@ -796,9 +807,9 @@ const SignArbitraryMsgResponse$json = {
 };
 
 /// Descriptor for `SignArbitraryMsgResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signArbitraryMsgResponseDescriptor =
-    $convert.base64Decode('ChhTaWduQXJiaXRyYXJ5TXNnUmVzcG9uc2USHAoJc2lnbmF0dXJlGAEgASgJUglzaWduYXR1cm'
-        'U=');
+final $typed_data.Uint8List signArbitraryMsgResponseDescriptor = $convert.base64Decode(
+    'ChhTaWduQXJiaXRyYXJ5TXNnUmVzcG9uc2USHAoJc2lnbmF0dXJlGAEgASgJUglzaWduYXR1cm'
+    'U=');
 
 @$core.Deprecated('Use signArbitraryMsgAsAddrRequestDescriptor instead')
 const SignArbitraryMsgAsAddrRequest$json = {
@@ -810,9 +821,9 @@ const SignArbitraryMsgAsAddrRequest$json = {
 };
 
 /// Descriptor for `SignArbitraryMsgAsAddrRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signArbitraryMsgAsAddrRequestDescriptor =
-    $convert.base64Decode('Ch1TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIYCgdhZG'
-        'RyZXNzGAIgASgJUgdhZGRyZXNz');
+final $typed_data.Uint8List signArbitraryMsgAsAddrRequestDescriptor = $convert.base64Decode(
+    'Ch1TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIYCgdhZG'
+    'RyZXNzGAIgASgJUgdhZGRyZXNz');
 
 @$core.Deprecated('Use signArbitraryMsgAsAddrResponseDescriptor instead')
 const SignArbitraryMsgAsAddrResponse$json = {
@@ -824,9 +835,9 @@ const SignArbitraryMsgAsAddrResponse$json = {
 };
 
 /// Descriptor for `SignArbitraryMsgAsAddrResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signArbitraryMsgAsAddrResponseDescriptor =
-    $convert.base64Decode('Ch5TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVzcG9uc2USIwoNdmVyaWZ5aW5nX2tleRgBIAEoCV'
-        'IMdmVyaWZ5aW5nS2V5EhwKCXNpZ25hdHVyZRgCIAEoCVIJc2lnbmF0dXJl');
+final $typed_data.Uint8List signArbitraryMsgAsAddrResponseDescriptor = $convert.base64Decode(
+    'Ch5TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVzcG9uc2USIwoNdmVyaWZ5aW5nX2tleRgBIAEoCV'
+    'IMdmVyaWZ5aW5nS2V5EhwKCXNpZ25hdHVyZRgCIAEoCVIJc2lnbmF0dXJl');
 
 @$core.Deprecated('Use verifySignatureRequestDescriptor instead')
 const VerifySignatureRequest$json = {
@@ -839,9 +850,9 @@ const VerifySignatureRequest$json = {
 };
 
 /// Descriptor for `VerifySignatureRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List verifySignatureRequestDescriptor =
-    $convert.base64Decode('ChZWZXJpZnlTaWduYXR1cmVSZXF1ZXN0EhAKA21zZxgBIAEoCVIDbXNnEhwKCXNpZ25hdHVyZR'
-        'gCIAEoCVIJc2lnbmF0dXJlEiMKDXZlcmlmeWluZ19rZXkYAyABKAlSDHZlcmlmeWluZ0tleQ==');
+final $typed_data.Uint8List verifySignatureRequestDescriptor = $convert.base64Decode(
+    'ChZWZXJpZnlTaWduYXR1cmVSZXF1ZXN0EhAKA21zZxgBIAEoCVIDbXNnEhwKCXNpZ25hdHVyZR'
+    'gCIAEoCVIJc2lnbmF0dXJlEiMKDXZlcmlmeWluZ19rZXkYAyABKAlSDHZlcmlmeWluZ0tleQ==');
 
 @$core.Deprecated('Use verifySignatureResponseDescriptor instead')
 const VerifySignatureResponse$json = {
@@ -852,8 +863,8 @@ const VerifySignatureResponse$json = {
 };
 
 /// Descriptor for `VerifySignatureResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List verifySignatureResponseDescriptor =
-    $convert.base64Decode('ChdWZXJpZnlTaWduYXR1cmVSZXNwb25zZRIUCgV2YWxpZBgBIAEoCFIFdmFsaWQ=');
+final $typed_data.Uint8List verifySignatureResponseDescriptor = $convert.base64Decode(
+    'ChdWZXJpZnlTaWduYXR1cmVSZXNwb25zZRIUCgV2YWxpZBgBIAEoCFIFdmFsaWQ=');
 
 @$core.Deprecated('Use getWalletAddressesRequestDescriptor instead')
 const GetWalletAddressesRequest$json = {
@@ -861,8 +872,8 @@ const GetWalletAddressesRequest$json = {
 };
 
 /// Descriptor for `GetWalletAddressesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletAddressesRequestDescriptor =
-    $convert.base64Decode('ChlHZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0');
+final $typed_data.Uint8List getWalletAddressesRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0');
 
 @$core.Deprecated('Use getWalletAddressesResponseDescriptor instead')
 const GetWalletAddressesResponse$json = {
@@ -873,9 +884,9 @@ const GetWalletAddressesResponse$json = {
 };
 
 /// Descriptor for `GetWalletAddressesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletAddressesResponseDescriptor =
-    $convert.base64Decode('ChpHZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3'
-        'Nlcw==');
+final $typed_data.Uint8List getWalletAddressesResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3'
+    'Nlcw==');
 
 @$core.Deprecated('Use myUnconfirmedUtxosRequestDescriptor instead')
 const MyUnconfirmedUtxosRequest$json = {
@@ -883,8 +894,8 @@ const MyUnconfirmedUtxosRequest$json = {
 };
 
 /// Descriptor for `MyUnconfirmedUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List myUnconfirmedUtxosRequestDescriptor =
-    $convert.base64Decode('ChlNeVVuY29uZmlybWVkVXR4b3NSZXF1ZXN0');
+final $typed_data.Uint8List myUnconfirmedUtxosRequestDescriptor = $convert.base64Decode(
+    'ChlNeVVuY29uZmlybWVkVXR4b3NSZXF1ZXN0');
 
 @$core.Deprecated('Use myUnconfirmedUtxosResponseDescriptor instead')
 const MyUnconfirmedUtxosResponse$json = {
@@ -895,9 +906,9 @@ const MyUnconfirmedUtxosResponse$json = {
 };
 
 /// Descriptor for `MyUnconfirmedUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List myUnconfirmedUtxosResponseDescriptor =
-    $convert.base64Decode('ChpNeVVuY29uZmlybWVkVXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0'
-        'pzb24=');
+final $typed_data.Uint8List myUnconfirmedUtxosResponseDescriptor = $convert.base64Decode(
+    'ChpNeVVuY29uZmlybWVkVXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0'
+    'pzb24=');
 
 @$core.Deprecated('Use openapiSchemaRequestDescriptor instead')
 const OpenapiSchemaRequest$json = {
@@ -905,7 +916,8 @@ const OpenapiSchemaRequest$json = {
 };
 
 /// Descriptor for `OpenapiSchemaRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List openapiSchemaRequestDescriptor = $convert.base64Decode('ChRPcGVuYXBpU2NoZW1hUmVxdWVzdA==');
+final $typed_data.Uint8List openapiSchemaRequestDescriptor = $convert.base64Decode(
+    'ChRPcGVuYXBpU2NoZW1hUmVxdWVzdA==');
 
 @$core.Deprecated('Use openapiSchemaResponseDescriptor instead')
 const OpenapiSchemaResponse$json = {
@@ -916,9 +928,9 @@ const OpenapiSchemaResponse$json = {
 };
 
 /// Descriptor for `OpenapiSchemaResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List openapiSchemaResponseDescriptor =
-    $convert.base64Decode('ChVPcGVuYXBpU2NoZW1hUmVzcG9uc2USHwoLc2NoZW1hX2pzb24YASABKAlSCnNjaGVtYUpzb2'
-        '4=');
+final $typed_data.Uint8List openapiSchemaResponseDescriptor = $convert.base64Decode(
+    'ChVPcGVuYXBpU2NoZW1hUmVzcG9uc2USHwoLc2NoZW1hX2pzb24YASABKAlSCnNjaGVtYUpzb2'
+    '4=');
 
 @$core.Deprecated('Use ammBurnRequestDescriptor instead')
 const AmmBurnRequest$json = {
@@ -931,9 +943,9 @@ const AmmBurnRequest$json = {
 };
 
 /// Descriptor for `AmmBurnRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ammBurnRequestDescriptor =
-    $convert.base64Decode('Cg5BbW1CdXJuUmVxdWVzdBIWCgZhc3NldDAYASABKAlSBmFzc2V0MBIWCgZhc3NldDEYAiABKA'
-        'lSBmFzc2V0MRImCg9scF90b2tlbl9hbW91bnQYAyABKANSDWxwVG9rZW5BbW91bnQ=');
+final $typed_data.Uint8List ammBurnRequestDescriptor = $convert.base64Decode(
+    'Cg5BbW1CdXJuUmVxdWVzdBIWCgZhc3NldDAYASABKAlSBmFzc2V0MBIWCgZhc3NldDEYAiABKA'
+    'lSBmFzc2V0MRImCg9scF90b2tlbl9hbW91bnQYAyABKANSDWxwVG9rZW5BbW91bnQ=');
 
 @$core.Deprecated('Use ammBurnResponseDescriptor instead')
 const AmmBurnResponse$json = {
@@ -944,8 +956,8 @@ const AmmBurnResponse$json = {
 };
 
 /// Descriptor for `AmmBurnResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ammBurnResponseDescriptor =
-    $convert.base64Decode('Cg9BbW1CdXJuUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List ammBurnResponseDescriptor = $convert.base64Decode(
+    'Cg9BbW1CdXJuUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use ammMintRequestDescriptor instead')
 const AmmMintRequest$json = {
@@ -959,10 +971,10 @@ const AmmMintRequest$json = {
 };
 
 /// Descriptor for `AmmMintRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ammMintRequestDescriptor =
-    $convert.base64Decode('Cg5BbW1NaW50UmVxdWVzdBIWCgZhc3NldDAYASABKAlSBmFzc2V0MBIWCgZhc3NldDEYAiABKA'
-        'lSBmFzc2V0MRIYCgdhbW91bnQwGAMgASgDUgdhbW91bnQwEhgKB2Ftb3VudDEYBCABKANSB2Ft'
-        'b3VudDE=');
+final $typed_data.Uint8List ammMintRequestDescriptor = $convert.base64Decode(
+    'Cg5BbW1NaW50UmVxdWVzdBIWCgZhc3NldDAYASABKAlSBmFzc2V0MBIWCgZhc3NldDEYAiABKA'
+    'lSBmFzc2V0MRIYCgdhbW91bnQwGAMgASgDUgdhbW91bnQwEhgKB2Ftb3VudDEYBCABKANSB2Ft'
+    'b3VudDE=');
 
 @$core.Deprecated('Use ammMintResponseDescriptor instead')
 const AmmMintResponse$json = {
@@ -973,8 +985,8 @@ const AmmMintResponse$json = {
 };
 
 /// Descriptor for `AmmMintResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ammMintResponseDescriptor =
-    $convert.base64Decode('Cg9BbW1NaW50UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List ammMintResponseDescriptor = $convert.base64Decode(
+    'Cg9BbW1NaW50UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use ammSwapRequestDescriptor instead')
 const AmmSwapRequest$json = {
@@ -987,10 +999,10 @@ const AmmSwapRequest$json = {
 };
 
 /// Descriptor for `AmmSwapRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ammSwapRequestDescriptor =
-    $convert.base64Decode('Cg5BbW1Td2FwUmVxdWVzdBIfCgthc3NldF9zcGVuZBgBIAEoCVIKYXNzZXRTcGVuZBIjCg1hc3'
-        'NldF9yZWNlaXZlGAIgASgJUgxhc3NldFJlY2VpdmUSIQoMYW1vdW50X3NwZW5kGAMgASgDUgth'
-        'bW91bnRTcGVuZA==');
+final $typed_data.Uint8List ammSwapRequestDescriptor = $convert.base64Decode(
+    'Cg5BbW1Td2FwUmVxdWVzdBIfCgthc3NldF9zcGVuZBgBIAEoCVIKYXNzZXRTcGVuZBIjCg1hc3'
+    'NldF9yZWNlaXZlGAIgASgJUgxhc3NldFJlY2VpdmUSIQoMYW1vdW50X3NwZW5kGAMgASgDUgth'
+    'bW91bnRTcGVuZA==');
 
 @$core.Deprecated('Use ammSwapResponseDescriptor instead')
 const AmmSwapResponse$json = {
@@ -1001,9 +1013,9 @@ const AmmSwapResponse$json = {
 };
 
 /// Descriptor for `AmmSwapResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ammSwapResponseDescriptor =
-    $convert.base64Decode('Cg9BbW1Td2FwUmVzcG9uc2USJQoOYW1vdW50X3JlY2VpdmUYASABKANSDWFtb3VudFJlY2Vpdm'
-        'U=');
+final $typed_data.Uint8List ammSwapResponseDescriptor = $convert.base64Decode(
+    'Cg9BbW1Td2FwUmVzcG9uc2USJQoOYW1vdW50X3JlY2VpdmUYASABKANSDWFtb3VudFJlY2Vpdm'
+    'U=');
 
 @$core.Deprecated('Use getAmmPoolStateRequestDescriptor instead')
 const GetAmmPoolStateRequest$json = {
@@ -1015,9 +1027,9 @@ const GetAmmPoolStateRequest$json = {
 };
 
 /// Descriptor for `GetAmmPoolStateRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getAmmPoolStateRequestDescriptor =
-    $convert.base64Decode('ChZHZXRBbW1Qb29sU3RhdGVSZXF1ZXN0EhYKBmFzc2V0MBgBIAEoCVIGYXNzZXQwEhYKBmFzc2'
-        'V0MRgCIAEoCVIGYXNzZXQx');
+final $typed_data.Uint8List getAmmPoolStateRequestDescriptor = $convert.base64Decode(
+    'ChZHZXRBbW1Qb29sU3RhdGVSZXF1ZXN0EhYKBmFzc2V0MBgBIAEoCVIGYXNzZXQwEhYKBmFzc2'
+    'V0MRgCIAEoCVIGYXNzZXQx');
 
 @$core.Deprecated('Use getAmmPoolStateResponseDescriptor instead')
 const GetAmmPoolStateResponse$json = {
@@ -1028,9 +1040,9 @@ const GetAmmPoolStateResponse$json = {
 };
 
 /// Descriptor for `GetAmmPoolStateResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getAmmPoolStateResponseDescriptor =
-    $convert.base64Decode('ChdHZXRBbW1Qb29sU3RhdGVSZXNwb25zZRImCg9wb29sX3N0YXRlX2pzb24YASABKAlSDXBvb2'
-        'xTdGF0ZUpzb24=');
+final $typed_data.Uint8List getAmmPoolStateResponseDescriptor = $convert.base64Decode(
+    'ChdHZXRBbW1Qb29sU3RhdGVSZXNwb25zZRImCg9wb29sX3N0YXRlX2pzb24YASABKAlSDXBvb2'
+    'xTdGF0ZUpzb24=');
 
 @$core.Deprecated('Use getAmmPriceRequestDescriptor instead')
 const GetAmmPriceRequest$json = {
@@ -1042,9 +1054,9 @@ const GetAmmPriceRequest$json = {
 };
 
 /// Descriptor for `GetAmmPriceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getAmmPriceRequestDescriptor =
-    $convert.base64Decode('ChJHZXRBbW1QcmljZVJlcXVlc3QSEgoEYmFzZRgBIAEoCVIEYmFzZRIUCgVxdW90ZRgCIAEoCV'
-        'IFcXVvdGU=');
+final $typed_data.Uint8List getAmmPriceRequestDescriptor = $convert.base64Decode(
+    'ChJHZXRBbW1QcmljZVJlcXVlc3QSEgoEYmFzZRgBIAEoCVIEYmFzZRIUCgVxdW90ZRgCIAEoCV'
+    'IFcXVvdGU=');
 
 @$core.Deprecated('Use getAmmPriceResponseDescriptor instead')
 const GetAmmPriceResponse$json = {
@@ -1055,8 +1067,8 @@ const GetAmmPriceResponse$json = {
 };
 
 /// Descriptor for `GetAmmPriceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getAmmPriceResponseDescriptor =
-    $convert.base64Decode('ChNHZXRBbW1QcmljZVJlc3BvbnNlEh0KCnByaWNlX2pzb24YASABKAlSCXByaWNlSnNvbg==');
+final $typed_data.Uint8List getAmmPriceResponseDescriptor = $convert.base64Decode(
+    'ChNHZXRBbW1QcmljZVJlc3BvbnNlEh0KCnByaWNlX2pzb24YASABKAlSCXByaWNlSnNvbg==');
 
 @$core.Deprecated('Use dutchAuctionBidRequestDescriptor instead')
 const DutchAuctionBidRequest$json = {
@@ -1068,9 +1080,9 @@ const DutchAuctionBidRequest$json = {
 };
 
 /// Descriptor for `DutchAuctionBidRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List dutchAuctionBidRequestDescriptor =
-    $convert.base64Decode('ChZEdXRjaEF1Y3Rpb25CaWRSZXF1ZXN0EigKEGR1dGNoX2F1Y3Rpb25faWQYASABKAlSDmR1dG'
-        'NoQXVjdGlvbklkEhkKCGJpZF9zaXplGAIgASgDUgdiaWRTaXpl');
+final $typed_data.Uint8List dutchAuctionBidRequestDescriptor = $convert.base64Decode(
+    'ChZEdXRjaEF1Y3Rpb25CaWRSZXF1ZXN0EigKEGR1dGNoX2F1Y3Rpb25faWQYASABKAlSDmR1dG'
+    'NoQXVjdGlvbklkEhkKCGJpZF9zaXplGAIgASgDUgdiaWRTaXpl');
 
 @$core.Deprecated('Use dutchAuctionBidResponseDescriptor instead')
 const DutchAuctionBidResponse$json = {
@@ -1081,9 +1093,9 @@ const DutchAuctionBidResponse$json = {
 };
 
 /// Descriptor for `DutchAuctionBidResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List dutchAuctionBidResponseDescriptor =
-    $convert.base64Decode('ChdEdXRjaEF1Y3Rpb25CaWRSZXNwb25zZRIfCgtiYXNlX2Ftb3VudBgBIAEoA1IKYmFzZUFtb3'
-        'VudA==');
+final $typed_data.Uint8List dutchAuctionBidResponseDescriptor = $convert.base64Decode(
+    'ChdEdXRjaEF1Y3Rpb25CaWRSZXNwb25zZRIfCgtiYXNlX2Ftb3VudBgBIAEoA1IKYmFzZUFtb3'
+    'VudA==');
 
 @$core.Deprecated('Use dutchAuctionCollectRequestDescriptor instead')
 const DutchAuctionCollectRequest$json = {
@@ -1094,9 +1106,9 @@ const DutchAuctionCollectRequest$json = {
 };
 
 /// Descriptor for `DutchAuctionCollectRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List dutchAuctionCollectRequestDescriptor =
-    $convert.base64Decode('ChpEdXRjaEF1Y3Rpb25Db2xsZWN0UmVxdWVzdBIoChBkdXRjaF9hdWN0aW9uX2lkGAEgASgJUg'
-        '5kdXRjaEF1Y3Rpb25JZA==');
+final $typed_data.Uint8List dutchAuctionCollectRequestDescriptor = $convert.base64Decode(
+    'ChpEdXRjaEF1Y3Rpb25Db2xsZWN0UmVxdWVzdBIoChBkdXRjaF9hdWN0aW9uX2lkGAEgASgJUg'
+    '5kdXRjaEF1Y3Rpb25JZA==');
 
 @$core.Deprecated('Use dutchAuctionCollectResponseDescriptor instead')
 const DutchAuctionCollectResponse$json = {
@@ -1108,9 +1120,9 @@ const DutchAuctionCollectResponse$json = {
 };
 
 /// Descriptor for `DutchAuctionCollectResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List dutchAuctionCollectResponseDescriptor =
-    $convert.base64Decode('ChtEdXRjaEF1Y3Rpb25Db2xsZWN0UmVzcG9uc2USHwoLYmFzZV9hbW91bnQYASABKANSCmJhc2'
-        'VBbW91bnQSIQoMcXVvdGVfYW1vdW50GAIgASgDUgtxdW90ZUFtb3VudA==');
+final $typed_data.Uint8List dutchAuctionCollectResponseDescriptor = $convert.base64Decode(
+    'ChtEdXRjaEF1Y3Rpb25Db2xsZWN0UmVzcG9uc2USHwoLYmFzZV9hbW91bnQYASABKANSCmJhc2'
+    'VBbW91bnQSIQoMcXVvdGVfYW1vdW50GAIgASgDUgtxdW90ZUFtb3VudA==');
 
 @$core.Deprecated('Use dutchAuctionCreateRequestDescriptor instead')
 const DutchAuctionCreateRequest$json = {
@@ -1127,12 +1139,12 @@ const DutchAuctionCreateRequest$json = {
 };
 
 /// Descriptor for `DutchAuctionCreateRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List dutchAuctionCreateRequestDescriptor =
-    $convert.base64Decode('ChlEdXRjaEF1Y3Rpb25DcmVhdGVSZXF1ZXN0Eh8KC3N0YXJ0X2Jsb2NrGAEgASgDUgpzdGFydE'
-        'Jsb2NrEhoKCGR1cmF0aW9uGAIgASgDUghkdXJhdGlvbhIdCgpiYXNlX2Fzc2V0GAMgASgJUgli'
-        'YXNlQXNzZXQSHwoLYmFzZV9hbW91bnQYBCABKANSCmJhc2VBbW91bnQSHwoLcXVvdGVfYXNzZX'
-        'QYBSABKAlSCnF1b3RlQXNzZXQSIwoNaW5pdGlhbF9wcmljZRgGIAEoA1IMaW5pdGlhbFByaWNl'
-        'Eh8KC2ZpbmFsX3ByaWNlGAcgASgDUgpmaW5hbFByaWNl');
+final $typed_data.Uint8List dutchAuctionCreateRequestDescriptor = $convert.base64Decode(
+    'ChlEdXRjaEF1Y3Rpb25DcmVhdGVSZXF1ZXN0Eh8KC3N0YXJ0X2Jsb2NrGAEgASgDUgpzdGFydE'
+    'Jsb2NrEhoKCGR1cmF0aW9uGAIgASgDUghkdXJhdGlvbhIdCgpiYXNlX2Fzc2V0GAMgASgJUgli'
+    'YXNlQXNzZXQSHwoLYmFzZV9hbW91bnQYBCABKANSCmJhc2VBbW91bnQSHwoLcXVvdGVfYXNzZX'
+    'QYBSABKAlSCnF1b3RlQXNzZXQSIwoNaW5pdGlhbF9wcmljZRgGIAEoA1IMaW5pdGlhbFByaWNl'
+    'Eh8KC2ZpbmFsX3ByaWNlGAcgASgDUgpmaW5hbFByaWNl');
 
 @$core.Deprecated('Use dutchAuctionCreateResponseDescriptor instead')
 const DutchAuctionCreateResponse$json = {
@@ -1143,8 +1155,8 @@ const DutchAuctionCreateResponse$json = {
 };
 
 /// Descriptor for `DutchAuctionCreateResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List dutchAuctionCreateResponseDescriptor =
-    $convert.base64Decode('ChpEdXRjaEF1Y3Rpb25DcmVhdGVSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
+final $typed_data.Uint8List dutchAuctionCreateResponseDescriptor = $convert.base64Decode(
+    'ChpEdXRjaEF1Y3Rpb25DcmVhdGVSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
 
 @$core.Deprecated('Use dutchAuctionsRequestDescriptor instead')
 const DutchAuctionsRequest$json = {
@@ -1152,7 +1164,8 @@ const DutchAuctionsRequest$json = {
 };
 
 /// Descriptor for `DutchAuctionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List dutchAuctionsRequestDescriptor = $convert.base64Decode('ChREdXRjaEF1Y3Rpb25zUmVxdWVzdA==');
+final $typed_data.Uint8List dutchAuctionsRequestDescriptor = $convert.base64Decode(
+    'ChREdXRjaEF1Y3Rpb25zUmVxdWVzdA==');
 
 @$core.Deprecated('Use dutchAuctionsResponseDescriptor instead')
 const DutchAuctionsResponse$json = {
@@ -1163,9 +1176,9 @@ const DutchAuctionsResponse$json = {
 };
 
 /// Descriptor for `DutchAuctionsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List dutchAuctionsResponseDescriptor =
-    $convert.base64Decode('ChVEdXRjaEF1Y3Rpb25zUmVzcG9uc2USIwoNYXVjdGlvbnNfanNvbhgBIAEoCVIMYXVjdGlvbn'
-        'NKc29u');
+final $typed_data.Uint8List dutchAuctionsResponseDescriptor = $convert.base64Decode(
+    'ChVEdXRjaEF1Y3Rpb25zUmVzcG9uc2USIwoNYXVjdGlvbnNfanNvbhgBIAEoCVIMYXVjdGlvbn'
+    'NKc29u');
 
 const $core.Map<$core.String, $core.dynamic> BitAssetsServiceBase$json = {
   '1': 'BitAssetsService',
@@ -1176,106 +1189,38 @@ const $core.Map<$core.String, $core.dynamic> BitAssetsServiceBase$json = {
     {'1': 'GetNewAddress', '2': '.bitassets.v1.GetNewAddressRequest', '3': '.bitassets.v1.GetNewAddressResponse'},
     {'1': 'Withdraw', '2': '.bitassets.v1.WithdrawRequest', '3': '.bitassets.v1.WithdrawResponse'},
     {'1': 'Transfer', '2': '.bitassets.v1.TransferRequest', '3': '.bitassets.v1.TransferResponse'},
-    {
-      '1': 'GetSidechainWealth',
-      '2': '.bitassets.v1.GetSidechainWealthRequest',
-      '3': '.bitassets.v1.GetSidechainWealthResponse'
-    },
+    {'1': 'GetSidechainWealth', '2': '.bitassets.v1.GetSidechainWealthRequest', '3': '.bitassets.v1.GetSidechainWealthResponse'},
     {'1': 'CreateDeposit', '2': '.bitassets.v1.CreateDepositRequest', '3': '.bitassets.v1.CreateDepositResponse'},
-    {
-      '1': 'GetPendingWithdrawalBundle',
-      '2': '.bitassets.v1.GetPendingWithdrawalBundleRequest',
-      '3': '.bitassets.v1.GetPendingWithdrawalBundleResponse'
-    },
+    {'1': 'GetPendingWithdrawalBundle', '2': '.bitassets.v1.GetPendingWithdrawalBundleRequest', '3': '.bitassets.v1.GetPendingWithdrawalBundleResponse'},
     {'1': 'ConnectPeer', '2': '.bitassets.v1.ConnectPeerRequest', '3': '.bitassets.v1.ConnectPeerResponse'},
     {'1': 'ForgetPeer', '2': '.bitassets.v1.ForgetPeerRequest', '3': '.bitassets.v1.ForgetPeerResponse'},
     {'1': 'ListPeers', '2': '.bitassets.v1.ListPeersRequest', '3': '.bitassets.v1.ListPeersResponse'},
     {'1': 'Mine', '2': '.bitassets.v1.MineRequest', '3': '.bitassets.v1.MineResponse'},
     {'1': 'GetBlock', '2': '.bitassets.v1.GetBlockRequest', '3': '.bitassets.v1.GetBlockResponse'},
-    {
-      '1': 'GetBestMainchainBlockHash',
-      '2': '.bitassets.v1.GetBestMainchainBlockHashRequest',
-      '3': '.bitassets.v1.GetBestMainchainBlockHashResponse'
-    },
-    {
-      '1': 'GetBestSidechainBlockHash',
-      '2': '.bitassets.v1.GetBestSidechainBlockHashRequest',
-      '3': '.bitassets.v1.GetBestSidechainBlockHashResponse'
-    },
-    {
-      '1': 'GetBmmInclusions',
-      '2': '.bitassets.v1.GetBmmInclusionsRequest',
-      '3': '.bitassets.v1.GetBmmInclusionsResponse'
-    },
+    {'1': 'GetBestMainchainBlockHash', '2': '.bitassets.v1.GetBestMainchainBlockHashRequest', '3': '.bitassets.v1.GetBestMainchainBlockHashResponse'},
+    {'1': 'GetBestSidechainBlockHash', '2': '.bitassets.v1.GetBestSidechainBlockHashRequest', '3': '.bitassets.v1.GetBestSidechainBlockHashResponse'},
+    {'1': 'GetBmmInclusions', '2': '.bitassets.v1.GetBmmInclusionsRequest', '3': '.bitassets.v1.GetBmmInclusionsResponse'},
     {'1': 'GetWalletUtxos', '2': '.bitassets.v1.GetWalletUtxosRequest', '3': '.bitassets.v1.GetWalletUtxosResponse'},
     {'1': 'ListUtxos', '2': '.bitassets.v1.ListUtxosRequest', '3': '.bitassets.v1.ListUtxosResponse'},
-    {
-      '1': 'RemoveFromMempool',
-      '2': '.bitassets.v1.RemoveFromMempoolRequest',
-      '3': '.bitassets.v1.RemoveFromMempoolResponse'
-    },
-    {
-      '1': 'GetLatestFailedWithdrawalBundleHeight',
-      '2': '.bitassets.v1.GetLatestFailedWithdrawalBundleHeightRequest',
-      '3': '.bitassets.v1.GetLatestFailedWithdrawalBundleHeightResponse'
-    },
-    {
-      '1': 'GenerateMnemonic',
-      '2': '.bitassets.v1.GenerateMnemonicRequest',
-      '3': '.bitassets.v1.GenerateMnemonicResponse'
-    },
-    {
-      '1': 'SetSeedFromMnemonic',
-      '2': '.bitassets.v1.SetSeedFromMnemonicRequest',
-      '3': '.bitassets.v1.SetSeedFromMnemonicResponse'
-    },
+    {'1': 'RemoveFromMempool', '2': '.bitassets.v1.RemoveFromMempoolRequest', '3': '.bitassets.v1.RemoveFromMempoolResponse'},
+    {'1': 'GetLatestFailedWithdrawalBundleHeight', '2': '.bitassets.v1.GetLatestFailedWithdrawalBundleHeightRequest', '3': '.bitassets.v1.GetLatestFailedWithdrawalBundleHeightResponse'},
+    {'1': 'GenerateMnemonic', '2': '.bitassets.v1.GenerateMnemonicRequest', '3': '.bitassets.v1.GenerateMnemonicResponse'},
+    {'1': 'SetSeedFromMnemonic', '2': '.bitassets.v1.SetSeedFromMnemonicRequest', '3': '.bitassets.v1.SetSeedFromMnemonicResponse'},
     {'1': 'CallRaw', '2': '.bitassets.v1.CallRawRequest', '3': '.bitassets.v1.CallRawResponse'},
     {'1': 'GetBitAssetData', '2': '.bitassets.v1.GetBitAssetDataRequest', '3': '.bitassets.v1.GetBitAssetDataResponse'},
     {'1': 'ListBitAssets', '2': '.bitassets.v1.ListBitAssetsRequest', '3': '.bitassets.v1.ListBitAssetsResponse'},
-    {
-      '1': 'RegisterBitAsset',
-      '2': '.bitassets.v1.RegisterBitAssetRequest',
-      '3': '.bitassets.v1.RegisterBitAssetResponse'
-    },
+    {'1': 'RegisterBitAsset', '2': '.bitassets.v1.RegisterBitAssetRequest', '3': '.bitassets.v1.RegisterBitAssetResponse'},
     {'1': 'ReserveBitAsset', '2': '.bitassets.v1.ReserveBitAssetRequest', '3': '.bitassets.v1.ReserveBitAssetResponse'},
-    {
-      '1': 'TransferBitAsset',
-      '2': '.bitassets.v1.TransferBitAssetRequest',
-      '3': '.bitassets.v1.TransferBitAssetResponse'
-    },
-    {
-      '1': 'GetNewEncryptionKey',
-      '2': '.bitassets.v1.GetNewEncryptionKeyRequest',
-      '3': '.bitassets.v1.GetNewEncryptionKeyResponse'
-    },
-    {
-      '1': 'GetNewVerifyingKey',
-      '2': '.bitassets.v1.GetNewVerifyingKeyRequest',
-      '3': '.bitassets.v1.GetNewVerifyingKeyResponse'
-    },
+    {'1': 'TransferBitAsset', '2': '.bitassets.v1.TransferBitAssetRequest', '3': '.bitassets.v1.TransferBitAssetResponse'},
+    {'1': 'GetNewEncryptionKey', '2': '.bitassets.v1.GetNewEncryptionKeyRequest', '3': '.bitassets.v1.GetNewEncryptionKeyResponse'},
+    {'1': 'GetNewVerifyingKey', '2': '.bitassets.v1.GetNewVerifyingKeyRequest', '3': '.bitassets.v1.GetNewVerifyingKeyResponse'},
     {'1': 'DecryptMsg', '2': '.bitassets.v1.DecryptMsgRequest', '3': '.bitassets.v1.DecryptMsgResponse'},
     {'1': 'EncryptMsg', '2': '.bitassets.v1.EncryptMsgRequest', '3': '.bitassets.v1.EncryptMsgResponse'},
-    {
-      '1': 'SignArbitraryMsg',
-      '2': '.bitassets.v1.SignArbitraryMsgRequest',
-      '3': '.bitassets.v1.SignArbitraryMsgResponse'
-    },
-    {
-      '1': 'SignArbitraryMsgAsAddr',
-      '2': '.bitassets.v1.SignArbitraryMsgAsAddrRequest',
-      '3': '.bitassets.v1.SignArbitraryMsgAsAddrResponse'
-    },
+    {'1': 'SignArbitraryMsg', '2': '.bitassets.v1.SignArbitraryMsgRequest', '3': '.bitassets.v1.SignArbitraryMsgResponse'},
+    {'1': 'SignArbitraryMsgAsAddr', '2': '.bitassets.v1.SignArbitraryMsgAsAddrRequest', '3': '.bitassets.v1.SignArbitraryMsgAsAddrResponse'},
     {'1': 'VerifySignature', '2': '.bitassets.v1.VerifySignatureRequest', '3': '.bitassets.v1.VerifySignatureResponse'},
-    {
-      '1': 'GetWalletAddresses',
-      '2': '.bitassets.v1.GetWalletAddressesRequest',
-      '3': '.bitassets.v1.GetWalletAddressesResponse'
-    },
-    {
-      '1': 'MyUnconfirmedUtxos',
-      '2': '.bitassets.v1.MyUnconfirmedUtxosRequest',
-      '3': '.bitassets.v1.MyUnconfirmedUtxosResponse'
-    },
+    {'1': 'GetWalletAddresses', '2': '.bitassets.v1.GetWalletAddressesRequest', '3': '.bitassets.v1.GetWalletAddressesResponse'},
+    {'1': 'MyUnconfirmedUtxos', '2': '.bitassets.v1.MyUnconfirmedUtxosRequest', '3': '.bitassets.v1.MyUnconfirmedUtxosResponse'},
     {'1': 'OpenapiSchema', '2': '.bitassets.v1.OpenapiSchemaRequest', '3': '.bitassets.v1.OpenapiSchemaResponse'},
     {'1': 'AmmBurn', '2': '.bitassets.v1.AmmBurnRequest', '3': '.bitassets.v1.AmmBurnResponse'},
     {'1': 'AmmMint', '2': '.bitassets.v1.AmmMintRequest', '3': '.bitassets.v1.AmmMintResponse'},
@@ -1283,16 +1228,8 @@ const $core.Map<$core.String, $core.dynamic> BitAssetsServiceBase$json = {
     {'1': 'GetAmmPoolState', '2': '.bitassets.v1.GetAmmPoolStateRequest', '3': '.bitassets.v1.GetAmmPoolStateResponse'},
     {'1': 'GetAmmPrice', '2': '.bitassets.v1.GetAmmPriceRequest', '3': '.bitassets.v1.GetAmmPriceResponse'},
     {'1': 'DutchAuctionBid', '2': '.bitassets.v1.DutchAuctionBidRequest', '3': '.bitassets.v1.DutchAuctionBidResponse'},
-    {
-      '1': 'DutchAuctionCollect',
-      '2': '.bitassets.v1.DutchAuctionCollectRequest',
-      '3': '.bitassets.v1.DutchAuctionCollectResponse'
-    },
-    {
-      '1': 'DutchAuctionCreate',
-      '2': '.bitassets.v1.DutchAuctionCreateRequest',
-      '3': '.bitassets.v1.DutchAuctionCreateResponse'
-    },
+    {'1': 'DutchAuctionCollect', '2': '.bitassets.v1.DutchAuctionCollectRequest', '3': '.bitassets.v1.DutchAuctionCollectResponse'},
+    {'1': 'DutchAuctionCreate', '2': '.bitassets.v1.DutchAuctionCreateRequest', '3': '.bitassets.v1.DutchAuctionCreateResponse'},
     {'1': 'DutchAuctions', '2': '.bitassets.v1.DutchAuctionsRequest', '3': '.bitassets.v1.DutchAuctionsResponse'},
   ],
 };
@@ -1398,86 +1335,87 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> BitAssetsS
 };
 
 /// Descriptor for `BitAssetsService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List bitAssetsServiceDescriptor =
-    $convert.base64Decode('ChBCaXRBc3NldHNTZXJ2aWNlEk8KCkdldEJhbGFuY2USHy5iaXRhc3NldHMudjEuR2V0QmFsYW'
-        '5jZVJlcXVlc3QaIC5iaXRhc3NldHMudjEuR2V0QmFsYW5jZVJlc3BvbnNlElgKDUdldEJsb2Nr'
-        'Q291bnQSIi5iaXRhc3NldHMudjEuR2V0QmxvY2tDb3VudFJlcXVlc3QaIy5iaXRhc3NldHMudj'
-        'EuR2V0QmxvY2tDb3VudFJlc3BvbnNlEj0KBFN0b3ASGS5iaXRhc3NldHMudjEuU3RvcFJlcXVl'
-        'c3QaGi5iaXRhc3NldHMudjEuU3RvcFJlc3BvbnNlElgKDUdldE5ld0FkZHJlc3MSIi5iaXRhc3'
-        'NldHMudjEuR2V0TmV3QWRkcmVzc1JlcXVlc3QaIy5iaXRhc3NldHMudjEuR2V0TmV3QWRkcmVz'
-        'c1Jlc3BvbnNlEkkKCFdpdGhkcmF3Eh0uYml0YXNzZXRzLnYxLldpdGhkcmF3UmVxdWVzdBoeLm'
-        'JpdGFzc2V0cy52MS5XaXRoZHJhd1Jlc3BvbnNlEkkKCFRyYW5zZmVyEh0uYml0YXNzZXRzLnYx'
-        'LlRyYW5zZmVyUmVxdWVzdBoeLmJpdGFzc2V0cy52MS5UcmFuc2ZlclJlc3BvbnNlEmcKEkdldF'
-        'NpZGVjaGFpbldlYWx0aBInLmJpdGFzc2V0cy52MS5HZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0'
-        'GiguYml0YXNzZXRzLnYxLkdldFNpZGVjaGFpbldlYWx0aFJlc3BvbnNlElgKDUNyZWF0ZURlcG'
-        '9zaXQSIi5iaXRhc3NldHMudjEuQ3JlYXRlRGVwb3NpdFJlcXVlc3QaIy5iaXRhc3NldHMudjEu'
-        'Q3JlYXRlRGVwb3NpdFJlc3BvbnNlEn8KGkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlEi8uYm'
-        'l0YXNzZXRzLnYxLkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlUmVxdWVzdBowLmJpdGFzc2V0'
-        'cy52MS5HZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlElIKC0Nvbm5lY3RQZWVyEi'
-        'AuYml0YXNzZXRzLnYxLkNvbm5lY3RQZWVyUmVxdWVzdBohLmJpdGFzc2V0cy52MS5Db25uZWN0'
-        'UGVlclJlc3BvbnNlEk8KCkZvcmdldFBlZXISHy5iaXRhc3NldHMudjEuRm9yZ2V0UGVlclJlcX'
-        'Vlc3QaIC5iaXRhc3NldHMudjEuRm9yZ2V0UGVlclJlc3BvbnNlEkwKCUxpc3RQZWVycxIeLmJp'
-        'dGFzc2V0cy52MS5MaXN0UGVlcnNSZXF1ZXN0Gh8uYml0YXNzZXRzLnYxLkxpc3RQZWVyc1Jlc3'
-        'BvbnNlEj0KBE1pbmUSGS5iaXRhc3NldHMudjEuTWluZVJlcXVlc3QaGi5iaXRhc3NldHMudjEu'
-        'TWluZVJlc3BvbnNlEkkKCEdldEJsb2NrEh0uYml0YXNzZXRzLnYxLkdldEJsb2NrUmVxdWVzdB'
-        'oeLmJpdGFzc2V0cy52MS5HZXRCbG9ja1Jlc3BvbnNlEnwKGUdldEJlc3RNYWluY2hhaW5CbG9j'
-        'a0hhc2gSLi5iaXRhc3NldHMudjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFzaFJlcXVlc3QaLy'
-        '5iaXRhc3NldHMudjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFzaFJlc3BvbnNlEnwKGUdldEJl'
-        'c3RTaWRlY2hhaW5CbG9ja0hhc2gSLi5iaXRhc3NldHMudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2'
-        'NrSGFzaFJlcXVlc3QaLy5iaXRhc3NldHMudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaFJl'
-        'c3BvbnNlEmEKEEdldEJtbUluY2x1c2lvbnMSJS5iaXRhc3NldHMudjEuR2V0Qm1tSW5jbHVzaW'
-        '9uc1JlcXVlc3QaJi5iaXRhc3NldHMudjEuR2V0Qm1tSW5jbHVzaW9uc1Jlc3BvbnNlElsKDkdl'
-        'dFdhbGxldFV0eG9zEiMuYml0YXNzZXRzLnYxLkdldFdhbGxldFV0eG9zUmVxdWVzdBokLmJpdG'
-        'Fzc2V0cy52MS5HZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEkwKCUxpc3RVdHhvcxIeLmJpdGFzc2V0'
-        'cy52MS5MaXN0VXR4b3NSZXF1ZXN0Gh8uYml0YXNzZXRzLnYxLkxpc3RVdHhvc1Jlc3BvbnNlEm'
-        'QKEVJlbW92ZUZyb21NZW1wb29sEiYuYml0YXNzZXRzLnYxLlJlbW92ZUZyb21NZW1wb29sUmVx'
-        'dWVzdBonLmJpdGFzc2V0cy52MS5SZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNlEqABCiVHZXRMYX'
-        'Rlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0EjouYml0YXNzZXRzLnYxLkdldExhdGVz'
-        'dEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHRSZXF1ZXN0GjsuYml0YXNzZXRzLnYxLkdldE'
-        'xhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHRSZXNwb25zZRJhChBHZW5lcmF0ZU1u'
-        'ZW1vbmljEiUuYml0YXNzZXRzLnYxLkdlbmVyYXRlTW5lbW9uaWNSZXF1ZXN0GiYuYml0YXNzZX'
-        'RzLnYxLkdlbmVyYXRlTW5lbW9uaWNSZXNwb25zZRJqChNTZXRTZWVkRnJvbU1uZW1vbmljEigu'
-        'Yml0YXNzZXRzLnYxLlNldFNlZWRGcm9tTW5lbW9uaWNSZXF1ZXN0GikuYml0YXNzZXRzLnYxLl'
-        'NldFNlZWRGcm9tTW5lbW9uaWNSZXNwb25zZRJGCgdDYWxsUmF3EhwuYml0YXNzZXRzLnYxLkNh'
-        'bGxSYXdSZXF1ZXN0Gh0uYml0YXNzZXRzLnYxLkNhbGxSYXdSZXNwb25zZRJeCg9HZXRCaXRBc3'
-        'NldERhdGESJC5iaXRhc3NldHMudjEuR2V0Qml0QXNzZXREYXRhUmVxdWVzdBolLmJpdGFzc2V0'
-        'cy52MS5HZXRCaXRBc3NldERhdGFSZXNwb25zZRJYCg1MaXN0Qml0QXNzZXRzEiIuYml0YXNzZX'
-        'RzLnYxLkxpc3RCaXRBc3NldHNSZXF1ZXN0GiMuYml0YXNzZXRzLnYxLkxpc3RCaXRBc3NldHNS'
-        'ZXNwb25zZRJhChBSZWdpc3RlckJpdEFzc2V0EiUuYml0YXNzZXRzLnYxLlJlZ2lzdGVyQml0QX'
-        'NzZXRSZXF1ZXN0GiYuYml0YXNzZXRzLnYxLlJlZ2lzdGVyQml0QXNzZXRSZXNwb25zZRJeCg9S'
-        'ZXNlcnZlQml0QXNzZXQSJC5iaXRhc3NldHMudjEuUmVzZXJ2ZUJpdEFzc2V0UmVxdWVzdBolLm'
-        'JpdGFzc2V0cy52MS5SZXNlcnZlQml0QXNzZXRSZXNwb25zZRJhChBUcmFuc2ZlckJpdEFzc2V0'
-        'EiUuYml0YXNzZXRzLnYxLlRyYW5zZmVyQml0QXNzZXRSZXF1ZXN0GiYuYml0YXNzZXRzLnYxLl'
-        'RyYW5zZmVyQml0QXNzZXRSZXNwb25zZRJqChNHZXROZXdFbmNyeXB0aW9uS2V5EiguYml0YXNz'
-        'ZXRzLnYxLkdldE5ld0VuY3J5cHRpb25LZXlSZXF1ZXN0GikuYml0YXNzZXRzLnYxLkdldE5ld0'
-        'VuY3J5cHRpb25LZXlSZXNwb25zZRJnChJHZXROZXdWZXJpZnlpbmdLZXkSJy5iaXRhc3NldHMu'
-        'djEuR2V0TmV3VmVyaWZ5aW5nS2V5UmVxdWVzdBooLmJpdGFzc2V0cy52MS5HZXROZXdWZXJpZn'
-        'lpbmdLZXlSZXNwb25zZRJPCgpEZWNyeXB0TXNnEh8uYml0YXNzZXRzLnYxLkRlY3J5cHRNc2dS'
-        'ZXF1ZXN0GiAuYml0YXNzZXRzLnYxLkRlY3J5cHRNc2dSZXNwb25zZRJPCgpFbmNyeXB0TXNnEh'
-        '8uYml0YXNzZXRzLnYxLkVuY3J5cHRNc2dSZXF1ZXN0GiAuYml0YXNzZXRzLnYxLkVuY3J5cHRN'
-        'c2dSZXNwb25zZRJhChBTaWduQXJiaXRyYXJ5TXNnEiUuYml0YXNzZXRzLnYxLlNpZ25BcmJpdH'
-        'JhcnlNc2dSZXF1ZXN0GiYuYml0YXNzZXRzLnYxLlNpZ25BcmJpdHJhcnlNc2dSZXNwb25zZRJz'
-        'ChZTaWduQXJiaXRyYXJ5TXNnQXNBZGRyEisuYml0YXNzZXRzLnYxLlNpZ25BcmJpdHJhcnlNc2'
-        'dBc0FkZHJSZXF1ZXN0GiwuYml0YXNzZXRzLnYxLlNpZ25BcmJpdHJhcnlNc2dBc0FkZHJSZXNw'
-        'b25zZRJeCg9WZXJpZnlTaWduYXR1cmUSJC5iaXRhc3NldHMudjEuVmVyaWZ5U2lnbmF0dXJlUm'
-        'VxdWVzdBolLmJpdGFzc2V0cy52MS5WZXJpZnlTaWduYXR1cmVSZXNwb25zZRJnChJHZXRXYWxs'
-        'ZXRBZGRyZXNzZXMSJy5iaXRhc3NldHMudjEuR2V0V2FsbGV0QWRkcmVzc2VzUmVxdWVzdBooLm'
-        'JpdGFzc2V0cy52MS5HZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRJnChJNeVVuY29uZmlybWVk'
-        'VXR4b3MSJy5iaXRhc3NldHMudjEuTXlVbmNvbmZpcm1lZFV0eG9zUmVxdWVzdBooLmJpdGFzc2'
-        'V0cy52MS5NeVVuY29uZmlybWVkVXR4b3NSZXNwb25zZRJYCg1PcGVuYXBpU2NoZW1hEiIuYml0'
-        'YXNzZXRzLnYxLk9wZW5hcGlTY2hlbWFSZXF1ZXN0GiMuYml0YXNzZXRzLnYxLk9wZW5hcGlTY2'
-        'hlbWFSZXNwb25zZRJGCgdBbW1CdXJuEhwuYml0YXNzZXRzLnYxLkFtbUJ1cm5SZXF1ZXN0Gh0u'
-        'Yml0YXNzZXRzLnYxLkFtbUJ1cm5SZXNwb25zZRJGCgdBbW1NaW50EhwuYml0YXNzZXRzLnYxLk'
-        'FtbU1pbnRSZXF1ZXN0Gh0uYml0YXNzZXRzLnYxLkFtbU1pbnRSZXNwb25zZRJGCgdBbW1Td2Fw'
-        'EhwuYml0YXNzZXRzLnYxLkFtbVN3YXBSZXF1ZXN0Gh0uYml0YXNzZXRzLnYxLkFtbVN3YXBSZX'
-        'Nwb25zZRJeCg9HZXRBbW1Qb29sU3RhdGUSJC5iaXRhc3NldHMudjEuR2V0QW1tUG9vbFN0YXRl'
-        'UmVxdWVzdBolLmJpdGFzc2V0cy52MS5HZXRBbW1Qb29sU3RhdGVSZXNwb25zZRJSCgtHZXRBbW'
-        '1QcmljZRIgLmJpdGFzc2V0cy52MS5HZXRBbW1QcmljZVJlcXVlc3QaIS5iaXRhc3NldHMudjEu'
-        'R2V0QW1tUHJpY2VSZXNwb25zZRJeCg9EdXRjaEF1Y3Rpb25CaWQSJC5iaXRhc3NldHMudjEuRH'
-        'V0Y2hBdWN0aW9uQmlkUmVxdWVzdBolLmJpdGFzc2V0cy52MS5EdXRjaEF1Y3Rpb25CaWRSZXNw'
-        'b25zZRJqChNEdXRjaEF1Y3Rpb25Db2xsZWN0EiguYml0YXNzZXRzLnYxLkR1dGNoQXVjdGlvbk'
-        'NvbGxlY3RSZXF1ZXN0GikuYml0YXNzZXRzLnYxLkR1dGNoQXVjdGlvbkNvbGxlY3RSZXNwb25z'
-        'ZRJnChJEdXRjaEF1Y3Rpb25DcmVhdGUSJy5iaXRhc3NldHMudjEuRHV0Y2hBdWN0aW9uQ3JlYX'
-        'RlUmVxdWVzdBooLmJpdGFzc2V0cy52MS5EdXRjaEF1Y3Rpb25DcmVhdGVSZXNwb25zZRJYCg1E'
-        'dXRjaEF1Y3Rpb25zEiIuYml0YXNzZXRzLnYxLkR1dGNoQXVjdGlvbnNSZXF1ZXN0GiMuYml0YX'
-        'NzZXRzLnYxLkR1dGNoQXVjdGlvbnNSZXNwb25zZQ==');
+final $typed_data.Uint8List bitAssetsServiceDescriptor = $convert.base64Decode(
+    'ChBCaXRBc3NldHNTZXJ2aWNlEk8KCkdldEJhbGFuY2USHy5iaXRhc3NldHMudjEuR2V0QmFsYW'
+    '5jZVJlcXVlc3QaIC5iaXRhc3NldHMudjEuR2V0QmFsYW5jZVJlc3BvbnNlElgKDUdldEJsb2Nr'
+    'Q291bnQSIi5iaXRhc3NldHMudjEuR2V0QmxvY2tDb3VudFJlcXVlc3QaIy5iaXRhc3NldHMudj'
+    'EuR2V0QmxvY2tDb3VudFJlc3BvbnNlEj0KBFN0b3ASGS5iaXRhc3NldHMudjEuU3RvcFJlcXVl'
+    'c3QaGi5iaXRhc3NldHMudjEuU3RvcFJlc3BvbnNlElgKDUdldE5ld0FkZHJlc3MSIi5iaXRhc3'
+    'NldHMudjEuR2V0TmV3QWRkcmVzc1JlcXVlc3QaIy5iaXRhc3NldHMudjEuR2V0TmV3QWRkcmVz'
+    'c1Jlc3BvbnNlEkkKCFdpdGhkcmF3Eh0uYml0YXNzZXRzLnYxLldpdGhkcmF3UmVxdWVzdBoeLm'
+    'JpdGFzc2V0cy52MS5XaXRoZHJhd1Jlc3BvbnNlEkkKCFRyYW5zZmVyEh0uYml0YXNzZXRzLnYx'
+    'LlRyYW5zZmVyUmVxdWVzdBoeLmJpdGFzc2V0cy52MS5UcmFuc2ZlclJlc3BvbnNlEmcKEkdldF'
+    'NpZGVjaGFpbldlYWx0aBInLmJpdGFzc2V0cy52MS5HZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0'
+    'GiguYml0YXNzZXRzLnYxLkdldFNpZGVjaGFpbldlYWx0aFJlc3BvbnNlElgKDUNyZWF0ZURlcG'
+    '9zaXQSIi5iaXRhc3NldHMudjEuQ3JlYXRlRGVwb3NpdFJlcXVlc3QaIy5iaXRhc3NldHMudjEu'
+    'Q3JlYXRlRGVwb3NpdFJlc3BvbnNlEn8KGkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlEi8uYm'
+    'l0YXNzZXRzLnYxLkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlUmVxdWVzdBowLmJpdGFzc2V0'
+    'cy52MS5HZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlElIKC0Nvbm5lY3RQZWVyEi'
+    'AuYml0YXNzZXRzLnYxLkNvbm5lY3RQZWVyUmVxdWVzdBohLmJpdGFzc2V0cy52MS5Db25uZWN0'
+    'UGVlclJlc3BvbnNlEk8KCkZvcmdldFBlZXISHy5iaXRhc3NldHMudjEuRm9yZ2V0UGVlclJlcX'
+    'Vlc3QaIC5iaXRhc3NldHMudjEuRm9yZ2V0UGVlclJlc3BvbnNlEkwKCUxpc3RQZWVycxIeLmJp'
+    'dGFzc2V0cy52MS5MaXN0UGVlcnNSZXF1ZXN0Gh8uYml0YXNzZXRzLnYxLkxpc3RQZWVyc1Jlc3'
+    'BvbnNlEj0KBE1pbmUSGS5iaXRhc3NldHMudjEuTWluZVJlcXVlc3QaGi5iaXRhc3NldHMudjEu'
+    'TWluZVJlc3BvbnNlEkkKCEdldEJsb2NrEh0uYml0YXNzZXRzLnYxLkdldEJsb2NrUmVxdWVzdB'
+    'oeLmJpdGFzc2V0cy52MS5HZXRCbG9ja1Jlc3BvbnNlEnwKGUdldEJlc3RNYWluY2hhaW5CbG9j'
+    'a0hhc2gSLi5iaXRhc3NldHMudjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFzaFJlcXVlc3QaLy'
+    '5iaXRhc3NldHMudjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFzaFJlc3BvbnNlEnwKGUdldEJl'
+    'c3RTaWRlY2hhaW5CbG9ja0hhc2gSLi5iaXRhc3NldHMudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2'
+    'NrSGFzaFJlcXVlc3QaLy5iaXRhc3NldHMudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaFJl'
+    'c3BvbnNlEmEKEEdldEJtbUluY2x1c2lvbnMSJS5iaXRhc3NldHMudjEuR2V0Qm1tSW5jbHVzaW'
+    '9uc1JlcXVlc3QaJi5iaXRhc3NldHMudjEuR2V0Qm1tSW5jbHVzaW9uc1Jlc3BvbnNlElsKDkdl'
+    'dFdhbGxldFV0eG9zEiMuYml0YXNzZXRzLnYxLkdldFdhbGxldFV0eG9zUmVxdWVzdBokLmJpdG'
+    'Fzc2V0cy52MS5HZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEkwKCUxpc3RVdHhvcxIeLmJpdGFzc2V0'
+    'cy52MS5MaXN0VXR4b3NSZXF1ZXN0Gh8uYml0YXNzZXRzLnYxLkxpc3RVdHhvc1Jlc3BvbnNlEm'
+    'QKEVJlbW92ZUZyb21NZW1wb29sEiYuYml0YXNzZXRzLnYxLlJlbW92ZUZyb21NZW1wb29sUmVx'
+    'dWVzdBonLmJpdGFzc2V0cy52MS5SZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNlEqABCiVHZXRMYX'
+    'Rlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0EjouYml0YXNzZXRzLnYxLkdldExhdGVz'
+    'dEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHRSZXF1ZXN0GjsuYml0YXNzZXRzLnYxLkdldE'
+    'xhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHRSZXNwb25zZRJhChBHZW5lcmF0ZU1u'
+    'ZW1vbmljEiUuYml0YXNzZXRzLnYxLkdlbmVyYXRlTW5lbW9uaWNSZXF1ZXN0GiYuYml0YXNzZX'
+    'RzLnYxLkdlbmVyYXRlTW5lbW9uaWNSZXNwb25zZRJqChNTZXRTZWVkRnJvbU1uZW1vbmljEigu'
+    'Yml0YXNzZXRzLnYxLlNldFNlZWRGcm9tTW5lbW9uaWNSZXF1ZXN0GikuYml0YXNzZXRzLnYxLl'
+    'NldFNlZWRGcm9tTW5lbW9uaWNSZXNwb25zZRJGCgdDYWxsUmF3EhwuYml0YXNzZXRzLnYxLkNh'
+    'bGxSYXdSZXF1ZXN0Gh0uYml0YXNzZXRzLnYxLkNhbGxSYXdSZXNwb25zZRJeCg9HZXRCaXRBc3'
+    'NldERhdGESJC5iaXRhc3NldHMudjEuR2V0Qml0QXNzZXREYXRhUmVxdWVzdBolLmJpdGFzc2V0'
+    'cy52MS5HZXRCaXRBc3NldERhdGFSZXNwb25zZRJYCg1MaXN0Qml0QXNzZXRzEiIuYml0YXNzZX'
+    'RzLnYxLkxpc3RCaXRBc3NldHNSZXF1ZXN0GiMuYml0YXNzZXRzLnYxLkxpc3RCaXRBc3NldHNS'
+    'ZXNwb25zZRJhChBSZWdpc3RlckJpdEFzc2V0EiUuYml0YXNzZXRzLnYxLlJlZ2lzdGVyQml0QX'
+    'NzZXRSZXF1ZXN0GiYuYml0YXNzZXRzLnYxLlJlZ2lzdGVyQml0QXNzZXRSZXNwb25zZRJeCg9S'
+    'ZXNlcnZlQml0QXNzZXQSJC5iaXRhc3NldHMudjEuUmVzZXJ2ZUJpdEFzc2V0UmVxdWVzdBolLm'
+    'JpdGFzc2V0cy52MS5SZXNlcnZlQml0QXNzZXRSZXNwb25zZRJhChBUcmFuc2ZlckJpdEFzc2V0'
+    'EiUuYml0YXNzZXRzLnYxLlRyYW5zZmVyQml0QXNzZXRSZXF1ZXN0GiYuYml0YXNzZXRzLnYxLl'
+    'RyYW5zZmVyQml0QXNzZXRSZXNwb25zZRJqChNHZXROZXdFbmNyeXB0aW9uS2V5EiguYml0YXNz'
+    'ZXRzLnYxLkdldE5ld0VuY3J5cHRpb25LZXlSZXF1ZXN0GikuYml0YXNzZXRzLnYxLkdldE5ld0'
+    'VuY3J5cHRpb25LZXlSZXNwb25zZRJnChJHZXROZXdWZXJpZnlpbmdLZXkSJy5iaXRhc3NldHMu'
+    'djEuR2V0TmV3VmVyaWZ5aW5nS2V5UmVxdWVzdBooLmJpdGFzc2V0cy52MS5HZXROZXdWZXJpZn'
+    'lpbmdLZXlSZXNwb25zZRJPCgpEZWNyeXB0TXNnEh8uYml0YXNzZXRzLnYxLkRlY3J5cHRNc2dS'
+    'ZXF1ZXN0GiAuYml0YXNzZXRzLnYxLkRlY3J5cHRNc2dSZXNwb25zZRJPCgpFbmNyeXB0TXNnEh'
+    '8uYml0YXNzZXRzLnYxLkVuY3J5cHRNc2dSZXF1ZXN0GiAuYml0YXNzZXRzLnYxLkVuY3J5cHRN'
+    'c2dSZXNwb25zZRJhChBTaWduQXJiaXRyYXJ5TXNnEiUuYml0YXNzZXRzLnYxLlNpZ25BcmJpdH'
+    'JhcnlNc2dSZXF1ZXN0GiYuYml0YXNzZXRzLnYxLlNpZ25BcmJpdHJhcnlNc2dSZXNwb25zZRJz'
+    'ChZTaWduQXJiaXRyYXJ5TXNnQXNBZGRyEisuYml0YXNzZXRzLnYxLlNpZ25BcmJpdHJhcnlNc2'
+    'dBc0FkZHJSZXF1ZXN0GiwuYml0YXNzZXRzLnYxLlNpZ25BcmJpdHJhcnlNc2dBc0FkZHJSZXNw'
+    'b25zZRJeCg9WZXJpZnlTaWduYXR1cmUSJC5iaXRhc3NldHMudjEuVmVyaWZ5U2lnbmF0dXJlUm'
+    'VxdWVzdBolLmJpdGFzc2V0cy52MS5WZXJpZnlTaWduYXR1cmVSZXNwb25zZRJnChJHZXRXYWxs'
+    'ZXRBZGRyZXNzZXMSJy5iaXRhc3NldHMudjEuR2V0V2FsbGV0QWRkcmVzc2VzUmVxdWVzdBooLm'
+    'JpdGFzc2V0cy52MS5HZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRJnChJNeVVuY29uZmlybWVk'
+    'VXR4b3MSJy5iaXRhc3NldHMudjEuTXlVbmNvbmZpcm1lZFV0eG9zUmVxdWVzdBooLmJpdGFzc2'
+    'V0cy52MS5NeVVuY29uZmlybWVkVXR4b3NSZXNwb25zZRJYCg1PcGVuYXBpU2NoZW1hEiIuYml0'
+    'YXNzZXRzLnYxLk9wZW5hcGlTY2hlbWFSZXF1ZXN0GiMuYml0YXNzZXRzLnYxLk9wZW5hcGlTY2'
+    'hlbWFSZXNwb25zZRJGCgdBbW1CdXJuEhwuYml0YXNzZXRzLnYxLkFtbUJ1cm5SZXF1ZXN0Gh0u'
+    'Yml0YXNzZXRzLnYxLkFtbUJ1cm5SZXNwb25zZRJGCgdBbW1NaW50EhwuYml0YXNzZXRzLnYxLk'
+    'FtbU1pbnRSZXF1ZXN0Gh0uYml0YXNzZXRzLnYxLkFtbU1pbnRSZXNwb25zZRJGCgdBbW1Td2Fw'
+    'EhwuYml0YXNzZXRzLnYxLkFtbVN3YXBSZXF1ZXN0Gh0uYml0YXNzZXRzLnYxLkFtbVN3YXBSZX'
+    'Nwb25zZRJeCg9HZXRBbW1Qb29sU3RhdGUSJC5iaXRhc3NldHMudjEuR2V0QW1tUG9vbFN0YXRl'
+    'UmVxdWVzdBolLmJpdGFzc2V0cy52MS5HZXRBbW1Qb29sU3RhdGVSZXNwb25zZRJSCgtHZXRBbW'
+    '1QcmljZRIgLmJpdGFzc2V0cy52MS5HZXRBbW1QcmljZVJlcXVlc3QaIS5iaXRhc3NldHMudjEu'
+    'R2V0QW1tUHJpY2VSZXNwb25zZRJeCg9EdXRjaEF1Y3Rpb25CaWQSJC5iaXRhc3NldHMudjEuRH'
+    'V0Y2hBdWN0aW9uQmlkUmVxdWVzdBolLmJpdGFzc2V0cy52MS5EdXRjaEF1Y3Rpb25CaWRSZXNw'
+    'b25zZRJqChNEdXRjaEF1Y3Rpb25Db2xsZWN0EiguYml0YXNzZXRzLnYxLkR1dGNoQXVjdGlvbk'
+    'NvbGxlY3RSZXF1ZXN0GikuYml0YXNzZXRzLnYxLkR1dGNoQXVjdGlvbkNvbGxlY3RSZXNwb25z'
+    'ZRJnChJEdXRjaEF1Y3Rpb25DcmVhdGUSJy5iaXRhc3NldHMudjEuRHV0Y2hBdWN0aW9uQ3JlYX'
+    'RlUmVxdWVzdBooLmJpdGFzc2V0cy52MS5EdXRjaEF1Y3Rpb25DcmVhdGVSZXNwb25zZRJYCg1E'
+    'dXRjaEF1Y3Rpb25zEiIuYml0YXNzZXRzLnYxLkR1dGNoQXVjdGlvbnNSZXF1ZXN0GiMuYml0YX'
+    'NzZXRzLnYxLkR1dGNoQXVjdGlvbnNSZXNwb25zZQ==');
+

--- a/sail_ui/lib/gen/bitassets/v1/bitassets.pbserver.dart
+++ b/sail_ui/lib/gen/bitassets/v1/bitassets.pbserver.dart
@@ -27,55 +27,38 @@ abstract class BitAssetsServiceBase extends $pb.GeneratedService {
   $async.Future<$0.GetNewAddressResponse> getNewAddress($pb.ServerContext ctx, $0.GetNewAddressRequest request);
   $async.Future<$0.WithdrawResponse> withdraw($pb.ServerContext ctx, $0.WithdrawRequest request);
   $async.Future<$0.TransferResponse> transfer($pb.ServerContext ctx, $0.TransferRequest request);
-  $async.Future<$0.GetSidechainWealthResponse> getSidechainWealth(
-      $pb.ServerContext ctx, $0.GetSidechainWealthRequest request);
+  $async.Future<$0.GetSidechainWealthResponse> getSidechainWealth($pb.ServerContext ctx, $0.GetSidechainWealthRequest request);
   $async.Future<$0.CreateDepositResponse> createDeposit($pb.ServerContext ctx, $0.CreateDepositRequest request);
-  $async.Future<$0.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-      $pb.ServerContext ctx, $0.GetPendingWithdrawalBundleRequest request);
+  $async.Future<$0.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ServerContext ctx, $0.GetPendingWithdrawalBundleRequest request);
   $async.Future<$0.ConnectPeerResponse> connectPeer($pb.ServerContext ctx, $0.ConnectPeerRequest request);
   $async.Future<$0.ForgetPeerResponse> forgetPeer($pb.ServerContext ctx, $0.ForgetPeerRequest request);
   $async.Future<$0.ListPeersResponse> listPeers($pb.ServerContext ctx, $0.ListPeersRequest request);
   $async.Future<$0.MineResponse> mine($pb.ServerContext ctx, $0.MineRequest request);
   $async.Future<$0.GetBlockResponse> getBlock($pb.ServerContext ctx, $0.GetBlockRequest request);
-  $async.Future<$0.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-      $pb.ServerContext ctx, $0.GetBestMainchainBlockHashRequest request);
-  $async.Future<$0.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-      $pb.ServerContext ctx, $0.GetBestSidechainBlockHashRequest request);
-  $async.Future<$0.GetBmmInclusionsResponse> getBmmInclusions(
-      $pb.ServerContext ctx, $0.GetBmmInclusionsRequest request);
+  $async.Future<$0.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ServerContext ctx, $0.GetBestMainchainBlockHashRequest request);
+  $async.Future<$0.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ServerContext ctx, $0.GetBestSidechainBlockHashRequest request);
+  $async.Future<$0.GetBmmInclusionsResponse> getBmmInclusions($pb.ServerContext ctx, $0.GetBmmInclusionsRequest request);
   $async.Future<$0.GetWalletUtxosResponse> getWalletUtxos($pb.ServerContext ctx, $0.GetWalletUtxosRequest request);
   $async.Future<$0.ListUtxosResponse> listUtxos($pb.ServerContext ctx, $0.ListUtxosRequest request);
-  $async.Future<$0.RemoveFromMempoolResponse> removeFromMempool(
-      $pb.ServerContext ctx, $0.RemoveFromMempoolRequest request);
-  $async.Future<$0.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-      $pb.ServerContext ctx, $0.GetLatestFailedWithdrawalBundleHeightRequest request);
-  $async.Future<$0.GenerateMnemonicResponse> generateMnemonic(
-      $pb.ServerContext ctx, $0.GenerateMnemonicRequest request);
-  $async.Future<$0.SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-      $pb.ServerContext ctx, $0.SetSeedFromMnemonicRequest request);
+  $async.Future<$0.RemoveFromMempoolResponse> removeFromMempool($pb.ServerContext ctx, $0.RemoveFromMempoolRequest request);
+  $async.Future<$0.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ServerContext ctx, $0.GetLatestFailedWithdrawalBundleHeightRequest request);
+  $async.Future<$0.GenerateMnemonicResponse> generateMnemonic($pb.ServerContext ctx, $0.GenerateMnemonicRequest request);
+  $async.Future<$0.SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ServerContext ctx, $0.SetSeedFromMnemonicRequest request);
   $async.Future<$0.CallRawResponse> callRaw($pb.ServerContext ctx, $0.CallRawRequest request);
   $async.Future<$0.GetBitAssetDataResponse> getBitAssetData($pb.ServerContext ctx, $0.GetBitAssetDataRequest request);
   $async.Future<$0.ListBitAssetsResponse> listBitAssets($pb.ServerContext ctx, $0.ListBitAssetsRequest request);
-  $async.Future<$0.RegisterBitAssetResponse> registerBitAsset(
-      $pb.ServerContext ctx, $0.RegisterBitAssetRequest request);
+  $async.Future<$0.RegisterBitAssetResponse> registerBitAsset($pb.ServerContext ctx, $0.RegisterBitAssetRequest request);
   $async.Future<$0.ReserveBitAssetResponse> reserveBitAsset($pb.ServerContext ctx, $0.ReserveBitAssetRequest request);
-  $async.Future<$0.TransferBitAssetResponse> transferBitAsset(
-      $pb.ServerContext ctx, $0.TransferBitAssetRequest request);
-  $async.Future<$0.GetNewEncryptionKeyResponse> getNewEncryptionKey(
-      $pb.ServerContext ctx, $0.GetNewEncryptionKeyRequest request);
-  $async.Future<$0.GetNewVerifyingKeyResponse> getNewVerifyingKey(
-      $pb.ServerContext ctx, $0.GetNewVerifyingKeyRequest request);
+  $async.Future<$0.TransferBitAssetResponse> transferBitAsset($pb.ServerContext ctx, $0.TransferBitAssetRequest request);
+  $async.Future<$0.GetNewEncryptionKeyResponse> getNewEncryptionKey($pb.ServerContext ctx, $0.GetNewEncryptionKeyRequest request);
+  $async.Future<$0.GetNewVerifyingKeyResponse> getNewVerifyingKey($pb.ServerContext ctx, $0.GetNewVerifyingKeyRequest request);
   $async.Future<$0.DecryptMsgResponse> decryptMsg($pb.ServerContext ctx, $0.DecryptMsgRequest request);
   $async.Future<$0.EncryptMsgResponse> encryptMsg($pb.ServerContext ctx, $0.EncryptMsgRequest request);
-  $async.Future<$0.SignArbitraryMsgResponse> signArbitraryMsg(
-      $pb.ServerContext ctx, $0.SignArbitraryMsgRequest request);
-  $async.Future<$0.SignArbitraryMsgAsAddrResponse> signArbitraryMsgAsAddr(
-      $pb.ServerContext ctx, $0.SignArbitraryMsgAsAddrRequest request);
+  $async.Future<$0.SignArbitraryMsgResponse> signArbitraryMsg($pb.ServerContext ctx, $0.SignArbitraryMsgRequest request);
+  $async.Future<$0.SignArbitraryMsgAsAddrResponse> signArbitraryMsgAsAddr($pb.ServerContext ctx, $0.SignArbitraryMsgAsAddrRequest request);
   $async.Future<$0.VerifySignatureResponse> verifySignature($pb.ServerContext ctx, $0.VerifySignatureRequest request);
-  $async.Future<$0.GetWalletAddressesResponse> getWalletAddresses(
-      $pb.ServerContext ctx, $0.GetWalletAddressesRequest request);
-  $async.Future<$0.MyUnconfirmedUtxosResponse> myUnconfirmedUtxos(
-      $pb.ServerContext ctx, $0.MyUnconfirmedUtxosRequest request);
+  $async.Future<$0.GetWalletAddressesResponse> getWalletAddresses($pb.ServerContext ctx, $0.GetWalletAddressesRequest request);
+  $async.Future<$0.MyUnconfirmedUtxosResponse> myUnconfirmedUtxos($pb.ServerContext ctx, $0.MyUnconfirmedUtxosRequest request);
   $async.Future<$0.OpenapiSchemaResponse> openapiSchema($pb.ServerContext ctx, $0.OpenapiSchemaRequest request);
   $async.Future<$0.AmmBurnResponse> ammBurn($pb.ServerContext ctx, $0.AmmBurnRequest request);
   $async.Future<$0.AmmMintResponse> ammMint($pb.ServerContext ctx, $0.AmmMintRequest request);
@@ -83,220 +66,119 @@ abstract class BitAssetsServiceBase extends $pb.GeneratedService {
   $async.Future<$0.GetAmmPoolStateResponse> getAmmPoolState($pb.ServerContext ctx, $0.GetAmmPoolStateRequest request);
   $async.Future<$0.GetAmmPriceResponse> getAmmPrice($pb.ServerContext ctx, $0.GetAmmPriceRequest request);
   $async.Future<$0.DutchAuctionBidResponse> dutchAuctionBid($pb.ServerContext ctx, $0.DutchAuctionBidRequest request);
-  $async.Future<$0.DutchAuctionCollectResponse> dutchAuctionCollect(
-      $pb.ServerContext ctx, $0.DutchAuctionCollectRequest request);
-  $async.Future<$0.DutchAuctionCreateResponse> dutchAuctionCreate(
-      $pb.ServerContext ctx, $0.DutchAuctionCreateRequest request);
+  $async.Future<$0.DutchAuctionCollectResponse> dutchAuctionCollect($pb.ServerContext ctx, $0.DutchAuctionCollectRequest request);
+  $async.Future<$0.DutchAuctionCreateResponse> dutchAuctionCreate($pb.ServerContext ctx, $0.DutchAuctionCreateRequest request);
   $async.Future<$0.DutchAuctionsResponse> dutchAuctions($pb.ServerContext ctx, $0.DutchAuctionsRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetBalance':
-        return $0.GetBalanceRequest();
-      case 'GetBlockCount':
-        return $0.GetBlockCountRequest();
-      case 'Stop':
-        return $0.StopRequest();
-      case 'GetNewAddress':
-        return $0.GetNewAddressRequest();
-      case 'Withdraw':
-        return $0.WithdrawRequest();
-      case 'Transfer':
-        return $0.TransferRequest();
-      case 'GetSidechainWealth':
-        return $0.GetSidechainWealthRequest();
-      case 'CreateDeposit':
-        return $0.CreateDepositRequest();
-      case 'GetPendingWithdrawalBundle':
-        return $0.GetPendingWithdrawalBundleRequest();
-      case 'ConnectPeer':
-        return $0.ConnectPeerRequest();
-      case 'ForgetPeer':
-        return $0.ForgetPeerRequest();
-      case 'ListPeers':
-        return $0.ListPeersRequest();
-      case 'Mine':
-        return $0.MineRequest();
-      case 'GetBlock':
-        return $0.GetBlockRequest();
-      case 'GetBestMainchainBlockHash':
-        return $0.GetBestMainchainBlockHashRequest();
-      case 'GetBestSidechainBlockHash':
-        return $0.GetBestSidechainBlockHashRequest();
-      case 'GetBmmInclusions':
-        return $0.GetBmmInclusionsRequest();
-      case 'GetWalletUtxos':
-        return $0.GetWalletUtxosRequest();
-      case 'ListUtxos':
-        return $0.ListUtxosRequest();
-      case 'RemoveFromMempool':
-        return $0.RemoveFromMempoolRequest();
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return $0.GetLatestFailedWithdrawalBundleHeightRequest();
-      case 'GenerateMnemonic':
-        return $0.GenerateMnemonicRequest();
-      case 'SetSeedFromMnemonic':
-        return $0.SetSeedFromMnemonicRequest();
-      case 'CallRaw':
-        return $0.CallRawRequest();
-      case 'GetBitAssetData':
-        return $0.GetBitAssetDataRequest();
-      case 'ListBitAssets':
-        return $0.ListBitAssetsRequest();
-      case 'RegisterBitAsset':
-        return $0.RegisterBitAssetRequest();
-      case 'ReserveBitAsset':
-        return $0.ReserveBitAssetRequest();
-      case 'TransferBitAsset':
-        return $0.TransferBitAssetRequest();
-      case 'GetNewEncryptionKey':
-        return $0.GetNewEncryptionKeyRequest();
-      case 'GetNewVerifyingKey':
-        return $0.GetNewVerifyingKeyRequest();
-      case 'DecryptMsg':
-        return $0.DecryptMsgRequest();
-      case 'EncryptMsg':
-        return $0.EncryptMsgRequest();
-      case 'SignArbitraryMsg':
-        return $0.SignArbitraryMsgRequest();
-      case 'SignArbitraryMsgAsAddr':
-        return $0.SignArbitraryMsgAsAddrRequest();
-      case 'VerifySignature':
-        return $0.VerifySignatureRequest();
-      case 'GetWalletAddresses':
-        return $0.GetWalletAddressesRequest();
-      case 'MyUnconfirmedUtxos':
-        return $0.MyUnconfirmedUtxosRequest();
-      case 'OpenapiSchema':
-        return $0.OpenapiSchemaRequest();
-      case 'AmmBurn':
-        return $0.AmmBurnRequest();
-      case 'AmmMint':
-        return $0.AmmMintRequest();
-      case 'AmmSwap':
-        return $0.AmmSwapRequest();
-      case 'GetAmmPoolState':
-        return $0.GetAmmPoolStateRequest();
-      case 'GetAmmPrice':
-        return $0.GetAmmPriceRequest();
-      case 'DutchAuctionBid':
-        return $0.DutchAuctionBidRequest();
-      case 'DutchAuctionCollect':
-        return $0.DutchAuctionCollectRequest();
-      case 'DutchAuctionCreate':
-        return $0.DutchAuctionCreateRequest();
-      case 'DutchAuctions':
-        return $0.DutchAuctionsRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return $0.GetBalanceRequest();
+      case 'GetBlockCount': return $0.GetBlockCountRequest();
+      case 'Stop': return $0.StopRequest();
+      case 'GetNewAddress': return $0.GetNewAddressRequest();
+      case 'Withdraw': return $0.WithdrawRequest();
+      case 'Transfer': return $0.TransferRequest();
+      case 'GetSidechainWealth': return $0.GetSidechainWealthRequest();
+      case 'CreateDeposit': return $0.CreateDepositRequest();
+      case 'GetPendingWithdrawalBundle': return $0.GetPendingWithdrawalBundleRequest();
+      case 'ConnectPeer': return $0.ConnectPeerRequest();
+      case 'ForgetPeer': return $0.ForgetPeerRequest();
+      case 'ListPeers': return $0.ListPeersRequest();
+      case 'Mine': return $0.MineRequest();
+      case 'GetBlock': return $0.GetBlockRequest();
+      case 'GetBestMainchainBlockHash': return $0.GetBestMainchainBlockHashRequest();
+      case 'GetBestSidechainBlockHash': return $0.GetBestSidechainBlockHashRequest();
+      case 'GetBmmInclusions': return $0.GetBmmInclusionsRequest();
+      case 'GetWalletUtxos': return $0.GetWalletUtxosRequest();
+      case 'ListUtxos': return $0.ListUtxosRequest();
+      case 'RemoveFromMempool': return $0.RemoveFromMempoolRequest();
+      case 'GetLatestFailedWithdrawalBundleHeight': return $0.GetLatestFailedWithdrawalBundleHeightRequest();
+      case 'GenerateMnemonic': return $0.GenerateMnemonicRequest();
+      case 'SetSeedFromMnemonic': return $0.SetSeedFromMnemonicRequest();
+      case 'CallRaw': return $0.CallRawRequest();
+      case 'GetBitAssetData': return $0.GetBitAssetDataRequest();
+      case 'ListBitAssets': return $0.ListBitAssetsRequest();
+      case 'RegisterBitAsset': return $0.RegisterBitAssetRequest();
+      case 'ReserveBitAsset': return $0.ReserveBitAssetRequest();
+      case 'TransferBitAsset': return $0.TransferBitAssetRequest();
+      case 'GetNewEncryptionKey': return $0.GetNewEncryptionKeyRequest();
+      case 'GetNewVerifyingKey': return $0.GetNewVerifyingKeyRequest();
+      case 'DecryptMsg': return $0.DecryptMsgRequest();
+      case 'EncryptMsg': return $0.EncryptMsgRequest();
+      case 'SignArbitraryMsg': return $0.SignArbitraryMsgRequest();
+      case 'SignArbitraryMsgAsAddr': return $0.SignArbitraryMsgAsAddrRequest();
+      case 'VerifySignature': return $0.VerifySignatureRequest();
+      case 'GetWalletAddresses': return $0.GetWalletAddressesRequest();
+      case 'MyUnconfirmedUtxos': return $0.MyUnconfirmedUtxosRequest();
+      case 'OpenapiSchema': return $0.OpenapiSchemaRequest();
+      case 'AmmBurn': return $0.AmmBurnRequest();
+      case 'AmmMint': return $0.AmmMintRequest();
+      case 'AmmSwap': return $0.AmmSwapRequest();
+      case 'GetAmmPoolState': return $0.GetAmmPoolStateRequest();
+      case 'GetAmmPrice': return $0.GetAmmPriceRequest();
+      case 'DutchAuctionBid': return $0.DutchAuctionBidRequest();
+      case 'DutchAuctionCollect': return $0.DutchAuctionCollectRequest();
+      case 'DutchAuctionCreate': return $0.DutchAuctionCreateRequest();
+      case 'DutchAuctions': return $0.DutchAuctionsRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetBalance':
-        return this.getBalance(ctx, request as $0.GetBalanceRequest);
-      case 'GetBlockCount':
-        return this.getBlockCount(ctx, request as $0.GetBlockCountRequest);
-      case 'Stop':
-        return this.stop(ctx, request as $0.StopRequest);
-      case 'GetNewAddress':
-        return this.getNewAddress(ctx, request as $0.GetNewAddressRequest);
-      case 'Withdraw':
-        return this.withdraw(ctx, request as $0.WithdrawRequest);
-      case 'Transfer':
-        return this.transfer(ctx, request as $0.TransferRequest);
-      case 'GetSidechainWealth':
-        return this.getSidechainWealth(ctx, request as $0.GetSidechainWealthRequest);
-      case 'CreateDeposit':
-        return this.createDeposit(ctx, request as $0.CreateDepositRequest);
-      case 'GetPendingWithdrawalBundle':
-        return this.getPendingWithdrawalBundle(ctx, request as $0.GetPendingWithdrawalBundleRequest);
-      case 'ConnectPeer':
-        return this.connectPeer(ctx, request as $0.ConnectPeerRequest);
-      case 'ForgetPeer':
-        return this.forgetPeer(ctx, request as $0.ForgetPeerRequest);
-      case 'ListPeers':
-        return this.listPeers(ctx, request as $0.ListPeersRequest);
-      case 'Mine':
-        return this.mine(ctx, request as $0.MineRequest);
-      case 'GetBlock':
-        return this.getBlock(ctx, request as $0.GetBlockRequest);
-      case 'GetBestMainchainBlockHash':
-        return this.getBestMainchainBlockHash(ctx, request as $0.GetBestMainchainBlockHashRequest);
-      case 'GetBestSidechainBlockHash':
-        return this.getBestSidechainBlockHash(ctx, request as $0.GetBestSidechainBlockHashRequest);
-      case 'GetBmmInclusions':
-        return this.getBmmInclusions(ctx, request as $0.GetBmmInclusionsRequest);
-      case 'GetWalletUtxos':
-        return this.getWalletUtxos(ctx, request as $0.GetWalletUtxosRequest);
-      case 'ListUtxos':
-        return this.listUtxos(ctx, request as $0.ListUtxosRequest);
-      case 'RemoveFromMempool':
-        return this.removeFromMempool(ctx, request as $0.RemoveFromMempoolRequest);
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return this
-            .getLatestFailedWithdrawalBundleHeight(ctx, request as $0.GetLatestFailedWithdrawalBundleHeightRequest);
-      case 'GenerateMnemonic':
-        return this.generateMnemonic(ctx, request as $0.GenerateMnemonicRequest);
-      case 'SetSeedFromMnemonic':
-        return this.setSeedFromMnemonic(ctx, request as $0.SetSeedFromMnemonicRequest);
-      case 'CallRaw':
-        return this.callRaw(ctx, request as $0.CallRawRequest);
-      case 'GetBitAssetData':
-        return this.getBitAssetData(ctx, request as $0.GetBitAssetDataRequest);
-      case 'ListBitAssets':
-        return this.listBitAssets(ctx, request as $0.ListBitAssetsRequest);
-      case 'RegisterBitAsset':
-        return this.registerBitAsset(ctx, request as $0.RegisterBitAssetRequest);
-      case 'ReserveBitAsset':
-        return this.reserveBitAsset(ctx, request as $0.ReserveBitAssetRequest);
-      case 'TransferBitAsset':
-        return this.transferBitAsset(ctx, request as $0.TransferBitAssetRequest);
-      case 'GetNewEncryptionKey':
-        return this.getNewEncryptionKey(ctx, request as $0.GetNewEncryptionKeyRequest);
-      case 'GetNewVerifyingKey':
-        return this.getNewVerifyingKey(ctx, request as $0.GetNewVerifyingKeyRequest);
-      case 'DecryptMsg':
-        return this.decryptMsg(ctx, request as $0.DecryptMsgRequest);
-      case 'EncryptMsg':
-        return this.encryptMsg(ctx, request as $0.EncryptMsgRequest);
-      case 'SignArbitraryMsg':
-        return this.signArbitraryMsg(ctx, request as $0.SignArbitraryMsgRequest);
-      case 'SignArbitraryMsgAsAddr':
-        return this.signArbitraryMsgAsAddr(ctx, request as $0.SignArbitraryMsgAsAddrRequest);
-      case 'VerifySignature':
-        return this.verifySignature(ctx, request as $0.VerifySignatureRequest);
-      case 'GetWalletAddresses':
-        return this.getWalletAddresses(ctx, request as $0.GetWalletAddressesRequest);
-      case 'MyUnconfirmedUtxos':
-        return this.myUnconfirmedUtxos(ctx, request as $0.MyUnconfirmedUtxosRequest);
-      case 'OpenapiSchema':
-        return this.openapiSchema(ctx, request as $0.OpenapiSchemaRequest);
-      case 'AmmBurn':
-        return this.ammBurn(ctx, request as $0.AmmBurnRequest);
-      case 'AmmMint':
-        return this.ammMint(ctx, request as $0.AmmMintRequest);
-      case 'AmmSwap':
-        return this.ammSwap(ctx, request as $0.AmmSwapRequest);
-      case 'GetAmmPoolState':
-        return this.getAmmPoolState(ctx, request as $0.GetAmmPoolStateRequest);
-      case 'GetAmmPrice':
-        return this.getAmmPrice(ctx, request as $0.GetAmmPriceRequest);
-      case 'DutchAuctionBid':
-        return this.dutchAuctionBid(ctx, request as $0.DutchAuctionBidRequest);
-      case 'DutchAuctionCollect':
-        return this.dutchAuctionCollect(ctx, request as $0.DutchAuctionCollectRequest);
-      case 'DutchAuctionCreate':
-        return this.dutchAuctionCreate(ctx, request as $0.DutchAuctionCreateRequest);
-      case 'DutchAuctions':
-        return this.dutchAuctions(ctx, request as $0.DutchAuctionsRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return this.getBalance(ctx, request as $0.GetBalanceRequest);
+      case 'GetBlockCount': return this.getBlockCount(ctx, request as $0.GetBlockCountRequest);
+      case 'Stop': return this.stop(ctx, request as $0.StopRequest);
+      case 'GetNewAddress': return this.getNewAddress(ctx, request as $0.GetNewAddressRequest);
+      case 'Withdraw': return this.withdraw(ctx, request as $0.WithdrawRequest);
+      case 'Transfer': return this.transfer(ctx, request as $0.TransferRequest);
+      case 'GetSidechainWealth': return this.getSidechainWealth(ctx, request as $0.GetSidechainWealthRequest);
+      case 'CreateDeposit': return this.createDeposit(ctx, request as $0.CreateDepositRequest);
+      case 'GetPendingWithdrawalBundle': return this.getPendingWithdrawalBundle(ctx, request as $0.GetPendingWithdrawalBundleRequest);
+      case 'ConnectPeer': return this.connectPeer(ctx, request as $0.ConnectPeerRequest);
+      case 'ForgetPeer': return this.forgetPeer(ctx, request as $0.ForgetPeerRequest);
+      case 'ListPeers': return this.listPeers(ctx, request as $0.ListPeersRequest);
+      case 'Mine': return this.mine(ctx, request as $0.MineRequest);
+      case 'GetBlock': return this.getBlock(ctx, request as $0.GetBlockRequest);
+      case 'GetBestMainchainBlockHash': return this.getBestMainchainBlockHash(ctx, request as $0.GetBestMainchainBlockHashRequest);
+      case 'GetBestSidechainBlockHash': return this.getBestSidechainBlockHash(ctx, request as $0.GetBestSidechainBlockHashRequest);
+      case 'GetBmmInclusions': return this.getBmmInclusions(ctx, request as $0.GetBmmInclusionsRequest);
+      case 'GetWalletUtxos': return this.getWalletUtxos(ctx, request as $0.GetWalletUtxosRequest);
+      case 'ListUtxos': return this.listUtxos(ctx, request as $0.ListUtxosRequest);
+      case 'RemoveFromMempool': return this.removeFromMempool(ctx, request as $0.RemoveFromMempoolRequest);
+      case 'GetLatestFailedWithdrawalBundleHeight': return this.getLatestFailedWithdrawalBundleHeight(ctx, request as $0.GetLatestFailedWithdrawalBundleHeightRequest);
+      case 'GenerateMnemonic': return this.generateMnemonic(ctx, request as $0.GenerateMnemonicRequest);
+      case 'SetSeedFromMnemonic': return this.setSeedFromMnemonic(ctx, request as $0.SetSeedFromMnemonicRequest);
+      case 'CallRaw': return this.callRaw(ctx, request as $0.CallRawRequest);
+      case 'GetBitAssetData': return this.getBitAssetData(ctx, request as $0.GetBitAssetDataRequest);
+      case 'ListBitAssets': return this.listBitAssets(ctx, request as $0.ListBitAssetsRequest);
+      case 'RegisterBitAsset': return this.registerBitAsset(ctx, request as $0.RegisterBitAssetRequest);
+      case 'ReserveBitAsset': return this.reserveBitAsset(ctx, request as $0.ReserveBitAssetRequest);
+      case 'TransferBitAsset': return this.transferBitAsset(ctx, request as $0.TransferBitAssetRequest);
+      case 'GetNewEncryptionKey': return this.getNewEncryptionKey(ctx, request as $0.GetNewEncryptionKeyRequest);
+      case 'GetNewVerifyingKey': return this.getNewVerifyingKey(ctx, request as $0.GetNewVerifyingKeyRequest);
+      case 'DecryptMsg': return this.decryptMsg(ctx, request as $0.DecryptMsgRequest);
+      case 'EncryptMsg': return this.encryptMsg(ctx, request as $0.EncryptMsgRequest);
+      case 'SignArbitraryMsg': return this.signArbitraryMsg(ctx, request as $0.SignArbitraryMsgRequest);
+      case 'SignArbitraryMsgAsAddr': return this.signArbitraryMsgAsAddr(ctx, request as $0.SignArbitraryMsgAsAddrRequest);
+      case 'VerifySignature': return this.verifySignature(ctx, request as $0.VerifySignatureRequest);
+      case 'GetWalletAddresses': return this.getWalletAddresses(ctx, request as $0.GetWalletAddressesRequest);
+      case 'MyUnconfirmedUtxos': return this.myUnconfirmedUtxos(ctx, request as $0.MyUnconfirmedUtxosRequest);
+      case 'OpenapiSchema': return this.openapiSchema(ctx, request as $0.OpenapiSchemaRequest);
+      case 'AmmBurn': return this.ammBurn(ctx, request as $0.AmmBurnRequest);
+      case 'AmmMint': return this.ammMint(ctx, request as $0.AmmMintRequest);
+      case 'AmmSwap': return this.ammSwap(ctx, request as $0.AmmSwapRequest);
+      case 'GetAmmPoolState': return this.getAmmPoolState(ctx, request as $0.GetAmmPoolStateRequest);
+      case 'GetAmmPrice': return this.getAmmPrice(ctx, request as $0.GetAmmPriceRequest);
+      case 'DutchAuctionBid': return this.dutchAuctionBid(ctx, request as $0.DutchAuctionBidRequest);
+      case 'DutchAuctionCollect': return this.dutchAuctionCollect(ctx, request as $0.DutchAuctionCollectRequest);
+      case 'DutchAuctionCreate': return this.dutchAuctionCreate(ctx, request as $0.DutchAuctionCreateRequest);
+      case 'DutchAuctions': return this.dutchAuctions(ctx, request as $0.DutchAuctionsRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => BitAssetsServiceBase$json;
   $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => BitAssetsServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/bitnames/v1/bitnames.connect.client.dart
+++ b/sail_ui/lib/gen/bitnames/v1/bitnames.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "bitnames.pb.dart" as bitnamesv1bitnames;
 import "bitnames.connect.spec.dart" as specs;
 
-extension type BitnamesServiceClient(connect.Transport _transport) {
+extension type BitnamesServiceClient (connect.Transport _transport) {
   /// Get wallet balance (total and available).
   Future<bitnamesv1bitnames.GetBalanceResponse> getBalance(
     bitnamesv1bitnames.GetBalanceRequest input, {

--- a/sail_ui/lib/gen/bitnames/v1/bitnames.pb.dart
+++ b/sail_ui/lib/gen/bitnames/v1/bitnames.pb.dart
@@ -18,25 +18,23 @@ import 'package:protobuf/protobuf.dart' as $pb;
 class GetBalanceRequest extends $pb.GeneratedMessage {
   factory GetBalanceRequest() => create();
   GetBalanceRequest._() : super();
-  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceRequest clone() => GetBalanceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) => super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -45,8 +43,7 @@ class GetBalanceRequest extends $pb.GeneratedMessage {
   GetBalanceRequest createEmptyInstance() => create();
   static $pb.PbList<GetBalanceRequest> createRepeated() => $pb.PbList<GetBalanceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
+  static GetBalanceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
   static GetBalanceRequest? _defaultInstance;
 }
 
@@ -65,27 +62,25 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBalanceResponse._() : super();
-  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'totalSats')
     ..aInt64(2, _omitFieldNames ? '' : 'availableSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceResponse clone() => GetBalanceResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) => super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -94,17 +89,13 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   GetBalanceResponse createEmptyInstance() => create();
   static $pb.PbList<GetBalanceResponse> createRepeated() => $pb.PbList<GetBalanceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
+  static GetBalanceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
   static GetBalanceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get totalSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set totalSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set totalSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTotalSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -113,10 +104,7 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get availableSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set availableSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set availableSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAvailableSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -126,25 +114,23 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
 class GetBlockCountRequest extends $pb.GeneratedMessage {
   factory GetBlockCountRequest() => create();
   GetBlockCountRequest._() : super();
-  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountRequest clone() => GetBlockCountRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) => super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -153,8 +139,7 @@ class GetBlockCountRequest extends $pb.GeneratedMessage {
   GetBlockCountRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountRequest> createRepeated() => $pb.PbList<GetBlockCountRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
+  static GetBlockCountRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
   static GetBlockCountRequest? _defaultInstance;
 }
 
@@ -169,26 +154,24 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockCountResponse._() : super();
-  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'count')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountResponse clone() => GetBlockCountResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) => super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -197,17 +180,13 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
   GetBlockCountResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountResponse> createRepeated() => $pb.PbList<GetBlockCountResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
+  static GetBlockCountResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
   static GetBlockCountResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get count => $_getI64(0);
   @$pb.TagNumber(1)
-  set count($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set count($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCount() => $_has(0);
   @$pb.TagNumber(1)
@@ -217,24 +196,23 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
 class StopRequest extends $pb.GeneratedMessage {
   factory StopRequest() => create();
   StopRequest._() : super();
-  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopRequest clone() => StopRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopRequest copyWith(void Function(StopRequest) updates) =>
-      super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopRequest copyWith(void Function(StopRequest) updates) => super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -250,24 +228,23 @@ class StopRequest extends $pb.GeneratedMessage {
 class StopResponse extends $pb.GeneratedMessage {
   factory StopResponse() => create();
   StopResponse._() : super();
-  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopResponse clone() => StopResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopResponse copyWith(void Function(StopResponse) updates) =>
-      super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopResponse copyWith(void Function(StopResponse) updates) => super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -283,25 +260,23 @@ class StopResponse extends $pb.GeneratedMessage {
 class GetNewAddressRequest extends $pb.GeneratedMessage {
   factory GetNewAddressRequest() => create();
   GetNewAddressRequest._() : super();
-  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressRequest clone() => GetNewAddressRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) => super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -310,8 +285,7 @@ class GetNewAddressRequest extends $pb.GeneratedMessage {
   GetNewAddressRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressRequest> createRepeated() => $pb.PbList<GetNewAddressRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
+  static GetNewAddressRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
   static GetNewAddressRequest? _defaultInstance;
 }
 
@@ -326,26 +300,24 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewAddressResponse._() : super();
-  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressResponse clone() => GetNewAddressResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) => super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -354,17 +326,13 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
   GetNewAddressResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressResponse> createRepeated() => $pb.PbList<GetNewAddressResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
+  static GetNewAddressResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
   static GetNewAddressResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -394,29 +362,27 @@ class WithdrawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawRequest._() : super();
-  factory WithdrawRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'sideFeeSats')
     ..aInt64(4, _omitFieldNames ? '' : 'mainFeeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawRequest clone() => WithdrawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) =>
-      super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) => super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -425,17 +391,13 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   WithdrawRequest createEmptyInstance() => create();
   static $pb.PbList<WithdrawRequest> createRepeated() => $pb.PbList<WithdrawRequest>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
+  static WithdrawRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
   static WithdrawRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -444,10 +406,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -456,10 +415,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get sideFeeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set sideFeeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set sideFeeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSideFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -468,10 +424,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get mainFeeSats => $_getI64(3);
   @$pb.TagNumber(4)
-  set mainFeeSats($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set mainFeeSats($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasMainFeeSats() => $_has(3);
   @$pb.TagNumber(4)
@@ -489,26 +442,24 @@ class WithdrawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawResponse._() : super();
-  factory WithdrawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawResponse clone() => WithdrawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) =>
-      super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) => super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -517,17 +468,13 @@ class WithdrawResponse extends $pb.GeneratedMessage {
   WithdrawResponse createEmptyInstance() => create();
   static $pb.PbList<WithdrawResponse> createRepeated() => $pb.PbList<WithdrawResponse>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
+  static WithdrawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
   static WithdrawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -557,29 +504,27 @@ class TransferRequest extends $pb.GeneratedMessage {
     return $result;
   }
   TransferRequest._() : super();
-  factory TransferRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
     ..aOS(4, _omitFieldNames ? '' : 'memo')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferRequest clone() => TransferRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferRequest copyWith(void Function(TransferRequest) updates) =>
-      super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferRequest copyWith(void Function(TransferRequest) updates) => super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -588,17 +533,13 @@ class TransferRequest extends $pb.GeneratedMessage {
   TransferRequest createEmptyInstance() => create();
   static $pb.PbList<TransferRequest> createRepeated() => $pb.PbList<TransferRequest>();
   @$core.pragma('dart2js:noInline')
-  static TransferRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
+  static TransferRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
   static TransferRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -607,10 +548,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -619,10 +557,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -631,10 +566,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get memo => $_getSZ(3);
   @$pb.TagNumber(4)
-  set memo($core.String v) {
-    $_setString(3, v);
-  }
-
+  set memo($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasMemo() => $_has(3);
   @$pb.TagNumber(4)
@@ -652,26 +584,24 @@ class TransferResponse extends $pb.GeneratedMessage {
     return $result;
   }
   TransferResponse._() : super();
-  factory TransferResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferResponse clone() => TransferResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferResponse copyWith(void Function(TransferResponse) updates) =>
-      super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferResponse copyWith(void Function(TransferResponse) updates) => super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -680,17 +610,13 @@ class TransferResponse extends $pb.GeneratedMessage {
   TransferResponse createEmptyInstance() => create();
   static $pb.PbList<TransferResponse> createRepeated() => $pb.PbList<TransferResponse>();
   @$core.pragma('dart2js:noInline')
-  static TransferResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
+  static TransferResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
   static TransferResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -700,25 +626,23 @@ class TransferResponse extends $pb.GeneratedMessage {
 class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   factory GetSidechainWealthRequest() => create();
   GetSidechainWealthRequest._() : super();
-  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthRequest clone() => GetSidechainWealthRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) => super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -727,8 +651,7 @@ class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   GetSidechainWealthRequest createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthRequest> createRepeated() => $pb.PbList<GetSidechainWealthRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
+  static GetSidechainWealthRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
   static GetSidechainWealthRequest? _defaultInstance;
 }
 
@@ -743,27 +666,24 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetSidechainWealthResponse._() : super();
-  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'sats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthResponse clone() => GetSidechainWealthResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) => super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -772,17 +692,13 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
   GetSidechainWealthResponse createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthResponse> createRepeated() => $pb.PbList<GetSidechainWealthResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
+  static GetSidechainWealthResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
   static GetSidechainWealthResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get sats => $_getI64(0);
   @$pb.TagNumber(1)
-  set sats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set sats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -808,28 +724,26 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositRequest._() : super();
-  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'valueSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositRequest clone() => CreateDepositRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) => super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -838,17 +752,13 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   CreateDepositRequest createEmptyInstance() => create();
   static $pb.PbList<CreateDepositRequest> createRepeated() => $pb.PbList<CreateDepositRequest>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
+  static CreateDepositRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
   static CreateDepositRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -857,10 +767,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get valueSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set valueSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set valueSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasValueSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -869,10 +776,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -890,26 +794,24 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositResponse._() : super();
-  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositResponse clone() => CreateDepositResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) => super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -918,17 +820,13 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
   CreateDepositResponse createEmptyInstance() => create();
   static $pb.PbList<CreateDepositResponse> createRepeated() => $pb.PbList<CreateDepositResponse>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
+  static CreateDepositResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
   static CreateDepositResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -938,38 +836,32 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
 class GetPendingWithdrawalBundleRequest extends $pb.GeneratedMessage {
   factory GetPendingWithdrawalBundleRequest() => create();
   GetPendingWithdrawalBundleRequest._() : super();
-  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleRequest clone() => GetPendingWithdrawalBundleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest))
-          as GetPendingWithdrawalBundleRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest)) as GetPendingWithdrawalBundleRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleRequest create() => GetPendingWithdrawalBundleRequest._();
   GetPendingWithdrawalBundleRequest createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleRequest>();
+  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
+  static GetPendingWithdrawalBundleRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
   static GetPendingWithdrawalBundleRequest? _defaultInstance;
 }
 
@@ -984,49 +876,40 @@ class GetPendingWithdrawalBundleResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetPendingWithdrawalBundleResponse._() : super();
-  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bundleJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleResponse clone() => GetPendingWithdrawalBundleResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse))
-          as GetPendingWithdrawalBundleResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse)) as GetPendingWithdrawalBundleResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleResponse create() => GetPendingWithdrawalBundleResponse._();
   GetPendingWithdrawalBundleResponse createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleResponse>();
+  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
+  static GetPendingWithdrawalBundleResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
   static GetPendingWithdrawalBundleResponse? _defaultInstance;
 
   /// JSON string of the bundle, empty if none.
   @$pb.TagNumber(1)
   $core.String get bundleJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bundleJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bundleJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBundleJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1044,26 +927,24 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ConnectPeerRequest._() : super();
-  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerRequest clone() => ConnectPeerRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) => super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1072,17 +953,13 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
   ConnectPeerRequest createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerRequest> createRepeated() => $pb.PbList<ConnectPeerRequest>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
+  static ConnectPeerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
   static ConnectPeerRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1092,25 +969,23 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
 class ConnectPeerResponse extends $pb.GeneratedMessage {
   factory ConnectPeerResponse() => create();
   ConnectPeerResponse._() : super();
-  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerResponse clone() => ConnectPeerResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) => super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1119,33 +994,30 @@ class ConnectPeerResponse extends $pb.GeneratedMessage {
   ConnectPeerResponse createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerResponse> createRepeated() => $pb.PbList<ConnectPeerResponse>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
+  static ConnectPeerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
   static ConnectPeerResponse? _defaultInstance;
 }
 
 class ListPeersRequest extends $pb.GeneratedMessage {
   factory ListPeersRequest() => create();
   ListPeersRequest._() : super();
-  factory ListPeersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersRequest clone() => ListPeersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) =>
-      super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) => super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1154,8 +1026,7 @@ class ListPeersRequest extends $pb.GeneratedMessage {
   ListPeersRequest createEmptyInstance() => create();
   static $pb.PbList<ListPeersRequest> createRepeated() => $pb.PbList<ListPeersRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
+  static ListPeersRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
   static ListPeersRequest? _defaultInstance;
 }
 
@@ -1170,26 +1041,24 @@ class ListPeersResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListPeersResponse._() : super();
-  factory ListPeersResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'peersJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersResponse clone() => ListPeersResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) =>
-      super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) => super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1198,17 +1067,13 @@ class ListPeersResponse extends $pb.GeneratedMessage {
   ListPeersResponse createEmptyInstance() => create();
   static $pb.PbList<ListPeersResponse> createRepeated() => $pb.PbList<ListPeersResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
+  static ListPeersResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
   static ListPeersResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get peersJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set peersJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set peersJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPeersJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1226,25 +1091,24 @@ class MineRequest extends $pb.GeneratedMessage {
     return $result;
   }
   MineRequest._() : super();
-  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineRequest clone() => MineRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineRequest copyWith(void Function(MineRequest) updates) =>
-      super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineRequest copyWith(void Function(MineRequest) updates) => super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1259,10 +1123,7 @@ class MineRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $fixnum.Int64 get feeSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasFeeSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -1280,25 +1141,24 @@ class MineResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MineResponse._() : super();
-  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bmmResultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineResponse clone() => MineResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineResponse copyWith(void Function(MineResponse) updates) =>
-      super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineResponse copyWith(void Function(MineResponse) updates) => super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1313,10 +1173,7 @@ class MineResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get bmmResultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bmmResultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bmmResultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBmmResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1334,26 +1191,24 @@ class GetBlockRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockRequest._() : super();
-  factory GetBlockRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockRequest clone() => GetBlockRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) => super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1362,17 +1217,13 @@ class GetBlockRequest extends $pb.GeneratedMessage {
   GetBlockRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockRequest> createRepeated() => $pb.PbList<GetBlockRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
+  static GetBlockRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
   static GetBlockRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1390,26 +1241,24 @@ class GetBlockResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockResponse._() : super();
-  factory GetBlockResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockResponse clone() => GetBlockResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) => super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1418,17 +1267,13 @@ class GetBlockResponse extends $pb.GeneratedMessage {
   GetBlockResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockResponse> createRepeated() => $pb.PbList<GetBlockResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
+  static GetBlockResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
   static GetBlockResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1438,38 +1283,32 @@ class GetBlockResponse extends $pb.GeneratedMessage {
 class GetBestMainchainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestMainchainBlockHashRequest() => create();
   GetBestMainchainBlockHashRequest._() : super();
-  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashRequest clone() => GetBestMainchainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest))
-          as GetBestMainchainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest)) as GetBestMainchainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashRequest create() => GetBestMainchainBlockHashRequest._();
   GetBestMainchainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashRequest>();
+  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() => $pb.PbList<GetBestMainchainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
+  static GetBestMainchainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
   static GetBestMainchainBlockHashRequest? _defaultInstance;
 }
 
@@ -1484,48 +1323,39 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestMainchainBlockHashResponse._() : super();
-  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashResponse clone() => GetBestMainchainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse))
-          as GetBestMainchainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse)) as GetBestMainchainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashResponse create() => GetBestMainchainBlockHashResponse._();
   GetBestMainchainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashResponse>();
+  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() => $pb.PbList<GetBestMainchainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
+  static GetBestMainchainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
   static GetBestMainchainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1535,38 +1365,32 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
 class GetBestSidechainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestSidechainBlockHashRequest() => create();
   GetBestSidechainBlockHashRequest._() : super();
-  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashRequest clone() => GetBestSidechainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest))
-          as GetBestSidechainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest)) as GetBestSidechainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashRequest create() => GetBestSidechainBlockHashRequest._();
   GetBestSidechainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashRequest>();
+  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() => $pb.PbList<GetBestSidechainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
+  static GetBestSidechainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
   static GetBestSidechainBlockHashRequest? _defaultInstance;
 }
 
@@ -1581,48 +1405,39 @@ class GetBestSidechainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestSidechainBlockHashResponse._() : super();
-  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashResponse clone() => GetBestSidechainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse))
-          as GetBestSidechainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse)) as GetBestSidechainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashResponse create() => GetBestSidechainBlockHashResponse._();
   GetBestSidechainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashResponse>();
+  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() => $pb.PbList<GetBestSidechainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
+  static GetBestSidechainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
   static GetBestSidechainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1640,26 +1455,24 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsRequest._() : super();
-  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockHash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsRequest clone() => GetBmmInclusionsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1668,17 +1481,13 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
   GetBmmInclusionsRequest createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsRequest> createRepeated() => $pb.PbList<GetBmmInclusionsRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
+  static GetBmmInclusionsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
   static GetBmmInclusionsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockHash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockHash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockHash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1696,26 +1505,24 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsResponse._() : super();
-  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'inclusions')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsResponse clone() => GetBmmInclusionsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1724,17 +1531,13 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
   GetBmmInclusionsResponse createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsResponse> createRepeated() => $pb.PbList<GetBmmInclusionsResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
+  static GetBmmInclusionsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
   static GetBmmInclusionsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get inclusions => $_getSZ(0);
   @$pb.TagNumber(1)
-  set inclusions($core.String v) {
-    $_setString(0, v);
-  }
-
+  set inclusions($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasInclusions() => $_has(0);
   @$pb.TagNumber(1)
@@ -1744,25 +1547,23 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
 class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   factory GetWalletUtxosRequest() => create();
   GetWalletUtxosRequest._() : super();
-  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosRequest clone() => GetWalletUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) => super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1771,8 +1572,7 @@ class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   GetWalletUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosRequest> createRepeated() => $pb.PbList<GetWalletUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
+  static GetWalletUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
   static GetWalletUtxosRequest? _defaultInstance;
 }
 
@@ -1787,26 +1587,24 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletUtxosResponse._() : super();
-  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosResponse clone() => GetWalletUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) => super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1815,17 +1613,13 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
   GetWalletUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosResponse> createRepeated() => $pb.PbList<GetWalletUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
+  static GetWalletUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
   static GetWalletUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1835,25 +1629,23 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
 class ListUtxosRequest extends $pb.GeneratedMessage {
   factory ListUtxosRequest() => create();
   ListUtxosRequest._() : super();
-  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosRequest clone() => ListUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) => super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1862,8 +1654,7 @@ class ListUtxosRequest extends $pb.GeneratedMessage {
   ListUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<ListUtxosRequest> createRepeated() => $pb.PbList<ListUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
+  static ListUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
   static ListUtxosRequest? _defaultInstance;
 }
 
@@ -1878,26 +1669,24 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListUtxosResponse._() : super();
-  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosResponse clone() => ListUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) => super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1906,17 +1695,13 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
   ListUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<ListUtxosResponse> createRepeated() => $pb.PbList<ListUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
+  static ListUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
   static ListUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1926,42 +1711,32 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
 class GetLatestFailedWithdrawalBundleHeightRequest extends $pb.GeneratedMessage {
   factory GetLatestFailedWithdrawalBundleHeightRequest() => create();
   GetLatestFailedWithdrawalBundleHeightRequest._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'),
-      createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest clone() =>
-      GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest))
-          as GetLatestFailedWithdrawalBundleHeightRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest clone() => GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest copyWith(void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest)) as GetLatestFailedWithdrawalBundleHeightRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightRequest create() => GetLatestFailedWithdrawalBundleHeightRequest._();
   GetLatestFailedWithdrawalBundleHeightRequest createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
+  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
   static GetLatestFailedWithdrawalBundleHeightRequest? _defaultInstance;
 }
 
@@ -1976,53 +1751,40 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
     return $result;
   }
   GetLatestFailedWithdrawalBundleHeightResponse._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'height')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse clone() =>
-      GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse))
-          as GetLatestFailedWithdrawalBundleHeightResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse clone() => GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse copyWith(void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse)) as GetLatestFailedWithdrawalBundleHeightResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightResponse create() => GetLatestFailedWithdrawalBundleHeightResponse._();
   GetLatestFailedWithdrawalBundleHeightResponse createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
+  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
   static GetLatestFailedWithdrawalBundleHeightResponse? _defaultInstance;
 
   /// 0 means no failed bundle.
   @$pb.TagNumber(1)
   $fixnum.Int64 get height => $_getI64(0);
   @$pb.TagNumber(1)
-  set height($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set height($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHeight() => $_has(0);
   @$pb.TagNumber(1)
@@ -2032,25 +1794,23 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
 class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   factory GenerateMnemonicRequest() => create();
   GenerateMnemonicRequest._() : super();
-  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicRequest clone() => GenerateMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) => super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2059,8 +1819,7 @@ class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   GenerateMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicRequest> createRepeated() => $pb.PbList<GenerateMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
+  static GenerateMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
   static GenerateMnemonicRequest? _defaultInstance;
 }
 
@@ -2075,26 +1834,24 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GenerateMnemonicResponse._() : super();
-  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicResponse clone() => GenerateMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) => super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2103,17 +1860,13 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
   GenerateMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicResponse> createRepeated() => $pb.PbList<GenerateMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
+  static GenerateMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
   static GenerateMnemonicResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2131,27 +1884,24 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SetSeedFromMnemonicRequest._() : super();
-  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicRequest clone() => SetSeedFromMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2160,17 +1910,13 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
   SetSeedFromMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicRequest> createRepeated() => $pb.PbList<SetSeedFromMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
+  static SetSeedFromMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
   static SetSeedFromMnemonicRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2180,26 +1926,23 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
 class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   factory SetSeedFromMnemonicResponse() => create();
   SetSeedFromMnemonicResponse._() : super();
-  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicResponse clone() => SetSeedFromMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2208,8 +1951,7 @@ class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   SetSeedFromMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicResponse> createRepeated() => $pb.PbList<SetSeedFromMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
+  static SetSeedFromMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
   static SetSeedFromMnemonicResponse? _defaultInstance;
 }
 
@@ -2228,26 +1970,25 @@ class CallRawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawRequest._() : super();
-  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'method')
     ..aOS(2, _omitFieldNames ? '' : 'paramsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawRequest clone() => CallRawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawRequest copyWith(void Function(CallRawRequest) updates) =>
-      super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawRequest copyWith(void Function(CallRawRequest) updates) => super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2262,10 +2003,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get method => $_getSZ(0);
   @$pb.TagNumber(1)
-  set method($core.String v) {
-    $_setString(0, v);
-  }
-
+  set method($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMethod() => $_has(0);
   @$pb.TagNumber(1)
@@ -2274,10 +2012,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get paramsJson => $_getSZ(1);
   @$pb.TagNumber(2)
-  set paramsJson($core.String v) {
-    $_setString(1, v);
-  }
-
+  set paramsJson($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasParamsJson() => $_has(1);
   @$pb.TagNumber(2)
@@ -2295,26 +2030,24 @@ class CallRawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawResponse._() : super();
-  factory CallRawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'resultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawResponse clone() => CallRawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawResponse copyWith(void Function(CallRawResponse) updates) =>
-      super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawResponse copyWith(void Function(CallRawResponse) updates) => super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2323,17 +2056,13 @@ class CallRawResponse extends $pb.GeneratedMessage {
   CallRawResponse createEmptyInstance() => create();
   static $pb.PbList<CallRawResponse> createRepeated() => $pb.PbList<CallRawResponse>();
   @$core.pragma('dart2js:noInline')
-  static CallRawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
+  static CallRawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
   static CallRawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get resultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set resultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set resultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2351,26 +2080,24 @@ class GetBitNameDataRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBitNameDataRequest._() : super();
-  factory GetBitNameDataRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBitNameDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBitNameDataRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBitNameDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitNameDataRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitNameDataRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBitNameDataRequest clone() => GetBitNameDataRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBitNameDataRequest copyWith(void Function(GetBitNameDataRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBitNameDataRequest)) as GetBitNameDataRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBitNameDataRequest copyWith(void Function(GetBitNameDataRequest) updates) => super.copyWith((message) => updates(message as GetBitNameDataRequest)) as GetBitNameDataRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2379,17 +2106,13 @@ class GetBitNameDataRequest extends $pb.GeneratedMessage {
   GetBitNameDataRequest createEmptyInstance() => create();
   static $pb.PbList<GetBitNameDataRequest> createRepeated() => $pb.PbList<GetBitNameDataRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBitNameDataRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitNameDataRequest>(create);
+  static GetBitNameDataRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitNameDataRequest>(create);
   static GetBitNameDataRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -2407,26 +2130,24 @@ class GetBitNameDataResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBitNameDataResponse._() : super();
-  factory GetBitNameDataResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBitNameDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBitNameDataResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBitNameDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitNameDataResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitNameDataResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'dataJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBitNameDataResponse clone() => GetBitNameDataResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBitNameDataResponse copyWith(void Function(GetBitNameDataResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBitNameDataResponse)) as GetBitNameDataResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBitNameDataResponse copyWith(void Function(GetBitNameDataResponse) updates) => super.copyWith((message) => updates(message as GetBitNameDataResponse)) as GetBitNameDataResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2435,17 +2156,13 @@ class GetBitNameDataResponse extends $pb.GeneratedMessage {
   GetBitNameDataResponse createEmptyInstance() => create();
   static $pb.PbList<GetBitNameDataResponse> createRepeated() => $pb.PbList<GetBitNameDataResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBitNameDataResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitNameDataResponse>(create);
+  static GetBitNameDataResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitNameDataResponse>(create);
   static GetBitNameDataResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get dataJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set dataJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set dataJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDataJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2455,25 +2172,23 @@ class GetBitNameDataResponse extends $pb.GeneratedMessage {
 class ListBitNamesRequest extends $pb.GeneratedMessage {
   factory ListBitNamesRequest() => create();
   ListBitNamesRequest._() : super();
-  factory ListBitNamesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListBitNamesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListBitNamesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListBitNamesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBitNamesRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBitNamesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListBitNamesRequest clone() => ListBitNamesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListBitNamesRequest copyWith(void Function(ListBitNamesRequest) updates) =>
-      super.copyWith((message) => updates(message as ListBitNamesRequest)) as ListBitNamesRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListBitNamesRequest copyWith(void Function(ListBitNamesRequest) updates) => super.copyWith((message) => updates(message as ListBitNamesRequest)) as ListBitNamesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2482,8 +2197,7 @@ class ListBitNamesRequest extends $pb.GeneratedMessage {
   ListBitNamesRequest createEmptyInstance() => create();
   static $pb.PbList<ListBitNamesRequest> createRepeated() => $pb.PbList<ListBitNamesRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListBitNamesRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBitNamesRequest>(create);
+  static ListBitNamesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBitNamesRequest>(create);
   static ListBitNamesRequest? _defaultInstance;
 }
 
@@ -2498,26 +2212,24 @@ class ListBitNamesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListBitNamesResponse._() : super();
-  factory ListBitNamesResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListBitNamesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListBitNamesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListBitNamesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBitNamesResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBitNamesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bitnamesJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListBitNamesResponse clone() => ListBitNamesResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListBitNamesResponse copyWith(void Function(ListBitNamesResponse) updates) =>
-      super.copyWith((message) => updates(message as ListBitNamesResponse)) as ListBitNamesResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListBitNamesResponse copyWith(void Function(ListBitNamesResponse) updates) => super.copyWith((message) => updates(message as ListBitNamesResponse)) as ListBitNamesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2526,17 +2238,13 @@ class ListBitNamesResponse extends $pb.GeneratedMessage {
   ListBitNamesResponse createEmptyInstance() => create();
   static $pb.PbList<ListBitNamesResponse> createRepeated() => $pb.PbList<ListBitNamesResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListBitNamesResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBitNamesResponse>(create);
+  static ListBitNamesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBitNamesResponse>(create);
   static ListBitNamesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get bitnamesJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bitnamesJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bitnamesJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBitnamesJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2558,27 +2266,25 @@ class RegisterBitNameRequest extends $pb.GeneratedMessage {
     return $result;
   }
   RegisterBitNameRequest._() : super();
-  factory RegisterBitNameRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RegisterBitNameRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RegisterBitNameRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RegisterBitNameRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RegisterBitNameRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RegisterBitNameRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'plainName')
     ..aOS(2, _omitFieldNames ? '' : 'dataJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RegisterBitNameRequest clone() => RegisterBitNameRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RegisterBitNameRequest copyWith(void Function(RegisterBitNameRequest) updates) =>
-      super.copyWith((message) => updates(message as RegisterBitNameRequest)) as RegisterBitNameRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RegisterBitNameRequest copyWith(void Function(RegisterBitNameRequest) updates) => super.copyWith((message) => updates(message as RegisterBitNameRequest)) as RegisterBitNameRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2587,17 +2293,13 @@ class RegisterBitNameRequest extends $pb.GeneratedMessage {
   RegisterBitNameRequest createEmptyInstance() => create();
   static $pb.PbList<RegisterBitNameRequest> createRepeated() => $pb.PbList<RegisterBitNameRequest>();
   @$core.pragma('dart2js:noInline')
-  static RegisterBitNameRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterBitNameRequest>(create);
+  static RegisterBitNameRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterBitNameRequest>(create);
   static RegisterBitNameRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get plainName => $_getSZ(0);
   @$pb.TagNumber(1)
-  set plainName($core.String v) {
-    $_setString(0, v);
-  }
-
+  set plainName($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPlainName() => $_has(0);
   @$pb.TagNumber(1)
@@ -2606,10 +2308,7 @@ class RegisterBitNameRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get dataJson => $_getSZ(1);
   @$pb.TagNumber(2)
-  set dataJson($core.String v) {
-    $_setString(1, v);
-  }
-
+  set dataJson($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasDataJson() => $_has(1);
   @$pb.TagNumber(2)
@@ -2627,26 +2326,24 @@ class RegisterBitNameResponse extends $pb.GeneratedMessage {
     return $result;
   }
   RegisterBitNameResponse._() : super();
-  factory RegisterBitNameResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RegisterBitNameResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RegisterBitNameResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RegisterBitNameResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RegisterBitNameResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RegisterBitNameResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RegisterBitNameResponse clone() => RegisterBitNameResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RegisterBitNameResponse copyWith(void Function(RegisterBitNameResponse) updates) =>
-      super.copyWith((message) => updates(message as RegisterBitNameResponse)) as RegisterBitNameResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RegisterBitNameResponse copyWith(void Function(RegisterBitNameResponse) updates) => super.copyWith((message) => updates(message as RegisterBitNameResponse)) as RegisterBitNameResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2655,17 +2352,13 @@ class RegisterBitNameResponse extends $pb.GeneratedMessage {
   RegisterBitNameResponse createEmptyInstance() => create();
   static $pb.PbList<RegisterBitNameResponse> createRepeated() => $pb.PbList<RegisterBitNameResponse>();
   @$core.pragma('dart2js:noInline')
-  static RegisterBitNameResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterBitNameResponse>(create);
+  static RegisterBitNameResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterBitNameResponse>(create);
   static RegisterBitNameResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2683,26 +2376,24 @@ class ReserveBitNameRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ReserveBitNameRequest._() : super();
-  factory ReserveBitNameRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReserveBitNameRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ReserveBitNameRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReserveBitNameRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReserveBitNameRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReserveBitNameRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ReserveBitNameRequest clone() => ReserveBitNameRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ReserveBitNameRequest copyWith(void Function(ReserveBitNameRequest) updates) =>
-      super.copyWith((message) => updates(message as ReserveBitNameRequest)) as ReserveBitNameRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ReserveBitNameRequest copyWith(void Function(ReserveBitNameRequest) updates) => super.copyWith((message) => updates(message as ReserveBitNameRequest)) as ReserveBitNameRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2711,17 +2402,13 @@ class ReserveBitNameRequest extends $pb.GeneratedMessage {
   ReserveBitNameRequest createEmptyInstance() => create();
   static $pb.PbList<ReserveBitNameRequest> createRepeated() => $pb.PbList<ReserveBitNameRequest>();
   @$core.pragma('dart2js:noInline')
-  static ReserveBitNameRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReserveBitNameRequest>(create);
+  static ReserveBitNameRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReserveBitNameRequest>(create);
   static ReserveBitNameRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -2739,26 +2426,24 @@ class ReserveBitNameResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ReserveBitNameResponse._() : super();
-  factory ReserveBitNameResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReserveBitNameResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ReserveBitNameResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReserveBitNameResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReserveBitNameResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReserveBitNameResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ReserveBitNameResponse clone() => ReserveBitNameResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ReserveBitNameResponse copyWith(void Function(ReserveBitNameResponse) updates) =>
-      super.copyWith((message) => updates(message as ReserveBitNameResponse)) as ReserveBitNameResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ReserveBitNameResponse copyWith(void Function(ReserveBitNameResponse) updates) => super.copyWith((message) => updates(message as ReserveBitNameResponse)) as ReserveBitNameResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2767,17 +2452,13 @@ class ReserveBitNameResponse extends $pb.GeneratedMessage {
   ReserveBitNameResponse createEmptyInstance() => create();
   static $pb.PbList<ReserveBitNameResponse> createRepeated() => $pb.PbList<ReserveBitNameResponse>();
   @$core.pragma('dart2js:noInline')
-  static ReserveBitNameResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReserveBitNameResponse>(create);
+  static ReserveBitNameResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReserveBitNameResponse>(create);
   static ReserveBitNameResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2787,26 +2468,23 @@ class ReserveBitNameResponse extends $pb.GeneratedMessage {
 class GetNewEncryptionKeyRequest extends $pb.GeneratedMessage {
   factory GetNewEncryptionKeyRequest() => create();
   GetNewEncryptionKeyRequest._() : super();
-  factory GetNewEncryptionKeyRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewEncryptionKeyRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewEncryptionKeyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewEncryptionKeyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewEncryptionKeyRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewEncryptionKeyRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewEncryptionKeyRequest clone() => GetNewEncryptionKeyRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewEncryptionKeyRequest copyWith(void Function(GetNewEncryptionKeyRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewEncryptionKeyRequest)) as GetNewEncryptionKeyRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewEncryptionKeyRequest copyWith(void Function(GetNewEncryptionKeyRequest) updates) => super.copyWith((message) => updates(message as GetNewEncryptionKeyRequest)) as GetNewEncryptionKeyRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2815,8 +2493,7 @@ class GetNewEncryptionKeyRequest extends $pb.GeneratedMessage {
   GetNewEncryptionKeyRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewEncryptionKeyRequest> createRepeated() => $pb.PbList<GetNewEncryptionKeyRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewEncryptionKeyRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewEncryptionKeyRequest>(create);
+  static GetNewEncryptionKeyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewEncryptionKeyRequest>(create);
   static GetNewEncryptionKeyRequest? _defaultInstance;
 }
 
@@ -2831,27 +2508,24 @@ class GetNewEncryptionKeyResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewEncryptionKeyResponse._() : super();
-  factory GetNewEncryptionKeyResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewEncryptionKeyResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewEncryptionKeyResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewEncryptionKeyResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewEncryptionKeyResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewEncryptionKeyResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'key')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewEncryptionKeyResponse clone() => GetNewEncryptionKeyResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewEncryptionKeyResponse copyWith(void Function(GetNewEncryptionKeyResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewEncryptionKeyResponse)) as GetNewEncryptionKeyResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewEncryptionKeyResponse copyWith(void Function(GetNewEncryptionKeyResponse) updates) => super.copyWith((message) => updates(message as GetNewEncryptionKeyResponse)) as GetNewEncryptionKeyResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2860,17 +2534,13 @@ class GetNewEncryptionKeyResponse extends $pb.GeneratedMessage {
   GetNewEncryptionKeyResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewEncryptionKeyResponse> createRepeated() => $pb.PbList<GetNewEncryptionKeyResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewEncryptionKeyResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewEncryptionKeyResponse>(create);
+  static GetNewEncryptionKeyResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewEncryptionKeyResponse>(create);
   static GetNewEncryptionKeyResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get key => $_getSZ(0);
   @$pb.TagNumber(1)
-  set key($core.String v) {
-    $_setString(0, v);
-  }
-
+  set key($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasKey() => $_has(0);
   @$pb.TagNumber(1)
@@ -2880,25 +2550,23 @@ class GetNewEncryptionKeyResponse extends $pb.GeneratedMessage {
 class GetNewVerifyingKeyRequest extends $pb.GeneratedMessage {
   factory GetNewVerifyingKeyRequest() => create();
   GetNewVerifyingKeyRequest._() : super();
-  factory GetNewVerifyingKeyRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewVerifyingKeyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewVerifyingKeyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewVerifyingKeyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewVerifyingKeyRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewVerifyingKeyRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewVerifyingKeyRequest clone() => GetNewVerifyingKeyRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewVerifyingKeyRequest copyWith(void Function(GetNewVerifyingKeyRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewVerifyingKeyRequest)) as GetNewVerifyingKeyRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewVerifyingKeyRequest copyWith(void Function(GetNewVerifyingKeyRequest) updates) => super.copyWith((message) => updates(message as GetNewVerifyingKeyRequest)) as GetNewVerifyingKeyRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2907,8 +2575,7 @@ class GetNewVerifyingKeyRequest extends $pb.GeneratedMessage {
   GetNewVerifyingKeyRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewVerifyingKeyRequest> createRepeated() => $pb.PbList<GetNewVerifyingKeyRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewVerifyingKeyRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewVerifyingKeyRequest>(create);
+  static GetNewVerifyingKeyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewVerifyingKeyRequest>(create);
   static GetNewVerifyingKeyRequest? _defaultInstance;
 }
 
@@ -2923,27 +2590,24 @@ class GetNewVerifyingKeyResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewVerifyingKeyResponse._() : super();
-  factory GetNewVerifyingKeyResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewVerifyingKeyResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewVerifyingKeyResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewVerifyingKeyResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewVerifyingKeyResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewVerifyingKeyResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'key')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewVerifyingKeyResponse clone() => GetNewVerifyingKeyResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewVerifyingKeyResponse copyWith(void Function(GetNewVerifyingKeyResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewVerifyingKeyResponse)) as GetNewVerifyingKeyResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewVerifyingKeyResponse copyWith(void Function(GetNewVerifyingKeyResponse) updates) => super.copyWith((message) => updates(message as GetNewVerifyingKeyResponse)) as GetNewVerifyingKeyResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2952,17 +2616,13 @@ class GetNewVerifyingKeyResponse extends $pb.GeneratedMessage {
   GetNewVerifyingKeyResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewVerifyingKeyResponse> createRepeated() => $pb.PbList<GetNewVerifyingKeyResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewVerifyingKeyResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewVerifyingKeyResponse>(create);
+  static GetNewVerifyingKeyResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewVerifyingKeyResponse>(create);
   static GetNewVerifyingKeyResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get key => $_getSZ(0);
   @$pb.TagNumber(1)
-  set key($core.String v) {
-    $_setString(0, v);
-  }
-
+  set key($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasKey() => $_has(0);
   @$pb.TagNumber(1)
@@ -2984,27 +2644,25 @@ class DecryptMsgRequest extends $pb.GeneratedMessage {
     return $result;
   }
   DecryptMsgRequest._() : super();
-  factory DecryptMsgRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DecryptMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DecryptMsgRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DecryptMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecryptMsgRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecryptMsgRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'ciphertext')
     ..aOS(2, _omitFieldNames ? '' : 'encryptionPubkey')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DecryptMsgRequest clone() => DecryptMsgRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DecryptMsgRequest copyWith(void Function(DecryptMsgRequest) updates) =>
-      super.copyWith((message) => updates(message as DecryptMsgRequest)) as DecryptMsgRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DecryptMsgRequest copyWith(void Function(DecryptMsgRequest) updates) => super.copyWith((message) => updates(message as DecryptMsgRequest)) as DecryptMsgRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3013,17 +2671,13 @@ class DecryptMsgRequest extends $pb.GeneratedMessage {
   DecryptMsgRequest createEmptyInstance() => create();
   static $pb.PbList<DecryptMsgRequest> createRepeated() => $pb.PbList<DecryptMsgRequest>();
   @$core.pragma('dart2js:noInline')
-  static DecryptMsgRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecryptMsgRequest>(create);
+  static DecryptMsgRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecryptMsgRequest>(create);
   static DecryptMsgRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get ciphertext => $_getSZ(0);
   @$pb.TagNumber(1)
-  set ciphertext($core.String v) {
-    $_setString(0, v);
-  }
-
+  set ciphertext($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCiphertext() => $_has(0);
   @$pb.TagNumber(1)
@@ -3032,10 +2686,7 @@ class DecryptMsgRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get encryptionPubkey => $_getSZ(1);
   @$pb.TagNumber(2)
-  set encryptionPubkey($core.String v) {
-    $_setString(1, v);
-  }
-
+  set encryptionPubkey($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasEncryptionPubkey() => $_has(1);
   @$pb.TagNumber(2)
@@ -3053,26 +2704,24 @@ class DecryptMsgResponse extends $pb.GeneratedMessage {
     return $result;
   }
   DecryptMsgResponse._() : super();
-  factory DecryptMsgResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DecryptMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DecryptMsgResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DecryptMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecryptMsgResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecryptMsgResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'plaintext')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DecryptMsgResponse clone() => DecryptMsgResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DecryptMsgResponse copyWith(void Function(DecryptMsgResponse) updates) =>
-      super.copyWith((message) => updates(message as DecryptMsgResponse)) as DecryptMsgResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DecryptMsgResponse copyWith(void Function(DecryptMsgResponse) updates) => super.copyWith((message) => updates(message as DecryptMsgResponse)) as DecryptMsgResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3081,17 +2730,13 @@ class DecryptMsgResponse extends $pb.GeneratedMessage {
   DecryptMsgResponse createEmptyInstance() => create();
   static $pb.PbList<DecryptMsgResponse> createRepeated() => $pb.PbList<DecryptMsgResponse>();
   @$core.pragma('dart2js:noInline')
-  static DecryptMsgResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecryptMsgResponse>(create);
+  static DecryptMsgResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecryptMsgResponse>(create);
   static DecryptMsgResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get plaintext => $_getSZ(0);
   @$pb.TagNumber(1)
-  set plaintext($core.String v) {
-    $_setString(0, v);
-  }
-
+  set plaintext($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPlaintext() => $_has(0);
   @$pb.TagNumber(1)
@@ -3113,27 +2758,25 @@ class EncryptMsgRequest extends $pb.GeneratedMessage {
     return $result;
   }
   EncryptMsgRequest._() : super();
-  factory EncryptMsgRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory EncryptMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory EncryptMsgRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EncryptMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptMsgRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptMsgRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'msg')
     ..aOS(2, _omitFieldNames ? '' : 'encryptionPubkey')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   EncryptMsgRequest clone() => EncryptMsgRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  EncryptMsgRequest copyWith(void Function(EncryptMsgRequest) updates) =>
-      super.copyWith((message) => updates(message as EncryptMsgRequest)) as EncryptMsgRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EncryptMsgRequest copyWith(void Function(EncryptMsgRequest) updates) => super.copyWith((message) => updates(message as EncryptMsgRequest)) as EncryptMsgRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3142,17 +2785,13 @@ class EncryptMsgRequest extends $pb.GeneratedMessage {
   EncryptMsgRequest createEmptyInstance() => create();
   static $pb.PbList<EncryptMsgRequest> createRepeated() => $pb.PbList<EncryptMsgRequest>();
   @$core.pragma('dart2js:noInline')
-  static EncryptMsgRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptMsgRequest>(create);
+  static EncryptMsgRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptMsgRequest>(create);
   static EncryptMsgRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get msg => $_getSZ(0);
   @$pb.TagNumber(1)
-  set msg($core.String v) {
-    $_setString(0, v);
-  }
-
+  set msg($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMsg() => $_has(0);
   @$pb.TagNumber(1)
@@ -3161,10 +2800,7 @@ class EncryptMsgRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get encryptionPubkey => $_getSZ(1);
   @$pb.TagNumber(2)
-  set encryptionPubkey($core.String v) {
-    $_setString(1, v);
-  }
-
+  set encryptionPubkey($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasEncryptionPubkey() => $_has(1);
   @$pb.TagNumber(2)
@@ -3182,26 +2818,24 @@ class EncryptMsgResponse extends $pb.GeneratedMessage {
     return $result;
   }
   EncryptMsgResponse._() : super();
-  factory EncryptMsgResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory EncryptMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory EncryptMsgResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EncryptMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptMsgResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptMsgResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'ciphertext')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   EncryptMsgResponse clone() => EncryptMsgResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  EncryptMsgResponse copyWith(void Function(EncryptMsgResponse) updates) =>
-      super.copyWith((message) => updates(message as EncryptMsgResponse)) as EncryptMsgResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EncryptMsgResponse copyWith(void Function(EncryptMsgResponse) updates) => super.copyWith((message) => updates(message as EncryptMsgResponse)) as EncryptMsgResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3210,17 +2844,13 @@ class EncryptMsgResponse extends $pb.GeneratedMessage {
   EncryptMsgResponse createEmptyInstance() => create();
   static $pb.PbList<EncryptMsgResponse> createRepeated() => $pb.PbList<EncryptMsgResponse>();
   @$core.pragma('dart2js:noInline')
-  static EncryptMsgResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptMsgResponse>(create);
+  static EncryptMsgResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptMsgResponse>(create);
   static EncryptMsgResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get ciphertext => $_getSZ(0);
   @$pb.TagNumber(1)
-  set ciphertext($core.String v) {
-    $_setString(0, v);
-  }
-
+  set ciphertext($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCiphertext() => $_has(0);
   @$pb.TagNumber(1)
@@ -3230,25 +2860,23 @@ class EncryptMsgResponse extends $pb.GeneratedMessage {
 class GetPaymailRequest extends $pb.GeneratedMessage {
   factory GetPaymailRequest() => create();
   GetPaymailRequest._() : super();
-  factory GetPaymailRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPaymailRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPaymailRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPaymailRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPaymailRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPaymailRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPaymailRequest clone() => GetPaymailRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPaymailRequest copyWith(void Function(GetPaymailRequest) updates) =>
-      super.copyWith((message) => updates(message as GetPaymailRequest)) as GetPaymailRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPaymailRequest copyWith(void Function(GetPaymailRequest) updates) => super.copyWith((message) => updates(message as GetPaymailRequest)) as GetPaymailRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3257,8 +2885,7 @@ class GetPaymailRequest extends $pb.GeneratedMessage {
   GetPaymailRequest createEmptyInstance() => create();
   static $pb.PbList<GetPaymailRequest> createRepeated() => $pb.PbList<GetPaymailRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetPaymailRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPaymailRequest>(create);
+  static GetPaymailRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPaymailRequest>(create);
   static GetPaymailRequest? _defaultInstance;
 }
 
@@ -3273,26 +2900,24 @@ class GetPaymailResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetPaymailResponse._() : super();
-  factory GetPaymailResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPaymailResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPaymailResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPaymailResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPaymailResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPaymailResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'paymailJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPaymailResponse clone() => GetPaymailResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPaymailResponse copyWith(void Function(GetPaymailResponse) updates) =>
-      super.copyWith((message) => updates(message as GetPaymailResponse)) as GetPaymailResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPaymailResponse copyWith(void Function(GetPaymailResponse) updates) => super.copyWith((message) => updates(message as GetPaymailResponse)) as GetPaymailResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3301,17 +2926,13 @@ class GetPaymailResponse extends $pb.GeneratedMessage {
   GetPaymailResponse createEmptyInstance() => create();
   static $pb.PbList<GetPaymailResponse> createRepeated() => $pb.PbList<GetPaymailResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetPaymailResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPaymailResponse>(create);
+  static GetPaymailResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPaymailResponse>(create);
   static GetPaymailResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get paymailJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set paymailJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set paymailJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPaymailJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -3329,26 +2950,24 @@ class ResolveCommitRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ResolveCommitRequest._() : super();
-  factory ResolveCommitRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ResolveCommitRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ResolveCommitRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ResolveCommitRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResolveCommitRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResolveCommitRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bitname')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ResolveCommitRequest clone() => ResolveCommitRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ResolveCommitRequest copyWith(void Function(ResolveCommitRequest) updates) =>
-      super.copyWith((message) => updates(message as ResolveCommitRequest)) as ResolveCommitRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ResolveCommitRequest copyWith(void Function(ResolveCommitRequest) updates) => super.copyWith((message) => updates(message as ResolveCommitRequest)) as ResolveCommitRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3357,17 +2976,13 @@ class ResolveCommitRequest extends $pb.GeneratedMessage {
   ResolveCommitRequest createEmptyInstance() => create();
   static $pb.PbList<ResolveCommitRequest> createRepeated() => $pb.PbList<ResolveCommitRequest>();
   @$core.pragma('dart2js:noInline')
-  static ResolveCommitRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResolveCommitRequest>(create);
+  static ResolveCommitRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResolveCommitRequest>(create);
   static ResolveCommitRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get bitname => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bitname($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bitname($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBitname() => $_has(0);
   @$pb.TagNumber(1)
@@ -3385,26 +3000,24 @@ class ResolveCommitResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ResolveCommitResponse._() : super();
-  factory ResolveCommitResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ResolveCommitResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ResolveCommitResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ResolveCommitResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResolveCommitResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResolveCommitResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'commitment')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ResolveCommitResponse clone() => ResolveCommitResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ResolveCommitResponse copyWith(void Function(ResolveCommitResponse) updates) =>
-      super.copyWith((message) => updates(message as ResolveCommitResponse)) as ResolveCommitResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ResolveCommitResponse copyWith(void Function(ResolveCommitResponse) updates) => super.copyWith((message) => updates(message as ResolveCommitResponse)) as ResolveCommitResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3413,17 +3026,13 @@ class ResolveCommitResponse extends $pb.GeneratedMessage {
   ResolveCommitResponse createEmptyInstance() => create();
   static $pb.PbList<ResolveCommitResponse> createRepeated() => $pb.PbList<ResolveCommitResponse>();
   @$core.pragma('dart2js:noInline')
-  static ResolveCommitResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResolveCommitResponse>(create);
+  static ResolveCommitResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResolveCommitResponse>(create);
   static ResolveCommitResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get commitment => $_getSZ(0);
   @$pb.TagNumber(1)
-  set commitment($core.String v) {
-    $_setString(0, v);
-  }
-
+  set commitment($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCommitment() => $_has(0);
   @$pb.TagNumber(1)
@@ -3445,27 +3054,25 @@ class SignArbitraryMsgRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SignArbitraryMsgRequest._() : super();
-  factory SignArbitraryMsgRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SignArbitraryMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SignArbitraryMsgRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignArbitraryMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'msg')
     ..aOS(2, _omitFieldNames ? '' : 'verifyingKey')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SignArbitraryMsgRequest clone() => SignArbitraryMsgRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SignArbitraryMsgRequest copyWith(void Function(SignArbitraryMsgRequest) updates) =>
-      super.copyWith((message) => updates(message as SignArbitraryMsgRequest)) as SignArbitraryMsgRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignArbitraryMsgRequest copyWith(void Function(SignArbitraryMsgRequest) updates) => super.copyWith((message) => updates(message as SignArbitraryMsgRequest)) as SignArbitraryMsgRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3474,17 +3081,13 @@ class SignArbitraryMsgRequest extends $pb.GeneratedMessage {
   SignArbitraryMsgRequest createEmptyInstance() => create();
   static $pb.PbList<SignArbitraryMsgRequest> createRepeated() => $pb.PbList<SignArbitraryMsgRequest>();
   @$core.pragma('dart2js:noInline')
-  static SignArbitraryMsgRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgRequest>(create);
+  static SignArbitraryMsgRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgRequest>(create);
   static SignArbitraryMsgRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get msg => $_getSZ(0);
   @$pb.TagNumber(1)
-  set msg($core.String v) {
-    $_setString(0, v);
-  }
-
+  set msg($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMsg() => $_has(0);
   @$pb.TagNumber(1)
@@ -3493,10 +3096,7 @@ class SignArbitraryMsgRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get verifyingKey => $_getSZ(1);
   @$pb.TagNumber(2)
-  set verifyingKey($core.String v) {
-    $_setString(1, v);
-  }
-
+  set verifyingKey($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasVerifyingKey() => $_has(1);
   @$pb.TagNumber(2)
@@ -3514,26 +3114,24 @@ class SignArbitraryMsgResponse extends $pb.GeneratedMessage {
     return $result;
   }
   SignArbitraryMsgResponse._() : super();
-  factory SignArbitraryMsgResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SignArbitraryMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SignArbitraryMsgResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignArbitraryMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'signature')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SignArbitraryMsgResponse clone() => SignArbitraryMsgResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SignArbitraryMsgResponse copyWith(void Function(SignArbitraryMsgResponse) updates) =>
-      super.copyWith((message) => updates(message as SignArbitraryMsgResponse)) as SignArbitraryMsgResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignArbitraryMsgResponse copyWith(void Function(SignArbitraryMsgResponse) updates) => super.copyWith((message) => updates(message as SignArbitraryMsgResponse)) as SignArbitraryMsgResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3542,17 +3140,13 @@ class SignArbitraryMsgResponse extends $pb.GeneratedMessage {
   SignArbitraryMsgResponse createEmptyInstance() => create();
   static $pb.PbList<SignArbitraryMsgResponse> createRepeated() => $pb.PbList<SignArbitraryMsgResponse>();
   @$core.pragma('dart2js:noInline')
-  static SignArbitraryMsgResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgResponse>(create);
+  static SignArbitraryMsgResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgResponse>(create);
   static SignArbitraryMsgResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get signature => $_getSZ(0);
   @$pb.TagNumber(1)
-  set signature($core.String v) {
-    $_setString(0, v);
-  }
-
+  set signature($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSignature() => $_has(0);
   @$pb.TagNumber(1)
@@ -3574,28 +3168,25 @@ class SignArbitraryMsgAsAddrRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SignArbitraryMsgAsAddrRequest._() : super();
-  factory SignArbitraryMsgAsAddrRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SignArbitraryMsgAsAddrRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SignArbitraryMsgAsAddrRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignArbitraryMsgAsAddrRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgAsAddrRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgAsAddrRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'msg')
     ..aOS(2, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SignArbitraryMsgAsAddrRequest clone() => SignArbitraryMsgAsAddrRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SignArbitraryMsgAsAddrRequest copyWith(void Function(SignArbitraryMsgAsAddrRequest) updates) =>
-      super.copyWith((message) => updates(message as SignArbitraryMsgAsAddrRequest)) as SignArbitraryMsgAsAddrRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignArbitraryMsgAsAddrRequest copyWith(void Function(SignArbitraryMsgAsAddrRequest) updates) => super.copyWith((message) => updates(message as SignArbitraryMsgAsAddrRequest)) as SignArbitraryMsgAsAddrRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3604,17 +3195,13 @@ class SignArbitraryMsgAsAddrRequest extends $pb.GeneratedMessage {
   SignArbitraryMsgAsAddrRequest createEmptyInstance() => create();
   static $pb.PbList<SignArbitraryMsgAsAddrRequest> createRepeated() => $pb.PbList<SignArbitraryMsgAsAddrRequest>();
   @$core.pragma('dart2js:noInline')
-  static SignArbitraryMsgAsAddrRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgAsAddrRequest>(create);
+  static SignArbitraryMsgAsAddrRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgAsAddrRequest>(create);
   static SignArbitraryMsgAsAddrRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get msg => $_getSZ(0);
   @$pb.TagNumber(1)
-  set msg($core.String v) {
-    $_setString(0, v);
-  }
-
+  set msg($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMsg() => $_has(0);
   @$pb.TagNumber(1)
@@ -3623,10 +3210,7 @@ class SignArbitraryMsgAsAddrRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get address => $_getSZ(1);
   @$pb.TagNumber(2)
-  set address($core.String v) {
-    $_setString(1, v);
-  }
-
+  set address($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAddress() => $_has(1);
   @$pb.TagNumber(2)
@@ -3648,28 +3232,25 @@ class SignArbitraryMsgAsAddrResponse extends $pb.GeneratedMessage {
     return $result;
   }
   SignArbitraryMsgAsAddrResponse._() : super();
-  factory SignArbitraryMsgAsAddrResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SignArbitraryMsgAsAddrResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SignArbitraryMsgAsAddrResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignArbitraryMsgAsAddrResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgAsAddrResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgAsAddrResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'verifyingKey')
     ..aOS(2, _omitFieldNames ? '' : 'signature')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SignArbitraryMsgAsAddrResponse clone() => SignArbitraryMsgAsAddrResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SignArbitraryMsgAsAddrResponse copyWith(void Function(SignArbitraryMsgAsAddrResponse) updates) =>
-      super.copyWith((message) => updates(message as SignArbitraryMsgAsAddrResponse)) as SignArbitraryMsgAsAddrResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignArbitraryMsgAsAddrResponse copyWith(void Function(SignArbitraryMsgAsAddrResponse) updates) => super.copyWith((message) => updates(message as SignArbitraryMsgAsAddrResponse)) as SignArbitraryMsgAsAddrResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3678,17 +3259,13 @@ class SignArbitraryMsgAsAddrResponse extends $pb.GeneratedMessage {
   SignArbitraryMsgAsAddrResponse createEmptyInstance() => create();
   static $pb.PbList<SignArbitraryMsgAsAddrResponse> createRepeated() => $pb.PbList<SignArbitraryMsgAsAddrResponse>();
   @$core.pragma('dart2js:noInline')
-  static SignArbitraryMsgAsAddrResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgAsAddrResponse>(create);
+  static SignArbitraryMsgAsAddrResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgAsAddrResponse>(create);
   static SignArbitraryMsgAsAddrResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get verifyingKey => $_getSZ(0);
   @$pb.TagNumber(1)
-  set verifyingKey($core.String v) {
-    $_setString(0, v);
-  }
-
+  set verifyingKey($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasVerifyingKey() => $_has(0);
   @$pb.TagNumber(1)
@@ -3697,10 +3274,7 @@ class SignArbitraryMsgAsAddrResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get signature => $_getSZ(1);
   @$pb.TagNumber(2)
-  set signature($core.String v) {
-    $_setString(1, v);
-  }
-
+  set signature($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasSignature() => $_has(1);
   @$pb.TagNumber(2)
@@ -3710,25 +3284,23 @@ class SignArbitraryMsgAsAddrResponse extends $pb.GeneratedMessage {
 class GetWalletAddressesRequest extends $pb.GeneratedMessage {
   factory GetWalletAddressesRequest() => create();
   GetWalletAddressesRequest._() : super();
-  factory GetWalletAddressesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletAddressesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletAddressesRequest clone() => GetWalletAddressesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletAddressesRequest copyWith(void Function(GetWalletAddressesRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletAddressesRequest)) as GetWalletAddressesRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletAddressesRequest copyWith(void Function(GetWalletAddressesRequest) updates) => super.copyWith((message) => updates(message as GetWalletAddressesRequest)) as GetWalletAddressesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3737,8 +3309,7 @@ class GetWalletAddressesRequest extends $pb.GeneratedMessage {
   GetWalletAddressesRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletAddressesRequest> createRepeated() => $pb.PbList<GetWalletAddressesRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletAddressesRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesRequest>(create);
+  static GetWalletAddressesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesRequest>(create);
   static GetWalletAddressesRequest? _defaultInstance;
 }
 
@@ -3753,27 +3324,24 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletAddressesResponse._() : super();
-  factory GetWalletAddressesResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletAddressesResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletAddressesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletAddressesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..pPS(1, _omitFieldNames ? '' : 'addresses')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletAddressesResponse clone() => GetWalletAddressesResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletAddressesResponse copyWith(void Function(GetWalletAddressesResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletAddressesResponse)) as GetWalletAddressesResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletAddressesResponse copyWith(void Function(GetWalletAddressesResponse) updates) => super.copyWith((message) => updates(message as GetWalletAddressesResponse)) as GetWalletAddressesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3782,8 +3350,7 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
   GetWalletAddressesResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletAddressesResponse> createRepeated() => $pb.PbList<GetWalletAddressesResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletAddressesResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesResponse>(create);
+  static GetWalletAddressesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesResponse>(create);
   static GetWalletAddressesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -3793,24 +3360,23 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
 class MyUtxosRequest extends $pb.GeneratedMessage {
   factory MyUtxosRequest() => create();
   MyUtxosRequest._() : super();
-  factory MyUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MyUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MyUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MyUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MyUtxosRequest clone() => MyUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MyUtxosRequest copyWith(void Function(MyUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as MyUtxosRequest)) as MyUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MyUtxosRequest copyWith(void Function(MyUtxosRequest) updates) => super.copyWith((message) => updates(message as MyUtxosRequest)) as MyUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3834,26 +3400,24 @@ class MyUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MyUtxosResponse._() : super();
-  factory MyUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MyUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MyUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MyUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MyUtxosResponse clone() => MyUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MyUtxosResponse copyWith(void Function(MyUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as MyUtxosResponse)) as MyUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MyUtxosResponse copyWith(void Function(MyUtxosResponse) updates) => super.copyWith((message) => updates(message as MyUtxosResponse)) as MyUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3862,17 +3426,13 @@ class MyUtxosResponse extends $pb.GeneratedMessage {
   MyUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<MyUtxosResponse> createRepeated() => $pb.PbList<MyUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static MyUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MyUtxosResponse>(create);
+  static MyUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MyUtxosResponse>(create);
   static MyUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -3882,25 +3442,23 @@ class MyUtxosResponse extends $pb.GeneratedMessage {
 class OpenapiSchemaRequest extends $pb.GeneratedMessage {
   factory OpenapiSchemaRequest() => create();
   OpenapiSchemaRequest._() : super();
-  factory OpenapiSchemaRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory OpenapiSchemaRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory OpenapiSchemaRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory OpenapiSchemaRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OpenapiSchemaRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OpenapiSchemaRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   OpenapiSchemaRequest clone() => OpenapiSchemaRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  OpenapiSchemaRequest copyWith(void Function(OpenapiSchemaRequest) updates) =>
-      super.copyWith((message) => updates(message as OpenapiSchemaRequest)) as OpenapiSchemaRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  OpenapiSchemaRequest copyWith(void Function(OpenapiSchemaRequest) updates) => super.copyWith((message) => updates(message as OpenapiSchemaRequest)) as OpenapiSchemaRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3909,8 +3467,7 @@ class OpenapiSchemaRequest extends $pb.GeneratedMessage {
   OpenapiSchemaRequest createEmptyInstance() => create();
   static $pb.PbList<OpenapiSchemaRequest> createRepeated() => $pb.PbList<OpenapiSchemaRequest>();
   @$core.pragma('dart2js:noInline')
-  static OpenapiSchemaRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpenapiSchemaRequest>(create);
+  static OpenapiSchemaRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpenapiSchemaRequest>(create);
   static OpenapiSchemaRequest? _defaultInstance;
 }
 
@@ -3925,26 +3482,24 @@ class OpenapiSchemaResponse extends $pb.GeneratedMessage {
     return $result;
   }
   OpenapiSchemaResponse._() : super();
-  factory OpenapiSchemaResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory OpenapiSchemaResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory OpenapiSchemaResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory OpenapiSchemaResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OpenapiSchemaResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OpenapiSchemaResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitnames.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'schemaJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   OpenapiSchemaResponse clone() => OpenapiSchemaResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  OpenapiSchemaResponse copyWith(void Function(OpenapiSchemaResponse) updates) =>
-      super.copyWith((message) => updates(message as OpenapiSchemaResponse)) as OpenapiSchemaResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  OpenapiSchemaResponse copyWith(void Function(OpenapiSchemaResponse) updates) => super.copyWith((message) => updates(message as OpenapiSchemaResponse)) as OpenapiSchemaResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3953,17 +3508,13 @@ class OpenapiSchemaResponse extends $pb.GeneratedMessage {
   OpenapiSchemaResponse createEmptyInstance() => create();
   static $pb.PbList<OpenapiSchemaResponse> createRepeated() => $pb.PbList<OpenapiSchemaResponse>();
   @$core.pragma('dart2js:noInline')
-  static OpenapiSchemaResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpenapiSchemaResponse>(create);
+  static OpenapiSchemaResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpenapiSchemaResponse>(create);
   static OpenapiSchemaResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get schemaJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set schemaJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set schemaJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSchemaJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -3975,104 +3526,118 @@ class BitnamesServiceApi {
   BitnamesServiceApi(this._client);
 
   $async.Future<GetBalanceResponse> getBalance($pb.ClientContext? ctx, GetBalanceRequest request) =>
-      _client.invoke<GetBalanceResponse>(ctx, 'BitnamesService', 'GetBalance', request, GetBalanceResponse());
+    _client.invoke<GetBalanceResponse>(ctx, 'BitnamesService', 'GetBalance', request, GetBalanceResponse())
+  ;
   $async.Future<GetBlockCountResponse> getBlockCount($pb.ClientContext? ctx, GetBlockCountRequest request) =>
-      _client.invoke<GetBlockCountResponse>(ctx, 'BitnamesService', 'GetBlockCount', request, GetBlockCountResponse());
+    _client.invoke<GetBlockCountResponse>(ctx, 'BitnamesService', 'GetBlockCount', request, GetBlockCountResponse())
+  ;
   $async.Future<StopResponse> stop($pb.ClientContext? ctx, StopRequest request) =>
-      _client.invoke<StopResponse>(ctx, 'BitnamesService', 'Stop', request, StopResponse());
+    _client.invoke<StopResponse>(ctx, 'BitnamesService', 'Stop', request, StopResponse())
+  ;
   $async.Future<GetNewAddressResponse> getNewAddress($pb.ClientContext? ctx, GetNewAddressRequest request) =>
-      _client.invoke<GetNewAddressResponse>(ctx, 'BitnamesService', 'GetNewAddress', request, GetNewAddressResponse());
+    _client.invoke<GetNewAddressResponse>(ctx, 'BitnamesService', 'GetNewAddress', request, GetNewAddressResponse())
+  ;
   $async.Future<WithdrawResponse> withdraw($pb.ClientContext? ctx, WithdrawRequest request) =>
-      _client.invoke<WithdrawResponse>(ctx, 'BitnamesService', 'Withdraw', request, WithdrawResponse());
+    _client.invoke<WithdrawResponse>(ctx, 'BitnamesService', 'Withdraw', request, WithdrawResponse())
+  ;
   $async.Future<TransferResponse> transfer($pb.ClientContext? ctx, TransferRequest request) =>
-      _client.invoke<TransferResponse>(ctx, 'BitnamesService', 'Transfer', request, TransferResponse());
-  $async.Future<GetSidechainWealthResponse> getSidechainWealth(
-          $pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
-      _client.invoke<GetSidechainWealthResponse>(
-          ctx, 'BitnamesService', 'GetSidechainWealth', request, GetSidechainWealthResponse());
+    _client.invoke<TransferResponse>(ctx, 'BitnamesService', 'Transfer', request, TransferResponse())
+  ;
+  $async.Future<GetSidechainWealthResponse> getSidechainWealth($pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
+    _client.invoke<GetSidechainWealthResponse>(ctx, 'BitnamesService', 'GetSidechainWealth', request, GetSidechainWealthResponse())
+  ;
   $async.Future<CreateDepositResponse> createDeposit($pb.ClientContext? ctx, CreateDepositRequest request) =>
-      _client.invoke<CreateDepositResponse>(ctx, 'BitnamesService', 'CreateDeposit', request, CreateDepositResponse());
-  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-          $pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
-      _client.invoke<GetPendingWithdrawalBundleResponse>(
-          ctx, 'BitnamesService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse());
+    _client.invoke<CreateDepositResponse>(ctx, 'BitnamesService', 'CreateDeposit', request, CreateDepositResponse())
+  ;
+  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
+    _client.invoke<GetPendingWithdrawalBundleResponse>(ctx, 'BitnamesService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse())
+  ;
   $async.Future<ConnectPeerResponse> connectPeer($pb.ClientContext? ctx, ConnectPeerRequest request) =>
-      _client.invoke<ConnectPeerResponse>(ctx, 'BitnamesService', 'ConnectPeer', request, ConnectPeerResponse());
+    _client.invoke<ConnectPeerResponse>(ctx, 'BitnamesService', 'ConnectPeer', request, ConnectPeerResponse())
+  ;
   $async.Future<ListPeersResponse> listPeers($pb.ClientContext? ctx, ListPeersRequest request) =>
-      _client.invoke<ListPeersResponse>(ctx, 'BitnamesService', 'ListPeers', request, ListPeersResponse());
+    _client.invoke<ListPeersResponse>(ctx, 'BitnamesService', 'ListPeers', request, ListPeersResponse())
+  ;
   $async.Future<MineResponse> mine($pb.ClientContext? ctx, MineRequest request) =>
-      _client.invoke<MineResponse>(ctx, 'BitnamesService', 'Mine', request, MineResponse());
+    _client.invoke<MineResponse>(ctx, 'BitnamesService', 'Mine', request, MineResponse())
+  ;
   $async.Future<GetBlockResponse> getBlock($pb.ClientContext? ctx, GetBlockRequest request) =>
-      _client.invoke<GetBlockResponse>(ctx, 'BitnamesService', 'GetBlock', request, GetBlockResponse());
-  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-          $pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
-      _client.invoke<GetBestMainchainBlockHashResponse>(
-          ctx, 'BitnamesService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse());
-  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-          $pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
-      _client.invoke<GetBestSidechainBlockHashResponse>(
-          ctx, 'BitnamesService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse());
+    _client.invoke<GetBlockResponse>(ctx, 'BitnamesService', 'GetBlock', request, GetBlockResponse())
+  ;
+  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
+    _client.invoke<GetBestMainchainBlockHashResponse>(ctx, 'BitnamesService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse())
+  ;
+  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
+    _client.invoke<GetBestSidechainBlockHashResponse>(ctx, 'BitnamesService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse())
+  ;
   $async.Future<GetBmmInclusionsResponse> getBmmInclusions($pb.ClientContext? ctx, GetBmmInclusionsRequest request) =>
-      _client.invoke<GetBmmInclusionsResponse>(
-          ctx, 'BitnamesService', 'GetBmmInclusions', request, GetBmmInclusionsResponse());
-  $async.Future<GetWalletUtxosResponse> getWalletUtxos($pb.ClientContext? ctx, GetWalletUtxosRequest request) => _client
-      .invoke<GetWalletUtxosResponse>(ctx, 'BitnamesService', 'GetWalletUtxos', request, GetWalletUtxosResponse());
+    _client.invoke<GetBmmInclusionsResponse>(ctx, 'BitnamesService', 'GetBmmInclusions', request, GetBmmInclusionsResponse())
+  ;
+  $async.Future<GetWalletUtxosResponse> getWalletUtxos($pb.ClientContext? ctx, GetWalletUtxosRequest request) =>
+    _client.invoke<GetWalletUtxosResponse>(ctx, 'BitnamesService', 'GetWalletUtxos', request, GetWalletUtxosResponse())
+  ;
   $async.Future<ListUtxosResponse> listUtxos($pb.ClientContext? ctx, ListUtxosRequest request) =>
-      _client.invoke<ListUtxosResponse>(ctx, 'BitnamesService', 'ListUtxos', request, ListUtxosResponse());
-  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-          $pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
-      _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'BitnamesService',
-          'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse());
+    _client.invoke<ListUtxosResponse>(ctx, 'BitnamesService', 'ListUtxos', request, ListUtxosResponse())
+  ;
+  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
+    _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'BitnamesService', 'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse())
+  ;
   $async.Future<GenerateMnemonicResponse> generateMnemonic($pb.ClientContext? ctx, GenerateMnemonicRequest request) =>
-      _client.invoke<GenerateMnemonicResponse>(
-          ctx, 'BitnamesService', 'GenerateMnemonic', request, GenerateMnemonicResponse());
-  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-          $pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
-      _client.invoke<SetSeedFromMnemonicResponse>(
-          ctx, 'BitnamesService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse());
+    _client.invoke<GenerateMnemonicResponse>(ctx, 'BitnamesService', 'GenerateMnemonic', request, GenerateMnemonicResponse())
+  ;
+  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
+    _client.invoke<SetSeedFromMnemonicResponse>(ctx, 'BitnamesService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse())
+  ;
   $async.Future<CallRawResponse> callRaw($pb.ClientContext? ctx, CallRawRequest request) =>
-      _client.invoke<CallRawResponse>(ctx, 'BitnamesService', 'CallRaw', request, CallRawResponse());
-  $async.Future<GetBitNameDataResponse> getBitNameData($pb.ClientContext? ctx, GetBitNameDataRequest request) => _client
-      .invoke<GetBitNameDataResponse>(ctx, 'BitnamesService', 'GetBitNameData', request, GetBitNameDataResponse());
+    _client.invoke<CallRawResponse>(ctx, 'BitnamesService', 'CallRaw', request, CallRawResponse())
+  ;
+  $async.Future<GetBitNameDataResponse> getBitNameData($pb.ClientContext? ctx, GetBitNameDataRequest request) =>
+    _client.invoke<GetBitNameDataResponse>(ctx, 'BitnamesService', 'GetBitNameData', request, GetBitNameDataResponse())
+  ;
   $async.Future<ListBitNamesResponse> listBitNames($pb.ClientContext? ctx, ListBitNamesRequest request) =>
-      _client.invoke<ListBitNamesResponse>(ctx, 'BitnamesService', 'ListBitNames', request, ListBitNamesResponse());
+    _client.invoke<ListBitNamesResponse>(ctx, 'BitnamesService', 'ListBitNames', request, ListBitNamesResponse())
+  ;
   $async.Future<RegisterBitNameResponse> registerBitName($pb.ClientContext? ctx, RegisterBitNameRequest request) =>
-      _client.invoke<RegisterBitNameResponse>(
-          ctx, 'BitnamesService', 'RegisterBitName', request, RegisterBitNameResponse());
-  $async.Future<ReserveBitNameResponse> reserveBitName($pb.ClientContext? ctx, ReserveBitNameRequest request) => _client
-      .invoke<ReserveBitNameResponse>(ctx, 'BitnamesService', 'ReserveBitName', request, ReserveBitNameResponse());
-  $async.Future<GetNewEncryptionKeyResponse> getNewEncryptionKey(
-          $pb.ClientContext? ctx, GetNewEncryptionKeyRequest request) =>
-      _client.invoke<GetNewEncryptionKeyResponse>(
-          ctx, 'BitnamesService', 'GetNewEncryptionKey', request, GetNewEncryptionKeyResponse());
-  $async.Future<GetNewVerifyingKeyResponse> getNewVerifyingKey(
-          $pb.ClientContext? ctx, GetNewVerifyingKeyRequest request) =>
-      _client.invoke<GetNewVerifyingKeyResponse>(
-          ctx, 'BitnamesService', 'GetNewVerifyingKey', request, GetNewVerifyingKeyResponse());
+    _client.invoke<RegisterBitNameResponse>(ctx, 'BitnamesService', 'RegisterBitName', request, RegisterBitNameResponse())
+  ;
+  $async.Future<ReserveBitNameResponse> reserveBitName($pb.ClientContext? ctx, ReserveBitNameRequest request) =>
+    _client.invoke<ReserveBitNameResponse>(ctx, 'BitnamesService', 'ReserveBitName', request, ReserveBitNameResponse())
+  ;
+  $async.Future<GetNewEncryptionKeyResponse> getNewEncryptionKey($pb.ClientContext? ctx, GetNewEncryptionKeyRequest request) =>
+    _client.invoke<GetNewEncryptionKeyResponse>(ctx, 'BitnamesService', 'GetNewEncryptionKey', request, GetNewEncryptionKeyResponse())
+  ;
+  $async.Future<GetNewVerifyingKeyResponse> getNewVerifyingKey($pb.ClientContext? ctx, GetNewVerifyingKeyRequest request) =>
+    _client.invoke<GetNewVerifyingKeyResponse>(ctx, 'BitnamesService', 'GetNewVerifyingKey', request, GetNewVerifyingKeyResponse())
+  ;
   $async.Future<DecryptMsgResponse> decryptMsg($pb.ClientContext? ctx, DecryptMsgRequest request) =>
-      _client.invoke<DecryptMsgResponse>(ctx, 'BitnamesService', 'DecryptMsg', request, DecryptMsgResponse());
+    _client.invoke<DecryptMsgResponse>(ctx, 'BitnamesService', 'DecryptMsg', request, DecryptMsgResponse())
+  ;
   $async.Future<EncryptMsgResponse> encryptMsg($pb.ClientContext? ctx, EncryptMsgRequest request) =>
-      _client.invoke<EncryptMsgResponse>(ctx, 'BitnamesService', 'EncryptMsg', request, EncryptMsgResponse());
+    _client.invoke<EncryptMsgResponse>(ctx, 'BitnamesService', 'EncryptMsg', request, EncryptMsgResponse())
+  ;
   $async.Future<GetPaymailResponse> getPaymail($pb.ClientContext? ctx, GetPaymailRequest request) =>
-      _client.invoke<GetPaymailResponse>(ctx, 'BitnamesService', 'GetPaymail', request, GetPaymailResponse());
+    _client.invoke<GetPaymailResponse>(ctx, 'BitnamesService', 'GetPaymail', request, GetPaymailResponse())
+  ;
   $async.Future<ResolveCommitResponse> resolveCommit($pb.ClientContext? ctx, ResolveCommitRequest request) =>
-      _client.invoke<ResolveCommitResponse>(ctx, 'BitnamesService', 'ResolveCommit', request, ResolveCommitResponse());
+    _client.invoke<ResolveCommitResponse>(ctx, 'BitnamesService', 'ResolveCommit', request, ResolveCommitResponse())
+  ;
   $async.Future<SignArbitraryMsgResponse> signArbitraryMsg($pb.ClientContext? ctx, SignArbitraryMsgRequest request) =>
-      _client.invoke<SignArbitraryMsgResponse>(
-          ctx, 'BitnamesService', 'SignArbitraryMsg', request, SignArbitraryMsgResponse());
-  $async.Future<SignArbitraryMsgAsAddrResponse> signArbitraryMsgAsAddr(
-          $pb.ClientContext? ctx, SignArbitraryMsgAsAddrRequest request) =>
-      _client.invoke<SignArbitraryMsgAsAddrResponse>(
-          ctx, 'BitnamesService', 'SignArbitraryMsgAsAddr', request, SignArbitraryMsgAsAddrResponse());
-  $async.Future<GetWalletAddressesResponse> getWalletAddresses(
-          $pb.ClientContext? ctx, GetWalletAddressesRequest request) =>
-      _client.invoke<GetWalletAddressesResponse>(
-          ctx, 'BitnamesService', 'GetWalletAddresses', request, GetWalletAddressesResponse());
+    _client.invoke<SignArbitraryMsgResponse>(ctx, 'BitnamesService', 'SignArbitraryMsg', request, SignArbitraryMsgResponse())
+  ;
+  $async.Future<SignArbitraryMsgAsAddrResponse> signArbitraryMsgAsAddr($pb.ClientContext? ctx, SignArbitraryMsgAsAddrRequest request) =>
+    _client.invoke<SignArbitraryMsgAsAddrResponse>(ctx, 'BitnamesService', 'SignArbitraryMsgAsAddr', request, SignArbitraryMsgAsAddrResponse())
+  ;
+  $async.Future<GetWalletAddressesResponse> getWalletAddresses($pb.ClientContext? ctx, GetWalletAddressesRequest request) =>
+    _client.invoke<GetWalletAddressesResponse>(ctx, 'BitnamesService', 'GetWalletAddresses', request, GetWalletAddressesResponse())
+  ;
   $async.Future<MyUtxosResponse> myUtxos($pb.ClientContext? ctx, MyUtxosRequest request) =>
-      _client.invoke<MyUtxosResponse>(ctx, 'BitnamesService', 'MyUtxos', request, MyUtxosResponse());
+    _client.invoke<MyUtxosResponse>(ctx, 'BitnamesService', 'MyUtxos', request, MyUtxosResponse())
+  ;
   $async.Future<OpenapiSchemaResponse> openapiSchema($pb.ClientContext? ctx, OpenapiSchemaRequest request) =>
-      _client.invoke<OpenapiSchemaResponse>(ctx, 'BitnamesService', 'OpenapiSchema', request, OpenapiSchemaResponse());
+    _client.invoke<OpenapiSchemaResponse>(ctx, 'BitnamesService', 'OpenapiSchema', request, OpenapiSchemaResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/bitnames/v1/bitnames.pbenum.dart
+++ b/sail_ui/lib/gen/bitnames/v1/bitnames.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/bitnames/v1/bitnames.pbjson.dart
+++ b/sail_ui/lib/gen/bitnames/v1/bitnames.pbjson.dart
@@ -19,7 +19,8 @@ const GetBalanceRequest$json = {
 };
 
 /// Descriptor for `GetBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode('ChFHZXRCYWxhbmNlUmVxdWVzdA==');
+final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode(
+    'ChFHZXRCYWxhbmNlUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBalanceResponseDescriptor instead')
 const GetBalanceResponse$json = {
@@ -31,9 +32,9 @@ const GetBalanceResponse$json = {
 };
 
 /// Descriptor for `GetBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceResponseDescriptor =
-    $convert.base64Decode('ChJHZXRCYWxhbmNlUmVzcG9uc2USHQoKdG90YWxfc2F0cxgBIAEoA1IJdG90YWxTYXRzEiUKDm'
-        'F2YWlsYWJsZV9zYXRzGAIgASgDUg1hdmFpbGFibGVTYXRz');
+final $typed_data.Uint8List getBalanceResponseDescriptor = $convert.base64Decode(
+    'ChJHZXRCYWxhbmNlUmVzcG9uc2USHQoKdG90YWxfc2F0cxgBIAEoA1IJdG90YWxTYXRzEiUKDm'
+    'F2YWlsYWJsZV9zYXRzGAIgASgDUg1hdmFpbGFibGVTYXRz');
 
 @$core.Deprecated('Use getBlockCountRequestDescriptor instead')
 const GetBlockCountRequest$json = {
@@ -41,7 +42,8 @@ const GetBlockCountRequest$json = {
 };
 
 /// Descriptor for `GetBlockCountRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode('ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
+final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
 
 @$core.Deprecated('Use getBlockCountResponseDescriptor instead')
 const GetBlockCountResponse$json = {
@@ -52,8 +54,8 @@ const GetBlockCountResponse$json = {
 };
 
 /// Descriptor for `GetBlockCountResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountResponseDescriptor =
-    $convert.base64Decode('ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
+final $typed_data.Uint8List getBlockCountResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
 
 @$core.Deprecated('Use stopRequestDescriptor instead')
 const StopRequest$json = {
@@ -61,7 +63,8 @@ const StopRequest$json = {
 };
 
 /// Descriptor for `StopRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode('CgtTdG9wUmVxdWVzdA==');
+final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode(
+    'CgtTdG9wUmVxdWVzdA==');
 
 @$core.Deprecated('Use stopResponseDescriptor instead')
 const StopResponse$json = {
@@ -69,7 +72,8 @@ const StopResponse$json = {
 };
 
 /// Descriptor for `StopResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode('CgxTdG9wUmVzcG9uc2U=');
+final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode(
+    'CgxTdG9wUmVzcG9uc2U=');
 
 @$core.Deprecated('Use getNewAddressRequestDescriptor instead')
 const GetNewAddressRequest$json = {
@@ -77,7 +81,8 @@ const GetNewAddressRequest$json = {
 };
 
 /// Descriptor for `GetNewAddressRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode('ChRHZXROZXdBZGRyZXNzUmVxdWVzdA==');
+final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode(
+    'ChRHZXROZXdBZGRyZXNzUmVxdWVzdA==');
 
 @$core.Deprecated('Use getNewAddressResponseDescriptor instead')
 const GetNewAddressResponse$json = {
@@ -88,8 +93,8 @@ const GetNewAddressResponse$json = {
 };
 
 /// Descriptor for `GetNewAddressResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressResponseDescriptor =
-    $convert.base64Decode('ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List getNewAddressResponseDescriptor = $convert.base64Decode(
+    'ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use withdrawRequestDescriptor instead')
 const WithdrawRequest$json = {
@@ -103,10 +108,10 @@ const WithdrawRequest$json = {
 };
 
 /// Descriptor for `WithdrawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawRequestDescriptor =
-    $convert.base64Decode('Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
-        'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
+final $typed_data.Uint8List withdrawRequestDescriptor = $convert.base64Decode(
+    'Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
+    'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
 
 @$core.Deprecated('Use withdrawResponseDescriptor instead')
 const WithdrawResponse$json = {
@@ -117,8 +122,8 @@ const WithdrawResponse$json = {
 };
 
 /// Descriptor for `WithdrawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawResponseDescriptor =
-    $convert.base64Decode('ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List withdrawResponseDescriptor = $convert.base64Decode(
+    'ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use transferRequestDescriptor instead')
 const TransferRequest$json = {
@@ -135,10 +140,10 @@ const TransferRequest$json = {
 };
 
 /// Descriptor for `TransferRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferRequestDescriptor =
-    $convert.base64Decode('Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cxIXCgRtZW1v'
-        'GAQgASgJSABSBG1lbW+IAQFCBwoFX21lbW8=');
+final $typed_data.Uint8List transferRequestDescriptor = $convert.base64Decode(
+    'Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cxIXCgRtZW1v'
+    'GAQgASgJSABSBG1lbW+IAQFCBwoFX21lbW8=');
 
 @$core.Deprecated('Use transferResponseDescriptor instead')
 const TransferResponse$json = {
@@ -149,8 +154,8 @@ const TransferResponse$json = {
 };
 
 /// Descriptor for `TransferResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferResponseDescriptor =
-    $convert.base64Decode('ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List transferResponseDescriptor = $convert.base64Decode(
+    'ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use getSidechainWealthRequestDescriptor instead')
 const GetSidechainWealthRequest$json = {
@@ -158,8 +163,8 @@ const GetSidechainWealthRequest$json = {
 };
 
 /// Descriptor for `GetSidechainWealthRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthRequestDescriptor =
-    $convert.base64Decode('ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
+final $typed_data.Uint8List getSidechainWealthRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
 
 @$core.Deprecated('Use getSidechainWealthResponseDescriptor instead')
 const GetSidechainWealthResponse$json = {
@@ -170,8 +175,8 @@ const GetSidechainWealthResponse$json = {
 };
 
 /// Descriptor for `GetSidechainWealthResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthResponseDescriptor =
-    $convert.base64Decode('ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
+final $typed_data.Uint8List getSidechainWealthResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
 
 @$core.Deprecated('Use createDepositRequestDescriptor instead')
 const CreateDepositRequest$json = {
@@ -184,9 +189,9 @@ const CreateDepositRequest$json = {
 };
 
 /// Descriptor for `CreateDepositRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositRequestDescriptor =
-    $convert.base64Decode('ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
-        'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List createDepositRequestDescriptor = $convert.base64Decode(
+    'ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
+    'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use createDepositResponseDescriptor instead')
 const CreateDepositResponse$json = {
@@ -197,8 +202,8 @@ const CreateDepositResponse$json = {
 };
 
 /// Descriptor for `CreateDepositResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositResponseDescriptor =
-    $convert.base64Decode('ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List createDepositResponseDescriptor = $convert.base64Decode(
+    'ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleRequestDescriptor instead')
 const GetPendingWithdrawalBundleRequest$json = {
@@ -206,8 +211,8 @@ const GetPendingWithdrawalBundleRequest$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor =
-    $convert.base64Decode('CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
+final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor = $convert.base64Decode(
+    'CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleResponseDescriptor instead')
 const GetPendingWithdrawalBundleResponse$json = {
@@ -218,9 +223,9 @@ const GetPendingWithdrawalBundleResponse$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor =
-    $convert.base64Decode('CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
-        'gJUgpidW5kbGVKc29u');
+final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor = $convert.base64Decode(
+    'CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
+    'gJUgpidW5kbGVKc29u');
 
 @$core.Deprecated('Use connectPeerRequestDescriptor instead')
 const ConnectPeerRequest$json = {
@@ -231,8 +236,8 @@ const ConnectPeerRequest$json = {
 };
 
 /// Descriptor for `ConnectPeerRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerRequestDescriptor =
-    $convert.base64Decode('ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List connectPeerRequestDescriptor = $convert.base64Decode(
+    'ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use connectPeerResponseDescriptor instead')
 const ConnectPeerResponse$json = {
@@ -240,7 +245,8 @@ const ConnectPeerResponse$json = {
 };
 
 /// Descriptor for `ConnectPeerResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode('ChNDb25uZWN0UGVlclJlc3BvbnNl');
+final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode(
+    'ChNDb25uZWN0UGVlclJlc3BvbnNl');
 
 @$core.Deprecated('Use listPeersRequestDescriptor instead')
 const ListPeersRequest$json = {
@@ -248,7 +254,8 @@ const ListPeersRequest$json = {
 };
 
 /// Descriptor for `ListPeersRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode('ChBMaXN0UGVlcnNSZXF1ZXN0');
+final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0UGVlcnNSZXF1ZXN0');
 
 @$core.Deprecated('Use listPeersResponseDescriptor instead')
 const ListPeersResponse$json = {
@@ -259,8 +266,8 @@ const ListPeersResponse$json = {
 };
 
 /// Descriptor for `ListPeersResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
+final $typed_data.Uint8List listPeersResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
 
 @$core.Deprecated('Use mineRequestDescriptor instead')
 const MineRequest$json = {
@@ -271,8 +278,8 @@ const MineRequest$json = {
 };
 
 /// Descriptor for `MineRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineRequestDescriptor =
-    $convert.base64Decode('CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List mineRequestDescriptor = $convert.base64Decode(
+    'CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use mineResponseDescriptor instead')
 const MineResponse$json = {
@@ -283,8 +290,8 @@ const MineResponse$json = {
 };
 
 /// Descriptor for `MineResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineResponseDescriptor =
-    $convert.base64Decode('CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
+final $typed_data.Uint8List mineResponseDescriptor = $convert.base64Decode(
+    'CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
 
 @$core.Deprecated('Use getBlockRequestDescriptor instead')
 const GetBlockRequest$json = {
@@ -295,8 +302,8 @@ const GetBlockRequest$json = {
 };
 
 /// Descriptor for `GetBlockRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockRequestDescriptor =
-    $convert.base64Decode('Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
+final $typed_data.Uint8List getBlockRequestDescriptor = $convert.base64Decode(
+    'Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
 
 @$core.Deprecated('Use getBlockResponseDescriptor instead')
 const GetBlockResponse$json = {
@@ -307,8 +314,8 @@ const GetBlockResponse$json = {
 };
 
 /// Descriptor for `GetBlockResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockResponseDescriptor =
-    $convert.base64Decode('ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
+final $typed_data.Uint8List getBlockResponseDescriptor = $convert.base64Decode(
+    'ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashRequestDescriptor instead')
 const GetBestMainchainBlockHashRequest$json = {
@@ -316,8 +323,8 @@ const GetBestMainchainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashResponseDescriptor instead')
 const GetBestMainchainBlockHashResponse$json = {
@@ -328,9 +335,9 @@ const GetBestMainchainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashRequestDescriptor instead')
 const GetBestSidechainBlockHashRequest$json = {
@@ -338,8 +345,8 @@ const GetBestSidechainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashResponseDescriptor instead')
 const GetBestSidechainBlockHashResponse$json = {
@@ -350,9 +357,9 @@ const GetBestSidechainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBmmInclusionsRequestDescriptor instead')
 const GetBmmInclusionsRequest$json = {
@@ -363,9 +370,9 @@ const GetBmmInclusionsRequest$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsRequestDescriptor =
-    $convert.base64Decode('ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
-        'g=');
+final $typed_data.Uint8List getBmmInclusionsRequestDescriptor = $convert.base64Decode(
+    'ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
+    'g=');
 
 @$core.Deprecated('Use getBmmInclusionsResponseDescriptor instead')
 const GetBmmInclusionsResponse$json = {
@@ -376,9 +383,9 @@ const GetBmmInclusionsResponse$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsResponseDescriptor =
-    $convert.base64Decode('ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
-        '9ucw==');
+final $typed_data.Uint8List getBmmInclusionsResponseDescriptor = $convert.base64Decode(
+    'ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
+    '9ucw==');
 
 @$core.Deprecated('Use getWalletUtxosRequestDescriptor instead')
 const GetWalletUtxosRequest$json = {
@@ -386,7 +393,8 @@ const GetWalletUtxosRequest$json = {
 };
 
 /// Descriptor for `GetWalletUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode('ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
+final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode(
+    'ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getWalletUtxosResponseDescriptor instead')
 const GetWalletUtxosResponse$json = {
@@ -397,9 +405,9 @@ const GetWalletUtxosResponse$json = {
 };
 
 /// Descriptor for `GetWalletUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosResponseDescriptor =
-    $convert.base64Decode('ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
-        '==');
+final $typed_data.Uint8List getWalletUtxosResponseDescriptor = $convert.base64Decode(
+    'ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
+    '==');
 
 @$core.Deprecated('Use listUtxosRequestDescriptor instead')
 const ListUtxosRequest$json = {
@@ -407,7 +415,8 @@ const ListUtxosRequest$json = {
 };
 
 /// Descriptor for `ListUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode('ChBMaXN0VXR4b3NSZXF1ZXN0');
+final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0VXR4b3NSZXF1ZXN0');
 
 @$core.Deprecated('Use listUtxosResponseDescriptor instead')
 const ListUtxosResponse$json = {
@@ -418,8 +427,8 @@ const ListUtxosResponse$json = {
 };
 
 /// Descriptor for `ListUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
+final $typed_data.Uint8List listUtxosResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightRequestDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightRequest$json = {
@@ -427,8 +436,8 @@ const GetLatestFailedWithdrawalBundleHeightRequest$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor =
-    $convert.base64Decode('CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor = $convert.base64Decode(
+    'CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightResponseDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightResponse$json = {
@@ -439,9 +448,9 @@ const GetLatestFailedWithdrawalBundleHeightResponse$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor =
-    $convert.base64Decode('Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
-        'h0GAEgASgDUgZoZWlnaHQ=');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor = $convert.base64Decode(
+    'Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
+    'h0GAEgASgDUgZoZWlnaHQ=');
 
 @$core.Deprecated('Use generateMnemonicRequestDescriptor instead')
 const GenerateMnemonicRequest$json = {
@@ -449,8 +458,8 @@ const GenerateMnemonicRequest$json = {
 };
 
 /// Descriptor for `GenerateMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicRequestDescriptor =
-    $convert.base64Decode('ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
+final $typed_data.Uint8List generateMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
 
 @$core.Deprecated('Use generateMnemonicResponseDescriptor instead')
 const GenerateMnemonicResponse$json = {
@@ -461,8 +470,8 @@ const GenerateMnemonicResponse$json = {
 };
 
 /// Descriptor for `GenerateMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicResponseDescriptor =
-    $convert.base64Decode('ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
+final $typed_data.Uint8List generateMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
 
 @$core.Deprecated('Use setSeedFromMnemonicRequestDescriptor instead')
 const SetSeedFromMnemonicRequest$json = {
@@ -473,9 +482,9 @@ const SetSeedFromMnemonicRequest$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor =
-    $convert.base64Decode('ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
-        'M=');
+final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
+    'M=');
 
 @$core.Deprecated('Use setSeedFromMnemonicResponseDescriptor instead')
 const SetSeedFromMnemonicResponse$json = {
@@ -483,8 +492,8 @@ const SetSeedFromMnemonicResponse$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor =
-    $convert.base64Decode('ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
+final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
 
 @$core.Deprecated('Use callRawRequestDescriptor instead')
 const CallRawRequest$json = {
@@ -496,9 +505,9 @@ const CallRawRequest$json = {
 };
 
 /// Descriptor for `CallRawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawRequestDescriptor =
-    $convert.base64Decode('Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
-        'gCIAEoCVIKcGFyYW1zSnNvbg==');
+final $typed_data.Uint8List callRawRequestDescriptor = $convert.base64Decode(
+    'Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
+    'gCIAEoCVIKcGFyYW1zSnNvbg==');
 
 @$core.Deprecated('Use callRawResponseDescriptor instead')
 const CallRawResponse$json = {
@@ -509,8 +518,8 @@ const CallRawResponse$json = {
 };
 
 /// Descriptor for `CallRawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawResponseDescriptor =
-    $convert.base64Decode('Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
+final $typed_data.Uint8List callRawResponseDescriptor = $convert.base64Decode(
+    'Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
 
 @$core.Deprecated('Use getBitNameDataRequestDescriptor instead')
 const GetBitNameDataRequest$json = {
@@ -521,8 +530,8 @@ const GetBitNameDataRequest$json = {
 };
 
 /// Descriptor for `GetBitNameDataRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBitNameDataRequestDescriptor =
-    $convert.base64Decode('ChVHZXRCaXROYW1lRGF0YVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZQ==');
+final $typed_data.Uint8List getBitNameDataRequestDescriptor = $convert.base64Decode(
+    'ChVHZXRCaXROYW1lRGF0YVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZQ==');
 
 @$core.Deprecated('Use getBitNameDataResponseDescriptor instead')
 const GetBitNameDataResponse$json = {
@@ -533,8 +542,8 @@ const GetBitNameDataResponse$json = {
 };
 
 /// Descriptor for `GetBitNameDataResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBitNameDataResponseDescriptor =
-    $convert.base64Decode('ChZHZXRCaXROYW1lRGF0YVJlc3BvbnNlEhsKCWRhdGFfanNvbhgBIAEoCVIIZGF0YUpzb24=');
+final $typed_data.Uint8List getBitNameDataResponseDescriptor = $convert.base64Decode(
+    'ChZHZXRCaXROYW1lRGF0YVJlc3BvbnNlEhsKCWRhdGFfanNvbhgBIAEoCVIIZGF0YUpzb24=');
 
 @$core.Deprecated('Use listBitNamesRequestDescriptor instead')
 const ListBitNamesRequest$json = {
@@ -542,7 +551,8 @@ const ListBitNamesRequest$json = {
 };
 
 /// Descriptor for `ListBitNamesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listBitNamesRequestDescriptor = $convert.base64Decode('ChNMaXN0Qml0TmFtZXNSZXF1ZXN0');
+final $typed_data.Uint8List listBitNamesRequestDescriptor = $convert.base64Decode(
+    'ChNMaXN0Qml0TmFtZXNSZXF1ZXN0');
 
 @$core.Deprecated('Use listBitNamesResponseDescriptor instead')
 const ListBitNamesResponse$json = {
@@ -553,9 +563,9 @@ const ListBitNamesResponse$json = {
 };
 
 /// Descriptor for `ListBitNamesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listBitNamesResponseDescriptor =
-    $convert.base64Decode('ChRMaXN0Qml0TmFtZXNSZXNwb25zZRIjCg1iaXRuYW1lc19qc29uGAEgASgJUgxiaXRuYW1lc0'
-        'pzb24=');
+final $typed_data.Uint8List listBitNamesResponseDescriptor = $convert.base64Decode(
+    'ChRMaXN0Qml0TmFtZXNSZXNwb25zZRIjCg1iaXRuYW1lc19qc29uGAEgASgJUgxiaXRuYW1lc0'
+    'pzb24=');
 
 @$core.Deprecated('Use registerBitNameRequestDescriptor instead')
 const RegisterBitNameRequest$json = {
@@ -567,9 +577,9 @@ const RegisterBitNameRequest$json = {
 };
 
 /// Descriptor for `RegisterBitNameRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerBitNameRequestDescriptor =
-    $convert.base64Decode('ChZSZWdpc3RlckJpdE5hbWVSZXF1ZXN0Eh0KCnBsYWluX25hbWUYASABKAlSCXBsYWluTmFtZR'
-        'IbCglkYXRhX2pzb24YAiABKAlSCGRhdGFKc29u');
+final $typed_data.Uint8List registerBitNameRequestDescriptor = $convert.base64Decode(
+    'ChZSZWdpc3RlckJpdE5hbWVSZXF1ZXN0Eh0KCnBsYWluX25hbWUYASABKAlSCXBsYWluTmFtZR'
+    'IbCglkYXRhX2pzb24YAiABKAlSCGRhdGFKc29u');
 
 @$core.Deprecated('Use registerBitNameResponseDescriptor instead')
 const RegisterBitNameResponse$json = {
@@ -580,8 +590,8 @@ const RegisterBitNameResponse$json = {
 };
 
 /// Descriptor for `RegisterBitNameResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerBitNameResponseDescriptor =
-    $convert.base64Decode('ChdSZWdpc3RlckJpdE5hbWVSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
+final $typed_data.Uint8List registerBitNameResponseDescriptor = $convert.base64Decode(
+    'ChdSZWdpc3RlckJpdE5hbWVSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
 
 @$core.Deprecated('Use reserveBitNameRequestDescriptor instead')
 const ReserveBitNameRequest$json = {
@@ -592,8 +602,8 @@ const ReserveBitNameRequest$json = {
 };
 
 /// Descriptor for `ReserveBitNameRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reserveBitNameRequestDescriptor =
-    $convert.base64Decode('ChVSZXNlcnZlQml0TmFtZVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZQ==');
+final $typed_data.Uint8List reserveBitNameRequestDescriptor = $convert.base64Decode(
+    'ChVSZXNlcnZlQml0TmFtZVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZQ==');
 
 @$core.Deprecated('Use reserveBitNameResponseDescriptor instead')
 const ReserveBitNameResponse$json = {
@@ -604,8 +614,8 @@ const ReserveBitNameResponse$json = {
 };
 
 /// Descriptor for `ReserveBitNameResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reserveBitNameResponseDescriptor =
-    $convert.base64Decode('ChZSZXNlcnZlQml0TmFtZVJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List reserveBitNameResponseDescriptor = $convert.base64Decode(
+    'ChZSZXNlcnZlQml0TmFtZVJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use getNewEncryptionKeyRequestDescriptor instead')
 const GetNewEncryptionKeyRequest$json = {
@@ -613,8 +623,8 @@ const GetNewEncryptionKeyRequest$json = {
 };
 
 /// Descriptor for `GetNewEncryptionKeyRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewEncryptionKeyRequestDescriptor =
-    $convert.base64Decode('ChpHZXROZXdFbmNyeXB0aW9uS2V5UmVxdWVzdA==');
+final $typed_data.Uint8List getNewEncryptionKeyRequestDescriptor = $convert.base64Decode(
+    'ChpHZXROZXdFbmNyeXB0aW9uS2V5UmVxdWVzdA==');
 
 @$core.Deprecated('Use getNewEncryptionKeyResponseDescriptor instead')
 const GetNewEncryptionKeyResponse$json = {
@@ -625,8 +635,8 @@ const GetNewEncryptionKeyResponse$json = {
 };
 
 /// Descriptor for `GetNewEncryptionKeyResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewEncryptionKeyResponseDescriptor =
-    $convert.base64Decode('ChtHZXROZXdFbmNyeXB0aW9uS2V5UmVzcG9uc2USEAoDa2V5GAEgASgJUgNrZXk=');
+final $typed_data.Uint8List getNewEncryptionKeyResponseDescriptor = $convert.base64Decode(
+    'ChtHZXROZXdFbmNyeXB0aW9uS2V5UmVzcG9uc2USEAoDa2V5GAEgASgJUgNrZXk=');
 
 @$core.Deprecated('Use getNewVerifyingKeyRequestDescriptor instead')
 const GetNewVerifyingKeyRequest$json = {
@@ -634,8 +644,8 @@ const GetNewVerifyingKeyRequest$json = {
 };
 
 /// Descriptor for `GetNewVerifyingKeyRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewVerifyingKeyRequestDescriptor =
-    $convert.base64Decode('ChlHZXROZXdWZXJpZnlpbmdLZXlSZXF1ZXN0');
+final $typed_data.Uint8List getNewVerifyingKeyRequestDescriptor = $convert.base64Decode(
+    'ChlHZXROZXdWZXJpZnlpbmdLZXlSZXF1ZXN0');
 
 @$core.Deprecated('Use getNewVerifyingKeyResponseDescriptor instead')
 const GetNewVerifyingKeyResponse$json = {
@@ -646,8 +656,8 @@ const GetNewVerifyingKeyResponse$json = {
 };
 
 /// Descriptor for `GetNewVerifyingKeyResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewVerifyingKeyResponseDescriptor =
-    $convert.base64Decode('ChpHZXROZXdWZXJpZnlpbmdLZXlSZXNwb25zZRIQCgNrZXkYASABKAlSA2tleQ==');
+final $typed_data.Uint8List getNewVerifyingKeyResponseDescriptor = $convert.base64Decode(
+    'ChpHZXROZXdWZXJpZnlpbmdLZXlSZXNwb25zZRIQCgNrZXkYASABKAlSA2tleQ==');
 
 @$core.Deprecated('Use decryptMsgRequestDescriptor instead')
 const DecryptMsgRequest$json = {
@@ -659,9 +669,9 @@ const DecryptMsgRequest$json = {
 };
 
 /// Descriptor for `DecryptMsgRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List decryptMsgRequestDescriptor =
-    $convert.base64Decode('ChFEZWNyeXB0TXNnUmVxdWVzdBIeCgpjaXBoZXJ0ZXh0GAEgASgJUgpjaXBoZXJ0ZXh0EisKEW'
-        'VuY3J5cHRpb25fcHVia2V5GAIgASgJUhBlbmNyeXB0aW9uUHVia2V5');
+final $typed_data.Uint8List decryptMsgRequestDescriptor = $convert.base64Decode(
+    'ChFEZWNyeXB0TXNnUmVxdWVzdBIeCgpjaXBoZXJ0ZXh0GAEgASgJUgpjaXBoZXJ0ZXh0EisKEW'
+    'VuY3J5cHRpb25fcHVia2V5GAIgASgJUhBlbmNyeXB0aW9uUHVia2V5');
 
 @$core.Deprecated('Use decryptMsgResponseDescriptor instead')
 const DecryptMsgResponse$json = {
@@ -672,8 +682,8 @@ const DecryptMsgResponse$json = {
 };
 
 /// Descriptor for `DecryptMsgResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List decryptMsgResponseDescriptor =
-    $convert.base64Decode('ChJEZWNyeXB0TXNnUmVzcG9uc2USHAoJcGxhaW50ZXh0GAEgASgJUglwbGFpbnRleHQ=');
+final $typed_data.Uint8List decryptMsgResponseDescriptor = $convert.base64Decode(
+    'ChJEZWNyeXB0TXNnUmVzcG9uc2USHAoJcGxhaW50ZXh0GAEgASgJUglwbGFpbnRleHQ=');
 
 @$core.Deprecated('Use encryptMsgRequestDescriptor instead')
 const EncryptMsgRequest$json = {
@@ -685,9 +695,9 @@ const EncryptMsgRequest$json = {
 };
 
 /// Descriptor for `EncryptMsgRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List encryptMsgRequestDescriptor =
-    $convert.base64Decode('ChFFbmNyeXB0TXNnUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIrChFlbmNyeXB0aW9uX3B1Ym'
-        'tleRgCIAEoCVIQZW5jcnlwdGlvblB1YmtleQ==');
+final $typed_data.Uint8List encryptMsgRequestDescriptor = $convert.base64Decode(
+    'ChFFbmNyeXB0TXNnUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIrChFlbmNyeXB0aW9uX3B1Ym'
+    'tleRgCIAEoCVIQZW5jcnlwdGlvblB1YmtleQ==');
 
 @$core.Deprecated('Use encryptMsgResponseDescriptor instead')
 const EncryptMsgResponse$json = {
@@ -698,8 +708,8 @@ const EncryptMsgResponse$json = {
 };
 
 /// Descriptor for `EncryptMsgResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List encryptMsgResponseDescriptor =
-    $convert.base64Decode('ChJFbmNyeXB0TXNnUmVzcG9uc2USHgoKY2lwaGVydGV4dBgBIAEoCVIKY2lwaGVydGV4dA==');
+final $typed_data.Uint8List encryptMsgResponseDescriptor = $convert.base64Decode(
+    'ChJFbmNyeXB0TXNnUmVzcG9uc2USHgoKY2lwaGVydGV4dBgBIAEoCVIKY2lwaGVydGV4dA==');
 
 @$core.Deprecated('Use getPaymailRequestDescriptor instead')
 const GetPaymailRequest$json = {
@@ -707,7 +717,8 @@ const GetPaymailRequest$json = {
 };
 
 /// Descriptor for `GetPaymailRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPaymailRequestDescriptor = $convert.base64Decode('ChFHZXRQYXltYWlsUmVxdWVzdA==');
+final $typed_data.Uint8List getPaymailRequestDescriptor = $convert.base64Decode(
+    'ChFHZXRQYXltYWlsUmVxdWVzdA==');
 
 @$core.Deprecated('Use getPaymailResponseDescriptor instead')
 const GetPaymailResponse$json = {
@@ -718,9 +729,9 @@ const GetPaymailResponse$json = {
 };
 
 /// Descriptor for `GetPaymailResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPaymailResponseDescriptor =
-    $convert.base64Decode('ChJHZXRQYXltYWlsUmVzcG9uc2USIQoMcGF5bWFpbF9qc29uGAEgASgJUgtwYXltYWlsSnNvbg'
-        '==');
+final $typed_data.Uint8List getPaymailResponseDescriptor = $convert.base64Decode(
+    'ChJHZXRQYXltYWlsUmVzcG9uc2USIQoMcGF5bWFpbF9qc29uGAEgASgJUgtwYXltYWlsSnNvbg'
+    '==');
 
 @$core.Deprecated('Use resolveCommitRequestDescriptor instead')
 const ResolveCommitRequest$json = {
@@ -731,8 +742,8 @@ const ResolveCommitRequest$json = {
 };
 
 /// Descriptor for `ResolveCommitRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List resolveCommitRequestDescriptor =
-    $convert.base64Decode('ChRSZXNvbHZlQ29tbWl0UmVxdWVzdBIYCgdiaXRuYW1lGAEgASgJUgdiaXRuYW1l');
+final $typed_data.Uint8List resolveCommitRequestDescriptor = $convert.base64Decode(
+    'ChRSZXNvbHZlQ29tbWl0UmVxdWVzdBIYCgdiaXRuYW1lGAEgASgJUgdiaXRuYW1l');
 
 @$core.Deprecated('Use resolveCommitResponseDescriptor instead')
 const ResolveCommitResponse$json = {
@@ -743,9 +754,9 @@ const ResolveCommitResponse$json = {
 };
 
 /// Descriptor for `ResolveCommitResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List resolveCommitResponseDescriptor =
-    $convert.base64Decode('ChVSZXNvbHZlQ29tbWl0UmVzcG9uc2USHgoKY29tbWl0bWVudBgBIAEoCVIKY29tbWl0bWVudA'
-        '==');
+final $typed_data.Uint8List resolveCommitResponseDescriptor = $convert.base64Decode(
+    'ChVSZXNvbHZlQ29tbWl0UmVzcG9uc2USHgoKY29tbWl0bWVudBgBIAEoCVIKY29tbWl0bWVudA'
+    '==');
 
 @$core.Deprecated('Use signArbitraryMsgRequestDescriptor instead')
 const SignArbitraryMsgRequest$json = {
@@ -757,9 +768,9 @@ const SignArbitraryMsgRequest$json = {
 };
 
 /// Descriptor for `SignArbitraryMsgRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signArbitraryMsgRequestDescriptor =
-    $convert.base64Decode('ChdTaWduQXJiaXRyYXJ5TXNnUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIjCg12ZXJpZnlpbm'
-        'dfa2V5GAIgASgJUgx2ZXJpZnlpbmdLZXk=');
+final $typed_data.Uint8List signArbitraryMsgRequestDescriptor = $convert.base64Decode(
+    'ChdTaWduQXJiaXRyYXJ5TXNnUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIjCg12ZXJpZnlpbm'
+    'dfa2V5GAIgASgJUgx2ZXJpZnlpbmdLZXk=');
 
 @$core.Deprecated('Use signArbitraryMsgResponseDescriptor instead')
 const SignArbitraryMsgResponse$json = {
@@ -770,9 +781,9 @@ const SignArbitraryMsgResponse$json = {
 };
 
 /// Descriptor for `SignArbitraryMsgResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signArbitraryMsgResponseDescriptor =
-    $convert.base64Decode('ChhTaWduQXJiaXRyYXJ5TXNnUmVzcG9uc2USHAoJc2lnbmF0dXJlGAEgASgJUglzaWduYXR1cm'
-        'U=');
+final $typed_data.Uint8List signArbitraryMsgResponseDescriptor = $convert.base64Decode(
+    'ChhTaWduQXJiaXRyYXJ5TXNnUmVzcG9uc2USHAoJc2lnbmF0dXJlGAEgASgJUglzaWduYXR1cm'
+    'U=');
 
 @$core.Deprecated('Use signArbitraryMsgAsAddrRequestDescriptor instead')
 const SignArbitraryMsgAsAddrRequest$json = {
@@ -784,9 +795,9 @@ const SignArbitraryMsgAsAddrRequest$json = {
 };
 
 /// Descriptor for `SignArbitraryMsgAsAddrRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signArbitraryMsgAsAddrRequestDescriptor =
-    $convert.base64Decode('Ch1TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIYCgdhZG'
-        'RyZXNzGAIgASgJUgdhZGRyZXNz');
+final $typed_data.Uint8List signArbitraryMsgAsAddrRequestDescriptor = $convert.base64Decode(
+    'Ch1TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIYCgdhZG'
+    'RyZXNzGAIgASgJUgdhZGRyZXNz');
 
 @$core.Deprecated('Use signArbitraryMsgAsAddrResponseDescriptor instead')
 const SignArbitraryMsgAsAddrResponse$json = {
@@ -798,9 +809,9 @@ const SignArbitraryMsgAsAddrResponse$json = {
 };
 
 /// Descriptor for `SignArbitraryMsgAsAddrResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signArbitraryMsgAsAddrResponseDescriptor =
-    $convert.base64Decode('Ch5TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVzcG9uc2USIwoNdmVyaWZ5aW5nX2tleRgBIAEoCV'
-        'IMdmVyaWZ5aW5nS2V5EhwKCXNpZ25hdHVyZRgCIAEoCVIJc2lnbmF0dXJl');
+final $typed_data.Uint8List signArbitraryMsgAsAddrResponseDescriptor = $convert.base64Decode(
+    'Ch5TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVzcG9uc2USIwoNdmVyaWZ5aW5nX2tleRgBIAEoCV'
+    'IMdmVyaWZ5aW5nS2V5EhwKCXNpZ25hdHVyZRgCIAEoCVIJc2lnbmF0dXJl');
 
 @$core.Deprecated('Use getWalletAddressesRequestDescriptor instead')
 const GetWalletAddressesRequest$json = {
@@ -808,8 +819,8 @@ const GetWalletAddressesRequest$json = {
 };
 
 /// Descriptor for `GetWalletAddressesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletAddressesRequestDescriptor =
-    $convert.base64Decode('ChlHZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0');
+final $typed_data.Uint8List getWalletAddressesRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0');
 
 @$core.Deprecated('Use getWalletAddressesResponseDescriptor instead')
 const GetWalletAddressesResponse$json = {
@@ -820,9 +831,9 @@ const GetWalletAddressesResponse$json = {
 };
 
 /// Descriptor for `GetWalletAddressesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletAddressesResponseDescriptor =
-    $convert.base64Decode('ChpHZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3'
-        'Nlcw==');
+final $typed_data.Uint8List getWalletAddressesResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3'
+    'Nlcw==');
 
 @$core.Deprecated('Use myUtxosRequestDescriptor instead')
 const MyUtxosRequest$json = {
@@ -830,7 +841,8 @@ const MyUtxosRequest$json = {
 };
 
 /// Descriptor for `MyUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List myUtxosRequestDescriptor = $convert.base64Decode('Cg5NeVV0eG9zUmVxdWVzdA==');
+final $typed_data.Uint8List myUtxosRequestDescriptor = $convert.base64Decode(
+    'Cg5NeVV0eG9zUmVxdWVzdA==');
 
 @$core.Deprecated('Use myUtxosResponseDescriptor instead')
 const MyUtxosResponse$json = {
@@ -841,8 +853,8 @@ const MyUtxosResponse$json = {
 };
 
 /// Descriptor for `MyUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List myUtxosResponseDescriptor =
-    $convert.base64Decode('Cg9NeVV0eG9zUmVzcG9uc2USHQoKdXR4b3NfanNvbhgBIAEoCVIJdXR4b3NKc29u');
+final $typed_data.Uint8List myUtxosResponseDescriptor = $convert.base64Decode(
+    'Cg9NeVV0eG9zUmVzcG9uc2USHQoKdXR4b3NfanNvbhgBIAEoCVIJdXR4b3NKc29u');
 
 @$core.Deprecated('Use openapiSchemaRequestDescriptor instead')
 const OpenapiSchemaRequest$json = {
@@ -850,7 +862,8 @@ const OpenapiSchemaRequest$json = {
 };
 
 /// Descriptor for `OpenapiSchemaRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List openapiSchemaRequestDescriptor = $convert.base64Decode('ChRPcGVuYXBpU2NoZW1hUmVxdWVzdA==');
+final $typed_data.Uint8List openapiSchemaRequestDescriptor = $convert.base64Decode(
+    'ChRPcGVuYXBpU2NoZW1hUmVxdWVzdA==');
 
 @$core.Deprecated('Use openapiSchemaResponseDescriptor instead')
 const OpenapiSchemaResponse$json = {
@@ -861,9 +874,9 @@ const OpenapiSchemaResponse$json = {
 };
 
 /// Descriptor for `OpenapiSchemaResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List openapiSchemaResponseDescriptor =
-    $convert.base64Decode('ChVPcGVuYXBpU2NoZW1hUmVzcG9uc2USHwoLc2NoZW1hX2pzb24YASABKAlSCnNjaGVtYUpzb2'
-        '4=');
+final $typed_data.Uint8List openapiSchemaResponseDescriptor = $convert.base64Decode(
+    'ChVPcGVuYXBpU2NoZW1hUmVzcG9uc2USHwoLc2NoZW1hX2pzb24YASABKAlSCnNjaGVtYUpzb2'
+    '4=');
 
 const $core.Map<$core.String, $core.dynamic> BitnamesServiceBase$json = {
   '1': 'BitnamesService',
@@ -874,87 +887,35 @@ const $core.Map<$core.String, $core.dynamic> BitnamesServiceBase$json = {
     {'1': 'GetNewAddress', '2': '.bitnames.v1.GetNewAddressRequest', '3': '.bitnames.v1.GetNewAddressResponse'},
     {'1': 'Withdraw', '2': '.bitnames.v1.WithdrawRequest', '3': '.bitnames.v1.WithdrawResponse'},
     {'1': 'Transfer', '2': '.bitnames.v1.TransferRequest', '3': '.bitnames.v1.TransferResponse'},
-    {
-      '1': 'GetSidechainWealth',
-      '2': '.bitnames.v1.GetSidechainWealthRequest',
-      '3': '.bitnames.v1.GetSidechainWealthResponse'
-    },
+    {'1': 'GetSidechainWealth', '2': '.bitnames.v1.GetSidechainWealthRequest', '3': '.bitnames.v1.GetSidechainWealthResponse'},
     {'1': 'CreateDeposit', '2': '.bitnames.v1.CreateDepositRequest', '3': '.bitnames.v1.CreateDepositResponse'},
-    {
-      '1': 'GetPendingWithdrawalBundle',
-      '2': '.bitnames.v1.GetPendingWithdrawalBundleRequest',
-      '3': '.bitnames.v1.GetPendingWithdrawalBundleResponse'
-    },
+    {'1': 'GetPendingWithdrawalBundle', '2': '.bitnames.v1.GetPendingWithdrawalBundleRequest', '3': '.bitnames.v1.GetPendingWithdrawalBundleResponse'},
     {'1': 'ConnectPeer', '2': '.bitnames.v1.ConnectPeerRequest', '3': '.bitnames.v1.ConnectPeerResponse'},
     {'1': 'ListPeers', '2': '.bitnames.v1.ListPeersRequest', '3': '.bitnames.v1.ListPeersResponse'},
     {'1': 'Mine', '2': '.bitnames.v1.MineRequest', '3': '.bitnames.v1.MineResponse'},
     {'1': 'GetBlock', '2': '.bitnames.v1.GetBlockRequest', '3': '.bitnames.v1.GetBlockResponse'},
-    {
-      '1': 'GetBestMainchainBlockHash',
-      '2': '.bitnames.v1.GetBestMainchainBlockHashRequest',
-      '3': '.bitnames.v1.GetBestMainchainBlockHashResponse'
-    },
-    {
-      '1': 'GetBestSidechainBlockHash',
-      '2': '.bitnames.v1.GetBestSidechainBlockHashRequest',
-      '3': '.bitnames.v1.GetBestSidechainBlockHashResponse'
-    },
-    {
-      '1': 'GetBmmInclusions',
-      '2': '.bitnames.v1.GetBmmInclusionsRequest',
-      '3': '.bitnames.v1.GetBmmInclusionsResponse'
-    },
+    {'1': 'GetBestMainchainBlockHash', '2': '.bitnames.v1.GetBestMainchainBlockHashRequest', '3': '.bitnames.v1.GetBestMainchainBlockHashResponse'},
+    {'1': 'GetBestSidechainBlockHash', '2': '.bitnames.v1.GetBestSidechainBlockHashRequest', '3': '.bitnames.v1.GetBestSidechainBlockHashResponse'},
+    {'1': 'GetBmmInclusions', '2': '.bitnames.v1.GetBmmInclusionsRequest', '3': '.bitnames.v1.GetBmmInclusionsResponse'},
     {'1': 'GetWalletUtxos', '2': '.bitnames.v1.GetWalletUtxosRequest', '3': '.bitnames.v1.GetWalletUtxosResponse'},
     {'1': 'ListUtxos', '2': '.bitnames.v1.ListUtxosRequest', '3': '.bitnames.v1.ListUtxosResponse'},
-    {
-      '1': 'GetLatestFailedWithdrawalBundleHeight',
-      '2': '.bitnames.v1.GetLatestFailedWithdrawalBundleHeightRequest',
-      '3': '.bitnames.v1.GetLatestFailedWithdrawalBundleHeightResponse'
-    },
-    {
-      '1': 'GenerateMnemonic',
-      '2': '.bitnames.v1.GenerateMnemonicRequest',
-      '3': '.bitnames.v1.GenerateMnemonicResponse'
-    },
-    {
-      '1': 'SetSeedFromMnemonic',
-      '2': '.bitnames.v1.SetSeedFromMnemonicRequest',
-      '3': '.bitnames.v1.SetSeedFromMnemonicResponse'
-    },
+    {'1': 'GetLatestFailedWithdrawalBundleHeight', '2': '.bitnames.v1.GetLatestFailedWithdrawalBundleHeightRequest', '3': '.bitnames.v1.GetLatestFailedWithdrawalBundleHeightResponse'},
+    {'1': 'GenerateMnemonic', '2': '.bitnames.v1.GenerateMnemonicRequest', '3': '.bitnames.v1.GenerateMnemonicResponse'},
+    {'1': 'SetSeedFromMnemonic', '2': '.bitnames.v1.SetSeedFromMnemonicRequest', '3': '.bitnames.v1.SetSeedFromMnemonicResponse'},
     {'1': 'CallRaw', '2': '.bitnames.v1.CallRawRequest', '3': '.bitnames.v1.CallRawResponse'},
     {'1': 'GetBitNameData', '2': '.bitnames.v1.GetBitNameDataRequest', '3': '.bitnames.v1.GetBitNameDataResponse'},
     {'1': 'ListBitNames', '2': '.bitnames.v1.ListBitNamesRequest', '3': '.bitnames.v1.ListBitNamesResponse'},
     {'1': 'RegisterBitName', '2': '.bitnames.v1.RegisterBitNameRequest', '3': '.bitnames.v1.RegisterBitNameResponse'},
     {'1': 'ReserveBitName', '2': '.bitnames.v1.ReserveBitNameRequest', '3': '.bitnames.v1.ReserveBitNameResponse'},
-    {
-      '1': 'GetNewEncryptionKey',
-      '2': '.bitnames.v1.GetNewEncryptionKeyRequest',
-      '3': '.bitnames.v1.GetNewEncryptionKeyResponse'
-    },
-    {
-      '1': 'GetNewVerifyingKey',
-      '2': '.bitnames.v1.GetNewVerifyingKeyRequest',
-      '3': '.bitnames.v1.GetNewVerifyingKeyResponse'
-    },
+    {'1': 'GetNewEncryptionKey', '2': '.bitnames.v1.GetNewEncryptionKeyRequest', '3': '.bitnames.v1.GetNewEncryptionKeyResponse'},
+    {'1': 'GetNewVerifyingKey', '2': '.bitnames.v1.GetNewVerifyingKeyRequest', '3': '.bitnames.v1.GetNewVerifyingKeyResponse'},
     {'1': 'DecryptMsg', '2': '.bitnames.v1.DecryptMsgRequest', '3': '.bitnames.v1.DecryptMsgResponse'},
     {'1': 'EncryptMsg', '2': '.bitnames.v1.EncryptMsgRequest', '3': '.bitnames.v1.EncryptMsgResponse'},
     {'1': 'GetPaymail', '2': '.bitnames.v1.GetPaymailRequest', '3': '.bitnames.v1.GetPaymailResponse'},
     {'1': 'ResolveCommit', '2': '.bitnames.v1.ResolveCommitRequest', '3': '.bitnames.v1.ResolveCommitResponse'},
-    {
-      '1': 'SignArbitraryMsg',
-      '2': '.bitnames.v1.SignArbitraryMsgRequest',
-      '3': '.bitnames.v1.SignArbitraryMsgResponse'
-    },
-    {
-      '1': 'SignArbitraryMsgAsAddr',
-      '2': '.bitnames.v1.SignArbitraryMsgAsAddrRequest',
-      '3': '.bitnames.v1.SignArbitraryMsgAsAddrResponse'
-    },
-    {
-      '1': 'GetWalletAddresses',
-      '2': '.bitnames.v1.GetWalletAddressesRequest',
-      '3': '.bitnames.v1.GetWalletAddressesResponse'
-    },
+    {'1': 'SignArbitraryMsg', '2': '.bitnames.v1.SignArbitraryMsgRequest', '3': '.bitnames.v1.SignArbitraryMsgResponse'},
+    {'1': 'SignArbitraryMsgAsAddr', '2': '.bitnames.v1.SignArbitraryMsgAsAddrRequest', '3': '.bitnames.v1.SignArbitraryMsgAsAddrResponse'},
+    {'1': 'GetWalletAddresses', '2': '.bitnames.v1.GetWalletAddressesRequest', '3': '.bitnames.v1.GetWalletAddressesResponse'},
     {'1': 'MyUtxos', '2': '.bitnames.v1.MyUtxosRequest', '3': '.bitnames.v1.MyUtxosResponse'},
     {'1': 'OpenapiSchema', '2': '.bitnames.v1.OpenapiSchemaRequest', '3': '.bitnames.v1.OpenapiSchemaResponse'},
   ],
@@ -1039,66 +1000,67 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> BitnamesSe
 };
 
 /// Descriptor for `BitnamesService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List bitnamesServiceDescriptor =
-    $convert.base64Decode('Cg9CaXRuYW1lc1NlcnZpY2USTQoKR2V0QmFsYW5jZRIeLmJpdG5hbWVzLnYxLkdldEJhbGFuY2'
-        'VSZXF1ZXN0Gh8uYml0bmFtZXMudjEuR2V0QmFsYW5jZVJlc3BvbnNlElYKDUdldEJsb2NrQ291'
-        'bnQSIS5iaXRuYW1lcy52MS5HZXRCbG9ja0NvdW50UmVxdWVzdBoiLmJpdG5hbWVzLnYxLkdldE'
-        'Jsb2NrQ291bnRSZXNwb25zZRI7CgRTdG9wEhguYml0bmFtZXMudjEuU3RvcFJlcXVlc3QaGS5i'
-        'aXRuYW1lcy52MS5TdG9wUmVzcG9uc2USVgoNR2V0TmV3QWRkcmVzcxIhLmJpdG5hbWVzLnYxLk'
-        'dldE5ld0FkZHJlc3NSZXF1ZXN0GiIuYml0bmFtZXMudjEuR2V0TmV3QWRkcmVzc1Jlc3BvbnNl'
-        'EkcKCFdpdGhkcmF3EhwuYml0bmFtZXMudjEuV2l0aGRyYXdSZXF1ZXN0Gh0uYml0bmFtZXMudj'
-        'EuV2l0aGRyYXdSZXNwb25zZRJHCghUcmFuc2ZlchIcLmJpdG5hbWVzLnYxLlRyYW5zZmVyUmVx'
-        'dWVzdBodLmJpdG5hbWVzLnYxLlRyYW5zZmVyUmVzcG9uc2USZQoSR2V0U2lkZWNoYWluV2VhbH'
-        'RoEiYuYml0bmFtZXMudjEuR2V0U2lkZWNoYWluV2VhbHRoUmVxdWVzdBonLmJpdG5hbWVzLnYx'
-        'LkdldFNpZGVjaGFpbldlYWx0aFJlc3BvbnNlElYKDUNyZWF0ZURlcG9zaXQSIS5iaXRuYW1lcy'
-        '52MS5DcmVhdGVEZXBvc2l0UmVxdWVzdBoiLmJpdG5hbWVzLnYxLkNyZWF0ZURlcG9zaXRSZXNw'
-        'b25zZRJ9ChpHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZRIuLmJpdG5hbWVzLnYxLkdldFBlbm'
-        'RpbmdXaXRoZHJhd2FsQnVuZGxlUmVxdWVzdBovLmJpdG5hbWVzLnYxLkdldFBlbmRpbmdXaXRo'
-        'ZHJhd2FsQnVuZGxlUmVzcG9uc2USUAoLQ29ubmVjdFBlZXISHy5iaXRuYW1lcy52MS5Db25uZW'
-        'N0UGVlclJlcXVlc3QaIC5iaXRuYW1lcy52MS5Db25uZWN0UGVlclJlc3BvbnNlEkoKCUxpc3RQ'
-        'ZWVycxIdLmJpdG5hbWVzLnYxLkxpc3RQZWVyc1JlcXVlc3QaHi5iaXRuYW1lcy52MS5MaXN0UG'
-        'VlcnNSZXNwb25zZRI7CgRNaW5lEhguYml0bmFtZXMudjEuTWluZVJlcXVlc3QaGS5iaXRuYW1l'
-        'cy52MS5NaW5lUmVzcG9uc2USRwoIR2V0QmxvY2sSHC5iaXRuYW1lcy52MS5HZXRCbG9ja1JlcX'
-        'Vlc3QaHS5iaXRuYW1lcy52MS5HZXRCbG9ja1Jlc3BvbnNlEnoKGUdldEJlc3RNYWluY2hhaW5C'
-        'bG9ja0hhc2gSLS5iaXRuYW1lcy52MS5HZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdB'
-        'ouLmJpdG5hbWVzLnYxLkdldEJlc3RNYWluY2hhaW5CbG9ja0hhc2hSZXNwb25zZRJ6ChlHZXRC'
-        'ZXN0U2lkZWNoYWluQmxvY2tIYXNoEi0uYml0bmFtZXMudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2'
-        'NrSGFzaFJlcXVlc3QaLi5iaXRuYW1lcy52MS5HZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVz'
-        'cG9uc2USXwoQR2V0Qm1tSW5jbHVzaW9ucxIkLmJpdG5hbWVzLnYxLkdldEJtbUluY2x1c2lvbn'
-        'NSZXF1ZXN0GiUuYml0bmFtZXMudjEuR2V0Qm1tSW5jbHVzaW9uc1Jlc3BvbnNlElkKDkdldFdh'
-        'bGxldFV0eG9zEiIuYml0bmFtZXMudjEuR2V0V2FsbGV0VXR4b3NSZXF1ZXN0GiMuYml0bmFtZX'
-        'MudjEuR2V0V2FsbGV0VXR4b3NSZXNwb25zZRJKCglMaXN0VXR4b3MSHS5iaXRuYW1lcy52MS5M'
-        'aXN0VXR4b3NSZXF1ZXN0Gh4uYml0bmFtZXMudjEuTGlzdFV0eG9zUmVzcG9uc2USngEKJUdldE'
-        'xhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHQSOS5iaXRuYW1lcy52MS5HZXRMYXRl'
-        'c3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdBo6LmJpdG5hbWVzLnYxLkdldE'
-        'xhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHRSZXNwb25zZRJfChBHZW5lcmF0ZU1u'
-        'ZW1vbmljEiQuYml0bmFtZXMudjEuR2VuZXJhdGVNbmVtb25pY1JlcXVlc3QaJS5iaXRuYW1lcy'
-        '52MS5HZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USaAoTU2V0U2VlZEZyb21NbmVtb25pYxInLmJp'
-        'dG5hbWVzLnYxLlNldFNlZWRGcm9tTW5lbW9uaWNSZXF1ZXN0GiguYml0bmFtZXMudjEuU2V0U2'
-        'VlZEZyb21NbmVtb25pY1Jlc3BvbnNlEkQKB0NhbGxSYXcSGy5iaXRuYW1lcy52MS5DYWxsUmF3'
-        'UmVxdWVzdBocLmJpdG5hbWVzLnYxLkNhbGxSYXdSZXNwb25zZRJZCg5HZXRCaXROYW1lRGF0YR'
-        'IiLmJpdG5hbWVzLnYxLkdldEJpdE5hbWVEYXRhUmVxdWVzdBojLmJpdG5hbWVzLnYxLkdldEJp'
-        'dE5hbWVEYXRhUmVzcG9uc2USUwoMTGlzdEJpdE5hbWVzEiAuYml0bmFtZXMudjEuTGlzdEJpdE'
-        '5hbWVzUmVxdWVzdBohLmJpdG5hbWVzLnYxLkxpc3RCaXROYW1lc1Jlc3BvbnNlElwKD1JlZ2lz'
-        'dGVyQml0TmFtZRIjLmJpdG5hbWVzLnYxLlJlZ2lzdGVyQml0TmFtZVJlcXVlc3QaJC5iaXRuYW'
-        '1lcy52MS5SZWdpc3RlckJpdE5hbWVSZXNwb25zZRJZCg5SZXNlcnZlQml0TmFtZRIiLmJpdG5h'
-        'bWVzLnYxLlJlc2VydmVCaXROYW1lUmVxdWVzdBojLmJpdG5hbWVzLnYxLlJlc2VydmVCaXROYW'
-        '1lUmVzcG9uc2USaAoTR2V0TmV3RW5jcnlwdGlvbktleRInLmJpdG5hbWVzLnYxLkdldE5ld0Vu'
-        'Y3J5cHRpb25LZXlSZXF1ZXN0GiguYml0bmFtZXMudjEuR2V0TmV3RW5jcnlwdGlvbktleVJlc3'
-        'BvbnNlEmUKEkdldE5ld1ZlcmlmeWluZ0tleRImLmJpdG5hbWVzLnYxLkdldE5ld1ZlcmlmeWlu'
-        'Z0tleVJlcXVlc3QaJy5iaXRuYW1lcy52MS5HZXROZXdWZXJpZnlpbmdLZXlSZXNwb25zZRJNCg'
-        'pEZWNyeXB0TXNnEh4uYml0bmFtZXMudjEuRGVjcnlwdE1zZ1JlcXVlc3QaHy5iaXRuYW1lcy52'
-        'MS5EZWNyeXB0TXNnUmVzcG9uc2USTQoKRW5jcnlwdE1zZxIeLmJpdG5hbWVzLnYxLkVuY3J5cH'
-        'RNc2dSZXF1ZXN0Gh8uYml0bmFtZXMudjEuRW5jcnlwdE1zZ1Jlc3BvbnNlEk0KCkdldFBheW1h'
-        'aWwSHi5iaXRuYW1lcy52MS5HZXRQYXltYWlsUmVxdWVzdBofLmJpdG5hbWVzLnYxLkdldFBheW'
-        '1haWxSZXNwb25zZRJWCg1SZXNvbHZlQ29tbWl0EiEuYml0bmFtZXMudjEuUmVzb2x2ZUNvbW1p'
-        'dFJlcXVlc3QaIi5iaXRuYW1lcy52MS5SZXNvbHZlQ29tbWl0UmVzcG9uc2USXwoQU2lnbkFyYm'
-        'l0cmFyeU1zZxIkLmJpdG5hbWVzLnYxLlNpZ25BcmJpdHJhcnlNc2dSZXF1ZXN0GiUuYml0bmFt'
-        'ZXMudjEuU2lnbkFyYml0cmFyeU1zZ1Jlc3BvbnNlEnEKFlNpZ25BcmJpdHJhcnlNc2dBc0FkZH'
-        'ISKi5iaXRuYW1lcy52MS5TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVxdWVzdBorLmJpdG5hbWVz'
-        'LnYxLlNpZ25BcmJpdHJhcnlNc2dBc0FkZHJSZXNwb25zZRJlChJHZXRXYWxsZXRBZGRyZXNzZX'
-        'MSJi5iaXRuYW1lcy52MS5HZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0GicuYml0bmFtZXMudjEu'
-        'R2V0V2FsbGV0QWRkcmVzc2VzUmVzcG9uc2USRAoHTXlVdHhvcxIbLmJpdG5hbWVzLnYxLk15VX'
-        'R4b3NSZXF1ZXN0GhwuYml0bmFtZXMudjEuTXlVdHhvc1Jlc3BvbnNlElYKDU9wZW5hcGlTY2hl'
-        'bWESIS5iaXRuYW1lcy52MS5PcGVuYXBpU2NoZW1hUmVxdWVzdBoiLmJpdG5hbWVzLnYxLk9wZW'
-        '5hcGlTY2hlbWFSZXNwb25zZQ==');
+final $typed_data.Uint8List bitnamesServiceDescriptor = $convert.base64Decode(
+    'Cg9CaXRuYW1lc1NlcnZpY2USTQoKR2V0QmFsYW5jZRIeLmJpdG5hbWVzLnYxLkdldEJhbGFuY2'
+    'VSZXF1ZXN0Gh8uYml0bmFtZXMudjEuR2V0QmFsYW5jZVJlc3BvbnNlElYKDUdldEJsb2NrQ291'
+    'bnQSIS5iaXRuYW1lcy52MS5HZXRCbG9ja0NvdW50UmVxdWVzdBoiLmJpdG5hbWVzLnYxLkdldE'
+    'Jsb2NrQ291bnRSZXNwb25zZRI7CgRTdG9wEhguYml0bmFtZXMudjEuU3RvcFJlcXVlc3QaGS5i'
+    'aXRuYW1lcy52MS5TdG9wUmVzcG9uc2USVgoNR2V0TmV3QWRkcmVzcxIhLmJpdG5hbWVzLnYxLk'
+    'dldE5ld0FkZHJlc3NSZXF1ZXN0GiIuYml0bmFtZXMudjEuR2V0TmV3QWRkcmVzc1Jlc3BvbnNl'
+    'EkcKCFdpdGhkcmF3EhwuYml0bmFtZXMudjEuV2l0aGRyYXdSZXF1ZXN0Gh0uYml0bmFtZXMudj'
+    'EuV2l0aGRyYXdSZXNwb25zZRJHCghUcmFuc2ZlchIcLmJpdG5hbWVzLnYxLlRyYW5zZmVyUmVx'
+    'dWVzdBodLmJpdG5hbWVzLnYxLlRyYW5zZmVyUmVzcG9uc2USZQoSR2V0U2lkZWNoYWluV2VhbH'
+    'RoEiYuYml0bmFtZXMudjEuR2V0U2lkZWNoYWluV2VhbHRoUmVxdWVzdBonLmJpdG5hbWVzLnYx'
+    'LkdldFNpZGVjaGFpbldlYWx0aFJlc3BvbnNlElYKDUNyZWF0ZURlcG9zaXQSIS5iaXRuYW1lcy'
+    '52MS5DcmVhdGVEZXBvc2l0UmVxdWVzdBoiLmJpdG5hbWVzLnYxLkNyZWF0ZURlcG9zaXRSZXNw'
+    'b25zZRJ9ChpHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZRIuLmJpdG5hbWVzLnYxLkdldFBlbm'
+    'RpbmdXaXRoZHJhd2FsQnVuZGxlUmVxdWVzdBovLmJpdG5hbWVzLnYxLkdldFBlbmRpbmdXaXRo'
+    'ZHJhd2FsQnVuZGxlUmVzcG9uc2USUAoLQ29ubmVjdFBlZXISHy5iaXRuYW1lcy52MS5Db25uZW'
+    'N0UGVlclJlcXVlc3QaIC5iaXRuYW1lcy52MS5Db25uZWN0UGVlclJlc3BvbnNlEkoKCUxpc3RQ'
+    'ZWVycxIdLmJpdG5hbWVzLnYxLkxpc3RQZWVyc1JlcXVlc3QaHi5iaXRuYW1lcy52MS5MaXN0UG'
+    'VlcnNSZXNwb25zZRI7CgRNaW5lEhguYml0bmFtZXMudjEuTWluZVJlcXVlc3QaGS5iaXRuYW1l'
+    'cy52MS5NaW5lUmVzcG9uc2USRwoIR2V0QmxvY2sSHC5iaXRuYW1lcy52MS5HZXRCbG9ja1JlcX'
+    'Vlc3QaHS5iaXRuYW1lcy52MS5HZXRCbG9ja1Jlc3BvbnNlEnoKGUdldEJlc3RNYWluY2hhaW5C'
+    'bG9ja0hhc2gSLS5iaXRuYW1lcy52MS5HZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdB'
+    'ouLmJpdG5hbWVzLnYxLkdldEJlc3RNYWluY2hhaW5CbG9ja0hhc2hSZXNwb25zZRJ6ChlHZXRC'
+    'ZXN0U2lkZWNoYWluQmxvY2tIYXNoEi0uYml0bmFtZXMudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2'
+    'NrSGFzaFJlcXVlc3QaLi5iaXRuYW1lcy52MS5HZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVz'
+    'cG9uc2USXwoQR2V0Qm1tSW5jbHVzaW9ucxIkLmJpdG5hbWVzLnYxLkdldEJtbUluY2x1c2lvbn'
+    'NSZXF1ZXN0GiUuYml0bmFtZXMudjEuR2V0Qm1tSW5jbHVzaW9uc1Jlc3BvbnNlElkKDkdldFdh'
+    'bGxldFV0eG9zEiIuYml0bmFtZXMudjEuR2V0V2FsbGV0VXR4b3NSZXF1ZXN0GiMuYml0bmFtZX'
+    'MudjEuR2V0V2FsbGV0VXR4b3NSZXNwb25zZRJKCglMaXN0VXR4b3MSHS5iaXRuYW1lcy52MS5M'
+    'aXN0VXR4b3NSZXF1ZXN0Gh4uYml0bmFtZXMudjEuTGlzdFV0eG9zUmVzcG9uc2USngEKJUdldE'
+    'xhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHQSOS5iaXRuYW1lcy52MS5HZXRMYXRl'
+    'c3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdBo6LmJpdG5hbWVzLnYxLkdldE'
+    'xhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHRSZXNwb25zZRJfChBHZW5lcmF0ZU1u'
+    'ZW1vbmljEiQuYml0bmFtZXMudjEuR2VuZXJhdGVNbmVtb25pY1JlcXVlc3QaJS5iaXRuYW1lcy'
+    '52MS5HZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USaAoTU2V0U2VlZEZyb21NbmVtb25pYxInLmJp'
+    'dG5hbWVzLnYxLlNldFNlZWRGcm9tTW5lbW9uaWNSZXF1ZXN0GiguYml0bmFtZXMudjEuU2V0U2'
+    'VlZEZyb21NbmVtb25pY1Jlc3BvbnNlEkQKB0NhbGxSYXcSGy5iaXRuYW1lcy52MS5DYWxsUmF3'
+    'UmVxdWVzdBocLmJpdG5hbWVzLnYxLkNhbGxSYXdSZXNwb25zZRJZCg5HZXRCaXROYW1lRGF0YR'
+    'IiLmJpdG5hbWVzLnYxLkdldEJpdE5hbWVEYXRhUmVxdWVzdBojLmJpdG5hbWVzLnYxLkdldEJp'
+    'dE5hbWVEYXRhUmVzcG9uc2USUwoMTGlzdEJpdE5hbWVzEiAuYml0bmFtZXMudjEuTGlzdEJpdE'
+    '5hbWVzUmVxdWVzdBohLmJpdG5hbWVzLnYxLkxpc3RCaXROYW1lc1Jlc3BvbnNlElwKD1JlZ2lz'
+    'dGVyQml0TmFtZRIjLmJpdG5hbWVzLnYxLlJlZ2lzdGVyQml0TmFtZVJlcXVlc3QaJC5iaXRuYW'
+    '1lcy52MS5SZWdpc3RlckJpdE5hbWVSZXNwb25zZRJZCg5SZXNlcnZlQml0TmFtZRIiLmJpdG5h'
+    'bWVzLnYxLlJlc2VydmVCaXROYW1lUmVxdWVzdBojLmJpdG5hbWVzLnYxLlJlc2VydmVCaXROYW'
+    '1lUmVzcG9uc2USaAoTR2V0TmV3RW5jcnlwdGlvbktleRInLmJpdG5hbWVzLnYxLkdldE5ld0Vu'
+    'Y3J5cHRpb25LZXlSZXF1ZXN0GiguYml0bmFtZXMudjEuR2V0TmV3RW5jcnlwdGlvbktleVJlc3'
+    'BvbnNlEmUKEkdldE5ld1ZlcmlmeWluZ0tleRImLmJpdG5hbWVzLnYxLkdldE5ld1ZlcmlmeWlu'
+    'Z0tleVJlcXVlc3QaJy5iaXRuYW1lcy52MS5HZXROZXdWZXJpZnlpbmdLZXlSZXNwb25zZRJNCg'
+    'pEZWNyeXB0TXNnEh4uYml0bmFtZXMudjEuRGVjcnlwdE1zZ1JlcXVlc3QaHy5iaXRuYW1lcy52'
+    'MS5EZWNyeXB0TXNnUmVzcG9uc2USTQoKRW5jcnlwdE1zZxIeLmJpdG5hbWVzLnYxLkVuY3J5cH'
+    'RNc2dSZXF1ZXN0Gh8uYml0bmFtZXMudjEuRW5jcnlwdE1zZ1Jlc3BvbnNlEk0KCkdldFBheW1h'
+    'aWwSHi5iaXRuYW1lcy52MS5HZXRQYXltYWlsUmVxdWVzdBofLmJpdG5hbWVzLnYxLkdldFBheW'
+    '1haWxSZXNwb25zZRJWCg1SZXNvbHZlQ29tbWl0EiEuYml0bmFtZXMudjEuUmVzb2x2ZUNvbW1p'
+    'dFJlcXVlc3QaIi5iaXRuYW1lcy52MS5SZXNvbHZlQ29tbWl0UmVzcG9uc2USXwoQU2lnbkFyYm'
+    'l0cmFyeU1zZxIkLmJpdG5hbWVzLnYxLlNpZ25BcmJpdHJhcnlNc2dSZXF1ZXN0GiUuYml0bmFt'
+    'ZXMudjEuU2lnbkFyYml0cmFyeU1zZ1Jlc3BvbnNlEnEKFlNpZ25BcmJpdHJhcnlNc2dBc0FkZH'
+    'ISKi5iaXRuYW1lcy52MS5TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVxdWVzdBorLmJpdG5hbWVz'
+    'LnYxLlNpZ25BcmJpdHJhcnlNc2dBc0FkZHJSZXNwb25zZRJlChJHZXRXYWxsZXRBZGRyZXNzZX'
+    'MSJi5iaXRuYW1lcy52MS5HZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0GicuYml0bmFtZXMudjEu'
+    'R2V0V2FsbGV0QWRkcmVzc2VzUmVzcG9uc2USRAoHTXlVdHhvcxIbLmJpdG5hbWVzLnYxLk15VX'
+    'R4b3NSZXF1ZXN0GhwuYml0bmFtZXMudjEuTXlVdHhvc1Jlc3BvbnNlElYKDU9wZW5hcGlTY2hl'
+    'bWESIS5iaXRuYW1lcy52MS5PcGVuYXBpU2NoZW1hUmVxdWVzdBoiLmJpdG5hbWVzLnYxLk9wZW'
+    '5hcGlTY2hlbWFSZXNwb25zZQ==');
+

--- a/sail_ui/lib/gen/bitnames/v1/bitnames.pbserver.dart
+++ b/sail_ui/lib/gen/bitnames/v1/bitnames.pbserver.dart
@@ -27,215 +27,125 @@ abstract class BitnamesServiceBase extends $pb.GeneratedService {
   $async.Future<$1.GetNewAddressResponse> getNewAddress($pb.ServerContext ctx, $1.GetNewAddressRequest request);
   $async.Future<$1.WithdrawResponse> withdraw($pb.ServerContext ctx, $1.WithdrawRequest request);
   $async.Future<$1.TransferResponse> transfer($pb.ServerContext ctx, $1.TransferRequest request);
-  $async.Future<$1.GetSidechainWealthResponse> getSidechainWealth(
-      $pb.ServerContext ctx, $1.GetSidechainWealthRequest request);
+  $async.Future<$1.GetSidechainWealthResponse> getSidechainWealth($pb.ServerContext ctx, $1.GetSidechainWealthRequest request);
   $async.Future<$1.CreateDepositResponse> createDeposit($pb.ServerContext ctx, $1.CreateDepositRequest request);
-  $async.Future<$1.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-      $pb.ServerContext ctx, $1.GetPendingWithdrawalBundleRequest request);
+  $async.Future<$1.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ServerContext ctx, $1.GetPendingWithdrawalBundleRequest request);
   $async.Future<$1.ConnectPeerResponse> connectPeer($pb.ServerContext ctx, $1.ConnectPeerRequest request);
   $async.Future<$1.ListPeersResponse> listPeers($pb.ServerContext ctx, $1.ListPeersRequest request);
   $async.Future<$1.MineResponse> mine($pb.ServerContext ctx, $1.MineRequest request);
   $async.Future<$1.GetBlockResponse> getBlock($pb.ServerContext ctx, $1.GetBlockRequest request);
-  $async.Future<$1.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-      $pb.ServerContext ctx, $1.GetBestMainchainBlockHashRequest request);
-  $async.Future<$1.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-      $pb.ServerContext ctx, $1.GetBestSidechainBlockHashRequest request);
-  $async.Future<$1.GetBmmInclusionsResponse> getBmmInclusions(
-      $pb.ServerContext ctx, $1.GetBmmInclusionsRequest request);
+  $async.Future<$1.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ServerContext ctx, $1.GetBestMainchainBlockHashRequest request);
+  $async.Future<$1.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ServerContext ctx, $1.GetBestSidechainBlockHashRequest request);
+  $async.Future<$1.GetBmmInclusionsResponse> getBmmInclusions($pb.ServerContext ctx, $1.GetBmmInclusionsRequest request);
   $async.Future<$1.GetWalletUtxosResponse> getWalletUtxos($pb.ServerContext ctx, $1.GetWalletUtxosRequest request);
   $async.Future<$1.ListUtxosResponse> listUtxos($pb.ServerContext ctx, $1.ListUtxosRequest request);
-  $async.Future<$1.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-      $pb.ServerContext ctx, $1.GetLatestFailedWithdrawalBundleHeightRequest request);
-  $async.Future<$1.GenerateMnemonicResponse> generateMnemonic(
-      $pb.ServerContext ctx, $1.GenerateMnemonicRequest request);
-  $async.Future<$1.SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-      $pb.ServerContext ctx, $1.SetSeedFromMnemonicRequest request);
+  $async.Future<$1.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ServerContext ctx, $1.GetLatestFailedWithdrawalBundleHeightRequest request);
+  $async.Future<$1.GenerateMnemonicResponse> generateMnemonic($pb.ServerContext ctx, $1.GenerateMnemonicRequest request);
+  $async.Future<$1.SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ServerContext ctx, $1.SetSeedFromMnemonicRequest request);
   $async.Future<$1.CallRawResponse> callRaw($pb.ServerContext ctx, $1.CallRawRequest request);
   $async.Future<$1.GetBitNameDataResponse> getBitNameData($pb.ServerContext ctx, $1.GetBitNameDataRequest request);
   $async.Future<$1.ListBitNamesResponse> listBitNames($pb.ServerContext ctx, $1.ListBitNamesRequest request);
   $async.Future<$1.RegisterBitNameResponse> registerBitName($pb.ServerContext ctx, $1.RegisterBitNameRequest request);
   $async.Future<$1.ReserveBitNameResponse> reserveBitName($pb.ServerContext ctx, $1.ReserveBitNameRequest request);
-  $async.Future<$1.GetNewEncryptionKeyResponse> getNewEncryptionKey(
-      $pb.ServerContext ctx, $1.GetNewEncryptionKeyRequest request);
-  $async.Future<$1.GetNewVerifyingKeyResponse> getNewVerifyingKey(
-      $pb.ServerContext ctx, $1.GetNewVerifyingKeyRequest request);
+  $async.Future<$1.GetNewEncryptionKeyResponse> getNewEncryptionKey($pb.ServerContext ctx, $1.GetNewEncryptionKeyRequest request);
+  $async.Future<$1.GetNewVerifyingKeyResponse> getNewVerifyingKey($pb.ServerContext ctx, $1.GetNewVerifyingKeyRequest request);
   $async.Future<$1.DecryptMsgResponse> decryptMsg($pb.ServerContext ctx, $1.DecryptMsgRequest request);
   $async.Future<$1.EncryptMsgResponse> encryptMsg($pb.ServerContext ctx, $1.EncryptMsgRequest request);
   $async.Future<$1.GetPaymailResponse> getPaymail($pb.ServerContext ctx, $1.GetPaymailRequest request);
   $async.Future<$1.ResolveCommitResponse> resolveCommit($pb.ServerContext ctx, $1.ResolveCommitRequest request);
-  $async.Future<$1.SignArbitraryMsgResponse> signArbitraryMsg(
-      $pb.ServerContext ctx, $1.SignArbitraryMsgRequest request);
-  $async.Future<$1.SignArbitraryMsgAsAddrResponse> signArbitraryMsgAsAddr(
-      $pb.ServerContext ctx, $1.SignArbitraryMsgAsAddrRequest request);
-  $async.Future<$1.GetWalletAddressesResponse> getWalletAddresses(
-      $pb.ServerContext ctx, $1.GetWalletAddressesRequest request);
+  $async.Future<$1.SignArbitraryMsgResponse> signArbitraryMsg($pb.ServerContext ctx, $1.SignArbitraryMsgRequest request);
+  $async.Future<$1.SignArbitraryMsgAsAddrResponse> signArbitraryMsgAsAddr($pb.ServerContext ctx, $1.SignArbitraryMsgAsAddrRequest request);
+  $async.Future<$1.GetWalletAddressesResponse> getWalletAddresses($pb.ServerContext ctx, $1.GetWalletAddressesRequest request);
   $async.Future<$1.MyUtxosResponse> myUtxos($pb.ServerContext ctx, $1.MyUtxosRequest request);
   $async.Future<$1.OpenapiSchemaResponse> openapiSchema($pb.ServerContext ctx, $1.OpenapiSchemaRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetBalance':
-        return $1.GetBalanceRequest();
-      case 'GetBlockCount':
-        return $1.GetBlockCountRequest();
-      case 'Stop':
-        return $1.StopRequest();
-      case 'GetNewAddress':
-        return $1.GetNewAddressRequest();
-      case 'Withdraw':
-        return $1.WithdrawRequest();
-      case 'Transfer':
-        return $1.TransferRequest();
-      case 'GetSidechainWealth':
-        return $1.GetSidechainWealthRequest();
-      case 'CreateDeposit':
-        return $1.CreateDepositRequest();
-      case 'GetPendingWithdrawalBundle':
-        return $1.GetPendingWithdrawalBundleRequest();
-      case 'ConnectPeer':
-        return $1.ConnectPeerRequest();
-      case 'ListPeers':
-        return $1.ListPeersRequest();
-      case 'Mine':
-        return $1.MineRequest();
-      case 'GetBlock':
-        return $1.GetBlockRequest();
-      case 'GetBestMainchainBlockHash':
-        return $1.GetBestMainchainBlockHashRequest();
-      case 'GetBestSidechainBlockHash':
-        return $1.GetBestSidechainBlockHashRequest();
-      case 'GetBmmInclusions':
-        return $1.GetBmmInclusionsRequest();
-      case 'GetWalletUtxos':
-        return $1.GetWalletUtxosRequest();
-      case 'ListUtxos':
-        return $1.ListUtxosRequest();
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return $1.GetLatestFailedWithdrawalBundleHeightRequest();
-      case 'GenerateMnemonic':
-        return $1.GenerateMnemonicRequest();
-      case 'SetSeedFromMnemonic':
-        return $1.SetSeedFromMnemonicRequest();
-      case 'CallRaw':
-        return $1.CallRawRequest();
-      case 'GetBitNameData':
-        return $1.GetBitNameDataRequest();
-      case 'ListBitNames':
-        return $1.ListBitNamesRequest();
-      case 'RegisterBitName':
-        return $1.RegisterBitNameRequest();
-      case 'ReserveBitName':
-        return $1.ReserveBitNameRequest();
-      case 'GetNewEncryptionKey':
-        return $1.GetNewEncryptionKeyRequest();
-      case 'GetNewVerifyingKey':
-        return $1.GetNewVerifyingKeyRequest();
-      case 'DecryptMsg':
-        return $1.DecryptMsgRequest();
-      case 'EncryptMsg':
-        return $1.EncryptMsgRequest();
-      case 'GetPaymail':
-        return $1.GetPaymailRequest();
-      case 'ResolveCommit':
-        return $1.ResolveCommitRequest();
-      case 'SignArbitraryMsg':
-        return $1.SignArbitraryMsgRequest();
-      case 'SignArbitraryMsgAsAddr':
-        return $1.SignArbitraryMsgAsAddrRequest();
-      case 'GetWalletAddresses':
-        return $1.GetWalletAddressesRequest();
-      case 'MyUtxos':
-        return $1.MyUtxosRequest();
-      case 'OpenapiSchema':
-        return $1.OpenapiSchemaRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return $1.GetBalanceRequest();
+      case 'GetBlockCount': return $1.GetBlockCountRequest();
+      case 'Stop': return $1.StopRequest();
+      case 'GetNewAddress': return $1.GetNewAddressRequest();
+      case 'Withdraw': return $1.WithdrawRequest();
+      case 'Transfer': return $1.TransferRequest();
+      case 'GetSidechainWealth': return $1.GetSidechainWealthRequest();
+      case 'CreateDeposit': return $1.CreateDepositRequest();
+      case 'GetPendingWithdrawalBundle': return $1.GetPendingWithdrawalBundleRequest();
+      case 'ConnectPeer': return $1.ConnectPeerRequest();
+      case 'ListPeers': return $1.ListPeersRequest();
+      case 'Mine': return $1.MineRequest();
+      case 'GetBlock': return $1.GetBlockRequest();
+      case 'GetBestMainchainBlockHash': return $1.GetBestMainchainBlockHashRequest();
+      case 'GetBestSidechainBlockHash': return $1.GetBestSidechainBlockHashRequest();
+      case 'GetBmmInclusions': return $1.GetBmmInclusionsRequest();
+      case 'GetWalletUtxos': return $1.GetWalletUtxosRequest();
+      case 'ListUtxos': return $1.ListUtxosRequest();
+      case 'GetLatestFailedWithdrawalBundleHeight': return $1.GetLatestFailedWithdrawalBundleHeightRequest();
+      case 'GenerateMnemonic': return $1.GenerateMnemonicRequest();
+      case 'SetSeedFromMnemonic': return $1.SetSeedFromMnemonicRequest();
+      case 'CallRaw': return $1.CallRawRequest();
+      case 'GetBitNameData': return $1.GetBitNameDataRequest();
+      case 'ListBitNames': return $1.ListBitNamesRequest();
+      case 'RegisterBitName': return $1.RegisterBitNameRequest();
+      case 'ReserveBitName': return $1.ReserveBitNameRequest();
+      case 'GetNewEncryptionKey': return $1.GetNewEncryptionKeyRequest();
+      case 'GetNewVerifyingKey': return $1.GetNewVerifyingKeyRequest();
+      case 'DecryptMsg': return $1.DecryptMsgRequest();
+      case 'EncryptMsg': return $1.EncryptMsgRequest();
+      case 'GetPaymail': return $1.GetPaymailRequest();
+      case 'ResolveCommit': return $1.ResolveCommitRequest();
+      case 'SignArbitraryMsg': return $1.SignArbitraryMsgRequest();
+      case 'SignArbitraryMsgAsAddr': return $1.SignArbitraryMsgAsAddrRequest();
+      case 'GetWalletAddresses': return $1.GetWalletAddressesRequest();
+      case 'MyUtxos': return $1.MyUtxosRequest();
+      case 'OpenapiSchema': return $1.OpenapiSchemaRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetBalance':
-        return this.getBalance(ctx, request as $1.GetBalanceRequest);
-      case 'GetBlockCount':
-        return this.getBlockCount(ctx, request as $1.GetBlockCountRequest);
-      case 'Stop':
-        return this.stop(ctx, request as $1.StopRequest);
-      case 'GetNewAddress':
-        return this.getNewAddress(ctx, request as $1.GetNewAddressRequest);
-      case 'Withdraw':
-        return this.withdraw(ctx, request as $1.WithdrawRequest);
-      case 'Transfer':
-        return this.transfer(ctx, request as $1.TransferRequest);
-      case 'GetSidechainWealth':
-        return this.getSidechainWealth(ctx, request as $1.GetSidechainWealthRequest);
-      case 'CreateDeposit':
-        return this.createDeposit(ctx, request as $1.CreateDepositRequest);
-      case 'GetPendingWithdrawalBundle':
-        return this.getPendingWithdrawalBundle(ctx, request as $1.GetPendingWithdrawalBundleRequest);
-      case 'ConnectPeer':
-        return this.connectPeer(ctx, request as $1.ConnectPeerRequest);
-      case 'ListPeers':
-        return this.listPeers(ctx, request as $1.ListPeersRequest);
-      case 'Mine':
-        return this.mine(ctx, request as $1.MineRequest);
-      case 'GetBlock':
-        return this.getBlock(ctx, request as $1.GetBlockRequest);
-      case 'GetBestMainchainBlockHash':
-        return this.getBestMainchainBlockHash(ctx, request as $1.GetBestMainchainBlockHashRequest);
-      case 'GetBestSidechainBlockHash':
-        return this.getBestSidechainBlockHash(ctx, request as $1.GetBestSidechainBlockHashRequest);
-      case 'GetBmmInclusions':
-        return this.getBmmInclusions(ctx, request as $1.GetBmmInclusionsRequest);
-      case 'GetWalletUtxos':
-        return this.getWalletUtxos(ctx, request as $1.GetWalletUtxosRequest);
-      case 'ListUtxos':
-        return this.listUtxos(ctx, request as $1.ListUtxosRequest);
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return this
-            .getLatestFailedWithdrawalBundleHeight(ctx, request as $1.GetLatestFailedWithdrawalBundleHeightRequest);
-      case 'GenerateMnemonic':
-        return this.generateMnemonic(ctx, request as $1.GenerateMnemonicRequest);
-      case 'SetSeedFromMnemonic':
-        return this.setSeedFromMnemonic(ctx, request as $1.SetSeedFromMnemonicRequest);
-      case 'CallRaw':
-        return this.callRaw(ctx, request as $1.CallRawRequest);
-      case 'GetBitNameData':
-        return this.getBitNameData(ctx, request as $1.GetBitNameDataRequest);
-      case 'ListBitNames':
-        return this.listBitNames(ctx, request as $1.ListBitNamesRequest);
-      case 'RegisterBitName':
-        return this.registerBitName(ctx, request as $1.RegisterBitNameRequest);
-      case 'ReserveBitName':
-        return this.reserveBitName(ctx, request as $1.ReserveBitNameRequest);
-      case 'GetNewEncryptionKey':
-        return this.getNewEncryptionKey(ctx, request as $1.GetNewEncryptionKeyRequest);
-      case 'GetNewVerifyingKey':
-        return this.getNewVerifyingKey(ctx, request as $1.GetNewVerifyingKeyRequest);
-      case 'DecryptMsg':
-        return this.decryptMsg(ctx, request as $1.DecryptMsgRequest);
-      case 'EncryptMsg':
-        return this.encryptMsg(ctx, request as $1.EncryptMsgRequest);
-      case 'GetPaymail':
-        return this.getPaymail(ctx, request as $1.GetPaymailRequest);
-      case 'ResolveCommit':
-        return this.resolveCommit(ctx, request as $1.ResolveCommitRequest);
-      case 'SignArbitraryMsg':
-        return this.signArbitraryMsg(ctx, request as $1.SignArbitraryMsgRequest);
-      case 'SignArbitraryMsgAsAddr':
-        return this.signArbitraryMsgAsAddr(ctx, request as $1.SignArbitraryMsgAsAddrRequest);
-      case 'GetWalletAddresses':
-        return this.getWalletAddresses(ctx, request as $1.GetWalletAddressesRequest);
-      case 'MyUtxos':
-        return this.myUtxos(ctx, request as $1.MyUtxosRequest);
-      case 'OpenapiSchema':
-        return this.openapiSchema(ctx, request as $1.OpenapiSchemaRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return this.getBalance(ctx, request as $1.GetBalanceRequest);
+      case 'GetBlockCount': return this.getBlockCount(ctx, request as $1.GetBlockCountRequest);
+      case 'Stop': return this.stop(ctx, request as $1.StopRequest);
+      case 'GetNewAddress': return this.getNewAddress(ctx, request as $1.GetNewAddressRequest);
+      case 'Withdraw': return this.withdraw(ctx, request as $1.WithdrawRequest);
+      case 'Transfer': return this.transfer(ctx, request as $1.TransferRequest);
+      case 'GetSidechainWealth': return this.getSidechainWealth(ctx, request as $1.GetSidechainWealthRequest);
+      case 'CreateDeposit': return this.createDeposit(ctx, request as $1.CreateDepositRequest);
+      case 'GetPendingWithdrawalBundle': return this.getPendingWithdrawalBundle(ctx, request as $1.GetPendingWithdrawalBundleRequest);
+      case 'ConnectPeer': return this.connectPeer(ctx, request as $1.ConnectPeerRequest);
+      case 'ListPeers': return this.listPeers(ctx, request as $1.ListPeersRequest);
+      case 'Mine': return this.mine(ctx, request as $1.MineRequest);
+      case 'GetBlock': return this.getBlock(ctx, request as $1.GetBlockRequest);
+      case 'GetBestMainchainBlockHash': return this.getBestMainchainBlockHash(ctx, request as $1.GetBestMainchainBlockHashRequest);
+      case 'GetBestSidechainBlockHash': return this.getBestSidechainBlockHash(ctx, request as $1.GetBestSidechainBlockHashRequest);
+      case 'GetBmmInclusions': return this.getBmmInclusions(ctx, request as $1.GetBmmInclusionsRequest);
+      case 'GetWalletUtxos': return this.getWalletUtxos(ctx, request as $1.GetWalletUtxosRequest);
+      case 'ListUtxos': return this.listUtxos(ctx, request as $1.ListUtxosRequest);
+      case 'GetLatestFailedWithdrawalBundleHeight': return this.getLatestFailedWithdrawalBundleHeight(ctx, request as $1.GetLatestFailedWithdrawalBundleHeightRequest);
+      case 'GenerateMnemonic': return this.generateMnemonic(ctx, request as $1.GenerateMnemonicRequest);
+      case 'SetSeedFromMnemonic': return this.setSeedFromMnemonic(ctx, request as $1.SetSeedFromMnemonicRequest);
+      case 'CallRaw': return this.callRaw(ctx, request as $1.CallRawRequest);
+      case 'GetBitNameData': return this.getBitNameData(ctx, request as $1.GetBitNameDataRequest);
+      case 'ListBitNames': return this.listBitNames(ctx, request as $1.ListBitNamesRequest);
+      case 'RegisterBitName': return this.registerBitName(ctx, request as $1.RegisterBitNameRequest);
+      case 'ReserveBitName': return this.reserveBitName(ctx, request as $1.ReserveBitNameRequest);
+      case 'GetNewEncryptionKey': return this.getNewEncryptionKey(ctx, request as $1.GetNewEncryptionKeyRequest);
+      case 'GetNewVerifyingKey': return this.getNewVerifyingKey(ctx, request as $1.GetNewVerifyingKeyRequest);
+      case 'DecryptMsg': return this.decryptMsg(ctx, request as $1.DecryptMsgRequest);
+      case 'EncryptMsg': return this.encryptMsg(ctx, request as $1.EncryptMsgRequest);
+      case 'GetPaymail': return this.getPaymail(ctx, request as $1.GetPaymailRequest);
+      case 'ResolveCommit': return this.resolveCommit(ctx, request as $1.ResolveCommitRequest);
+      case 'SignArbitraryMsg': return this.signArbitraryMsg(ctx, request as $1.SignArbitraryMsgRequest);
+      case 'SignArbitraryMsgAsAddr': return this.signArbitraryMsgAsAddr(ctx, request as $1.SignArbitraryMsgAsAddrRequest);
+      case 'GetWalletAddresses': return this.getWalletAddresses(ctx, request as $1.GetWalletAddressesRequest);
+      case 'MyUtxos': return this.myUtxos(ctx, request as $1.MyUtxosRequest);
+      case 'OpenapiSchema': return this.openapiSchema(ctx, request as $1.OpenapiSchemaRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => BitnamesServiceBase$json;
   $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => BitnamesServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/coinshift/v1/coinshift.connect.client.dart
+++ b/sail_ui/lib/gen/coinshift/v1/coinshift.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "coinshift.pb.dart" as coinshiftv1coinshift;
 import "coinshift.connect.spec.dart" as specs;
 
-extension type CoinShiftServiceClient(connect.Transport _transport) {
+extension type CoinShiftServiceClient (connect.Transport _transport) {
   /// Get wallet balance (total and available).
   Future<coinshiftv1coinshift.GetBalanceResponse> getBalance(
     coinshiftv1coinshift.GetBalanceRequest input, {

--- a/sail_ui/lib/gen/coinshift/v1/coinshift.pb.dart
+++ b/sail_ui/lib/gen/coinshift/v1/coinshift.pb.dart
@@ -18,25 +18,23 @@ import 'package:protobuf/protobuf.dart' as $pb;
 class GetBalanceRequest extends $pb.GeneratedMessage {
   factory GetBalanceRequest() => create();
   GetBalanceRequest._() : super();
-  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceRequest clone() => GetBalanceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) => super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -45,8 +43,7 @@ class GetBalanceRequest extends $pb.GeneratedMessage {
   GetBalanceRequest createEmptyInstance() => create();
   static $pb.PbList<GetBalanceRequest> createRepeated() => $pb.PbList<GetBalanceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
+  static GetBalanceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
   static GetBalanceRequest? _defaultInstance;
 }
 
@@ -65,27 +62,25 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBalanceResponse._() : super();
-  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'totalSats')
     ..aInt64(2, _omitFieldNames ? '' : 'availableSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceResponse clone() => GetBalanceResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) => super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -94,17 +89,13 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   GetBalanceResponse createEmptyInstance() => create();
   static $pb.PbList<GetBalanceResponse> createRepeated() => $pb.PbList<GetBalanceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
+  static GetBalanceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
   static GetBalanceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get totalSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set totalSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set totalSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTotalSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -113,10 +104,7 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get availableSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set availableSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set availableSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAvailableSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -126,25 +114,23 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
 class GetBlockCountRequest extends $pb.GeneratedMessage {
   factory GetBlockCountRequest() => create();
   GetBlockCountRequest._() : super();
-  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountRequest clone() => GetBlockCountRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) => super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -153,8 +139,7 @@ class GetBlockCountRequest extends $pb.GeneratedMessage {
   GetBlockCountRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountRequest> createRepeated() => $pb.PbList<GetBlockCountRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
+  static GetBlockCountRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
   static GetBlockCountRequest? _defaultInstance;
 }
 
@@ -169,26 +154,24 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockCountResponse._() : super();
-  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'count')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountResponse clone() => GetBlockCountResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) => super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -197,17 +180,13 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
   GetBlockCountResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountResponse> createRepeated() => $pb.PbList<GetBlockCountResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
+  static GetBlockCountResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
   static GetBlockCountResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get count => $_getI64(0);
   @$pb.TagNumber(1)
-  set count($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set count($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCount() => $_has(0);
   @$pb.TagNumber(1)
@@ -217,24 +196,23 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
 class StopRequest extends $pb.GeneratedMessage {
   factory StopRequest() => create();
   StopRequest._() : super();
-  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopRequest clone() => StopRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopRequest copyWith(void Function(StopRequest) updates) =>
-      super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopRequest copyWith(void Function(StopRequest) updates) => super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -250,24 +228,23 @@ class StopRequest extends $pb.GeneratedMessage {
 class StopResponse extends $pb.GeneratedMessage {
   factory StopResponse() => create();
   StopResponse._() : super();
-  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopResponse clone() => StopResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopResponse copyWith(void Function(StopResponse) updates) =>
-      super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopResponse copyWith(void Function(StopResponse) updates) => super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -283,25 +260,23 @@ class StopResponse extends $pb.GeneratedMessage {
 class GetNewAddressRequest extends $pb.GeneratedMessage {
   factory GetNewAddressRequest() => create();
   GetNewAddressRequest._() : super();
-  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressRequest clone() => GetNewAddressRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) => super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -310,8 +285,7 @@ class GetNewAddressRequest extends $pb.GeneratedMessage {
   GetNewAddressRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressRequest> createRepeated() => $pb.PbList<GetNewAddressRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
+  static GetNewAddressRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
   static GetNewAddressRequest? _defaultInstance;
 }
 
@@ -326,26 +300,24 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewAddressResponse._() : super();
-  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressResponse clone() => GetNewAddressResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) => super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -354,17 +326,13 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
   GetNewAddressResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressResponse> createRepeated() => $pb.PbList<GetNewAddressResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
+  static GetNewAddressResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
   static GetNewAddressResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -394,29 +362,27 @@ class WithdrawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawRequest._() : super();
-  factory WithdrawRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'sideFeeSats')
     ..aInt64(4, _omitFieldNames ? '' : 'mainFeeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawRequest clone() => WithdrawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) =>
-      super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) => super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -425,17 +391,13 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   WithdrawRequest createEmptyInstance() => create();
   static $pb.PbList<WithdrawRequest> createRepeated() => $pb.PbList<WithdrawRequest>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
+  static WithdrawRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
   static WithdrawRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -444,10 +406,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -456,10 +415,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get sideFeeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set sideFeeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set sideFeeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSideFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -468,10 +424,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get mainFeeSats => $_getI64(3);
   @$pb.TagNumber(4)
-  set mainFeeSats($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set mainFeeSats($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasMainFeeSats() => $_has(3);
   @$pb.TagNumber(4)
@@ -489,26 +442,24 @@ class WithdrawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawResponse._() : super();
-  factory WithdrawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawResponse clone() => WithdrawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) =>
-      super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) => super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -517,17 +468,13 @@ class WithdrawResponse extends $pb.GeneratedMessage {
   WithdrawResponse createEmptyInstance() => create();
   static $pb.PbList<WithdrawResponse> createRepeated() => $pb.PbList<WithdrawResponse>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
+  static WithdrawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
   static WithdrawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -553,28 +500,26 @@ class TransferRequest extends $pb.GeneratedMessage {
     return $result;
   }
   TransferRequest._() : super();
-  factory TransferRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferRequest clone() => TransferRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferRequest copyWith(void Function(TransferRequest) updates) =>
-      super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferRequest copyWith(void Function(TransferRequest) updates) => super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -583,17 +528,13 @@ class TransferRequest extends $pb.GeneratedMessage {
   TransferRequest createEmptyInstance() => create();
   static $pb.PbList<TransferRequest> createRepeated() => $pb.PbList<TransferRequest>();
   @$core.pragma('dart2js:noInline')
-  static TransferRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
+  static TransferRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
   static TransferRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -602,10 +543,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -614,10 +552,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -635,26 +570,24 @@ class TransferResponse extends $pb.GeneratedMessage {
     return $result;
   }
   TransferResponse._() : super();
-  factory TransferResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferResponse clone() => TransferResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferResponse copyWith(void Function(TransferResponse) updates) =>
-      super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferResponse copyWith(void Function(TransferResponse) updates) => super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -663,17 +596,13 @@ class TransferResponse extends $pb.GeneratedMessage {
   TransferResponse createEmptyInstance() => create();
   static $pb.PbList<TransferResponse> createRepeated() => $pb.PbList<TransferResponse>();
   @$core.pragma('dart2js:noInline')
-  static TransferResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
+  static TransferResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
   static TransferResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -683,25 +612,23 @@ class TransferResponse extends $pb.GeneratedMessage {
 class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   factory GetSidechainWealthRequest() => create();
   GetSidechainWealthRequest._() : super();
-  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthRequest clone() => GetSidechainWealthRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) => super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -710,8 +637,7 @@ class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   GetSidechainWealthRequest createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthRequest> createRepeated() => $pb.PbList<GetSidechainWealthRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
+  static GetSidechainWealthRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
   static GetSidechainWealthRequest? _defaultInstance;
 }
 
@@ -726,27 +652,24 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetSidechainWealthResponse._() : super();
-  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'sats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthResponse clone() => GetSidechainWealthResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) => super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -755,17 +678,13 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
   GetSidechainWealthResponse createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthResponse> createRepeated() => $pb.PbList<GetSidechainWealthResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
+  static GetSidechainWealthResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
   static GetSidechainWealthResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get sats => $_getI64(0);
   @$pb.TagNumber(1)
-  set sats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set sats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -791,28 +710,26 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositRequest._() : super();
-  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'valueSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositRequest clone() => CreateDepositRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) => super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -821,17 +738,13 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   CreateDepositRequest createEmptyInstance() => create();
   static $pb.PbList<CreateDepositRequest> createRepeated() => $pb.PbList<CreateDepositRequest>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
+  static CreateDepositRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
   static CreateDepositRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -840,10 +753,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get valueSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set valueSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set valueSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasValueSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -852,10 +762,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -873,26 +780,24 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositResponse._() : super();
-  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositResponse clone() => CreateDepositResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) => super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -901,17 +806,13 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
   CreateDepositResponse createEmptyInstance() => create();
   static $pb.PbList<CreateDepositResponse> createRepeated() => $pb.PbList<CreateDepositResponse>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
+  static CreateDepositResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
   static CreateDepositResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -921,38 +822,32 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
 class GetPendingWithdrawalBundleRequest extends $pb.GeneratedMessage {
   factory GetPendingWithdrawalBundleRequest() => create();
   GetPendingWithdrawalBundleRequest._() : super();
-  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleRequest clone() => GetPendingWithdrawalBundleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest))
-          as GetPendingWithdrawalBundleRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest)) as GetPendingWithdrawalBundleRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleRequest create() => GetPendingWithdrawalBundleRequest._();
   GetPendingWithdrawalBundleRequest createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleRequest>();
+  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
+  static GetPendingWithdrawalBundleRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
   static GetPendingWithdrawalBundleRequest? _defaultInstance;
 }
 
@@ -967,49 +862,40 @@ class GetPendingWithdrawalBundleResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetPendingWithdrawalBundleResponse._() : super();
-  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bundleJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleResponse clone() => GetPendingWithdrawalBundleResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse))
-          as GetPendingWithdrawalBundleResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse)) as GetPendingWithdrawalBundleResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleResponse create() => GetPendingWithdrawalBundleResponse._();
   GetPendingWithdrawalBundleResponse createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleResponse>();
+  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
+  static GetPendingWithdrawalBundleResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
   static GetPendingWithdrawalBundleResponse? _defaultInstance;
 
   /// JSON string of the bundle, empty if none.
   @$pb.TagNumber(1)
   $core.String get bundleJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bundleJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bundleJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBundleJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1027,26 +913,24 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ConnectPeerRequest._() : super();
-  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerRequest clone() => ConnectPeerRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) => super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1055,17 +939,13 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
   ConnectPeerRequest createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerRequest> createRepeated() => $pb.PbList<ConnectPeerRequest>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
+  static ConnectPeerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
   static ConnectPeerRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1075,25 +955,23 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
 class ConnectPeerResponse extends $pb.GeneratedMessage {
   factory ConnectPeerResponse() => create();
   ConnectPeerResponse._() : super();
-  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerResponse clone() => ConnectPeerResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) => super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1102,8 +980,7 @@ class ConnectPeerResponse extends $pb.GeneratedMessage {
   ConnectPeerResponse createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerResponse> createRepeated() => $pb.PbList<ConnectPeerResponse>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
+  static ConnectPeerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
   static ConnectPeerResponse? _defaultInstance;
 }
 
@@ -1118,26 +995,24 @@ class ForgetPeerRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ForgetPeerRequest._() : super();
-  factory ForgetPeerRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ForgetPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ForgetPeerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ForgetPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForgetPeerRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForgetPeerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ForgetPeerRequest clone() => ForgetPeerRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ForgetPeerRequest copyWith(void Function(ForgetPeerRequest) updates) =>
-      super.copyWith((message) => updates(message as ForgetPeerRequest)) as ForgetPeerRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ForgetPeerRequest copyWith(void Function(ForgetPeerRequest) updates) => super.copyWith((message) => updates(message as ForgetPeerRequest)) as ForgetPeerRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1146,17 +1021,13 @@ class ForgetPeerRequest extends $pb.GeneratedMessage {
   ForgetPeerRequest createEmptyInstance() => create();
   static $pb.PbList<ForgetPeerRequest> createRepeated() => $pb.PbList<ForgetPeerRequest>();
   @$core.pragma('dart2js:noInline')
-  static ForgetPeerRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForgetPeerRequest>(create);
+  static ForgetPeerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForgetPeerRequest>(create);
   static ForgetPeerRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1166,25 +1037,23 @@ class ForgetPeerRequest extends $pb.GeneratedMessage {
 class ForgetPeerResponse extends $pb.GeneratedMessage {
   factory ForgetPeerResponse() => create();
   ForgetPeerResponse._() : super();
-  factory ForgetPeerResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ForgetPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ForgetPeerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ForgetPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForgetPeerResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForgetPeerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ForgetPeerResponse clone() => ForgetPeerResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ForgetPeerResponse copyWith(void Function(ForgetPeerResponse) updates) =>
-      super.copyWith((message) => updates(message as ForgetPeerResponse)) as ForgetPeerResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ForgetPeerResponse copyWith(void Function(ForgetPeerResponse) updates) => super.copyWith((message) => updates(message as ForgetPeerResponse)) as ForgetPeerResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1193,33 +1062,30 @@ class ForgetPeerResponse extends $pb.GeneratedMessage {
   ForgetPeerResponse createEmptyInstance() => create();
   static $pb.PbList<ForgetPeerResponse> createRepeated() => $pb.PbList<ForgetPeerResponse>();
   @$core.pragma('dart2js:noInline')
-  static ForgetPeerResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForgetPeerResponse>(create);
+  static ForgetPeerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForgetPeerResponse>(create);
   static ForgetPeerResponse? _defaultInstance;
 }
 
 class ListPeersRequest extends $pb.GeneratedMessage {
   factory ListPeersRequest() => create();
   ListPeersRequest._() : super();
-  factory ListPeersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersRequest clone() => ListPeersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) =>
-      super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) => super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1228,8 +1094,7 @@ class ListPeersRequest extends $pb.GeneratedMessage {
   ListPeersRequest createEmptyInstance() => create();
   static $pb.PbList<ListPeersRequest> createRepeated() => $pb.PbList<ListPeersRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
+  static ListPeersRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
   static ListPeersRequest? _defaultInstance;
 }
 
@@ -1244,26 +1109,24 @@ class ListPeersResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListPeersResponse._() : super();
-  factory ListPeersResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'peersJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersResponse clone() => ListPeersResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) =>
-      super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) => super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1272,17 +1135,13 @@ class ListPeersResponse extends $pb.GeneratedMessage {
   ListPeersResponse createEmptyInstance() => create();
   static $pb.PbList<ListPeersResponse> createRepeated() => $pb.PbList<ListPeersResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
+  static ListPeersResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
   static ListPeersResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get peersJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set peersJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set peersJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPeersJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1300,25 +1159,24 @@ class MineRequest extends $pb.GeneratedMessage {
     return $result;
   }
   MineRequest._() : super();
-  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineRequest clone() => MineRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineRequest copyWith(void Function(MineRequest) updates) =>
-      super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineRequest copyWith(void Function(MineRequest) updates) => super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1333,10 +1191,7 @@ class MineRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $fixnum.Int64 get feeSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasFeeSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -1354,25 +1209,24 @@ class MineResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MineResponse._() : super();
-  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bmmResultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineResponse clone() => MineResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineResponse copyWith(void Function(MineResponse) updates) =>
-      super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineResponse copyWith(void Function(MineResponse) updates) => super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1387,10 +1241,7 @@ class MineResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get bmmResultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bmmResultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bmmResultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBmmResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1408,26 +1259,24 @@ class GetBlockRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockRequest._() : super();
-  factory GetBlockRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockRequest clone() => GetBlockRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) => super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1436,17 +1285,13 @@ class GetBlockRequest extends $pb.GeneratedMessage {
   GetBlockRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockRequest> createRepeated() => $pb.PbList<GetBlockRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
+  static GetBlockRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
   static GetBlockRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1464,26 +1309,24 @@ class GetBlockResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockResponse._() : super();
-  factory GetBlockResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockResponse clone() => GetBlockResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) => super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1492,17 +1335,13 @@ class GetBlockResponse extends $pb.GeneratedMessage {
   GetBlockResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockResponse> createRepeated() => $pb.PbList<GetBlockResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
+  static GetBlockResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
   static GetBlockResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1512,38 +1351,32 @@ class GetBlockResponse extends $pb.GeneratedMessage {
 class GetBestMainchainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestMainchainBlockHashRequest() => create();
   GetBestMainchainBlockHashRequest._() : super();
-  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashRequest clone() => GetBestMainchainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest))
-          as GetBestMainchainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest)) as GetBestMainchainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashRequest create() => GetBestMainchainBlockHashRequest._();
   GetBestMainchainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashRequest>();
+  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() => $pb.PbList<GetBestMainchainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
+  static GetBestMainchainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
   static GetBestMainchainBlockHashRequest? _defaultInstance;
 }
 
@@ -1558,48 +1391,39 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestMainchainBlockHashResponse._() : super();
-  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashResponse clone() => GetBestMainchainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse))
-          as GetBestMainchainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse)) as GetBestMainchainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashResponse create() => GetBestMainchainBlockHashResponse._();
   GetBestMainchainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashResponse>();
+  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() => $pb.PbList<GetBestMainchainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
+  static GetBestMainchainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
   static GetBestMainchainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1609,38 +1433,32 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
 class GetBestSidechainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestSidechainBlockHashRequest() => create();
   GetBestSidechainBlockHashRequest._() : super();
-  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashRequest clone() => GetBestSidechainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest))
-          as GetBestSidechainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest)) as GetBestSidechainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashRequest create() => GetBestSidechainBlockHashRequest._();
   GetBestSidechainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashRequest>();
+  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() => $pb.PbList<GetBestSidechainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
+  static GetBestSidechainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
   static GetBestSidechainBlockHashRequest? _defaultInstance;
 }
 
@@ -1655,48 +1473,39 @@ class GetBestSidechainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestSidechainBlockHashResponse._() : super();
-  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashResponse clone() => GetBestSidechainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse))
-          as GetBestSidechainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse)) as GetBestSidechainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashResponse create() => GetBestSidechainBlockHashResponse._();
   GetBestSidechainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashResponse>();
+  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() => $pb.PbList<GetBestSidechainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
+  static GetBestSidechainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
   static GetBestSidechainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1714,26 +1523,24 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsRequest._() : super();
-  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockHash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsRequest clone() => GetBmmInclusionsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1742,17 +1549,13 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
   GetBmmInclusionsRequest createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsRequest> createRepeated() => $pb.PbList<GetBmmInclusionsRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
+  static GetBmmInclusionsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
   static GetBmmInclusionsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockHash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockHash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockHash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1770,26 +1573,24 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsResponse._() : super();
-  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'inclusions')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsResponse clone() => GetBmmInclusionsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1798,17 +1599,13 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
   GetBmmInclusionsResponse createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsResponse> createRepeated() => $pb.PbList<GetBmmInclusionsResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
+  static GetBmmInclusionsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
   static GetBmmInclusionsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get inclusions => $_getSZ(0);
   @$pb.TagNumber(1)
-  set inclusions($core.String v) {
-    $_setString(0, v);
-  }
-
+  set inclusions($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasInclusions() => $_has(0);
   @$pb.TagNumber(1)
@@ -1818,25 +1615,23 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
 class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   factory GetWalletUtxosRequest() => create();
   GetWalletUtxosRequest._() : super();
-  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosRequest clone() => GetWalletUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) => super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1845,8 +1640,7 @@ class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   GetWalletUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosRequest> createRepeated() => $pb.PbList<GetWalletUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
+  static GetWalletUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
   static GetWalletUtxosRequest? _defaultInstance;
 }
 
@@ -1861,26 +1655,24 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletUtxosResponse._() : super();
-  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosResponse clone() => GetWalletUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) => super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1889,17 +1681,13 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
   GetWalletUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosResponse> createRepeated() => $pb.PbList<GetWalletUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
+  static GetWalletUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
   static GetWalletUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1909,25 +1697,23 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
 class ListUtxosRequest extends $pb.GeneratedMessage {
   factory ListUtxosRequest() => create();
   ListUtxosRequest._() : super();
-  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosRequest clone() => ListUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) => super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1936,8 +1722,7 @@ class ListUtxosRequest extends $pb.GeneratedMessage {
   ListUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<ListUtxosRequest> createRepeated() => $pb.PbList<ListUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
+  static ListUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
   static ListUtxosRequest? _defaultInstance;
 }
 
@@ -1952,26 +1737,24 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListUtxosResponse._() : super();
-  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosResponse clone() => ListUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) => super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1980,17 +1763,13 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
   ListUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<ListUtxosResponse> createRepeated() => $pb.PbList<ListUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
+  static ListUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
   static ListUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2008,26 +1787,24 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
     return $result;
   }
   RemoveFromMempoolRequest._() : super();
-  factory RemoveFromMempoolRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFromMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFromMempoolRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFromMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveFromMempoolRequest clone() => RemoveFromMempoolRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveFromMempoolRequest copyWith(void Function(RemoveFromMempoolRequest) updates) =>
-      super.copyWith((message) => updates(message as RemoveFromMempoolRequest)) as RemoveFromMempoolRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveFromMempoolRequest copyWith(void Function(RemoveFromMempoolRequest) updates) => super.copyWith((message) => updates(message as RemoveFromMempoolRequest)) as RemoveFromMempoolRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2036,17 +1813,13 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
   RemoveFromMempoolRequest createEmptyInstance() => create();
   static $pb.PbList<RemoveFromMempoolRequest> createRepeated() => $pb.PbList<RemoveFromMempoolRequest>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFromMempoolRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolRequest>(create);
+  static RemoveFromMempoolRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolRequest>(create);
   static RemoveFromMempoolRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2056,25 +1829,23 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
 class RemoveFromMempoolResponse extends $pb.GeneratedMessage {
   factory RemoveFromMempoolResponse() => create();
   RemoveFromMempoolResponse._() : super();
-  factory RemoveFromMempoolResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFromMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFromMempoolResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFromMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveFromMempoolResponse clone() => RemoveFromMempoolResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveFromMempoolResponse copyWith(void Function(RemoveFromMempoolResponse) updates) =>
-      super.copyWith((message) => updates(message as RemoveFromMempoolResponse)) as RemoveFromMempoolResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveFromMempoolResponse copyWith(void Function(RemoveFromMempoolResponse) updates) => super.copyWith((message) => updates(message as RemoveFromMempoolResponse)) as RemoveFromMempoolResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2083,50 +1854,39 @@ class RemoveFromMempoolResponse extends $pb.GeneratedMessage {
   RemoveFromMempoolResponse createEmptyInstance() => create();
   static $pb.PbList<RemoveFromMempoolResponse> createRepeated() => $pb.PbList<RemoveFromMempoolResponse>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFromMempoolResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolResponse>(create);
+  static RemoveFromMempoolResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolResponse>(create);
   static RemoveFromMempoolResponse? _defaultInstance;
 }
 
 class GetLatestFailedWithdrawalBundleHeightRequest extends $pb.GeneratedMessage {
   factory GetLatestFailedWithdrawalBundleHeightRequest() => create();
   GetLatestFailedWithdrawalBundleHeightRequest._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'),
-      createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest clone() =>
-      GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest))
-          as GetLatestFailedWithdrawalBundleHeightRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest clone() => GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest copyWith(void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest)) as GetLatestFailedWithdrawalBundleHeightRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightRequest create() => GetLatestFailedWithdrawalBundleHeightRequest._();
   GetLatestFailedWithdrawalBundleHeightRequest createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
+  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
   static GetLatestFailedWithdrawalBundleHeightRequest? _defaultInstance;
 }
 
@@ -2141,53 +1901,40 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
     return $result;
   }
   GetLatestFailedWithdrawalBundleHeightResponse._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'height')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse clone() =>
-      GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse))
-          as GetLatestFailedWithdrawalBundleHeightResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse clone() => GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse copyWith(void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse)) as GetLatestFailedWithdrawalBundleHeightResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightResponse create() => GetLatestFailedWithdrawalBundleHeightResponse._();
   GetLatestFailedWithdrawalBundleHeightResponse createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
+  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
   static GetLatestFailedWithdrawalBundleHeightResponse? _defaultInstance;
 
   /// 0 means no failed bundle.
   @$pb.TagNumber(1)
   $fixnum.Int64 get height => $_getI64(0);
   @$pb.TagNumber(1)
-  set height($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set height($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHeight() => $_has(0);
   @$pb.TagNumber(1)
@@ -2197,25 +1944,23 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
 class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   factory GenerateMnemonicRequest() => create();
   GenerateMnemonicRequest._() : super();
-  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicRequest clone() => GenerateMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) => super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2224,8 +1969,7 @@ class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   GenerateMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicRequest> createRepeated() => $pb.PbList<GenerateMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
+  static GenerateMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
   static GenerateMnemonicRequest? _defaultInstance;
 }
 
@@ -2240,26 +1984,24 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GenerateMnemonicResponse._() : super();
-  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicResponse clone() => GenerateMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) => super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2268,17 +2010,13 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
   GenerateMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicResponse> createRepeated() => $pb.PbList<GenerateMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
+  static GenerateMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
   static GenerateMnemonicResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2296,27 +2034,24 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SetSeedFromMnemonicRequest._() : super();
-  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicRequest clone() => SetSeedFromMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2325,17 +2060,13 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
   SetSeedFromMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicRequest> createRepeated() => $pb.PbList<SetSeedFromMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
+  static SetSeedFromMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
   static SetSeedFromMnemonicRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2345,26 +2076,23 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
 class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   factory SetSeedFromMnemonicResponse() => create();
   SetSeedFromMnemonicResponse._() : super();
-  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicResponse clone() => SetSeedFromMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2373,8 +2101,7 @@ class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   SetSeedFromMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicResponse> createRepeated() => $pb.PbList<SetSeedFromMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
+  static SetSeedFromMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
   static SetSeedFromMnemonicResponse? _defaultInstance;
 }
 
@@ -2393,26 +2120,25 @@ class CallRawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawRequest._() : super();
-  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'method')
     ..aOS(2, _omitFieldNames ? '' : 'paramsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawRequest clone() => CallRawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawRequest copyWith(void Function(CallRawRequest) updates) =>
-      super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawRequest copyWith(void Function(CallRawRequest) updates) => super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2427,10 +2153,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get method => $_getSZ(0);
   @$pb.TagNumber(1)
-  set method($core.String v) {
-    $_setString(0, v);
-  }
-
+  set method($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMethod() => $_has(0);
   @$pb.TagNumber(1)
@@ -2439,10 +2162,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get paramsJson => $_getSZ(1);
   @$pb.TagNumber(2)
-  set paramsJson($core.String v) {
-    $_setString(1, v);
-  }
-
+  set paramsJson($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasParamsJson() => $_has(1);
   @$pb.TagNumber(2)
@@ -2460,26 +2180,24 @@ class CallRawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawResponse._() : super();
-  factory CallRawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'resultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawResponse clone() => CallRawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawResponse copyWith(void Function(CallRawResponse) updates) =>
-      super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawResponse copyWith(void Function(CallRawResponse) updates) => super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2488,17 +2206,13 @@ class CallRawResponse extends $pb.GeneratedMessage {
   CallRawResponse createEmptyInstance() => create();
   static $pb.PbList<CallRawResponse> createRepeated() => $pb.PbList<CallRawResponse>();
   @$core.pragma('dart2js:noInline')
-  static CallRawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
+  static CallRawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
   static CallRawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get resultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set resultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set resultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2508,25 +2222,23 @@ class CallRawResponse extends $pb.GeneratedMessage {
 class GetWalletAddressesRequest extends $pb.GeneratedMessage {
   factory GetWalletAddressesRequest() => create();
   GetWalletAddressesRequest._() : super();
-  factory GetWalletAddressesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletAddressesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletAddressesRequest clone() => GetWalletAddressesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletAddressesRequest copyWith(void Function(GetWalletAddressesRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletAddressesRequest)) as GetWalletAddressesRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletAddressesRequest copyWith(void Function(GetWalletAddressesRequest) updates) => super.copyWith((message) => updates(message as GetWalletAddressesRequest)) as GetWalletAddressesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2535,8 +2247,7 @@ class GetWalletAddressesRequest extends $pb.GeneratedMessage {
   GetWalletAddressesRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletAddressesRequest> createRepeated() => $pb.PbList<GetWalletAddressesRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletAddressesRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesRequest>(create);
+  static GetWalletAddressesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesRequest>(create);
   static GetWalletAddressesRequest? _defaultInstance;
 }
 
@@ -2551,27 +2262,24 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletAddressesResponse._() : super();
-  factory GetWalletAddressesResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletAddressesResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletAddressesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletAddressesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..pPS(1, _omitFieldNames ? '' : 'addresses')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletAddressesResponse clone() => GetWalletAddressesResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletAddressesResponse copyWith(void Function(GetWalletAddressesResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletAddressesResponse)) as GetWalletAddressesResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletAddressesResponse copyWith(void Function(GetWalletAddressesResponse) updates) => super.copyWith((message) => updates(message as GetWalletAddressesResponse)) as GetWalletAddressesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2580,8 +2288,7 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
   GetWalletAddressesResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletAddressesResponse> createRepeated() => $pb.PbList<GetWalletAddressesResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletAddressesResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesResponse>(create);
+  static GetWalletAddressesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesResponse>(create);
   static GetWalletAddressesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -2591,25 +2298,23 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
 class OpenapiSchemaRequest extends $pb.GeneratedMessage {
   factory OpenapiSchemaRequest() => create();
   OpenapiSchemaRequest._() : super();
-  factory OpenapiSchemaRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory OpenapiSchemaRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory OpenapiSchemaRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory OpenapiSchemaRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OpenapiSchemaRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OpenapiSchemaRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   OpenapiSchemaRequest clone() => OpenapiSchemaRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  OpenapiSchemaRequest copyWith(void Function(OpenapiSchemaRequest) updates) =>
-      super.copyWith((message) => updates(message as OpenapiSchemaRequest)) as OpenapiSchemaRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  OpenapiSchemaRequest copyWith(void Function(OpenapiSchemaRequest) updates) => super.copyWith((message) => updates(message as OpenapiSchemaRequest)) as OpenapiSchemaRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2618,8 +2323,7 @@ class OpenapiSchemaRequest extends $pb.GeneratedMessage {
   OpenapiSchemaRequest createEmptyInstance() => create();
   static $pb.PbList<OpenapiSchemaRequest> createRepeated() => $pb.PbList<OpenapiSchemaRequest>();
   @$core.pragma('dart2js:noInline')
-  static OpenapiSchemaRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpenapiSchemaRequest>(create);
+  static OpenapiSchemaRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpenapiSchemaRequest>(create);
   static OpenapiSchemaRequest? _defaultInstance;
 }
 
@@ -2634,26 +2338,24 @@ class OpenapiSchemaResponse extends $pb.GeneratedMessage {
     return $result;
   }
   OpenapiSchemaResponse._() : super();
-  factory OpenapiSchemaResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory OpenapiSchemaResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory OpenapiSchemaResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory OpenapiSchemaResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OpenapiSchemaResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'OpenapiSchemaResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'schemaJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   OpenapiSchemaResponse clone() => OpenapiSchemaResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  OpenapiSchemaResponse copyWith(void Function(OpenapiSchemaResponse) updates) =>
-      super.copyWith((message) => updates(message as OpenapiSchemaResponse)) as OpenapiSchemaResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  OpenapiSchemaResponse copyWith(void Function(OpenapiSchemaResponse) updates) => super.copyWith((message) => updates(message as OpenapiSchemaResponse)) as OpenapiSchemaResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2662,17 +2364,13 @@ class OpenapiSchemaResponse extends $pb.GeneratedMessage {
   OpenapiSchemaResponse createEmptyInstance() => create();
   static $pb.PbList<OpenapiSchemaResponse> createRepeated() => $pb.PbList<OpenapiSchemaResponse>();
   @$core.pragma('dart2js:noInline')
-  static OpenapiSchemaResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpenapiSchemaResponse>(create);
+  static OpenapiSchemaResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpenapiSchemaResponse>(create);
   static OpenapiSchemaResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get schemaJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set schemaJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set schemaJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSchemaJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2714,14 +2412,10 @@ class CreateSwapRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CreateSwapRequest._() : super();
-  factory CreateSwapRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateSwapRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateSwapRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateSwapRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateSwapRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateSwapRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'l2AmountSats')
     ..aInt64(2, _omitFieldNames ? '' : 'l1AmountSats')
     ..aOS(3, _omitFieldNames ? '' : 'l1RecipientAddress')
@@ -2729,17 +2423,19 @@ class CreateSwapRequest extends $pb.GeneratedMessage {
     ..aOS(5, _omitFieldNames ? '' : 'l2Recipient')
     ..a<$core.int>(6, _omitFieldNames ? '' : 'requiredConfirmations', $pb.PbFieldType.O3)
     ..aInt64(7, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateSwapRequest clone() => CreateSwapRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateSwapRequest copyWith(void Function(CreateSwapRequest) updates) =>
-      super.copyWith((message) => updates(message as CreateSwapRequest)) as CreateSwapRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateSwapRequest copyWith(void Function(CreateSwapRequest) updates) => super.copyWith((message) => updates(message as CreateSwapRequest)) as CreateSwapRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2748,17 +2444,13 @@ class CreateSwapRequest extends $pb.GeneratedMessage {
   CreateSwapRequest createEmptyInstance() => create();
   static $pb.PbList<CreateSwapRequest> createRepeated() => $pb.PbList<CreateSwapRequest>();
   @$core.pragma('dart2js:noInline')
-  static CreateSwapRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateSwapRequest>(create);
+  static CreateSwapRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateSwapRequest>(create);
   static CreateSwapRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get l2AmountSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set l2AmountSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set l2AmountSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasL2AmountSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -2767,10 +2459,7 @@ class CreateSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get l1AmountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set l1AmountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set l1AmountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasL1AmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -2779,10 +2468,7 @@ class CreateSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get l1RecipientAddress => $_getSZ(2);
   @$pb.TagNumber(3)
-  set l1RecipientAddress($core.String v) {
-    $_setString(2, v);
-  }
-
+  set l1RecipientAddress($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasL1RecipientAddress() => $_has(2);
   @$pb.TagNumber(3)
@@ -2791,10 +2477,7 @@ class CreateSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get parentChain => $_getSZ(3);
   @$pb.TagNumber(4)
-  set parentChain($core.String v) {
-    $_setString(3, v);
-  }
-
+  set parentChain($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasParentChain() => $_has(3);
   @$pb.TagNumber(4)
@@ -2803,10 +2486,7 @@ class CreateSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get l2Recipient => $_getSZ(4);
   @$pb.TagNumber(5)
-  set l2Recipient($core.String v) {
-    $_setString(4, v);
-  }
-
+  set l2Recipient($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasL2Recipient() => $_has(4);
   @$pb.TagNumber(5)
@@ -2815,10 +2495,7 @@ class CreateSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get requiredConfirmations => $_getIZ(5);
   @$pb.TagNumber(6)
-  set requiredConfirmations($core.int v) {
-    $_setSignedInt32(5, v);
-  }
-
+  set requiredConfirmations($core.int v) { $_setSignedInt32(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasRequiredConfirmations() => $_has(5);
   @$pb.TagNumber(6)
@@ -2827,10 +2504,7 @@ class CreateSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get feeSats => $_getI64(6);
   @$pb.TagNumber(7)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(6, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasFeeSats() => $_has(6);
   @$pb.TagNumber(7)
@@ -2852,27 +2526,25 @@ class CreateSwapResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CreateSwapResponse._() : super();
-  factory CreateSwapResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateSwapResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateSwapResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateSwapResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateSwapResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateSwapResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'swapId')
     ..aOS(2, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateSwapResponse clone() => CreateSwapResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateSwapResponse copyWith(void Function(CreateSwapResponse) updates) =>
-      super.copyWith((message) => updates(message as CreateSwapResponse)) as CreateSwapResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateSwapResponse copyWith(void Function(CreateSwapResponse) updates) => super.copyWith((message) => updates(message as CreateSwapResponse)) as CreateSwapResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2881,17 +2553,13 @@ class CreateSwapResponse extends $pb.GeneratedMessage {
   CreateSwapResponse createEmptyInstance() => create();
   static $pb.PbList<CreateSwapResponse> createRepeated() => $pb.PbList<CreateSwapResponse>();
   @$core.pragma('dart2js:noInline')
-  static CreateSwapResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateSwapResponse>(create);
+  static CreateSwapResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateSwapResponse>(create);
   static CreateSwapResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get swapId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set swapId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set swapId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSwapId() => $_has(0);
   @$pb.TagNumber(1)
@@ -2900,10 +2568,7 @@ class CreateSwapResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get txid => $_getSZ(1);
   @$pb.TagNumber(2)
-  set txid($core.String v) {
-    $_setString(1, v);
-  }
-
+  set txid($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasTxid() => $_has(1);
   @$pb.TagNumber(2)
@@ -2925,27 +2590,25 @@ class ClaimSwapRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ClaimSwapRequest._() : super();
-  factory ClaimSwapRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ClaimSwapRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ClaimSwapRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ClaimSwapRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ClaimSwapRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ClaimSwapRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'swapId')
     ..aOS(2, _omitFieldNames ? '' : 'l2ClaimerAddress')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ClaimSwapRequest clone() => ClaimSwapRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ClaimSwapRequest copyWith(void Function(ClaimSwapRequest) updates) =>
-      super.copyWith((message) => updates(message as ClaimSwapRequest)) as ClaimSwapRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ClaimSwapRequest copyWith(void Function(ClaimSwapRequest) updates) => super.copyWith((message) => updates(message as ClaimSwapRequest)) as ClaimSwapRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2954,17 +2617,13 @@ class ClaimSwapRequest extends $pb.GeneratedMessage {
   ClaimSwapRequest createEmptyInstance() => create();
   static $pb.PbList<ClaimSwapRequest> createRepeated() => $pb.PbList<ClaimSwapRequest>();
   @$core.pragma('dart2js:noInline')
-  static ClaimSwapRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ClaimSwapRequest>(create);
+  static ClaimSwapRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ClaimSwapRequest>(create);
   static ClaimSwapRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get swapId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set swapId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set swapId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSwapId() => $_has(0);
   @$pb.TagNumber(1)
@@ -2973,10 +2632,7 @@ class ClaimSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get l2ClaimerAddress => $_getSZ(1);
   @$pb.TagNumber(2)
-  set l2ClaimerAddress($core.String v) {
-    $_setString(1, v);
-  }
-
+  set l2ClaimerAddress($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasL2ClaimerAddress() => $_has(1);
   @$pb.TagNumber(2)
@@ -2994,26 +2650,24 @@ class ClaimSwapResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ClaimSwapResponse._() : super();
-  factory ClaimSwapResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ClaimSwapResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ClaimSwapResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ClaimSwapResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ClaimSwapResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ClaimSwapResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ClaimSwapResponse clone() => ClaimSwapResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ClaimSwapResponse copyWith(void Function(ClaimSwapResponse) updates) =>
-      super.copyWith((message) => updates(message as ClaimSwapResponse)) as ClaimSwapResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ClaimSwapResponse copyWith(void Function(ClaimSwapResponse) updates) => super.copyWith((message) => updates(message as ClaimSwapResponse)) as ClaimSwapResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3022,17 +2676,13 @@ class ClaimSwapResponse extends $pb.GeneratedMessage {
   ClaimSwapResponse createEmptyInstance() => create();
   static $pb.PbList<ClaimSwapResponse> createRepeated() => $pb.PbList<ClaimSwapResponse>();
   @$core.pragma('dart2js:noInline')
-  static ClaimSwapResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ClaimSwapResponse>(create);
+  static ClaimSwapResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ClaimSwapResponse>(create);
   static ClaimSwapResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -3050,26 +2700,24 @@ class GetSwapStatusRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetSwapStatusRequest._() : super();
-  factory GetSwapStatusRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSwapStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSwapStatusRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSwapStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSwapStatusRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSwapStatusRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'swapId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSwapStatusRequest clone() => GetSwapStatusRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSwapStatusRequest copyWith(void Function(GetSwapStatusRequest) updates) =>
-      super.copyWith((message) => updates(message as GetSwapStatusRequest)) as GetSwapStatusRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSwapStatusRequest copyWith(void Function(GetSwapStatusRequest) updates) => super.copyWith((message) => updates(message as GetSwapStatusRequest)) as GetSwapStatusRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3078,17 +2726,13 @@ class GetSwapStatusRequest extends $pb.GeneratedMessage {
   GetSwapStatusRequest createEmptyInstance() => create();
   static $pb.PbList<GetSwapStatusRequest> createRepeated() => $pb.PbList<GetSwapStatusRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetSwapStatusRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSwapStatusRequest>(create);
+  static GetSwapStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSwapStatusRequest>(create);
   static GetSwapStatusRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get swapId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set swapId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set swapId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSwapId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3106,26 +2750,24 @@ class GetSwapStatusResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetSwapStatusResponse._() : super();
-  factory GetSwapStatusResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSwapStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSwapStatusResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSwapStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSwapStatusResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSwapStatusResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'swapJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSwapStatusResponse clone() => GetSwapStatusResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSwapStatusResponse copyWith(void Function(GetSwapStatusResponse) updates) =>
-      super.copyWith((message) => updates(message as GetSwapStatusResponse)) as GetSwapStatusResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSwapStatusResponse copyWith(void Function(GetSwapStatusResponse) updates) => super.copyWith((message) => updates(message as GetSwapStatusResponse)) as GetSwapStatusResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3134,17 +2776,13 @@ class GetSwapStatusResponse extends $pb.GeneratedMessage {
   GetSwapStatusResponse createEmptyInstance() => create();
   static $pb.PbList<GetSwapStatusResponse> createRepeated() => $pb.PbList<GetSwapStatusResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetSwapStatusResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSwapStatusResponse>(create);
+  static GetSwapStatusResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSwapStatusResponse>(create);
   static GetSwapStatusResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get swapJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set swapJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set swapJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSwapJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -3154,25 +2792,23 @@ class GetSwapStatusResponse extends $pb.GeneratedMessage {
 class ListSwapsRequest extends $pb.GeneratedMessage {
   factory ListSwapsRequest() => create();
   ListSwapsRequest._() : super();
-  factory ListSwapsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListSwapsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListSwapsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListSwapsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListSwapsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListSwapsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListSwapsRequest clone() => ListSwapsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListSwapsRequest copyWith(void Function(ListSwapsRequest) updates) =>
-      super.copyWith((message) => updates(message as ListSwapsRequest)) as ListSwapsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListSwapsRequest copyWith(void Function(ListSwapsRequest) updates) => super.copyWith((message) => updates(message as ListSwapsRequest)) as ListSwapsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3181,8 +2817,7 @@ class ListSwapsRequest extends $pb.GeneratedMessage {
   ListSwapsRequest createEmptyInstance() => create();
   static $pb.PbList<ListSwapsRequest> createRepeated() => $pb.PbList<ListSwapsRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListSwapsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListSwapsRequest>(create);
+  static ListSwapsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListSwapsRequest>(create);
   static ListSwapsRequest? _defaultInstance;
 }
 
@@ -3197,26 +2832,24 @@ class ListSwapsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListSwapsResponse._() : super();
-  factory ListSwapsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListSwapsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListSwapsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListSwapsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListSwapsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListSwapsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'swapsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListSwapsResponse clone() => ListSwapsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListSwapsResponse copyWith(void Function(ListSwapsResponse) updates) =>
-      super.copyWith((message) => updates(message as ListSwapsResponse)) as ListSwapsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListSwapsResponse copyWith(void Function(ListSwapsResponse) updates) => super.copyWith((message) => updates(message as ListSwapsResponse)) as ListSwapsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3225,17 +2858,13 @@ class ListSwapsResponse extends $pb.GeneratedMessage {
   ListSwapsResponse createEmptyInstance() => create();
   static $pb.PbList<ListSwapsResponse> createRepeated() => $pb.PbList<ListSwapsResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListSwapsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListSwapsResponse>(create);
+  static ListSwapsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListSwapsResponse>(create);
   static ListSwapsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get swapsJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set swapsJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set swapsJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSwapsJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -3253,27 +2882,24 @@ class ListSwapsByRecipientRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ListSwapsByRecipientRequest._() : super();
-  factory ListSwapsByRecipientRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListSwapsByRecipientRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListSwapsByRecipientRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListSwapsByRecipientRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListSwapsByRecipientRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListSwapsByRecipientRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'recipient')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListSwapsByRecipientRequest clone() => ListSwapsByRecipientRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListSwapsByRecipientRequest copyWith(void Function(ListSwapsByRecipientRequest) updates) =>
-      super.copyWith((message) => updates(message as ListSwapsByRecipientRequest)) as ListSwapsByRecipientRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListSwapsByRecipientRequest copyWith(void Function(ListSwapsByRecipientRequest) updates) => super.copyWith((message) => updates(message as ListSwapsByRecipientRequest)) as ListSwapsByRecipientRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3282,17 +2908,13 @@ class ListSwapsByRecipientRequest extends $pb.GeneratedMessage {
   ListSwapsByRecipientRequest createEmptyInstance() => create();
   static $pb.PbList<ListSwapsByRecipientRequest> createRepeated() => $pb.PbList<ListSwapsByRecipientRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListSwapsByRecipientRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListSwapsByRecipientRequest>(create);
+  static ListSwapsByRecipientRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListSwapsByRecipientRequest>(create);
   static ListSwapsByRecipientRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get recipient => $_getSZ(0);
   @$pb.TagNumber(1)
-  set recipient($core.String v) {
-    $_setString(0, v);
-  }
-
+  set recipient($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasRecipient() => $_has(0);
   @$pb.TagNumber(1)
@@ -3310,27 +2932,24 @@ class ListSwapsByRecipientResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListSwapsByRecipientResponse._() : super();
-  factory ListSwapsByRecipientResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListSwapsByRecipientResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListSwapsByRecipientResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListSwapsByRecipientResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListSwapsByRecipientResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListSwapsByRecipientResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'swapsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListSwapsByRecipientResponse clone() => ListSwapsByRecipientResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListSwapsByRecipientResponse copyWith(void Function(ListSwapsByRecipientResponse) updates) =>
-      super.copyWith((message) => updates(message as ListSwapsByRecipientResponse)) as ListSwapsByRecipientResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListSwapsByRecipientResponse copyWith(void Function(ListSwapsByRecipientResponse) updates) => super.copyWith((message) => updates(message as ListSwapsByRecipientResponse)) as ListSwapsByRecipientResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3339,17 +2958,13 @@ class ListSwapsByRecipientResponse extends $pb.GeneratedMessage {
   ListSwapsByRecipientResponse createEmptyInstance() => create();
   static $pb.PbList<ListSwapsByRecipientResponse> createRepeated() => $pb.PbList<ListSwapsByRecipientResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListSwapsByRecipientResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListSwapsByRecipientResponse>(create);
+  static ListSwapsByRecipientResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListSwapsByRecipientResponse>(create);
   static ListSwapsByRecipientResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get swapsJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set swapsJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set swapsJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSwapsJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -3375,28 +2990,26 @@ class UpdateSwapL1TxidRequest extends $pb.GeneratedMessage {
     return $result;
   }
   UpdateSwapL1TxidRequest._() : super();
-  factory UpdateSwapL1TxidRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UpdateSwapL1TxidRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory UpdateSwapL1TxidRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UpdateSwapL1TxidRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UpdateSwapL1TxidRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UpdateSwapL1TxidRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'swapId')
     ..aOS(2, _omitFieldNames ? '' : 'l1TxidHex')
     ..a<$core.int>(3, _omitFieldNames ? '' : 'confirmations', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   UpdateSwapL1TxidRequest clone() => UpdateSwapL1TxidRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  UpdateSwapL1TxidRequest copyWith(void Function(UpdateSwapL1TxidRequest) updates) =>
-      super.copyWith((message) => updates(message as UpdateSwapL1TxidRequest)) as UpdateSwapL1TxidRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UpdateSwapL1TxidRequest copyWith(void Function(UpdateSwapL1TxidRequest) updates) => super.copyWith((message) => updates(message as UpdateSwapL1TxidRequest)) as UpdateSwapL1TxidRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3405,17 +3018,13 @@ class UpdateSwapL1TxidRequest extends $pb.GeneratedMessage {
   UpdateSwapL1TxidRequest createEmptyInstance() => create();
   static $pb.PbList<UpdateSwapL1TxidRequest> createRepeated() => $pb.PbList<UpdateSwapL1TxidRequest>();
   @$core.pragma('dart2js:noInline')
-  static UpdateSwapL1TxidRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UpdateSwapL1TxidRequest>(create);
+  static UpdateSwapL1TxidRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UpdateSwapL1TxidRequest>(create);
   static UpdateSwapL1TxidRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get swapId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set swapId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set swapId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSwapId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3424,10 +3033,7 @@ class UpdateSwapL1TxidRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get l1TxidHex => $_getSZ(1);
   @$pb.TagNumber(2)
-  set l1TxidHex($core.String v) {
-    $_setString(1, v);
-  }
-
+  set l1TxidHex($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasL1TxidHex() => $_has(1);
   @$pb.TagNumber(2)
@@ -3436,10 +3042,7 @@ class UpdateSwapL1TxidRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get confirmations => $_getIZ(2);
   @$pb.TagNumber(3)
-  set confirmations($core.int v) {
-    $_setSignedInt32(2, v);
-  }
-
+  set confirmations($core.int v) { $_setSignedInt32(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasConfirmations() => $_has(2);
   @$pb.TagNumber(3)
@@ -3449,25 +3052,23 @@ class UpdateSwapL1TxidRequest extends $pb.GeneratedMessage {
 class UpdateSwapL1TxidResponse extends $pb.GeneratedMessage {
   factory UpdateSwapL1TxidResponse() => create();
   UpdateSwapL1TxidResponse._() : super();
-  factory UpdateSwapL1TxidResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UpdateSwapL1TxidResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory UpdateSwapL1TxidResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UpdateSwapL1TxidResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UpdateSwapL1TxidResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UpdateSwapL1TxidResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   UpdateSwapL1TxidResponse clone() => UpdateSwapL1TxidResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  UpdateSwapL1TxidResponse copyWith(void Function(UpdateSwapL1TxidResponse) updates) =>
-      super.copyWith((message) => updates(message as UpdateSwapL1TxidResponse)) as UpdateSwapL1TxidResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UpdateSwapL1TxidResponse copyWith(void Function(UpdateSwapL1TxidResponse) updates) => super.copyWith((message) => updates(message as UpdateSwapL1TxidResponse)) as UpdateSwapL1TxidResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3476,33 +3077,30 @@ class UpdateSwapL1TxidResponse extends $pb.GeneratedMessage {
   UpdateSwapL1TxidResponse createEmptyInstance() => create();
   static $pb.PbList<UpdateSwapL1TxidResponse> createRepeated() => $pb.PbList<UpdateSwapL1TxidResponse>();
   @$core.pragma('dart2js:noInline')
-  static UpdateSwapL1TxidResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UpdateSwapL1TxidResponse>(create);
+  static UpdateSwapL1TxidResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UpdateSwapL1TxidResponse>(create);
   static UpdateSwapL1TxidResponse? _defaultInstance;
 }
 
 class ReconstructSwapsRequest extends $pb.GeneratedMessage {
   factory ReconstructSwapsRequest() => create();
   ReconstructSwapsRequest._() : super();
-  factory ReconstructSwapsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReconstructSwapsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ReconstructSwapsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReconstructSwapsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReconstructSwapsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReconstructSwapsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ReconstructSwapsRequest clone() => ReconstructSwapsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ReconstructSwapsRequest copyWith(void Function(ReconstructSwapsRequest) updates) =>
-      super.copyWith((message) => updates(message as ReconstructSwapsRequest)) as ReconstructSwapsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ReconstructSwapsRequest copyWith(void Function(ReconstructSwapsRequest) updates) => super.copyWith((message) => updates(message as ReconstructSwapsRequest)) as ReconstructSwapsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3511,8 +3109,7 @@ class ReconstructSwapsRequest extends $pb.GeneratedMessage {
   ReconstructSwapsRequest createEmptyInstance() => create();
   static $pb.PbList<ReconstructSwapsRequest> createRepeated() => $pb.PbList<ReconstructSwapsRequest>();
   @$core.pragma('dart2js:noInline')
-  static ReconstructSwapsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReconstructSwapsRequest>(create);
+  static ReconstructSwapsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReconstructSwapsRequest>(create);
   static ReconstructSwapsRequest? _defaultInstance;
 }
 
@@ -3527,26 +3124,24 @@ class ReconstructSwapsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ReconstructSwapsResponse._() : super();
-  factory ReconstructSwapsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReconstructSwapsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ReconstructSwapsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReconstructSwapsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReconstructSwapsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReconstructSwapsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'coinshift.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'count')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ReconstructSwapsResponse clone() => ReconstructSwapsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ReconstructSwapsResponse copyWith(void Function(ReconstructSwapsResponse) updates) =>
-      super.copyWith((message) => updates(message as ReconstructSwapsResponse)) as ReconstructSwapsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ReconstructSwapsResponse copyWith(void Function(ReconstructSwapsResponse) updates) => super.copyWith((message) => updates(message as ReconstructSwapsResponse)) as ReconstructSwapsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3555,17 +3150,13 @@ class ReconstructSwapsResponse extends $pb.GeneratedMessage {
   ReconstructSwapsResponse createEmptyInstance() => create();
   static $pb.PbList<ReconstructSwapsResponse> createRepeated() => $pb.PbList<ReconstructSwapsResponse>();
   @$core.pragma('dart2js:noInline')
-  static ReconstructSwapsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReconstructSwapsResponse>(create);
+  static ReconstructSwapsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReconstructSwapsResponse>(create);
   static ReconstructSwapsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get count => $_getI64(0);
   @$pb.TagNumber(1)
-  set count($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set count($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCount() => $_has(0);
   @$pb.TagNumber(1)
@@ -3577,94 +3168,106 @@ class CoinShiftServiceApi {
   CoinShiftServiceApi(this._client);
 
   $async.Future<GetBalanceResponse> getBalance($pb.ClientContext? ctx, GetBalanceRequest request) =>
-      _client.invoke<GetBalanceResponse>(ctx, 'CoinShiftService', 'GetBalance', request, GetBalanceResponse());
+    _client.invoke<GetBalanceResponse>(ctx, 'CoinShiftService', 'GetBalance', request, GetBalanceResponse())
+  ;
   $async.Future<GetBlockCountResponse> getBlockCount($pb.ClientContext? ctx, GetBlockCountRequest request) =>
-      _client.invoke<GetBlockCountResponse>(ctx, 'CoinShiftService', 'GetBlockCount', request, GetBlockCountResponse());
+    _client.invoke<GetBlockCountResponse>(ctx, 'CoinShiftService', 'GetBlockCount', request, GetBlockCountResponse())
+  ;
   $async.Future<StopResponse> stop($pb.ClientContext? ctx, StopRequest request) =>
-      _client.invoke<StopResponse>(ctx, 'CoinShiftService', 'Stop', request, StopResponse());
+    _client.invoke<StopResponse>(ctx, 'CoinShiftService', 'Stop', request, StopResponse())
+  ;
   $async.Future<GetNewAddressResponse> getNewAddress($pb.ClientContext? ctx, GetNewAddressRequest request) =>
-      _client.invoke<GetNewAddressResponse>(ctx, 'CoinShiftService', 'GetNewAddress', request, GetNewAddressResponse());
+    _client.invoke<GetNewAddressResponse>(ctx, 'CoinShiftService', 'GetNewAddress', request, GetNewAddressResponse())
+  ;
   $async.Future<WithdrawResponse> withdraw($pb.ClientContext? ctx, WithdrawRequest request) =>
-      _client.invoke<WithdrawResponse>(ctx, 'CoinShiftService', 'Withdraw', request, WithdrawResponse());
+    _client.invoke<WithdrawResponse>(ctx, 'CoinShiftService', 'Withdraw', request, WithdrawResponse())
+  ;
   $async.Future<TransferResponse> transfer($pb.ClientContext? ctx, TransferRequest request) =>
-      _client.invoke<TransferResponse>(ctx, 'CoinShiftService', 'Transfer', request, TransferResponse());
-  $async.Future<GetSidechainWealthResponse> getSidechainWealth(
-          $pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
-      _client.invoke<GetSidechainWealthResponse>(
-          ctx, 'CoinShiftService', 'GetSidechainWealth', request, GetSidechainWealthResponse());
+    _client.invoke<TransferResponse>(ctx, 'CoinShiftService', 'Transfer', request, TransferResponse())
+  ;
+  $async.Future<GetSidechainWealthResponse> getSidechainWealth($pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
+    _client.invoke<GetSidechainWealthResponse>(ctx, 'CoinShiftService', 'GetSidechainWealth', request, GetSidechainWealthResponse())
+  ;
   $async.Future<CreateDepositResponse> createDeposit($pb.ClientContext? ctx, CreateDepositRequest request) =>
-      _client.invoke<CreateDepositResponse>(ctx, 'CoinShiftService', 'CreateDeposit', request, CreateDepositResponse());
-  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-          $pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
-      _client.invoke<GetPendingWithdrawalBundleResponse>(
-          ctx, 'CoinShiftService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse());
+    _client.invoke<CreateDepositResponse>(ctx, 'CoinShiftService', 'CreateDeposit', request, CreateDepositResponse())
+  ;
+  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
+    _client.invoke<GetPendingWithdrawalBundleResponse>(ctx, 'CoinShiftService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse())
+  ;
   $async.Future<ConnectPeerResponse> connectPeer($pb.ClientContext? ctx, ConnectPeerRequest request) =>
-      _client.invoke<ConnectPeerResponse>(ctx, 'CoinShiftService', 'ConnectPeer', request, ConnectPeerResponse());
+    _client.invoke<ConnectPeerResponse>(ctx, 'CoinShiftService', 'ConnectPeer', request, ConnectPeerResponse())
+  ;
   $async.Future<ForgetPeerResponse> forgetPeer($pb.ClientContext? ctx, ForgetPeerRequest request) =>
-      _client.invoke<ForgetPeerResponse>(ctx, 'CoinShiftService', 'ForgetPeer', request, ForgetPeerResponse());
+    _client.invoke<ForgetPeerResponse>(ctx, 'CoinShiftService', 'ForgetPeer', request, ForgetPeerResponse())
+  ;
   $async.Future<ListPeersResponse> listPeers($pb.ClientContext? ctx, ListPeersRequest request) =>
-      _client.invoke<ListPeersResponse>(ctx, 'CoinShiftService', 'ListPeers', request, ListPeersResponse());
+    _client.invoke<ListPeersResponse>(ctx, 'CoinShiftService', 'ListPeers', request, ListPeersResponse())
+  ;
   $async.Future<MineResponse> mine($pb.ClientContext? ctx, MineRequest request) =>
-      _client.invoke<MineResponse>(ctx, 'CoinShiftService', 'Mine', request, MineResponse());
+    _client.invoke<MineResponse>(ctx, 'CoinShiftService', 'Mine', request, MineResponse())
+  ;
   $async.Future<GetBlockResponse> getBlock($pb.ClientContext? ctx, GetBlockRequest request) =>
-      _client.invoke<GetBlockResponse>(ctx, 'CoinShiftService', 'GetBlock', request, GetBlockResponse());
-  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-          $pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
-      _client.invoke<GetBestMainchainBlockHashResponse>(
-          ctx, 'CoinShiftService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse());
-  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-          $pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
-      _client.invoke<GetBestSidechainBlockHashResponse>(
-          ctx, 'CoinShiftService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse());
+    _client.invoke<GetBlockResponse>(ctx, 'CoinShiftService', 'GetBlock', request, GetBlockResponse())
+  ;
+  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
+    _client.invoke<GetBestMainchainBlockHashResponse>(ctx, 'CoinShiftService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse())
+  ;
+  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
+    _client.invoke<GetBestSidechainBlockHashResponse>(ctx, 'CoinShiftService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse())
+  ;
   $async.Future<GetBmmInclusionsResponse> getBmmInclusions($pb.ClientContext? ctx, GetBmmInclusionsRequest request) =>
-      _client.invoke<GetBmmInclusionsResponse>(
-          ctx, 'CoinShiftService', 'GetBmmInclusions', request, GetBmmInclusionsResponse());
-  $async.Future<GetWalletUtxosResponse> getWalletUtxos($pb.ClientContext? ctx, GetWalletUtxosRequest request) => _client
-      .invoke<GetWalletUtxosResponse>(ctx, 'CoinShiftService', 'GetWalletUtxos', request, GetWalletUtxosResponse());
+    _client.invoke<GetBmmInclusionsResponse>(ctx, 'CoinShiftService', 'GetBmmInclusions', request, GetBmmInclusionsResponse())
+  ;
+  $async.Future<GetWalletUtxosResponse> getWalletUtxos($pb.ClientContext? ctx, GetWalletUtxosRequest request) =>
+    _client.invoke<GetWalletUtxosResponse>(ctx, 'CoinShiftService', 'GetWalletUtxos', request, GetWalletUtxosResponse())
+  ;
   $async.Future<ListUtxosResponse> listUtxos($pb.ClientContext? ctx, ListUtxosRequest request) =>
-      _client.invoke<ListUtxosResponse>(ctx, 'CoinShiftService', 'ListUtxos', request, ListUtxosResponse());
-  $async.Future<RemoveFromMempoolResponse> removeFromMempool(
-          $pb.ClientContext? ctx, RemoveFromMempoolRequest request) =>
-      _client.invoke<RemoveFromMempoolResponse>(
-          ctx, 'CoinShiftService', 'RemoveFromMempool', request, RemoveFromMempoolResponse());
-  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-          $pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
-      _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'CoinShiftService',
-          'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse());
+    _client.invoke<ListUtxosResponse>(ctx, 'CoinShiftService', 'ListUtxos', request, ListUtxosResponse())
+  ;
+  $async.Future<RemoveFromMempoolResponse> removeFromMempool($pb.ClientContext? ctx, RemoveFromMempoolRequest request) =>
+    _client.invoke<RemoveFromMempoolResponse>(ctx, 'CoinShiftService', 'RemoveFromMempool', request, RemoveFromMempoolResponse())
+  ;
+  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
+    _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'CoinShiftService', 'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse())
+  ;
   $async.Future<GenerateMnemonicResponse> generateMnemonic($pb.ClientContext? ctx, GenerateMnemonicRequest request) =>
-      _client.invoke<GenerateMnemonicResponse>(
-          ctx, 'CoinShiftService', 'GenerateMnemonic', request, GenerateMnemonicResponse());
-  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-          $pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
-      _client.invoke<SetSeedFromMnemonicResponse>(
-          ctx, 'CoinShiftService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse());
+    _client.invoke<GenerateMnemonicResponse>(ctx, 'CoinShiftService', 'GenerateMnemonic', request, GenerateMnemonicResponse())
+  ;
+  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
+    _client.invoke<SetSeedFromMnemonicResponse>(ctx, 'CoinShiftService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse())
+  ;
   $async.Future<CallRawResponse> callRaw($pb.ClientContext? ctx, CallRawRequest request) =>
-      _client.invoke<CallRawResponse>(ctx, 'CoinShiftService', 'CallRaw', request, CallRawResponse());
-  $async.Future<GetWalletAddressesResponse> getWalletAddresses(
-          $pb.ClientContext? ctx, GetWalletAddressesRequest request) =>
-      _client.invoke<GetWalletAddressesResponse>(
-          ctx, 'CoinShiftService', 'GetWalletAddresses', request, GetWalletAddressesResponse());
+    _client.invoke<CallRawResponse>(ctx, 'CoinShiftService', 'CallRaw', request, CallRawResponse())
+  ;
+  $async.Future<GetWalletAddressesResponse> getWalletAddresses($pb.ClientContext? ctx, GetWalletAddressesRequest request) =>
+    _client.invoke<GetWalletAddressesResponse>(ctx, 'CoinShiftService', 'GetWalletAddresses', request, GetWalletAddressesResponse())
+  ;
   $async.Future<OpenapiSchemaResponse> openapiSchema($pb.ClientContext? ctx, OpenapiSchemaRequest request) =>
-      _client.invoke<OpenapiSchemaResponse>(ctx, 'CoinShiftService', 'OpenapiSchema', request, OpenapiSchemaResponse());
+    _client.invoke<OpenapiSchemaResponse>(ctx, 'CoinShiftService', 'OpenapiSchema', request, OpenapiSchemaResponse())
+  ;
   $async.Future<CreateSwapResponse> createSwap($pb.ClientContext? ctx, CreateSwapRequest request) =>
-      _client.invoke<CreateSwapResponse>(ctx, 'CoinShiftService', 'CreateSwap', request, CreateSwapResponse());
+    _client.invoke<CreateSwapResponse>(ctx, 'CoinShiftService', 'CreateSwap', request, CreateSwapResponse())
+  ;
   $async.Future<ClaimSwapResponse> claimSwap($pb.ClientContext? ctx, ClaimSwapRequest request) =>
-      _client.invoke<ClaimSwapResponse>(ctx, 'CoinShiftService', 'ClaimSwap', request, ClaimSwapResponse());
+    _client.invoke<ClaimSwapResponse>(ctx, 'CoinShiftService', 'ClaimSwap', request, ClaimSwapResponse())
+  ;
   $async.Future<GetSwapStatusResponse> getSwapStatus($pb.ClientContext? ctx, GetSwapStatusRequest request) =>
-      _client.invoke<GetSwapStatusResponse>(ctx, 'CoinShiftService', 'GetSwapStatus', request, GetSwapStatusResponse());
+    _client.invoke<GetSwapStatusResponse>(ctx, 'CoinShiftService', 'GetSwapStatus', request, GetSwapStatusResponse())
+  ;
   $async.Future<ListSwapsResponse> listSwaps($pb.ClientContext? ctx, ListSwapsRequest request) =>
-      _client.invoke<ListSwapsResponse>(ctx, 'CoinShiftService', 'ListSwaps', request, ListSwapsResponse());
-  $async.Future<ListSwapsByRecipientResponse> listSwapsByRecipient(
-          $pb.ClientContext? ctx, ListSwapsByRecipientRequest request) =>
-      _client.invoke<ListSwapsByRecipientResponse>(
-          ctx, 'CoinShiftService', 'ListSwapsByRecipient', request, ListSwapsByRecipientResponse());
+    _client.invoke<ListSwapsResponse>(ctx, 'CoinShiftService', 'ListSwaps', request, ListSwapsResponse())
+  ;
+  $async.Future<ListSwapsByRecipientResponse> listSwapsByRecipient($pb.ClientContext? ctx, ListSwapsByRecipientRequest request) =>
+    _client.invoke<ListSwapsByRecipientResponse>(ctx, 'CoinShiftService', 'ListSwapsByRecipient', request, ListSwapsByRecipientResponse())
+  ;
   $async.Future<UpdateSwapL1TxidResponse> updateSwapL1Txid($pb.ClientContext? ctx, UpdateSwapL1TxidRequest request) =>
-      _client.invoke<UpdateSwapL1TxidResponse>(
-          ctx, 'CoinShiftService', 'UpdateSwapL1Txid', request, UpdateSwapL1TxidResponse());
+    _client.invoke<UpdateSwapL1TxidResponse>(ctx, 'CoinShiftService', 'UpdateSwapL1Txid', request, UpdateSwapL1TxidResponse())
+  ;
   $async.Future<ReconstructSwapsResponse> reconstructSwaps($pb.ClientContext? ctx, ReconstructSwapsRequest request) =>
-      _client.invoke<ReconstructSwapsResponse>(
-          ctx, 'CoinShiftService', 'ReconstructSwaps', request, ReconstructSwapsResponse());
+    _client.invoke<ReconstructSwapsResponse>(ctx, 'CoinShiftService', 'ReconstructSwaps', request, ReconstructSwapsResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/coinshift/v1/coinshift.pbenum.dart
+++ b/sail_ui/lib/gen/coinshift/v1/coinshift.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/coinshift/v1/coinshift.pbjson.dart
+++ b/sail_ui/lib/gen/coinshift/v1/coinshift.pbjson.dart
@@ -19,7 +19,8 @@ const GetBalanceRequest$json = {
 };
 
 /// Descriptor for `GetBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode('ChFHZXRCYWxhbmNlUmVxdWVzdA==');
+final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode(
+    'ChFHZXRCYWxhbmNlUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBalanceResponseDescriptor instead')
 const GetBalanceResponse$json = {
@@ -31,9 +32,9 @@ const GetBalanceResponse$json = {
 };
 
 /// Descriptor for `GetBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceResponseDescriptor =
-    $convert.base64Decode('ChJHZXRCYWxhbmNlUmVzcG9uc2USHQoKdG90YWxfc2F0cxgBIAEoA1IJdG90YWxTYXRzEiUKDm'
-        'F2YWlsYWJsZV9zYXRzGAIgASgDUg1hdmFpbGFibGVTYXRz');
+final $typed_data.Uint8List getBalanceResponseDescriptor = $convert.base64Decode(
+    'ChJHZXRCYWxhbmNlUmVzcG9uc2USHQoKdG90YWxfc2F0cxgBIAEoA1IJdG90YWxTYXRzEiUKDm'
+    'F2YWlsYWJsZV9zYXRzGAIgASgDUg1hdmFpbGFibGVTYXRz');
 
 @$core.Deprecated('Use getBlockCountRequestDescriptor instead')
 const GetBlockCountRequest$json = {
@@ -41,7 +42,8 @@ const GetBlockCountRequest$json = {
 };
 
 /// Descriptor for `GetBlockCountRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode('ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
+final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
 
 @$core.Deprecated('Use getBlockCountResponseDescriptor instead')
 const GetBlockCountResponse$json = {
@@ -52,8 +54,8 @@ const GetBlockCountResponse$json = {
 };
 
 /// Descriptor for `GetBlockCountResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountResponseDescriptor =
-    $convert.base64Decode('ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
+final $typed_data.Uint8List getBlockCountResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
 
 @$core.Deprecated('Use stopRequestDescriptor instead')
 const StopRequest$json = {
@@ -61,7 +63,8 @@ const StopRequest$json = {
 };
 
 /// Descriptor for `StopRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode('CgtTdG9wUmVxdWVzdA==');
+final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode(
+    'CgtTdG9wUmVxdWVzdA==');
 
 @$core.Deprecated('Use stopResponseDescriptor instead')
 const StopResponse$json = {
@@ -69,7 +72,8 @@ const StopResponse$json = {
 };
 
 /// Descriptor for `StopResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode('CgxTdG9wUmVzcG9uc2U=');
+final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode(
+    'CgxTdG9wUmVzcG9uc2U=');
 
 @$core.Deprecated('Use getNewAddressRequestDescriptor instead')
 const GetNewAddressRequest$json = {
@@ -77,7 +81,8 @@ const GetNewAddressRequest$json = {
 };
 
 /// Descriptor for `GetNewAddressRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode('ChRHZXROZXdBZGRyZXNzUmVxdWVzdA==');
+final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode(
+    'ChRHZXROZXdBZGRyZXNzUmVxdWVzdA==');
 
 @$core.Deprecated('Use getNewAddressResponseDescriptor instead')
 const GetNewAddressResponse$json = {
@@ -88,8 +93,8 @@ const GetNewAddressResponse$json = {
 };
 
 /// Descriptor for `GetNewAddressResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressResponseDescriptor =
-    $convert.base64Decode('ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List getNewAddressResponseDescriptor = $convert.base64Decode(
+    'ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use withdrawRequestDescriptor instead')
 const WithdrawRequest$json = {
@@ -103,10 +108,10 @@ const WithdrawRequest$json = {
 };
 
 /// Descriptor for `WithdrawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawRequestDescriptor =
-    $convert.base64Decode('Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
-        'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
+final $typed_data.Uint8List withdrawRequestDescriptor = $convert.base64Decode(
+    'Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
+    'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
 
 @$core.Deprecated('Use withdrawResponseDescriptor instead')
 const WithdrawResponse$json = {
@@ -117,8 +122,8 @@ const WithdrawResponse$json = {
 };
 
 /// Descriptor for `WithdrawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawResponseDescriptor =
-    $convert.base64Decode('ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List withdrawResponseDescriptor = $convert.base64Decode(
+    'ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use transferRequestDescriptor instead')
 const TransferRequest$json = {
@@ -131,9 +136,9 @@ const TransferRequest$json = {
 };
 
 /// Descriptor for `TransferRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferRequestDescriptor =
-    $convert.base64Decode('Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List transferRequestDescriptor = $convert.base64Decode(
+    'Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use transferResponseDescriptor instead')
 const TransferResponse$json = {
@@ -144,8 +149,8 @@ const TransferResponse$json = {
 };
 
 /// Descriptor for `TransferResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferResponseDescriptor =
-    $convert.base64Decode('ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List transferResponseDescriptor = $convert.base64Decode(
+    'ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use getSidechainWealthRequestDescriptor instead')
 const GetSidechainWealthRequest$json = {
@@ -153,8 +158,8 @@ const GetSidechainWealthRequest$json = {
 };
 
 /// Descriptor for `GetSidechainWealthRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthRequestDescriptor =
-    $convert.base64Decode('ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
+final $typed_data.Uint8List getSidechainWealthRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
 
 @$core.Deprecated('Use getSidechainWealthResponseDescriptor instead')
 const GetSidechainWealthResponse$json = {
@@ -165,8 +170,8 @@ const GetSidechainWealthResponse$json = {
 };
 
 /// Descriptor for `GetSidechainWealthResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthResponseDescriptor =
-    $convert.base64Decode('ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
+final $typed_data.Uint8List getSidechainWealthResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
 
 @$core.Deprecated('Use createDepositRequestDescriptor instead')
 const CreateDepositRequest$json = {
@@ -179,9 +184,9 @@ const CreateDepositRequest$json = {
 };
 
 /// Descriptor for `CreateDepositRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositRequestDescriptor =
-    $convert.base64Decode('ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
-        'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List createDepositRequestDescriptor = $convert.base64Decode(
+    'ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
+    'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use createDepositResponseDescriptor instead')
 const CreateDepositResponse$json = {
@@ -192,8 +197,8 @@ const CreateDepositResponse$json = {
 };
 
 /// Descriptor for `CreateDepositResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositResponseDescriptor =
-    $convert.base64Decode('ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List createDepositResponseDescriptor = $convert.base64Decode(
+    'ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleRequestDescriptor instead')
 const GetPendingWithdrawalBundleRequest$json = {
@@ -201,8 +206,8 @@ const GetPendingWithdrawalBundleRequest$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor =
-    $convert.base64Decode('CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
+final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor = $convert.base64Decode(
+    'CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleResponseDescriptor instead')
 const GetPendingWithdrawalBundleResponse$json = {
@@ -213,9 +218,9 @@ const GetPendingWithdrawalBundleResponse$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor =
-    $convert.base64Decode('CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
-        'gJUgpidW5kbGVKc29u');
+final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor = $convert.base64Decode(
+    'CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
+    'gJUgpidW5kbGVKc29u');
 
 @$core.Deprecated('Use connectPeerRequestDescriptor instead')
 const ConnectPeerRequest$json = {
@@ -226,8 +231,8 @@ const ConnectPeerRequest$json = {
 };
 
 /// Descriptor for `ConnectPeerRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerRequestDescriptor =
-    $convert.base64Decode('ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List connectPeerRequestDescriptor = $convert.base64Decode(
+    'ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use connectPeerResponseDescriptor instead')
 const ConnectPeerResponse$json = {
@@ -235,7 +240,8 @@ const ConnectPeerResponse$json = {
 };
 
 /// Descriptor for `ConnectPeerResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode('ChNDb25uZWN0UGVlclJlc3BvbnNl');
+final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode(
+    'ChNDb25uZWN0UGVlclJlc3BvbnNl');
 
 @$core.Deprecated('Use forgetPeerRequestDescriptor instead')
 const ForgetPeerRequest$json = {
@@ -246,8 +252,8 @@ const ForgetPeerRequest$json = {
 };
 
 /// Descriptor for `ForgetPeerRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List forgetPeerRequestDescriptor =
-    $convert.base64Decode('ChFGb3JnZXRQZWVyUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNz');
+final $typed_data.Uint8List forgetPeerRequestDescriptor = $convert.base64Decode(
+    'ChFGb3JnZXRQZWVyUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNz');
 
 @$core.Deprecated('Use forgetPeerResponseDescriptor instead')
 const ForgetPeerResponse$json = {
@@ -255,7 +261,8 @@ const ForgetPeerResponse$json = {
 };
 
 /// Descriptor for `ForgetPeerResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List forgetPeerResponseDescriptor = $convert.base64Decode('ChJGb3JnZXRQZWVyUmVzcG9uc2U=');
+final $typed_data.Uint8List forgetPeerResponseDescriptor = $convert.base64Decode(
+    'ChJGb3JnZXRQZWVyUmVzcG9uc2U=');
 
 @$core.Deprecated('Use listPeersRequestDescriptor instead')
 const ListPeersRequest$json = {
@@ -263,7 +270,8 @@ const ListPeersRequest$json = {
 };
 
 /// Descriptor for `ListPeersRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode('ChBMaXN0UGVlcnNSZXF1ZXN0');
+final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0UGVlcnNSZXF1ZXN0');
 
 @$core.Deprecated('Use listPeersResponseDescriptor instead')
 const ListPeersResponse$json = {
@@ -274,8 +282,8 @@ const ListPeersResponse$json = {
 };
 
 /// Descriptor for `ListPeersResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
+final $typed_data.Uint8List listPeersResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
 
 @$core.Deprecated('Use mineRequestDescriptor instead')
 const MineRequest$json = {
@@ -286,8 +294,8 @@ const MineRequest$json = {
 };
 
 /// Descriptor for `MineRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineRequestDescriptor =
-    $convert.base64Decode('CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List mineRequestDescriptor = $convert.base64Decode(
+    'CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use mineResponseDescriptor instead')
 const MineResponse$json = {
@@ -298,8 +306,8 @@ const MineResponse$json = {
 };
 
 /// Descriptor for `MineResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineResponseDescriptor =
-    $convert.base64Decode('CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
+final $typed_data.Uint8List mineResponseDescriptor = $convert.base64Decode(
+    'CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
 
 @$core.Deprecated('Use getBlockRequestDescriptor instead')
 const GetBlockRequest$json = {
@@ -310,8 +318,8 @@ const GetBlockRequest$json = {
 };
 
 /// Descriptor for `GetBlockRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockRequestDescriptor =
-    $convert.base64Decode('Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
+final $typed_data.Uint8List getBlockRequestDescriptor = $convert.base64Decode(
+    'Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
 
 @$core.Deprecated('Use getBlockResponseDescriptor instead')
 const GetBlockResponse$json = {
@@ -322,8 +330,8 @@ const GetBlockResponse$json = {
 };
 
 /// Descriptor for `GetBlockResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockResponseDescriptor =
-    $convert.base64Decode('ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
+final $typed_data.Uint8List getBlockResponseDescriptor = $convert.base64Decode(
+    'ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashRequestDescriptor instead')
 const GetBestMainchainBlockHashRequest$json = {
@@ -331,8 +339,8 @@ const GetBestMainchainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashResponseDescriptor instead')
 const GetBestMainchainBlockHashResponse$json = {
@@ -343,9 +351,9 @@ const GetBestMainchainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashRequestDescriptor instead')
 const GetBestSidechainBlockHashRequest$json = {
@@ -353,8 +361,8 @@ const GetBestSidechainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashResponseDescriptor instead')
 const GetBestSidechainBlockHashResponse$json = {
@@ -365,9 +373,9 @@ const GetBestSidechainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBmmInclusionsRequestDescriptor instead')
 const GetBmmInclusionsRequest$json = {
@@ -378,9 +386,9 @@ const GetBmmInclusionsRequest$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsRequestDescriptor =
-    $convert.base64Decode('ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
-        'g=');
+final $typed_data.Uint8List getBmmInclusionsRequestDescriptor = $convert.base64Decode(
+    'ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
+    'g=');
 
 @$core.Deprecated('Use getBmmInclusionsResponseDescriptor instead')
 const GetBmmInclusionsResponse$json = {
@@ -391,9 +399,9 @@ const GetBmmInclusionsResponse$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsResponseDescriptor =
-    $convert.base64Decode('ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
-        '9ucw==');
+final $typed_data.Uint8List getBmmInclusionsResponseDescriptor = $convert.base64Decode(
+    'ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
+    '9ucw==');
 
 @$core.Deprecated('Use getWalletUtxosRequestDescriptor instead')
 const GetWalletUtxosRequest$json = {
@@ -401,7 +409,8 @@ const GetWalletUtxosRequest$json = {
 };
 
 /// Descriptor for `GetWalletUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode('ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
+final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode(
+    'ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getWalletUtxosResponseDescriptor instead')
 const GetWalletUtxosResponse$json = {
@@ -412,9 +421,9 @@ const GetWalletUtxosResponse$json = {
 };
 
 /// Descriptor for `GetWalletUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosResponseDescriptor =
-    $convert.base64Decode('ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
-        '==');
+final $typed_data.Uint8List getWalletUtxosResponseDescriptor = $convert.base64Decode(
+    'ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
+    '==');
 
 @$core.Deprecated('Use listUtxosRequestDescriptor instead')
 const ListUtxosRequest$json = {
@@ -422,7 +431,8 @@ const ListUtxosRequest$json = {
 };
 
 /// Descriptor for `ListUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode('ChBMaXN0VXR4b3NSZXF1ZXN0');
+final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0VXR4b3NSZXF1ZXN0');
 
 @$core.Deprecated('Use listUtxosResponseDescriptor instead')
 const ListUtxosResponse$json = {
@@ -433,8 +443,8 @@ const ListUtxosResponse$json = {
 };
 
 /// Descriptor for `ListUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
+final $typed_data.Uint8List listUtxosResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
 
 @$core.Deprecated('Use removeFromMempoolRequestDescriptor instead')
 const RemoveFromMempoolRequest$json = {
@@ -445,8 +455,8 @@ const RemoveFromMempoolRequest$json = {
 };
 
 /// Descriptor for `RemoveFromMempoolRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFromMempoolRequestDescriptor =
-    $convert.base64Decode('ChhSZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List removeFromMempoolRequestDescriptor = $convert.base64Decode(
+    'ChhSZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use removeFromMempoolResponseDescriptor instead')
 const RemoveFromMempoolResponse$json = {
@@ -454,8 +464,8 @@ const RemoveFromMempoolResponse$json = {
 };
 
 /// Descriptor for `RemoveFromMempoolResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFromMempoolResponseDescriptor =
-    $convert.base64Decode('ChlSZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNl');
+final $typed_data.Uint8List removeFromMempoolResponseDescriptor = $convert.base64Decode(
+    'ChlSZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNl');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightRequestDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightRequest$json = {
@@ -463,8 +473,8 @@ const GetLatestFailedWithdrawalBundleHeightRequest$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor =
-    $convert.base64Decode('CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor = $convert.base64Decode(
+    'CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightResponseDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightResponse$json = {
@@ -475,9 +485,9 @@ const GetLatestFailedWithdrawalBundleHeightResponse$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor =
-    $convert.base64Decode('Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
-        'h0GAEgASgDUgZoZWlnaHQ=');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor = $convert.base64Decode(
+    'Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
+    'h0GAEgASgDUgZoZWlnaHQ=');
 
 @$core.Deprecated('Use generateMnemonicRequestDescriptor instead')
 const GenerateMnemonicRequest$json = {
@@ -485,8 +495,8 @@ const GenerateMnemonicRequest$json = {
 };
 
 /// Descriptor for `GenerateMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicRequestDescriptor =
-    $convert.base64Decode('ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
+final $typed_data.Uint8List generateMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
 
 @$core.Deprecated('Use generateMnemonicResponseDescriptor instead')
 const GenerateMnemonicResponse$json = {
@@ -497,8 +507,8 @@ const GenerateMnemonicResponse$json = {
 };
 
 /// Descriptor for `GenerateMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicResponseDescriptor =
-    $convert.base64Decode('ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
+final $typed_data.Uint8List generateMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
 
 @$core.Deprecated('Use setSeedFromMnemonicRequestDescriptor instead')
 const SetSeedFromMnemonicRequest$json = {
@@ -509,9 +519,9 @@ const SetSeedFromMnemonicRequest$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor =
-    $convert.base64Decode('ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
-        'M=');
+final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
+    'M=');
 
 @$core.Deprecated('Use setSeedFromMnemonicResponseDescriptor instead')
 const SetSeedFromMnemonicResponse$json = {
@@ -519,8 +529,8 @@ const SetSeedFromMnemonicResponse$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor =
-    $convert.base64Decode('ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
+final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
 
 @$core.Deprecated('Use callRawRequestDescriptor instead')
 const CallRawRequest$json = {
@@ -532,9 +542,9 @@ const CallRawRequest$json = {
 };
 
 /// Descriptor for `CallRawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawRequestDescriptor =
-    $convert.base64Decode('Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
-        'gCIAEoCVIKcGFyYW1zSnNvbg==');
+final $typed_data.Uint8List callRawRequestDescriptor = $convert.base64Decode(
+    'Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
+    'gCIAEoCVIKcGFyYW1zSnNvbg==');
 
 @$core.Deprecated('Use callRawResponseDescriptor instead')
 const CallRawResponse$json = {
@@ -545,8 +555,8 @@ const CallRawResponse$json = {
 };
 
 /// Descriptor for `CallRawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawResponseDescriptor =
-    $convert.base64Decode('Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
+final $typed_data.Uint8List callRawResponseDescriptor = $convert.base64Decode(
+    'Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
 
 @$core.Deprecated('Use getWalletAddressesRequestDescriptor instead')
 const GetWalletAddressesRequest$json = {
@@ -554,8 +564,8 @@ const GetWalletAddressesRequest$json = {
 };
 
 /// Descriptor for `GetWalletAddressesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletAddressesRequestDescriptor =
-    $convert.base64Decode('ChlHZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0');
+final $typed_data.Uint8List getWalletAddressesRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0');
 
 @$core.Deprecated('Use getWalletAddressesResponseDescriptor instead')
 const GetWalletAddressesResponse$json = {
@@ -566,9 +576,9 @@ const GetWalletAddressesResponse$json = {
 };
 
 /// Descriptor for `GetWalletAddressesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletAddressesResponseDescriptor =
-    $convert.base64Decode('ChpHZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3'
-        'Nlcw==');
+final $typed_data.Uint8List getWalletAddressesResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3'
+    'Nlcw==');
 
 @$core.Deprecated('Use openapiSchemaRequestDescriptor instead')
 const OpenapiSchemaRequest$json = {
@@ -576,7 +586,8 @@ const OpenapiSchemaRequest$json = {
 };
 
 /// Descriptor for `OpenapiSchemaRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List openapiSchemaRequestDescriptor = $convert.base64Decode('ChRPcGVuYXBpU2NoZW1hUmVxdWVzdA==');
+final $typed_data.Uint8List openapiSchemaRequestDescriptor = $convert.base64Decode(
+    'ChRPcGVuYXBpU2NoZW1hUmVxdWVzdA==');
 
 @$core.Deprecated('Use openapiSchemaResponseDescriptor instead')
 const OpenapiSchemaResponse$json = {
@@ -587,9 +598,9 @@ const OpenapiSchemaResponse$json = {
 };
 
 /// Descriptor for `OpenapiSchemaResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List openapiSchemaResponseDescriptor =
-    $convert.base64Decode('ChVPcGVuYXBpU2NoZW1hUmVzcG9uc2USHwoLc2NoZW1hX2pzb24YASABKAlSCnNjaGVtYUpzb2'
-        '4=');
+final $typed_data.Uint8List openapiSchemaResponseDescriptor = $convert.base64Decode(
+    'ChVPcGVuYXBpU2NoZW1hUmVzcG9uc2USHwoLc2NoZW1hX2pzb24YASABKAlSCnNjaGVtYUpzb2'
+    '4=');
 
 @$core.Deprecated('Use createSwapRequestDescriptor instead')
 const CreateSwapRequest$json = {
@@ -610,14 +621,14 @@ const CreateSwapRequest$json = {
 };
 
 /// Descriptor for `CreateSwapRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createSwapRequestDescriptor =
-    $convert.base64Decode('ChFDcmVhdGVTd2FwUmVxdWVzdBIkCg5sMl9hbW91bnRfc2F0cxgBIAEoA1IMbDJBbW91bnRTYX'
-        'RzEiQKDmwxX2Ftb3VudF9zYXRzGAIgASgDUgxsMUFtb3VudFNhdHMSMAoUbDFfcmVjaXBpZW50'
-        'X2FkZHJlc3MYAyABKAlSEmwxUmVjaXBpZW50QWRkcmVzcxIhCgxwYXJlbnRfY2hhaW4YBCABKA'
-        'lSC3BhcmVudENoYWluEiYKDGwyX3JlY2lwaWVudBgFIAEoCUgAUgtsMlJlY2lwaWVudIgBARI6'
-        'ChZyZXF1aXJlZF9jb25maXJtYXRpb25zGAYgASgFSAFSFXJlcXVpcmVkQ29uZmlybWF0aW9uc4'
-        'gBARIZCghmZWVfc2F0cxgHIAEoA1IHZmVlU2F0c0IPCg1fbDJfcmVjaXBpZW50QhkKF19yZXF1'
-        'aXJlZF9jb25maXJtYXRpb25z');
+final $typed_data.Uint8List createSwapRequestDescriptor = $convert.base64Decode(
+    'ChFDcmVhdGVTd2FwUmVxdWVzdBIkCg5sMl9hbW91bnRfc2F0cxgBIAEoA1IMbDJBbW91bnRTYX'
+    'RzEiQKDmwxX2Ftb3VudF9zYXRzGAIgASgDUgxsMUFtb3VudFNhdHMSMAoUbDFfcmVjaXBpZW50'
+    'X2FkZHJlc3MYAyABKAlSEmwxUmVjaXBpZW50QWRkcmVzcxIhCgxwYXJlbnRfY2hhaW4YBCABKA'
+    'lSC3BhcmVudENoYWluEiYKDGwyX3JlY2lwaWVudBgFIAEoCUgAUgtsMlJlY2lwaWVudIgBARI6'
+    'ChZyZXF1aXJlZF9jb25maXJtYXRpb25zGAYgASgFSAFSFXJlcXVpcmVkQ29uZmlybWF0aW9uc4'
+    'gBARIZCghmZWVfc2F0cxgHIAEoA1IHZmVlU2F0c0IPCg1fbDJfcmVjaXBpZW50QhkKF19yZXF1'
+    'aXJlZF9jb25maXJtYXRpb25z');
 
 @$core.Deprecated('Use createSwapResponseDescriptor instead')
 const CreateSwapResponse$json = {
@@ -629,9 +640,9 @@ const CreateSwapResponse$json = {
 };
 
 /// Descriptor for `CreateSwapResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createSwapResponseDescriptor =
-    $convert.base64Decode('ChJDcmVhdGVTd2FwUmVzcG9uc2USFwoHc3dhcF9pZBgBIAEoCVIGc3dhcElkEhIKBHR4aWQYAi'
-        'ABKAlSBHR4aWQ=');
+final $typed_data.Uint8List createSwapResponseDescriptor = $convert.base64Decode(
+    'ChJDcmVhdGVTd2FwUmVzcG9uc2USFwoHc3dhcF9pZBgBIAEoCVIGc3dhcElkEhIKBHR4aWQYAi'
+    'ABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use claimSwapRequestDescriptor instead')
 const ClaimSwapRequest$json = {
@@ -646,10 +657,10 @@ const ClaimSwapRequest$json = {
 };
 
 /// Descriptor for `ClaimSwapRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List claimSwapRequestDescriptor =
-    $convert.base64Decode('ChBDbGFpbVN3YXBSZXF1ZXN0EhcKB3N3YXBfaWQYASABKAlSBnN3YXBJZBIxChJsMl9jbGFpbW'
-        'VyX2FkZHJlc3MYAiABKAlIAFIQbDJDbGFpbWVyQWRkcmVzc4gBAUIVChNfbDJfY2xhaW1lcl9h'
-        'ZGRyZXNz');
+final $typed_data.Uint8List claimSwapRequestDescriptor = $convert.base64Decode(
+    'ChBDbGFpbVN3YXBSZXF1ZXN0EhcKB3N3YXBfaWQYASABKAlSBnN3YXBJZBIxChJsMl9jbGFpbW'
+    'VyX2FkZHJlc3MYAiABKAlIAFIQbDJDbGFpbWVyQWRkcmVzc4gBAUIVChNfbDJfY2xhaW1lcl9h'
+    'ZGRyZXNz');
 
 @$core.Deprecated('Use claimSwapResponseDescriptor instead')
 const ClaimSwapResponse$json = {
@@ -660,8 +671,8 @@ const ClaimSwapResponse$json = {
 };
 
 /// Descriptor for `ClaimSwapResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List claimSwapResponseDescriptor =
-    $convert.base64Decode('ChFDbGFpbVN3YXBSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
+final $typed_data.Uint8List claimSwapResponseDescriptor = $convert.base64Decode(
+    'ChFDbGFpbVN3YXBSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
 
 @$core.Deprecated('Use getSwapStatusRequestDescriptor instead')
 const GetSwapStatusRequest$json = {
@@ -672,8 +683,8 @@ const GetSwapStatusRequest$json = {
 };
 
 /// Descriptor for `GetSwapStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSwapStatusRequestDescriptor =
-    $convert.base64Decode('ChRHZXRTd2FwU3RhdHVzUmVxdWVzdBIXCgdzd2FwX2lkGAEgASgJUgZzd2FwSWQ=');
+final $typed_data.Uint8List getSwapStatusRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRTd2FwU3RhdHVzUmVxdWVzdBIXCgdzd2FwX2lkGAEgASgJUgZzd2FwSWQ=');
 
 @$core.Deprecated('Use getSwapStatusResponseDescriptor instead')
 const GetSwapStatusResponse$json = {
@@ -684,8 +695,8 @@ const GetSwapStatusResponse$json = {
 };
 
 /// Descriptor for `GetSwapStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSwapStatusResponseDescriptor =
-    $convert.base64Decode('ChVHZXRTd2FwU3RhdHVzUmVzcG9uc2USGwoJc3dhcF9qc29uGAEgASgJUghzd2FwSnNvbg==');
+final $typed_data.Uint8List getSwapStatusResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRTd2FwU3RhdHVzUmVzcG9uc2USGwoJc3dhcF9qc29uGAEgASgJUghzd2FwSnNvbg==');
 
 @$core.Deprecated('Use listSwapsRequestDescriptor instead')
 const ListSwapsRequest$json = {
@@ -693,7 +704,8 @@ const ListSwapsRequest$json = {
 };
 
 /// Descriptor for `ListSwapsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listSwapsRequestDescriptor = $convert.base64Decode('ChBMaXN0U3dhcHNSZXF1ZXN0');
+final $typed_data.Uint8List listSwapsRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0U3dhcHNSZXF1ZXN0');
 
 @$core.Deprecated('Use listSwapsResponseDescriptor instead')
 const ListSwapsResponse$json = {
@@ -704,8 +716,8 @@ const ListSwapsResponse$json = {
 };
 
 /// Descriptor for `ListSwapsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listSwapsResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0U3dhcHNSZXNwb25zZRIdCgpzd2Fwc19qc29uGAEgASgJUglzd2Fwc0pzb24=');
+final $typed_data.Uint8List listSwapsResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0U3dhcHNSZXNwb25zZRIdCgpzd2Fwc19qc29uGAEgASgJUglzd2Fwc0pzb24=');
 
 @$core.Deprecated('Use listSwapsByRecipientRequestDescriptor instead')
 const ListSwapsByRecipientRequest$json = {
@@ -716,9 +728,9 @@ const ListSwapsByRecipientRequest$json = {
 };
 
 /// Descriptor for `ListSwapsByRecipientRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listSwapsByRecipientRequestDescriptor =
-    $convert.base64Decode('ChtMaXN0U3dhcHNCeVJlY2lwaWVudFJlcXVlc3QSHAoJcmVjaXBpZW50GAEgASgJUglyZWNpcG'
-        'llbnQ=');
+final $typed_data.Uint8List listSwapsByRecipientRequestDescriptor = $convert.base64Decode(
+    'ChtMaXN0U3dhcHNCeVJlY2lwaWVudFJlcXVlc3QSHAoJcmVjaXBpZW50GAEgASgJUglyZWNpcG'
+    'llbnQ=');
 
 @$core.Deprecated('Use listSwapsByRecipientResponseDescriptor instead')
 const ListSwapsByRecipientResponse$json = {
@@ -729,9 +741,9 @@ const ListSwapsByRecipientResponse$json = {
 };
 
 /// Descriptor for `ListSwapsByRecipientResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listSwapsByRecipientResponseDescriptor =
-    $convert.base64Decode('ChxMaXN0U3dhcHNCeVJlY2lwaWVudFJlc3BvbnNlEh0KCnN3YXBzX2pzb24YASABKAlSCXN3YX'
-        'BzSnNvbg==');
+final $typed_data.Uint8List listSwapsByRecipientResponseDescriptor = $convert.base64Decode(
+    'ChxMaXN0U3dhcHNCeVJlY2lwaWVudFJlc3BvbnNlEh0KCnN3YXBzX2pzb24YASABKAlSCXN3YX'
+    'BzSnNvbg==');
 
 @$core.Deprecated('Use updateSwapL1TxidRequestDescriptor instead')
 const UpdateSwapL1TxidRequest$json = {
@@ -744,10 +756,10 @@ const UpdateSwapL1TxidRequest$json = {
 };
 
 /// Descriptor for `UpdateSwapL1TxidRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List updateSwapL1TxidRequestDescriptor =
-    $convert.base64Decode('ChdVcGRhdGVTd2FwTDFUeGlkUmVxdWVzdBIXCgdzd2FwX2lkGAEgASgJUgZzd2FwSWQSHgoLbD'
-        'FfdHhpZF9oZXgYAiABKAlSCWwxVHhpZEhleBIkCg1jb25maXJtYXRpb25zGAMgASgFUg1jb25m'
-        'aXJtYXRpb25z');
+final $typed_data.Uint8List updateSwapL1TxidRequestDescriptor = $convert.base64Decode(
+    'ChdVcGRhdGVTd2FwTDFUeGlkUmVxdWVzdBIXCgdzd2FwX2lkGAEgASgJUgZzd2FwSWQSHgoLbD'
+    'FfdHhpZF9oZXgYAiABKAlSCWwxVHhpZEhleBIkCg1jb25maXJtYXRpb25zGAMgASgFUg1jb25m'
+    'aXJtYXRpb25z');
 
 @$core.Deprecated('Use updateSwapL1TxidResponseDescriptor instead')
 const UpdateSwapL1TxidResponse$json = {
@@ -755,8 +767,8 @@ const UpdateSwapL1TxidResponse$json = {
 };
 
 /// Descriptor for `UpdateSwapL1TxidResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List updateSwapL1TxidResponseDescriptor =
-    $convert.base64Decode('ChhVcGRhdGVTd2FwTDFUeGlkUmVzcG9uc2U=');
+final $typed_data.Uint8List updateSwapL1TxidResponseDescriptor = $convert.base64Decode(
+    'ChhVcGRhdGVTd2FwTDFUeGlkUmVzcG9uc2U=');
 
 @$core.Deprecated('Use reconstructSwapsRequestDescriptor instead')
 const ReconstructSwapsRequest$json = {
@@ -764,8 +776,8 @@ const ReconstructSwapsRequest$json = {
 };
 
 /// Descriptor for `ReconstructSwapsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reconstructSwapsRequestDescriptor =
-    $convert.base64Decode('ChdSZWNvbnN0cnVjdFN3YXBzUmVxdWVzdA==');
+final $typed_data.Uint8List reconstructSwapsRequestDescriptor = $convert.base64Decode(
+    'ChdSZWNvbnN0cnVjdFN3YXBzUmVxdWVzdA==');
 
 @$core.Deprecated('Use reconstructSwapsResponseDescriptor instead')
 const ReconstructSwapsResponse$json = {
@@ -776,8 +788,8 @@ const ReconstructSwapsResponse$json = {
 };
 
 /// Descriptor for `ReconstructSwapsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reconstructSwapsResponseDescriptor =
-    $convert.base64Decode('ChhSZWNvbnN0cnVjdFN3YXBzUmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
+final $typed_data.Uint8List reconstructSwapsResponseDescriptor = $convert.base64Decode(
+    'ChhSZWNvbnN0cnVjdFN3YXBzUmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
 
 const $core.Map<$core.String, $core.dynamic> CoinShiftServiceBase$json = {
   '1': 'CoinShiftService',
@@ -788,85 +800,33 @@ const $core.Map<$core.String, $core.dynamic> CoinShiftServiceBase$json = {
     {'1': 'GetNewAddress', '2': '.coinshift.v1.GetNewAddressRequest', '3': '.coinshift.v1.GetNewAddressResponse'},
     {'1': 'Withdraw', '2': '.coinshift.v1.WithdrawRequest', '3': '.coinshift.v1.WithdrawResponse'},
     {'1': 'Transfer', '2': '.coinshift.v1.TransferRequest', '3': '.coinshift.v1.TransferResponse'},
-    {
-      '1': 'GetSidechainWealth',
-      '2': '.coinshift.v1.GetSidechainWealthRequest',
-      '3': '.coinshift.v1.GetSidechainWealthResponse'
-    },
+    {'1': 'GetSidechainWealth', '2': '.coinshift.v1.GetSidechainWealthRequest', '3': '.coinshift.v1.GetSidechainWealthResponse'},
     {'1': 'CreateDeposit', '2': '.coinshift.v1.CreateDepositRequest', '3': '.coinshift.v1.CreateDepositResponse'},
-    {
-      '1': 'GetPendingWithdrawalBundle',
-      '2': '.coinshift.v1.GetPendingWithdrawalBundleRequest',
-      '3': '.coinshift.v1.GetPendingWithdrawalBundleResponse'
-    },
+    {'1': 'GetPendingWithdrawalBundle', '2': '.coinshift.v1.GetPendingWithdrawalBundleRequest', '3': '.coinshift.v1.GetPendingWithdrawalBundleResponse'},
     {'1': 'ConnectPeer', '2': '.coinshift.v1.ConnectPeerRequest', '3': '.coinshift.v1.ConnectPeerResponse'},
     {'1': 'ForgetPeer', '2': '.coinshift.v1.ForgetPeerRequest', '3': '.coinshift.v1.ForgetPeerResponse'},
     {'1': 'ListPeers', '2': '.coinshift.v1.ListPeersRequest', '3': '.coinshift.v1.ListPeersResponse'},
     {'1': 'Mine', '2': '.coinshift.v1.MineRequest', '3': '.coinshift.v1.MineResponse'},
     {'1': 'GetBlock', '2': '.coinshift.v1.GetBlockRequest', '3': '.coinshift.v1.GetBlockResponse'},
-    {
-      '1': 'GetBestMainchainBlockHash',
-      '2': '.coinshift.v1.GetBestMainchainBlockHashRequest',
-      '3': '.coinshift.v1.GetBestMainchainBlockHashResponse'
-    },
-    {
-      '1': 'GetBestSidechainBlockHash',
-      '2': '.coinshift.v1.GetBestSidechainBlockHashRequest',
-      '3': '.coinshift.v1.GetBestSidechainBlockHashResponse'
-    },
-    {
-      '1': 'GetBmmInclusions',
-      '2': '.coinshift.v1.GetBmmInclusionsRequest',
-      '3': '.coinshift.v1.GetBmmInclusionsResponse'
-    },
+    {'1': 'GetBestMainchainBlockHash', '2': '.coinshift.v1.GetBestMainchainBlockHashRequest', '3': '.coinshift.v1.GetBestMainchainBlockHashResponse'},
+    {'1': 'GetBestSidechainBlockHash', '2': '.coinshift.v1.GetBestSidechainBlockHashRequest', '3': '.coinshift.v1.GetBestSidechainBlockHashResponse'},
+    {'1': 'GetBmmInclusions', '2': '.coinshift.v1.GetBmmInclusionsRequest', '3': '.coinshift.v1.GetBmmInclusionsResponse'},
     {'1': 'GetWalletUtxos', '2': '.coinshift.v1.GetWalletUtxosRequest', '3': '.coinshift.v1.GetWalletUtxosResponse'},
     {'1': 'ListUtxos', '2': '.coinshift.v1.ListUtxosRequest', '3': '.coinshift.v1.ListUtxosResponse'},
-    {
-      '1': 'RemoveFromMempool',
-      '2': '.coinshift.v1.RemoveFromMempoolRequest',
-      '3': '.coinshift.v1.RemoveFromMempoolResponse'
-    },
-    {
-      '1': 'GetLatestFailedWithdrawalBundleHeight',
-      '2': '.coinshift.v1.GetLatestFailedWithdrawalBundleHeightRequest',
-      '3': '.coinshift.v1.GetLatestFailedWithdrawalBundleHeightResponse'
-    },
-    {
-      '1': 'GenerateMnemonic',
-      '2': '.coinshift.v1.GenerateMnemonicRequest',
-      '3': '.coinshift.v1.GenerateMnemonicResponse'
-    },
-    {
-      '1': 'SetSeedFromMnemonic',
-      '2': '.coinshift.v1.SetSeedFromMnemonicRequest',
-      '3': '.coinshift.v1.SetSeedFromMnemonicResponse'
-    },
+    {'1': 'RemoveFromMempool', '2': '.coinshift.v1.RemoveFromMempoolRequest', '3': '.coinshift.v1.RemoveFromMempoolResponse'},
+    {'1': 'GetLatestFailedWithdrawalBundleHeight', '2': '.coinshift.v1.GetLatestFailedWithdrawalBundleHeightRequest', '3': '.coinshift.v1.GetLatestFailedWithdrawalBundleHeightResponse'},
+    {'1': 'GenerateMnemonic', '2': '.coinshift.v1.GenerateMnemonicRequest', '3': '.coinshift.v1.GenerateMnemonicResponse'},
+    {'1': 'SetSeedFromMnemonic', '2': '.coinshift.v1.SetSeedFromMnemonicRequest', '3': '.coinshift.v1.SetSeedFromMnemonicResponse'},
     {'1': 'CallRaw', '2': '.coinshift.v1.CallRawRequest', '3': '.coinshift.v1.CallRawResponse'},
-    {
-      '1': 'GetWalletAddresses',
-      '2': '.coinshift.v1.GetWalletAddressesRequest',
-      '3': '.coinshift.v1.GetWalletAddressesResponse'
-    },
+    {'1': 'GetWalletAddresses', '2': '.coinshift.v1.GetWalletAddressesRequest', '3': '.coinshift.v1.GetWalletAddressesResponse'},
     {'1': 'OpenapiSchema', '2': '.coinshift.v1.OpenapiSchemaRequest', '3': '.coinshift.v1.OpenapiSchemaResponse'},
     {'1': 'CreateSwap', '2': '.coinshift.v1.CreateSwapRequest', '3': '.coinshift.v1.CreateSwapResponse'},
     {'1': 'ClaimSwap', '2': '.coinshift.v1.ClaimSwapRequest', '3': '.coinshift.v1.ClaimSwapResponse'},
     {'1': 'GetSwapStatus', '2': '.coinshift.v1.GetSwapStatusRequest', '3': '.coinshift.v1.GetSwapStatusResponse'},
     {'1': 'ListSwaps', '2': '.coinshift.v1.ListSwapsRequest', '3': '.coinshift.v1.ListSwapsResponse'},
-    {
-      '1': 'ListSwapsByRecipient',
-      '2': '.coinshift.v1.ListSwapsByRecipientRequest',
-      '3': '.coinshift.v1.ListSwapsByRecipientResponse'
-    },
-    {
-      '1': 'UpdateSwapL1Txid',
-      '2': '.coinshift.v1.UpdateSwapL1TxidRequest',
-      '3': '.coinshift.v1.UpdateSwapL1TxidResponse'
-    },
-    {
-      '1': 'ReconstructSwaps',
-      '2': '.coinshift.v1.ReconstructSwapsRequest',
-      '3': '.coinshift.v1.ReconstructSwapsResponse'
-    },
+    {'1': 'ListSwapsByRecipient', '2': '.coinshift.v1.ListSwapsByRecipientRequest', '3': '.coinshift.v1.ListSwapsByRecipientResponse'},
+    {'1': 'UpdateSwapL1Txid', '2': '.coinshift.v1.UpdateSwapL1TxidRequest', '3': '.coinshift.v1.UpdateSwapL1TxidResponse'},
+    {'1': 'ReconstructSwaps', '2': '.coinshift.v1.ReconstructSwapsRequest', '3': '.coinshift.v1.ReconstructSwapsResponse'},
   ],
 };
 
@@ -941,60 +901,61 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> CoinShiftS
 };
 
 /// Descriptor for `CoinShiftService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List coinShiftServiceDescriptor =
-    $convert.base64Decode('ChBDb2luU2hpZnRTZXJ2aWNlEk8KCkdldEJhbGFuY2USHy5jb2luc2hpZnQudjEuR2V0QmFsYW'
-        '5jZVJlcXVlc3QaIC5jb2luc2hpZnQudjEuR2V0QmFsYW5jZVJlc3BvbnNlElgKDUdldEJsb2Nr'
-        'Q291bnQSIi5jb2luc2hpZnQudjEuR2V0QmxvY2tDb3VudFJlcXVlc3QaIy5jb2luc2hpZnQudj'
-        'EuR2V0QmxvY2tDb3VudFJlc3BvbnNlEj0KBFN0b3ASGS5jb2luc2hpZnQudjEuU3RvcFJlcXVl'
-        'c3QaGi5jb2luc2hpZnQudjEuU3RvcFJlc3BvbnNlElgKDUdldE5ld0FkZHJlc3MSIi5jb2luc2'
-        'hpZnQudjEuR2V0TmV3QWRkcmVzc1JlcXVlc3QaIy5jb2luc2hpZnQudjEuR2V0TmV3QWRkcmVz'
-        'c1Jlc3BvbnNlEkkKCFdpdGhkcmF3Eh0uY29pbnNoaWZ0LnYxLldpdGhkcmF3UmVxdWVzdBoeLm'
-        'NvaW5zaGlmdC52MS5XaXRoZHJhd1Jlc3BvbnNlEkkKCFRyYW5zZmVyEh0uY29pbnNoaWZ0LnYx'
-        'LlRyYW5zZmVyUmVxdWVzdBoeLmNvaW5zaGlmdC52MS5UcmFuc2ZlclJlc3BvbnNlEmcKEkdldF'
-        'NpZGVjaGFpbldlYWx0aBInLmNvaW5zaGlmdC52MS5HZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0'
-        'GiguY29pbnNoaWZ0LnYxLkdldFNpZGVjaGFpbldlYWx0aFJlc3BvbnNlElgKDUNyZWF0ZURlcG'
-        '9zaXQSIi5jb2luc2hpZnQudjEuQ3JlYXRlRGVwb3NpdFJlcXVlc3QaIy5jb2luc2hpZnQudjEu'
-        'Q3JlYXRlRGVwb3NpdFJlc3BvbnNlEn8KGkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlEi8uY2'
-        '9pbnNoaWZ0LnYxLkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlUmVxdWVzdBowLmNvaW5zaGlm'
-        'dC52MS5HZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlElIKC0Nvbm5lY3RQZWVyEi'
-        'AuY29pbnNoaWZ0LnYxLkNvbm5lY3RQZWVyUmVxdWVzdBohLmNvaW5zaGlmdC52MS5Db25uZWN0'
-        'UGVlclJlc3BvbnNlEk8KCkZvcmdldFBlZXISHy5jb2luc2hpZnQudjEuRm9yZ2V0UGVlclJlcX'
-        'Vlc3QaIC5jb2luc2hpZnQudjEuRm9yZ2V0UGVlclJlc3BvbnNlEkwKCUxpc3RQZWVycxIeLmNv'
-        'aW5zaGlmdC52MS5MaXN0UGVlcnNSZXF1ZXN0Gh8uY29pbnNoaWZ0LnYxLkxpc3RQZWVyc1Jlc3'
-        'BvbnNlEj0KBE1pbmUSGS5jb2luc2hpZnQudjEuTWluZVJlcXVlc3QaGi5jb2luc2hpZnQudjEu'
-        'TWluZVJlc3BvbnNlEkkKCEdldEJsb2NrEh0uY29pbnNoaWZ0LnYxLkdldEJsb2NrUmVxdWVzdB'
-        'oeLmNvaW5zaGlmdC52MS5HZXRCbG9ja1Jlc3BvbnNlEnwKGUdldEJlc3RNYWluY2hhaW5CbG9j'
-        'a0hhc2gSLi5jb2luc2hpZnQudjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFzaFJlcXVlc3QaLy'
-        '5jb2luc2hpZnQudjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFzaFJlc3BvbnNlEnwKGUdldEJl'
-        'c3RTaWRlY2hhaW5CbG9ja0hhc2gSLi5jb2luc2hpZnQudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2'
-        'NrSGFzaFJlcXVlc3QaLy5jb2luc2hpZnQudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaFJl'
-        'c3BvbnNlEmEKEEdldEJtbUluY2x1c2lvbnMSJS5jb2luc2hpZnQudjEuR2V0Qm1tSW5jbHVzaW'
-        '9uc1JlcXVlc3QaJi5jb2luc2hpZnQudjEuR2V0Qm1tSW5jbHVzaW9uc1Jlc3BvbnNlElsKDkdl'
-        'dFdhbGxldFV0eG9zEiMuY29pbnNoaWZ0LnYxLkdldFdhbGxldFV0eG9zUmVxdWVzdBokLmNvaW'
-        '5zaGlmdC52MS5HZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEkwKCUxpc3RVdHhvcxIeLmNvaW5zaGlm'
-        'dC52MS5MaXN0VXR4b3NSZXF1ZXN0Gh8uY29pbnNoaWZ0LnYxLkxpc3RVdHhvc1Jlc3BvbnNlEm'
-        'QKEVJlbW92ZUZyb21NZW1wb29sEiYuY29pbnNoaWZ0LnYxLlJlbW92ZUZyb21NZW1wb29sUmVx'
-        'dWVzdBonLmNvaW5zaGlmdC52MS5SZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNlEqABCiVHZXRMYX'
-        'Rlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0EjouY29pbnNoaWZ0LnYxLkdldExhdGVz'
-        'dEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHRSZXF1ZXN0GjsuY29pbnNoaWZ0LnYxLkdldE'
-        'xhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHRSZXNwb25zZRJhChBHZW5lcmF0ZU1u'
-        'ZW1vbmljEiUuY29pbnNoaWZ0LnYxLkdlbmVyYXRlTW5lbW9uaWNSZXF1ZXN0GiYuY29pbnNoaW'
-        'Z0LnYxLkdlbmVyYXRlTW5lbW9uaWNSZXNwb25zZRJqChNTZXRTZWVkRnJvbU1uZW1vbmljEigu'
-        'Y29pbnNoaWZ0LnYxLlNldFNlZWRGcm9tTW5lbW9uaWNSZXF1ZXN0GikuY29pbnNoaWZ0LnYxLl'
-        'NldFNlZWRGcm9tTW5lbW9uaWNSZXNwb25zZRJGCgdDYWxsUmF3EhwuY29pbnNoaWZ0LnYxLkNh'
-        'bGxSYXdSZXF1ZXN0Gh0uY29pbnNoaWZ0LnYxLkNhbGxSYXdSZXNwb25zZRJnChJHZXRXYWxsZX'
-        'RBZGRyZXNzZXMSJy5jb2luc2hpZnQudjEuR2V0V2FsbGV0QWRkcmVzc2VzUmVxdWVzdBooLmNv'
-        'aW5zaGlmdC52MS5HZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRJYCg1PcGVuYXBpU2NoZW1hEi'
-        'IuY29pbnNoaWZ0LnYxLk9wZW5hcGlTY2hlbWFSZXF1ZXN0GiMuY29pbnNoaWZ0LnYxLk9wZW5h'
-        'cGlTY2hlbWFSZXNwb25zZRJPCgpDcmVhdGVTd2FwEh8uY29pbnNoaWZ0LnYxLkNyZWF0ZVN3YX'
-        'BSZXF1ZXN0GiAuY29pbnNoaWZ0LnYxLkNyZWF0ZVN3YXBSZXNwb25zZRJMCglDbGFpbVN3YXAS'
-        'Hi5jb2luc2hpZnQudjEuQ2xhaW1Td2FwUmVxdWVzdBofLmNvaW5zaGlmdC52MS5DbGFpbVN3YX'
-        'BSZXNwb25zZRJYCg1HZXRTd2FwU3RhdHVzEiIuY29pbnNoaWZ0LnYxLkdldFN3YXBTdGF0dXNS'
-        'ZXF1ZXN0GiMuY29pbnNoaWZ0LnYxLkdldFN3YXBTdGF0dXNSZXNwb25zZRJMCglMaXN0U3dhcH'
-        'MSHi5jb2luc2hpZnQudjEuTGlzdFN3YXBzUmVxdWVzdBofLmNvaW5zaGlmdC52MS5MaXN0U3dh'
-        'cHNSZXNwb25zZRJtChRMaXN0U3dhcHNCeVJlY2lwaWVudBIpLmNvaW5zaGlmdC52MS5MaXN0U3'
-        'dhcHNCeVJlY2lwaWVudFJlcXVlc3QaKi5jb2luc2hpZnQudjEuTGlzdFN3YXBzQnlSZWNpcGll'
-        'bnRSZXNwb25zZRJhChBVcGRhdGVTd2FwTDFUeGlkEiUuY29pbnNoaWZ0LnYxLlVwZGF0ZVN3YX'
-        'BMMVR4aWRSZXF1ZXN0GiYuY29pbnNoaWZ0LnYxLlVwZGF0ZVN3YXBMMVR4aWRSZXNwb25zZRJh'
-        'ChBSZWNvbnN0cnVjdFN3YXBzEiUuY29pbnNoaWZ0LnYxLlJlY29uc3RydWN0U3dhcHNSZXF1ZX'
-        'N0GiYuY29pbnNoaWZ0LnYxLlJlY29uc3RydWN0U3dhcHNSZXNwb25zZQ==');
+final $typed_data.Uint8List coinShiftServiceDescriptor = $convert.base64Decode(
+    'ChBDb2luU2hpZnRTZXJ2aWNlEk8KCkdldEJhbGFuY2USHy5jb2luc2hpZnQudjEuR2V0QmFsYW'
+    '5jZVJlcXVlc3QaIC5jb2luc2hpZnQudjEuR2V0QmFsYW5jZVJlc3BvbnNlElgKDUdldEJsb2Nr'
+    'Q291bnQSIi5jb2luc2hpZnQudjEuR2V0QmxvY2tDb3VudFJlcXVlc3QaIy5jb2luc2hpZnQudj'
+    'EuR2V0QmxvY2tDb3VudFJlc3BvbnNlEj0KBFN0b3ASGS5jb2luc2hpZnQudjEuU3RvcFJlcXVl'
+    'c3QaGi5jb2luc2hpZnQudjEuU3RvcFJlc3BvbnNlElgKDUdldE5ld0FkZHJlc3MSIi5jb2luc2'
+    'hpZnQudjEuR2V0TmV3QWRkcmVzc1JlcXVlc3QaIy5jb2luc2hpZnQudjEuR2V0TmV3QWRkcmVz'
+    'c1Jlc3BvbnNlEkkKCFdpdGhkcmF3Eh0uY29pbnNoaWZ0LnYxLldpdGhkcmF3UmVxdWVzdBoeLm'
+    'NvaW5zaGlmdC52MS5XaXRoZHJhd1Jlc3BvbnNlEkkKCFRyYW5zZmVyEh0uY29pbnNoaWZ0LnYx'
+    'LlRyYW5zZmVyUmVxdWVzdBoeLmNvaW5zaGlmdC52MS5UcmFuc2ZlclJlc3BvbnNlEmcKEkdldF'
+    'NpZGVjaGFpbldlYWx0aBInLmNvaW5zaGlmdC52MS5HZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0'
+    'GiguY29pbnNoaWZ0LnYxLkdldFNpZGVjaGFpbldlYWx0aFJlc3BvbnNlElgKDUNyZWF0ZURlcG'
+    '9zaXQSIi5jb2luc2hpZnQudjEuQ3JlYXRlRGVwb3NpdFJlcXVlc3QaIy5jb2luc2hpZnQudjEu'
+    'Q3JlYXRlRGVwb3NpdFJlc3BvbnNlEn8KGkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlEi8uY2'
+    '9pbnNoaWZ0LnYxLkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlUmVxdWVzdBowLmNvaW5zaGlm'
+    'dC52MS5HZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlElIKC0Nvbm5lY3RQZWVyEi'
+    'AuY29pbnNoaWZ0LnYxLkNvbm5lY3RQZWVyUmVxdWVzdBohLmNvaW5zaGlmdC52MS5Db25uZWN0'
+    'UGVlclJlc3BvbnNlEk8KCkZvcmdldFBlZXISHy5jb2luc2hpZnQudjEuRm9yZ2V0UGVlclJlcX'
+    'Vlc3QaIC5jb2luc2hpZnQudjEuRm9yZ2V0UGVlclJlc3BvbnNlEkwKCUxpc3RQZWVycxIeLmNv'
+    'aW5zaGlmdC52MS5MaXN0UGVlcnNSZXF1ZXN0Gh8uY29pbnNoaWZ0LnYxLkxpc3RQZWVyc1Jlc3'
+    'BvbnNlEj0KBE1pbmUSGS5jb2luc2hpZnQudjEuTWluZVJlcXVlc3QaGi5jb2luc2hpZnQudjEu'
+    'TWluZVJlc3BvbnNlEkkKCEdldEJsb2NrEh0uY29pbnNoaWZ0LnYxLkdldEJsb2NrUmVxdWVzdB'
+    'oeLmNvaW5zaGlmdC52MS5HZXRCbG9ja1Jlc3BvbnNlEnwKGUdldEJlc3RNYWluY2hhaW5CbG9j'
+    'a0hhc2gSLi5jb2luc2hpZnQudjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFzaFJlcXVlc3QaLy'
+    '5jb2luc2hpZnQudjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFzaFJlc3BvbnNlEnwKGUdldEJl'
+    'c3RTaWRlY2hhaW5CbG9ja0hhc2gSLi5jb2luc2hpZnQudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2'
+    'NrSGFzaFJlcXVlc3QaLy5jb2luc2hpZnQudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaFJl'
+    'c3BvbnNlEmEKEEdldEJtbUluY2x1c2lvbnMSJS5jb2luc2hpZnQudjEuR2V0Qm1tSW5jbHVzaW'
+    '9uc1JlcXVlc3QaJi5jb2luc2hpZnQudjEuR2V0Qm1tSW5jbHVzaW9uc1Jlc3BvbnNlElsKDkdl'
+    'dFdhbGxldFV0eG9zEiMuY29pbnNoaWZ0LnYxLkdldFdhbGxldFV0eG9zUmVxdWVzdBokLmNvaW'
+    '5zaGlmdC52MS5HZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEkwKCUxpc3RVdHhvcxIeLmNvaW5zaGlm'
+    'dC52MS5MaXN0VXR4b3NSZXF1ZXN0Gh8uY29pbnNoaWZ0LnYxLkxpc3RVdHhvc1Jlc3BvbnNlEm'
+    'QKEVJlbW92ZUZyb21NZW1wb29sEiYuY29pbnNoaWZ0LnYxLlJlbW92ZUZyb21NZW1wb29sUmVx'
+    'dWVzdBonLmNvaW5zaGlmdC52MS5SZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNlEqABCiVHZXRMYX'
+    'Rlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0EjouY29pbnNoaWZ0LnYxLkdldExhdGVz'
+    'dEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHRSZXF1ZXN0GjsuY29pbnNoaWZ0LnYxLkdldE'
+    'xhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHRSZXNwb25zZRJhChBHZW5lcmF0ZU1u'
+    'ZW1vbmljEiUuY29pbnNoaWZ0LnYxLkdlbmVyYXRlTW5lbW9uaWNSZXF1ZXN0GiYuY29pbnNoaW'
+    'Z0LnYxLkdlbmVyYXRlTW5lbW9uaWNSZXNwb25zZRJqChNTZXRTZWVkRnJvbU1uZW1vbmljEigu'
+    'Y29pbnNoaWZ0LnYxLlNldFNlZWRGcm9tTW5lbW9uaWNSZXF1ZXN0GikuY29pbnNoaWZ0LnYxLl'
+    'NldFNlZWRGcm9tTW5lbW9uaWNSZXNwb25zZRJGCgdDYWxsUmF3EhwuY29pbnNoaWZ0LnYxLkNh'
+    'bGxSYXdSZXF1ZXN0Gh0uY29pbnNoaWZ0LnYxLkNhbGxSYXdSZXNwb25zZRJnChJHZXRXYWxsZX'
+    'RBZGRyZXNzZXMSJy5jb2luc2hpZnQudjEuR2V0V2FsbGV0QWRkcmVzc2VzUmVxdWVzdBooLmNv'
+    'aW5zaGlmdC52MS5HZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRJYCg1PcGVuYXBpU2NoZW1hEi'
+    'IuY29pbnNoaWZ0LnYxLk9wZW5hcGlTY2hlbWFSZXF1ZXN0GiMuY29pbnNoaWZ0LnYxLk9wZW5h'
+    'cGlTY2hlbWFSZXNwb25zZRJPCgpDcmVhdGVTd2FwEh8uY29pbnNoaWZ0LnYxLkNyZWF0ZVN3YX'
+    'BSZXF1ZXN0GiAuY29pbnNoaWZ0LnYxLkNyZWF0ZVN3YXBSZXNwb25zZRJMCglDbGFpbVN3YXAS'
+    'Hi5jb2luc2hpZnQudjEuQ2xhaW1Td2FwUmVxdWVzdBofLmNvaW5zaGlmdC52MS5DbGFpbVN3YX'
+    'BSZXNwb25zZRJYCg1HZXRTd2FwU3RhdHVzEiIuY29pbnNoaWZ0LnYxLkdldFN3YXBTdGF0dXNS'
+    'ZXF1ZXN0GiMuY29pbnNoaWZ0LnYxLkdldFN3YXBTdGF0dXNSZXNwb25zZRJMCglMaXN0U3dhcH'
+    'MSHi5jb2luc2hpZnQudjEuTGlzdFN3YXBzUmVxdWVzdBofLmNvaW5zaGlmdC52MS5MaXN0U3dh'
+    'cHNSZXNwb25zZRJtChRMaXN0U3dhcHNCeVJlY2lwaWVudBIpLmNvaW5zaGlmdC52MS5MaXN0U3'
+    'dhcHNCeVJlY2lwaWVudFJlcXVlc3QaKi5jb2luc2hpZnQudjEuTGlzdFN3YXBzQnlSZWNpcGll'
+    'bnRSZXNwb25zZRJhChBVcGRhdGVTd2FwTDFUeGlkEiUuY29pbnNoaWZ0LnYxLlVwZGF0ZVN3YX'
+    'BMMVR4aWRSZXF1ZXN0GiYuY29pbnNoaWZ0LnYxLlVwZGF0ZVN3YXBMMVR4aWRSZXNwb25zZRJh'
+    'ChBSZWNvbnN0cnVjdFN3YXBzEiUuY29pbnNoaWZ0LnYxLlJlY29uc3RydWN0U3dhcHNSZXF1ZX'
+    'N0GiYuY29pbnNoaWZ0LnYxLlJlY29uc3RydWN0U3dhcHNSZXNwb25zZQ==');
+

--- a/sail_ui/lib/gen/coinshift/v1/coinshift.pbserver.dart
+++ b/sail_ui/lib/gen/coinshift/v1/coinshift.pbserver.dart
@@ -27,195 +27,113 @@ abstract class CoinShiftServiceBase extends $pb.GeneratedService {
   $async.Future<$2.GetNewAddressResponse> getNewAddress($pb.ServerContext ctx, $2.GetNewAddressRequest request);
   $async.Future<$2.WithdrawResponse> withdraw($pb.ServerContext ctx, $2.WithdrawRequest request);
   $async.Future<$2.TransferResponse> transfer($pb.ServerContext ctx, $2.TransferRequest request);
-  $async.Future<$2.GetSidechainWealthResponse> getSidechainWealth(
-      $pb.ServerContext ctx, $2.GetSidechainWealthRequest request);
+  $async.Future<$2.GetSidechainWealthResponse> getSidechainWealth($pb.ServerContext ctx, $2.GetSidechainWealthRequest request);
   $async.Future<$2.CreateDepositResponse> createDeposit($pb.ServerContext ctx, $2.CreateDepositRequest request);
-  $async.Future<$2.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-      $pb.ServerContext ctx, $2.GetPendingWithdrawalBundleRequest request);
+  $async.Future<$2.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ServerContext ctx, $2.GetPendingWithdrawalBundleRequest request);
   $async.Future<$2.ConnectPeerResponse> connectPeer($pb.ServerContext ctx, $2.ConnectPeerRequest request);
   $async.Future<$2.ForgetPeerResponse> forgetPeer($pb.ServerContext ctx, $2.ForgetPeerRequest request);
   $async.Future<$2.ListPeersResponse> listPeers($pb.ServerContext ctx, $2.ListPeersRequest request);
   $async.Future<$2.MineResponse> mine($pb.ServerContext ctx, $2.MineRequest request);
   $async.Future<$2.GetBlockResponse> getBlock($pb.ServerContext ctx, $2.GetBlockRequest request);
-  $async.Future<$2.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-      $pb.ServerContext ctx, $2.GetBestMainchainBlockHashRequest request);
-  $async.Future<$2.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-      $pb.ServerContext ctx, $2.GetBestSidechainBlockHashRequest request);
-  $async.Future<$2.GetBmmInclusionsResponse> getBmmInclusions(
-      $pb.ServerContext ctx, $2.GetBmmInclusionsRequest request);
+  $async.Future<$2.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ServerContext ctx, $2.GetBestMainchainBlockHashRequest request);
+  $async.Future<$2.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ServerContext ctx, $2.GetBestSidechainBlockHashRequest request);
+  $async.Future<$2.GetBmmInclusionsResponse> getBmmInclusions($pb.ServerContext ctx, $2.GetBmmInclusionsRequest request);
   $async.Future<$2.GetWalletUtxosResponse> getWalletUtxos($pb.ServerContext ctx, $2.GetWalletUtxosRequest request);
   $async.Future<$2.ListUtxosResponse> listUtxos($pb.ServerContext ctx, $2.ListUtxosRequest request);
-  $async.Future<$2.RemoveFromMempoolResponse> removeFromMempool(
-      $pb.ServerContext ctx, $2.RemoveFromMempoolRequest request);
-  $async.Future<$2.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-      $pb.ServerContext ctx, $2.GetLatestFailedWithdrawalBundleHeightRequest request);
-  $async.Future<$2.GenerateMnemonicResponse> generateMnemonic(
-      $pb.ServerContext ctx, $2.GenerateMnemonicRequest request);
-  $async.Future<$2.SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-      $pb.ServerContext ctx, $2.SetSeedFromMnemonicRequest request);
+  $async.Future<$2.RemoveFromMempoolResponse> removeFromMempool($pb.ServerContext ctx, $2.RemoveFromMempoolRequest request);
+  $async.Future<$2.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ServerContext ctx, $2.GetLatestFailedWithdrawalBundleHeightRequest request);
+  $async.Future<$2.GenerateMnemonicResponse> generateMnemonic($pb.ServerContext ctx, $2.GenerateMnemonicRequest request);
+  $async.Future<$2.SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ServerContext ctx, $2.SetSeedFromMnemonicRequest request);
   $async.Future<$2.CallRawResponse> callRaw($pb.ServerContext ctx, $2.CallRawRequest request);
-  $async.Future<$2.GetWalletAddressesResponse> getWalletAddresses(
-      $pb.ServerContext ctx, $2.GetWalletAddressesRequest request);
+  $async.Future<$2.GetWalletAddressesResponse> getWalletAddresses($pb.ServerContext ctx, $2.GetWalletAddressesRequest request);
   $async.Future<$2.OpenapiSchemaResponse> openapiSchema($pb.ServerContext ctx, $2.OpenapiSchemaRequest request);
   $async.Future<$2.CreateSwapResponse> createSwap($pb.ServerContext ctx, $2.CreateSwapRequest request);
   $async.Future<$2.ClaimSwapResponse> claimSwap($pb.ServerContext ctx, $2.ClaimSwapRequest request);
   $async.Future<$2.GetSwapStatusResponse> getSwapStatus($pb.ServerContext ctx, $2.GetSwapStatusRequest request);
   $async.Future<$2.ListSwapsResponse> listSwaps($pb.ServerContext ctx, $2.ListSwapsRequest request);
-  $async.Future<$2.ListSwapsByRecipientResponse> listSwapsByRecipient(
-      $pb.ServerContext ctx, $2.ListSwapsByRecipientRequest request);
-  $async.Future<$2.UpdateSwapL1TxidResponse> updateSwapL1Txid(
-      $pb.ServerContext ctx, $2.UpdateSwapL1TxidRequest request);
-  $async.Future<$2.ReconstructSwapsResponse> reconstructSwaps(
-      $pb.ServerContext ctx, $2.ReconstructSwapsRequest request);
+  $async.Future<$2.ListSwapsByRecipientResponse> listSwapsByRecipient($pb.ServerContext ctx, $2.ListSwapsByRecipientRequest request);
+  $async.Future<$2.UpdateSwapL1TxidResponse> updateSwapL1Txid($pb.ServerContext ctx, $2.UpdateSwapL1TxidRequest request);
+  $async.Future<$2.ReconstructSwapsResponse> reconstructSwaps($pb.ServerContext ctx, $2.ReconstructSwapsRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetBalance':
-        return $2.GetBalanceRequest();
-      case 'GetBlockCount':
-        return $2.GetBlockCountRequest();
-      case 'Stop':
-        return $2.StopRequest();
-      case 'GetNewAddress':
-        return $2.GetNewAddressRequest();
-      case 'Withdraw':
-        return $2.WithdrawRequest();
-      case 'Transfer':
-        return $2.TransferRequest();
-      case 'GetSidechainWealth':
-        return $2.GetSidechainWealthRequest();
-      case 'CreateDeposit':
-        return $2.CreateDepositRequest();
-      case 'GetPendingWithdrawalBundle':
-        return $2.GetPendingWithdrawalBundleRequest();
-      case 'ConnectPeer':
-        return $2.ConnectPeerRequest();
-      case 'ForgetPeer':
-        return $2.ForgetPeerRequest();
-      case 'ListPeers':
-        return $2.ListPeersRequest();
-      case 'Mine':
-        return $2.MineRequest();
-      case 'GetBlock':
-        return $2.GetBlockRequest();
-      case 'GetBestMainchainBlockHash':
-        return $2.GetBestMainchainBlockHashRequest();
-      case 'GetBestSidechainBlockHash':
-        return $2.GetBestSidechainBlockHashRequest();
-      case 'GetBmmInclusions':
-        return $2.GetBmmInclusionsRequest();
-      case 'GetWalletUtxos':
-        return $2.GetWalletUtxosRequest();
-      case 'ListUtxos':
-        return $2.ListUtxosRequest();
-      case 'RemoveFromMempool':
-        return $2.RemoveFromMempoolRequest();
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return $2.GetLatestFailedWithdrawalBundleHeightRequest();
-      case 'GenerateMnemonic':
-        return $2.GenerateMnemonicRequest();
-      case 'SetSeedFromMnemonic':
-        return $2.SetSeedFromMnemonicRequest();
-      case 'CallRaw':
-        return $2.CallRawRequest();
-      case 'GetWalletAddresses':
-        return $2.GetWalletAddressesRequest();
-      case 'OpenapiSchema':
-        return $2.OpenapiSchemaRequest();
-      case 'CreateSwap':
-        return $2.CreateSwapRequest();
-      case 'ClaimSwap':
-        return $2.ClaimSwapRequest();
-      case 'GetSwapStatus':
-        return $2.GetSwapStatusRequest();
-      case 'ListSwaps':
-        return $2.ListSwapsRequest();
-      case 'ListSwapsByRecipient':
-        return $2.ListSwapsByRecipientRequest();
-      case 'UpdateSwapL1Txid':
-        return $2.UpdateSwapL1TxidRequest();
-      case 'ReconstructSwaps':
-        return $2.ReconstructSwapsRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return $2.GetBalanceRequest();
+      case 'GetBlockCount': return $2.GetBlockCountRequest();
+      case 'Stop': return $2.StopRequest();
+      case 'GetNewAddress': return $2.GetNewAddressRequest();
+      case 'Withdraw': return $2.WithdrawRequest();
+      case 'Transfer': return $2.TransferRequest();
+      case 'GetSidechainWealth': return $2.GetSidechainWealthRequest();
+      case 'CreateDeposit': return $2.CreateDepositRequest();
+      case 'GetPendingWithdrawalBundle': return $2.GetPendingWithdrawalBundleRequest();
+      case 'ConnectPeer': return $2.ConnectPeerRequest();
+      case 'ForgetPeer': return $2.ForgetPeerRequest();
+      case 'ListPeers': return $2.ListPeersRequest();
+      case 'Mine': return $2.MineRequest();
+      case 'GetBlock': return $2.GetBlockRequest();
+      case 'GetBestMainchainBlockHash': return $2.GetBestMainchainBlockHashRequest();
+      case 'GetBestSidechainBlockHash': return $2.GetBestSidechainBlockHashRequest();
+      case 'GetBmmInclusions': return $2.GetBmmInclusionsRequest();
+      case 'GetWalletUtxos': return $2.GetWalletUtxosRequest();
+      case 'ListUtxos': return $2.ListUtxosRequest();
+      case 'RemoveFromMempool': return $2.RemoveFromMempoolRequest();
+      case 'GetLatestFailedWithdrawalBundleHeight': return $2.GetLatestFailedWithdrawalBundleHeightRequest();
+      case 'GenerateMnemonic': return $2.GenerateMnemonicRequest();
+      case 'SetSeedFromMnemonic': return $2.SetSeedFromMnemonicRequest();
+      case 'CallRaw': return $2.CallRawRequest();
+      case 'GetWalletAddresses': return $2.GetWalletAddressesRequest();
+      case 'OpenapiSchema': return $2.OpenapiSchemaRequest();
+      case 'CreateSwap': return $2.CreateSwapRequest();
+      case 'ClaimSwap': return $2.ClaimSwapRequest();
+      case 'GetSwapStatus': return $2.GetSwapStatusRequest();
+      case 'ListSwaps': return $2.ListSwapsRequest();
+      case 'ListSwapsByRecipient': return $2.ListSwapsByRecipientRequest();
+      case 'UpdateSwapL1Txid': return $2.UpdateSwapL1TxidRequest();
+      case 'ReconstructSwaps': return $2.ReconstructSwapsRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetBalance':
-        return this.getBalance(ctx, request as $2.GetBalanceRequest);
-      case 'GetBlockCount':
-        return this.getBlockCount(ctx, request as $2.GetBlockCountRequest);
-      case 'Stop':
-        return this.stop(ctx, request as $2.StopRequest);
-      case 'GetNewAddress':
-        return this.getNewAddress(ctx, request as $2.GetNewAddressRequest);
-      case 'Withdraw':
-        return this.withdraw(ctx, request as $2.WithdrawRequest);
-      case 'Transfer':
-        return this.transfer(ctx, request as $2.TransferRequest);
-      case 'GetSidechainWealth':
-        return this.getSidechainWealth(ctx, request as $2.GetSidechainWealthRequest);
-      case 'CreateDeposit':
-        return this.createDeposit(ctx, request as $2.CreateDepositRequest);
-      case 'GetPendingWithdrawalBundle':
-        return this.getPendingWithdrawalBundle(ctx, request as $2.GetPendingWithdrawalBundleRequest);
-      case 'ConnectPeer':
-        return this.connectPeer(ctx, request as $2.ConnectPeerRequest);
-      case 'ForgetPeer':
-        return this.forgetPeer(ctx, request as $2.ForgetPeerRequest);
-      case 'ListPeers':
-        return this.listPeers(ctx, request as $2.ListPeersRequest);
-      case 'Mine':
-        return this.mine(ctx, request as $2.MineRequest);
-      case 'GetBlock':
-        return this.getBlock(ctx, request as $2.GetBlockRequest);
-      case 'GetBestMainchainBlockHash':
-        return this.getBestMainchainBlockHash(ctx, request as $2.GetBestMainchainBlockHashRequest);
-      case 'GetBestSidechainBlockHash':
-        return this.getBestSidechainBlockHash(ctx, request as $2.GetBestSidechainBlockHashRequest);
-      case 'GetBmmInclusions':
-        return this.getBmmInclusions(ctx, request as $2.GetBmmInclusionsRequest);
-      case 'GetWalletUtxos':
-        return this.getWalletUtxos(ctx, request as $2.GetWalletUtxosRequest);
-      case 'ListUtxos':
-        return this.listUtxos(ctx, request as $2.ListUtxosRequest);
-      case 'RemoveFromMempool':
-        return this.removeFromMempool(ctx, request as $2.RemoveFromMempoolRequest);
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return this
-            .getLatestFailedWithdrawalBundleHeight(ctx, request as $2.GetLatestFailedWithdrawalBundleHeightRequest);
-      case 'GenerateMnemonic':
-        return this.generateMnemonic(ctx, request as $2.GenerateMnemonicRequest);
-      case 'SetSeedFromMnemonic':
-        return this.setSeedFromMnemonic(ctx, request as $2.SetSeedFromMnemonicRequest);
-      case 'CallRaw':
-        return this.callRaw(ctx, request as $2.CallRawRequest);
-      case 'GetWalletAddresses':
-        return this.getWalletAddresses(ctx, request as $2.GetWalletAddressesRequest);
-      case 'OpenapiSchema':
-        return this.openapiSchema(ctx, request as $2.OpenapiSchemaRequest);
-      case 'CreateSwap':
-        return this.createSwap(ctx, request as $2.CreateSwapRequest);
-      case 'ClaimSwap':
-        return this.claimSwap(ctx, request as $2.ClaimSwapRequest);
-      case 'GetSwapStatus':
-        return this.getSwapStatus(ctx, request as $2.GetSwapStatusRequest);
-      case 'ListSwaps':
-        return this.listSwaps(ctx, request as $2.ListSwapsRequest);
-      case 'ListSwapsByRecipient':
-        return this.listSwapsByRecipient(ctx, request as $2.ListSwapsByRecipientRequest);
-      case 'UpdateSwapL1Txid':
-        return this.updateSwapL1Txid(ctx, request as $2.UpdateSwapL1TxidRequest);
-      case 'ReconstructSwaps':
-        return this.reconstructSwaps(ctx, request as $2.ReconstructSwapsRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return this.getBalance(ctx, request as $2.GetBalanceRequest);
+      case 'GetBlockCount': return this.getBlockCount(ctx, request as $2.GetBlockCountRequest);
+      case 'Stop': return this.stop(ctx, request as $2.StopRequest);
+      case 'GetNewAddress': return this.getNewAddress(ctx, request as $2.GetNewAddressRequest);
+      case 'Withdraw': return this.withdraw(ctx, request as $2.WithdrawRequest);
+      case 'Transfer': return this.transfer(ctx, request as $2.TransferRequest);
+      case 'GetSidechainWealth': return this.getSidechainWealth(ctx, request as $2.GetSidechainWealthRequest);
+      case 'CreateDeposit': return this.createDeposit(ctx, request as $2.CreateDepositRequest);
+      case 'GetPendingWithdrawalBundle': return this.getPendingWithdrawalBundle(ctx, request as $2.GetPendingWithdrawalBundleRequest);
+      case 'ConnectPeer': return this.connectPeer(ctx, request as $2.ConnectPeerRequest);
+      case 'ForgetPeer': return this.forgetPeer(ctx, request as $2.ForgetPeerRequest);
+      case 'ListPeers': return this.listPeers(ctx, request as $2.ListPeersRequest);
+      case 'Mine': return this.mine(ctx, request as $2.MineRequest);
+      case 'GetBlock': return this.getBlock(ctx, request as $2.GetBlockRequest);
+      case 'GetBestMainchainBlockHash': return this.getBestMainchainBlockHash(ctx, request as $2.GetBestMainchainBlockHashRequest);
+      case 'GetBestSidechainBlockHash': return this.getBestSidechainBlockHash(ctx, request as $2.GetBestSidechainBlockHashRequest);
+      case 'GetBmmInclusions': return this.getBmmInclusions(ctx, request as $2.GetBmmInclusionsRequest);
+      case 'GetWalletUtxos': return this.getWalletUtxos(ctx, request as $2.GetWalletUtxosRequest);
+      case 'ListUtxos': return this.listUtxos(ctx, request as $2.ListUtxosRequest);
+      case 'RemoveFromMempool': return this.removeFromMempool(ctx, request as $2.RemoveFromMempoolRequest);
+      case 'GetLatestFailedWithdrawalBundleHeight': return this.getLatestFailedWithdrawalBundleHeight(ctx, request as $2.GetLatestFailedWithdrawalBundleHeightRequest);
+      case 'GenerateMnemonic': return this.generateMnemonic(ctx, request as $2.GenerateMnemonicRequest);
+      case 'SetSeedFromMnemonic': return this.setSeedFromMnemonic(ctx, request as $2.SetSeedFromMnemonicRequest);
+      case 'CallRaw': return this.callRaw(ctx, request as $2.CallRawRequest);
+      case 'GetWalletAddresses': return this.getWalletAddresses(ctx, request as $2.GetWalletAddressesRequest);
+      case 'OpenapiSchema': return this.openapiSchema(ctx, request as $2.OpenapiSchemaRequest);
+      case 'CreateSwap': return this.createSwap(ctx, request as $2.CreateSwapRequest);
+      case 'ClaimSwap': return this.claimSwap(ctx, request as $2.ClaimSwapRequest);
+      case 'GetSwapStatus': return this.getSwapStatus(ctx, request as $2.GetSwapStatusRequest);
+      case 'ListSwaps': return this.listSwaps(ctx, request as $2.ListSwapsRequest);
+      case 'ListSwapsByRecipient': return this.listSwapsByRecipient(ctx, request as $2.ListSwapsByRecipientRequest);
+      case 'UpdateSwapL1Txid': return this.updateSwapL1Txid(ctx, request as $2.UpdateSwapL1TxidRequest);
+      case 'ReconstructSwaps': return this.reconstructSwaps(ctx, request as $2.ReconstructSwapsRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => CoinShiftServiceBase$json;
   $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => CoinShiftServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/google/protobuf/empty.pb.dart
+++ b/sail_ui/lib/gen/google/protobuf/empty.pb.dart
@@ -23,22 +23,22 @@ import 'package:protobuf/protobuf.dart' as $pb;
 class Empty extends $pb.GeneratedMessage {
   factory Empty() => create();
   Empty._() : super();
-  factory Empty.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Empty.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory Empty.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Empty.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Empty',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Empty', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   Empty clone() => Empty()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
   Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty)) as Empty;
 
   $pb.BuilderInfo get info_ => _i;
@@ -51,5 +51,6 @@ class Empty extends $pb.GeneratedMessage {
   static Empty getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Empty>(create);
   static Empty? _defaultInstance;
 }
+
 
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/google/protobuf/empty.pbenum.dart
+++ b/sail_ui/lib/gen/google/protobuf/empty.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/google/protobuf/empty.pbjson.dart
+++ b/sail_ui/lib/gen/google/protobuf/empty.pbjson.dart
@@ -19,4 +19,6 @@ const Empty$json = {
 };
 
 /// Descriptor for `Empty`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List emptyDescriptor = $convert.base64Decode('CgVFbXB0eQ==');
+final $typed_data.Uint8List emptyDescriptor = $convert.base64Decode(
+    'CgVFbXB0eQ==');
+

--- a/sail_ui/lib/gen/google/protobuf/empty.pbserver.dart
+++ b/sail_ui/lib/gen/google/protobuf/empty.pbserver.dart
@@ -11,3 +11,4 @@
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 export 'empty.pb.dart';
+

--- a/sail_ui/lib/gen/orchestrator/v1/bitcoin_conf.connect.client.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/bitcoin_conf.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "bitcoin_conf.pb.dart" as orchestratorv1bitcoin_conf;
 import "bitcoin_conf.connect.spec.dart" as specs;
 
-extension type BitcoinConfServiceClient(connect.Transport _transport) {
+extension type BitcoinConfServiceClient (connect.Transport _transport) {
   /// Get current Bitcoin Core configuration state.
   Future<orchestratorv1bitcoin_conf.GetBitcoinConfigResponse> getBitcoinConfig(
     orchestratorv1bitcoin_conf.GetBitcoinConfigRequest input, {

--- a/sail_ui/lib/gen/orchestrator/v1/bitcoin_conf.pb.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/bitcoin_conf.pb.dart
@@ -17,25 +17,23 @@ import 'package:protobuf/protobuf.dart' as $pb;
 class GetBitcoinConfigRequest extends $pb.GeneratedMessage {
   factory GetBitcoinConfigRequest() => create();
   GetBitcoinConfigRequest._() : super();
-  factory GetBitcoinConfigRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBitcoinConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBitcoinConfigRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBitcoinConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitcoinConfigRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitcoinConfigRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBitcoinConfigRequest clone() => GetBitcoinConfigRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBitcoinConfigRequest copyWith(void Function(GetBitcoinConfigRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBitcoinConfigRequest)) as GetBitcoinConfigRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBitcoinConfigRequest copyWith(void Function(GetBitcoinConfigRequest) updates) => super.copyWith((message) => updates(message as GetBitcoinConfigRequest)) as GetBitcoinConfigRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -44,8 +42,7 @@ class GetBitcoinConfigRequest extends $pb.GeneratedMessage {
   GetBitcoinConfigRequest createEmptyInstance() => create();
   static $pb.PbList<GetBitcoinConfigRequest> createRepeated() => $pb.PbList<GetBitcoinConfigRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBitcoinConfigRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitcoinConfigRequest>(create);
+  static GetBitcoinConfigRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitcoinConfigRequest>(create);
   static GetBitcoinConfigRequest? _defaultInstance;
 }
 
@@ -96,14 +93,10 @@ class GetBitcoinConfigResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBitcoinConfigResponse._() : super();
-  factory GetBitcoinConfigResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBitcoinConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBitcoinConfigResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBitcoinConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitcoinConfigResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBitcoinConfigResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'network')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'rpcPort', $pb.PbFieldType.O3)
     ..aOB(3, _omitFieldNames ? '' : 'hasPrivateConf')
@@ -114,17 +107,19 @@ class GetBitcoinConfigResponse extends $pb.GeneratedMessage {
     ..aOB(8, _omitFieldNames ? '' : 'isDemoMode')
     ..aOS(9, _omitFieldNames ? '' : 'rpcUser')
     ..aOS(10, _omitFieldNames ? '' : 'rpcPassword')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBitcoinConfigResponse clone() => GetBitcoinConfigResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBitcoinConfigResponse copyWith(void Function(GetBitcoinConfigResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBitcoinConfigResponse)) as GetBitcoinConfigResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBitcoinConfigResponse copyWith(void Function(GetBitcoinConfigResponse) updates) => super.copyWith((message) => updates(message as GetBitcoinConfigResponse)) as GetBitcoinConfigResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -133,17 +128,13 @@ class GetBitcoinConfigResponse extends $pb.GeneratedMessage {
   GetBitcoinConfigResponse createEmptyInstance() => create();
   static $pb.PbList<GetBitcoinConfigResponse> createRepeated() => $pb.PbList<GetBitcoinConfigResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBitcoinConfigResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitcoinConfigResponse>(create);
+  static GetBitcoinConfigResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBitcoinConfigResponse>(create);
   static GetBitcoinConfigResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get network => $_getSZ(0);
   @$pb.TagNumber(1)
-  set network($core.String v) {
-    $_setString(0, v);
-  }
-
+  set network($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasNetwork() => $_has(0);
   @$pb.TagNumber(1)
@@ -152,10 +143,7 @@ class GetBitcoinConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get rpcPort => $_getIZ(1);
   @$pb.TagNumber(2)
-  set rpcPort($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set rpcPort($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasRpcPort() => $_has(1);
   @$pb.TagNumber(2)
@@ -164,10 +152,7 @@ class GetBitcoinConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get hasPrivateConf => $_getBF(2);
   @$pb.TagNumber(3)
-  set hasPrivateConf($core.bool v) {
-    $_setBool(2, v);
-  }
-
+  set hasPrivateConf($core.bool v) { $_setBool(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasHasPrivateConf() => $_has(2);
   @$pb.TagNumber(3)
@@ -176,10 +161,7 @@ class GetBitcoinConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get configPath => $_getSZ(3);
   @$pb.TagNumber(4)
-  set configPath($core.String v) {
-    $_setString(3, v);
-  }
-
+  set configPath($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasConfigPath() => $_has(3);
   @$pb.TagNumber(4)
@@ -188,10 +170,7 @@ class GetBitcoinConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get detectedDataDir => $_getSZ(4);
   @$pb.TagNumber(5)
-  set detectedDataDir($core.String v) {
-    $_setString(4, v);
-  }
-
+  set detectedDataDir($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasDetectedDataDir() => $_has(4);
   @$pb.TagNumber(5)
@@ -200,10 +179,7 @@ class GetBitcoinConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get configContent => $_getSZ(5);
   @$pb.TagNumber(6)
-  set configContent($core.String v) {
-    $_setString(5, v);
-  }
-
+  set configContent($core.String v) { $_setString(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasConfigContent() => $_has(5);
   @$pb.TagNumber(6)
@@ -212,10 +188,7 @@ class GetBitcoinConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.bool get networkSupportsSidechains => $_getBF(6);
   @$pb.TagNumber(7)
-  set networkSupportsSidechains($core.bool v) {
-    $_setBool(6, v);
-  }
-
+  set networkSupportsSidechains($core.bool v) { $_setBool(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasNetworkSupportsSidechains() => $_has(6);
   @$pb.TagNumber(7)
@@ -224,10 +197,7 @@ class GetBitcoinConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.bool get isDemoMode => $_getBF(7);
   @$pb.TagNumber(8)
-  set isDemoMode($core.bool v) {
-    $_setBool(7, v);
-  }
-
+  set isDemoMode($core.bool v) { $_setBool(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasIsDemoMode() => $_has(7);
   @$pb.TagNumber(8)
@@ -239,10 +209,7 @@ class GetBitcoinConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.String get rpcUser => $_getSZ(8);
   @$pb.TagNumber(9)
-  set rpcUser($core.String v) {
-    $_setString(8, v);
-  }
-
+  set rpcUser($core.String v) { $_setString(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasRpcUser() => $_has(8);
   @$pb.TagNumber(9)
@@ -251,10 +218,7 @@ class GetBitcoinConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.String get rpcPassword => $_getSZ(9);
   @$pb.TagNumber(10)
-  set rpcPassword($core.String v) {
-    $_setString(9, v);
-  }
-
+  set rpcPassword($core.String v) { $_setString(9, v); }
   @$pb.TagNumber(10)
   $core.bool hasRpcPassword() => $_has(9);
   @$pb.TagNumber(10)
@@ -272,27 +236,24 @@ class SetBitcoinConfigNetworkRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SetBitcoinConfigNetworkRequest._() : super();
-  factory SetBitcoinConfigNetworkRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetBitcoinConfigNetworkRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetBitcoinConfigNetworkRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetBitcoinConfigNetworkRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetBitcoinConfigNetworkRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetBitcoinConfigNetworkRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'network')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetBitcoinConfigNetworkRequest clone() => SetBitcoinConfigNetworkRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetBitcoinConfigNetworkRequest copyWith(void Function(SetBitcoinConfigNetworkRequest) updates) =>
-      super.copyWith((message) => updates(message as SetBitcoinConfigNetworkRequest)) as SetBitcoinConfigNetworkRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetBitcoinConfigNetworkRequest copyWith(void Function(SetBitcoinConfigNetworkRequest) updates) => super.copyWith((message) => updates(message as SetBitcoinConfigNetworkRequest)) as SetBitcoinConfigNetworkRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -301,17 +262,13 @@ class SetBitcoinConfigNetworkRequest extends $pb.GeneratedMessage {
   SetBitcoinConfigNetworkRequest createEmptyInstance() => create();
   static $pb.PbList<SetBitcoinConfigNetworkRequest> createRepeated() => $pb.PbList<SetBitcoinConfigNetworkRequest>();
   @$core.pragma('dart2js:noInline')
-  static SetBitcoinConfigNetworkRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetBitcoinConfigNetworkRequest>(create);
+  static SetBitcoinConfigNetworkRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetBitcoinConfigNetworkRequest>(create);
   static SetBitcoinConfigNetworkRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get network => $_getSZ(0);
   @$pb.TagNumber(1)
-  set network($core.String v) {
-    $_setString(0, v);
-  }
-
+  set network($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasNetwork() => $_has(0);
   @$pb.TagNumber(1)
@@ -321,27 +278,23 @@ class SetBitcoinConfigNetworkRequest extends $pb.GeneratedMessage {
 class SetBitcoinConfigNetworkResponse extends $pb.GeneratedMessage {
   factory SetBitcoinConfigNetworkResponse() => create();
   SetBitcoinConfigNetworkResponse._() : super();
-  factory SetBitcoinConfigNetworkResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetBitcoinConfigNetworkResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetBitcoinConfigNetworkResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetBitcoinConfigNetworkResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetBitcoinConfigNetworkResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetBitcoinConfigNetworkResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetBitcoinConfigNetworkResponse clone() => SetBitcoinConfigNetworkResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetBitcoinConfigNetworkResponse copyWith(void Function(SetBitcoinConfigNetworkResponse) updates) =>
-      super.copyWith((message) => updates(message as SetBitcoinConfigNetworkResponse))
-          as SetBitcoinConfigNetworkResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetBitcoinConfigNetworkResponse copyWith(void Function(SetBitcoinConfigNetworkResponse) updates) => super.copyWith((message) => updates(message as SetBitcoinConfigNetworkResponse)) as SetBitcoinConfigNetworkResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -350,8 +303,7 @@ class SetBitcoinConfigNetworkResponse extends $pb.GeneratedMessage {
   SetBitcoinConfigNetworkResponse createEmptyInstance() => create();
   static $pb.PbList<SetBitcoinConfigNetworkResponse> createRepeated() => $pb.PbList<SetBitcoinConfigNetworkResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetBitcoinConfigNetworkResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetBitcoinConfigNetworkResponse>(create);
+  static SetBitcoinConfigNetworkResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetBitcoinConfigNetworkResponse>(create);
   static SetBitcoinConfigNetworkResponse? _defaultInstance;
 }
 
@@ -370,28 +322,25 @@ class SetBitcoinConfigDataDirRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SetBitcoinConfigDataDirRequest._() : super();
-  factory SetBitcoinConfigDataDirRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetBitcoinConfigDataDirRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetBitcoinConfigDataDirRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetBitcoinConfigDataDirRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetBitcoinConfigDataDirRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetBitcoinConfigDataDirRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'dataDir')
     ..aOS(2, _omitFieldNames ? '' : 'network')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetBitcoinConfigDataDirRequest clone() => SetBitcoinConfigDataDirRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetBitcoinConfigDataDirRequest copyWith(void Function(SetBitcoinConfigDataDirRequest) updates) =>
-      super.copyWith((message) => updates(message as SetBitcoinConfigDataDirRequest)) as SetBitcoinConfigDataDirRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetBitcoinConfigDataDirRequest copyWith(void Function(SetBitcoinConfigDataDirRequest) updates) => super.copyWith((message) => updates(message as SetBitcoinConfigDataDirRequest)) as SetBitcoinConfigDataDirRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -400,17 +349,13 @@ class SetBitcoinConfigDataDirRequest extends $pb.GeneratedMessage {
   SetBitcoinConfigDataDirRequest createEmptyInstance() => create();
   static $pb.PbList<SetBitcoinConfigDataDirRequest> createRepeated() => $pb.PbList<SetBitcoinConfigDataDirRequest>();
   @$core.pragma('dart2js:noInline')
-  static SetBitcoinConfigDataDirRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetBitcoinConfigDataDirRequest>(create);
+  static SetBitcoinConfigDataDirRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetBitcoinConfigDataDirRequest>(create);
   static SetBitcoinConfigDataDirRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get dataDir => $_getSZ(0);
   @$pb.TagNumber(1)
-  set dataDir($core.String v) {
-    $_setString(0, v);
-  }
-
+  set dataDir($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDataDir() => $_has(0);
   @$pb.TagNumber(1)
@@ -419,10 +364,7 @@ class SetBitcoinConfigDataDirRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get network => $_getSZ(1);
   @$pb.TagNumber(2)
-  set network($core.String v) {
-    $_setString(1, v);
-  }
-
+  set network($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasNetwork() => $_has(1);
   @$pb.TagNumber(2)
@@ -432,27 +374,23 @@ class SetBitcoinConfigDataDirRequest extends $pb.GeneratedMessage {
 class SetBitcoinConfigDataDirResponse extends $pb.GeneratedMessage {
   factory SetBitcoinConfigDataDirResponse() => create();
   SetBitcoinConfigDataDirResponse._() : super();
-  factory SetBitcoinConfigDataDirResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetBitcoinConfigDataDirResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetBitcoinConfigDataDirResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetBitcoinConfigDataDirResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetBitcoinConfigDataDirResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetBitcoinConfigDataDirResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetBitcoinConfigDataDirResponse clone() => SetBitcoinConfigDataDirResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetBitcoinConfigDataDirResponse copyWith(void Function(SetBitcoinConfigDataDirResponse) updates) =>
-      super.copyWith((message) => updates(message as SetBitcoinConfigDataDirResponse))
-          as SetBitcoinConfigDataDirResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetBitcoinConfigDataDirResponse copyWith(void Function(SetBitcoinConfigDataDirResponse) updates) => super.copyWith((message) => updates(message as SetBitcoinConfigDataDirResponse)) as SetBitcoinConfigDataDirResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -461,8 +399,7 @@ class SetBitcoinConfigDataDirResponse extends $pb.GeneratedMessage {
   SetBitcoinConfigDataDirResponse createEmptyInstance() => create();
   static $pb.PbList<SetBitcoinConfigDataDirResponse> createRepeated() => $pb.PbList<SetBitcoinConfigDataDirResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetBitcoinConfigDataDirResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetBitcoinConfigDataDirResponse>(create);
+  static SetBitcoinConfigDataDirResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetBitcoinConfigDataDirResponse>(create);
   static SetBitcoinConfigDataDirResponse? _defaultInstance;
 }
 
@@ -477,26 +414,24 @@ class WriteBitcoinConfigRequest extends $pb.GeneratedMessage {
     return $result;
   }
   WriteBitcoinConfigRequest._() : super();
-  factory WriteBitcoinConfigRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteBitcoinConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WriteBitcoinConfigRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WriteBitcoinConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteBitcoinConfigRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteBitcoinConfigRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'configContent')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WriteBitcoinConfigRequest clone() => WriteBitcoinConfigRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WriteBitcoinConfigRequest copyWith(void Function(WriteBitcoinConfigRequest) updates) =>
-      super.copyWith((message) => updates(message as WriteBitcoinConfigRequest)) as WriteBitcoinConfigRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WriteBitcoinConfigRequest copyWith(void Function(WriteBitcoinConfigRequest) updates) => super.copyWith((message) => updates(message as WriteBitcoinConfigRequest)) as WriteBitcoinConfigRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -505,17 +440,13 @@ class WriteBitcoinConfigRequest extends $pb.GeneratedMessage {
   WriteBitcoinConfigRequest createEmptyInstance() => create();
   static $pb.PbList<WriteBitcoinConfigRequest> createRepeated() => $pb.PbList<WriteBitcoinConfigRequest>();
   @$core.pragma('dart2js:noInline')
-  static WriteBitcoinConfigRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteBitcoinConfigRequest>(create);
+  static WriteBitcoinConfigRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteBitcoinConfigRequest>(create);
   static WriteBitcoinConfigRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get configContent => $_getSZ(0);
   @$pb.TagNumber(1)
-  set configContent($core.String v) {
-    $_setString(0, v);
-  }
-
+  set configContent($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasConfigContent() => $_has(0);
   @$pb.TagNumber(1)
@@ -525,26 +456,23 @@ class WriteBitcoinConfigRequest extends $pb.GeneratedMessage {
 class WriteBitcoinConfigResponse extends $pb.GeneratedMessage {
   factory WriteBitcoinConfigResponse() => create();
   WriteBitcoinConfigResponse._() : super();
-  factory WriteBitcoinConfigResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteBitcoinConfigResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WriteBitcoinConfigResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WriteBitcoinConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteBitcoinConfigResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteBitcoinConfigResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WriteBitcoinConfigResponse clone() => WriteBitcoinConfigResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WriteBitcoinConfigResponse copyWith(void Function(WriteBitcoinConfigResponse) updates) =>
-      super.copyWith((message) => updates(message as WriteBitcoinConfigResponse)) as WriteBitcoinConfigResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WriteBitcoinConfigResponse copyWith(void Function(WriteBitcoinConfigResponse) updates) => super.copyWith((message) => updates(message as WriteBitcoinConfigResponse)) as WriteBitcoinConfigResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -553,8 +481,7 @@ class WriteBitcoinConfigResponse extends $pb.GeneratedMessage {
   WriteBitcoinConfigResponse createEmptyInstance() => create();
   static $pb.PbList<WriteBitcoinConfigResponse> createRepeated() => $pb.PbList<WriteBitcoinConfigResponse>();
   @$core.pragma('dart2js:noInline')
-  static WriteBitcoinConfigResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteBitcoinConfigResponse>(create);
+  static WriteBitcoinConfigResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteBitcoinConfigResponse>(create);
   static WriteBitcoinConfigResponse? _defaultInstance;
 }
 
@@ -563,21 +490,19 @@ class BitcoinConfServiceApi {
   BitcoinConfServiceApi(this._client);
 
   $async.Future<GetBitcoinConfigResponse> getBitcoinConfig($pb.ClientContext? ctx, GetBitcoinConfigRequest request) =>
-      _client.invoke<GetBitcoinConfigResponse>(
-          ctx, 'BitcoinConfService', 'GetBitcoinConfig', request, GetBitcoinConfigResponse());
-  $async.Future<SetBitcoinConfigNetworkResponse> setBitcoinConfigNetwork(
-          $pb.ClientContext? ctx, SetBitcoinConfigNetworkRequest request) =>
-      _client.invoke<SetBitcoinConfigNetworkResponse>(
-          ctx, 'BitcoinConfService', 'SetBitcoinConfigNetwork', request, SetBitcoinConfigNetworkResponse());
-  $async.Future<SetBitcoinConfigDataDirResponse> setBitcoinConfigDataDir(
-          $pb.ClientContext? ctx, SetBitcoinConfigDataDirRequest request) =>
-      _client.invoke<SetBitcoinConfigDataDirResponse>(
-          ctx, 'BitcoinConfService', 'SetBitcoinConfigDataDir', request, SetBitcoinConfigDataDirResponse());
-  $async.Future<WriteBitcoinConfigResponse> writeBitcoinConfig(
-          $pb.ClientContext? ctx, WriteBitcoinConfigRequest request) =>
-      _client.invoke<WriteBitcoinConfigResponse>(
-          ctx, 'BitcoinConfService', 'WriteBitcoinConfig', request, WriteBitcoinConfigResponse());
+    _client.invoke<GetBitcoinConfigResponse>(ctx, 'BitcoinConfService', 'GetBitcoinConfig', request, GetBitcoinConfigResponse())
+  ;
+  $async.Future<SetBitcoinConfigNetworkResponse> setBitcoinConfigNetwork($pb.ClientContext? ctx, SetBitcoinConfigNetworkRequest request) =>
+    _client.invoke<SetBitcoinConfigNetworkResponse>(ctx, 'BitcoinConfService', 'SetBitcoinConfigNetwork', request, SetBitcoinConfigNetworkResponse())
+  ;
+  $async.Future<SetBitcoinConfigDataDirResponse> setBitcoinConfigDataDir($pb.ClientContext? ctx, SetBitcoinConfigDataDirRequest request) =>
+    _client.invoke<SetBitcoinConfigDataDirResponse>(ctx, 'BitcoinConfService', 'SetBitcoinConfigDataDir', request, SetBitcoinConfigDataDirResponse())
+  ;
+  $async.Future<WriteBitcoinConfigResponse> writeBitcoinConfig($pb.ClientContext? ctx, WriteBitcoinConfigRequest request) =>
+    _client.invoke<WriteBitcoinConfigResponse>(ctx, 'BitcoinConfService', 'WriteBitcoinConfig', request, WriteBitcoinConfigResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/orchestrator/v1/bitcoin_conf.pbenum.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/bitcoin_conf.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/orchestrator/v1/bitcoin_conf.pbjson.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/bitcoin_conf.pbjson.dart
@@ -19,8 +19,8 @@ const GetBitcoinConfigRequest$json = {
 };
 
 /// Descriptor for `GetBitcoinConfigRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBitcoinConfigRequestDescriptor =
-    $convert.base64Decode('ChdHZXRCaXRjb2luQ29uZmlnUmVxdWVzdA==');
+final $typed_data.Uint8List getBitcoinConfigRequestDescriptor = $convert.base64Decode(
+    'ChdHZXRCaXRjb2luQ29uZmlnUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBitcoinConfigResponseDescriptor instead')
 const GetBitcoinConfigResponse$json = {
@@ -40,15 +40,15 @@ const GetBitcoinConfigResponse$json = {
 };
 
 /// Descriptor for `GetBitcoinConfigResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBitcoinConfigResponseDescriptor =
-    $convert.base64Decode('ChhHZXRCaXRjb2luQ29uZmlnUmVzcG9uc2USGAoHbmV0d29yaxgBIAEoCVIHbmV0d29yaxIZCg'
-        'hycGNfcG9ydBgCIAEoBVIHcnBjUG9ydBIoChBoYXNfcHJpdmF0ZV9jb25mGAMgASgIUg5oYXNQ'
-        'cml2YXRlQ29uZhIfCgtjb25maWdfcGF0aBgEIAEoCVIKY29uZmlnUGF0aBIqChFkZXRlY3RlZF'
-        '9kYXRhX2RpchgFIAEoCVIPZGV0ZWN0ZWREYXRhRGlyEiUKDmNvbmZpZ19jb250ZW50GAYgASgJ'
-        'Ug1jb25maWdDb250ZW50Ej4KG25ldHdvcmtfc3VwcG9ydHNfc2lkZWNoYWlucxgHIAEoCFIZbm'
-        'V0d29ya1N1cHBvcnRzU2lkZWNoYWlucxIgCgxpc19kZW1vX21vZGUYCCABKAhSCmlzRGVtb01v'
-        'ZGUSGQoIcnBjX3VzZXIYCSABKAlSB3JwY1VzZXISIQoMcnBjX3Bhc3N3b3JkGAogASgJUgtycG'
-        'NQYXNzd29yZA==');
+final $typed_data.Uint8List getBitcoinConfigResponseDescriptor = $convert.base64Decode(
+    'ChhHZXRCaXRjb2luQ29uZmlnUmVzcG9uc2USGAoHbmV0d29yaxgBIAEoCVIHbmV0d29yaxIZCg'
+    'hycGNfcG9ydBgCIAEoBVIHcnBjUG9ydBIoChBoYXNfcHJpdmF0ZV9jb25mGAMgASgIUg5oYXNQ'
+    'cml2YXRlQ29uZhIfCgtjb25maWdfcGF0aBgEIAEoCVIKY29uZmlnUGF0aBIqChFkZXRlY3RlZF'
+    '9kYXRhX2RpchgFIAEoCVIPZGV0ZWN0ZWREYXRhRGlyEiUKDmNvbmZpZ19jb250ZW50GAYgASgJ'
+    'Ug1jb25maWdDb250ZW50Ej4KG25ldHdvcmtfc3VwcG9ydHNfc2lkZWNoYWlucxgHIAEoCFIZbm'
+    'V0d29ya1N1cHBvcnRzU2lkZWNoYWlucxIgCgxpc19kZW1vX21vZGUYCCABKAhSCmlzRGVtb01v'
+    'ZGUSGQoIcnBjX3VzZXIYCSABKAlSB3JwY1VzZXISIQoMcnBjX3Bhc3N3b3JkGAogASgJUgtycG'
+    'NQYXNzd29yZA==');
 
 @$core.Deprecated('Use setBitcoinConfigNetworkRequestDescriptor instead')
 const SetBitcoinConfigNetworkRequest$json = {
@@ -59,9 +59,9 @@ const SetBitcoinConfigNetworkRequest$json = {
 };
 
 /// Descriptor for `SetBitcoinConfigNetworkRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setBitcoinConfigNetworkRequestDescriptor =
-    $convert.base64Decode('Ch5TZXRCaXRjb2luQ29uZmlnTmV0d29ya1JlcXVlc3QSGAoHbmV0d29yaxgBIAEoCVIHbmV0d2'
-        '9yaw==');
+final $typed_data.Uint8List setBitcoinConfigNetworkRequestDescriptor = $convert.base64Decode(
+    'Ch5TZXRCaXRjb2luQ29uZmlnTmV0d29ya1JlcXVlc3QSGAoHbmV0d29yaxgBIAEoCVIHbmV0d2'
+    '9yaw==');
 
 @$core.Deprecated('Use setBitcoinConfigNetworkResponseDescriptor instead')
 const SetBitcoinConfigNetworkResponse$json = {
@@ -69,8 +69,8 @@ const SetBitcoinConfigNetworkResponse$json = {
 };
 
 /// Descriptor for `SetBitcoinConfigNetworkResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setBitcoinConfigNetworkResponseDescriptor =
-    $convert.base64Decode('Ch9TZXRCaXRjb2luQ29uZmlnTmV0d29ya1Jlc3BvbnNl');
+final $typed_data.Uint8List setBitcoinConfigNetworkResponseDescriptor = $convert.base64Decode(
+    'Ch9TZXRCaXRjb2luQ29uZmlnTmV0d29ya1Jlc3BvbnNl');
 
 @$core.Deprecated('Use setBitcoinConfigDataDirRequestDescriptor instead')
 const SetBitcoinConfigDataDirRequest$json = {
@@ -82,9 +82,9 @@ const SetBitcoinConfigDataDirRequest$json = {
 };
 
 /// Descriptor for `SetBitcoinConfigDataDirRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setBitcoinConfigDataDirRequestDescriptor =
-    $convert.base64Decode('Ch5TZXRCaXRjb2luQ29uZmlnRGF0YURpclJlcXVlc3QSGQoIZGF0YV9kaXIYASABKAlSB2RhdG'
-        'FEaXISGAoHbmV0d29yaxgCIAEoCVIHbmV0d29yaw==');
+final $typed_data.Uint8List setBitcoinConfigDataDirRequestDescriptor = $convert.base64Decode(
+    'Ch5TZXRCaXRjb2luQ29uZmlnRGF0YURpclJlcXVlc3QSGQoIZGF0YV9kaXIYASABKAlSB2RhdG'
+    'FEaXISGAoHbmV0d29yaxgCIAEoCVIHbmV0d29yaw==');
 
 @$core.Deprecated('Use setBitcoinConfigDataDirResponseDescriptor instead')
 const SetBitcoinConfigDataDirResponse$json = {
@@ -92,8 +92,8 @@ const SetBitcoinConfigDataDirResponse$json = {
 };
 
 /// Descriptor for `SetBitcoinConfigDataDirResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setBitcoinConfigDataDirResponseDescriptor =
-    $convert.base64Decode('Ch9TZXRCaXRjb2luQ29uZmlnRGF0YURpclJlc3BvbnNl');
+final $typed_data.Uint8List setBitcoinConfigDataDirResponseDescriptor = $convert.base64Decode(
+    'Ch9TZXRCaXRjb2luQ29uZmlnRGF0YURpclJlc3BvbnNl');
 
 @$core.Deprecated('Use writeBitcoinConfigRequestDescriptor instead')
 const WriteBitcoinConfigRequest$json = {
@@ -104,9 +104,9 @@ const WriteBitcoinConfigRequest$json = {
 };
 
 /// Descriptor for `WriteBitcoinConfigRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List writeBitcoinConfigRequestDescriptor =
-    $convert.base64Decode('ChlXcml0ZUJpdGNvaW5Db25maWdSZXF1ZXN0EiUKDmNvbmZpZ19jb250ZW50GAEgASgJUg1jb2'
-        '5maWdDb250ZW50');
+final $typed_data.Uint8List writeBitcoinConfigRequestDescriptor = $convert.base64Decode(
+    'ChlXcml0ZUJpdGNvaW5Db25maWdSZXF1ZXN0EiUKDmNvbmZpZ19jb250ZW50GAEgASgJUg1jb2'
+    '5maWdDb250ZW50');
 
 @$core.Deprecated('Use writeBitcoinConfigResponseDescriptor instead')
 const WriteBitcoinConfigResponse$json = {
@@ -114,32 +114,16 @@ const WriteBitcoinConfigResponse$json = {
 };
 
 /// Descriptor for `WriteBitcoinConfigResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List writeBitcoinConfigResponseDescriptor =
-    $convert.base64Decode('ChpXcml0ZUJpdGNvaW5Db25maWdSZXNwb25zZQ==');
+final $typed_data.Uint8List writeBitcoinConfigResponseDescriptor = $convert.base64Decode(
+    'ChpXcml0ZUJpdGNvaW5Db25maWdSZXNwb25zZQ==');
 
 const $core.Map<$core.String, $core.dynamic> BitcoinConfServiceBase$json = {
   '1': 'BitcoinConfService',
   '2': [
-    {
-      '1': 'GetBitcoinConfig',
-      '2': '.orchestrator.v1.GetBitcoinConfigRequest',
-      '3': '.orchestrator.v1.GetBitcoinConfigResponse'
-    },
-    {
-      '1': 'SetBitcoinConfigNetwork',
-      '2': '.orchestrator.v1.SetBitcoinConfigNetworkRequest',
-      '3': '.orchestrator.v1.SetBitcoinConfigNetworkResponse'
-    },
-    {
-      '1': 'SetBitcoinConfigDataDir',
-      '2': '.orchestrator.v1.SetBitcoinConfigDataDirRequest',
-      '3': '.orchestrator.v1.SetBitcoinConfigDataDirResponse'
-    },
-    {
-      '1': 'WriteBitcoinConfig',
-      '2': '.orchestrator.v1.WriteBitcoinConfigRequest',
-      '3': '.orchestrator.v1.WriteBitcoinConfigResponse'
-    },
+    {'1': 'GetBitcoinConfig', '2': '.orchestrator.v1.GetBitcoinConfigRequest', '3': '.orchestrator.v1.GetBitcoinConfigResponse'},
+    {'1': 'SetBitcoinConfigNetwork', '2': '.orchestrator.v1.SetBitcoinConfigNetworkRequest', '3': '.orchestrator.v1.SetBitcoinConfigNetworkResponse'},
+    {'1': 'SetBitcoinConfigDataDir', '2': '.orchestrator.v1.SetBitcoinConfigDataDirRequest', '3': '.orchestrator.v1.SetBitcoinConfigDataDirResponse'},
+    {'1': 'WriteBitcoinConfig', '2': '.orchestrator.v1.WriteBitcoinConfigRequest', '3': '.orchestrator.v1.WriteBitcoinConfigResponse'},
   ],
 };
 
@@ -156,13 +140,14 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> BitcoinCon
 };
 
 /// Descriptor for `BitcoinConfService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List bitcoinConfServiceDescriptor =
-    $convert.base64Decode('ChJCaXRjb2luQ29uZlNlcnZpY2USZwoQR2V0Qml0Y29pbkNvbmZpZxIoLm9yY2hlc3RyYXRvci'
-        '52MS5HZXRCaXRjb2luQ29uZmlnUmVxdWVzdBopLm9yY2hlc3RyYXRvci52MS5HZXRCaXRjb2lu'
-        'Q29uZmlnUmVzcG9uc2USfAoXU2V0Qml0Y29pbkNvbmZpZ05ldHdvcmsSLy5vcmNoZXN0cmF0b3'
-        'IudjEuU2V0Qml0Y29pbkNvbmZpZ05ldHdvcmtSZXF1ZXN0GjAub3JjaGVzdHJhdG9yLnYxLlNl'
-        'dEJpdGNvaW5Db25maWdOZXR3b3JrUmVzcG9uc2USfAoXU2V0Qml0Y29pbkNvbmZpZ0RhdGFEaX'
-        'ISLy5vcmNoZXN0cmF0b3IudjEuU2V0Qml0Y29pbkNvbmZpZ0RhdGFEaXJSZXF1ZXN0GjAub3Jj'
-        'aGVzdHJhdG9yLnYxLlNldEJpdGNvaW5Db25maWdEYXRhRGlyUmVzcG9uc2USbQoSV3JpdGVCaX'
-        'Rjb2luQ29uZmlnEioub3JjaGVzdHJhdG9yLnYxLldyaXRlQml0Y29pbkNvbmZpZ1JlcXVlc3Qa'
-        'Ky5vcmNoZXN0cmF0b3IudjEuV3JpdGVCaXRjb2luQ29uZmlnUmVzcG9uc2U=');
+final $typed_data.Uint8List bitcoinConfServiceDescriptor = $convert.base64Decode(
+    'ChJCaXRjb2luQ29uZlNlcnZpY2USZwoQR2V0Qml0Y29pbkNvbmZpZxIoLm9yY2hlc3RyYXRvci'
+    '52MS5HZXRCaXRjb2luQ29uZmlnUmVxdWVzdBopLm9yY2hlc3RyYXRvci52MS5HZXRCaXRjb2lu'
+    'Q29uZmlnUmVzcG9uc2USfAoXU2V0Qml0Y29pbkNvbmZpZ05ldHdvcmsSLy5vcmNoZXN0cmF0b3'
+    'IudjEuU2V0Qml0Y29pbkNvbmZpZ05ldHdvcmtSZXF1ZXN0GjAub3JjaGVzdHJhdG9yLnYxLlNl'
+    'dEJpdGNvaW5Db25maWdOZXR3b3JrUmVzcG9uc2USfAoXU2V0Qml0Y29pbkNvbmZpZ0RhdGFEaX'
+    'ISLy5vcmNoZXN0cmF0b3IudjEuU2V0Qml0Y29pbkNvbmZpZ0RhdGFEaXJSZXF1ZXN0GjAub3Jj'
+    'aGVzdHJhdG9yLnYxLlNldEJpdGNvaW5Db25maWdEYXRhRGlyUmVzcG9uc2USbQoSV3JpdGVCaX'
+    'Rjb2luQ29uZmlnEioub3JjaGVzdHJhdG9yLnYxLldyaXRlQml0Y29pbkNvbmZpZ1JlcXVlc3Qa'
+    'Ky5vcmNoZXN0cmF0b3IudjEuV3JpdGVCaXRjb2luQ29uZmlnUmVzcG9uc2U=');
+

--- a/sail_ui/lib/gen/orchestrator/v1/bitcoin_conf.pbserver.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/bitcoin_conf.pbserver.dart
@@ -21,47 +21,32 @@ import 'bitcoin_conf.pbjson.dart';
 export 'bitcoin_conf.pb.dart';
 
 abstract class BitcoinConfServiceBase extends $pb.GeneratedService {
-  $async.Future<$3.GetBitcoinConfigResponse> getBitcoinConfig(
-      $pb.ServerContext ctx, $3.GetBitcoinConfigRequest request);
-  $async.Future<$3.SetBitcoinConfigNetworkResponse> setBitcoinConfigNetwork(
-      $pb.ServerContext ctx, $3.SetBitcoinConfigNetworkRequest request);
-  $async.Future<$3.SetBitcoinConfigDataDirResponse> setBitcoinConfigDataDir(
-      $pb.ServerContext ctx, $3.SetBitcoinConfigDataDirRequest request);
-  $async.Future<$3.WriteBitcoinConfigResponse> writeBitcoinConfig(
-      $pb.ServerContext ctx, $3.WriteBitcoinConfigRequest request);
+  $async.Future<$3.GetBitcoinConfigResponse> getBitcoinConfig($pb.ServerContext ctx, $3.GetBitcoinConfigRequest request);
+  $async.Future<$3.SetBitcoinConfigNetworkResponse> setBitcoinConfigNetwork($pb.ServerContext ctx, $3.SetBitcoinConfigNetworkRequest request);
+  $async.Future<$3.SetBitcoinConfigDataDirResponse> setBitcoinConfigDataDir($pb.ServerContext ctx, $3.SetBitcoinConfigDataDirRequest request);
+  $async.Future<$3.WriteBitcoinConfigResponse> writeBitcoinConfig($pb.ServerContext ctx, $3.WriteBitcoinConfigRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetBitcoinConfig':
-        return $3.GetBitcoinConfigRequest();
-      case 'SetBitcoinConfigNetwork':
-        return $3.SetBitcoinConfigNetworkRequest();
-      case 'SetBitcoinConfigDataDir':
-        return $3.SetBitcoinConfigDataDirRequest();
-      case 'WriteBitcoinConfig':
-        return $3.WriteBitcoinConfigRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBitcoinConfig': return $3.GetBitcoinConfigRequest();
+      case 'SetBitcoinConfigNetwork': return $3.SetBitcoinConfigNetworkRequest();
+      case 'SetBitcoinConfigDataDir': return $3.SetBitcoinConfigDataDirRequest();
+      case 'WriteBitcoinConfig': return $3.WriteBitcoinConfigRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetBitcoinConfig':
-        return this.getBitcoinConfig(ctx, request as $3.GetBitcoinConfigRequest);
-      case 'SetBitcoinConfigNetwork':
-        return this.setBitcoinConfigNetwork(ctx, request as $3.SetBitcoinConfigNetworkRequest);
-      case 'SetBitcoinConfigDataDir':
-        return this.setBitcoinConfigDataDir(ctx, request as $3.SetBitcoinConfigDataDirRequest);
-      case 'WriteBitcoinConfig':
-        return this.writeBitcoinConfig(ctx, request as $3.WriteBitcoinConfigRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBitcoinConfig': return this.getBitcoinConfig(ctx, request as $3.GetBitcoinConfigRequest);
+      case 'SetBitcoinConfigNetwork': return this.setBitcoinConfigNetwork(ctx, request as $3.SetBitcoinConfigNetworkRequest);
+      case 'SetBitcoinConfigDataDir': return this.setBitcoinConfigDataDir(ctx, request as $3.SetBitcoinConfigDataDirRequest);
+      case 'WriteBitcoinConfig': return this.writeBitcoinConfig(ctx, request as $3.WriteBitcoinConfigRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => BitcoinConfServiceBase$json;
-  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson =>
-      BitcoinConfServiceBase$messageJson;
+  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => BitcoinConfServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/orchestrator/v1/enforcer_conf.connect.client.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/enforcer_conf.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "enforcer_conf.pb.dart" as orchestratorv1enforcer_conf;
 import "enforcer_conf.connect.spec.dart" as specs;
 
-extension type EnforcerConfServiceClient(connect.Transport _transport) {
+extension type EnforcerConfServiceClient (connect.Transport _transport) {
   /// Get current Enforcer configuration state.
   Future<orchestratorv1enforcer_conf.GetEnforcerConfigResponse> getEnforcerConfig(
     orchestratorv1enforcer_conf.GetEnforcerConfigRequest input, {

--- a/sail_ui/lib/gen/orchestrator/v1/enforcer_conf.pb.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/enforcer_conf.pb.dart
@@ -17,25 +17,23 @@ import 'package:protobuf/protobuf.dart' as $pb;
 class GetEnforcerConfigRequest extends $pb.GeneratedMessage {
   factory GetEnforcerConfigRequest() => create();
   GetEnforcerConfigRequest._() : super();
-  factory GetEnforcerConfigRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetEnforcerConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetEnforcerConfigRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetEnforcerConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEnforcerConfigRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEnforcerConfigRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetEnforcerConfigRequest clone() => GetEnforcerConfigRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetEnforcerConfigRequest copyWith(void Function(GetEnforcerConfigRequest) updates) =>
-      super.copyWith((message) => updates(message as GetEnforcerConfigRequest)) as GetEnforcerConfigRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetEnforcerConfigRequest copyWith(void Function(GetEnforcerConfigRequest) updates) => super.copyWith((message) => updates(message as GetEnforcerConfigRequest)) as GetEnforcerConfigRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -44,8 +42,7 @@ class GetEnforcerConfigRequest extends $pb.GeneratedMessage {
   GetEnforcerConfigRequest createEmptyInstance() => create();
   static $pb.PbList<GetEnforcerConfigRequest> createRepeated() => $pb.PbList<GetEnforcerConfigRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetEnforcerConfigRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEnforcerConfigRequest>(create);
+  static GetEnforcerConfigRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEnforcerConfigRequest>(create);
   static GetEnforcerConfigRequest? _defaultInstance;
 }
 
@@ -80,35 +77,29 @@ class GetEnforcerConfigResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetEnforcerConfigResponse._() : super();
-  factory GetEnforcerConfigResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetEnforcerConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetEnforcerConfigResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetEnforcerConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEnforcerConfigResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEnforcerConfigResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'configContent')
     ..aOS(2, _omitFieldNames ? '' : 'configPath')
     ..aOB(3, _omitFieldNames ? '' : 'nodeRpcDiffers')
     ..aOS(4, _omitFieldNames ? '' : 'defaultConfig')
     ..pPS(5, _omitFieldNames ? '' : 'cliArgs')
-    ..m<$core.String, $core.String>(6, _omitFieldNames ? '' : 'expectedNodeRpcSettings',
-        entryClassName: 'GetEnforcerConfigResponse.ExpectedNodeRpcSettingsEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OS,
-        packageName: const $pb.PackageName('orchestrator.v1'))
-    ..hasRequiredFields = false;
+    ..m<$core.String, $core.String>(6, _omitFieldNames ? '' : 'expectedNodeRpcSettings', entryClassName: 'GetEnforcerConfigResponse.ExpectedNodeRpcSettingsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS, packageName: const $pb.PackageName('orchestrator.v1'))
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetEnforcerConfigResponse clone() => GetEnforcerConfigResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetEnforcerConfigResponse copyWith(void Function(GetEnforcerConfigResponse) updates) =>
-      super.copyWith((message) => updates(message as GetEnforcerConfigResponse)) as GetEnforcerConfigResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetEnforcerConfigResponse copyWith(void Function(GetEnforcerConfigResponse) updates) => super.copyWith((message) => updates(message as GetEnforcerConfigResponse)) as GetEnforcerConfigResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -117,17 +108,13 @@ class GetEnforcerConfigResponse extends $pb.GeneratedMessage {
   GetEnforcerConfigResponse createEmptyInstance() => create();
   static $pb.PbList<GetEnforcerConfigResponse> createRepeated() => $pb.PbList<GetEnforcerConfigResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetEnforcerConfigResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEnforcerConfigResponse>(create);
+  static GetEnforcerConfigResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEnforcerConfigResponse>(create);
   static GetEnforcerConfigResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get configContent => $_getSZ(0);
   @$pb.TagNumber(1)
-  set configContent($core.String v) {
-    $_setString(0, v);
-  }
-
+  set configContent($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasConfigContent() => $_has(0);
   @$pb.TagNumber(1)
@@ -136,10 +123,7 @@ class GetEnforcerConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get configPath => $_getSZ(1);
   @$pb.TagNumber(2)
-  set configPath($core.String v) {
-    $_setString(1, v);
-  }
-
+  set configPath($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasConfigPath() => $_has(1);
   @$pb.TagNumber(2)
@@ -148,10 +132,7 @@ class GetEnforcerConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get nodeRpcDiffers => $_getBF(2);
   @$pb.TagNumber(3)
-  set nodeRpcDiffers($core.bool v) {
-    $_setBool(2, v);
-  }
-
+  set nodeRpcDiffers($core.bool v) { $_setBool(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasNodeRpcDiffers() => $_has(2);
   @$pb.TagNumber(3)
@@ -160,10 +141,7 @@ class GetEnforcerConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get defaultConfig => $_getSZ(3);
   @$pb.TagNumber(4)
-  set defaultConfig($core.String v) {
-    $_setString(3, v);
-  }
-
+  set defaultConfig($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasDefaultConfig() => $_has(3);
   @$pb.TagNumber(4)
@@ -187,27 +165,24 @@ class WriteEnforcerConfigRequest extends $pb.GeneratedMessage {
     return $result;
   }
   WriteEnforcerConfigRequest._() : super();
-  factory WriteEnforcerConfigRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteEnforcerConfigRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WriteEnforcerConfigRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WriteEnforcerConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteEnforcerConfigRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteEnforcerConfigRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'configContent')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WriteEnforcerConfigRequest clone() => WriteEnforcerConfigRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WriteEnforcerConfigRequest copyWith(void Function(WriteEnforcerConfigRequest) updates) =>
-      super.copyWith((message) => updates(message as WriteEnforcerConfigRequest)) as WriteEnforcerConfigRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WriteEnforcerConfigRequest copyWith(void Function(WriteEnforcerConfigRequest) updates) => super.copyWith((message) => updates(message as WriteEnforcerConfigRequest)) as WriteEnforcerConfigRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -216,17 +191,13 @@ class WriteEnforcerConfigRequest extends $pb.GeneratedMessage {
   WriteEnforcerConfigRequest createEmptyInstance() => create();
   static $pb.PbList<WriteEnforcerConfigRequest> createRepeated() => $pb.PbList<WriteEnforcerConfigRequest>();
   @$core.pragma('dart2js:noInline')
-  static WriteEnforcerConfigRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteEnforcerConfigRequest>(create);
+  static WriteEnforcerConfigRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteEnforcerConfigRequest>(create);
   static WriteEnforcerConfigRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get configContent => $_getSZ(0);
   @$pb.TagNumber(1)
-  set configContent($core.String v) {
-    $_setString(0, v);
-  }
-
+  set configContent($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasConfigContent() => $_has(0);
   @$pb.TagNumber(1)
@@ -236,26 +207,23 @@ class WriteEnforcerConfigRequest extends $pb.GeneratedMessage {
 class WriteEnforcerConfigResponse extends $pb.GeneratedMessage {
   factory WriteEnforcerConfigResponse() => create();
   WriteEnforcerConfigResponse._() : super();
-  factory WriteEnforcerConfigResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteEnforcerConfigResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WriteEnforcerConfigResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WriteEnforcerConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteEnforcerConfigResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteEnforcerConfigResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WriteEnforcerConfigResponse clone() => WriteEnforcerConfigResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WriteEnforcerConfigResponse copyWith(void Function(WriteEnforcerConfigResponse) updates) =>
-      super.copyWith((message) => updates(message as WriteEnforcerConfigResponse)) as WriteEnforcerConfigResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WriteEnforcerConfigResponse copyWith(void Function(WriteEnforcerConfigResponse) updates) => super.copyWith((message) => updates(message as WriteEnforcerConfigResponse)) as WriteEnforcerConfigResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -264,84 +232,71 @@ class WriteEnforcerConfigResponse extends $pb.GeneratedMessage {
   WriteEnforcerConfigResponse createEmptyInstance() => create();
   static $pb.PbList<WriteEnforcerConfigResponse> createRepeated() => $pb.PbList<WriteEnforcerConfigResponse>();
   @$core.pragma('dart2js:noInline')
-  static WriteEnforcerConfigResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteEnforcerConfigResponse>(create);
+  static WriteEnforcerConfigResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteEnforcerConfigResponse>(create);
   static WriteEnforcerConfigResponse? _defaultInstance;
 }
 
 class SyncNodeRpcFromBitcoinConfRequest extends $pb.GeneratedMessage {
   factory SyncNodeRpcFromBitcoinConfRequest() => create();
   SyncNodeRpcFromBitcoinConfRequest._() : super();
-  factory SyncNodeRpcFromBitcoinConfRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SyncNodeRpcFromBitcoinConfRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SyncNodeRpcFromBitcoinConfRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SyncNodeRpcFromBitcoinConfRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SyncNodeRpcFromBitcoinConfRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SyncNodeRpcFromBitcoinConfRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SyncNodeRpcFromBitcoinConfRequest clone() => SyncNodeRpcFromBitcoinConfRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SyncNodeRpcFromBitcoinConfRequest copyWith(void Function(SyncNodeRpcFromBitcoinConfRequest) updates) =>
-      super.copyWith((message) => updates(message as SyncNodeRpcFromBitcoinConfRequest))
-          as SyncNodeRpcFromBitcoinConfRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SyncNodeRpcFromBitcoinConfRequest copyWith(void Function(SyncNodeRpcFromBitcoinConfRequest) updates) => super.copyWith((message) => updates(message as SyncNodeRpcFromBitcoinConfRequest)) as SyncNodeRpcFromBitcoinConfRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SyncNodeRpcFromBitcoinConfRequest create() => SyncNodeRpcFromBitcoinConfRequest._();
   SyncNodeRpcFromBitcoinConfRequest createEmptyInstance() => create();
-  static $pb.PbList<SyncNodeRpcFromBitcoinConfRequest> createRepeated() =>
-      $pb.PbList<SyncNodeRpcFromBitcoinConfRequest>();
+  static $pb.PbList<SyncNodeRpcFromBitcoinConfRequest> createRepeated() => $pb.PbList<SyncNodeRpcFromBitcoinConfRequest>();
   @$core.pragma('dart2js:noInline')
-  static SyncNodeRpcFromBitcoinConfRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncNodeRpcFromBitcoinConfRequest>(create);
+  static SyncNodeRpcFromBitcoinConfRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncNodeRpcFromBitcoinConfRequest>(create);
   static SyncNodeRpcFromBitcoinConfRequest? _defaultInstance;
 }
 
 class SyncNodeRpcFromBitcoinConfResponse extends $pb.GeneratedMessage {
   factory SyncNodeRpcFromBitcoinConfResponse() => create();
   SyncNodeRpcFromBitcoinConfResponse._() : super();
-  factory SyncNodeRpcFromBitcoinConfResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SyncNodeRpcFromBitcoinConfResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SyncNodeRpcFromBitcoinConfResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SyncNodeRpcFromBitcoinConfResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SyncNodeRpcFromBitcoinConfResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SyncNodeRpcFromBitcoinConfResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SyncNodeRpcFromBitcoinConfResponse clone() => SyncNodeRpcFromBitcoinConfResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SyncNodeRpcFromBitcoinConfResponse copyWith(void Function(SyncNodeRpcFromBitcoinConfResponse) updates) =>
-      super.copyWith((message) => updates(message as SyncNodeRpcFromBitcoinConfResponse))
-          as SyncNodeRpcFromBitcoinConfResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SyncNodeRpcFromBitcoinConfResponse copyWith(void Function(SyncNodeRpcFromBitcoinConfResponse) updates) => super.copyWith((message) => updates(message as SyncNodeRpcFromBitcoinConfResponse)) as SyncNodeRpcFromBitcoinConfResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SyncNodeRpcFromBitcoinConfResponse create() => SyncNodeRpcFromBitcoinConfResponse._();
   SyncNodeRpcFromBitcoinConfResponse createEmptyInstance() => create();
-  static $pb.PbList<SyncNodeRpcFromBitcoinConfResponse> createRepeated() =>
-      $pb.PbList<SyncNodeRpcFromBitcoinConfResponse>();
+  static $pb.PbList<SyncNodeRpcFromBitcoinConfResponse> createRepeated() => $pb.PbList<SyncNodeRpcFromBitcoinConfResponse>();
   @$core.pragma('dart2js:noInline')
-  static SyncNodeRpcFromBitcoinConfResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncNodeRpcFromBitcoinConfResponse>(create);
+  static SyncNodeRpcFromBitcoinConfResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncNodeRpcFromBitcoinConfResponse>(create);
   static SyncNodeRpcFromBitcoinConfResponse? _defaultInstance;
 }
 
@@ -349,19 +304,17 @@ class EnforcerConfServiceApi {
   $pb.RpcClient _client;
   EnforcerConfServiceApi(this._client);
 
-  $async.Future<GetEnforcerConfigResponse> getEnforcerConfig(
-          $pb.ClientContext? ctx, GetEnforcerConfigRequest request) =>
-      _client.invoke<GetEnforcerConfigResponse>(
-          ctx, 'EnforcerConfService', 'GetEnforcerConfig', request, GetEnforcerConfigResponse());
-  $async.Future<WriteEnforcerConfigResponse> writeEnforcerConfig(
-          $pb.ClientContext? ctx, WriteEnforcerConfigRequest request) =>
-      _client.invoke<WriteEnforcerConfigResponse>(
-          ctx, 'EnforcerConfService', 'WriteEnforcerConfig', request, WriteEnforcerConfigResponse());
-  $async.Future<SyncNodeRpcFromBitcoinConfResponse> syncNodeRpcFromBitcoinConf(
-          $pb.ClientContext? ctx, SyncNodeRpcFromBitcoinConfRequest request) =>
-      _client.invoke<SyncNodeRpcFromBitcoinConfResponse>(
-          ctx, 'EnforcerConfService', 'SyncNodeRpcFromBitcoinConf', request, SyncNodeRpcFromBitcoinConfResponse());
+  $async.Future<GetEnforcerConfigResponse> getEnforcerConfig($pb.ClientContext? ctx, GetEnforcerConfigRequest request) =>
+    _client.invoke<GetEnforcerConfigResponse>(ctx, 'EnforcerConfService', 'GetEnforcerConfig', request, GetEnforcerConfigResponse())
+  ;
+  $async.Future<WriteEnforcerConfigResponse> writeEnforcerConfig($pb.ClientContext? ctx, WriteEnforcerConfigRequest request) =>
+    _client.invoke<WriteEnforcerConfigResponse>(ctx, 'EnforcerConfService', 'WriteEnforcerConfig', request, WriteEnforcerConfigResponse())
+  ;
+  $async.Future<SyncNodeRpcFromBitcoinConfResponse> syncNodeRpcFromBitcoinConf($pb.ClientContext? ctx, SyncNodeRpcFromBitcoinConfRequest request) =>
+    _client.invoke<SyncNodeRpcFromBitcoinConfResponse>(ctx, 'EnforcerConfService', 'SyncNodeRpcFromBitcoinConf', request, SyncNodeRpcFromBitcoinConfResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/orchestrator/v1/enforcer_conf.pbenum.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/enforcer_conf.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/orchestrator/v1/enforcer_conf.pbjson.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/enforcer_conf.pbjson.dart
@@ -19,8 +19,8 @@ const GetEnforcerConfigRequest$json = {
 };
 
 /// Descriptor for `GetEnforcerConfigRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getEnforcerConfigRequestDescriptor =
-    $convert.base64Decode('ChhHZXRFbmZvcmNlckNvbmZpZ1JlcXVlc3Q=');
+final $typed_data.Uint8List getEnforcerConfigRequestDescriptor = $convert.base64Decode(
+    'ChhHZXRFbmZvcmNlckNvbmZpZ1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getEnforcerConfigResponseDescriptor instead')
 const GetEnforcerConfigResponse$json = {
@@ -31,14 +31,7 @@ const GetEnforcerConfigResponse$json = {
     {'1': 'node_rpc_differs', '3': 3, '4': 1, '5': 8, '10': 'nodeRpcDiffers'},
     {'1': 'default_config', '3': 4, '4': 1, '5': 9, '10': 'defaultConfig'},
     {'1': 'cli_args', '3': 5, '4': 3, '5': 9, '10': 'cliArgs'},
-    {
-      '1': 'expected_node_rpc_settings',
-      '3': 6,
-      '4': 3,
-      '5': 11,
-      '6': '.orchestrator.v1.GetEnforcerConfigResponse.ExpectedNodeRpcSettingsEntry',
-      '10': 'expectedNodeRpcSettings'
-    },
+    {'1': 'expected_node_rpc_settings', '3': 6, '4': 3, '5': 11, '6': '.orchestrator.v1.GetEnforcerConfigResponse.ExpectedNodeRpcSettingsEntry', '10': 'expectedNodeRpcSettings'},
   ],
   '3': [GetEnforcerConfigResponse_ExpectedNodeRpcSettingsEntry$json],
 };
@@ -54,15 +47,15 @@ const GetEnforcerConfigResponse_ExpectedNodeRpcSettingsEntry$json = {
 };
 
 /// Descriptor for `GetEnforcerConfigResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getEnforcerConfigResponseDescriptor =
-    $convert.base64Decode('ChlHZXRFbmZvcmNlckNvbmZpZ1Jlc3BvbnNlEiUKDmNvbmZpZ19jb250ZW50GAEgASgJUg1jb2'
-        '5maWdDb250ZW50Eh8KC2NvbmZpZ19wYXRoGAIgASgJUgpjb25maWdQYXRoEigKEG5vZGVfcnBj'
-        'X2RpZmZlcnMYAyABKAhSDm5vZGVScGNEaWZmZXJzEiUKDmRlZmF1bHRfY29uZmlnGAQgASgJUg'
-        '1kZWZhdWx0Q29uZmlnEhkKCGNsaV9hcmdzGAUgAygJUgdjbGlBcmdzEoQBChpleHBlY3RlZF9u'
-        'b2RlX3JwY19zZXR0aW5ncxgGIAMoCzJHLm9yY2hlc3RyYXRvci52MS5HZXRFbmZvcmNlckNvbm'
-        'ZpZ1Jlc3BvbnNlLkV4cGVjdGVkTm9kZVJwY1NldHRpbmdzRW50cnlSF2V4cGVjdGVkTm9kZVJw'
-        'Y1NldHRpbmdzGkoKHEV4cGVjdGVkTm9kZVJwY1NldHRpbmdzRW50cnkSEAoDa2V5GAEgASgJUg'
-        'NrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+final $typed_data.Uint8List getEnforcerConfigResponseDescriptor = $convert.base64Decode(
+    'ChlHZXRFbmZvcmNlckNvbmZpZ1Jlc3BvbnNlEiUKDmNvbmZpZ19jb250ZW50GAEgASgJUg1jb2'
+    '5maWdDb250ZW50Eh8KC2NvbmZpZ19wYXRoGAIgASgJUgpjb25maWdQYXRoEigKEG5vZGVfcnBj'
+    'X2RpZmZlcnMYAyABKAhSDm5vZGVScGNEaWZmZXJzEiUKDmRlZmF1bHRfY29uZmlnGAQgASgJUg'
+    '1kZWZhdWx0Q29uZmlnEhkKCGNsaV9hcmdzGAUgAygJUgdjbGlBcmdzEoQBChpleHBlY3RlZF9u'
+    'b2RlX3JwY19zZXR0aW5ncxgGIAMoCzJHLm9yY2hlc3RyYXRvci52MS5HZXRFbmZvcmNlckNvbm'
+    'ZpZ1Jlc3BvbnNlLkV4cGVjdGVkTm9kZVJwY1NldHRpbmdzRW50cnlSF2V4cGVjdGVkTm9kZVJw'
+    'Y1NldHRpbmdzGkoKHEV4cGVjdGVkTm9kZVJwY1NldHRpbmdzRW50cnkSEAoDa2V5GAEgASgJUg'
+    'NrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
 
 @$core.Deprecated('Use writeEnforcerConfigRequestDescriptor instead')
 const WriteEnforcerConfigRequest$json = {
@@ -73,9 +66,9 @@ const WriteEnforcerConfigRequest$json = {
 };
 
 /// Descriptor for `WriteEnforcerConfigRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List writeEnforcerConfigRequestDescriptor =
-    $convert.base64Decode('ChpXcml0ZUVuZm9yY2VyQ29uZmlnUmVxdWVzdBIlCg5jb25maWdfY29udGVudBgBIAEoCVINY2'
-        '9uZmlnQ29udGVudA==');
+final $typed_data.Uint8List writeEnforcerConfigRequestDescriptor = $convert.base64Decode(
+    'ChpXcml0ZUVuZm9yY2VyQ29uZmlnUmVxdWVzdBIlCg5jb25maWdfY29udGVudBgBIAEoCVINY2'
+    '9uZmlnQ29udGVudA==');
 
 @$core.Deprecated('Use writeEnforcerConfigResponseDescriptor instead')
 const WriteEnforcerConfigResponse$json = {
@@ -83,8 +76,8 @@ const WriteEnforcerConfigResponse$json = {
 };
 
 /// Descriptor for `WriteEnforcerConfigResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List writeEnforcerConfigResponseDescriptor =
-    $convert.base64Decode('ChtXcml0ZUVuZm9yY2VyQ29uZmlnUmVzcG9uc2U=');
+final $typed_data.Uint8List writeEnforcerConfigResponseDescriptor = $convert.base64Decode(
+    'ChtXcml0ZUVuZm9yY2VyQ29uZmlnUmVzcG9uc2U=');
 
 @$core.Deprecated('Use syncNodeRpcFromBitcoinConfRequestDescriptor instead')
 const SyncNodeRpcFromBitcoinConfRequest$json = {
@@ -92,8 +85,8 @@ const SyncNodeRpcFromBitcoinConfRequest$json = {
 };
 
 /// Descriptor for `SyncNodeRpcFromBitcoinConfRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List syncNodeRpcFromBitcoinConfRequestDescriptor =
-    $convert.base64Decode('CiFTeW5jTm9kZVJwY0Zyb21CaXRjb2luQ29uZlJlcXVlc3Q=');
+final $typed_data.Uint8List syncNodeRpcFromBitcoinConfRequestDescriptor = $convert.base64Decode(
+    'CiFTeW5jTm9kZVJwY0Zyb21CaXRjb2luQ29uZlJlcXVlc3Q=');
 
 @$core.Deprecated('Use syncNodeRpcFromBitcoinConfResponseDescriptor instead')
 const SyncNodeRpcFromBitcoinConfResponse$json = {
@@ -101,27 +94,15 @@ const SyncNodeRpcFromBitcoinConfResponse$json = {
 };
 
 /// Descriptor for `SyncNodeRpcFromBitcoinConfResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List syncNodeRpcFromBitcoinConfResponseDescriptor =
-    $convert.base64Decode('CiJTeW5jTm9kZVJwY0Zyb21CaXRjb2luQ29uZlJlc3BvbnNl');
+final $typed_data.Uint8List syncNodeRpcFromBitcoinConfResponseDescriptor = $convert.base64Decode(
+    'CiJTeW5jTm9kZVJwY0Zyb21CaXRjb2luQ29uZlJlc3BvbnNl');
 
 const $core.Map<$core.String, $core.dynamic> EnforcerConfServiceBase$json = {
   '1': 'EnforcerConfService',
   '2': [
-    {
-      '1': 'GetEnforcerConfig',
-      '2': '.orchestrator.v1.GetEnforcerConfigRequest',
-      '3': '.orchestrator.v1.GetEnforcerConfigResponse'
-    },
-    {
-      '1': 'WriteEnforcerConfig',
-      '2': '.orchestrator.v1.WriteEnforcerConfigRequest',
-      '3': '.orchestrator.v1.WriteEnforcerConfigResponse'
-    },
-    {
-      '1': 'SyncNodeRpcFromBitcoinConf',
-      '2': '.orchestrator.v1.SyncNodeRpcFromBitcoinConfRequest',
-      '3': '.orchestrator.v1.SyncNodeRpcFromBitcoinConfResponse'
-    },
+    {'1': 'GetEnforcerConfig', '2': '.orchestrator.v1.GetEnforcerConfigRequest', '3': '.orchestrator.v1.GetEnforcerConfigResponse'},
+    {'1': 'WriteEnforcerConfig', '2': '.orchestrator.v1.WriteEnforcerConfigRequest', '3': '.orchestrator.v1.WriteEnforcerConfigResponse'},
+    {'1': 'SyncNodeRpcFromBitcoinConf', '2': '.orchestrator.v1.SyncNodeRpcFromBitcoinConfRequest', '3': '.orchestrator.v1.SyncNodeRpcFromBitcoinConfResponse'},
   ],
 };
 
@@ -129,8 +110,7 @@ const $core.Map<$core.String, $core.dynamic> EnforcerConfServiceBase$json = {
 const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> EnforcerConfServiceBase$messageJson = {
   '.orchestrator.v1.GetEnforcerConfigRequest': GetEnforcerConfigRequest$json,
   '.orchestrator.v1.GetEnforcerConfigResponse': GetEnforcerConfigResponse$json,
-  '.orchestrator.v1.GetEnforcerConfigResponse.ExpectedNodeRpcSettingsEntry':
-      GetEnforcerConfigResponse_ExpectedNodeRpcSettingsEntry$json,
+  '.orchestrator.v1.GetEnforcerConfigResponse.ExpectedNodeRpcSettingsEntry': GetEnforcerConfigResponse_ExpectedNodeRpcSettingsEntry$json,
   '.orchestrator.v1.WriteEnforcerConfigRequest': WriteEnforcerConfigRequest$json,
   '.orchestrator.v1.WriteEnforcerConfigResponse': WriteEnforcerConfigResponse$json,
   '.orchestrator.v1.SyncNodeRpcFromBitcoinConfRequest': SyncNodeRpcFromBitcoinConfRequest$json,
@@ -138,11 +118,12 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> EnforcerCo
 };
 
 /// Descriptor for `EnforcerConfService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List enforcerConfServiceDescriptor =
-    $convert.base64Decode('ChNFbmZvcmNlckNvbmZTZXJ2aWNlEmoKEUdldEVuZm9yY2VyQ29uZmlnEikub3JjaGVzdHJhdG'
-        '9yLnYxLkdldEVuZm9yY2VyQ29uZmlnUmVxdWVzdBoqLm9yY2hlc3RyYXRvci52MS5HZXRFbmZv'
-        'cmNlckNvbmZpZ1Jlc3BvbnNlEnAKE1dyaXRlRW5mb3JjZXJDb25maWcSKy5vcmNoZXN0cmF0b3'
-        'IudjEuV3JpdGVFbmZvcmNlckNvbmZpZ1JlcXVlc3QaLC5vcmNoZXN0cmF0b3IudjEuV3JpdGVF'
-        'bmZvcmNlckNvbmZpZ1Jlc3BvbnNlEoUBChpTeW5jTm9kZVJwY0Zyb21CaXRjb2luQ29uZhIyLm'
-        '9yY2hlc3RyYXRvci52MS5TeW5jTm9kZVJwY0Zyb21CaXRjb2luQ29uZlJlcXVlc3QaMy5vcmNo'
-        'ZXN0cmF0b3IudjEuU3luY05vZGVScGNGcm9tQml0Y29pbkNvbmZSZXNwb25zZQ==');
+final $typed_data.Uint8List enforcerConfServiceDescriptor = $convert.base64Decode(
+    'ChNFbmZvcmNlckNvbmZTZXJ2aWNlEmoKEUdldEVuZm9yY2VyQ29uZmlnEikub3JjaGVzdHJhdG'
+    '9yLnYxLkdldEVuZm9yY2VyQ29uZmlnUmVxdWVzdBoqLm9yY2hlc3RyYXRvci52MS5HZXRFbmZv'
+    'cmNlckNvbmZpZ1Jlc3BvbnNlEnAKE1dyaXRlRW5mb3JjZXJDb25maWcSKy5vcmNoZXN0cmF0b3'
+    'IudjEuV3JpdGVFbmZvcmNlckNvbmZpZ1JlcXVlc3QaLC5vcmNoZXN0cmF0b3IudjEuV3JpdGVF'
+    'bmZvcmNlckNvbmZpZ1Jlc3BvbnNlEoUBChpTeW5jTm9kZVJwY0Zyb21CaXRjb2luQ29uZhIyLm'
+    '9yY2hlc3RyYXRvci52MS5TeW5jTm9kZVJwY0Zyb21CaXRjb2luQ29uZlJlcXVlc3QaMy5vcmNo'
+    'ZXN0cmF0b3IudjEuU3luY05vZGVScGNGcm9tQml0Y29pbkNvbmZSZXNwb25zZQ==');
+

--- a/sail_ui/lib/gen/orchestrator/v1/enforcer_conf.pbserver.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/enforcer_conf.pbserver.dart
@@ -21,41 +21,29 @@ import 'enforcer_conf.pbjson.dart';
 export 'enforcer_conf.pb.dart';
 
 abstract class EnforcerConfServiceBase extends $pb.GeneratedService {
-  $async.Future<$4.GetEnforcerConfigResponse> getEnforcerConfig(
-      $pb.ServerContext ctx, $4.GetEnforcerConfigRequest request);
-  $async.Future<$4.WriteEnforcerConfigResponse> writeEnforcerConfig(
-      $pb.ServerContext ctx, $4.WriteEnforcerConfigRequest request);
-  $async.Future<$4.SyncNodeRpcFromBitcoinConfResponse> syncNodeRpcFromBitcoinConf(
-      $pb.ServerContext ctx, $4.SyncNodeRpcFromBitcoinConfRequest request);
+  $async.Future<$4.GetEnforcerConfigResponse> getEnforcerConfig($pb.ServerContext ctx, $4.GetEnforcerConfigRequest request);
+  $async.Future<$4.WriteEnforcerConfigResponse> writeEnforcerConfig($pb.ServerContext ctx, $4.WriteEnforcerConfigRequest request);
+  $async.Future<$4.SyncNodeRpcFromBitcoinConfResponse> syncNodeRpcFromBitcoinConf($pb.ServerContext ctx, $4.SyncNodeRpcFromBitcoinConfRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetEnforcerConfig':
-        return $4.GetEnforcerConfigRequest();
-      case 'WriteEnforcerConfig':
-        return $4.WriteEnforcerConfigRequest();
-      case 'SyncNodeRpcFromBitcoinConf':
-        return $4.SyncNodeRpcFromBitcoinConfRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetEnforcerConfig': return $4.GetEnforcerConfigRequest();
+      case 'WriteEnforcerConfig': return $4.WriteEnforcerConfigRequest();
+      case 'SyncNodeRpcFromBitcoinConf': return $4.SyncNodeRpcFromBitcoinConfRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetEnforcerConfig':
-        return this.getEnforcerConfig(ctx, request as $4.GetEnforcerConfigRequest);
-      case 'WriteEnforcerConfig':
-        return this.writeEnforcerConfig(ctx, request as $4.WriteEnforcerConfigRequest);
-      case 'SyncNodeRpcFromBitcoinConf':
-        return this.syncNodeRpcFromBitcoinConf(ctx, request as $4.SyncNodeRpcFromBitcoinConfRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetEnforcerConfig': return this.getEnforcerConfig(ctx, request as $4.GetEnforcerConfigRequest);
+      case 'WriteEnforcerConfig': return this.writeEnforcerConfig(ctx, request as $4.WriteEnforcerConfigRequest);
+      case 'SyncNodeRpcFromBitcoinConf': return this.syncNodeRpcFromBitcoinConf(ctx, request as $4.SyncNodeRpcFromBitcoinConfRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => EnforcerConfServiceBase$json;
-  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson =>
-      EnforcerConfServiceBase$messageJson;
+  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => EnforcerConfServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.client.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "orchestrator.pb.dart" as orchestratorv1orchestrator;
 import "orchestrator.connect.spec.dart" as specs;
 
-extension type OrchestratorServiceClient(connect.Transport _transport) {
+extension type OrchestratorServiceClient (connect.Transport _transport) {
   /// List all configured binaries and their status.
   Future<orchestratorv1orchestrator.ListBinariesResponse> listBinaries(
     orchestratorv1orchestrator.ListBinariesRequest input, {
@@ -248,6 +248,27 @@ extension type OrchestratorServiceClient(connect.Transport _transport) {
   }) {
     return connect.Client(_transport).unary(
       specs.OrchestratorService.getSyncStatus,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
+  /// Snapshot of every binary the orchestrator is currently downloading.
+  /// Reads from the in-memory DownloadManager state — light, polled by the
+  /// frontend's DownloadProvider on a fast (100ms) cadence while a download
+  /// is in flight, and dropping back to 2s when the response is empty.
+  Future<orchestratorv1orchestrator.GetDownloadStatusResponse> getDownloadStatus(
+    orchestratorv1orchestrator.GetDownloadStatusRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.OrchestratorService.getDownloadStatus,
       input,
       signal: signal,
       headers: headers,

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.spec.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.spec.dart
@@ -128,6 +128,17 @@ abstract final class OrchestratorService {
     orchestratorv1orchestrator.GetSyncStatusResponse.new,
   );
 
+  /// Snapshot of every binary the orchestrator is currently downloading.
+  /// Reads from the in-memory DownloadManager state — light, polled by the
+  /// frontend's DownloadProvider on a fast (100ms) cadence while a download
+  /// is in flight, and dropping back to 2s when the response is empty.
+  static const getDownloadStatus = connect.Spec(
+    '/$name/GetDownloadStatus',
+    connect.StreamType.unary,
+    orchestratorv1orchestrator.GetDownloadStatusRequest.new,
+    orchestratorv1orchestrator.GetDownloadStatusResponse.new,
+  );
+
   /// Get wallet balance from Bitcoin Core (proxied via orchestrator).
   static const getMainchainBalance = connect.Spec(
     '/$name/GetMainchainBalance',

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -118,14 +118,10 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     return $result;
   }
   BinaryStatusMsg._() : super();
-  factory BinaryStatusMsg.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory BinaryStatusMsg.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory BinaryStatusMsg.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BinaryStatusMsg.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinaryStatusMsg',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BinaryStatusMsg', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOS(2, _omitFieldNames ? '' : 'displayName')
     ..aOB(3, _omitFieldNames ? '' : 'running')
@@ -147,20 +143,21 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     ..aOB(19, _omitFieldNames ? '' : 'portInUse')
     ..aOS(20, _omitFieldNames ? '' : 'version')
     ..aOS(21, _omitFieldNames ? '' : 'repoUrl')
-    ..pc<StartupLogEntryMsg>(22, _omitFieldNames ? '' : 'startupLogs', $pb.PbFieldType.PM,
-        subBuilder: StartupLogEntryMsg.create)
+    ..pc<StartupLogEntryMsg>(22, _omitFieldNames ? '' : 'startupLogs', $pb.PbFieldType.PM, subBuilder: StartupLogEntryMsg.create)
     ..aOS(23, _omitFieldNames ? '' : 'binaryPath')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   BinaryStatusMsg clone() => BinaryStatusMsg()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  BinaryStatusMsg copyWith(void Function(BinaryStatusMsg) updates) =>
-      super.copyWith((message) => updates(message as BinaryStatusMsg)) as BinaryStatusMsg;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BinaryStatusMsg copyWith(void Function(BinaryStatusMsg) updates) => super.copyWith((message) => updates(message as BinaryStatusMsg)) as BinaryStatusMsg;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -169,17 +166,13 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   BinaryStatusMsg createEmptyInstance() => create();
   static $pb.PbList<BinaryStatusMsg> createRepeated() => $pb.PbList<BinaryStatusMsg>();
   @$core.pragma('dart2js:noInline')
-  static BinaryStatusMsg getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinaryStatusMsg>(create);
+  static BinaryStatusMsg getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BinaryStatusMsg>(create);
   static BinaryStatusMsg? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -188,10 +181,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get displayName => $_getSZ(1);
   @$pb.TagNumber(2)
-  set displayName($core.String v) {
-    $_setString(1, v);
-  }
-
+  set displayName($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasDisplayName() => $_has(1);
   @$pb.TagNumber(2)
@@ -200,10 +190,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get running => $_getBF(2);
   @$pb.TagNumber(3)
-  set running($core.bool v) {
-    $_setBool(2, v);
-  }
-
+  set running($core.bool v) { $_setBool(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasRunning() => $_has(2);
   @$pb.TagNumber(3)
@@ -212,10 +199,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get healthy => $_getBF(3);
   @$pb.TagNumber(4)
-  set healthy($core.bool v) {
-    $_setBool(3, v);
-  }
-
+  set healthy($core.bool v) { $_setBool(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasHealthy() => $_has(3);
   @$pb.TagNumber(4)
@@ -224,10 +208,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.int get pid => $_getIZ(4);
   @$pb.TagNumber(5)
-  set pid($core.int v) {
-    $_setSignedInt32(4, v);
-  }
-
+  set pid($core.int v) { $_setSignedInt32(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasPid() => $_has(4);
   @$pb.TagNumber(5)
@@ -236,10 +217,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get uptimeSeconds => $_getI64(5);
   @$pb.TagNumber(6)
-  set uptimeSeconds($fixnum.Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set uptimeSeconds($fixnum.Int64 v) { $_setInt64(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasUptimeSeconds() => $_has(5);
   @$pb.TagNumber(6)
@@ -248,10 +226,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.int get chainLayer => $_getIZ(6);
   @$pb.TagNumber(7)
-  set chainLayer($core.int v) {
-    $_setSignedInt32(6, v);
-  }
-
+  set chainLayer($core.int v) { $_setSignedInt32(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasChainLayer() => $_has(6);
   @$pb.TagNumber(7)
@@ -260,10 +235,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.int get port => $_getIZ(7);
   @$pb.TagNumber(8)
-  set port($core.int v) {
-    $_setSignedInt32(7, v);
-  }
-
+  set port($core.int v) { $_setSignedInt32(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasPort() => $_has(7);
   @$pb.TagNumber(8)
@@ -272,10 +244,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.String get error => $_getSZ(8);
   @$pb.TagNumber(9)
-  set error($core.String v) {
-    $_setString(8, v);
-  }
-
+  set error($core.String v) { $_setString(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasError() => $_has(8);
   @$pb.TagNumber(9)
@@ -284,10 +253,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.bool get connected => $_getBF(9);
   @$pb.TagNumber(10)
-  set connected($core.bool v) {
-    $_setBool(9, v);
-  }
-
+  set connected($core.bool v) { $_setBool(9, v); }
   @$pb.TagNumber(10)
   $core.bool hasConnected() => $_has(9);
   @$pb.TagNumber(10)
@@ -296,10 +262,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $core.String get startupError => $_getSZ(10);
   @$pb.TagNumber(11)
-  set startupError($core.String v) {
-    $_setString(10, v);
-  }
-
+  set startupError($core.String v) { $_setString(10, v); }
   @$pb.TagNumber(11)
   $core.bool hasStartupError() => $_has(10);
   @$pb.TagNumber(11)
@@ -308,10 +271,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $core.String get connectionError => $_getSZ(11);
   @$pb.TagNumber(12)
-  set connectionError($core.String v) {
-    $_setString(11, v);
-  }
-
+  set connectionError($core.String v) { $_setString(11, v); }
   @$pb.TagNumber(12)
   $core.bool hasConnectionError() => $_has(11);
   @$pb.TagNumber(12)
@@ -320,10 +280,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(13)
   $core.bool get stopping => $_getBF(12);
   @$pb.TagNumber(13)
-  set stopping($core.bool v) {
-    $_setBool(12, v);
-  }
-
+  set stopping($core.bool v) { $_setBool(12, v); }
   @$pb.TagNumber(13)
   $core.bool hasStopping() => $_has(12);
   @$pb.TagNumber(13)
@@ -332,10 +289,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(14)
   $core.bool get initializing => $_getBF(13);
   @$pb.TagNumber(14)
-  set initializing($core.bool v) {
-    $_setBool(13, v);
-  }
-
+  set initializing($core.bool v) { $_setBool(13, v); }
   @$pb.TagNumber(14)
   $core.bool hasInitializing() => $_has(13);
   @$pb.TagNumber(14)
@@ -344,10 +298,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(15)
   $core.bool get connectModeOnly => $_getBF(14);
   @$pb.TagNumber(15)
-  set connectModeOnly($core.bool v) {
-    $_setBool(14, v);
-  }
-
+  set connectModeOnly($core.bool v) { $_setBool(14, v); }
   @$pb.TagNumber(15)
   $core.bool hasConnectModeOnly() => $_has(14);
   @$pb.TagNumber(15)
@@ -356,10 +307,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(16)
   $core.bool get downloadable => $_getBF(15);
   @$pb.TagNumber(16)
-  set downloadable($core.bool v) {
-    $_setBool(15, v);
-  }
-
+  set downloadable($core.bool v) { $_setBool(15, v); }
   @$pb.TagNumber(16)
   $core.bool hasDownloadable() => $_has(15);
   @$pb.TagNumber(16)
@@ -368,10 +316,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(17)
   $core.String get description => $_getSZ(16);
   @$pb.TagNumber(17)
-  set description($core.String v) {
-    $_setString(16, v);
-  }
-
+  set description($core.String v) { $_setString(16, v); }
   @$pb.TagNumber(17)
   $core.bool hasDescription() => $_has(16);
   @$pb.TagNumber(17)
@@ -380,10 +325,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(18)
   $core.bool get downloaded => $_getBF(17);
   @$pb.TagNumber(18)
-  set downloaded($core.bool v) {
-    $_setBool(17, v);
-  }
-
+  set downloaded($core.bool v) { $_setBool(17, v); }
   @$pb.TagNumber(18)
   $core.bool hasDownloaded() => $_has(17);
   @$pb.TagNumber(18)
@@ -392,10 +334,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(19)
   $core.bool get portInUse => $_getBF(18);
   @$pb.TagNumber(19)
-  set portInUse($core.bool v) {
-    $_setBool(18, v);
-  }
-
+  set portInUse($core.bool v) { $_setBool(18, v); }
   @$pb.TagNumber(19)
   $core.bool hasPortInUse() => $_has(18);
   @$pb.TagNumber(19)
@@ -404,10 +343,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(20)
   $core.String get version => $_getSZ(19);
   @$pb.TagNumber(20)
-  set version($core.String v) {
-    $_setString(19, v);
-  }
-
+  set version($core.String v) { $_setString(19, v); }
   @$pb.TagNumber(20)
   $core.bool hasVersion() => $_has(19);
   @$pb.TagNumber(20)
@@ -416,10 +352,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(21)
   $core.String get repoUrl => $_getSZ(20);
   @$pb.TagNumber(21)
-  set repoUrl($core.String v) {
-    $_setString(20, v);
-  }
-
+  set repoUrl($core.String v) { $_setString(20, v); }
   @$pb.TagNumber(21)
   $core.bool hasRepoUrl() => $_has(20);
   @$pb.TagNumber(21)
@@ -434,10 +367,7 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(23)
   $core.String get binaryPath => $_getSZ(22);
   @$pb.TagNumber(23)
-  set binaryPath($core.String v) {
-    $_setString(22, v);
-  }
-
+  set binaryPath($core.String v) { $_setString(22, v); }
   @$pb.TagNumber(23)
   $core.bool hasBinaryPath() => $_has(22);
   @$pb.TagNumber(23)
@@ -459,27 +389,25 @@ class StartupLogEntryMsg extends $pb.GeneratedMessage {
     return $result;
   }
   StartupLogEntryMsg._() : super();
-  factory StartupLogEntryMsg.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StartupLogEntryMsg.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StartupLogEntryMsg.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StartupLogEntryMsg.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartupLogEntryMsg',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartupLogEntryMsg', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'timestampUnix')
     ..aOS(2, _omitFieldNames ? '' : 'message')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StartupLogEntryMsg clone() => StartupLogEntryMsg()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StartupLogEntryMsg copyWith(void Function(StartupLogEntryMsg) updates) =>
-      super.copyWith((message) => updates(message as StartupLogEntryMsg)) as StartupLogEntryMsg;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StartupLogEntryMsg copyWith(void Function(StartupLogEntryMsg) updates) => super.copyWith((message) => updates(message as StartupLogEntryMsg)) as StartupLogEntryMsg;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -488,17 +416,13 @@ class StartupLogEntryMsg extends $pb.GeneratedMessage {
   StartupLogEntryMsg createEmptyInstance() => create();
   static $pb.PbList<StartupLogEntryMsg> createRepeated() => $pb.PbList<StartupLogEntryMsg>();
   @$core.pragma('dart2js:noInline')
-  static StartupLogEntryMsg getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartupLogEntryMsg>(create);
+  static StartupLogEntryMsg getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartupLogEntryMsg>(create);
   static StartupLogEntryMsg? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get timestampUnix => $_getI64(0);
   @$pb.TagNumber(1)
-  set timestampUnix($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set timestampUnix($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTimestampUnix() => $_has(0);
   @$pb.TagNumber(1)
@@ -507,10 +431,7 @@ class StartupLogEntryMsg extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get message => $_getSZ(1);
   @$pb.TagNumber(2)
-  set message($core.String v) {
-    $_setString(1, v);
-  }
-
+  set message($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasMessage() => $_has(1);
   @$pb.TagNumber(2)
@@ -520,25 +441,23 @@ class StartupLogEntryMsg extends $pb.GeneratedMessage {
 class ListBinariesRequest extends $pb.GeneratedMessage {
   factory ListBinariesRequest() => create();
   ListBinariesRequest._() : super();
-  factory ListBinariesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListBinariesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListBinariesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListBinariesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBinariesRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBinariesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListBinariesRequest clone() => ListBinariesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListBinariesRequest copyWith(void Function(ListBinariesRequest) updates) =>
-      super.copyWith((message) => updates(message as ListBinariesRequest)) as ListBinariesRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListBinariesRequest copyWith(void Function(ListBinariesRequest) updates) => super.copyWith((message) => updates(message as ListBinariesRequest)) as ListBinariesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -547,8 +466,7 @@ class ListBinariesRequest extends $pb.GeneratedMessage {
   ListBinariesRequest createEmptyInstance() => create();
   static $pb.PbList<ListBinariesRequest> createRepeated() => $pb.PbList<ListBinariesRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListBinariesRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBinariesRequest>(create);
+  static ListBinariesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBinariesRequest>(create);
   static ListBinariesRequest? _defaultInstance;
 }
 
@@ -563,26 +481,24 @@ class ListBinariesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListBinariesResponse._() : super();
-  factory ListBinariesResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListBinariesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListBinariesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListBinariesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBinariesResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBinariesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..pc<BinaryStatusMsg>(1, _omitFieldNames ? '' : 'binaries', $pb.PbFieldType.PM, subBuilder: BinaryStatusMsg.create)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListBinariesResponse clone() => ListBinariesResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListBinariesResponse copyWith(void Function(ListBinariesResponse) updates) =>
-      super.copyWith((message) => updates(message as ListBinariesResponse)) as ListBinariesResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListBinariesResponse copyWith(void Function(ListBinariesResponse) updates) => super.copyWith((message) => updates(message as ListBinariesResponse)) as ListBinariesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -591,8 +507,7 @@ class ListBinariesResponse extends $pb.GeneratedMessage {
   ListBinariesResponse createEmptyInstance() => create();
   static $pb.PbList<ListBinariesResponse> createRepeated() => $pb.PbList<ListBinariesResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListBinariesResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBinariesResponse>(create);
+  static ListBinariesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBinariesResponse>(create);
   static ListBinariesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -610,26 +525,24 @@ class GetBinaryStatusRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBinaryStatusRequest._() : super();
-  factory GetBinaryStatusRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBinaryStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBinaryStatusRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBinaryStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBinaryStatusRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBinaryStatusRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBinaryStatusRequest clone() => GetBinaryStatusRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBinaryStatusRequest copyWith(void Function(GetBinaryStatusRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBinaryStatusRequest)) as GetBinaryStatusRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBinaryStatusRequest copyWith(void Function(GetBinaryStatusRequest) updates) => super.copyWith((message) => updates(message as GetBinaryStatusRequest)) as GetBinaryStatusRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -638,17 +551,13 @@ class GetBinaryStatusRequest extends $pb.GeneratedMessage {
   GetBinaryStatusRequest createEmptyInstance() => create();
   static $pb.PbList<GetBinaryStatusRequest> createRepeated() => $pb.PbList<GetBinaryStatusRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBinaryStatusRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBinaryStatusRequest>(create);
+  static GetBinaryStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBinaryStatusRequest>(create);
   static GetBinaryStatusRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -666,26 +575,24 @@ class GetBinaryStatusResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBinaryStatusResponse._() : super();
-  factory GetBinaryStatusResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBinaryStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBinaryStatusResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBinaryStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBinaryStatusResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBinaryStatusResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOM<BinaryStatusMsg>(1, _omitFieldNames ? '' : 'status', subBuilder: BinaryStatusMsg.create)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBinaryStatusResponse clone() => GetBinaryStatusResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBinaryStatusResponse copyWith(void Function(GetBinaryStatusResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBinaryStatusResponse)) as GetBinaryStatusResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBinaryStatusResponse copyWith(void Function(GetBinaryStatusResponse) updates) => super.copyWith((message) => updates(message as GetBinaryStatusResponse)) as GetBinaryStatusResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -694,17 +601,13 @@ class GetBinaryStatusResponse extends $pb.GeneratedMessage {
   GetBinaryStatusResponse createEmptyInstance() => create();
   static $pb.PbList<GetBinaryStatusResponse> createRepeated() => $pb.PbList<GetBinaryStatusResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBinaryStatusResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBinaryStatusResponse>(create);
+  static GetBinaryStatusResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBinaryStatusResponse>(create);
   static GetBinaryStatusResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   BinaryStatusMsg get status => $_getN(0);
   @$pb.TagNumber(1)
-  set status(BinaryStatusMsg v) {
-    setField(1, v);
-  }
-
+  set status(BinaryStatusMsg v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasStatus() => $_has(0);
   @$pb.TagNumber(1)
@@ -728,27 +631,25 @@ class DownloadBinaryRequest extends $pb.GeneratedMessage {
     return $result;
   }
   DownloadBinaryRequest._() : super();
-  factory DownloadBinaryRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DownloadBinaryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DownloadBinaryRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DownloadBinaryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DownloadBinaryRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DownloadBinaryRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOB(2, _omitFieldNames ? '' : 'force')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DownloadBinaryRequest clone() => DownloadBinaryRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DownloadBinaryRequest copyWith(void Function(DownloadBinaryRequest) updates) =>
-      super.copyWith((message) => updates(message as DownloadBinaryRequest)) as DownloadBinaryRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DownloadBinaryRequest copyWith(void Function(DownloadBinaryRequest) updates) => super.copyWith((message) => updates(message as DownloadBinaryRequest)) as DownloadBinaryRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -757,17 +658,13 @@ class DownloadBinaryRequest extends $pb.GeneratedMessage {
   DownloadBinaryRequest createEmptyInstance() => create();
   static $pb.PbList<DownloadBinaryRequest> createRepeated() => $pb.PbList<DownloadBinaryRequest>();
   @$core.pragma('dart2js:noInline')
-  static DownloadBinaryRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DownloadBinaryRequest>(create);
+  static DownloadBinaryRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DownloadBinaryRequest>(create);
   static DownloadBinaryRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -776,10 +673,7 @@ class DownloadBinaryRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get force => $_getBF(1);
   @$pb.TagNumber(2)
-  set force($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set force($core.bool v) { $_setBool(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasForce() => $_has(1);
   @$pb.TagNumber(2)
@@ -789,25 +683,23 @@ class DownloadBinaryRequest extends $pb.GeneratedMessage {
 class DownloadBinaryResponse extends $pb.GeneratedMessage {
   factory DownloadBinaryResponse() => create();
   DownloadBinaryResponse._() : super();
-  factory DownloadBinaryResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DownloadBinaryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DownloadBinaryResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DownloadBinaryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DownloadBinaryResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DownloadBinaryResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DownloadBinaryResponse clone() => DownloadBinaryResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DownloadBinaryResponse copyWith(void Function(DownloadBinaryResponse) updates) =>
-      super.copyWith((message) => updates(message as DownloadBinaryResponse)) as DownloadBinaryResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DownloadBinaryResponse copyWith(void Function(DownloadBinaryResponse) updates) => super.copyWith((message) => updates(message as DownloadBinaryResponse)) as DownloadBinaryResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -816,8 +708,7 @@ class DownloadBinaryResponse extends $pb.GeneratedMessage {
   DownloadBinaryResponse createEmptyInstance() => create();
   static $pb.PbList<DownloadBinaryResponse> createRepeated() => $pb.PbList<DownloadBinaryResponse>();
   @$core.pragma('dart2js:noInline')
-  static DownloadBinaryResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DownloadBinaryResponse>(create);
+  static DownloadBinaryResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DownloadBinaryResponse>(create);
   static DownloadBinaryResponse? _defaultInstance;
 }
 
@@ -840,32 +731,26 @@ class StartBinaryRequest extends $pb.GeneratedMessage {
     return $result;
   }
   StartBinaryRequest._() : super();
-  factory StartBinaryRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StartBinaryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StartBinaryRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StartBinaryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartBinaryRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartBinaryRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..pPS(2, _omitFieldNames ? '' : 'extraArgs')
-    ..m<$core.String, $core.String>(3, _omitFieldNames ? '' : 'env',
-        entryClassName: 'StartBinaryRequest.EnvEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OS,
-        packageName: const $pb.PackageName('orchestrator.v1'))
-    ..hasRequiredFields = false;
+    ..m<$core.String, $core.String>(3, _omitFieldNames ? '' : 'env', entryClassName: 'StartBinaryRequest.EnvEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS, packageName: const $pb.PackageName('orchestrator.v1'))
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StartBinaryRequest clone() => StartBinaryRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StartBinaryRequest copyWith(void Function(StartBinaryRequest) updates) =>
-      super.copyWith((message) => updates(message as StartBinaryRequest)) as StartBinaryRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StartBinaryRequest copyWith(void Function(StartBinaryRequest) updates) => super.copyWith((message) => updates(message as StartBinaryRequest)) as StartBinaryRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -874,17 +759,13 @@ class StartBinaryRequest extends $pb.GeneratedMessage {
   StartBinaryRequest createEmptyInstance() => create();
   static $pb.PbList<StartBinaryRequest> createRepeated() => $pb.PbList<StartBinaryRequest>();
   @$core.pragma('dart2js:noInline')
-  static StartBinaryRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartBinaryRequest>(create);
+  static StartBinaryRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartBinaryRequest>(create);
   static StartBinaryRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -908,26 +789,24 @@ class StartBinaryResponse extends $pb.GeneratedMessage {
     return $result;
   }
   StartBinaryResponse._() : super();
-  factory StartBinaryResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StartBinaryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StartBinaryResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StartBinaryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartBinaryResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartBinaryResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'pid', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StartBinaryResponse clone() => StartBinaryResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StartBinaryResponse copyWith(void Function(StartBinaryResponse) updates) =>
-      super.copyWith((message) => updates(message as StartBinaryResponse)) as StartBinaryResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StartBinaryResponse copyWith(void Function(StartBinaryResponse) updates) => super.copyWith((message) => updates(message as StartBinaryResponse)) as StartBinaryResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -936,17 +815,13 @@ class StartBinaryResponse extends $pb.GeneratedMessage {
   StartBinaryResponse createEmptyInstance() => create();
   static $pb.PbList<StartBinaryResponse> createRepeated() => $pb.PbList<StartBinaryResponse>();
   @$core.pragma('dart2js:noInline')
-  static StartBinaryResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartBinaryResponse>(create);
+  static StartBinaryResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartBinaryResponse>(create);
   static StartBinaryResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get pid => $_getIZ(0);
   @$pb.TagNumber(1)
-  set pid($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set pid($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPid() => $_has(0);
   @$pb.TagNumber(1)
@@ -968,27 +843,25 @@ class StopBinaryRequest extends $pb.GeneratedMessage {
     return $result;
   }
   StopBinaryRequest._() : super();
-  factory StopBinaryRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopBinaryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopBinaryRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopBinaryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopBinaryRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopBinaryRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOB(2, _omitFieldNames ? '' : 'force')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopBinaryRequest clone() => StopBinaryRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopBinaryRequest copyWith(void Function(StopBinaryRequest) updates) =>
-      super.copyWith((message) => updates(message as StopBinaryRequest)) as StopBinaryRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopBinaryRequest copyWith(void Function(StopBinaryRequest) updates) => super.copyWith((message) => updates(message as StopBinaryRequest)) as StopBinaryRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -997,17 +870,13 @@ class StopBinaryRequest extends $pb.GeneratedMessage {
   StopBinaryRequest createEmptyInstance() => create();
   static $pb.PbList<StopBinaryRequest> createRepeated() => $pb.PbList<StopBinaryRequest>();
   @$core.pragma('dart2js:noInline')
-  static StopBinaryRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StopBinaryRequest>(create);
+  static StopBinaryRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StopBinaryRequest>(create);
   static StopBinaryRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -1016,10 +885,7 @@ class StopBinaryRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get force => $_getBF(1);
   @$pb.TagNumber(2)
-  set force($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set force($core.bool v) { $_setBool(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasForce() => $_has(1);
   @$pb.TagNumber(2)
@@ -1029,25 +895,23 @@ class StopBinaryRequest extends $pb.GeneratedMessage {
 class StopBinaryResponse extends $pb.GeneratedMessage {
   factory StopBinaryResponse() => create();
   StopBinaryResponse._() : super();
-  factory StopBinaryResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopBinaryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopBinaryResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopBinaryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopBinaryResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopBinaryResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopBinaryResponse clone() => StopBinaryResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopBinaryResponse copyWith(void Function(StopBinaryResponse) updates) =>
-      super.copyWith((message) => updates(message as StopBinaryResponse)) as StopBinaryResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopBinaryResponse copyWith(void Function(StopBinaryResponse) updates) => super.copyWith((message) => updates(message as StopBinaryResponse)) as StopBinaryResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1056,8 +920,7 @@ class StopBinaryResponse extends $pb.GeneratedMessage {
   StopBinaryResponse createEmptyInstance() => create();
   static $pb.PbList<StopBinaryResponse> createRepeated() => $pb.PbList<StopBinaryResponse>();
   @$core.pragma('dart2js:noInline')
-  static StopBinaryResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StopBinaryResponse>(create);
+  static StopBinaryResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StopBinaryResponse>(create);
   static StopBinaryResponse? _defaultInstance;
 }
 
@@ -1076,27 +939,25 @@ class StreamLogsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   StreamLogsRequest._() : super();
-  factory StreamLogsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StreamLogsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StreamLogsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StreamLogsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamLogsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamLogsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'tail', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StreamLogsRequest clone() => StreamLogsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StreamLogsRequest copyWith(void Function(StreamLogsRequest) updates) =>
-      super.copyWith((message) => updates(message as StreamLogsRequest)) as StreamLogsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StreamLogsRequest copyWith(void Function(StreamLogsRequest) updates) => super.copyWith((message) => updates(message as StreamLogsRequest)) as StreamLogsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1105,17 +966,13 @@ class StreamLogsRequest extends $pb.GeneratedMessage {
   StreamLogsRequest createEmptyInstance() => create();
   static $pb.PbList<StreamLogsRequest> createRepeated() => $pb.PbList<StreamLogsRequest>();
   @$core.pragma('dart2js:noInline')
-  static StreamLogsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamLogsRequest>(create);
+  static StreamLogsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamLogsRequest>(create);
   static StreamLogsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -1124,10 +981,7 @@ class StreamLogsRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get tail => $_getIZ(1);
   @$pb.TagNumber(2)
-  set tail($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set tail($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasTail() => $_has(1);
   @$pb.TagNumber(2)
@@ -1153,28 +1007,26 @@ class StreamLogsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   StreamLogsResponse._() : super();
-  factory StreamLogsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StreamLogsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StreamLogsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StreamLogsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamLogsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamLogsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'stream')
     ..aOS(2, _omitFieldNames ? '' : 'line')
     ..aInt64(3, _omitFieldNames ? '' : 'timestampUnix')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StreamLogsResponse clone() => StreamLogsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StreamLogsResponse copyWith(void Function(StreamLogsResponse) updates) =>
-      super.copyWith((message) => updates(message as StreamLogsResponse)) as StreamLogsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StreamLogsResponse copyWith(void Function(StreamLogsResponse) updates) => super.copyWith((message) => updates(message as StreamLogsResponse)) as StreamLogsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1183,17 +1035,13 @@ class StreamLogsResponse extends $pb.GeneratedMessage {
   StreamLogsResponse createEmptyInstance() => create();
   static $pb.PbList<StreamLogsResponse> createRepeated() => $pb.PbList<StreamLogsResponse>();
   @$core.pragma('dart2js:noInline')
-  static StreamLogsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamLogsResponse>(create);
+  static StreamLogsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamLogsResponse>(create);
   static StreamLogsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get stream => $_getSZ(0);
   @$pb.TagNumber(1)
-  set stream($core.String v) {
-    $_setString(0, v);
-  }
-
+  set stream($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasStream() => $_has(0);
   @$pb.TagNumber(1)
@@ -1202,10 +1050,7 @@ class StreamLogsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get line => $_getSZ(1);
   @$pb.TagNumber(2)
-  set line($core.String v) {
-    $_setString(1, v);
-  }
-
+  set line($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasLine() => $_has(1);
   @$pb.TagNumber(2)
@@ -1214,10 +1059,7 @@ class StreamLogsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get timestampUnix => $_getI64(2);
   @$pb.TagNumber(3)
-  set timestampUnix($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set timestampUnix($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasTimestampUnix() => $_has(2);
   @$pb.TagNumber(3)
@@ -1255,35 +1097,29 @@ class StartWithL1Request extends $pb.GeneratedMessage {
     return $result;
   }
   StartWithL1Request._() : super();
-  factory StartWithL1Request.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StartWithL1Request.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StartWithL1Request.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StartWithL1Request.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartWithL1Request',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartWithL1Request', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'target')
     ..pPS(2, _omitFieldNames ? '' : 'targetArgs')
-    ..m<$core.String, $core.String>(3, _omitFieldNames ? '' : 'targetEnv',
-        entryClassName: 'StartWithL1Request.TargetEnvEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OS,
-        packageName: const $pb.PackageName('orchestrator.v1'))
+    ..m<$core.String, $core.String>(3, _omitFieldNames ? '' : 'targetEnv', entryClassName: 'StartWithL1Request.TargetEnvEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS, packageName: const $pb.PackageName('orchestrator.v1'))
     ..pPS(4, _omitFieldNames ? '' : 'coreArgs')
     ..pPS(5, _omitFieldNames ? '' : 'enforcerArgs')
     ..aOB(6, _omitFieldNames ? '' : 'immediate')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StartWithL1Request clone() => StartWithL1Request()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StartWithL1Request copyWith(void Function(StartWithL1Request) updates) =>
-      super.copyWith((message) => updates(message as StartWithL1Request)) as StartWithL1Request;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StartWithL1Request copyWith(void Function(StartWithL1Request) updates) => super.copyWith((message) => updates(message as StartWithL1Request)) as StartWithL1Request;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1292,17 +1128,13 @@ class StartWithL1Request extends $pb.GeneratedMessage {
   StartWithL1Request createEmptyInstance() => create();
   static $pb.PbList<StartWithL1Request> createRepeated() => $pb.PbList<StartWithL1Request>();
   @$core.pragma('dart2js:noInline')
-  static StartWithL1Request getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartWithL1Request>(create);
+  static StartWithL1Request getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartWithL1Request>(create);
   static StartWithL1Request? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get target => $_getSZ(0);
   @$pb.TagNumber(1)
-  set target($core.String v) {
-    $_setString(0, v);
-  }
-
+  set target($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTarget() => $_has(0);
   @$pb.TagNumber(1)
@@ -1323,10 +1155,7 @@ class StartWithL1Request extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.bool get immediate => $_getBF(5);
   @$pb.TagNumber(6)
-  set immediate($core.bool v) {
-    $_setBool(5, v);
-  }
-
+  set immediate($core.bool v) { $_setBool(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasImmediate() => $_has(5);
   @$pb.TagNumber(6)
@@ -1336,25 +1165,23 @@ class StartWithL1Request extends $pb.GeneratedMessage {
 class StartWithL1Response extends $pb.GeneratedMessage {
   factory StartWithL1Response() => create();
   StartWithL1Response._() : super();
-  factory StartWithL1Response.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StartWithL1Response.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StartWithL1Response.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StartWithL1Response.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartWithL1Response',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StartWithL1Response', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StartWithL1Response clone() => StartWithL1Response()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StartWithL1Response copyWith(void Function(StartWithL1Response) updates) =>
-      super.copyWith((message) => updates(message as StartWithL1Response)) as StartWithL1Response;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StartWithL1Response copyWith(void Function(StartWithL1Response) updates) => super.copyWith((message) => updates(message as StartWithL1Response)) as StartWithL1Response;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1363,8 +1190,7 @@ class StartWithL1Response extends $pb.GeneratedMessage {
   StartWithL1Response createEmptyInstance() => create();
   static $pb.PbList<StartWithL1Response> createRepeated() => $pb.PbList<StartWithL1Response>();
   @$core.pragma('dart2js:noInline')
-  static StartWithL1Response getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartWithL1Response>(create);
+  static StartWithL1Response getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StartWithL1Response>(create);
   static StartWithL1Response? _defaultInstance;
 }
 
@@ -1379,26 +1205,24 @@ class RestartDaemonRequest extends $pb.GeneratedMessage {
     return $result;
   }
   RestartDaemonRequest._() : super();
-  factory RestartDaemonRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RestartDaemonRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RestartDaemonRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RestartDaemonRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RestartDaemonRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RestartDaemonRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RestartDaemonRequest clone() => RestartDaemonRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RestartDaemonRequest copyWith(void Function(RestartDaemonRequest) updates) =>
-      super.copyWith((message) => updates(message as RestartDaemonRequest)) as RestartDaemonRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RestartDaemonRequest copyWith(void Function(RestartDaemonRequest) updates) => super.copyWith((message) => updates(message as RestartDaemonRequest)) as RestartDaemonRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1407,17 +1231,13 @@ class RestartDaemonRequest extends $pb.GeneratedMessage {
   RestartDaemonRequest createEmptyInstance() => create();
   static $pb.PbList<RestartDaemonRequest> createRepeated() => $pb.PbList<RestartDaemonRequest>();
   @$core.pragma('dart2js:noInline')
-  static RestartDaemonRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RestartDaemonRequest>(create);
+  static RestartDaemonRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RestartDaemonRequest>(create);
   static RestartDaemonRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -1427,25 +1247,23 @@ class RestartDaemonRequest extends $pb.GeneratedMessage {
 class RestartDaemonResponse extends $pb.GeneratedMessage {
   factory RestartDaemonResponse() => create();
   RestartDaemonResponse._() : super();
-  factory RestartDaemonResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RestartDaemonResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RestartDaemonResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RestartDaemonResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RestartDaemonResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RestartDaemonResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RestartDaemonResponse clone() => RestartDaemonResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RestartDaemonResponse copyWith(void Function(RestartDaemonResponse) updates) =>
-      super.copyWith((message) => updates(message as RestartDaemonResponse)) as RestartDaemonResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RestartDaemonResponse copyWith(void Function(RestartDaemonResponse) updates) => super.copyWith((message) => updates(message as RestartDaemonResponse)) as RestartDaemonResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1454,8 +1272,7 @@ class RestartDaemonResponse extends $pb.GeneratedMessage {
   RestartDaemonResponse createEmptyInstance() => create();
   static $pb.PbList<RestartDaemonResponse> createRepeated() => $pb.PbList<RestartDaemonResponse>();
   @$core.pragma('dart2js:noInline')
-  static RestartDaemonResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RestartDaemonResponse>(create);
+  static RestartDaemonResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RestartDaemonResponse>(create);
   static RestartDaemonResponse? _defaultInstance;
 }
 
@@ -1470,26 +1287,24 @@ class ShutdownAllRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ShutdownAllRequest._() : super();
-  factory ShutdownAllRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ShutdownAllRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ShutdownAllRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ShutdownAllRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShutdownAllRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShutdownAllRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'force')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ShutdownAllRequest clone() => ShutdownAllRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ShutdownAllRequest copyWith(void Function(ShutdownAllRequest) updates) =>
-      super.copyWith((message) => updates(message as ShutdownAllRequest)) as ShutdownAllRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ShutdownAllRequest copyWith(void Function(ShutdownAllRequest) updates) => super.copyWith((message) => updates(message as ShutdownAllRequest)) as ShutdownAllRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1498,17 +1313,13 @@ class ShutdownAllRequest extends $pb.GeneratedMessage {
   ShutdownAllRequest createEmptyInstance() => create();
   static $pb.PbList<ShutdownAllRequest> createRepeated() => $pb.PbList<ShutdownAllRequest>();
   @$core.pragma('dart2js:noInline')
-  static ShutdownAllRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShutdownAllRequest>(create);
+  static ShutdownAllRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShutdownAllRequest>(create);
   static ShutdownAllRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get force => $_getBF(0);
   @$pb.TagNumber(1)
-  set force($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set force($core.bool v) { $_setBool(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasForce() => $_has(0);
   @$pb.TagNumber(1)
@@ -1542,30 +1353,28 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ShutdownAllResponse._() : super();
-  factory ShutdownAllResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ShutdownAllResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ShutdownAllResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ShutdownAllResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShutdownAllResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShutdownAllResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'totalCount', $pb.PbFieldType.O3)
     ..a<$core.int>(2, _omitFieldNames ? '' : 'completedCount', $pb.PbFieldType.O3)
     ..aOS(3, _omitFieldNames ? '' : 'currentBinary')
     ..aOB(4, _omitFieldNames ? '' : 'done')
     ..aOS(5, _omitFieldNames ? '' : 'error')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ShutdownAllResponse clone() => ShutdownAllResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ShutdownAllResponse copyWith(void Function(ShutdownAllResponse) updates) =>
-      super.copyWith((message) => updates(message as ShutdownAllResponse)) as ShutdownAllResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ShutdownAllResponse copyWith(void Function(ShutdownAllResponse) updates) => super.copyWith((message) => updates(message as ShutdownAllResponse)) as ShutdownAllResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1574,17 +1383,13 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
   ShutdownAllResponse createEmptyInstance() => create();
   static $pb.PbList<ShutdownAllResponse> createRepeated() => $pb.PbList<ShutdownAllResponse>();
   @$core.pragma('dart2js:noInline')
-  static ShutdownAllResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShutdownAllResponse>(create);
+  static ShutdownAllResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShutdownAllResponse>(create);
   static ShutdownAllResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get totalCount => $_getIZ(0);
   @$pb.TagNumber(1)
-  set totalCount($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set totalCount($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTotalCount() => $_has(0);
   @$pb.TagNumber(1)
@@ -1593,10 +1398,7 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get completedCount => $_getIZ(1);
   @$pb.TagNumber(2)
-  set completedCount($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set completedCount($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasCompletedCount() => $_has(1);
   @$pb.TagNumber(2)
@@ -1605,10 +1407,7 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get currentBinary => $_getSZ(2);
   @$pb.TagNumber(3)
-  set currentBinary($core.String v) {
-    $_setString(2, v);
-  }
-
+  set currentBinary($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasCurrentBinary() => $_has(2);
   @$pb.TagNumber(3)
@@ -1617,10 +1416,7 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get done => $_getBF(3);
   @$pb.TagNumber(4)
-  set done($core.bool v) {
-    $_setBool(3, v);
-  }
-
+  set done($core.bool v) { $_setBool(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasDone() => $_has(3);
   @$pb.TagNumber(4)
@@ -1629,10 +1425,7 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get error => $_getSZ(4);
   @$pb.TagNumber(5)
-  set error($core.String v) {
-    $_setString(4, v);
-  }
-
+  set error($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasError() => $_has(4);
   @$pb.TagNumber(5)
@@ -1642,25 +1435,23 @@ class ShutdownAllResponse extends $pb.GeneratedMessage {
 class GetBTCPriceRequest extends $pb.GeneratedMessage {
   factory GetBTCPriceRequest() => create();
   GetBTCPriceRequest._() : super();
-  factory GetBTCPriceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBTCPriceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBTCPriceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBTCPriceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBTCPriceRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBTCPriceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBTCPriceRequest clone() => GetBTCPriceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBTCPriceRequest copyWith(void Function(GetBTCPriceRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBTCPriceRequest)) as GetBTCPriceRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBTCPriceRequest copyWith(void Function(GetBTCPriceRequest) updates) => super.copyWith((message) => updates(message as GetBTCPriceRequest)) as GetBTCPriceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1669,8 +1460,7 @@ class GetBTCPriceRequest extends $pb.GeneratedMessage {
   GetBTCPriceRequest createEmptyInstance() => create();
   static $pb.PbList<GetBTCPriceRequest> createRepeated() => $pb.PbList<GetBTCPriceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBTCPriceRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBTCPriceRequest>(create);
+  static GetBTCPriceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBTCPriceRequest>(create);
   static GetBTCPriceRequest? _defaultInstance;
 }
 
@@ -1689,27 +1479,25 @@ class GetBTCPriceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBTCPriceResponse._() : super();
-  factory GetBTCPriceResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBTCPriceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBTCPriceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBTCPriceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBTCPriceResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBTCPriceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.double>(1, _omitFieldNames ? '' : 'btcusd', $pb.PbFieldType.OD)
     ..aInt64(2, _omitFieldNames ? '' : 'lastUpdatedUnix')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBTCPriceResponse clone() => GetBTCPriceResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBTCPriceResponse copyWith(void Function(GetBTCPriceResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBTCPriceResponse)) as GetBTCPriceResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBTCPriceResponse copyWith(void Function(GetBTCPriceResponse) updates) => super.copyWith((message) => updates(message as GetBTCPriceResponse)) as GetBTCPriceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1718,17 +1506,13 @@ class GetBTCPriceResponse extends $pb.GeneratedMessage {
   GetBTCPriceResponse createEmptyInstance() => create();
   static $pb.PbList<GetBTCPriceResponse> createRepeated() => $pb.PbList<GetBTCPriceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBTCPriceResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBTCPriceResponse>(create);
+  static GetBTCPriceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBTCPriceResponse>(create);
   static GetBTCPriceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.double get btcusd => $_getN(0);
   @$pb.TagNumber(1)
-  set btcusd($core.double v) {
-    $_setDouble(0, v);
-  }
-
+  set btcusd($core.double v) { $_setDouble(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBtcusd() => $_has(0);
   @$pb.TagNumber(1)
@@ -1737,10 +1521,7 @@ class GetBTCPriceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get lastUpdatedUnix => $_getI64(1);
   @$pb.TagNumber(2)
-  set lastUpdatedUnix($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set lastUpdatedUnix($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasLastUpdatedUnix() => $_has(1);
   @$pb.TagNumber(2)
@@ -1750,38 +1531,32 @@ class GetBTCPriceResponse extends $pb.GeneratedMessage {
 class GetMainchainBlockchainInfoRequest extends $pb.GeneratedMessage {
   factory GetMainchainBlockchainInfoRequest() => create();
   GetMainchainBlockchainInfoRequest._() : super();
-  factory GetMainchainBlockchainInfoRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetMainchainBlockchainInfoRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetMainchainBlockchainInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetMainchainBlockchainInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBlockchainInfoRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBlockchainInfoRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetMainchainBlockchainInfoRequest clone() => GetMainchainBlockchainInfoRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetMainchainBlockchainInfoRequest copyWith(void Function(GetMainchainBlockchainInfoRequest) updates) =>
-      super.copyWith((message) => updates(message as GetMainchainBlockchainInfoRequest))
-          as GetMainchainBlockchainInfoRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetMainchainBlockchainInfoRequest copyWith(void Function(GetMainchainBlockchainInfoRequest) updates) => super.copyWith((message) => updates(message as GetMainchainBlockchainInfoRequest)) as GetMainchainBlockchainInfoRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetMainchainBlockchainInfoRequest create() => GetMainchainBlockchainInfoRequest._();
   GetMainchainBlockchainInfoRequest createEmptyInstance() => create();
-  static $pb.PbList<GetMainchainBlockchainInfoRequest> createRepeated() =>
-      $pb.PbList<GetMainchainBlockchainInfoRequest>();
+  static $pb.PbList<GetMainchainBlockchainInfoRequest> createRepeated() => $pb.PbList<GetMainchainBlockchainInfoRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetMainchainBlockchainInfoRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBlockchainInfoRequest>(create);
+  static GetMainchainBlockchainInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBlockchainInfoRequest>(create);
   static GetMainchainBlockchainInfoRequest? _defaultInstance;
 }
 
@@ -1840,15 +1615,10 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetMainchainBlockchainInfoResponse._() : super();
-  factory GetMainchainBlockchainInfoResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetMainchainBlockchainInfoResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetMainchainBlockchainInfoResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetMainchainBlockchainInfoResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBlockchainInfoResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBlockchainInfoResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'chain')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'blocks', $pb.PbFieldType.O3)
     ..a<$core.int>(3, _omitFieldNames ? '' : 'headers', $pb.PbFieldType.O3)
@@ -1861,38 +1631,34 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
     ..aOS(10, _omitFieldNames ? '' : 'chainWork')
     ..aInt64(11, _omitFieldNames ? '' : 'sizeOnDisk')
     ..aOB(12, _omitFieldNames ? '' : 'pruned')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetMainchainBlockchainInfoResponse clone() => GetMainchainBlockchainInfoResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetMainchainBlockchainInfoResponse copyWith(void Function(GetMainchainBlockchainInfoResponse) updates) =>
-      super.copyWith((message) => updates(message as GetMainchainBlockchainInfoResponse))
-          as GetMainchainBlockchainInfoResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetMainchainBlockchainInfoResponse copyWith(void Function(GetMainchainBlockchainInfoResponse) updates) => super.copyWith((message) => updates(message as GetMainchainBlockchainInfoResponse)) as GetMainchainBlockchainInfoResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetMainchainBlockchainInfoResponse create() => GetMainchainBlockchainInfoResponse._();
   GetMainchainBlockchainInfoResponse createEmptyInstance() => create();
-  static $pb.PbList<GetMainchainBlockchainInfoResponse> createRepeated() =>
-      $pb.PbList<GetMainchainBlockchainInfoResponse>();
+  static $pb.PbList<GetMainchainBlockchainInfoResponse> createRepeated() => $pb.PbList<GetMainchainBlockchainInfoResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetMainchainBlockchainInfoResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBlockchainInfoResponse>(create);
+  static GetMainchainBlockchainInfoResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBlockchainInfoResponse>(create);
   static GetMainchainBlockchainInfoResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get chain => $_getSZ(0);
   @$pb.TagNumber(1)
-  set chain($core.String v) {
-    $_setString(0, v);
-  }
-
+  set chain($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasChain() => $_has(0);
   @$pb.TagNumber(1)
@@ -1901,10 +1667,7 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get blocks => $_getIZ(1);
   @$pb.TagNumber(2)
-  set blocks($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set blocks($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasBlocks() => $_has(1);
   @$pb.TagNumber(2)
@@ -1913,10 +1676,7 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get headers => $_getIZ(2);
   @$pb.TagNumber(3)
-  set headers($core.int v) {
-    $_setSignedInt32(2, v);
-  }
-
+  set headers($core.int v) { $_setSignedInt32(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasHeaders() => $_has(2);
   @$pb.TagNumber(3)
@@ -1925,10 +1685,7 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get bestBlockHash => $_getSZ(3);
   @$pb.TagNumber(4)
-  set bestBlockHash($core.String v) {
-    $_setString(3, v);
-  }
-
+  set bestBlockHash($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasBestBlockHash() => $_has(3);
   @$pb.TagNumber(4)
@@ -1937,10 +1694,7 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.double get difficulty => $_getN(4);
   @$pb.TagNumber(5)
-  set difficulty($core.double v) {
-    $_setDouble(4, v);
-  }
-
+  set difficulty($core.double v) { $_setDouble(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasDifficulty() => $_has(4);
   @$pb.TagNumber(5)
@@ -1949,10 +1703,7 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get time => $_getI64(5);
   @$pb.TagNumber(6)
-  set time($fixnum.Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set time($fixnum.Int64 v) { $_setInt64(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasTime() => $_has(5);
   @$pb.TagNumber(6)
@@ -1961,10 +1712,7 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get medianTime => $_getI64(6);
   @$pb.TagNumber(7)
-  set medianTime($fixnum.Int64 v) {
-    $_setInt64(6, v);
-  }
-
+  set medianTime($fixnum.Int64 v) { $_setInt64(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasMedianTime() => $_has(6);
   @$pb.TagNumber(7)
@@ -1973,10 +1721,7 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.double get verificationProgress => $_getN(7);
   @$pb.TagNumber(8)
-  set verificationProgress($core.double v) {
-    $_setDouble(7, v);
-  }
-
+  set verificationProgress($core.double v) { $_setDouble(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasVerificationProgress() => $_has(7);
   @$pb.TagNumber(8)
@@ -1985,10 +1730,7 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.bool get initialBlockDownload => $_getBF(8);
   @$pb.TagNumber(9)
-  set initialBlockDownload($core.bool v) {
-    $_setBool(8, v);
-  }
-
+  set initialBlockDownload($core.bool v) { $_setBool(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasInitialBlockDownload() => $_has(8);
   @$pb.TagNumber(9)
@@ -1997,10 +1739,7 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.String get chainWork => $_getSZ(9);
   @$pb.TagNumber(10)
-  set chainWork($core.String v) {
-    $_setString(9, v);
-  }
-
+  set chainWork($core.String v) { $_setString(9, v); }
   @$pb.TagNumber(10)
   $core.bool hasChainWork() => $_has(9);
   @$pb.TagNumber(10)
@@ -2009,10 +1748,7 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $fixnum.Int64 get sizeOnDisk => $_getI64(10);
   @$pb.TagNumber(11)
-  set sizeOnDisk($fixnum.Int64 v) {
-    $_setInt64(10, v);
-  }
-
+  set sizeOnDisk($fixnum.Int64 v) { $_setInt64(10, v); }
   @$pb.TagNumber(11)
   $core.bool hasSizeOnDisk() => $_has(10);
   @$pb.TagNumber(11)
@@ -2021,10 +1757,7 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $core.bool get pruned => $_getBF(11);
   @$pb.TagNumber(12)
-  set pruned($core.bool v) {
-    $_setBool(11, v);
-  }
-
+  set pruned($core.bool v) { $_setBool(11, v); }
   @$pb.TagNumber(12)
   $core.bool hasPruned() => $_has(11);
   @$pb.TagNumber(12)
@@ -2034,38 +1767,32 @@ class GetMainchainBlockchainInfoResponse extends $pb.GeneratedMessage {
 class GetEnforcerBlockchainInfoRequest extends $pb.GeneratedMessage {
   factory GetEnforcerBlockchainInfoRequest() => create();
   GetEnforcerBlockchainInfoRequest._() : super();
-  factory GetEnforcerBlockchainInfoRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetEnforcerBlockchainInfoRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetEnforcerBlockchainInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetEnforcerBlockchainInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEnforcerBlockchainInfoRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEnforcerBlockchainInfoRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetEnforcerBlockchainInfoRequest clone() => GetEnforcerBlockchainInfoRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetEnforcerBlockchainInfoRequest copyWith(void Function(GetEnforcerBlockchainInfoRequest) updates) =>
-      super.copyWith((message) => updates(message as GetEnforcerBlockchainInfoRequest))
-          as GetEnforcerBlockchainInfoRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetEnforcerBlockchainInfoRequest copyWith(void Function(GetEnforcerBlockchainInfoRequest) updates) => super.copyWith((message) => updates(message as GetEnforcerBlockchainInfoRequest)) as GetEnforcerBlockchainInfoRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetEnforcerBlockchainInfoRequest create() => GetEnforcerBlockchainInfoRequest._();
   GetEnforcerBlockchainInfoRequest createEmptyInstance() => create();
-  static $pb.PbList<GetEnforcerBlockchainInfoRequest> createRepeated() =>
-      $pb.PbList<GetEnforcerBlockchainInfoRequest>();
+  static $pb.PbList<GetEnforcerBlockchainInfoRequest> createRepeated() => $pb.PbList<GetEnforcerBlockchainInfoRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetEnforcerBlockchainInfoRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEnforcerBlockchainInfoRequest>(create);
+  static GetEnforcerBlockchainInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEnforcerBlockchainInfoRequest>(create);
   static GetEnforcerBlockchainInfoRequest? _defaultInstance;
 }
 
@@ -2088,50 +1815,41 @@ class GetEnforcerBlockchainInfoResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetEnforcerBlockchainInfoResponse._() : super();
-  factory GetEnforcerBlockchainInfoResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetEnforcerBlockchainInfoResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetEnforcerBlockchainInfoResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetEnforcerBlockchainInfoResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEnforcerBlockchainInfoResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetEnforcerBlockchainInfoResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'blocks', $pb.PbFieldType.O3)
     ..a<$core.int>(2, _omitFieldNames ? '' : 'headers', $pb.PbFieldType.O3)
     ..aInt64(3, _omitFieldNames ? '' : 'time')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetEnforcerBlockchainInfoResponse clone() => GetEnforcerBlockchainInfoResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetEnforcerBlockchainInfoResponse copyWith(void Function(GetEnforcerBlockchainInfoResponse) updates) =>
-      super.copyWith((message) => updates(message as GetEnforcerBlockchainInfoResponse))
-          as GetEnforcerBlockchainInfoResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetEnforcerBlockchainInfoResponse copyWith(void Function(GetEnforcerBlockchainInfoResponse) updates) => super.copyWith((message) => updates(message as GetEnforcerBlockchainInfoResponse)) as GetEnforcerBlockchainInfoResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetEnforcerBlockchainInfoResponse create() => GetEnforcerBlockchainInfoResponse._();
   GetEnforcerBlockchainInfoResponse createEmptyInstance() => create();
-  static $pb.PbList<GetEnforcerBlockchainInfoResponse> createRepeated() =>
-      $pb.PbList<GetEnforcerBlockchainInfoResponse>();
+  static $pb.PbList<GetEnforcerBlockchainInfoResponse> createRepeated() => $pb.PbList<GetEnforcerBlockchainInfoResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetEnforcerBlockchainInfoResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEnforcerBlockchainInfoResponse>(create);
+  static GetEnforcerBlockchainInfoResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetEnforcerBlockchainInfoResponse>(create);
   static GetEnforcerBlockchainInfoResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get blocks => $_getIZ(0);
   @$pb.TagNumber(1)
-  set blocks($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set blocks($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlocks() => $_has(0);
   @$pb.TagNumber(1)
@@ -2140,10 +1858,7 @@ class GetEnforcerBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get headers => $_getIZ(1);
   @$pb.TagNumber(2)
-  set headers($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set headers($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasHeaders() => $_has(1);
   @$pb.TagNumber(2)
@@ -2152,10 +1867,7 @@ class GetEnforcerBlockchainInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get time => $_getI64(2);
   @$pb.TagNumber(3)
-  set time($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set time($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasTime() => $_has(2);
   @$pb.TagNumber(3)
@@ -2165,25 +1877,23 @@ class GetEnforcerBlockchainInfoResponse extends $pb.GeneratedMessage {
 class GetSyncStatusRequest extends $pb.GeneratedMessage {
   factory GetSyncStatusRequest() => create();
   GetSyncStatusRequest._() : super();
-  factory GetSyncStatusRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSyncStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSyncStatusRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSyncStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSyncStatusRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSyncStatusRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSyncStatusRequest clone() => GetSyncStatusRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSyncStatusRequest copyWith(void Function(GetSyncStatusRequest) updates) =>
-      super.copyWith((message) => updates(message as GetSyncStatusRequest)) as GetSyncStatusRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSyncStatusRequest copyWith(void Function(GetSyncStatusRequest) updates) => super.copyWith((message) => updates(message as GetSyncStatusRequest)) as GetSyncStatusRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2192,8 +1902,7 @@ class GetSyncStatusRequest extends $pb.GeneratedMessage {
   GetSyncStatusRequest createEmptyInstance() => create();
   static $pb.PbList<GetSyncStatusRequest> createRepeated() => $pb.PbList<GetSyncStatusRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetSyncStatusRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSyncStatusRequest>(create);
+  static GetSyncStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSyncStatusRequest>(create);
   static GetSyncStatusRequest? _defaultInstance;
 }
 
@@ -2216,29 +1925,26 @@ class GetSyncStatusResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetSyncStatusResponse._() : super();
-  factory GetSyncStatusResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSyncStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSyncStatusResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSyncStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSyncStatusResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSyncStatusResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOM<ChainSync>(1, _omitFieldNames ? '' : 'mainchain', subBuilder: ChainSync.create)
     ..aOM<ChainSync>(2, _omitFieldNames ? '' : 'enforcer', subBuilder: ChainSync.create)
-    ..pc<SidechainStatus>(3, _omitFieldNames ? '' : 'sidechains', $pb.PbFieldType.PM,
-        subBuilder: SidechainStatus.create)
-    ..hasRequiredFields = false;
+    ..pc<SidechainStatus>(3, _omitFieldNames ? '' : 'sidechains', $pb.PbFieldType.PM, subBuilder: SidechainStatus.create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSyncStatusResponse clone() => GetSyncStatusResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSyncStatusResponse copyWith(void Function(GetSyncStatusResponse) updates) =>
-      super.copyWith((message) => updates(message as GetSyncStatusResponse)) as GetSyncStatusResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSyncStatusResponse copyWith(void Function(GetSyncStatusResponse) updates) => super.copyWith((message) => updates(message as GetSyncStatusResponse)) as GetSyncStatusResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2247,17 +1953,13 @@ class GetSyncStatusResponse extends $pb.GeneratedMessage {
   GetSyncStatusResponse createEmptyInstance() => create();
   static $pb.PbList<GetSyncStatusResponse> createRepeated() => $pb.PbList<GetSyncStatusResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetSyncStatusResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSyncStatusResponse>(create);
+  static GetSyncStatusResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSyncStatusResponse>(create);
   static GetSyncStatusResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   ChainSync get mainchain => $_getN(0);
   @$pb.TagNumber(1)
-  set mainchain(ChainSync v) {
-    setField(1, v);
-  }
-
+  set mainchain(ChainSync v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasMainchain() => $_has(0);
   @$pb.TagNumber(1)
@@ -2268,10 +1970,7 @@ class GetSyncStatusResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   ChainSync get enforcer => $_getN(1);
   @$pb.TagNumber(2)
-  set enforcer(ChainSync v) {
-    setField(2, v);
-  }
-
+  set enforcer(ChainSync v) { setField(2, v); }
   @$pb.TagNumber(2)
   $core.bool hasEnforcer() => $_has(1);
   @$pb.TagNumber(2)
@@ -2303,30 +2002,25 @@ class SidechainStatus extends $pb.GeneratedMessage {
     return $result;
   }
   SidechainStatus._() : super();
-  factory SidechainStatus.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SidechainStatus.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SidechainStatus.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SidechainStatus.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SidechainStatus',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..e<SidechainType>(1, _omitFieldNames ? '' : 'type', $pb.PbFieldType.OE,
-        defaultOrMaker: SidechainType.SIDECHAIN_TYPE_UNSPECIFIED,
-        valueOf: SidechainType.valueOf,
-        enumValues: SidechainType.values)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SidechainStatus', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..e<SidechainType>(1, _omitFieldNames ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: SidechainType.SIDECHAIN_TYPE_UNSPECIFIED, valueOf: SidechainType.valueOf, enumValues: SidechainType.values)
     ..aOM<ChainSync>(2, _omitFieldNames ? '' : 'sync', subBuilder: ChainSync.create)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SidechainStatus clone() => SidechainStatus()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SidechainStatus copyWith(void Function(SidechainStatus) updates) =>
-      super.copyWith((message) => updates(message as SidechainStatus)) as SidechainStatus;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SidechainStatus copyWith(void Function(SidechainStatus) updates) => super.copyWith((message) => updates(message as SidechainStatus)) as SidechainStatus;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2335,17 +2029,13 @@ class SidechainStatus extends $pb.GeneratedMessage {
   SidechainStatus createEmptyInstance() => create();
   static $pb.PbList<SidechainStatus> createRepeated() => $pb.PbList<SidechainStatus>();
   @$core.pragma('dart2js:noInline')
-  static SidechainStatus getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SidechainStatus>(create);
+  static SidechainStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SidechainStatus>(create);
   static SidechainStatus? _defaultInstance;
 
   @$pb.TagNumber(1)
   SidechainType get type => $_getN(0);
   @$pb.TagNumber(1)
-  set type(SidechainType v) {
-    setField(1, v);
-  }
-
+  set type(SidechainType v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasType() => $_has(0);
   @$pb.TagNumber(1)
@@ -2354,10 +2044,7 @@ class SidechainStatus extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   ChainSync get sync => $_getN(1);
   @$pb.TagNumber(2)
-  set sync(ChainSync v) {
-    setField(2, v);
-  }
-
+  set sync(ChainSync v) { setField(2, v); }
   @$pb.TagNumber(2)
   $core.bool hasSync() => $_has(1);
   @$pb.TagNumber(2)
@@ -2372,7 +2059,6 @@ class ChainSync extends $pb.GeneratedMessage {
     $core.int? headers,
     $fixnum.Int64? time,
     $core.String? error,
-    $core.bool? isDownloading,
   }) {
     final $result = create();
     if (blocks != null) {
@@ -2387,35 +2073,30 @@ class ChainSync extends $pb.GeneratedMessage {
     if (error != null) {
       $result.error = error;
     }
-    if (isDownloading != null) {
-      $result.isDownloading = isDownloading;
-    }
     return $result;
   }
   ChainSync._() : super();
-  factory ChainSync.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChainSync.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ChainSync.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ChainSync.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ChainSync',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ChainSync', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'blocks', $pb.PbFieldType.O3)
     ..a<$core.int>(2, _omitFieldNames ? '' : 'headers', $pb.PbFieldType.O3)
     ..aInt64(3, _omitFieldNames ? '' : 'time')
     ..aOS(4, _omitFieldNames ? '' : 'error')
-    ..aOB(5, _omitFieldNames ? '' : 'isDownloading')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ChainSync clone() => ChainSync()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ChainSync copyWith(void Function(ChainSync) updates) =>
-      super.copyWith((message) => updates(message as ChainSync)) as ChainSync;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ChainSync copyWith(void Function(ChainSync) updates) => super.copyWith((message) => updates(message as ChainSync)) as ChainSync;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2427,28 +2108,22 @@ class ChainSync extends $pb.GeneratedMessage {
   static ChainSync getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChainSync>(create);
   static ChainSync? _defaultInstance;
 
-  /// While is_downloading=true: blocks = MB downloaded, headers = MB total.
-  /// Otherwise: blocks = current tip height, headers = bitcoind's header
-  /// count (or this daemon's own headers if mainchain is unavailable).
+  /// Current tip height for the chain.
   @$pb.TagNumber(1)
   $core.int get blocks => $_getIZ(0);
   @$pb.TagNumber(1)
-  set blocks($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set blocks($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlocks() => $_has(0);
   @$pb.TagNumber(1)
   void clearBlocks() => clearField(1);
 
+  /// bitcoind's header count, or this daemon's own headers if mainchain is
+  /// unavailable.
   @$pb.TagNumber(2)
   $core.int get headers => $_getIZ(1);
   @$pb.TagNumber(2)
-  set headers($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set headers($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasHeaders() => $_has(1);
   @$pb.TagNumber(2)
@@ -2458,10 +2133,7 @@ class ChainSync extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get time => $_getI64(2);
   @$pb.TagNumber(3)
-  set time($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set time($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasTime() => $_has(2);
   @$pb.TagNumber(3)
@@ -2472,54 +2144,206 @@ class ChainSync extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get error => $_getSZ(3);
   @$pb.TagNumber(4)
-  set error($core.String v) {
-    $_setString(3, v);
-  }
-
+  set error($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasError() => $_has(3);
   @$pb.TagNumber(4)
   void clearError() => clearField(4);
+}
 
-  /// When true, the orchestrator is currently downloading the binary for
-  /// this slot — blocks/headers carry MB downloaded / MB total instead of
-  /// chain heights. The UI uses this to format "X MB" vs "N blocks".
-  @$pb.TagNumber(5)
-  $core.bool get isDownloading => $_getBF(4);
-  @$pb.TagNumber(5)
-  set isDownloading($core.bool v) {
-    $_setBool(4, v);
+class GetDownloadStatusRequest extends $pb.GeneratedMessage {
+  factory GetDownloadStatusRequest() => create();
+  GetDownloadStatusRequest._() : super();
+  factory GetDownloadStatusRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetDownloadStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetDownloadStatusRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetDownloadStatusRequest clone() => GetDownloadStatusRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetDownloadStatusRequest copyWith(void Function(GetDownloadStatusRequest) updates) => super.copyWith((message) => updates(message as GetDownloadStatusRequest)) as GetDownloadStatusRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetDownloadStatusRequest create() => GetDownloadStatusRequest._();
+  GetDownloadStatusRequest createEmptyInstance() => create();
+  static $pb.PbList<GetDownloadStatusRequest> createRepeated() => $pb.PbList<GetDownloadStatusRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetDownloadStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetDownloadStatusRequest>(create);
+  static GetDownloadStatusRequest? _defaultInstance;
+}
+
+class GetDownloadStatusResponse extends $pb.GeneratedMessage {
+  factory GetDownloadStatusResponse({
+    $core.Iterable<DownloadStatus>? downloads,
+  }) {
+    final $result = create();
+    if (downloads != null) {
+      $result.downloads.addAll(downloads);
+    }
+    return $result;
   }
+  GetDownloadStatusResponse._() : super();
+  factory GetDownloadStatusResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetDownloadStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  @$pb.TagNumber(5)
-  $core.bool hasIsDownloading() => $_has(4);
-  @$pb.TagNumber(5)
-  void clearIsDownloading() => clearField(5);
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetDownloadStatusResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..pc<DownloadStatus>(1, _omitFieldNames ? '' : 'downloads', $pb.PbFieldType.PM, subBuilder: DownloadStatus.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetDownloadStatusResponse clone() => GetDownloadStatusResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetDownloadStatusResponse copyWith(void Function(GetDownloadStatusResponse) updates) => super.copyWith((message) => updates(message as GetDownloadStatusResponse)) as GetDownloadStatusResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetDownloadStatusResponse create() => GetDownloadStatusResponse._();
+  GetDownloadStatusResponse createEmptyInstance() => create();
+  static $pb.PbList<GetDownloadStatusResponse> createRepeated() => $pb.PbList<GetDownloadStatusResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetDownloadStatusResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetDownloadStatusResponse>(create);
+  static GetDownloadStatusResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<DownloadStatus> get downloads => $_getList(0);
+}
+
+class DownloadStatus extends $pb.GeneratedMessage {
+  factory DownloadStatus({
+    BinaryType? binary,
+    $fixnum.Int64? mbDownloaded,
+    $fixnum.Int64? mbTotal,
+    $core.String? message,
+  }) {
+    final $result = create();
+    if (binary != null) {
+      $result.binary = binary;
+    }
+    if (mbDownloaded != null) {
+      $result.mbDownloaded = mbDownloaded;
+    }
+    if (mbTotal != null) {
+      $result.mbTotal = mbTotal;
+    }
+    if (message != null) {
+      $result.message = message;
+    }
+    return $result;
+  }
+  DownloadStatus._() : super();
+  factory DownloadStatus.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DownloadStatus.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DownloadStatus', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..e<BinaryType>(1, _omitFieldNames ? '' : 'binary', $pb.PbFieldType.OE, defaultOrMaker: BinaryType.BINARY_TYPE_UNSPECIFIED, valueOf: BinaryType.valueOf, enumValues: BinaryType.values)
+    ..aInt64(2, _omitFieldNames ? '' : 'mbDownloaded')
+    ..aInt64(3, _omitFieldNames ? '' : 'mbTotal')
+    ..aOS(4, _omitFieldNames ? '' : 'message')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DownloadStatus clone() => DownloadStatus()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DownloadStatus copyWith(void Function(DownloadStatus) updates) => super.copyWith((message) => updates(message as DownloadStatus)) as DownloadStatus;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DownloadStatus create() => DownloadStatus._();
+  DownloadStatus createEmptyInstance() => create();
+  static $pb.PbList<DownloadStatus> createRepeated() => $pb.PbList<DownloadStatus>();
+  @$core.pragma('dart2js:noInline')
+  static DownloadStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DownloadStatus>(create);
+  static DownloadStatus? _defaultInstance;
+
+  /// Typed identifier for the binary being downloaded.
+  @$pb.TagNumber(1)
+  BinaryType get binary => $_getN(0);
+  @$pb.TagNumber(1)
+  set binary(BinaryType v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasBinary() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearBinary() => clearField(1);
+
+  /// Megabytes downloaded so far. Source of truth lives in DownloadManager.
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get mbDownloaded => $_getI64(1);
+  @$pb.TagNumber(2)
+  set mbDownloaded($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMbDownloaded() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMbDownloaded() => clearField(2);
+
+  /// Total size in megabytes, or -1 when the server hasn't reported a
+  /// Content-Length yet.
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get mbTotal => $_getI64(2);
+  @$pb.TagNumber(3)
+  set mbTotal($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMbTotal() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMbTotal() => clearField(3);
+
+  /// Optional human-readable progress string ("verifying hash", ...).
+  @$pb.TagNumber(4)
+  $core.String get message => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set message($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMessage() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMessage() => clearField(4);
 }
 
 class GetMainchainBalanceRequest extends $pb.GeneratedMessage {
   factory GetMainchainBalanceRequest() => create();
   GetMainchainBalanceRequest._() : super();
-  factory GetMainchainBalanceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetMainchainBalanceRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetMainchainBalanceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetMainchainBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBalanceRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBalanceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetMainchainBalanceRequest clone() => GetMainchainBalanceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetMainchainBalanceRequest copyWith(void Function(GetMainchainBalanceRequest) updates) =>
-      super.copyWith((message) => updates(message as GetMainchainBalanceRequest)) as GetMainchainBalanceRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetMainchainBalanceRequest copyWith(void Function(GetMainchainBalanceRequest) updates) => super.copyWith((message) => updates(message as GetMainchainBalanceRequest)) as GetMainchainBalanceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2528,8 +2352,7 @@ class GetMainchainBalanceRequest extends $pb.GeneratedMessage {
   GetMainchainBalanceRequest createEmptyInstance() => create();
   static $pb.PbList<GetMainchainBalanceRequest> createRepeated() => $pb.PbList<GetMainchainBalanceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetMainchainBalanceRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBalanceRequest>(create);
+  static GetMainchainBalanceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBalanceRequest>(create);
   static GetMainchainBalanceRequest? _defaultInstance;
 }
 
@@ -2548,28 +2371,25 @@ class GetMainchainBalanceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetMainchainBalanceResponse._() : super();
-  factory GetMainchainBalanceResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetMainchainBalanceResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetMainchainBalanceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetMainchainBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBalanceResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMainchainBalanceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.double>(1, _omitFieldNames ? '' : 'confirmed', $pb.PbFieldType.OD)
     ..a<$core.double>(2, _omitFieldNames ? '' : 'unconfirmed', $pb.PbFieldType.OD)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetMainchainBalanceResponse clone() => GetMainchainBalanceResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetMainchainBalanceResponse copyWith(void Function(GetMainchainBalanceResponse) updates) =>
-      super.copyWith((message) => updates(message as GetMainchainBalanceResponse)) as GetMainchainBalanceResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetMainchainBalanceResponse copyWith(void Function(GetMainchainBalanceResponse) updates) => super.copyWith((message) => updates(message as GetMainchainBalanceResponse)) as GetMainchainBalanceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2578,17 +2398,13 @@ class GetMainchainBalanceResponse extends $pb.GeneratedMessage {
   GetMainchainBalanceResponse createEmptyInstance() => create();
   static $pb.PbList<GetMainchainBalanceResponse> createRepeated() => $pb.PbList<GetMainchainBalanceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetMainchainBalanceResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBalanceResponse>(create);
+  static GetMainchainBalanceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMainchainBalanceResponse>(create);
   static GetMainchainBalanceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.double get confirmed => $_getN(0);
   @$pb.TagNumber(1)
-  set confirmed($core.double v) {
-    $_setDouble(0, v);
-  }
-
+  set confirmed($core.double v) { $_setDouble(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasConfirmed() => $_has(0);
   @$pb.TagNumber(1)
@@ -2597,10 +2413,7 @@ class GetMainchainBalanceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.double get unconfirmed => $_getN(1);
   @$pb.TagNumber(2)
-  set unconfirmed($core.double v) {
-    $_setDouble(1, v);
-  }
-
+  set unconfirmed($core.double v) { $_setDouble(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasUnconfirmed() => $_has(1);
   @$pb.TagNumber(2)
@@ -2638,31 +2451,29 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
     return $result;
   }
   PreviewResetDataRequest._() : super();
-  factory PreviewResetDataRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PreviewResetDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory PreviewResetDataRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PreviewResetDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PreviewResetDataRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PreviewResetDataRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'deleteBlockchainData')
     ..aOB(2, _omitFieldNames ? '' : 'deleteNodeSoftware')
     ..aOB(3, _omitFieldNames ? '' : 'deleteLogs')
     ..aOB(4, _omitFieldNames ? '' : 'deleteSettings')
     ..aOB(5, _omitFieldNames ? '' : 'deleteWalletFiles')
     ..aOB(6, _omitFieldNames ? '' : 'alsoResetSidechains')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   PreviewResetDataRequest clone() => PreviewResetDataRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  PreviewResetDataRequest copyWith(void Function(PreviewResetDataRequest) updates) =>
-      super.copyWith((message) => updates(message as PreviewResetDataRequest)) as PreviewResetDataRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PreviewResetDataRequest copyWith(void Function(PreviewResetDataRequest) updates) => super.copyWith((message) => updates(message as PreviewResetDataRequest)) as PreviewResetDataRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2671,17 +2482,13 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
   PreviewResetDataRequest createEmptyInstance() => create();
   static $pb.PbList<PreviewResetDataRequest> createRepeated() => $pb.PbList<PreviewResetDataRequest>();
   @$core.pragma('dart2js:noInline')
-  static PreviewResetDataRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PreviewResetDataRequest>(create);
+  static PreviewResetDataRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PreviewResetDataRequest>(create);
   static PreviewResetDataRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get deleteBlockchainData => $_getBF(0);
   @$pb.TagNumber(1)
-  set deleteBlockchainData($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set deleteBlockchainData($core.bool v) { $_setBool(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeleteBlockchainData() => $_has(0);
   @$pb.TagNumber(1)
@@ -2690,10 +2497,7 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get deleteNodeSoftware => $_getBF(1);
   @$pb.TagNumber(2)
-  set deleteNodeSoftware($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set deleteNodeSoftware($core.bool v) { $_setBool(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasDeleteNodeSoftware() => $_has(1);
   @$pb.TagNumber(2)
@@ -2702,10 +2506,7 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get deleteLogs => $_getBF(2);
   @$pb.TagNumber(3)
-  set deleteLogs($core.bool v) {
-    $_setBool(2, v);
-  }
-
+  set deleteLogs($core.bool v) { $_setBool(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasDeleteLogs() => $_has(2);
   @$pb.TagNumber(3)
@@ -2714,10 +2515,7 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get deleteSettings => $_getBF(3);
   @$pb.TagNumber(4)
-  set deleteSettings($core.bool v) {
-    $_setBool(3, v);
-  }
-
+  set deleteSettings($core.bool v) { $_setBool(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasDeleteSettings() => $_has(3);
   @$pb.TagNumber(4)
@@ -2726,10 +2524,7 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.bool get deleteWalletFiles => $_getBF(4);
   @$pb.TagNumber(5)
-  set deleteWalletFiles($core.bool v) {
-    $_setBool(4, v);
-  }
-
+  set deleteWalletFiles($core.bool v) { $_setBool(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasDeleteWalletFiles() => $_has(4);
   @$pb.TagNumber(5)
@@ -2738,10 +2533,7 @@ class PreviewResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.bool get alsoResetSidechains => $_getBF(5);
   @$pb.TagNumber(6)
-  set alsoResetSidechains($core.bool v) {
-    $_setBool(5, v);
-  }
-
+  set alsoResetSidechains($core.bool v) { $_setBool(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasAlsoResetSidechains() => $_has(5);
   @$pb.TagNumber(6)
@@ -2759,26 +2551,24 @@ class PreviewResetDataResponse extends $pb.GeneratedMessage {
     return $result;
   }
   PreviewResetDataResponse._() : super();
-  factory PreviewResetDataResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PreviewResetDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory PreviewResetDataResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PreviewResetDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PreviewResetDataResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PreviewResetDataResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..pc<ResetFileInfo>(1, _omitFieldNames ? '' : 'files', $pb.PbFieldType.PM, subBuilder: ResetFileInfo.create)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   PreviewResetDataResponse clone() => PreviewResetDataResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  PreviewResetDataResponse copyWith(void Function(PreviewResetDataResponse) updates) =>
-      super.copyWith((message) => updates(message as PreviewResetDataResponse)) as PreviewResetDataResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PreviewResetDataResponse copyWith(void Function(PreviewResetDataResponse) updates) => super.copyWith((message) => updates(message as PreviewResetDataResponse)) as PreviewResetDataResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2787,8 +2577,7 @@ class PreviewResetDataResponse extends $pb.GeneratedMessage {
   PreviewResetDataResponse createEmptyInstance() => create();
   static $pb.PbList<PreviewResetDataResponse> createRepeated() => $pb.PbList<PreviewResetDataResponse>();
   @$core.pragma('dart2js:noInline')
-  static PreviewResetDataResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PreviewResetDataResponse>(create);
+  static PreviewResetDataResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PreviewResetDataResponse>(create);
   static PreviewResetDataResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -2818,28 +2607,27 @@ class ResetFileInfo extends $pb.GeneratedMessage {
     return $result;
   }
   ResetFileInfo._() : super();
-  factory ResetFileInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ResetFileInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ResetFileInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ResetFileInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResetFileInfo',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResetFileInfo', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'path')
     ..aOS(2, _omitFieldNames ? '' : 'category')
     ..aInt64(3, _omitFieldNames ? '' : 'sizeBytes')
     ..aOB(4, _omitFieldNames ? '' : 'isDirectory')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ResetFileInfo clone() => ResetFileInfo()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ResetFileInfo copyWith(void Function(ResetFileInfo) updates) =>
-      super.copyWith((message) => updates(message as ResetFileInfo)) as ResetFileInfo;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ResetFileInfo copyWith(void Function(ResetFileInfo) updates) => super.copyWith((message) => updates(message as ResetFileInfo)) as ResetFileInfo;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2854,10 +2642,7 @@ class ResetFileInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get path => $_getSZ(0);
   @$pb.TagNumber(1)
-  set path($core.String v) {
-    $_setString(0, v);
-  }
-
+  set path($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPath() => $_has(0);
   @$pb.TagNumber(1)
@@ -2866,10 +2651,7 @@ class ResetFileInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get category => $_getSZ(1);
   @$pb.TagNumber(2)
-  set category($core.String v) {
-    $_setString(1, v);
-  }
-
+  set category($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasCategory() => $_has(1);
   @$pb.TagNumber(2)
@@ -2878,10 +2660,7 @@ class ResetFileInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get sizeBytes => $_getI64(2);
   @$pb.TagNumber(3)
-  set sizeBytes($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set sizeBytes($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSizeBytes() => $_has(2);
   @$pb.TagNumber(3)
@@ -2890,10 +2669,7 @@ class ResetFileInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get isDirectory => $_getBF(3);
   @$pb.TagNumber(4)
-  set isDirectory($core.bool v) {
-    $_setBool(3, v);
-  }
-
+  set isDirectory($core.bool v) { $_setBool(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasIsDirectory() => $_has(3);
   @$pb.TagNumber(4)
@@ -2931,31 +2707,29 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
     return $result;
   }
   StreamResetDataRequest._() : super();
-  factory StreamResetDataRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StreamResetDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StreamResetDataRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StreamResetDataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamResetDataRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamResetDataRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'deleteBlockchainData')
     ..aOB(2, _omitFieldNames ? '' : 'deleteNodeSoftware')
     ..aOB(3, _omitFieldNames ? '' : 'deleteLogs')
     ..aOB(4, _omitFieldNames ? '' : 'deleteSettings')
     ..aOB(5, _omitFieldNames ? '' : 'deleteWalletFiles')
     ..aOB(6, _omitFieldNames ? '' : 'alsoResetSidechains')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StreamResetDataRequest clone() => StreamResetDataRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StreamResetDataRequest copyWith(void Function(StreamResetDataRequest) updates) =>
-      super.copyWith((message) => updates(message as StreamResetDataRequest)) as StreamResetDataRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StreamResetDataRequest copyWith(void Function(StreamResetDataRequest) updates) => super.copyWith((message) => updates(message as StreamResetDataRequest)) as StreamResetDataRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2964,17 +2738,13 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
   StreamResetDataRequest createEmptyInstance() => create();
   static $pb.PbList<StreamResetDataRequest> createRepeated() => $pb.PbList<StreamResetDataRequest>();
   @$core.pragma('dart2js:noInline')
-  static StreamResetDataRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamResetDataRequest>(create);
+  static StreamResetDataRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamResetDataRequest>(create);
   static StreamResetDataRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get deleteBlockchainData => $_getBF(0);
   @$pb.TagNumber(1)
-  set deleteBlockchainData($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set deleteBlockchainData($core.bool v) { $_setBool(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeleteBlockchainData() => $_has(0);
   @$pb.TagNumber(1)
@@ -2983,10 +2753,7 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get deleteNodeSoftware => $_getBF(1);
   @$pb.TagNumber(2)
-  set deleteNodeSoftware($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set deleteNodeSoftware($core.bool v) { $_setBool(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasDeleteNodeSoftware() => $_has(1);
   @$pb.TagNumber(2)
@@ -2995,10 +2762,7 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get deleteLogs => $_getBF(2);
   @$pb.TagNumber(3)
-  set deleteLogs($core.bool v) {
-    $_setBool(2, v);
-  }
-
+  set deleteLogs($core.bool v) { $_setBool(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasDeleteLogs() => $_has(2);
   @$pb.TagNumber(3)
@@ -3007,10 +2771,7 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get deleteSettings => $_getBF(3);
   @$pb.TagNumber(4)
-  set deleteSettings($core.bool v) {
-    $_setBool(3, v);
-  }
-
+  set deleteSettings($core.bool v) { $_setBool(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasDeleteSettings() => $_has(3);
   @$pb.TagNumber(4)
@@ -3019,10 +2780,7 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.bool get deleteWalletFiles => $_getBF(4);
   @$pb.TagNumber(5)
-  set deleteWalletFiles($core.bool v) {
-    $_setBool(4, v);
-  }
-
+  set deleteWalletFiles($core.bool v) { $_setBool(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasDeleteWalletFiles() => $_has(4);
   @$pb.TagNumber(5)
@@ -3031,10 +2789,7 @@ class StreamResetDataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.bool get alsoResetSidechains => $_getBF(5);
   @$pb.TagNumber(6)
-  set alsoResetSidechains($core.bool v) {
-    $_setBool(5, v);
-  }
-
+  set alsoResetSidechains($core.bool v) { $_setBool(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasAlsoResetSidechains() => $_has(5);
   @$pb.TagNumber(6)
@@ -3076,14 +2831,10 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
     return $result;
   }
   StreamResetDataResponse._() : super();
-  factory StreamResetDataResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StreamResetDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StreamResetDataResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StreamResetDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamResetDataResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StreamResetDataResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'path')
     ..aOS(2, _omitFieldNames ? '' : 'category')
     ..aOB(3, _omitFieldNames ? '' : 'success')
@@ -3091,17 +2842,19 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
     ..aOB(5, _omitFieldNames ? '' : 'done')
     ..a<$core.int>(6, _omitFieldNames ? '' : 'deletedCount', $pb.PbFieldType.O3)
     ..a<$core.int>(7, _omitFieldNames ? '' : 'failedCount', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StreamResetDataResponse clone() => StreamResetDataResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StreamResetDataResponse copyWith(void Function(StreamResetDataResponse) updates) =>
-      super.copyWith((message) => updates(message as StreamResetDataResponse)) as StreamResetDataResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StreamResetDataResponse copyWith(void Function(StreamResetDataResponse) updates) => super.copyWith((message) => updates(message as StreamResetDataResponse)) as StreamResetDataResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3110,17 +2863,13 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   StreamResetDataResponse createEmptyInstance() => create();
   static $pb.PbList<StreamResetDataResponse> createRepeated() => $pb.PbList<StreamResetDataResponse>();
   @$core.pragma('dart2js:noInline')
-  static StreamResetDataResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamResetDataResponse>(create);
+  static StreamResetDataResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StreamResetDataResponse>(create);
   static StreamResetDataResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get path => $_getSZ(0);
   @$pb.TagNumber(1)
-  set path($core.String v) {
-    $_setString(0, v);
-  }
-
+  set path($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPath() => $_has(0);
   @$pb.TagNumber(1)
@@ -3129,10 +2878,7 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get category => $_getSZ(1);
   @$pb.TagNumber(2)
-  set category($core.String v) {
-    $_setString(1, v);
-  }
-
+  set category($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasCategory() => $_has(1);
   @$pb.TagNumber(2)
@@ -3141,10 +2887,7 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get success => $_getBF(2);
   @$pb.TagNumber(3)
-  set success($core.bool v) {
-    $_setBool(2, v);
-  }
-
+  set success($core.bool v) { $_setBool(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSuccess() => $_has(2);
   @$pb.TagNumber(3)
@@ -3153,10 +2896,7 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get error => $_getSZ(3);
   @$pb.TagNumber(4)
-  set error($core.String v) {
-    $_setString(3, v);
-  }
-
+  set error($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasError() => $_has(3);
   @$pb.TagNumber(4)
@@ -3165,10 +2905,7 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.bool get done => $_getBF(4);
   @$pb.TagNumber(5)
-  set done($core.bool v) {
-    $_setBool(4, v);
-  }
-
+  set done($core.bool v) { $_setBool(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasDone() => $_has(4);
   @$pb.TagNumber(5)
@@ -3177,10 +2914,7 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get deletedCount => $_getIZ(5);
   @$pb.TagNumber(6)
-  set deletedCount($core.int v) {
-    $_setSignedInt32(5, v);
-  }
-
+  set deletedCount($core.int v) { $_setSignedInt32(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasDeletedCount() => $_has(5);
   @$pb.TagNumber(6)
@@ -3189,10 +2923,7 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.int get failedCount => $_getIZ(6);
   @$pb.TagNumber(7)
-  set failedCount($core.int v) {
-    $_setSignedInt32(6, v);
-  }
-
+  set failedCount($core.int v) { $_setSignedInt32(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasFailedCount() => $_has(6);
   @$pb.TagNumber(7)
@@ -3202,25 +2933,23 @@ class StreamResetDataResponse extends $pb.GeneratedMessage {
 class GetCoreMempoolInfoRequest extends $pb.GeneratedMessage {
   factory GetCoreMempoolInfoRequest() => create();
   GetCoreMempoolInfoRequest._() : super();
-  factory GetCoreMempoolInfoRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetCoreMempoolInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetCoreMempoolInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetCoreMempoolInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetCoreMempoolInfoRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetCoreMempoolInfoRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetCoreMempoolInfoRequest clone() => GetCoreMempoolInfoRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetCoreMempoolInfoRequest copyWith(void Function(GetCoreMempoolInfoRequest) updates) =>
-      super.copyWith((message) => updates(message as GetCoreMempoolInfoRequest)) as GetCoreMempoolInfoRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetCoreMempoolInfoRequest copyWith(void Function(GetCoreMempoolInfoRequest) updates) => super.copyWith((message) => updates(message as GetCoreMempoolInfoRequest)) as GetCoreMempoolInfoRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3229,8 +2958,7 @@ class GetCoreMempoolInfoRequest extends $pb.GeneratedMessage {
   GetCoreMempoolInfoRequest createEmptyInstance() => create();
   static $pb.PbList<GetCoreMempoolInfoRequest> createRepeated() => $pb.PbList<GetCoreMempoolInfoRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetCoreMempoolInfoRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCoreMempoolInfoRequest>(create);
+  static GetCoreMempoolInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCoreMempoolInfoRequest>(create);
   static GetCoreMempoolInfoRequest? _defaultInstance;
 }
 
@@ -3287,15 +3015,10 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetCoreMempoolInfoResponse._() : super();
-  factory GetCoreMempoolInfoResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetCoreMempoolInfoResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetCoreMempoolInfoResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetCoreMempoolInfoResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetCoreMempoolInfoResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetCoreMempoolInfoResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'loaded')
     ..aInt64(2, _omitFieldNames ? '' : 'size')
     ..aInt64(3, _omitFieldNames ? '' : 'bytes')
@@ -3307,17 +3030,19 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
     ..a<$core.double>(9, _omitFieldNames ? '' : 'incrementalRelayFee', $pb.PbFieldType.OD)
     ..aInt64(10, _omitFieldNames ? '' : 'unbroadcastCount')
     ..aOB(11, _omitFieldNames ? '' : 'fullRbf')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetCoreMempoolInfoResponse clone() => GetCoreMempoolInfoResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetCoreMempoolInfoResponse copyWith(void Function(GetCoreMempoolInfoResponse) updates) =>
-      super.copyWith((message) => updates(message as GetCoreMempoolInfoResponse)) as GetCoreMempoolInfoResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetCoreMempoolInfoResponse copyWith(void Function(GetCoreMempoolInfoResponse) updates) => super.copyWith((message) => updates(message as GetCoreMempoolInfoResponse)) as GetCoreMempoolInfoResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3326,17 +3051,13 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
   GetCoreMempoolInfoResponse createEmptyInstance() => create();
   static $pb.PbList<GetCoreMempoolInfoResponse> createRepeated() => $pb.PbList<GetCoreMempoolInfoResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetCoreMempoolInfoResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCoreMempoolInfoResponse>(create);
+  static GetCoreMempoolInfoResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCoreMempoolInfoResponse>(create);
   static GetCoreMempoolInfoResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get loaded => $_getBF(0);
   @$pb.TagNumber(1)
-  set loaded($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set loaded($core.bool v) { $_setBool(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasLoaded() => $_has(0);
   @$pb.TagNumber(1)
@@ -3346,10 +3067,7 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get size => $_getI64(1);
   @$pb.TagNumber(2)
-  set size($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set size($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasSize() => $_has(1);
   @$pb.TagNumber(2)
@@ -3359,10 +3077,7 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get bytes => $_getI64(2);
   @$pb.TagNumber(3)
-  set bytes($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set bytes($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasBytes() => $_has(2);
   @$pb.TagNumber(3)
@@ -3372,10 +3087,7 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get usage => $_getI64(3);
   @$pb.TagNumber(4)
-  set usage($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set usage($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasUsage() => $_has(3);
   @$pb.TagNumber(4)
@@ -3385,10 +3097,7 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.double get totalFee => $_getN(4);
   @$pb.TagNumber(5)
-  set totalFee($core.double v) {
-    $_setDouble(4, v);
-  }
-
+  set totalFee($core.double v) { $_setDouble(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasTotalFee() => $_has(4);
   @$pb.TagNumber(5)
@@ -3398,10 +3107,7 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get maxMempool => $_getI64(5);
   @$pb.TagNumber(6)
-  set maxMempool($fixnum.Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set maxMempool($fixnum.Int64 v) { $_setInt64(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasMaxMempool() => $_has(5);
   @$pb.TagNumber(6)
@@ -3411,10 +3117,7 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.double get mempoolMinFee => $_getN(6);
   @$pb.TagNumber(7)
-  set mempoolMinFee($core.double v) {
-    $_setDouble(6, v);
-  }
-
+  set mempoolMinFee($core.double v) { $_setDouble(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasMempoolMinFee() => $_has(6);
   @$pb.TagNumber(7)
@@ -3424,10 +3127,7 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.double get minRelayTxFee => $_getN(7);
   @$pb.TagNumber(8)
-  set minRelayTxFee($core.double v) {
-    $_setDouble(7, v);
-  }
-
+  set minRelayTxFee($core.double v) { $_setDouble(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasMinRelayTxFee() => $_has(7);
   @$pb.TagNumber(8)
@@ -3437,10 +3137,7 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.double get incrementalRelayFee => $_getN(8);
   @$pb.TagNumber(9)
-  set incrementalRelayFee($core.double v) {
-    $_setDouble(8, v);
-  }
-
+  set incrementalRelayFee($core.double v) { $_setDouble(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasIncrementalRelayFee() => $_has(8);
   @$pb.TagNumber(9)
@@ -3450,10 +3147,7 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $fixnum.Int64 get unbroadcastCount => $_getI64(9);
   @$pb.TagNumber(10)
-  set unbroadcastCount($fixnum.Int64 v) {
-    $_setInt64(9, v);
-  }
-
+  set unbroadcastCount($fixnum.Int64 v) { $_setInt64(9, v); }
   @$pb.TagNumber(10)
   $core.bool hasUnbroadcastCount() => $_has(9);
   @$pb.TagNumber(10)
@@ -3462,10 +3156,7 @@ class GetCoreMempoolInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $core.bool get fullRbf => $_getBF(10);
   @$pb.TagNumber(11)
-  set fullRbf($core.bool v) {
-    $_setBool(10, v);
-  }
-
+  set fullRbf($core.bool v) { $_setBool(10, v); }
   @$pb.TagNumber(11)
   $core.bool hasFullRbf() => $_has(10);
   @$pb.TagNumber(11)
@@ -3491,28 +3182,26 @@ class CoreRawCallRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CoreRawCallRequest._() : super();
-  factory CoreRawCallRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CoreRawCallRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CoreRawCallRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CoreRawCallRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CoreRawCallRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CoreRawCallRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'method')
     ..aOS(2, _omitFieldNames ? '' : 'paramsJson')
     ..aOS(3, _omitFieldNames ? '' : 'wallet')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CoreRawCallRequest clone() => CoreRawCallRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CoreRawCallRequest copyWith(void Function(CoreRawCallRequest) updates) =>
-      super.copyWith((message) => updates(message as CoreRawCallRequest)) as CoreRawCallRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CoreRawCallRequest copyWith(void Function(CoreRawCallRequest) updates) => super.copyWith((message) => updates(message as CoreRawCallRequest)) as CoreRawCallRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3521,18 +3210,14 @@ class CoreRawCallRequest extends $pb.GeneratedMessage {
   CoreRawCallRequest createEmptyInstance() => create();
   static $pb.PbList<CoreRawCallRequest> createRepeated() => $pb.PbList<CoreRawCallRequest>();
   @$core.pragma('dart2js:noInline')
-  static CoreRawCallRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CoreRawCallRequest>(create);
+  static CoreRawCallRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CoreRawCallRequest>(create);
   static CoreRawCallRequest? _defaultInstance;
 
   /// bitcoind RPC method name (e.g. "finalizepsbt").
   @$pb.TagNumber(1)
   $core.String get method => $_getSZ(0);
   @$pb.TagNumber(1)
-  set method($core.String v) {
-    $_setString(0, v);
-  }
-
+  set method($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMethod() => $_has(0);
   @$pb.TagNumber(1)
@@ -3543,10 +3228,7 @@ class CoreRawCallRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get paramsJson => $_getSZ(1);
   @$pb.TagNumber(2)
-  set paramsJson($core.String v) {
-    $_setString(1, v);
-  }
-
+  set paramsJson($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasParamsJson() => $_has(1);
   @$pb.TagNumber(2)
@@ -3559,10 +3241,7 @@ class CoreRawCallRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get wallet => $_getSZ(2);
   @$pb.TagNumber(3)
-  set wallet($core.String v) {
-    $_setString(2, v);
-  }
-
+  set wallet($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasWallet() => $_has(2);
   @$pb.TagNumber(3)
@@ -3580,26 +3259,24 @@ class CoreRawCallResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CoreRawCallResponse._() : super();
-  factory CoreRawCallResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CoreRawCallResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CoreRawCallResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CoreRawCallResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CoreRawCallResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CoreRawCallResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'resultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CoreRawCallResponse clone() => CoreRawCallResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CoreRawCallResponse copyWith(void Function(CoreRawCallResponse) updates) =>
-      super.copyWith((message) => updates(message as CoreRawCallResponse)) as CoreRawCallResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CoreRawCallResponse copyWith(void Function(CoreRawCallResponse) updates) => super.copyWith((message) => updates(message as CoreRawCallResponse)) as CoreRawCallResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3608,18 +3285,14 @@ class CoreRawCallResponse extends $pb.GeneratedMessage {
   CoreRawCallResponse createEmptyInstance() => create();
   static $pb.PbList<CoreRawCallResponse> createRepeated() => $pb.PbList<CoreRawCallResponse>();
   @$core.pragma('dart2js:noInline')
-  static CoreRawCallResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CoreRawCallResponse>(create);
+  static CoreRawCallResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CoreRawCallResponse>(create);
   static CoreRawCallResponse? _defaultInstance;
 
   /// JSON-encoded result. Caller decodes to its expected shape.
   @$pb.TagNumber(1)
   $core.String get resultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set resultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set resultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -3631,53 +3304,64 @@ class OrchestratorServiceApi {
   OrchestratorServiceApi(this._client);
 
   $async.Future<ListBinariesResponse> listBinaries($pb.ClientContext? ctx, ListBinariesRequest request) =>
-      _client.invoke<ListBinariesResponse>(ctx, 'OrchestratorService', 'ListBinaries', request, ListBinariesResponse());
+    _client.invoke<ListBinariesResponse>(ctx, 'OrchestratorService', 'ListBinaries', request, ListBinariesResponse())
+  ;
   $async.Future<GetBinaryStatusResponse> getBinaryStatus($pb.ClientContext? ctx, GetBinaryStatusRequest request) =>
-      _client.invoke<GetBinaryStatusResponse>(
-          ctx, 'OrchestratorService', 'GetBinaryStatus', request, GetBinaryStatusResponse());
-  $async.Future<DownloadBinaryResponse> downloadBinary($pb.ClientContext? ctx, DownloadBinaryRequest request) => _client
-      .invoke<DownloadBinaryResponse>(ctx, 'OrchestratorService', 'DownloadBinary', request, DownloadBinaryResponse());
+    _client.invoke<GetBinaryStatusResponse>(ctx, 'OrchestratorService', 'GetBinaryStatus', request, GetBinaryStatusResponse())
+  ;
+  $async.Future<DownloadBinaryResponse> downloadBinary($pb.ClientContext? ctx, DownloadBinaryRequest request) =>
+    _client.invoke<DownloadBinaryResponse>(ctx, 'OrchestratorService', 'DownloadBinary', request, DownloadBinaryResponse())
+  ;
   $async.Future<StartBinaryResponse> startBinary($pb.ClientContext? ctx, StartBinaryRequest request) =>
-      _client.invoke<StartBinaryResponse>(ctx, 'OrchestratorService', 'StartBinary', request, StartBinaryResponse());
+    _client.invoke<StartBinaryResponse>(ctx, 'OrchestratorService', 'StartBinary', request, StartBinaryResponse())
+  ;
   $async.Future<StopBinaryResponse> stopBinary($pb.ClientContext? ctx, StopBinaryRequest request) =>
-      _client.invoke<StopBinaryResponse>(ctx, 'OrchestratorService', 'StopBinary', request, StopBinaryResponse());
+    _client.invoke<StopBinaryResponse>(ctx, 'OrchestratorService', 'StopBinary', request, StopBinaryResponse())
+  ;
   $async.Future<StreamLogsResponse> streamLogs($pb.ClientContext? ctx, StreamLogsRequest request) =>
-      _client.invoke<StreamLogsResponse>(ctx, 'OrchestratorService', 'StreamLogs', request, StreamLogsResponse());
+    _client.invoke<StreamLogsResponse>(ctx, 'OrchestratorService', 'StreamLogs', request, StreamLogsResponse())
+  ;
   $async.Future<StartWithL1Response> startWithL1($pb.ClientContext? ctx, StartWithL1Request request) =>
-      _client.invoke<StartWithL1Response>(ctx, 'OrchestratorService', 'StartWithL1', request, StartWithL1Response());
-  $async.Future<RestartDaemonResponse> restartDaemon($pb.ClientContext? ctx, RestartDaemonRequest request) => _client
-      .invoke<RestartDaemonResponse>(ctx, 'OrchestratorService', 'RestartDaemon', request, RestartDaemonResponse());
+    _client.invoke<StartWithL1Response>(ctx, 'OrchestratorService', 'StartWithL1', request, StartWithL1Response())
+  ;
+  $async.Future<RestartDaemonResponse> restartDaemon($pb.ClientContext? ctx, RestartDaemonRequest request) =>
+    _client.invoke<RestartDaemonResponse>(ctx, 'OrchestratorService', 'RestartDaemon', request, RestartDaemonResponse())
+  ;
   $async.Future<ShutdownAllResponse> shutdownAll($pb.ClientContext? ctx, ShutdownAllRequest request) =>
-      _client.invoke<ShutdownAllResponse>(ctx, 'OrchestratorService', 'ShutdownAll', request, ShutdownAllResponse());
+    _client.invoke<ShutdownAllResponse>(ctx, 'OrchestratorService', 'ShutdownAll', request, ShutdownAllResponse())
+  ;
   $async.Future<GetBTCPriceResponse> getBTCPrice($pb.ClientContext? ctx, GetBTCPriceRequest request) =>
-      _client.invoke<GetBTCPriceResponse>(ctx, 'OrchestratorService', 'GetBTCPrice', request, GetBTCPriceResponse());
-  $async.Future<GetMainchainBlockchainInfoResponse> getMainchainBlockchainInfo(
-          $pb.ClientContext? ctx, GetMainchainBlockchainInfoRequest request) =>
-      _client.invoke<GetMainchainBlockchainInfoResponse>(
-          ctx, 'OrchestratorService', 'GetMainchainBlockchainInfo', request, GetMainchainBlockchainInfoResponse());
-  $async.Future<GetEnforcerBlockchainInfoResponse> getEnforcerBlockchainInfo(
-          $pb.ClientContext? ctx, GetEnforcerBlockchainInfoRequest request) =>
-      _client.invoke<GetEnforcerBlockchainInfoResponse>(
-          ctx, 'OrchestratorService', 'GetEnforcerBlockchainInfo', request, GetEnforcerBlockchainInfoResponse());
-  $async.Future<GetSyncStatusResponse> getSyncStatus($pb.ClientContext? ctx, GetSyncStatusRequest request) => _client
-      .invoke<GetSyncStatusResponse>(ctx, 'OrchestratorService', 'GetSyncStatus', request, GetSyncStatusResponse());
-  $async.Future<GetMainchainBalanceResponse> getMainchainBalance(
-          $pb.ClientContext? ctx, GetMainchainBalanceRequest request) =>
-      _client.invoke<GetMainchainBalanceResponse>(
-          ctx, 'OrchestratorService', 'GetMainchainBalance', request, GetMainchainBalanceResponse());
+    _client.invoke<GetBTCPriceResponse>(ctx, 'OrchestratorService', 'GetBTCPrice', request, GetBTCPriceResponse())
+  ;
+  $async.Future<GetMainchainBlockchainInfoResponse> getMainchainBlockchainInfo($pb.ClientContext? ctx, GetMainchainBlockchainInfoRequest request) =>
+    _client.invoke<GetMainchainBlockchainInfoResponse>(ctx, 'OrchestratorService', 'GetMainchainBlockchainInfo', request, GetMainchainBlockchainInfoResponse())
+  ;
+  $async.Future<GetEnforcerBlockchainInfoResponse> getEnforcerBlockchainInfo($pb.ClientContext? ctx, GetEnforcerBlockchainInfoRequest request) =>
+    _client.invoke<GetEnforcerBlockchainInfoResponse>(ctx, 'OrchestratorService', 'GetEnforcerBlockchainInfo', request, GetEnforcerBlockchainInfoResponse())
+  ;
+  $async.Future<GetSyncStatusResponse> getSyncStatus($pb.ClientContext? ctx, GetSyncStatusRequest request) =>
+    _client.invoke<GetSyncStatusResponse>(ctx, 'OrchestratorService', 'GetSyncStatus', request, GetSyncStatusResponse())
+  ;
+  $async.Future<GetDownloadStatusResponse> getDownloadStatus($pb.ClientContext? ctx, GetDownloadStatusRequest request) =>
+    _client.invoke<GetDownloadStatusResponse>(ctx, 'OrchestratorService', 'GetDownloadStatus', request, GetDownloadStatusResponse())
+  ;
+  $async.Future<GetMainchainBalanceResponse> getMainchainBalance($pb.ClientContext? ctx, GetMainchainBalanceRequest request) =>
+    _client.invoke<GetMainchainBalanceResponse>(ctx, 'OrchestratorService', 'GetMainchainBalance', request, GetMainchainBalanceResponse())
+  ;
   $async.Future<PreviewResetDataResponse> previewResetData($pb.ClientContext? ctx, PreviewResetDataRequest request) =>
-      _client.invoke<PreviewResetDataResponse>(
-          ctx, 'OrchestratorService', 'PreviewResetData', request, PreviewResetDataResponse());
+    _client.invoke<PreviewResetDataResponse>(ctx, 'OrchestratorService', 'PreviewResetData', request, PreviewResetDataResponse())
+  ;
   $async.Future<StreamResetDataResponse> streamResetData($pb.ClientContext? ctx, StreamResetDataRequest request) =>
-      _client.invoke<StreamResetDataResponse>(
-          ctx, 'OrchestratorService', 'StreamResetData', request, StreamResetDataResponse());
-  $async.Future<GetCoreMempoolInfoResponse> getCoreMempoolInfo(
-          $pb.ClientContext? ctx, GetCoreMempoolInfoRequest request) =>
-      _client.invoke<GetCoreMempoolInfoResponse>(
-          ctx, 'OrchestratorService', 'GetCoreMempoolInfo', request, GetCoreMempoolInfoResponse());
+    _client.invoke<StreamResetDataResponse>(ctx, 'OrchestratorService', 'StreamResetData', request, StreamResetDataResponse())
+  ;
+  $async.Future<GetCoreMempoolInfoResponse> getCoreMempoolInfo($pb.ClientContext? ctx, GetCoreMempoolInfoRequest request) =>
+    _client.invoke<GetCoreMempoolInfoResponse>(ctx, 'OrchestratorService', 'GetCoreMempoolInfo', request, GetCoreMempoolInfoResponse())
+  ;
   $async.Future<CoreRawCallResponse> coreRawCall($pb.ClientContext? ctx, CoreRawCallRequest request) =>
-      _client.invoke<CoreRawCallResponse>(ctx, 'OrchestratorService', 'CoreRawCall', request, CoreRawCallResponse());
+    _client.invoke<CoreRawCallResponse>(ctx, 'OrchestratorService', 'CoreRawCall', request, CoreRawCallResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbenum.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbenum.dart
@@ -18,22 +18,16 @@ import 'package:protobuf/protobuf.dart' as $pb;
 /// a frontend sees it, the binary is known to the orchestrator but doesn't
 /// have a typed enum value yet.
 class SidechainType extends $pb.ProtobufEnum {
-  static const SidechainType SIDECHAIN_TYPE_UNSPECIFIED =
-      SidechainType._(0, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_UNSPECIFIED');
-  static const SidechainType SIDECHAIN_TYPE_THUNDER =
-      SidechainType._(1, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_THUNDER');
+  static const SidechainType SIDECHAIN_TYPE_UNSPECIFIED = SidechainType._(0, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_UNSPECIFIED');
+  static const SidechainType SIDECHAIN_TYPE_THUNDER = SidechainType._(1, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_THUNDER');
   static const SidechainType SIDECHAIN_TYPE_ZSIDE = SidechainType._(2, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_ZSIDE');
-  static const SidechainType SIDECHAIN_TYPE_BITNAMES =
-      SidechainType._(3, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_BITNAMES');
-  static const SidechainType SIDECHAIN_TYPE_BITASSETS =
-      SidechainType._(4, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_BITASSETS');
-  static const SidechainType SIDECHAIN_TYPE_TRUTHCOIN =
-      SidechainType._(5, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_TRUTHCOIN');
+  static const SidechainType SIDECHAIN_TYPE_BITNAMES = SidechainType._(3, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_BITNAMES');
+  static const SidechainType SIDECHAIN_TYPE_BITASSETS = SidechainType._(4, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_BITASSETS');
+  static const SidechainType SIDECHAIN_TYPE_TRUTHCOIN = SidechainType._(5, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_TRUTHCOIN');
   static const SidechainType SIDECHAIN_TYPE_PHOTON = SidechainType._(6, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_PHOTON');
-  static const SidechainType SIDECHAIN_TYPE_COINSHIFT =
-      SidechainType._(7, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_COINSHIFT');
+  static const SidechainType SIDECHAIN_TYPE_COINSHIFT = SidechainType._(7, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_COINSHIFT');
 
-  static const $core.List<SidechainType> values = <SidechainType>[
+  static const $core.List<SidechainType> values = <SidechainType> [
     SIDECHAIN_TYPE_UNSPECIFIED,
     SIDECHAIN_TYPE_THUNDER,
     SIDECHAIN_TYPE_ZSIDE,
@@ -49,5 +43,50 @@ class SidechainType extends $pb.ProtobufEnum {
 
   const SidechainType._($core.int v, $core.String n) : super(v, n);
 }
+
+/// BinaryType is the single typed identifier for any binary the system tracks.
+/// Used wire-side by the orchestrator and consumed directly by the Flutter
+/// frontends — there is no parallel Dart enum. UNSPECIFIED is reserved for
+/// forwards-compat: when a frontend sees it, the binary is known to the
+/// orchestrator but doesn't have a typed enum value yet.
+class BinaryType extends $pb.ProtobufEnum {
+  static const BinaryType BINARY_TYPE_UNSPECIFIED = BinaryType._(0, _omitEnumNames ? '' : 'BINARY_TYPE_UNSPECIFIED');
+  static const BinaryType BINARY_TYPE_BITCOIND = BinaryType._(1, _omitEnumNames ? '' : 'BINARY_TYPE_BITCOIND');
+  static const BinaryType BINARY_TYPE_ENFORCER = BinaryType._(2, _omitEnumNames ? '' : 'BINARY_TYPE_ENFORCER');
+  static const BinaryType BINARY_TYPE_BITWINDOWD = BinaryType._(3, _omitEnumNames ? '' : 'BINARY_TYPE_BITWINDOWD');
+  static const BinaryType BINARY_TYPE_THUNDER = BinaryType._(4, _omitEnumNames ? '' : 'BINARY_TYPE_THUNDER');
+  static const BinaryType BINARY_TYPE_ZSIDE = BinaryType._(5, _omitEnumNames ? '' : 'BINARY_TYPE_ZSIDE');
+  static const BinaryType BINARY_TYPE_BITNAMES = BinaryType._(6, _omitEnumNames ? '' : 'BINARY_TYPE_BITNAMES');
+  static const BinaryType BINARY_TYPE_BITASSETS = BinaryType._(7, _omitEnumNames ? '' : 'BINARY_TYPE_BITASSETS');
+  static const BinaryType BINARY_TYPE_TRUTHCOIN = BinaryType._(8, _omitEnumNames ? '' : 'BINARY_TYPE_TRUTHCOIN');
+  static const BinaryType BINARY_TYPE_PHOTON = BinaryType._(9, _omitEnumNames ? '' : 'BINARY_TYPE_PHOTON');
+  static const BinaryType BINARY_TYPE_COINSHIFT = BinaryType._(10, _omitEnumNames ? '' : 'BINARY_TYPE_COINSHIFT');
+  static const BinaryType BINARY_TYPE_GRPCURL = BinaryType._(11, _omitEnumNames ? '' : 'BINARY_TYPE_GRPCURL');
+  static const BinaryType BINARY_TYPE_ORCHESTRATORD = BinaryType._(12, _omitEnumNames ? '' : 'BINARY_TYPE_ORCHESTRATORD');
+  static const BinaryType BINARY_TYPE_ZSIDED = BinaryType._(13, _omitEnumNames ? '' : 'BINARY_TYPE_ZSIDED');
+
+  static const $core.List<BinaryType> values = <BinaryType> [
+    BINARY_TYPE_UNSPECIFIED,
+    BINARY_TYPE_BITCOIND,
+    BINARY_TYPE_ENFORCER,
+    BINARY_TYPE_BITWINDOWD,
+    BINARY_TYPE_THUNDER,
+    BINARY_TYPE_ZSIDE,
+    BINARY_TYPE_BITNAMES,
+    BINARY_TYPE_BITASSETS,
+    BINARY_TYPE_TRUTHCOIN,
+    BINARY_TYPE_PHOTON,
+    BINARY_TYPE_COINSHIFT,
+    BINARY_TYPE_GRPCURL,
+    BINARY_TYPE_ORCHESTRATORD,
+    BINARY_TYPE_ZSIDED,
+  ];
+
+  static final $core.Map<$core.int, BinaryType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static BinaryType? valueOf($core.int value) => _byValue[value];
+
+  const BinaryType._($core.int v, $core.String n) : super(v, n);
+}
+
 
 const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -29,12 +29,43 @@ const SidechainType$json = {
 };
 
 /// Descriptor for `SidechainType`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List sidechainTypeDescriptor =
-    $convert.base64Decode('Cg1TaWRlY2hhaW5UeXBlEh4KGlNJREVDSEFJTl9UWVBFX1VOU1BFQ0lGSUVEEAASGgoWU0lERU'
-        'NIQUlOX1RZUEVfVEhVTkRFUhABEhgKFFNJREVDSEFJTl9UWVBFX1pTSURFEAISGwoXU0lERUNI'
-        'QUlOX1RZUEVfQklUTkFNRVMQAxIcChhTSURFQ0hBSU5fVFlQRV9CSVRBU1NFVFMQBBIcChhTSU'
-        'RFQ0hBSU5fVFlQRV9UUlVUSENPSU4QBRIZChVTSURFQ0hBSU5fVFlQRV9QSE9UT04QBhIcChhT'
-        'SURFQ0hBSU5fVFlQRV9DT0lOU0hJRlQQBw==');
+final $typed_data.Uint8List sidechainTypeDescriptor = $convert.base64Decode(
+    'Cg1TaWRlY2hhaW5UeXBlEh4KGlNJREVDSEFJTl9UWVBFX1VOU1BFQ0lGSUVEEAASGgoWU0lERU'
+    'NIQUlOX1RZUEVfVEhVTkRFUhABEhgKFFNJREVDSEFJTl9UWVBFX1pTSURFEAISGwoXU0lERUNI'
+    'QUlOX1RZUEVfQklUTkFNRVMQAxIcChhTSURFQ0hBSU5fVFlQRV9CSVRBU1NFVFMQBBIcChhTSU'
+    'RFQ0hBSU5fVFlQRV9UUlVUSENPSU4QBRIZChVTSURFQ0hBSU5fVFlQRV9QSE9UT04QBhIcChhT'
+    'SURFQ0hBSU5fVFlQRV9DT0lOU0hJRlQQBw==');
+
+@$core.Deprecated('Use binaryTypeDescriptor instead')
+const BinaryType$json = {
+  '1': 'BinaryType',
+  '2': [
+    {'1': 'BINARY_TYPE_UNSPECIFIED', '2': 0},
+    {'1': 'BINARY_TYPE_BITCOIND', '2': 1},
+    {'1': 'BINARY_TYPE_ENFORCER', '2': 2},
+    {'1': 'BINARY_TYPE_BITWINDOWD', '2': 3},
+    {'1': 'BINARY_TYPE_THUNDER', '2': 4},
+    {'1': 'BINARY_TYPE_ZSIDE', '2': 5},
+    {'1': 'BINARY_TYPE_BITNAMES', '2': 6},
+    {'1': 'BINARY_TYPE_BITASSETS', '2': 7},
+    {'1': 'BINARY_TYPE_TRUTHCOIN', '2': 8},
+    {'1': 'BINARY_TYPE_PHOTON', '2': 9},
+    {'1': 'BINARY_TYPE_COINSHIFT', '2': 10},
+    {'1': 'BINARY_TYPE_GRPCURL', '2': 11},
+    {'1': 'BINARY_TYPE_ORCHESTRATORD', '2': 12},
+    {'1': 'BINARY_TYPE_ZSIDED', '2': 13},
+  ],
+};
+
+/// Descriptor for `BinaryType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List binaryTypeDescriptor = $convert.base64Decode(
+    'CgpCaW5hcnlUeXBlEhsKF0JJTkFSWV9UWVBFX1VOU1BFQ0lGSUVEEAASGAoUQklOQVJZX1RZUE'
+    'VfQklUQ09JTkQQARIYChRCSU5BUllfVFlQRV9FTkZPUkNFUhACEhoKFkJJTkFSWV9UWVBFX0JJ'
+    'VFdJTkRPV0QQAxIXChNCSU5BUllfVFlQRV9USFVOREVSEAQSFQoRQklOQVJZX1RZUEVfWlNJRE'
+    'UQBRIYChRCSU5BUllfVFlQRV9CSVROQU1FUxAGEhkKFUJJTkFSWV9UWVBFX0JJVEFTU0VUUxAH'
+    'EhkKFUJJTkFSWV9UWVBFX1RSVVRIQ09JThAIEhYKEkJJTkFSWV9UWVBFX1BIT1RPThAJEhkKFU'
+    'JJTkFSWV9UWVBFX0NPSU5TSElGVBAKEhcKE0JJTkFSWV9UWVBFX0dSUENVUkwQCxIdChlCSU5B'
+    'UllfVFlQRV9PUkNIRVNUUkFUT1JEEAwSFgoSQklOQVJZX1RZUEVfWlNJREVEEA0=');
 
 @$core.Deprecated('Use binaryStatusMsgDescriptor instead')
 const BinaryStatusMsg$json = {
@@ -67,21 +98,21 @@ const BinaryStatusMsg$json = {
 };
 
 /// Descriptor for `BinaryStatusMsg`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List binaryStatusMsgDescriptor =
-    $convert.base64Decode('Cg9CaW5hcnlTdGF0dXNNc2cSEgoEbmFtZRgBIAEoCVIEbmFtZRIhCgxkaXNwbGF5X25hbWUYAi'
-        'ABKAlSC2Rpc3BsYXlOYW1lEhgKB3J1bm5pbmcYAyABKAhSB3J1bm5pbmcSGAoHaGVhbHRoeRgE'
-        'IAEoCFIHaGVhbHRoeRIQCgNwaWQYBSABKAVSA3BpZBIlCg51cHRpbWVfc2Vjb25kcxgGIAEoA1'
-        'INdXB0aW1lU2Vjb25kcxIfCgtjaGFpbl9sYXllchgHIAEoBVIKY2hhaW5MYXllchISCgRwb3J0'
-        'GAggASgFUgRwb3J0EhQKBWVycm9yGAkgASgJUgVlcnJvchIcCgljb25uZWN0ZWQYCiABKAhSCW'
-        'Nvbm5lY3RlZBIjCg1zdGFydHVwX2Vycm9yGAsgASgJUgxzdGFydHVwRXJyb3ISKQoQY29ubmVj'
-        'dGlvbl9lcnJvchgMIAEoCVIPY29ubmVjdGlvbkVycm9yEhoKCHN0b3BwaW5nGA0gASgIUghzdG'
-        '9wcGluZxIiCgxpbml0aWFsaXppbmcYDiABKAhSDGluaXRpYWxpemluZxIqChFjb25uZWN0X21v'
-        'ZGVfb25seRgPIAEoCFIPY29ubmVjdE1vZGVPbmx5EiIKDGRvd25sb2FkYWJsZRgQIAEoCFIMZG'
-        '93bmxvYWRhYmxlEiAKC2Rlc2NyaXB0aW9uGBEgASgJUgtkZXNjcmlwdGlvbhIeCgpkb3dubG9h'
-        'ZGVkGBIgASgIUgpkb3dubG9hZGVkEh4KC3BvcnRfaW5fdXNlGBMgASgIUglwb3J0SW5Vc2USGA'
-        'oHdmVyc2lvbhgUIAEoCVIHdmVyc2lvbhIZCghyZXBvX3VybBgVIAEoCVIHcmVwb1VybBJGCgxz'
-        'dGFydHVwX2xvZ3MYFiADKAsyIy5vcmNoZXN0cmF0b3IudjEuU3RhcnR1cExvZ0VudHJ5TXNnUg'
-        'tzdGFydHVwTG9ncxIfCgtiaW5hcnlfcGF0aBgXIAEoCVIKYmluYXJ5UGF0aA==');
+final $typed_data.Uint8List binaryStatusMsgDescriptor = $convert.base64Decode(
+    'Cg9CaW5hcnlTdGF0dXNNc2cSEgoEbmFtZRgBIAEoCVIEbmFtZRIhCgxkaXNwbGF5X25hbWUYAi'
+    'ABKAlSC2Rpc3BsYXlOYW1lEhgKB3J1bm5pbmcYAyABKAhSB3J1bm5pbmcSGAoHaGVhbHRoeRgE'
+    'IAEoCFIHaGVhbHRoeRIQCgNwaWQYBSABKAVSA3BpZBIlCg51cHRpbWVfc2Vjb25kcxgGIAEoA1'
+    'INdXB0aW1lU2Vjb25kcxIfCgtjaGFpbl9sYXllchgHIAEoBVIKY2hhaW5MYXllchISCgRwb3J0'
+    'GAggASgFUgRwb3J0EhQKBWVycm9yGAkgASgJUgVlcnJvchIcCgljb25uZWN0ZWQYCiABKAhSCW'
+    'Nvbm5lY3RlZBIjCg1zdGFydHVwX2Vycm9yGAsgASgJUgxzdGFydHVwRXJyb3ISKQoQY29ubmVj'
+    'dGlvbl9lcnJvchgMIAEoCVIPY29ubmVjdGlvbkVycm9yEhoKCHN0b3BwaW5nGA0gASgIUghzdG'
+    '9wcGluZxIiCgxpbml0aWFsaXppbmcYDiABKAhSDGluaXRpYWxpemluZxIqChFjb25uZWN0X21v'
+    'ZGVfb25seRgPIAEoCFIPY29ubmVjdE1vZGVPbmx5EiIKDGRvd25sb2FkYWJsZRgQIAEoCFIMZG'
+    '93bmxvYWRhYmxlEiAKC2Rlc2NyaXB0aW9uGBEgASgJUgtkZXNjcmlwdGlvbhIeCgpkb3dubG9h'
+    'ZGVkGBIgASgIUgpkb3dubG9hZGVkEh4KC3BvcnRfaW5fdXNlGBMgASgIUglwb3J0SW5Vc2USGA'
+    'oHdmVyc2lvbhgUIAEoCVIHdmVyc2lvbhIZCghyZXBvX3VybBgVIAEoCVIHcmVwb1VybBJGCgxz'
+    'dGFydHVwX2xvZ3MYFiADKAsyIy5vcmNoZXN0cmF0b3IudjEuU3RhcnR1cExvZ0VudHJ5TXNnUg'
+    'tzdGFydHVwTG9ncxIfCgtiaW5hcnlfcGF0aBgXIAEoCVIKYmluYXJ5UGF0aA==');
 
 @$core.Deprecated('Use startupLogEntryMsgDescriptor instead')
 const StartupLogEntryMsg$json = {
@@ -93,9 +124,9 @@ const StartupLogEntryMsg$json = {
 };
 
 /// Descriptor for `StartupLogEntryMsg`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startupLogEntryMsgDescriptor =
-    $convert.base64Decode('ChJTdGFydHVwTG9nRW50cnlNc2cSJQoOdGltZXN0YW1wX3VuaXgYASABKANSDXRpbWVzdGFtcF'
-        'VuaXgSGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZQ==');
+final $typed_data.Uint8List startupLogEntryMsgDescriptor = $convert.base64Decode(
+    'ChJTdGFydHVwTG9nRW50cnlNc2cSJQoOdGltZXN0YW1wX3VuaXgYASABKANSDXRpbWVzdGFtcF'
+    'VuaXgSGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZQ==');
 
 @$core.Deprecated('Use listBinariesRequestDescriptor instead')
 const ListBinariesRequest$json = {
@@ -103,7 +134,8 @@ const ListBinariesRequest$json = {
 };
 
 /// Descriptor for `ListBinariesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listBinariesRequestDescriptor = $convert.base64Decode('ChNMaXN0QmluYXJpZXNSZXF1ZXN0');
+final $typed_data.Uint8List listBinariesRequestDescriptor = $convert.base64Decode(
+    'ChNMaXN0QmluYXJpZXNSZXF1ZXN0');
 
 @$core.Deprecated('Use listBinariesResponseDescriptor instead')
 const ListBinariesResponse$json = {
@@ -114,9 +146,9 @@ const ListBinariesResponse$json = {
 };
 
 /// Descriptor for `ListBinariesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listBinariesResponseDescriptor =
-    $convert.base64Decode('ChRMaXN0QmluYXJpZXNSZXNwb25zZRI8CghiaW5hcmllcxgBIAMoCzIgLm9yY2hlc3RyYXRvci'
-        '52MS5CaW5hcnlTdGF0dXNNc2dSCGJpbmFyaWVz');
+final $typed_data.Uint8List listBinariesResponseDescriptor = $convert.base64Decode(
+    'ChRMaXN0QmluYXJpZXNSZXNwb25zZRI8CghiaW5hcmllcxgBIAMoCzIgLm9yY2hlc3RyYXRvci'
+    '52MS5CaW5hcnlTdGF0dXNNc2dSCGJpbmFyaWVz');
 
 @$core.Deprecated('Use getBinaryStatusRequestDescriptor instead')
 const GetBinaryStatusRequest$json = {
@@ -127,8 +159,8 @@ const GetBinaryStatusRequest$json = {
 };
 
 /// Descriptor for `GetBinaryStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBinaryStatusRequestDescriptor =
-    $convert.base64Decode('ChZHZXRCaW5hcnlTdGF0dXNSZXF1ZXN0EhIKBG5hbWUYASABKAlSBG5hbWU=');
+final $typed_data.Uint8List getBinaryStatusRequestDescriptor = $convert.base64Decode(
+    'ChZHZXRCaW5hcnlTdGF0dXNSZXF1ZXN0EhIKBG5hbWUYASABKAlSBG5hbWU=');
 
 @$core.Deprecated('Use getBinaryStatusResponseDescriptor instead')
 const GetBinaryStatusResponse$json = {
@@ -139,9 +171,9 @@ const GetBinaryStatusResponse$json = {
 };
 
 /// Descriptor for `GetBinaryStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBinaryStatusResponseDescriptor =
-    $convert.base64Decode('ChdHZXRCaW5hcnlTdGF0dXNSZXNwb25zZRI4CgZzdGF0dXMYASABKAsyIC5vcmNoZXN0cmF0b3'
-        'IudjEuQmluYXJ5U3RhdHVzTXNnUgZzdGF0dXM=');
+final $typed_data.Uint8List getBinaryStatusResponseDescriptor = $convert.base64Decode(
+    'ChdHZXRCaW5hcnlTdGF0dXNSZXNwb25zZRI4CgZzdGF0dXMYASABKAsyIC5vcmNoZXN0cmF0b3'
+    'IudjEuQmluYXJ5U3RhdHVzTXNnUgZzdGF0dXM=');
 
 @$core.Deprecated('Use downloadBinaryRequestDescriptor instead')
 const DownloadBinaryRequest$json = {
@@ -153,9 +185,9 @@ const DownloadBinaryRequest$json = {
 };
 
 /// Descriptor for `DownloadBinaryRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List downloadBinaryRequestDescriptor =
-    $convert.base64Decode('ChVEb3dubG9hZEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIUCgVmb3JjZRgCIA'
-        'EoCFIFZm9yY2U=');
+final $typed_data.Uint8List downloadBinaryRequestDescriptor = $convert.base64Decode(
+    'ChVEb3dubG9hZEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIUCgVmb3JjZRgCIA'
+    'EoCFIFZm9yY2U=');
 
 @$core.Deprecated('Use downloadBinaryResponseDescriptor instead')
 const DownloadBinaryResponse$json = {
@@ -163,8 +195,8 @@ const DownloadBinaryResponse$json = {
 };
 
 /// Descriptor for `DownloadBinaryResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List downloadBinaryResponseDescriptor =
-    $convert.base64Decode('ChZEb3dubG9hZEJpbmFyeVJlc3BvbnNl');
+final $typed_data.Uint8List downloadBinaryResponseDescriptor = $convert.base64Decode(
+    'ChZEb3dubG9hZEJpbmFyeVJlc3BvbnNl');
 
 @$core.Deprecated('Use startBinaryRequestDescriptor instead')
 const StartBinaryRequest$json = {
@@ -188,11 +220,11 @@ const StartBinaryRequest_EnvEntry$json = {
 };
 
 /// Descriptor for `StartBinaryRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startBinaryRequestDescriptor =
-    $convert.base64Decode('ChJTdGFydEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIdCgpleHRyYV9hcmdzGA'
-        'IgAygJUglleHRyYUFyZ3MSPgoDZW52GAMgAygLMiwub3JjaGVzdHJhdG9yLnYxLlN0YXJ0Qmlu'
-        'YXJ5UmVxdWVzdC5FbnZFbnRyeVIDZW52GjYKCEVudkVudHJ5EhAKA2tleRgBIAEoCVIDa2V5Eh'
-        'QKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+final $typed_data.Uint8List startBinaryRequestDescriptor = $convert.base64Decode(
+    'ChJTdGFydEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIdCgpleHRyYV9hcmdzGA'
+    'IgAygJUglleHRyYUFyZ3MSPgoDZW52GAMgAygLMiwub3JjaGVzdHJhdG9yLnYxLlN0YXJ0Qmlu'
+    'YXJ5UmVxdWVzdC5FbnZFbnRyeVIDZW52GjYKCEVudkVudHJ5EhAKA2tleRgBIAEoCVIDa2V5Eh'
+    'QKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
 
 @$core.Deprecated('Use startBinaryResponseDescriptor instead')
 const StartBinaryResponse$json = {
@@ -203,8 +235,8 @@ const StartBinaryResponse$json = {
 };
 
 /// Descriptor for `StartBinaryResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startBinaryResponseDescriptor =
-    $convert.base64Decode('ChNTdGFydEJpbmFyeVJlc3BvbnNlEhAKA3BpZBgBIAEoBVIDcGlk');
+final $typed_data.Uint8List startBinaryResponseDescriptor = $convert.base64Decode(
+    'ChNTdGFydEJpbmFyeVJlc3BvbnNlEhAKA3BpZBgBIAEoBVIDcGlk');
 
 @$core.Deprecated('Use stopBinaryRequestDescriptor instead')
 const StopBinaryRequest$json = {
@@ -216,9 +248,9 @@ const StopBinaryRequest$json = {
 };
 
 /// Descriptor for `StopBinaryRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopBinaryRequestDescriptor =
-    $convert.base64Decode('ChFTdG9wQmluYXJ5UmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhQKBWZvcmNlGAIgASgIUg'
-        'Vmb3JjZQ==');
+final $typed_data.Uint8List stopBinaryRequestDescriptor = $convert.base64Decode(
+    'ChFTdG9wQmluYXJ5UmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhQKBWZvcmNlGAIgASgIUg'
+    'Vmb3JjZQ==');
 
 @$core.Deprecated('Use stopBinaryResponseDescriptor instead')
 const StopBinaryResponse$json = {
@@ -226,7 +258,8 @@ const StopBinaryResponse$json = {
 };
 
 /// Descriptor for `StopBinaryResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopBinaryResponseDescriptor = $convert.base64Decode('ChJTdG9wQmluYXJ5UmVzcG9uc2U=');
+final $typed_data.Uint8List stopBinaryResponseDescriptor = $convert.base64Decode(
+    'ChJTdG9wQmluYXJ5UmVzcG9uc2U=');
 
 @$core.Deprecated('Use streamLogsRequestDescriptor instead')
 const StreamLogsRequest$json = {
@@ -238,9 +271,9 @@ const StreamLogsRequest$json = {
 };
 
 /// Descriptor for `StreamLogsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List streamLogsRequestDescriptor =
-    $convert.base64Decode('ChFTdHJlYW1Mb2dzUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhIKBHRhaWwYAiABKAVSBH'
-        'RhaWw=');
+final $typed_data.Uint8List streamLogsRequestDescriptor = $convert.base64Decode(
+    'ChFTdHJlYW1Mb2dzUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhIKBHRhaWwYAiABKAVSBH'
+    'RhaWw=');
 
 @$core.Deprecated('Use streamLogsResponseDescriptor instead')
 const StreamLogsResponse$json = {
@@ -253,9 +286,9 @@ const StreamLogsResponse$json = {
 };
 
 /// Descriptor for `StreamLogsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List streamLogsResponseDescriptor =
-    $convert.base64Decode('ChJTdHJlYW1Mb2dzUmVzcG9uc2USFgoGc3RyZWFtGAEgASgJUgZzdHJlYW0SEgoEbGluZRgCIA'
-        'EoCVIEbGluZRIlCg50aW1lc3RhbXBfdW5peBgDIAEoA1INdGltZXN0YW1wVW5peA==');
+final $typed_data.Uint8List streamLogsResponseDescriptor = $convert.base64Decode(
+    'ChJTdHJlYW1Mb2dzUmVzcG9uc2USFgoGc3RyZWFtGAEgASgJUgZzdHJlYW0SEgoEbGluZRgCIA'
+    'EoCVIEbGluZRIlCg50aW1lc3RhbXBfdW5peBgDIAEoA1INdGltZXN0YW1wVW5peA==');
 
 @$core.Deprecated('Use startWithL1RequestDescriptor instead')
 const StartWithL1Request$json = {
@@ -263,14 +296,7 @@ const StartWithL1Request$json = {
   '2': [
     {'1': 'target', '3': 1, '4': 1, '5': 9, '10': 'target'},
     {'1': 'target_args', '3': 2, '4': 3, '5': 9, '10': 'targetArgs'},
-    {
-      '1': 'target_env',
-      '3': 3,
-      '4': 3,
-      '5': 11,
-      '6': '.orchestrator.v1.StartWithL1Request.TargetEnvEntry',
-      '10': 'targetEnv'
-    },
+    {'1': 'target_env', '3': 3, '4': 3, '5': 11, '6': '.orchestrator.v1.StartWithL1Request.TargetEnvEntry', '10': 'targetEnv'},
     {'1': 'core_args', '3': 4, '4': 3, '5': 9, '10': 'coreArgs'},
     {'1': 'enforcer_args', '3': 5, '4': 3, '5': 9, '10': 'enforcerArgs'},
     {'1': 'immediate', '3': 6, '4': 1, '5': 8, '10': 'immediate'},
@@ -289,13 +315,13 @@ const StartWithL1Request_TargetEnvEntry$json = {
 };
 
 /// Descriptor for `StartWithL1Request`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startWithL1RequestDescriptor =
-    $convert.base64Decode('ChJTdGFydFdpdGhMMVJlcXVlc3QSFgoGdGFyZ2V0GAEgASgJUgZ0YXJnZXQSHwoLdGFyZ2V0X2'
-        'FyZ3MYAiADKAlSCnRhcmdldEFyZ3MSUQoKdGFyZ2V0X2VudhgDIAMoCzIyLm9yY2hlc3RyYXRv'
-        'ci52MS5TdGFydFdpdGhMMVJlcXVlc3QuVGFyZ2V0RW52RW50cnlSCXRhcmdldEVudhIbCgljb3'
-        'JlX2FyZ3MYBCADKAlSCGNvcmVBcmdzEiMKDWVuZm9yY2VyX2FyZ3MYBSADKAlSDGVuZm9yY2Vy'
-        'QXJncxIcCglpbW1lZGlhdGUYBiABKAhSCWltbWVkaWF0ZRo8Cg5UYXJnZXRFbnZFbnRyeRIQCg'
-        'NrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
+final $typed_data.Uint8List startWithL1RequestDescriptor = $convert.base64Decode(
+    'ChJTdGFydFdpdGhMMVJlcXVlc3QSFgoGdGFyZ2V0GAEgASgJUgZ0YXJnZXQSHwoLdGFyZ2V0X2'
+    'FyZ3MYAiADKAlSCnRhcmdldEFyZ3MSUQoKdGFyZ2V0X2VudhgDIAMoCzIyLm9yY2hlc3RyYXRv'
+    'ci52MS5TdGFydFdpdGhMMVJlcXVlc3QuVGFyZ2V0RW52RW50cnlSCXRhcmdldEVudhIbCgljb3'
+    'JlX2FyZ3MYBCADKAlSCGNvcmVBcmdzEiMKDWVuZm9yY2VyX2FyZ3MYBSADKAlSDGVuZm9yY2Vy'
+    'QXJncxIcCglpbW1lZGlhdGUYBiABKAhSCWltbWVkaWF0ZRo8Cg5UYXJnZXRFbnZFbnRyeRIQCg'
+    'NrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
 
 @$core.Deprecated('Use startWithL1ResponseDescriptor instead')
 const StartWithL1Response$json = {
@@ -303,7 +329,8 @@ const StartWithL1Response$json = {
 };
 
 /// Descriptor for `StartWithL1Response`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startWithL1ResponseDescriptor = $convert.base64Decode('ChNTdGFydFdpdGhMMVJlc3BvbnNl');
+final $typed_data.Uint8List startWithL1ResponseDescriptor = $convert.base64Decode(
+    'ChNTdGFydFdpdGhMMVJlc3BvbnNl');
 
 @$core.Deprecated('Use restartDaemonRequestDescriptor instead')
 const RestartDaemonRequest$json = {
@@ -314,8 +341,8 @@ const RestartDaemonRequest$json = {
 };
 
 /// Descriptor for `RestartDaemonRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List restartDaemonRequestDescriptor =
-    $convert.base64Decode('ChRSZXN0YXJ0RGFlbW9uUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1l');
+final $typed_data.Uint8List restartDaemonRequestDescriptor = $convert.base64Decode(
+    'ChRSZXN0YXJ0RGFlbW9uUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1l');
 
 @$core.Deprecated('Use restartDaemonResponseDescriptor instead')
 const RestartDaemonResponse$json = {
@@ -323,7 +350,8 @@ const RestartDaemonResponse$json = {
 };
 
 /// Descriptor for `RestartDaemonResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List restartDaemonResponseDescriptor = $convert.base64Decode('ChVSZXN0YXJ0RGFlbW9uUmVzcG9uc2U=');
+final $typed_data.Uint8List restartDaemonResponseDescriptor = $convert.base64Decode(
+    'ChVSZXN0YXJ0RGFlbW9uUmVzcG9uc2U=');
 
 @$core.Deprecated('Use shutdownAllRequestDescriptor instead')
 const ShutdownAllRequest$json = {
@@ -334,8 +362,8 @@ const ShutdownAllRequest$json = {
 };
 
 /// Descriptor for `ShutdownAllRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List shutdownAllRequestDescriptor =
-    $convert.base64Decode('ChJTaHV0ZG93bkFsbFJlcXVlc3QSFAoFZm9yY2UYASABKAhSBWZvcmNl');
+final $typed_data.Uint8List shutdownAllRequestDescriptor = $convert.base64Decode(
+    'ChJTaHV0ZG93bkFsbFJlcXVlc3QSFAoFZm9yY2UYASABKAhSBWZvcmNl');
 
 @$core.Deprecated('Use shutdownAllResponseDescriptor instead')
 const ShutdownAllResponse$json = {
@@ -350,11 +378,11 @@ const ShutdownAllResponse$json = {
 };
 
 /// Descriptor for `ShutdownAllResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List shutdownAllResponseDescriptor =
-    $convert.base64Decode('ChNTaHV0ZG93bkFsbFJlc3BvbnNlEh8KC3RvdGFsX2NvdW50GAEgASgFUgp0b3RhbENvdW50Ei'
-        'cKD2NvbXBsZXRlZF9jb3VudBgCIAEoBVIOY29tcGxldGVkQ291bnQSJQoOY3VycmVudF9iaW5h'
-        'cnkYAyABKAlSDWN1cnJlbnRCaW5hcnkSEgoEZG9uZRgEIAEoCFIEZG9uZRIUCgVlcnJvchgFIA'
-        'EoCVIFZXJyb3I=');
+final $typed_data.Uint8List shutdownAllResponseDescriptor = $convert.base64Decode(
+    'ChNTaHV0ZG93bkFsbFJlc3BvbnNlEh8KC3RvdGFsX2NvdW50GAEgASgFUgp0b3RhbENvdW50Ei'
+    'cKD2NvbXBsZXRlZF9jb3VudBgCIAEoBVIOY29tcGxldGVkQ291bnQSJQoOY3VycmVudF9iaW5h'
+    'cnkYAyABKAlSDWN1cnJlbnRCaW5hcnkSEgoEZG9uZRgEIAEoCFIEZG9uZRIUCgVlcnJvchgFIA'
+    'EoCVIFZXJyb3I=');
 
 @$core.Deprecated('Use getBTCPriceRequestDescriptor instead')
 const GetBTCPriceRequest$json = {
@@ -362,7 +390,8 @@ const GetBTCPriceRequest$json = {
 };
 
 /// Descriptor for `GetBTCPriceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBTCPriceRequestDescriptor = $convert.base64Decode('ChJHZXRCVENQcmljZVJlcXVlc3Q=');
+final $typed_data.Uint8List getBTCPriceRequestDescriptor = $convert.base64Decode(
+    'ChJHZXRCVENQcmljZVJlcXVlc3Q=');
 
 @$core.Deprecated('Use getBTCPriceResponseDescriptor instead')
 const GetBTCPriceResponse$json = {
@@ -374,9 +403,9 @@ const GetBTCPriceResponse$json = {
 };
 
 /// Descriptor for `GetBTCPriceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBTCPriceResponseDescriptor =
-    $convert.base64Decode('ChNHZXRCVENQcmljZVJlc3BvbnNlEhYKBmJ0Y3VzZBgBIAEoAVIGYnRjdXNkEioKEWxhc3RfdX'
-        'BkYXRlZF91bml4GAIgASgDUg9sYXN0VXBkYXRlZFVuaXg=');
+final $typed_data.Uint8List getBTCPriceResponseDescriptor = $convert.base64Decode(
+    'ChNHZXRCVENQcmljZVJlc3BvbnNlEhYKBmJ0Y3VzZBgBIAEoAVIGYnRjdXNkEioKEWxhc3RfdX'
+    'BkYXRlZF91bml4GAIgASgDUg9sYXN0VXBkYXRlZFVuaXg=');
 
 @$core.Deprecated('Use getMainchainBlockchainInfoRequestDescriptor instead')
 const GetMainchainBlockchainInfoRequest$json = {
@@ -384,8 +413,8 @@ const GetMainchainBlockchainInfoRequest$json = {
 };
 
 /// Descriptor for `GetMainchainBlockchainInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getMainchainBlockchainInfoRequestDescriptor =
-    $convert.base64Decode('CiFHZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1JlcXVlc3Q=');
+final $typed_data.Uint8List getMainchainBlockchainInfoRequestDescriptor = $convert.base64Decode(
+    'CiFHZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getMainchainBlockchainInfoResponseDescriptor instead')
 const GetMainchainBlockchainInfoResponse$json = {
@@ -407,15 +436,15 @@ const GetMainchainBlockchainInfoResponse$json = {
 };
 
 /// Descriptor for `GetMainchainBlockchainInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getMainchainBlockchainInfoResponseDescriptor =
-    $convert.base64Decode('CiJHZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1Jlc3BvbnNlEhQKBWNoYWluGAEgASgJUgVjaG'
-        'FpbhIWCgZibG9ja3MYAiABKAVSBmJsb2NrcxIYCgdoZWFkZXJzGAMgASgFUgdoZWFkZXJzEiYK'
-        'D2Jlc3RfYmxvY2tfaGFzaBgEIAEoCVINYmVzdEJsb2NrSGFzaBIeCgpkaWZmaWN1bHR5GAUgAS'
-        'gBUgpkaWZmaWN1bHR5EhIKBHRpbWUYBiABKANSBHRpbWUSHwoLbWVkaWFuX3RpbWUYByABKANS'
-        'Cm1lZGlhblRpbWUSMwoVdmVyaWZpY2F0aW9uX3Byb2dyZXNzGAggASgBUhR2ZXJpZmljYXRpb2'
-        '5Qcm9ncmVzcxI0ChZpbml0aWFsX2Jsb2NrX2Rvd25sb2FkGAkgASgIUhRpbml0aWFsQmxvY2tE'
-        'b3dubG9hZBIdCgpjaGFpbl93b3JrGAogASgJUgljaGFpbldvcmsSIAoMc2l6ZV9vbl9kaXNrGA'
-        'sgASgDUgpzaXplT25EaXNrEhYKBnBydW5lZBgMIAEoCFIGcHJ1bmVk');
+final $typed_data.Uint8List getMainchainBlockchainInfoResponseDescriptor = $convert.base64Decode(
+    'CiJHZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1Jlc3BvbnNlEhQKBWNoYWluGAEgASgJUgVjaG'
+    'FpbhIWCgZibG9ja3MYAiABKAVSBmJsb2NrcxIYCgdoZWFkZXJzGAMgASgFUgdoZWFkZXJzEiYK'
+    'D2Jlc3RfYmxvY2tfaGFzaBgEIAEoCVINYmVzdEJsb2NrSGFzaBIeCgpkaWZmaWN1bHR5GAUgAS'
+    'gBUgpkaWZmaWN1bHR5EhIKBHRpbWUYBiABKANSBHRpbWUSHwoLbWVkaWFuX3RpbWUYByABKANS'
+    'Cm1lZGlhblRpbWUSMwoVdmVyaWZpY2F0aW9uX3Byb2dyZXNzGAggASgBUhR2ZXJpZmljYXRpb2'
+    '5Qcm9ncmVzcxI0ChZpbml0aWFsX2Jsb2NrX2Rvd25sb2FkGAkgASgIUhRpbml0aWFsQmxvY2tE'
+    'b3dubG9hZBIdCgpjaGFpbl93b3JrGAogASgJUgljaGFpbldvcmsSIAoMc2l6ZV9vbl9kaXNrGA'
+    'sgASgDUgpzaXplT25EaXNrEhYKBnBydW5lZBgMIAEoCFIGcHJ1bmVk');
 
 @$core.Deprecated('Use getEnforcerBlockchainInfoRequestDescriptor instead')
 const GetEnforcerBlockchainInfoRequest$json = {
@@ -423,8 +452,8 @@ const GetEnforcerBlockchainInfoRequest$json = {
 };
 
 /// Descriptor for `GetEnforcerBlockchainInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getEnforcerBlockchainInfoRequestDescriptor =
-    $convert.base64Decode('CiBHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvUmVxdWVzdA==');
+final $typed_data.Uint8List getEnforcerBlockchainInfoRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvUmVxdWVzdA==');
 
 @$core.Deprecated('Use getEnforcerBlockchainInfoResponseDescriptor instead')
 const GetEnforcerBlockchainInfoResponse$json = {
@@ -437,9 +466,9 @@ const GetEnforcerBlockchainInfoResponse$json = {
 };
 
 /// Descriptor for `GetEnforcerBlockchainInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getEnforcerBlockchainInfoResponseDescriptor =
-    $convert.base64Decode('CiFHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvUmVzcG9uc2USFgoGYmxvY2tzGAEgASgFUgZibG'
-        '9ja3MSGAoHaGVhZGVycxgCIAEoBVIHaGVhZGVycxISCgR0aW1lGAMgASgDUgR0aW1l');
+final $typed_data.Uint8List getEnforcerBlockchainInfoResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvUmVzcG9uc2USFgoGYmxvY2tzGAEgASgFUgZibG'
+    '9ja3MSGAoHaGVhZGVycxgCIAEoBVIHaGVhZGVycxISCgR0aW1lGAMgASgDUgR0aW1l');
 
 @$core.Deprecated('Use getSyncStatusRequestDescriptor instead')
 const GetSyncStatusRequest$json = {
@@ -447,7 +476,8 @@ const GetSyncStatusRequest$json = {
 };
 
 /// Descriptor for `GetSyncStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSyncStatusRequestDescriptor = $convert.base64Decode('ChRHZXRTeW5jU3RhdHVzUmVxdWVzdA==');
+final $typed_data.Uint8List getSyncStatusRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRTeW5jU3RhdHVzUmVxdWVzdA==');
 
 @$core.Deprecated('Use getSyncStatusResponseDescriptor instead')
 const GetSyncStatusResponse$json = {
@@ -460,11 +490,11 @@ const GetSyncStatusResponse$json = {
 };
 
 /// Descriptor for `GetSyncStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSyncStatusResponseDescriptor =
-    $convert.base64Decode('ChVHZXRTeW5jU3RhdHVzUmVzcG9uc2USOAoJbWFpbmNoYWluGAEgASgLMhoub3JjaGVzdHJhdG'
-        '9yLnYxLkNoYWluU3luY1IJbWFpbmNoYWluEjYKCGVuZm9yY2VyGAIgASgLMhoub3JjaGVzdHJh'
-        'dG9yLnYxLkNoYWluU3luY1IIZW5mb3JjZXISQAoKc2lkZWNoYWlucxgDIAMoCzIgLm9yY2hlc3'
-        'RyYXRvci52MS5TaWRlY2hhaW5TdGF0dXNSCnNpZGVjaGFpbnM=');
+final $typed_data.Uint8List getSyncStatusResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRTeW5jU3RhdHVzUmVzcG9uc2USOAoJbWFpbmNoYWluGAEgASgLMhoub3JjaGVzdHJhdG'
+    '9yLnYxLkNoYWluU3luY1IJbWFpbmNoYWluEjYKCGVuZm9yY2VyGAIgASgLMhoub3JjaGVzdHJh'
+    'dG9yLnYxLkNoYWluU3luY1IIZW5mb3JjZXISQAoKc2lkZWNoYWlucxgDIAMoCzIgLm9yY2hlc3'
+    'RyYXRvci52MS5TaWRlY2hhaW5TdGF0dXNSCnNpZGVjaGFpbnM=');
 
 @$core.Deprecated('Use sidechainStatusDescriptor instead')
 const SidechainStatus$json = {
@@ -476,10 +506,10 @@ const SidechainStatus$json = {
 };
 
 /// Descriptor for `SidechainStatus`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List sidechainStatusDescriptor =
-    $convert.base64Decode('Cg9TaWRlY2hhaW5TdGF0dXMSMgoEdHlwZRgBIAEoDjIeLm9yY2hlc3RyYXRvci52MS5TaWRlY2'
-        'hhaW5UeXBlUgR0eXBlEi4KBHN5bmMYAiABKAsyGi5vcmNoZXN0cmF0b3IudjEuQ2hhaW5TeW5j'
-        'UgRzeW5j');
+final $typed_data.Uint8List sidechainStatusDescriptor = $convert.base64Decode(
+    'Cg9TaWRlY2hhaW5TdGF0dXMSMgoEdHlwZRgBIAEoDjIeLm9yY2hlc3RyYXRvci52MS5TaWRlY2'
+    'hhaW5UeXBlUgR0eXBlEi4KBHN5bmMYAiABKAsyGi5vcmNoZXN0cmF0b3IudjEuQ2hhaW5TeW5j'
+    'UgRzeW5j');
 
 @$core.Deprecated('Use chainSyncDescriptor instead')
 const ChainSync$json = {
@@ -489,15 +519,52 @@ const ChainSync$json = {
     {'1': 'headers', '3': 2, '4': 1, '5': 5, '10': 'headers'},
     {'1': 'time', '3': 3, '4': 1, '5': 3, '10': 'time'},
     {'1': 'error', '3': 4, '4': 1, '5': 9, '10': 'error'},
-    {'1': 'is_downloading', '3': 5, '4': 1, '5': 8, '10': 'isDownloading'},
   ],
 };
 
 /// Descriptor for `ChainSync`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List chainSyncDescriptor =
-    $convert.base64Decode('CglDaGFpblN5bmMSFgoGYmxvY2tzGAEgASgFUgZibG9ja3MSGAoHaGVhZGVycxgCIAEoBVIHaG'
-        'VhZGVycxISCgR0aW1lGAMgASgDUgR0aW1lEhQKBWVycm9yGAQgASgJUgVlcnJvchIlCg5pc19k'
-        'b3dubG9hZGluZxgFIAEoCFINaXNEb3dubG9hZGluZw==');
+final $typed_data.Uint8List chainSyncDescriptor = $convert.base64Decode(
+    'CglDaGFpblN5bmMSFgoGYmxvY2tzGAEgASgFUgZibG9ja3MSGAoHaGVhZGVycxgCIAEoBVIHaG'
+    'VhZGVycxISCgR0aW1lGAMgASgDUgR0aW1lEhQKBWVycm9yGAQgASgJUgVlcnJvcg==');
+
+@$core.Deprecated('Use getDownloadStatusRequestDescriptor instead')
+const GetDownloadStatusRequest$json = {
+  '1': 'GetDownloadStatusRequest',
+};
+
+/// Descriptor for `GetDownloadStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getDownloadStatusRequestDescriptor = $convert.base64Decode(
+    'ChhHZXREb3dubG9hZFN0YXR1c1JlcXVlc3Q=');
+
+@$core.Deprecated('Use getDownloadStatusResponseDescriptor instead')
+const GetDownloadStatusResponse$json = {
+  '1': 'GetDownloadStatusResponse',
+  '2': [
+    {'1': 'downloads', '3': 1, '4': 3, '5': 11, '6': '.orchestrator.v1.DownloadStatus', '10': 'downloads'},
+  ],
+};
+
+/// Descriptor for `GetDownloadStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getDownloadStatusResponseDescriptor = $convert.base64Decode(
+    'ChlHZXREb3dubG9hZFN0YXR1c1Jlc3BvbnNlEj0KCWRvd25sb2FkcxgBIAMoCzIfLm9yY2hlc3'
+    'RyYXRvci52MS5Eb3dubG9hZFN0YXR1c1IJZG93bmxvYWRz');
+
+@$core.Deprecated('Use downloadStatusDescriptor instead')
+const DownloadStatus$json = {
+  '1': 'DownloadStatus',
+  '2': [
+    {'1': 'binary', '3': 1, '4': 1, '5': 14, '6': '.orchestrator.v1.BinaryType', '10': 'binary'},
+    {'1': 'mb_downloaded', '3': 2, '4': 1, '5': 3, '10': 'mbDownloaded'},
+    {'1': 'mb_total', '3': 3, '4': 1, '5': 3, '10': 'mbTotal'},
+    {'1': 'message', '3': 4, '4': 1, '5': 9, '10': 'message'},
+  ],
+};
+
+/// Descriptor for `DownloadStatus`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List downloadStatusDescriptor = $convert.base64Decode(
+    'Cg5Eb3dubG9hZFN0YXR1cxIzCgZiaW5hcnkYASABKA4yGy5vcmNoZXN0cmF0b3IudjEuQmluYX'
+    'J5VHlwZVIGYmluYXJ5EiMKDW1iX2Rvd25sb2FkZWQYAiABKANSDG1iRG93bmxvYWRlZBIZCght'
+    'Yl90b3RhbBgDIAEoA1IHbWJUb3RhbBIYCgdtZXNzYWdlGAQgASgJUgdtZXNzYWdl');
 
 @$core.Deprecated('Use getMainchainBalanceRequestDescriptor instead')
 const GetMainchainBalanceRequest$json = {
@@ -505,8 +572,8 @@ const GetMainchainBalanceRequest$json = {
 };
 
 /// Descriptor for `GetMainchainBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getMainchainBalanceRequestDescriptor =
-    $convert.base64Decode('ChpHZXRNYWluY2hhaW5CYWxhbmNlUmVxdWVzdA==');
+final $typed_data.Uint8List getMainchainBalanceRequestDescriptor = $convert.base64Decode(
+    'ChpHZXRNYWluY2hhaW5CYWxhbmNlUmVxdWVzdA==');
 
 @$core.Deprecated('Use getMainchainBalanceResponseDescriptor instead')
 const GetMainchainBalanceResponse$json = {
@@ -518,9 +585,9 @@ const GetMainchainBalanceResponse$json = {
 };
 
 /// Descriptor for `GetMainchainBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getMainchainBalanceResponseDescriptor =
-    $convert.base64Decode('ChtHZXRNYWluY2hhaW5CYWxhbmNlUmVzcG9uc2USHAoJY29uZmlybWVkGAEgASgBUgljb25maX'
-        'JtZWQSIAoLdW5jb25maXJtZWQYAiABKAFSC3VuY29uZmlybWVk');
+final $typed_data.Uint8List getMainchainBalanceResponseDescriptor = $convert.base64Decode(
+    'ChtHZXRNYWluY2hhaW5CYWxhbmNlUmVzcG9uc2USHAoJY29uZmlybWVkGAEgASgBUgljb25maX'
+    'JtZWQSIAoLdW5jb25maXJtZWQYAiABKAFSC3VuY29uZmlybWVk');
 
 @$core.Deprecated('Use previewResetDataRequestDescriptor instead')
 const PreviewResetDataRequest$json = {
@@ -536,13 +603,13 @@ const PreviewResetDataRequest$json = {
 };
 
 /// Descriptor for `PreviewResetDataRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List previewResetDataRequestDescriptor =
-    $convert.base64Decode('ChdQcmV2aWV3UmVzZXREYXRhUmVxdWVzdBI0ChZkZWxldGVfYmxvY2tjaGFpbl9kYXRhGAEgAS'
-        'gIUhRkZWxldGVCbG9ja2NoYWluRGF0YRIwChRkZWxldGVfbm9kZV9zb2Z0d2FyZRgCIAEoCFIS'
-        'ZGVsZXRlTm9kZVNvZnR3YXJlEh8KC2RlbGV0ZV9sb2dzGAMgASgIUgpkZWxldGVMb2dzEicKD2'
-        'RlbGV0ZV9zZXR0aW5ncxgEIAEoCFIOZGVsZXRlU2V0dGluZ3MSLgoTZGVsZXRlX3dhbGxldF9m'
-        'aWxlcxgFIAEoCFIRZGVsZXRlV2FsbGV0RmlsZXMSMgoVYWxzb19yZXNldF9zaWRlY2hhaW5zGA'
-        'YgASgIUhNhbHNvUmVzZXRTaWRlY2hhaW5z');
+final $typed_data.Uint8List previewResetDataRequestDescriptor = $convert.base64Decode(
+    'ChdQcmV2aWV3UmVzZXREYXRhUmVxdWVzdBI0ChZkZWxldGVfYmxvY2tjaGFpbl9kYXRhGAEgAS'
+    'gIUhRkZWxldGVCbG9ja2NoYWluRGF0YRIwChRkZWxldGVfbm9kZV9zb2Z0d2FyZRgCIAEoCFIS'
+    'ZGVsZXRlTm9kZVNvZnR3YXJlEh8KC2RlbGV0ZV9sb2dzGAMgASgIUgpkZWxldGVMb2dzEicKD2'
+    'RlbGV0ZV9zZXR0aW5ncxgEIAEoCFIOZGVsZXRlU2V0dGluZ3MSLgoTZGVsZXRlX3dhbGxldF9m'
+    'aWxlcxgFIAEoCFIRZGVsZXRlV2FsbGV0RmlsZXMSMgoVYWxzb19yZXNldF9zaWRlY2hhaW5zGA'
+    'YgASgIUhNhbHNvUmVzZXRTaWRlY2hhaW5z');
 
 @$core.Deprecated('Use previewResetDataResponseDescriptor instead')
 const PreviewResetDataResponse$json = {
@@ -553,9 +620,9 @@ const PreviewResetDataResponse$json = {
 };
 
 /// Descriptor for `PreviewResetDataResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List previewResetDataResponseDescriptor =
-    $convert.base64Decode('ChhQcmV2aWV3UmVzZXREYXRhUmVzcG9uc2USNAoFZmlsZXMYASADKAsyHi5vcmNoZXN0cmF0b3'
-        'IudjEuUmVzZXRGaWxlSW5mb1IFZmlsZXM=');
+final $typed_data.Uint8List previewResetDataResponseDescriptor = $convert.base64Decode(
+    'ChhQcmV2aWV3UmVzZXREYXRhUmVzcG9uc2USNAoFZmlsZXMYASADKAsyHi5vcmNoZXN0cmF0b3'
+    'IudjEuUmVzZXRGaWxlSW5mb1IFZmlsZXM=');
 
 @$core.Deprecated('Use resetFileInfoDescriptor instead')
 const ResetFileInfo$json = {
@@ -569,10 +636,10 @@ const ResetFileInfo$json = {
 };
 
 /// Descriptor for `ResetFileInfo`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List resetFileInfoDescriptor =
-    $convert.base64Decode('Cg1SZXNldEZpbGVJbmZvEhIKBHBhdGgYASABKAlSBHBhdGgSGgoIY2F0ZWdvcnkYAiABKAlSCG'
-        'NhdGVnb3J5Eh0KCnNpemVfYnl0ZXMYAyABKANSCXNpemVCeXRlcxIhCgxpc19kaXJlY3RvcnkY'
-        'BCABKAhSC2lzRGlyZWN0b3J5');
+final $typed_data.Uint8List resetFileInfoDescriptor = $convert.base64Decode(
+    'Cg1SZXNldEZpbGVJbmZvEhIKBHBhdGgYASABKAlSBHBhdGgSGgoIY2F0ZWdvcnkYAiABKAlSCG'
+    'NhdGVnb3J5Eh0KCnNpemVfYnl0ZXMYAyABKANSCXNpemVCeXRlcxIhCgxpc19kaXJlY3RvcnkY'
+    'BCABKAhSC2lzRGlyZWN0b3J5');
 
 @$core.Deprecated('Use streamResetDataRequestDescriptor instead')
 const StreamResetDataRequest$json = {
@@ -588,13 +655,13 @@ const StreamResetDataRequest$json = {
 };
 
 /// Descriptor for `StreamResetDataRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List streamResetDataRequestDescriptor =
-    $convert.base64Decode('ChZTdHJlYW1SZXNldERhdGFSZXF1ZXN0EjQKFmRlbGV0ZV9ibG9ja2NoYWluX2RhdGEYASABKA'
-        'hSFGRlbGV0ZUJsb2NrY2hhaW5EYXRhEjAKFGRlbGV0ZV9ub2RlX3NvZnR3YXJlGAIgASgIUhJk'
-        'ZWxldGVOb2RlU29mdHdhcmUSHwoLZGVsZXRlX2xvZ3MYAyABKAhSCmRlbGV0ZUxvZ3MSJwoPZG'
-        'VsZXRlX3NldHRpbmdzGAQgASgIUg5kZWxldGVTZXR0aW5ncxIuChNkZWxldGVfd2FsbGV0X2Zp'
-        'bGVzGAUgASgIUhFkZWxldGVXYWxsZXRGaWxlcxIyChVhbHNvX3Jlc2V0X3NpZGVjaGFpbnMYBi'
-        'ABKAhSE2Fsc29SZXNldFNpZGVjaGFpbnM=');
+final $typed_data.Uint8List streamResetDataRequestDescriptor = $convert.base64Decode(
+    'ChZTdHJlYW1SZXNldERhdGFSZXF1ZXN0EjQKFmRlbGV0ZV9ibG9ja2NoYWluX2RhdGEYASABKA'
+    'hSFGRlbGV0ZUJsb2NrY2hhaW5EYXRhEjAKFGRlbGV0ZV9ub2RlX3NvZnR3YXJlGAIgASgIUhJk'
+    'ZWxldGVOb2RlU29mdHdhcmUSHwoLZGVsZXRlX2xvZ3MYAyABKAhSCmRlbGV0ZUxvZ3MSJwoPZG'
+    'VsZXRlX3NldHRpbmdzGAQgASgIUg5kZWxldGVTZXR0aW5ncxIuChNkZWxldGVfd2FsbGV0X2Zp'
+    'bGVzGAUgASgIUhFkZWxldGVXYWxsZXRGaWxlcxIyChVhbHNvX3Jlc2V0X3NpZGVjaGFpbnMYBi'
+    'ABKAhSE2Fsc29SZXNldFNpZGVjaGFpbnM=');
 
 @$core.Deprecated('Use streamResetDataResponseDescriptor instead')
 const StreamResetDataResponse$json = {
@@ -611,11 +678,11 @@ const StreamResetDataResponse$json = {
 };
 
 /// Descriptor for `StreamResetDataResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List streamResetDataResponseDescriptor =
-    $convert.base64Decode('ChdTdHJlYW1SZXNldERhdGFSZXNwb25zZRISCgRwYXRoGAEgASgJUgRwYXRoEhoKCGNhdGVnb3'
-        'J5GAIgASgJUghjYXRlZ29yeRIYCgdzdWNjZXNzGAMgASgIUgdzdWNjZXNzEhQKBWVycm9yGAQg'
-        'ASgJUgVlcnJvchISCgRkb25lGAUgASgIUgRkb25lEiMKDWRlbGV0ZWRfY291bnQYBiABKAVSDG'
-        'RlbGV0ZWRDb3VudBIhCgxmYWlsZWRfY291bnQYByABKAVSC2ZhaWxlZENvdW50');
+final $typed_data.Uint8List streamResetDataResponseDescriptor = $convert.base64Decode(
+    'ChdTdHJlYW1SZXNldERhdGFSZXNwb25zZRISCgRwYXRoGAEgASgJUgRwYXRoEhoKCGNhdGVnb3'
+    'J5GAIgASgJUghjYXRlZ29yeRIYCgdzdWNjZXNzGAMgASgIUgdzdWNjZXNzEhQKBWVycm9yGAQg'
+    'ASgJUgVlcnJvchISCgRkb25lGAUgASgIUgRkb25lEiMKDWRlbGV0ZWRfY291bnQYBiABKAVSDG'
+    'RlbGV0ZWRDb3VudBIhCgxmYWlsZWRfY291bnQYByABKAVSC2ZhaWxlZENvdW50');
 
 @$core.Deprecated('Use getCoreMempoolInfoRequestDescriptor instead')
 const GetCoreMempoolInfoRequest$json = {
@@ -623,8 +690,8 @@ const GetCoreMempoolInfoRequest$json = {
 };
 
 /// Descriptor for `GetCoreMempoolInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getCoreMempoolInfoRequestDescriptor =
-    $convert.base64Decode('ChlHZXRDb3JlTWVtcG9vbEluZm9SZXF1ZXN0');
+final $typed_data.Uint8List getCoreMempoolInfoRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRDb3JlTWVtcG9vbEluZm9SZXF1ZXN0');
 
 @$core.Deprecated('Use getCoreMempoolInfoResponseDescriptor instead')
 const GetCoreMempoolInfoResponse$json = {
@@ -645,14 +712,14 @@ const GetCoreMempoolInfoResponse$json = {
 };
 
 /// Descriptor for `GetCoreMempoolInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getCoreMempoolInfoResponseDescriptor =
-    $convert.base64Decode('ChpHZXRDb3JlTWVtcG9vbEluZm9SZXNwb25zZRIWCgZsb2FkZWQYASABKAhSBmxvYWRlZBISCg'
-        'RzaXplGAIgASgDUgRzaXplEhQKBWJ5dGVzGAMgASgDUgVieXRlcxIUCgV1c2FnZRgEIAEoA1IF'
-        'dXNhZ2USGwoJdG90YWxfZmVlGAUgASgBUgh0b3RhbEZlZRIfCgttYXhfbWVtcG9vbBgGIAEoA1'
-        'IKbWF4TWVtcG9vbBImCg9tZW1wb29sX21pbl9mZWUYByABKAFSDW1lbXBvb2xNaW5GZWUSJwoQ'
-        'bWluX3JlbGF5X3R4X2ZlZRgIIAEoAVINbWluUmVsYXlUeEZlZRIyChVpbmNyZW1lbnRhbF9yZW'
-        'xheV9mZWUYCSABKAFSE2luY3JlbWVudGFsUmVsYXlGZWUSKwoRdW5icm9hZGNhc3RfY291bnQY'
-        'CiABKANSEHVuYnJvYWRjYXN0Q291bnQSGQoIZnVsbF9yYmYYCyABKAhSB2Z1bGxSYmY=');
+final $typed_data.Uint8List getCoreMempoolInfoResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRDb3JlTWVtcG9vbEluZm9SZXNwb25zZRIWCgZsb2FkZWQYASABKAhSBmxvYWRlZBISCg'
+    'RzaXplGAIgASgDUgRzaXplEhQKBWJ5dGVzGAMgASgDUgVieXRlcxIUCgV1c2FnZRgEIAEoA1IF'
+    'dXNhZ2USGwoJdG90YWxfZmVlGAUgASgBUgh0b3RhbEZlZRIfCgttYXhfbWVtcG9vbBgGIAEoA1'
+    'IKbWF4TWVtcG9vbBImCg9tZW1wb29sX21pbl9mZWUYByABKAFSDW1lbXBvb2xNaW5GZWUSJwoQ'
+    'bWluX3JlbGF5X3R4X2ZlZRgIIAEoAVINbWluUmVsYXlUeEZlZRIyChVpbmNyZW1lbnRhbF9yZW'
+    'xheV9mZWUYCSABKAFSE2luY3JlbWVudGFsUmVsYXlGZWUSKwoRdW5icm9hZGNhc3RfY291bnQY'
+    'CiABKANSEHVuYnJvYWRjYXN0Q291bnQSGQoIZnVsbF9yYmYYCyABKAhSB2Z1bGxSYmY=');
 
 @$core.Deprecated('Use coreRawCallRequestDescriptor instead')
 const CoreRawCallRequest$json = {
@@ -665,9 +732,9 @@ const CoreRawCallRequest$json = {
 };
 
 /// Descriptor for `CoreRawCallRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List coreRawCallRequestDescriptor =
-    $convert.base64Decode('ChJDb3JlUmF3Q2FsbFJlcXVlc3QSFgoGbWV0aG9kGAEgASgJUgZtZXRob2QSHwoLcGFyYW1zX2'
-        'pzb24YAiABKAlSCnBhcmFtc0pzb24SFgoGd2FsbGV0GAMgASgJUgZ3YWxsZXQ=');
+final $typed_data.Uint8List coreRawCallRequestDescriptor = $convert.base64Decode(
+    'ChJDb3JlUmF3Q2FsbFJlcXVlc3QSFgoGbWV0aG9kGAEgASgJUgZtZXRob2QSHwoLcGFyYW1zX2'
+    'pzb24YAiABKAlSCnBhcmFtc0pzb24SFgoGd2FsbGV0GAMgASgJUgZ3YWxsZXQ=');
 
 @$core.Deprecated('Use coreRawCallResponseDescriptor instead')
 const CoreRawCallResponse$json = {
@@ -678,72 +745,30 @@ const CoreRawCallResponse$json = {
 };
 
 /// Descriptor for `CoreRawCallResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List coreRawCallResponseDescriptor =
-    $convert.base64Decode('ChNDb3JlUmF3Q2FsbFJlc3BvbnNlEh8KC3Jlc3VsdF9qc29uGAEgASgJUgpyZXN1bHRKc29u');
+final $typed_data.Uint8List coreRawCallResponseDescriptor = $convert.base64Decode(
+    'ChNDb3JlUmF3Q2FsbFJlc3BvbnNlEh8KC3Jlc3VsdF9qc29uGAEgASgJUgpyZXN1bHRKc29u');
 
 const $core.Map<$core.String, $core.dynamic> OrchestratorServiceBase$json = {
   '1': 'OrchestratorService',
   '2': [
     {'1': 'ListBinaries', '2': '.orchestrator.v1.ListBinariesRequest', '3': '.orchestrator.v1.ListBinariesResponse'},
-    {
-      '1': 'GetBinaryStatus',
-      '2': '.orchestrator.v1.GetBinaryStatusRequest',
-      '3': '.orchestrator.v1.GetBinaryStatusResponse'
-    },
-    {
-      '1': 'DownloadBinary',
-      '2': '.orchestrator.v1.DownloadBinaryRequest',
-      '3': '.orchestrator.v1.DownloadBinaryResponse'
-    },
+    {'1': 'GetBinaryStatus', '2': '.orchestrator.v1.GetBinaryStatusRequest', '3': '.orchestrator.v1.GetBinaryStatusResponse'},
+    {'1': 'DownloadBinary', '2': '.orchestrator.v1.DownloadBinaryRequest', '3': '.orchestrator.v1.DownloadBinaryResponse'},
     {'1': 'StartBinary', '2': '.orchestrator.v1.StartBinaryRequest', '3': '.orchestrator.v1.StartBinaryResponse'},
     {'1': 'StopBinary', '2': '.orchestrator.v1.StopBinaryRequest', '3': '.orchestrator.v1.StopBinaryResponse'},
-    {
-      '1': 'StreamLogs',
-      '2': '.orchestrator.v1.StreamLogsRequest',
-      '3': '.orchestrator.v1.StreamLogsResponse',
-      '6': true
-    },
+    {'1': 'StreamLogs', '2': '.orchestrator.v1.StreamLogsRequest', '3': '.orchestrator.v1.StreamLogsResponse', '6': true},
     {'1': 'StartWithL1', '2': '.orchestrator.v1.StartWithL1Request', '3': '.orchestrator.v1.StartWithL1Response'},
     {'1': 'RestartDaemon', '2': '.orchestrator.v1.RestartDaemonRequest', '3': '.orchestrator.v1.RestartDaemonResponse'},
-    {
-      '1': 'ShutdownAll',
-      '2': '.orchestrator.v1.ShutdownAllRequest',
-      '3': '.orchestrator.v1.ShutdownAllResponse',
-      '6': true
-    },
+    {'1': 'ShutdownAll', '2': '.orchestrator.v1.ShutdownAllRequest', '3': '.orchestrator.v1.ShutdownAllResponse', '6': true},
     {'1': 'GetBTCPrice', '2': '.orchestrator.v1.GetBTCPriceRequest', '3': '.orchestrator.v1.GetBTCPriceResponse'},
-    {
-      '1': 'GetMainchainBlockchainInfo',
-      '2': '.orchestrator.v1.GetMainchainBlockchainInfoRequest',
-      '3': '.orchestrator.v1.GetMainchainBlockchainInfoResponse'
-    },
-    {
-      '1': 'GetEnforcerBlockchainInfo',
-      '2': '.orchestrator.v1.GetEnforcerBlockchainInfoRequest',
-      '3': '.orchestrator.v1.GetEnforcerBlockchainInfoResponse'
-    },
+    {'1': 'GetMainchainBlockchainInfo', '2': '.orchestrator.v1.GetMainchainBlockchainInfoRequest', '3': '.orchestrator.v1.GetMainchainBlockchainInfoResponse'},
+    {'1': 'GetEnforcerBlockchainInfo', '2': '.orchestrator.v1.GetEnforcerBlockchainInfoRequest', '3': '.orchestrator.v1.GetEnforcerBlockchainInfoResponse'},
     {'1': 'GetSyncStatus', '2': '.orchestrator.v1.GetSyncStatusRequest', '3': '.orchestrator.v1.GetSyncStatusResponse'},
-    {
-      '1': 'GetMainchainBalance',
-      '2': '.orchestrator.v1.GetMainchainBalanceRequest',
-      '3': '.orchestrator.v1.GetMainchainBalanceResponse'
-    },
-    {
-      '1': 'PreviewResetData',
-      '2': '.orchestrator.v1.PreviewResetDataRequest',
-      '3': '.orchestrator.v1.PreviewResetDataResponse'
-    },
-    {
-      '1': 'StreamResetData',
-      '2': '.orchestrator.v1.StreamResetDataRequest',
-      '3': '.orchestrator.v1.StreamResetDataResponse',
-      '6': true
-    },
-    {
-      '1': 'GetCoreMempoolInfo',
-      '2': '.orchestrator.v1.GetCoreMempoolInfoRequest',
-      '3': '.orchestrator.v1.GetCoreMempoolInfoResponse'
-    },
+    {'1': 'GetDownloadStatus', '2': '.orchestrator.v1.GetDownloadStatusRequest', '3': '.orchestrator.v1.GetDownloadStatusResponse'},
+    {'1': 'GetMainchainBalance', '2': '.orchestrator.v1.GetMainchainBalanceRequest', '3': '.orchestrator.v1.GetMainchainBalanceResponse'},
+    {'1': 'PreviewResetData', '2': '.orchestrator.v1.PreviewResetDataRequest', '3': '.orchestrator.v1.PreviewResetDataResponse'},
+    {'1': 'StreamResetData', '2': '.orchestrator.v1.StreamResetDataRequest', '3': '.orchestrator.v1.StreamResetDataResponse', '6': true},
+    {'1': 'GetCoreMempoolInfo', '2': '.orchestrator.v1.GetCoreMempoolInfoRequest', '3': '.orchestrator.v1.GetCoreMempoolInfoResponse'},
     {'1': 'CoreRawCall', '2': '.orchestrator.v1.CoreRawCallRequest', '3': '.orchestrator.v1.CoreRawCallResponse'},
   ],
 };
@@ -782,6 +807,9 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> Orchestrat
   '.orchestrator.v1.GetSyncStatusResponse': GetSyncStatusResponse$json,
   '.orchestrator.v1.ChainSync': ChainSync$json,
   '.orchestrator.v1.SidechainStatus': SidechainStatus$json,
+  '.orchestrator.v1.GetDownloadStatusRequest': GetDownloadStatusRequest$json,
+  '.orchestrator.v1.GetDownloadStatusResponse': GetDownloadStatusResponse$json,
+  '.orchestrator.v1.DownloadStatus': DownloadStatus$json,
   '.orchestrator.v1.GetMainchainBalanceRequest': GetMainchainBalanceRequest$json,
   '.orchestrator.v1.GetMainchainBalanceResponse': GetMainchainBalanceResponse$json,
   '.orchestrator.v1.PreviewResetDataRequest': PreviewResetDataRequest$json,
@@ -796,38 +824,41 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> Orchestrat
 };
 
 /// Descriptor for `OrchestratorService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List orchestratorServiceDescriptor =
-    $convert.base64Decode('ChNPcmNoZXN0cmF0b3JTZXJ2aWNlElsKDExpc3RCaW5hcmllcxIkLm9yY2hlc3RyYXRvci52MS'
-        '5MaXN0QmluYXJpZXNSZXF1ZXN0GiUub3JjaGVzdHJhdG9yLnYxLkxpc3RCaW5hcmllc1Jlc3Bv'
-        'bnNlEmQKD0dldEJpbmFyeVN0YXR1cxInLm9yY2hlc3RyYXRvci52MS5HZXRCaW5hcnlTdGF0dX'
-        'NSZXF1ZXN0Gigub3JjaGVzdHJhdG9yLnYxLkdldEJpbmFyeVN0YXR1c1Jlc3BvbnNlEmEKDkRv'
-        'd25sb2FkQmluYXJ5EiYub3JjaGVzdHJhdG9yLnYxLkRvd25sb2FkQmluYXJ5UmVxdWVzdBonLm'
-        '9yY2hlc3RyYXRvci52MS5Eb3dubG9hZEJpbmFyeVJlc3BvbnNlElgKC1N0YXJ0QmluYXJ5EiMu'
-        'b3JjaGVzdHJhdG9yLnYxLlN0YXJ0QmluYXJ5UmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5TdG'
-        'FydEJpbmFyeVJlc3BvbnNlElUKClN0b3BCaW5hcnkSIi5vcmNoZXN0cmF0b3IudjEuU3RvcEJp'
-        'bmFyeVJlcXVlc3QaIy5vcmNoZXN0cmF0b3IudjEuU3RvcEJpbmFyeVJlc3BvbnNlElcKClN0cm'
-        'VhbUxvZ3MSIi5vcmNoZXN0cmF0b3IudjEuU3RyZWFtTG9nc1JlcXVlc3QaIy5vcmNoZXN0cmF0'
-        'b3IudjEuU3RyZWFtTG9nc1Jlc3BvbnNlMAESWAoLU3RhcnRXaXRoTDESIy5vcmNoZXN0cmF0b3'
-        'IudjEuU3RhcnRXaXRoTDFSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLlN0YXJ0V2l0aEwxUmVz'
-        'cG9uc2USXgoNUmVzdGFydERhZW1vbhIlLm9yY2hlc3RyYXRvci52MS5SZXN0YXJ0RGFlbW9uUm'
-        'VxdWVzdBomLm9yY2hlc3RyYXRvci52MS5SZXN0YXJ0RGFlbW9uUmVzcG9uc2USWgoLU2h1dGRv'
-        'd25BbGwSIy5vcmNoZXN0cmF0b3IudjEuU2h1dGRvd25BbGxSZXF1ZXN0GiQub3JjaGVzdHJhdG'
-        '9yLnYxLlNodXRkb3duQWxsUmVzcG9uc2UwARJYCgtHZXRCVENQcmljZRIjLm9yY2hlc3RyYXRv'
-        'ci52MS5HZXRCVENQcmljZVJlcXVlc3QaJC5vcmNoZXN0cmF0b3IudjEuR2V0QlRDUHJpY2VSZX'
-        'Nwb25zZRKFAQoaR2V0TWFpbmNoYWluQmxvY2tjaGFpbkluZm8SMi5vcmNoZXN0cmF0b3IudjEu'
-        'R2V0TWFpbmNoYWluQmxvY2tjaGFpbkluZm9SZXF1ZXN0GjMub3JjaGVzdHJhdG9yLnYxLkdldE'
-        '1haW5jaGFpbkJsb2NrY2hhaW5JbmZvUmVzcG9uc2USggEKGUdldEVuZm9yY2VyQmxvY2tjaGFp'
-        'bkluZm8SMS5vcmNoZXN0cmF0b3IudjEuR2V0RW5mb3JjZXJCbG9ja2NoYWluSW5mb1JlcXVlc3'
-        'QaMi5vcmNoZXN0cmF0b3IudjEuR2V0RW5mb3JjZXJCbG9ja2NoYWluSW5mb1Jlc3BvbnNlEl4K'
-        'DUdldFN5bmNTdGF0dXMSJS5vcmNoZXN0cmF0b3IudjEuR2V0U3luY1N0YXR1c1JlcXVlc3QaJi'
-        '5vcmNoZXN0cmF0b3IudjEuR2V0U3luY1N0YXR1c1Jlc3BvbnNlEnAKE0dldE1haW5jaGFpbkJh'
-        'bGFuY2USKy5vcmNoZXN0cmF0b3IudjEuR2V0TWFpbmNoYWluQmFsYW5jZVJlcXVlc3QaLC5vcm'
-        'NoZXN0cmF0b3IudjEuR2V0TWFpbmNoYWluQmFsYW5jZVJlc3BvbnNlEmcKEFByZXZpZXdSZXNl'
-        'dERhdGESKC5vcmNoZXN0cmF0b3IudjEuUHJldmlld1Jlc2V0RGF0YVJlcXVlc3QaKS5vcmNoZX'
-        'N0cmF0b3IudjEuUHJldmlld1Jlc2V0RGF0YVJlc3BvbnNlEmYKD1N0cmVhbVJlc2V0RGF0YRIn'
-        'Lm9yY2hlc3RyYXRvci52MS5TdHJlYW1SZXNldERhdGFSZXF1ZXN0Gigub3JjaGVzdHJhdG9yLn'
-        'YxLlN0cmVhbVJlc2V0RGF0YVJlc3BvbnNlMAESbQoSR2V0Q29yZU1lbXBvb2xJbmZvEioub3Jj'
-        'aGVzdHJhdG9yLnYxLkdldENvcmVNZW1wb29sSW5mb1JlcXVlc3QaKy5vcmNoZXN0cmF0b3Iudj'
-        'EuR2V0Q29yZU1lbXBvb2xJbmZvUmVzcG9uc2USWAoLQ29yZVJhd0NhbGwSIy5vcmNoZXN0cmF0'
-        'b3IudjEuQ29yZVJhd0NhbGxSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLkNvcmVSYXdDYWxsUm'
-        'VzcG9uc2U=');
+final $typed_data.Uint8List orchestratorServiceDescriptor = $convert.base64Decode(
+    'ChNPcmNoZXN0cmF0b3JTZXJ2aWNlElsKDExpc3RCaW5hcmllcxIkLm9yY2hlc3RyYXRvci52MS'
+    '5MaXN0QmluYXJpZXNSZXF1ZXN0GiUub3JjaGVzdHJhdG9yLnYxLkxpc3RCaW5hcmllc1Jlc3Bv'
+    'bnNlEmQKD0dldEJpbmFyeVN0YXR1cxInLm9yY2hlc3RyYXRvci52MS5HZXRCaW5hcnlTdGF0dX'
+    'NSZXF1ZXN0Gigub3JjaGVzdHJhdG9yLnYxLkdldEJpbmFyeVN0YXR1c1Jlc3BvbnNlEmEKDkRv'
+    'd25sb2FkQmluYXJ5EiYub3JjaGVzdHJhdG9yLnYxLkRvd25sb2FkQmluYXJ5UmVxdWVzdBonLm'
+    '9yY2hlc3RyYXRvci52MS5Eb3dubG9hZEJpbmFyeVJlc3BvbnNlElgKC1N0YXJ0QmluYXJ5EiMu'
+    'b3JjaGVzdHJhdG9yLnYxLlN0YXJ0QmluYXJ5UmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5TdG'
+    'FydEJpbmFyeVJlc3BvbnNlElUKClN0b3BCaW5hcnkSIi5vcmNoZXN0cmF0b3IudjEuU3RvcEJp'
+    'bmFyeVJlcXVlc3QaIy5vcmNoZXN0cmF0b3IudjEuU3RvcEJpbmFyeVJlc3BvbnNlElcKClN0cm'
+    'VhbUxvZ3MSIi5vcmNoZXN0cmF0b3IudjEuU3RyZWFtTG9nc1JlcXVlc3QaIy5vcmNoZXN0cmF0'
+    'b3IudjEuU3RyZWFtTG9nc1Jlc3BvbnNlMAESWAoLU3RhcnRXaXRoTDESIy5vcmNoZXN0cmF0b3'
+    'IudjEuU3RhcnRXaXRoTDFSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLlN0YXJ0V2l0aEwxUmVz'
+    'cG9uc2USXgoNUmVzdGFydERhZW1vbhIlLm9yY2hlc3RyYXRvci52MS5SZXN0YXJ0RGFlbW9uUm'
+    'VxdWVzdBomLm9yY2hlc3RyYXRvci52MS5SZXN0YXJ0RGFlbW9uUmVzcG9uc2USWgoLU2h1dGRv'
+    'd25BbGwSIy5vcmNoZXN0cmF0b3IudjEuU2h1dGRvd25BbGxSZXF1ZXN0GiQub3JjaGVzdHJhdG'
+    '9yLnYxLlNodXRkb3duQWxsUmVzcG9uc2UwARJYCgtHZXRCVENQcmljZRIjLm9yY2hlc3RyYXRv'
+    'ci52MS5HZXRCVENQcmljZVJlcXVlc3QaJC5vcmNoZXN0cmF0b3IudjEuR2V0QlRDUHJpY2VSZX'
+    'Nwb25zZRKFAQoaR2V0TWFpbmNoYWluQmxvY2tjaGFpbkluZm8SMi5vcmNoZXN0cmF0b3IudjEu'
+    'R2V0TWFpbmNoYWluQmxvY2tjaGFpbkluZm9SZXF1ZXN0GjMub3JjaGVzdHJhdG9yLnYxLkdldE'
+    '1haW5jaGFpbkJsb2NrY2hhaW5JbmZvUmVzcG9uc2USggEKGUdldEVuZm9yY2VyQmxvY2tjaGFp'
+    'bkluZm8SMS5vcmNoZXN0cmF0b3IudjEuR2V0RW5mb3JjZXJCbG9ja2NoYWluSW5mb1JlcXVlc3'
+    'QaMi5vcmNoZXN0cmF0b3IudjEuR2V0RW5mb3JjZXJCbG9ja2NoYWluSW5mb1Jlc3BvbnNlEl4K'
+    'DUdldFN5bmNTdGF0dXMSJS5vcmNoZXN0cmF0b3IudjEuR2V0U3luY1N0YXR1c1JlcXVlc3QaJi'
+    '5vcmNoZXN0cmF0b3IudjEuR2V0U3luY1N0YXR1c1Jlc3BvbnNlEmoKEUdldERvd25sb2FkU3Rh'
+    'dHVzEikub3JjaGVzdHJhdG9yLnYxLkdldERvd25sb2FkU3RhdHVzUmVxdWVzdBoqLm9yY2hlc3'
+    'RyYXRvci52MS5HZXREb3dubG9hZFN0YXR1c1Jlc3BvbnNlEnAKE0dldE1haW5jaGFpbkJhbGFu'
+    'Y2USKy5vcmNoZXN0cmF0b3IudjEuR2V0TWFpbmNoYWluQmFsYW5jZVJlcXVlc3QaLC5vcmNoZX'
+    'N0cmF0b3IudjEuR2V0TWFpbmNoYWluQmFsYW5jZVJlc3BvbnNlEmcKEFByZXZpZXdSZXNldERh'
+    'dGESKC5vcmNoZXN0cmF0b3IudjEuUHJldmlld1Jlc2V0RGF0YVJlcXVlc3QaKS5vcmNoZXN0cm'
+    'F0b3IudjEuUHJldmlld1Jlc2V0RGF0YVJlc3BvbnNlEmYKD1N0cmVhbVJlc2V0RGF0YRInLm9y'
+    'Y2hlc3RyYXRvci52MS5TdHJlYW1SZXNldERhdGFSZXF1ZXN0Gigub3JjaGVzdHJhdG9yLnYxLl'
+    'N0cmVhbVJlc2V0RGF0YVJlc3BvbnNlMAESbQoSR2V0Q29yZU1lbXBvb2xJbmZvEioub3JjaGVz'
+    'dHJhdG9yLnYxLkdldENvcmVNZW1wb29sSW5mb1JlcXVlc3QaKy5vcmNoZXN0cmF0b3IudjEuR2'
+    'V0Q29yZU1lbXBvb2xJbmZvUmVzcG9uc2USWAoLQ29yZVJhd0NhbGwSIy5vcmNoZXN0cmF0b3Iu'
+    'djEuQ29yZVJhd0NhbGxSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLkNvcmVSYXdDYWxsUmVzcG'
+    '9uc2U=');
+

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbserver.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbserver.dart
@@ -31,108 +31,67 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
   $async.Future<$5.RestartDaemonResponse> restartDaemon($pb.ServerContext ctx, $5.RestartDaemonRequest request);
   $async.Future<$5.ShutdownAllResponse> shutdownAll($pb.ServerContext ctx, $5.ShutdownAllRequest request);
   $async.Future<$5.GetBTCPriceResponse> getBTCPrice($pb.ServerContext ctx, $5.GetBTCPriceRequest request);
-  $async.Future<$5.GetMainchainBlockchainInfoResponse> getMainchainBlockchainInfo(
-      $pb.ServerContext ctx, $5.GetMainchainBlockchainInfoRequest request);
-  $async.Future<$5.GetEnforcerBlockchainInfoResponse> getEnforcerBlockchainInfo(
-      $pb.ServerContext ctx, $5.GetEnforcerBlockchainInfoRequest request);
+  $async.Future<$5.GetMainchainBlockchainInfoResponse> getMainchainBlockchainInfo($pb.ServerContext ctx, $5.GetMainchainBlockchainInfoRequest request);
+  $async.Future<$5.GetEnforcerBlockchainInfoResponse> getEnforcerBlockchainInfo($pb.ServerContext ctx, $5.GetEnforcerBlockchainInfoRequest request);
   $async.Future<$5.GetSyncStatusResponse> getSyncStatus($pb.ServerContext ctx, $5.GetSyncStatusRequest request);
-  $async.Future<$5.GetMainchainBalanceResponse> getMainchainBalance(
-      $pb.ServerContext ctx, $5.GetMainchainBalanceRequest request);
-  $async.Future<$5.PreviewResetDataResponse> previewResetData(
-      $pb.ServerContext ctx, $5.PreviewResetDataRequest request);
+  $async.Future<$5.GetDownloadStatusResponse> getDownloadStatus($pb.ServerContext ctx, $5.GetDownloadStatusRequest request);
+  $async.Future<$5.GetMainchainBalanceResponse> getMainchainBalance($pb.ServerContext ctx, $5.GetMainchainBalanceRequest request);
+  $async.Future<$5.PreviewResetDataResponse> previewResetData($pb.ServerContext ctx, $5.PreviewResetDataRequest request);
   $async.Future<$5.StreamResetDataResponse> streamResetData($pb.ServerContext ctx, $5.StreamResetDataRequest request);
-  $async.Future<$5.GetCoreMempoolInfoResponse> getCoreMempoolInfo(
-      $pb.ServerContext ctx, $5.GetCoreMempoolInfoRequest request);
+  $async.Future<$5.GetCoreMempoolInfoResponse> getCoreMempoolInfo($pb.ServerContext ctx, $5.GetCoreMempoolInfoRequest request);
   $async.Future<$5.CoreRawCallResponse> coreRawCall($pb.ServerContext ctx, $5.CoreRawCallRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'ListBinaries':
-        return $5.ListBinariesRequest();
-      case 'GetBinaryStatus':
-        return $5.GetBinaryStatusRequest();
-      case 'DownloadBinary':
-        return $5.DownloadBinaryRequest();
-      case 'StartBinary':
-        return $5.StartBinaryRequest();
-      case 'StopBinary':
-        return $5.StopBinaryRequest();
-      case 'StreamLogs':
-        return $5.StreamLogsRequest();
-      case 'StartWithL1':
-        return $5.StartWithL1Request();
-      case 'RestartDaemon':
-        return $5.RestartDaemonRequest();
-      case 'ShutdownAll':
-        return $5.ShutdownAllRequest();
-      case 'GetBTCPrice':
-        return $5.GetBTCPriceRequest();
-      case 'GetMainchainBlockchainInfo':
-        return $5.GetMainchainBlockchainInfoRequest();
-      case 'GetEnforcerBlockchainInfo':
-        return $5.GetEnforcerBlockchainInfoRequest();
-      case 'GetSyncStatus':
-        return $5.GetSyncStatusRequest();
-      case 'GetMainchainBalance':
-        return $5.GetMainchainBalanceRequest();
-      case 'PreviewResetData':
-        return $5.PreviewResetDataRequest();
-      case 'StreamResetData':
-        return $5.StreamResetDataRequest();
-      case 'GetCoreMempoolInfo':
-        return $5.GetCoreMempoolInfoRequest();
-      case 'CoreRawCall':
-        return $5.CoreRawCallRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'ListBinaries': return $5.ListBinariesRequest();
+      case 'GetBinaryStatus': return $5.GetBinaryStatusRequest();
+      case 'DownloadBinary': return $5.DownloadBinaryRequest();
+      case 'StartBinary': return $5.StartBinaryRequest();
+      case 'StopBinary': return $5.StopBinaryRequest();
+      case 'StreamLogs': return $5.StreamLogsRequest();
+      case 'StartWithL1': return $5.StartWithL1Request();
+      case 'RestartDaemon': return $5.RestartDaemonRequest();
+      case 'ShutdownAll': return $5.ShutdownAllRequest();
+      case 'GetBTCPrice': return $5.GetBTCPriceRequest();
+      case 'GetMainchainBlockchainInfo': return $5.GetMainchainBlockchainInfoRequest();
+      case 'GetEnforcerBlockchainInfo': return $5.GetEnforcerBlockchainInfoRequest();
+      case 'GetSyncStatus': return $5.GetSyncStatusRequest();
+      case 'GetDownloadStatus': return $5.GetDownloadStatusRequest();
+      case 'GetMainchainBalance': return $5.GetMainchainBalanceRequest();
+      case 'PreviewResetData': return $5.PreviewResetDataRequest();
+      case 'StreamResetData': return $5.StreamResetDataRequest();
+      case 'GetCoreMempoolInfo': return $5.GetCoreMempoolInfoRequest();
+      case 'CoreRawCall': return $5.CoreRawCallRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'ListBinaries':
-        return this.listBinaries(ctx, request as $5.ListBinariesRequest);
-      case 'GetBinaryStatus':
-        return this.getBinaryStatus(ctx, request as $5.GetBinaryStatusRequest);
-      case 'DownloadBinary':
-        return this.downloadBinary(ctx, request as $5.DownloadBinaryRequest);
-      case 'StartBinary':
-        return this.startBinary(ctx, request as $5.StartBinaryRequest);
-      case 'StopBinary':
-        return this.stopBinary(ctx, request as $5.StopBinaryRequest);
-      case 'StreamLogs':
-        return this.streamLogs(ctx, request as $5.StreamLogsRequest);
-      case 'StartWithL1':
-        return this.startWithL1(ctx, request as $5.StartWithL1Request);
-      case 'RestartDaemon':
-        return this.restartDaemon(ctx, request as $5.RestartDaemonRequest);
-      case 'ShutdownAll':
-        return this.shutdownAll(ctx, request as $5.ShutdownAllRequest);
-      case 'GetBTCPrice':
-        return this.getBTCPrice(ctx, request as $5.GetBTCPriceRequest);
-      case 'GetMainchainBlockchainInfo':
-        return this.getMainchainBlockchainInfo(ctx, request as $5.GetMainchainBlockchainInfoRequest);
-      case 'GetEnforcerBlockchainInfo':
-        return this.getEnforcerBlockchainInfo(ctx, request as $5.GetEnforcerBlockchainInfoRequest);
-      case 'GetSyncStatus':
-        return this.getSyncStatus(ctx, request as $5.GetSyncStatusRequest);
-      case 'GetMainchainBalance':
-        return this.getMainchainBalance(ctx, request as $5.GetMainchainBalanceRequest);
-      case 'PreviewResetData':
-        return this.previewResetData(ctx, request as $5.PreviewResetDataRequest);
-      case 'StreamResetData':
-        return this.streamResetData(ctx, request as $5.StreamResetDataRequest);
-      case 'GetCoreMempoolInfo':
-        return this.getCoreMempoolInfo(ctx, request as $5.GetCoreMempoolInfoRequest);
-      case 'CoreRawCall':
-        return this.coreRawCall(ctx, request as $5.CoreRawCallRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'ListBinaries': return this.listBinaries(ctx, request as $5.ListBinariesRequest);
+      case 'GetBinaryStatus': return this.getBinaryStatus(ctx, request as $5.GetBinaryStatusRequest);
+      case 'DownloadBinary': return this.downloadBinary(ctx, request as $5.DownloadBinaryRequest);
+      case 'StartBinary': return this.startBinary(ctx, request as $5.StartBinaryRequest);
+      case 'StopBinary': return this.stopBinary(ctx, request as $5.StopBinaryRequest);
+      case 'StreamLogs': return this.streamLogs(ctx, request as $5.StreamLogsRequest);
+      case 'StartWithL1': return this.startWithL1(ctx, request as $5.StartWithL1Request);
+      case 'RestartDaemon': return this.restartDaemon(ctx, request as $5.RestartDaemonRequest);
+      case 'ShutdownAll': return this.shutdownAll(ctx, request as $5.ShutdownAllRequest);
+      case 'GetBTCPrice': return this.getBTCPrice(ctx, request as $5.GetBTCPriceRequest);
+      case 'GetMainchainBlockchainInfo': return this.getMainchainBlockchainInfo(ctx, request as $5.GetMainchainBlockchainInfoRequest);
+      case 'GetEnforcerBlockchainInfo': return this.getEnforcerBlockchainInfo(ctx, request as $5.GetEnforcerBlockchainInfoRequest);
+      case 'GetSyncStatus': return this.getSyncStatus(ctx, request as $5.GetSyncStatusRequest);
+      case 'GetDownloadStatus': return this.getDownloadStatus(ctx, request as $5.GetDownloadStatusRequest);
+      case 'GetMainchainBalance': return this.getMainchainBalance(ctx, request as $5.GetMainchainBalanceRequest);
+      case 'PreviewResetData': return this.previewResetData(ctx, request as $5.PreviewResetDataRequest);
+      case 'StreamResetData': return this.streamResetData(ctx, request as $5.StreamResetDataRequest);
+      case 'GetCoreMempoolInfo': return this.getCoreMempoolInfo(ctx, request as $5.GetCoreMempoolInfoRequest);
+      case 'CoreRawCall': return this.coreRawCall(ctx, request as $5.CoreRawCallRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => OrchestratorServiceBase$json;
-  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson =>
-      OrchestratorServiceBase$messageJson;
+  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => OrchestratorServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/orchestrator/v1/sidechain_conf.connect.client.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/sidechain_conf.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "sidechain_conf.pb.dart" as orchestratorv1sidechain_conf;
 import "sidechain_conf.connect.spec.dart" as specs;
 
-extension type SidechainConfServiceClient(connect.Transport _transport) {
+extension type SidechainConfServiceClient (connect.Transport _transport) {
   /// Get current sidechain configuration state.
   Future<orchestratorv1sidechain_conf.GetSidechainConfigResponse> getSidechainConfig(
     orchestratorv1sidechain_conf.GetSidechainConfigRequest input, {

--- a/sail_ui/lib/gen/orchestrator/v1/sidechain_conf.pb.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/sidechain_conf.pb.dart
@@ -25,26 +25,24 @@ class GetSidechainConfigRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetSidechainConfigRequest._() : super();
-  factory GetSidechainConfigRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainConfigRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainConfigRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainConfigRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'sidechainName')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainConfigRequest clone() => GetSidechainConfigRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainConfigRequest copyWith(void Function(GetSidechainConfigRequest) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainConfigRequest)) as GetSidechainConfigRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainConfigRequest copyWith(void Function(GetSidechainConfigRequest) updates) => super.copyWith((message) => updates(message as GetSidechainConfigRequest)) as GetSidechainConfigRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -53,17 +51,13 @@ class GetSidechainConfigRequest extends $pb.GeneratedMessage {
   GetSidechainConfigRequest createEmptyInstance() => create();
   static $pb.PbList<GetSidechainConfigRequest> createRepeated() => $pb.PbList<GetSidechainConfigRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainConfigRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainConfigRequest>(create);
+  static GetSidechainConfigRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainConfigRequest>(create);
   static GetSidechainConfigRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sidechainName => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sidechainName($core.String v) {
-    $_setString(0, v);
-  }
-
+  set sidechainName($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSidechainName() => $_has(0);
   @$pb.TagNumber(1)
@@ -97,31 +91,28 @@ class GetSidechainConfigResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetSidechainConfigResponse._() : super();
-  factory GetSidechainConfigResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainConfigResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainConfigResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainConfigResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainConfigResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'configContent')
     ..aOS(2, _omitFieldNames ? '' : 'configPath')
     ..aOS(3, _omitFieldNames ? '' : 'defaultConfig')
     ..pPS(4, _omitFieldNames ? '' : 'cliArgs')
     ..aOS(5, _omitFieldNames ? '' : 'network')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainConfigResponse clone() => GetSidechainConfigResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainConfigResponse copyWith(void Function(GetSidechainConfigResponse) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainConfigResponse)) as GetSidechainConfigResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainConfigResponse copyWith(void Function(GetSidechainConfigResponse) updates) => super.copyWith((message) => updates(message as GetSidechainConfigResponse)) as GetSidechainConfigResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -130,17 +121,13 @@ class GetSidechainConfigResponse extends $pb.GeneratedMessage {
   GetSidechainConfigResponse createEmptyInstance() => create();
   static $pb.PbList<GetSidechainConfigResponse> createRepeated() => $pb.PbList<GetSidechainConfigResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainConfigResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainConfigResponse>(create);
+  static GetSidechainConfigResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainConfigResponse>(create);
   static GetSidechainConfigResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get configContent => $_getSZ(0);
   @$pb.TagNumber(1)
-  set configContent($core.String v) {
-    $_setString(0, v);
-  }
-
+  set configContent($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasConfigContent() => $_has(0);
   @$pb.TagNumber(1)
@@ -149,10 +136,7 @@ class GetSidechainConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get configPath => $_getSZ(1);
   @$pb.TagNumber(2)
-  set configPath($core.String v) {
-    $_setString(1, v);
-  }
-
+  set configPath($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasConfigPath() => $_has(1);
   @$pb.TagNumber(2)
@@ -161,10 +145,7 @@ class GetSidechainConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get defaultConfig => $_getSZ(2);
   @$pb.TagNumber(3)
-  set defaultConfig($core.String v) {
-    $_setString(2, v);
-  }
-
+  set defaultConfig($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasDefaultConfig() => $_has(2);
   @$pb.TagNumber(3)
@@ -176,10 +157,7 @@ class GetSidechainConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get network => $_getSZ(4);
   @$pb.TagNumber(5)
-  set network($core.String v) {
-    $_setString(4, v);
-  }
-
+  set network($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasNetwork() => $_has(4);
   @$pb.TagNumber(5)
@@ -201,28 +179,25 @@ class WriteSidechainConfigRequest extends $pb.GeneratedMessage {
     return $result;
   }
   WriteSidechainConfigRequest._() : super();
-  factory WriteSidechainConfigRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteSidechainConfigRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WriteSidechainConfigRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WriteSidechainConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteSidechainConfigRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteSidechainConfigRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'sidechainName')
     ..aOS(2, _omitFieldNames ? '' : 'configContent')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WriteSidechainConfigRequest clone() => WriteSidechainConfigRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WriteSidechainConfigRequest copyWith(void Function(WriteSidechainConfigRequest) updates) =>
-      super.copyWith((message) => updates(message as WriteSidechainConfigRequest)) as WriteSidechainConfigRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WriteSidechainConfigRequest copyWith(void Function(WriteSidechainConfigRequest) updates) => super.copyWith((message) => updates(message as WriteSidechainConfigRequest)) as WriteSidechainConfigRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -231,17 +206,13 @@ class WriteSidechainConfigRequest extends $pb.GeneratedMessage {
   WriteSidechainConfigRequest createEmptyInstance() => create();
   static $pb.PbList<WriteSidechainConfigRequest> createRepeated() => $pb.PbList<WriteSidechainConfigRequest>();
   @$core.pragma('dart2js:noInline')
-  static WriteSidechainConfigRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteSidechainConfigRequest>(create);
+  static WriteSidechainConfigRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteSidechainConfigRequest>(create);
   static WriteSidechainConfigRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sidechainName => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sidechainName($core.String v) {
-    $_setString(0, v);
-  }
-
+  set sidechainName($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSidechainName() => $_has(0);
   @$pb.TagNumber(1)
@@ -250,10 +221,7 @@ class WriteSidechainConfigRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get configContent => $_getSZ(1);
   @$pb.TagNumber(2)
-  set configContent($core.String v) {
-    $_setString(1, v);
-  }
-
+  set configContent($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasConfigContent() => $_has(1);
   @$pb.TagNumber(2)
@@ -263,26 +231,23 @@ class WriteSidechainConfigRequest extends $pb.GeneratedMessage {
 class WriteSidechainConfigResponse extends $pb.GeneratedMessage {
   factory WriteSidechainConfigResponse() => create();
   WriteSidechainConfigResponse._() : super();
-  factory WriteSidechainConfigResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteSidechainConfigResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WriteSidechainConfigResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WriteSidechainConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteSidechainConfigResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteSidechainConfigResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WriteSidechainConfigResponse clone() => WriteSidechainConfigResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WriteSidechainConfigResponse copyWith(void Function(WriteSidechainConfigResponse) updates) =>
-      super.copyWith((message) => updates(message as WriteSidechainConfigResponse)) as WriteSidechainConfigResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WriteSidechainConfigResponse copyWith(void Function(WriteSidechainConfigResponse) updates) => super.copyWith((message) => updates(message as WriteSidechainConfigResponse)) as WriteSidechainConfigResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -291,8 +256,7 @@ class WriteSidechainConfigResponse extends $pb.GeneratedMessage {
   WriteSidechainConfigResponse createEmptyInstance() => create();
   static $pb.PbList<WriteSidechainConfigResponse> createRepeated() => $pb.PbList<WriteSidechainConfigResponse>();
   @$core.pragma('dart2js:noInline')
-  static WriteSidechainConfigResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteSidechainConfigResponse>(create);
+  static WriteSidechainConfigResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteSidechainConfigResponse>(create);
   static WriteSidechainConfigResponse? _defaultInstance;
 }
 
@@ -307,52 +271,39 @@ class SyncSidechainNetworkFromBitcoinConfRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SyncSidechainNetworkFromBitcoinConfRequest._() : super();
-  factory SyncSidechainNetworkFromBitcoinConfRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SyncSidechainNetworkFromBitcoinConfRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SyncSidechainNetworkFromBitcoinConfRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SyncSidechainNetworkFromBitcoinConfRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'SyncSidechainNetworkFromBitcoinConfRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SyncSidechainNetworkFromBitcoinConfRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'sidechainName')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  SyncSidechainNetworkFromBitcoinConfRequest clone() =>
-      SyncSidechainNetworkFromBitcoinConfRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SyncSidechainNetworkFromBitcoinConfRequest copyWith(
-          void Function(SyncSidechainNetworkFromBitcoinConfRequest) updates) =>
-      super.copyWith((message) => updates(message as SyncSidechainNetworkFromBitcoinConfRequest))
-          as SyncSidechainNetworkFromBitcoinConfRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SyncSidechainNetworkFromBitcoinConfRequest clone() => SyncSidechainNetworkFromBitcoinConfRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SyncSidechainNetworkFromBitcoinConfRequest copyWith(void Function(SyncSidechainNetworkFromBitcoinConfRequest) updates) => super.copyWith((message) => updates(message as SyncSidechainNetworkFromBitcoinConfRequest)) as SyncSidechainNetworkFromBitcoinConfRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SyncSidechainNetworkFromBitcoinConfRequest create() => SyncSidechainNetworkFromBitcoinConfRequest._();
   SyncSidechainNetworkFromBitcoinConfRequest createEmptyInstance() => create();
-  static $pb.PbList<SyncSidechainNetworkFromBitcoinConfRequest> createRepeated() =>
-      $pb.PbList<SyncSidechainNetworkFromBitcoinConfRequest>();
+  static $pb.PbList<SyncSidechainNetworkFromBitcoinConfRequest> createRepeated() => $pb.PbList<SyncSidechainNetworkFromBitcoinConfRequest>();
   @$core.pragma('dart2js:noInline')
-  static SyncSidechainNetworkFromBitcoinConfRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncSidechainNetworkFromBitcoinConfRequest>(create);
+  static SyncSidechainNetworkFromBitcoinConfRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncSidechainNetworkFromBitcoinConfRequest>(create);
   static SyncSidechainNetworkFromBitcoinConfRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sidechainName => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sidechainName($core.String v) {
-    $_setString(0, v);
-  }
-
+  set sidechainName($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSidechainName() => $_has(0);
   @$pb.TagNumber(1)
@@ -362,42 +313,32 @@ class SyncSidechainNetworkFromBitcoinConfRequest extends $pb.GeneratedMessage {
 class SyncSidechainNetworkFromBitcoinConfResponse extends $pb.GeneratedMessage {
   factory SyncSidechainNetworkFromBitcoinConfResponse() => create();
   SyncSidechainNetworkFromBitcoinConfResponse._() : super();
-  factory SyncSidechainNetworkFromBitcoinConfResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SyncSidechainNetworkFromBitcoinConfResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SyncSidechainNetworkFromBitcoinConfResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SyncSidechainNetworkFromBitcoinConfResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'SyncSidechainNetworkFromBitcoinConfResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'),
-      createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SyncSidechainNetworkFromBitcoinConfResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  SyncSidechainNetworkFromBitcoinConfResponse clone() =>
-      SyncSidechainNetworkFromBitcoinConfResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SyncSidechainNetworkFromBitcoinConfResponse copyWith(
-          void Function(SyncSidechainNetworkFromBitcoinConfResponse) updates) =>
-      super.copyWith((message) => updates(message as SyncSidechainNetworkFromBitcoinConfResponse))
-          as SyncSidechainNetworkFromBitcoinConfResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SyncSidechainNetworkFromBitcoinConfResponse clone() => SyncSidechainNetworkFromBitcoinConfResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SyncSidechainNetworkFromBitcoinConfResponse copyWith(void Function(SyncSidechainNetworkFromBitcoinConfResponse) updates) => super.copyWith((message) => updates(message as SyncSidechainNetworkFromBitcoinConfResponse)) as SyncSidechainNetworkFromBitcoinConfResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SyncSidechainNetworkFromBitcoinConfResponse create() => SyncSidechainNetworkFromBitcoinConfResponse._();
   SyncSidechainNetworkFromBitcoinConfResponse createEmptyInstance() => create();
-  static $pb.PbList<SyncSidechainNetworkFromBitcoinConfResponse> createRepeated() =>
-      $pb.PbList<SyncSidechainNetworkFromBitcoinConfResponse>();
+  static $pb.PbList<SyncSidechainNetworkFromBitcoinConfResponse> createRepeated() => $pb.PbList<SyncSidechainNetworkFromBitcoinConfResponse>();
   @$core.pragma('dart2js:noInline')
-  static SyncSidechainNetworkFromBitcoinConfResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncSidechainNetworkFromBitcoinConfResponse>(create);
+  static SyncSidechainNetworkFromBitcoinConfResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncSidechainNetworkFromBitcoinConfResponse>(create);
   static SyncSidechainNetworkFromBitcoinConfResponse? _defaultInstance;
 }
 
@@ -405,19 +346,17 @@ class SidechainConfServiceApi {
   $pb.RpcClient _client;
   SidechainConfServiceApi(this._client);
 
-  $async.Future<GetSidechainConfigResponse> getSidechainConfig(
-          $pb.ClientContext? ctx, GetSidechainConfigRequest request) =>
-      _client.invoke<GetSidechainConfigResponse>(
-          ctx, 'SidechainConfService', 'GetSidechainConfig', request, GetSidechainConfigResponse());
-  $async.Future<WriteSidechainConfigResponse> writeSidechainConfig(
-          $pb.ClientContext? ctx, WriteSidechainConfigRequest request) =>
-      _client.invoke<WriteSidechainConfigResponse>(
-          ctx, 'SidechainConfService', 'WriteSidechainConfig', request, WriteSidechainConfigResponse());
-  $async.Future<SyncSidechainNetworkFromBitcoinConfResponse> syncSidechainNetworkFromBitcoinConf(
-          $pb.ClientContext? ctx, SyncSidechainNetworkFromBitcoinConfRequest request) =>
-      _client.invoke<SyncSidechainNetworkFromBitcoinConfResponse>(ctx, 'SidechainConfService',
-          'SyncSidechainNetworkFromBitcoinConf', request, SyncSidechainNetworkFromBitcoinConfResponse());
+  $async.Future<GetSidechainConfigResponse> getSidechainConfig($pb.ClientContext? ctx, GetSidechainConfigRequest request) =>
+    _client.invoke<GetSidechainConfigResponse>(ctx, 'SidechainConfService', 'GetSidechainConfig', request, GetSidechainConfigResponse())
+  ;
+  $async.Future<WriteSidechainConfigResponse> writeSidechainConfig($pb.ClientContext? ctx, WriteSidechainConfigRequest request) =>
+    _client.invoke<WriteSidechainConfigResponse>(ctx, 'SidechainConfService', 'WriteSidechainConfig', request, WriteSidechainConfigResponse())
+  ;
+  $async.Future<SyncSidechainNetworkFromBitcoinConfResponse> syncSidechainNetworkFromBitcoinConf($pb.ClientContext? ctx, SyncSidechainNetworkFromBitcoinConfRequest request) =>
+    _client.invoke<SyncSidechainNetworkFromBitcoinConfResponse>(ctx, 'SidechainConfService', 'SyncSidechainNetworkFromBitcoinConf', request, SyncSidechainNetworkFromBitcoinConfResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/orchestrator/v1/sidechain_conf.pbenum.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/sidechain_conf.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/orchestrator/v1/sidechain_conf.pbjson.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/sidechain_conf.pbjson.dart
@@ -22,9 +22,9 @@ const GetSidechainConfigRequest$json = {
 };
 
 /// Descriptor for `GetSidechainConfigRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainConfigRequestDescriptor =
-    $convert.base64Decode('ChlHZXRTaWRlY2hhaW5Db25maWdSZXF1ZXN0EiUKDnNpZGVjaGFpbl9uYW1lGAEgASgJUg1zaW'
-        'RlY2hhaW5OYW1l');
+final $typed_data.Uint8List getSidechainConfigRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRTaWRlY2hhaW5Db25maWdSZXF1ZXN0EiUKDnNpZGVjaGFpbl9uYW1lGAEgASgJUg1zaW'
+    'RlY2hhaW5OYW1l');
 
 @$core.Deprecated('Use getSidechainConfigResponseDescriptor instead')
 const GetSidechainConfigResponse$json = {
@@ -39,11 +39,11 @@ const GetSidechainConfigResponse$json = {
 };
 
 /// Descriptor for `GetSidechainConfigResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainConfigResponseDescriptor =
-    $convert.base64Decode('ChpHZXRTaWRlY2hhaW5Db25maWdSZXNwb25zZRIlCg5jb25maWdfY29udGVudBgBIAEoCVINY2'
-        '9uZmlnQ29udGVudBIfCgtjb25maWdfcGF0aBgCIAEoCVIKY29uZmlnUGF0aBIlCg5kZWZhdWx0'
-        'X2NvbmZpZxgDIAEoCVINZGVmYXVsdENvbmZpZxIZCghjbGlfYXJncxgEIAMoCVIHY2xpQXJncx'
-        'IYCgduZXR3b3JrGAUgASgJUgduZXR3b3Jr');
+final $typed_data.Uint8List getSidechainConfigResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRTaWRlY2hhaW5Db25maWdSZXNwb25zZRIlCg5jb25maWdfY29udGVudBgBIAEoCVINY2'
+    '9uZmlnQ29udGVudBIfCgtjb25maWdfcGF0aBgCIAEoCVIKY29uZmlnUGF0aBIlCg5kZWZhdWx0'
+    'X2NvbmZpZxgDIAEoCVINZGVmYXVsdENvbmZpZxIZCghjbGlfYXJncxgEIAMoCVIHY2xpQXJncx'
+    'IYCgduZXR3b3JrGAUgASgJUgduZXR3b3Jr');
 
 @$core.Deprecated('Use writeSidechainConfigRequestDescriptor instead')
 const WriteSidechainConfigRequest$json = {
@@ -55,9 +55,9 @@ const WriteSidechainConfigRequest$json = {
 };
 
 /// Descriptor for `WriteSidechainConfigRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List writeSidechainConfigRequestDescriptor =
-    $convert.base64Decode('ChtXcml0ZVNpZGVjaGFpbkNvbmZpZ1JlcXVlc3QSJQoOc2lkZWNoYWluX25hbWUYASABKAlSDX'
-        'NpZGVjaGFpbk5hbWUSJQoOY29uZmlnX2NvbnRlbnQYAiABKAlSDWNvbmZpZ0NvbnRlbnQ=');
+final $typed_data.Uint8List writeSidechainConfigRequestDescriptor = $convert.base64Decode(
+    'ChtXcml0ZVNpZGVjaGFpbkNvbmZpZ1JlcXVlc3QSJQoOc2lkZWNoYWluX25hbWUYASABKAlSDX'
+    'NpZGVjaGFpbk5hbWUSJQoOY29uZmlnX2NvbnRlbnQYAiABKAlSDWNvbmZpZ0NvbnRlbnQ=');
 
 @$core.Deprecated('Use writeSidechainConfigResponseDescriptor instead')
 const WriteSidechainConfigResponse$json = {
@@ -65,8 +65,8 @@ const WriteSidechainConfigResponse$json = {
 };
 
 /// Descriptor for `WriteSidechainConfigResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List writeSidechainConfigResponseDescriptor =
-    $convert.base64Decode('ChxXcml0ZVNpZGVjaGFpbkNvbmZpZ1Jlc3BvbnNl');
+final $typed_data.Uint8List writeSidechainConfigResponseDescriptor = $convert.base64Decode(
+    'ChxXcml0ZVNpZGVjaGFpbkNvbmZpZ1Jlc3BvbnNl');
 
 @$core.Deprecated('Use syncSidechainNetworkFromBitcoinConfRequestDescriptor instead')
 const SyncSidechainNetworkFromBitcoinConfRequest$json = {
@@ -77,9 +77,9 @@ const SyncSidechainNetworkFromBitcoinConfRequest$json = {
 };
 
 /// Descriptor for `SyncSidechainNetworkFromBitcoinConfRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List syncSidechainNetworkFromBitcoinConfRequestDescriptor =
-    $convert.base64Decode('CipTeW5jU2lkZWNoYWluTmV0d29ya0Zyb21CaXRjb2luQ29uZlJlcXVlc3QSJQoOc2lkZWNoYW'
-        'luX25hbWUYASABKAlSDXNpZGVjaGFpbk5hbWU=');
+final $typed_data.Uint8List syncSidechainNetworkFromBitcoinConfRequestDescriptor = $convert.base64Decode(
+    'CipTeW5jU2lkZWNoYWluTmV0d29ya0Zyb21CaXRjb2luQ29uZlJlcXVlc3QSJQoOc2lkZWNoYW'
+    'luX25hbWUYASABKAlSDXNpZGVjaGFpbk5hbWU=');
 
 @$core.Deprecated('Use syncSidechainNetworkFromBitcoinConfResponseDescriptor instead')
 const SyncSidechainNetworkFromBitcoinConfResponse$json = {
@@ -87,27 +87,15 @@ const SyncSidechainNetworkFromBitcoinConfResponse$json = {
 };
 
 /// Descriptor for `SyncSidechainNetworkFromBitcoinConfResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List syncSidechainNetworkFromBitcoinConfResponseDescriptor =
-    $convert.base64Decode('CitTeW5jU2lkZWNoYWluTmV0d29ya0Zyb21CaXRjb2luQ29uZlJlc3BvbnNl');
+final $typed_data.Uint8List syncSidechainNetworkFromBitcoinConfResponseDescriptor = $convert.base64Decode(
+    'CitTeW5jU2lkZWNoYWluTmV0d29ya0Zyb21CaXRjb2luQ29uZlJlc3BvbnNl');
 
 const $core.Map<$core.String, $core.dynamic> SidechainConfServiceBase$json = {
   '1': 'SidechainConfService',
   '2': [
-    {
-      '1': 'GetSidechainConfig',
-      '2': '.orchestrator.v1.GetSidechainConfigRequest',
-      '3': '.orchestrator.v1.GetSidechainConfigResponse'
-    },
-    {
-      '1': 'WriteSidechainConfig',
-      '2': '.orchestrator.v1.WriteSidechainConfigRequest',
-      '3': '.orchestrator.v1.WriteSidechainConfigResponse'
-    },
-    {
-      '1': 'SyncSidechainNetworkFromBitcoinConf',
-      '2': '.orchestrator.v1.SyncSidechainNetworkFromBitcoinConfRequest',
-      '3': '.orchestrator.v1.SyncSidechainNetworkFromBitcoinConfResponse'
-    },
+    {'1': 'GetSidechainConfig', '2': '.orchestrator.v1.GetSidechainConfigRequest', '3': '.orchestrator.v1.GetSidechainConfigResponse'},
+    {'1': 'WriteSidechainConfig', '2': '.orchestrator.v1.WriteSidechainConfigRequest', '3': '.orchestrator.v1.WriteSidechainConfigResponse'},
+    {'1': 'SyncSidechainNetworkFromBitcoinConf', '2': '.orchestrator.v1.SyncSidechainNetworkFromBitcoinConfRequest', '3': '.orchestrator.v1.SyncSidechainNetworkFromBitcoinConfResponse'},
   ],
 };
 
@@ -122,12 +110,13 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> SidechainC
 };
 
 /// Descriptor for `SidechainConfService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List sidechainConfServiceDescriptor =
-    $convert.base64Decode('ChRTaWRlY2hhaW5Db25mU2VydmljZRJtChJHZXRTaWRlY2hhaW5Db25maWcSKi5vcmNoZXN0cm'
-        'F0b3IudjEuR2V0U2lkZWNoYWluQ29uZmlnUmVxdWVzdBorLm9yY2hlc3RyYXRvci52MS5HZXRT'
-        'aWRlY2hhaW5Db25maWdSZXNwb25zZRJzChRXcml0ZVNpZGVjaGFpbkNvbmZpZxIsLm9yY2hlc3'
-        'RyYXRvci52MS5Xcml0ZVNpZGVjaGFpbkNvbmZpZ1JlcXVlc3QaLS5vcmNoZXN0cmF0b3IudjEu'
-        'V3JpdGVTaWRlY2hhaW5Db25maWdSZXNwb25zZRKgAQojU3luY1NpZGVjaGFpbk5ldHdvcmtGcm'
-        '9tQml0Y29pbkNvbmYSOy5vcmNoZXN0cmF0b3IudjEuU3luY1NpZGVjaGFpbk5ldHdvcmtGcm9t'
-        'Qml0Y29pbkNvbmZSZXF1ZXN0Gjwub3JjaGVzdHJhdG9yLnYxLlN5bmNTaWRlY2hhaW5OZXR3b3'
-        'JrRnJvbUJpdGNvaW5Db25mUmVzcG9uc2U=');
+final $typed_data.Uint8List sidechainConfServiceDescriptor = $convert.base64Decode(
+    'ChRTaWRlY2hhaW5Db25mU2VydmljZRJtChJHZXRTaWRlY2hhaW5Db25maWcSKi5vcmNoZXN0cm'
+    'F0b3IudjEuR2V0U2lkZWNoYWluQ29uZmlnUmVxdWVzdBorLm9yY2hlc3RyYXRvci52MS5HZXRT'
+    'aWRlY2hhaW5Db25maWdSZXNwb25zZRJzChRXcml0ZVNpZGVjaGFpbkNvbmZpZxIsLm9yY2hlc3'
+    'RyYXRvci52MS5Xcml0ZVNpZGVjaGFpbkNvbmZpZ1JlcXVlc3QaLS5vcmNoZXN0cmF0b3IudjEu'
+    'V3JpdGVTaWRlY2hhaW5Db25maWdSZXNwb25zZRKgAQojU3luY1NpZGVjaGFpbk5ldHdvcmtGcm'
+    '9tQml0Y29pbkNvbmYSOy5vcmNoZXN0cmF0b3IudjEuU3luY1NpZGVjaGFpbk5ldHdvcmtGcm9t'
+    'Qml0Y29pbkNvbmZSZXF1ZXN0Gjwub3JjaGVzdHJhdG9yLnYxLlN5bmNTaWRlY2hhaW5OZXR3b3'
+    'JrRnJvbUJpdGNvaW5Db25mUmVzcG9uc2U=');
+

--- a/sail_ui/lib/gen/orchestrator/v1/sidechain_conf.pbserver.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/sidechain_conf.pbserver.dart
@@ -21,41 +21,29 @@ import 'sidechain_conf.pbjson.dart';
 export 'sidechain_conf.pb.dart';
 
 abstract class SidechainConfServiceBase extends $pb.GeneratedService {
-  $async.Future<$6.GetSidechainConfigResponse> getSidechainConfig(
-      $pb.ServerContext ctx, $6.GetSidechainConfigRequest request);
-  $async.Future<$6.WriteSidechainConfigResponse> writeSidechainConfig(
-      $pb.ServerContext ctx, $6.WriteSidechainConfigRequest request);
-  $async.Future<$6.SyncSidechainNetworkFromBitcoinConfResponse> syncSidechainNetworkFromBitcoinConf(
-      $pb.ServerContext ctx, $6.SyncSidechainNetworkFromBitcoinConfRequest request);
+  $async.Future<$6.GetSidechainConfigResponse> getSidechainConfig($pb.ServerContext ctx, $6.GetSidechainConfigRequest request);
+  $async.Future<$6.WriteSidechainConfigResponse> writeSidechainConfig($pb.ServerContext ctx, $6.WriteSidechainConfigRequest request);
+  $async.Future<$6.SyncSidechainNetworkFromBitcoinConfResponse> syncSidechainNetworkFromBitcoinConf($pb.ServerContext ctx, $6.SyncSidechainNetworkFromBitcoinConfRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetSidechainConfig':
-        return $6.GetSidechainConfigRequest();
-      case 'WriteSidechainConfig':
-        return $6.WriteSidechainConfigRequest();
-      case 'SyncSidechainNetworkFromBitcoinConf':
-        return $6.SyncSidechainNetworkFromBitcoinConfRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetSidechainConfig': return $6.GetSidechainConfigRequest();
+      case 'WriteSidechainConfig': return $6.WriteSidechainConfigRequest();
+      case 'SyncSidechainNetworkFromBitcoinConf': return $6.SyncSidechainNetworkFromBitcoinConfRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetSidechainConfig':
-        return this.getSidechainConfig(ctx, request as $6.GetSidechainConfigRequest);
-      case 'WriteSidechainConfig':
-        return this.writeSidechainConfig(ctx, request as $6.WriteSidechainConfigRequest);
-      case 'SyncSidechainNetworkFromBitcoinConf':
-        return this.syncSidechainNetworkFromBitcoinConf(ctx, request as $6.SyncSidechainNetworkFromBitcoinConfRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetSidechainConfig': return this.getSidechainConfig(ctx, request as $6.GetSidechainConfigRequest);
+      case 'WriteSidechainConfig': return this.writeSidechainConfig(ctx, request as $6.WriteSidechainConfigRequest);
+      case 'SyncSidechainNetworkFromBitcoinConf': return this.syncSidechainNetworkFromBitcoinConf(ctx, request as $6.SyncSidechainNetworkFromBitcoinConfRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => SidechainConfServiceBase$json;
-  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson =>
-      SidechainConfServiceBase$messageJson;
+  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => SidechainConfServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/orchestrator/v1/thunder_conf.connect.client.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/thunder_conf.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "thunder_conf.pb.dart" as orchestratorv1thunder_conf;
 import "thunder_conf.connect.spec.dart" as specs;
 
-extension type ThunderConfServiceClient(connect.Transport _transport) {
+extension type ThunderConfServiceClient (connect.Transport _transport) {
   /// Get current Thunder sidechain configuration state.
   Future<orchestratorv1thunder_conf.GetThunderConfigResponse> getThunderConfig(
     orchestratorv1thunder_conf.GetThunderConfigRequest input, {

--- a/sail_ui/lib/gen/orchestrator/v1/thunder_conf.pb.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/thunder_conf.pb.dart
@@ -17,25 +17,23 @@ import 'package:protobuf/protobuf.dart' as $pb;
 class GetThunderConfigRequest extends $pb.GeneratedMessage {
   factory GetThunderConfigRequest() => create();
   GetThunderConfigRequest._() : super();
-  factory GetThunderConfigRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetThunderConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetThunderConfigRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetThunderConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetThunderConfigRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetThunderConfigRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetThunderConfigRequest clone() => GetThunderConfigRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetThunderConfigRequest copyWith(void Function(GetThunderConfigRequest) updates) =>
-      super.copyWith((message) => updates(message as GetThunderConfigRequest)) as GetThunderConfigRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetThunderConfigRequest copyWith(void Function(GetThunderConfigRequest) updates) => super.copyWith((message) => updates(message as GetThunderConfigRequest)) as GetThunderConfigRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -44,8 +42,7 @@ class GetThunderConfigRequest extends $pb.GeneratedMessage {
   GetThunderConfigRequest createEmptyInstance() => create();
   static $pb.PbList<GetThunderConfigRequest> createRepeated() => $pb.PbList<GetThunderConfigRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetThunderConfigRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetThunderConfigRequest>(create);
+  static GetThunderConfigRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetThunderConfigRequest>(create);
   static GetThunderConfigRequest? _defaultInstance;
 }
 
@@ -76,30 +73,28 @@ class GetThunderConfigResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetThunderConfigResponse._() : super();
-  factory GetThunderConfigResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetThunderConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetThunderConfigResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetThunderConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetThunderConfigResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetThunderConfigResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'configContent')
     ..aOS(2, _omitFieldNames ? '' : 'configPath')
     ..aOS(3, _omitFieldNames ? '' : 'defaultConfig')
     ..pPS(4, _omitFieldNames ? '' : 'cliArgs')
     ..aOS(5, _omitFieldNames ? '' : 'network')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetThunderConfigResponse clone() => GetThunderConfigResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetThunderConfigResponse copyWith(void Function(GetThunderConfigResponse) updates) =>
-      super.copyWith((message) => updates(message as GetThunderConfigResponse)) as GetThunderConfigResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetThunderConfigResponse copyWith(void Function(GetThunderConfigResponse) updates) => super.copyWith((message) => updates(message as GetThunderConfigResponse)) as GetThunderConfigResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -108,17 +103,13 @@ class GetThunderConfigResponse extends $pb.GeneratedMessage {
   GetThunderConfigResponse createEmptyInstance() => create();
   static $pb.PbList<GetThunderConfigResponse> createRepeated() => $pb.PbList<GetThunderConfigResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetThunderConfigResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetThunderConfigResponse>(create);
+  static GetThunderConfigResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetThunderConfigResponse>(create);
   static GetThunderConfigResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get configContent => $_getSZ(0);
   @$pb.TagNumber(1)
-  set configContent($core.String v) {
-    $_setString(0, v);
-  }
-
+  set configContent($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasConfigContent() => $_has(0);
   @$pb.TagNumber(1)
@@ -127,10 +118,7 @@ class GetThunderConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get configPath => $_getSZ(1);
   @$pb.TagNumber(2)
-  set configPath($core.String v) {
-    $_setString(1, v);
-  }
-
+  set configPath($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasConfigPath() => $_has(1);
   @$pb.TagNumber(2)
@@ -139,10 +127,7 @@ class GetThunderConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get defaultConfig => $_getSZ(2);
   @$pb.TagNumber(3)
-  set defaultConfig($core.String v) {
-    $_setString(2, v);
-  }
-
+  set defaultConfig($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasDefaultConfig() => $_has(2);
   @$pb.TagNumber(3)
@@ -154,10 +139,7 @@ class GetThunderConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get network => $_getSZ(4);
   @$pb.TagNumber(5)
-  set network($core.String v) {
-    $_setString(4, v);
-  }
-
+  set network($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasNetwork() => $_has(4);
   @$pb.TagNumber(5)
@@ -175,26 +157,24 @@ class WriteThunderConfigRequest extends $pb.GeneratedMessage {
     return $result;
   }
   WriteThunderConfigRequest._() : super();
-  factory WriteThunderConfigRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteThunderConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WriteThunderConfigRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WriteThunderConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteThunderConfigRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteThunderConfigRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'configContent')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WriteThunderConfigRequest clone() => WriteThunderConfigRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WriteThunderConfigRequest copyWith(void Function(WriteThunderConfigRequest) updates) =>
-      super.copyWith((message) => updates(message as WriteThunderConfigRequest)) as WriteThunderConfigRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WriteThunderConfigRequest copyWith(void Function(WriteThunderConfigRequest) updates) => super.copyWith((message) => updates(message as WriteThunderConfigRequest)) as WriteThunderConfigRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -203,17 +183,13 @@ class WriteThunderConfigRequest extends $pb.GeneratedMessage {
   WriteThunderConfigRequest createEmptyInstance() => create();
   static $pb.PbList<WriteThunderConfigRequest> createRepeated() => $pb.PbList<WriteThunderConfigRequest>();
   @$core.pragma('dart2js:noInline')
-  static WriteThunderConfigRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteThunderConfigRequest>(create);
+  static WriteThunderConfigRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteThunderConfigRequest>(create);
   static WriteThunderConfigRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get configContent => $_getSZ(0);
   @$pb.TagNumber(1)
-  set configContent($core.String v) {
-    $_setString(0, v);
-  }
-
+  set configContent($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasConfigContent() => $_has(0);
   @$pb.TagNumber(1)
@@ -223,26 +199,23 @@ class WriteThunderConfigRequest extends $pb.GeneratedMessage {
 class WriteThunderConfigResponse extends $pb.GeneratedMessage {
   factory WriteThunderConfigResponse() => create();
   WriteThunderConfigResponse._() : super();
-  factory WriteThunderConfigResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteThunderConfigResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WriteThunderConfigResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WriteThunderConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteThunderConfigResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteThunderConfigResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WriteThunderConfigResponse clone() => WriteThunderConfigResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WriteThunderConfigResponse copyWith(void Function(WriteThunderConfigResponse) updates) =>
-      super.copyWith((message) => updates(message as WriteThunderConfigResponse)) as WriteThunderConfigResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WriteThunderConfigResponse copyWith(void Function(WriteThunderConfigResponse) updates) => super.copyWith((message) => updates(message as WriteThunderConfigResponse)) as WriteThunderConfigResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -251,84 +224,71 @@ class WriteThunderConfigResponse extends $pb.GeneratedMessage {
   WriteThunderConfigResponse createEmptyInstance() => create();
   static $pb.PbList<WriteThunderConfigResponse> createRepeated() => $pb.PbList<WriteThunderConfigResponse>();
   @$core.pragma('dart2js:noInline')
-  static WriteThunderConfigResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteThunderConfigResponse>(create);
+  static WriteThunderConfigResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteThunderConfigResponse>(create);
   static WriteThunderConfigResponse? _defaultInstance;
 }
 
 class SyncNetworkFromBitcoinConfRequest extends $pb.GeneratedMessage {
   factory SyncNetworkFromBitcoinConfRequest() => create();
   SyncNetworkFromBitcoinConfRequest._() : super();
-  factory SyncNetworkFromBitcoinConfRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SyncNetworkFromBitcoinConfRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SyncNetworkFromBitcoinConfRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SyncNetworkFromBitcoinConfRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SyncNetworkFromBitcoinConfRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SyncNetworkFromBitcoinConfRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SyncNetworkFromBitcoinConfRequest clone() => SyncNetworkFromBitcoinConfRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SyncNetworkFromBitcoinConfRequest copyWith(void Function(SyncNetworkFromBitcoinConfRequest) updates) =>
-      super.copyWith((message) => updates(message as SyncNetworkFromBitcoinConfRequest))
-          as SyncNetworkFromBitcoinConfRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SyncNetworkFromBitcoinConfRequest copyWith(void Function(SyncNetworkFromBitcoinConfRequest) updates) => super.copyWith((message) => updates(message as SyncNetworkFromBitcoinConfRequest)) as SyncNetworkFromBitcoinConfRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SyncNetworkFromBitcoinConfRequest create() => SyncNetworkFromBitcoinConfRequest._();
   SyncNetworkFromBitcoinConfRequest createEmptyInstance() => create();
-  static $pb.PbList<SyncNetworkFromBitcoinConfRequest> createRepeated() =>
-      $pb.PbList<SyncNetworkFromBitcoinConfRequest>();
+  static $pb.PbList<SyncNetworkFromBitcoinConfRequest> createRepeated() => $pb.PbList<SyncNetworkFromBitcoinConfRequest>();
   @$core.pragma('dart2js:noInline')
-  static SyncNetworkFromBitcoinConfRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncNetworkFromBitcoinConfRequest>(create);
+  static SyncNetworkFromBitcoinConfRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncNetworkFromBitcoinConfRequest>(create);
   static SyncNetworkFromBitcoinConfRequest? _defaultInstance;
 }
 
 class SyncNetworkFromBitcoinConfResponse extends $pb.GeneratedMessage {
   factory SyncNetworkFromBitcoinConfResponse() => create();
   SyncNetworkFromBitcoinConfResponse._() : super();
-  factory SyncNetworkFromBitcoinConfResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SyncNetworkFromBitcoinConfResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SyncNetworkFromBitcoinConfResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SyncNetworkFromBitcoinConfResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SyncNetworkFromBitcoinConfResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SyncNetworkFromBitcoinConfResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SyncNetworkFromBitcoinConfResponse clone() => SyncNetworkFromBitcoinConfResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SyncNetworkFromBitcoinConfResponse copyWith(void Function(SyncNetworkFromBitcoinConfResponse) updates) =>
-      super.copyWith((message) => updates(message as SyncNetworkFromBitcoinConfResponse))
-          as SyncNetworkFromBitcoinConfResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SyncNetworkFromBitcoinConfResponse copyWith(void Function(SyncNetworkFromBitcoinConfResponse) updates) => super.copyWith((message) => updates(message as SyncNetworkFromBitcoinConfResponse)) as SyncNetworkFromBitcoinConfResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SyncNetworkFromBitcoinConfResponse create() => SyncNetworkFromBitcoinConfResponse._();
   SyncNetworkFromBitcoinConfResponse createEmptyInstance() => create();
-  static $pb.PbList<SyncNetworkFromBitcoinConfResponse> createRepeated() =>
-      $pb.PbList<SyncNetworkFromBitcoinConfResponse>();
+  static $pb.PbList<SyncNetworkFromBitcoinConfResponse> createRepeated() => $pb.PbList<SyncNetworkFromBitcoinConfResponse>();
   @$core.pragma('dart2js:noInline')
-  static SyncNetworkFromBitcoinConfResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncNetworkFromBitcoinConfResponse>(create);
+  static SyncNetworkFromBitcoinConfResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncNetworkFromBitcoinConfResponse>(create);
   static SyncNetworkFromBitcoinConfResponse? _defaultInstance;
 }
 
@@ -337,17 +297,16 @@ class ThunderConfServiceApi {
   ThunderConfServiceApi(this._client);
 
   $async.Future<GetThunderConfigResponse> getThunderConfig($pb.ClientContext? ctx, GetThunderConfigRequest request) =>
-      _client.invoke<GetThunderConfigResponse>(
-          ctx, 'ThunderConfService', 'GetThunderConfig', request, GetThunderConfigResponse());
-  $async.Future<WriteThunderConfigResponse> writeThunderConfig(
-          $pb.ClientContext? ctx, WriteThunderConfigRequest request) =>
-      _client.invoke<WriteThunderConfigResponse>(
-          ctx, 'ThunderConfService', 'WriteThunderConfig', request, WriteThunderConfigResponse());
-  $async.Future<SyncNetworkFromBitcoinConfResponse> syncNetworkFromBitcoinConf(
-          $pb.ClientContext? ctx, SyncNetworkFromBitcoinConfRequest request) =>
-      _client.invoke<SyncNetworkFromBitcoinConfResponse>(
-          ctx, 'ThunderConfService', 'SyncNetworkFromBitcoinConf', request, SyncNetworkFromBitcoinConfResponse());
+    _client.invoke<GetThunderConfigResponse>(ctx, 'ThunderConfService', 'GetThunderConfig', request, GetThunderConfigResponse())
+  ;
+  $async.Future<WriteThunderConfigResponse> writeThunderConfig($pb.ClientContext? ctx, WriteThunderConfigRequest request) =>
+    _client.invoke<WriteThunderConfigResponse>(ctx, 'ThunderConfService', 'WriteThunderConfig', request, WriteThunderConfigResponse())
+  ;
+  $async.Future<SyncNetworkFromBitcoinConfResponse> syncNetworkFromBitcoinConf($pb.ClientContext? ctx, SyncNetworkFromBitcoinConfRequest request) =>
+    _client.invoke<SyncNetworkFromBitcoinConfResponse>(ctx, 'ThunderConfService', 'SyncNetworkFromBitcoinConf', request, SyncNetworkFromBitcoinConfResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/orchestrator/v1/thunder_conf.pbenum.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/thunder_conf.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/orchestrator/v1/thunder_conf.pbjson.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/thunder_conf.pbjson.dart
@@ -19,8 +19,8 @@ const GetThunderConfigRequest$json = {
 };
 
 /// Descriptor for `GetThunderConfigRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getThunderConfigRequestDescriptor =
-    $convert.base64Decode('ChdHZXRUaHVuZGVyQ29uZmlnUmVxdWVzdA==');
+final $typed_data.Uint8List getThunderConfigRequestDescriptor = $convert.base64Decode(
+    'ChdHZXRUaHVuZGVyQ29uZmlnUmVxdWVzdA==');
 
 @$core.Deprecated('Use getThunderConfigResponseDescriptor instead')
 const GetThunderConfigResponse$json = {
@@ -35,11 +35,11 @@ const GetThunderConfigResponse$json = {
 };
 
 /// Descriptor for `GetThunderConfigResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getThunderConfigResponseDescriptor =
-    $convert.base64Decode('ChhHZXRUaHVuZGVyQ29uZmlnUmVzcG9uc2USJQoOY29uZmlnX2NvbnRlbnQYASABKAlSDWNvbm'
-        'ZpZ0NvbnRlbnQSHwoLY29uZmlnX3BhdGgYAiABKAlSCmNvbmZpZ1BhdGgSJQoOZGVmYXVsdF9j'
-        'b25maWcYAyABKAlSDWRlZmF1bHRDb25maWcSGQoIY2xpX2FyZ3MYBCADKAlSB2NsaUFyZ3MSGA'
-        'oHbmV0d29yaxgFIAEoCVIHbmV0d29yaw==');
+final $typed_data.Uint8List getThunderConfigResponseDescriptor = $convert.base64Decode(
+    'ChhHZXRUaHVuZGVyQ29uZmlnUmVzcG9uc2USJQoOY29uZmlnX2NvbnRlbnQYASABKAlSDWNvbm'
+    'ZpZ0NvbnRlbnQSHwoLY29uZmlnX3BhdGgYAiABKAlSCmNvbmZpZ1BhdGgSJQoOZGVmYXVsdF9j'
+    'b25maWcYAyABKAlSDWRlZmF1bHRDb25maWcSGQoIY2xpX2FyZ3MYBCADKAlSB2NsaUFyZ3MSGA'
+    'oHbmV0d29yaxgFIAEoCVIHbmV0d29yaw==');
 
 @$core.Deprecated('Use writeThunderConfigRequestDescriptor instead')
 const WriteThunderConfigRequest$json = {
@@ -50,9 +50,9 @@ const WriteThunderConfigRequest$json = {
 };
 
 /// Descriptor for `WriteThunderConfigRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List writeThunderConfigRequestDescriptor =
-    $convert.base64Decode('ChlXcml0ZVRodW5kZXJDb25maWdSZXF1ZXN0EiUKDmNvbmZpZ19jb250ZW50GAEgASgJUg1jb2'
-        '5maWdDb250ZW50');
+final $typed_data.Uint8List writeThunderConfigRequestDescriptor = $convert.base64Decode(
+    'ChlXcml0ZVRodW5kZXJDb25maWdSZXF1ZXN0EiUKDmNvbmZpZ19jb250ZW50GAEgASgJUg1jb2'
+    '5maWdDb250ZW50');
 
 @$core.Deprecated('Use writeThunderConfigResponseDescriptor instead')
 const WriteThunderConfigResponse$json = {
@@ -60,8 +60,8 @@ const WriteThunderConfigResponse$json = {
 };
 
 /// Descriptor for `WriteThunderConfigResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List writeThunderConfigResponseDescriptor =
-    $convert.base64Decode('ChpXcml0ZVRodW5kZXJDb25maWdSZXNwb25zZQ==');
+final $typed_data.Uint8List writeThunderConfigResponseDescriptor = $convert.base64Decode(
+    'ChpXcml0ZVRodW5kZXJDb25maWdSZXNwb25zZQ==');
 
 @$core.Deprecated('Use syncNetworkFromBitcoinConfRequestDescriptor instead')
 const SyncNetworkFromBitcoinConfRequest$json = {
@@ -69,8 +69,8 @@ const SyncNetworkFromBitcoinConfRequest$json = {
 };
 
 /// Descriptor for `SyncNetworkFromBitcoinConfRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List syncNetworkFromBitcoinConfRequestDescriptor =
-    $convert.base64Decode('CiFTeW5jTmV0d29ya0Zyb21CaXRjb2luQ29uZlJlcXVlc3Q=');
+final $typed_data.Uint8List syncNetworkFromBitcoinConfRequestDescriptor = $convert.base64Decode(
+    'CiFTeW5jTmV0d29ya0Zyb21CaXRjb2luQ29uZlJlcXVlc3Q=');
 
 @$core.Deprecated('Use syncNetworkFromBitcoinConfResponseDescriptor instead')
 const SyncNetworkFromBitcoinConfResponse$json = {
@@ -78,27 +78,15 @@ const SyncNetworkFromBitcoinConfResponse$json = {
 };
 
 /// Descriptor for `SyncNetworkFromBitcoinConfResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List syncNetworkFromBitcoinConfResponseDescriptor =
-    $convert.base64Decode('CiJTeW5jTmV0d29ya0Zyb21CaXRjb2luQ29uZlJlc3BvbnNl');
+final $typed_data.Uint8List syncNetworkFromBitcoinConfResponseDescriptor = $convert.base64Decode(
+    'CiJTeW5jTmV0d29ya0Zyb21CaXRjb2luQ29uZlJlc3BvbnNl');
 
 const $core.Map<$core.String, $core.dynamic> ThunderConfServiceBase$json = {
   '1': 'ThunderConfService',
   '2': [
-    {
-      '1': 'GetThunderConfig',
-      '2': '.orchestrator.v1.GetThunderConfigRequest',
-      '3': '.orchestrator.v1.GetThunderConfigResponse'
-    },
-    {
-      '1': 'WriteThunderConfig',
-      '2': '.orchestrator.v1.WriteThunderConfigRequest',
-      '3': '.orchestrator.v1.WriteThunderConfigResponse'
-    },
-    {
-      '1': 'SyncNetworkFromBitcoinConf',
-      '2': '.orchestrator.v1.SyncNetworkFromBitcoinConfRequest',
-      '3': '.orchestrator.v1.SyncNetworkFromBitcoinConfResponse'
-    },
+    {'1': 'GetThunderConfig', '2': '.orchestrator.v1.GetThunderConfigRequest', '3': '.orchestrator.v1.GetThunderConfigResponse'},
+    {'1': 'WriteThunderConfig', '2': '.orchestrator.v1.WriteThunderConfigRequest', '3': '.orchestrator.v1.WriteThunderConfigResponse'},
+    {'1': 'SyncNetworkFromBitcoinConf', '2': '.orchestrator.v1.SyncNetworkFromBitcoinConfRequest', '3': '.orchestrator.v1.SyncNetworkFromBitcoinConfResponse'},
   ],
 };
 
@@ -113,11 +101,12 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> ThunderCon
 };
 
 /// Descriptor for `ThunderConfService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List thunderConfServiceDescriptor =
-    $convert.base64Decode('ChJUaHVuZGVyQ29uZlNlcnZpY2USZwoQR2V0VGh1bmRlckNvbmZpZxIoLm9yY2hlc3RyYXRvci'
-        '52MS5HZXRUaHVuZGVyQ29uZmlnUmVxdWVzdBopLm9yY2hlc3RyYXRvci52MS5HZXRUaHVuZGVy'
-        'Q29uZmlnUmVzcG9uc2USbQoSV3JpdGVUaHVuZGVyQ29uZmlnEioub3JjaGVzdHJhdG9yLnYxLl'
-        'dyaXRlVGh1bmRlckNvbmZpZ1JlcXVlc3QaKy5vcmNoZXN0cmF0b3IudjEuV3JpdGVUaHVuZGVy'
-        'Q29uZmlnUmVzcG9uc2UShQEKGlN5bmNOZXR3b3JrRnJvbUJpdGNvaW5Db25mEjIub3JjaGVzdH'
-        'JhdG9yLnYxLlN5bmNOZXR3b3JrRnJvbUJpdGNvaW5Db25mUmVxdWVzdBozLm9yY2hlc3RyYXRv'
-        'ci52MS5TeW5jTmV0d29ya0Zyb21CaXRjb2luQ29uZlJlc3BvbnNl');
+final $typed_data.Uint8List thunderConfServiceDescriptor = $convert.base64Decode(
+    'ChJUaHVuZGVyQ29uZlNlcnZpY2USZwoQR2V0VGh1bmRlckNvbmZpZxIoLm9yY2hlc3RyYXRvci'
+    '52MS5HZXRUaHVuZGVyQ29uZmlnUmVxdWVzdBopLm9yY2hlc3RyYXRvci52MS5HZXRUaHVuZGVy'
+    'Q29uZmlnUmVzcG9uc2USbQoSV3JpdGVUaHVuZGVyQ29uZmlnEioub3JjaGVzdHJhdG9yLnYxLl'
+    'dyaXRlVGh1bmRlckNvbmZpZ1JlcXVlc3QaKy5vcmNoZXN0cmF0b3IudjEuV3JpdGVUaHVuZGVy'
+    'Q29uZmlnUmVzcG9uc2UShQEKGlN5bmNOZXR3b3JrRnJvbUJpdGNvaW5Db25mEjIub3JjaGVzdH'
+    'JhdG9yLnYxLlN5bmNOZXR3b3JrRnJvbUJpdGNvaW5Db25mUmVxdWVzdBozLm9yY2hlc3RyYXRv'
+    'ci52MS5TeW5jTmV0d29ya0Zyb21CaXRjb2luQ29uZlJlc3BvbnNl');
+

--- a/sail_ui/lib/gen/orchestrator/v1/thunder_conf.pbserver.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/thunder_conf.pbserver.dart
@@ -21,41 +21,29 @@ import 'thunder_conf.pbjson.dart';
 export 'thunder_conf.pb.dart';
 
 abstract class ThunderConfServiceBase extends $pb.GeneratedService {
-  $async.Future<$7.GetThunderConfigResponse> getThunderConfig(
-      $pb.ServerContext ctx, $7.GetThunderConfigRequest request);
-  $async.Future<$7.WriteThunderConfigResponse> writeThunderConfig(
-      $pb.ServerContext ctx, $7.WriteThunderConfigRequest request);
-  $async.Future<$7.SyncNetworkFromBitcoinConfResponse> syncNetworkFromBitcoinConf(
-      $pb.ServerContext ctx, $7.SyncNetworkFromBitcoinConfRequest request);
+  $async.Future<$7.GetThunderConfigResponse> getThunderConfig($pb.ServerContext ctx, $7.GetThunderConfigRequest request);
+  $async.Future<$7.WriteThunderConfigResponse> writeThunderConfig($pb.ServerContext ctx, $7.WriteThunderConfigRequest request);
+  $async.Future<$7.SyncNetworkFromBitcoinConfResponse> syncNetworkFromBitcoinConf($pb.ServerContext ctx, $7.SyncNetworkFromBitcoinConfRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetThunderConfig':
-        return $7.GetThunderConfigRequest();
-      case 'WriteThunderConfig':
-        return $7.WriteThunderConfigRequest();
-      case 'SyncNetworkFromBitcoinConf':
-        return $7.SyncNetworkFromBitcoinConfRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetThunderConfig': return $7.GetThunderConfigRequest();
+      case 'WriteThunderConfig': return $7.WriteThunderConfigRequest();
+      case 'SyncNetworkFromBitcoinConf': return $7.SyncNetworkFromBitcoinConfRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetThunderConfig':
-        return this.getThunderConfig(ctx, request as $7.GetThunderConfigRequest);
-      case 'WriteThunderConfig':
-        return this.writeThunderConfig(ctx, request as $7.WriteThunderConfigRequest);
-      case 'SyncNetworkFromBitcoinConf':
-        return this.syncNetworkFromBitcoinConf(ctx, request as $7.SyncNetworkFromBitcoinConfRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetThunderConfig': return this.getThunderConfig(ctx, request as $7.GetThunderConfigRequest);
+      case 'WriteThunderConfig': return this.writeThunderConfig(ctx, request as $7.WriteThunderConfigRequest);
+      case 'SyncNetworkFromBitcoinConf': return this.syncNetworkFromBitcoinConf(ctx, request as $7.SyncNetworkFromBitcoinConfRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => ThunderConfServiceBase$json;
-  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson =>
-      ThunderConfServiceBase$messageJson;
+  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => ThunderConfServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/orchestrator/v1/zside_conf.connect.client.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/zside_conf.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "zside_conf.pb.dart" as orchestratorv1zside_conf;
 import "zside_conf.connect.spec.dart" as specs;
 
-extension type ZSideConfServiceClient(connect.Transport _transport) {
+extension type ZSideConfServiceClient (connect.Transport _transport) {
   /// Get current ZSide sidechain configuration state.
   Future<orchestratorv1zside_conf.GetZSideConfigResponse> getZSideConfig(
     orchestratorv1zside_conf.GetZSideConfigRequest input, {

--- a/sail_ui/lib/gen/orchestrator/v1/zside_conf.pb.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/zside_conf.pb.dart
@@ -17,25 +17,23 @@ import 'package:protobuf/protobuf.dart' as $pb;
 class GetZSideConfigRequest extends $pb.GeneratedMessage {
   factory GetZSideConfigRequest() => create();
   GetZSideConfigRequest._() : super();
-  factory GetZSideConfigRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetZSideConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetZSideConfigRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetZSideConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetZSideConfigRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetZSideConfigRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetZSideConfigRequest clone() => GetZSideConfigRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetZSideConfigRequest copyWith(void Function(GetZSideConfigRequest) updates) =>
-      super.copyWith((message) => updates(message as GetZSideConfigRequest)) as GetZSideConfigRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetZSideConfigRequest copyWith(void Function(GetZSideConfigRequest) updates) => super.copyWith((message) => updates(message as GetZSideConfigRequest)) as GetZSideConfigRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -44,8 +42,7 @@ class GetZSideConfigRequest extends $pb.GeneratedMessage {
   GetZSideConfigRequest createEmptyInstance() => create();
   static $pb.PbList<GetZSideConfigRequest> createRepeated() => $pb.PbList<GetZSideConfigRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetZSideConfigRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetZSideConfigRequest>(create);
+  static GetZSideConfigRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetZSideConfigRequest>(create);
   static GetZSideConfigRequest? _defaultInstance;
 }
 
@@ -76,30 +73,28 @@ class GetZSideConfigResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetZSideConfigResponse._() : super();
-  factory GetZSideConfigResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetZSideConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetZSideConfigResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetZSideConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetZSideConfigResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetZSideConfigResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'configContent')
     ..aOS(2, _omitFieldNames ? '' : 'configPath')
     ..aOS(3, _omitFieldNames ? '' : 'defaultConfig')
     ..pPS(4, _omitFieldNames ? '' : 'cliArgs')
     ..aOS(5, _omitFieldNames ? '' : 'network')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetZSideConfigResponse clone() => GetZSideConfigResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetZSideConfigResponse copyWith(void Function(GetZSideConfigResponse) updates) =>
-      super.copyWith((message) => updates(message as GetZSideConfigResponse)) as GetZSideConfigResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetZSideConfigResponse copyWith(void Function(GetZSideConfigResponse) updates) => super.copyWith((message) => updates(message as GetZSideConfigResponse)) as GetZSideConfigResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -108,17 +103,13 @@ class GetZSideConfigResponse extends $pb.GeneratedMessage {
   GetZSideConfigResponse createEmptyInstance() => create();
   static $pb.PbList<GetZSideConfigResponse> createRepeated() => $pb.PbList<GetZSideConfigResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetZSideConfigResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetZSideConfigResponse>(create);
+  static GetZSideConfigResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetZSideConfigResponse>(create);
   static GetZSideConfigResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get configContent => $_getSZ(0);
   @$pb.TagNumber(1)
-  set configContent($core.String v) {
-    $_setString(0, v);
-  }
-
+  set configContent($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasConfigContent() => $_has(0);
   @$pb.TagNumber(1)
@@ -127,10 +118,7 @@ class GetZSideConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get configPath => $_getSZ(1);
   @$pb.TagNumber(2)
-  set configPath($core.String v) {
-    $_setString(1, v);
-  }
-
+  set configPath($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasConfigPath() => $_has(1);
   @$pb.TagNumber(2)
@@ -139,10 +127,7 @@ class GetZSideConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get defaultConfig => $_getSZ(2);
   @$pb.TagNumber(3)
-  set defaultConfig($core.String v) {
-    $_setString(2, v);
-  }
-
+  set defaultConfig($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasDefaultConfig() => $_has(2);
   @$pb.TagNumber(3)
@@ -154,10 +139,7 @@ class GetZSideConfigResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get network => $_getSZ(4);
   @$pb.TagNumber(5)
-  set network($core.String v) {
-    $_setString(4, v);
-  }
-
+  set network($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasNetwork() => $_has(4);
   @$pb.TagNumber(5)
@@ -175,26 +157,24 @@ class WriteZSideConfigRequest extends $pb.GeneratedMessage {
     return $result;
   }
   WriteZSideConfigRequest._() : super();
-  factory WriteZSideConfigRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteZSideConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WriteZSideConfigRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WriteZSideConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteZSideConfigRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteZSideConfigRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'configContent')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WriteZSideConfigRequest clone() => WriteZSideConfigRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WriteZSideConfigRequest copyWith(void Function(WriteZSideConfigRequest) updates) =>
-      super.copyWith((message) => updates(message as WriteZSideConfigRequest)) as WriteZSideConfigRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WriteZSideConfigRequest copyWith(void Function(WriteZSideConfigRequest) updates) => super.copyWith((message) => updates(message as WriteZSideConfigRequest)) as WriteZSideConfigRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -203,17 +183,13 @@ class WriteZSideConfigRequest extends $pb.GeneratedMessage {
   WriteZSideConfigRequest createEmptyInstance() => create();
   static $pb.PbList<WriteZSideConfigRequest> createRepeated() => $pb.PbList<WriteZSideConfigRequest>();
   @$core.pragma('dart2js:noInline')
-  static WriteZSideConfigRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteZSideConfigRequest>(create);
+  static WriteZSideConfigRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteZSideConfigRequest>(create);
   static WriteZSideConfigRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get configContent => $_getSZ(0);
   @$pb.TagNumber(1)
-  set configContent($core.String v) {
-    $_setString(0, v);
-  }
-
+  set configContent($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasConfigContent() => $_has(0);
   @$pb.TagNumber(1)
@@ -223,25 +199,23 @@ class WriteZSideConfigRequest extends $pb.GeneratedMessage {
 class WriteZSideConfigResponse extends $pb.GeneratedMessage {
   factory WriteZSideConfigResponse() => create();
   WriteZSideConfigResponse._() : super();
-  factory WriteZSideConfigResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteZSideConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WriteZSideConfigResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WriteZSideConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteZSideConfigResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WriteZSideConfigResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WriteZSideConfigResponse clone() => WriteZSideConfigResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WriteZSideConfigResponse copyWith(void Function(WriteZSideConfigResponse) updates) =>
-      super.copyWith((message) => updates(message as WriteZSideConfigResponse)) as WriteZSideConfigResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WriteZSideConfigResponse copyWith(void Function(WriteZSideConfigResponse) updates) => super.copyWith((message) => updates(message as WriteZSideConfigResponse)) as WriteZSideConfigResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -250,84 +224,71 @@ class WriteZSideConfigResponse extends $pb.GeneratedMessage {
   WriteZSideConfigResponse createEmptyInstance() => create();
   static $pb.PbList<WriteZSideConfigResponse> createRepeated() => $pb.PbList<WriteZSideConfigResponse>();
   @$core.pragma('dart2js:noInline')
-  static WriteZSideConfigResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteZSideConfigResponse>(create);
+  static WriteZSideConfigResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteZSideConfigResponse>(create);
   static WriteZSideConfigResponse? _defaultInstance;
 }
 
 class ZSideSyncNetworkFromBitcoinConfRequest extends $pb.GeneratedMessage {
   factory ZSideSyncNetworkFromBitcoinConfRequest() => create();
   ZSideSyncNetworkFromBitcoinConfRequest._() : super();
-  factory ZSideSyncNetworkFromBitcoinConfRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ZSideSyncNetworkFromBitcoinConfRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ZSideSyncNetworkFromBitcoinConfRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ZSideSyncNetworkFromBitcoinConfRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ZSideSyncNetworkFromBitcoinConfRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ZSideSyncNetworkFromBitcoinConfRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ZSideSyncNetworkFromBitcoinConfRequest clone() => ZSideSyncNetworkFromBitcoinConfRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ZSideSyncNetworkFromBitcoinConfRequest copyWith(void Function(ZSideSyncNetworkFromBitcoinConfRequest) updates) =>
-      super.copyWith((message) => updates(message as ZSideSyncNetworkFromBitcoinConfRequest))
-          as ZSideSyncNetworkFromBitcoinConfRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ZSideSyncNetworkFromBitcoinConfRequest copyWith(void Function(ZSideSyncNetworkFromBitcoinConfRequest) updates) => super.copyWith((message) => updates(message as ZSideSyncNetworkFromBitcoinConfRequest)) as ZSideSyncNetworkFromBitcoinConfRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ZSideSyncNetworkFromBitcoinConfRequest create() => ZSideSyncNetworkFromBitcoinConfRequest._();
   ZSideSyncNetworkFromBitcoinConfRequest createEmptyInstance() => create();
-  static $pb.PbList<ZSideSyncNetworkFromBitcoinConfRequest> createRepeated() =>
-      $pb.PbList<ZSideSyncNetworkFromBitcoinConfRequest>();
+  static $pb.PbList<ZSideSyncNetworkFromBitcoinConfRequest> createRepeated() => $pb.PbList<ZSideSyncNetworkFromBitcoinConfRequest>();
   @$core.pragma('dart2js:noInline')
-  static ZSideSyncNetworkFromBitcoinConfRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ZSideSyncNetworkFromBitcoinConfRequest>(create);
+  static ZSideSyncNetworkFromBitcoinConfRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ZSideSyncNetworkFromBitcoinConfRequest>(create);
   static ZSideSyncNetworkFromBitcoinConfRequest? _defaultInstance;
 }
 
 class ZSideSyncNetworkFromBitcoinConfResponse extends $pb.GeneratedMessage {
   factory ZSideSyncNetworkFromBitcoinConfResponse() => create();
   ZSideSyncNetworkFromBitcoinConfResponse._() : super();
-  factory ZSideSyncNetworkFromBitcoinConfResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ZSideSyncNetworkFromBitcoinConfResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ZSideSyncNetworkFromBitcoinConfResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ZSideSyncNetworkFromBitcoinConfResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ZSideSyncNetworkFromBitcoinConfResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ZSideSyncNetworkFromBitcoinConfResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ZSideSyncNetworkFromBitcoinConfResponse clone() => ZSideSyncNetworkFromBitcoinConfResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ZSideSyncNetworkFromBitcoinConfResponse copyWith(void Function(ZSideSyncNetworkFromBitcoinConfResponse) updates) =>
-      super.copyWith((message) => updates(message as ZSideSyncNetworkFromBitcoinConfResponse))
-          as ZSideSyncNetworkFromBitcoinConfResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ZSideSyncNetworkFromBitcoinConfResponse copyWith(void Function(ZSideSyncNetworkFromBitcoinConfResponse) updates) => super.copyWith((message) => updates(message as ZSideSyncNetworkFromBitcoinConfResponse)) as ZSideSyncNetworkFromBitcoinConfResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ZSideSyncNetworkFromBitcoinConfResponse create() => ZSideSyncNetworkFromBitcoinConfResponse._();
   ZSideSyncNetworkFromBitcoinConfResponse createEmptyInstance() => create();
-  static $pb.PbList<ZSideSyncNetworkFromBitcoinConfResponse> createRepeated() =>
-      $pb.PbList<ZSideSyncNetworkFromBitcoinConfResponse>();
+  static $pb.PbList<ZSideSyncNetworkFromBitcoinConfResponse> createRepeated() => $pb.PbList<ZSideSyncNetworkFromBitcoinConfResponse>();
   @$core.pragma('dart2js:noInline')
-  static ZSideSyncNetworkFromBitcoinConfResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ZSideSyncNetworkFromBitcoinConfResponse>(create);
+  static ZSideSyncNetworkFromBitcoinConfResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ZSideSyncNetworkFromBitcoinConfResponse>(create);
   static ZSideSyncNetworkFromBitcoinConfResponse? _defaultInstance;
 }
 
@@ -335,16 +296,17 @@ class ZSideConfServiceApi {
   $pb.RpcClient _client;
   ZSideConfServiceApi(this._client);
 
-  $async.Future<GetZSideConfigResponse> getZSideConfig($pb.ClientContext? ctx, GetZSideConfigRequest request) => _client
-      .invoke<GetZSideConfigResponse>(ctx, 'ZSideConfService', 'GetZSideConfig', request, GetZSideConfigResponse());
+  $async.Future<GetZSideConfigResponse> getZSideConfig($pb.ClientContext? ctx, GetZSideConfigRequest request) =>
+    _client.invoke<GetZSideConfigResponse>(ctx, 'ZSideConfService', 'GetZSideConfig', request, GetZSideConfigResponse())
+  ;
   $async.Future<WriteZSideConfigResponse> writeZSideConfig($pb.ClientContext? ctx, WriteZSideConfigRequest request) =>
-      _client.invoke<WriteZSideConfigResponse>(
-          ctx, 'ZSideConfService', 'WriteZSideConfig', request, WriteZSideConfigResponse());
-  $async.Future<ZSideSyncNetworkFromBitcoinConfResponse> syncNetworkFromBitcoinConf(
-          $pb.ClientContext? ctx, ZSideSyncNetworkFromBitcoinConfRequest request) =>
-      _client.invoke<ZSideSyncNetworkFromBitcoinConfResponse>(
-          ctx, 'ZSideConfService', 'SyncNetworkFromBitcoinConf', request, ZSideSyncNetworkFromBitcoinConfResponse());
+    _client.invoke<WriteZSideConfigResponse>(ctx, 'ZSideConfService', 'WriteZSideConfig', request, WriteZSideConfigResponse())
+  ;
+  $async.Future<ZSideSyncNetworkFromBitcoinConfResponse> syncNetworkFromBitcoinConf($pb.ClientContext? ctx, ZSideSyncNetworkFromBitcoinConfRequest request) =>
+    _client.invoke<ZSideSyncNetworkFromBitcoinConfResponse>(ctx, 'ZSideConfService', 'SyncNetworkFromBitcoinConf', request, ZSideSyncNetworkFromBitcoinConfResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/orchestrator/v1/zside_conf.pbenum.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/zside_conf.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/orchestrator/v1/zside_conf.pbjson.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/zside_conf.pbjson.dart
@@ -19,7 +19,8 @@ const GetZSideConfigRequest$json = {
 };
 
 /// Descriptor for `GetZSideConfigRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getZSideConfigRequestDescriptor = $convert.base64Decode('ChVHZXRaU2lkZUNvbmZpZ1JlcXVlc3Q=');
+final $typed_data.Uint8List getZSideConfigRequestDescriptor = $convert.base64Decode(
+    'ChVHZXRaU2lkZUNvbmZpZ1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getZSideConfigResponseDescriptor instead')
 const GetZSideConfigResponse$json = {
@@ -34,11 +35,11 @@ const GetZSideConfigResponse$json = {
 };
 
 /// Descriptor for `GetZSideConfigResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getZSideConfigResponseDescriptor =
-    $convert.base64Decode('ChZHZXRaU2lkZUNvbmZpZ1Jlc3BvbnNlEiUKDmNvbmZpZ19jb250ZW50GAEgASgJUg1jb25maW'
-        'dDb250ZW50Eh8KC2NvbmZpZ19wYXRoGAIgASgJUgpjb25maWdQYXRoEiUKDmRlZmF1bHRfY29u'
-        'ZmlnGAMgASgJUg1kZWZhdWx0Q29uZmlnEhkKCGNsaV9hcmdzGAQgAygJUgdjbGlBcmdzEhgKB2'
-        '5ldHdvcmsYBSABKAlSB25ldHdvcms=');
+final $typed_data.Uint8List getZSideConfigResponseDescriptor = $convert.base64Decode(
+    'ChZHZXRaU2lkZUNvbmZpZ1Jlc3BvbnNlEiUKDmNvbmZpZ19jb250ZW50GAEgASgJUg1jb25maW'
+    'dDb250ZW50Eh8KC2NvbmZpZ19wYXRoGAIgASgJUgpjb25maWdQYXRoEiUKDmRlZmF1bHRfY29u'
+    'ZmlnGAMgASgJUg1kZWZhdWx0Q29uZmlnEhkKCGNsaV9hcmdzGAQgAygJUgdjbGlBcmdzEhgKB2'
+    '5ldHdvcmsYBSABKAlSB25ldHdvcms=');
 
 @$core.Deprecated('Use writeZSideConfigRequestDescriptor instead')
 const WriteZSideConfigRequest$json = {
@@ -49,9 +50,9 @@ const WriteZSideConfigRequest$json = {
 };
 
 /// Descriptor for `WriteZSideConfigRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List writeZSideConfigRequestDescriptor =
-    $convert.base64Decode('ChdXcml0ZVpTaWRlQ29uZmlnUmVxdWVzdBIlCg5jb25maWdfY29udGVudBgBIAEoCVINY29uZm'
-        'lnQ29udGVudA==');
+final $typed_data.Uint8List writeZSideConfigRequestDescriptor = $convert.base64Decode(
+    'ChdXcml0ZVpTaWRlQ29uZmlnUmVxdWVzdBIlCg5jb25maWdfY29udGVudBgBIAEoCVINY29uZm'
+    'lnQ29udGVudA==');
 
 @$core.Deprecated('Use writeZSideConfigResponseDescriptor instead')
 const WriteZSideConfigResponse$json = {
@@ -59,8 +60,8 @@ const WriteZSideConfigResponse$json = {
 };
 
 /// Descriptor for `WriteZSideConfigResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List writeZSideConfigResponseDescriptor =
-    $convert.base64Decode('ChhXcml0ZVpTaWRlQ29uZmlnUmVzcG9uc2U=');
+final $typed_data.Uint8List writeZSideConfigResponseDescriptor = $convert.base64Decode(
+    'ChhXcml0ZVpTaWRlQ29uZmlnUmVzcG9uc2U=');
 
 @$core.Deprecated('Use zSideSyncNetworkFromBitcoinConfRequestDescriptor instead')
 const ZSideSyncNetworkFromBitcoinConfRequest$json = {
@@ -68,8 +69,8 @@ const ZSideSyncNetworkFromBitcoinConfRequest$json = {
 };
 
 /// Descriptor for `ZSideSyncNetworkFromBitcoinConfRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List zSideSyncNetworkFromBitcoinConfRequestDescriptor =
-    $convert.base64Decode('CiZaU2lkZVN5bmNOZXR3b3JrRnJvbUJpdGNvaW5Db25mUmVxdWVzdA==');
+final $typed_data.Uint8List zSideSyncNetworkFromBitcoinConfRequestDescriptor = $convert.base64Decode(
+    'CiZaU2lkZVN5bmNOZXR3b3JrRnJvbUJpdGNvaW5Db25mUmVxdWVzdA==');
 
 @$core.Deprecated('Use zSideSyncNetworkFromBitcoinConfResponseDescriptor instead')
 const ZSideSyncNetworkFromBitcoinConfResponse$json = {
@@ -77,27 +78,15 @@ const ZSideSyncNetworkFromBitcoinConfResponse$json = {
 };
 
 /// Descriptor for `ZSideSyncNetworkFromBitcoinConfResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List zSideSyncNetworkFromBitcoinConfResponseDescriptor =
-    $convert.base64Decode('CidaU2lkZVN5bmNOZXR3b3JrRnJvbUJpdGNvaW5Db25mUmVzcG9uc2U=');
+final $typed_data.Uint8List zSideSyncNetworkFromBitcoinConfResponseDescriptor = $convert.base64Decode(
+    'CidaU2lkZVN5bmNOZXR3b3JrRnJvbUJpdGNvaW5Db25mUmVzcG9uc2U=');
 
 const $core.Map<$core.String, $core.dynamic> ZSideConfServiceBase$json = {
   '1': 'ZSideConfService',
   '2': [
-    {
-      '1': 'GetZSideConfig',
-      '2': '.orchestrator.v1.GetZSideConfigRequest',
-      '3': '.orchestrator.v1.GetZSideConfigResponse'
-    },
-    {
-      '1': 'WriteZSideConfig',
-      '2': '.orchestrator.v1.WriteZSideConfigRequest',
-      '3': '.orchestrator.v1.WriteZSideConfigResponse'
-    },
-    {
-      '1': 'SyncNetworkFromBitcoinConf',
-      '2': '.orchestrator.v1.ZSideSyncNetworkFromBitcoinConfRequest',
-      '3': '.orchestrator.v1.ZSideSyncNetworkFromBitcoinConfResponse'
-    },
+    {'1': 'GetZSideConfig', '2': '.orchestrator.v1.GetZSideConfigRequest', '3': '.orchestrator.v1.GetZSideConfigResponse'},
+    {'1': 'WriteZSideConfig', '2': '.orchestrator.v1.WriteZSideConfigRequest', '3': '.orchestrator.v1.WriteZSideConfigResponse'},
+    {'1': 'SyncNetworkFromBitcoinConf', '2': '.orchestrator.v1.ZSideSyncNetworkFromBitcoinConfRequest', '3': '.orchestrator.v1.ZSideSyncNetworkFromBitcoinConfResponse'},
   ],
 };
 
@@ -112,11 +101,12 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> ZSideConfS
 };
 
 /// Descriptor for `ZSideConfService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List zSideConfServiceDescriptor =
-    $convert.base64Decode('ChBaU2lkZUNvbmZTZXJ2aWNlEmEKDkdldFpTaWRlQ29uZmlnEiYub3JjaGVzdHJhdG9yLnYxLk'
-        'dldFpTaWRlQ29uZmlnUmVxdWVzdBonLm9yY2hlc3RyYXRvci52MS5HZXRaU2lkZUNvbmZpZ1Jl'
-        'c3BvbnNlEmcKEFdyaXRlWlNpZGVDb25maWcSKC5vcmNoZXN0cmF0b3IudjEuV3JpdGVaU2lkZU'
-        'NvbmZpZ1JlcXVlc3QaKS5vcmNoZXN0cmF0b3IudjEuV3JpdGVaU2lkZUNvbmZpZ1Jlc3BvbnNl'
-        'Eo8BChpTeW5jTmV0d29ya0Zyb21CaXRjb2luQ29uZhI3Lm9yY2hlc3RyYXRvci52MS5aU2lkZV'
-        'N5bmNOZXR3b3JrRnJvbUJpdGNvaW5Db25mUmVxdWVzdBo4Lm9yY2hlc3RyYXRvci52MS5aU2lk'
-        'ZVN5bmNOZXR3b3JrRnJvbUJpdGNvaW5Db25mUmVzcG9uc2U=');
+final $typed_data.Uint8List zSideConfServiceDescriptor = $convert.base64Decode(
+    'ChBaU2lkZUNvbmZTZXJ2aWNlEmEKDkdldFpTaWRlQ29uZmlnEiYub3JjaGVzdHJhdG9yLnYxLk'
+    'dldFpTaWRlQ29uZmlnUmVxdWVzdBonLm9yY2hlc3RyYXRvci52MS5HZXRaU2lkZUNvbmZpZ1Jl'
+    'c3BvbnNlEmcKEFdyaXRlWlNpZGVDb25maWcSKC5vcmNoZXN0cmF0b3IudjEuV3JpdGVaU2lkZU'
+    'NvbmZpZ1JlcXVlc3QaKS5vcmNoZXN0cmF0b3IudjEuV3JpdGVaU2lkZUNvbmZpZ1Jlc3BvbnNl'
+    'Eo8BChpTeW5jTmV0d29ya0Zyb21CaXRjb2luQ29uZhI3Lm9yY2hlc3RyYXRvci52MS5aU2lkZV'
+    'N5bmNOZXR3b3JrRnJvbUJpdGNvaW5Db25mUmVxdWVzdBo4Lm9yY2hlc3RyYXRvci52MS5aU2lk'
+    'ZVN5bmNOZXR3b3JrRnJvbUJpdGNvaW5Db25mUmVzcG9uc2U=');
+

--- a/sail_ui/lib/gen/orchestrator/v1/zside_conf.pbserver.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/zside_conf.pbserver.dart
@@ -22,38 +22,28 @@ export 'zside_conf.pb.dart';
 
 abstract class ZSideConfServiceBase extends $pb.GeneratedService {
   $async.Future<$8.GetZSideConfigResponse> getZSideConfig($pb.ServerContext ctx, $8.GetZSideConfigRequest request);
-  $async.Future<$8.WriteZSideConfigResponse> writeZSideConfig(
-      $pb.ServerContext ctx, $8.WriteZSideConfigRequest request);
-  $async.Future<$8.ZSideSyncNetworkFromBitcoinConfResponse> syncNetworkFromBitcoinConf(
-      $pb.ServerContext ctx, $8.ZSideSyncNetworkFromBitcoinConfRequest request);
+  $async.Future<$8.WriteZSideConfigResponse> writeZSideConfig($pb.ServerContext ctx, $8.WriteZSideConfigRequest request);
+  $async.Future<$8.ZSideSyncNetworkFromBitcoinConfResponse> syncNetworkFromBitcoinConf($pb.ServerContext ctx, $8.ZSideSyncNetworkFromBitcoinConfRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetZSideConfig':
-        return $8.GetZSideConfigRequest();
-      case 'WriteZSideConfig':
-        return $8.WriteZSideConfigRequest();
-      case 'SyncNetworkFromBitcoinConf':
-        return $8.ZSideSyncNetworkFromBitcoinConfRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetZSideConfig': return $8.GetZSideConfigRequest();
+      case 'WriteZSideConfig': return $8.WriteZSideConfigRequest();
+      case 'SyncNetworkFromBitcoinConf': return $8.ZSideSyncNetworkFromBitcoinConfRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetZSideConfig':
-        return this.getZSideConfig(ctx, request as $8.GetZSideConfigRequest);
-      case 'WriteZSideConfig':
-        return this.writeZSideConfig(ctx, request as $8.WriteZSideConfigRequest);
-      case 'SyncNetworkFromBitcoinConf':
-        return this.syncNetworkFromBitcoinConf(ctx, request as $8.ZSideSyncNetworkFromBitcoinConfRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetZSideConfig': return this.getZSideConfig(ctx, request as $8.GetZSideConfigRequest);
+      case 'WriteZSideConfig': return this.writeZSideConfig(ctx, request as $8.WriteZSideConfigRequest);
+      case 'SyncNetworkFromBitcoinConf': return this.syncNetworkFromBitcoinConf(ctx, request as $8.ZSideSyncNetworkFromBitcoinConfRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => ZSideConfServiceBase$json;
   $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => ZSideConfServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/photon/v1/photon.connect.client.dart
+++ b/sail_ui/lib/gen/photon/v1/photon.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "photon.pb.dart" as photonv1photon;
 import "photon.connect.spec.dart" as specs;
 
-extension type PhotonServiceClient(connect.Transport _transport) {
+extension type PhotonServiceClient (connect.Transport _transport) {
   /// Get wallet balance (total and available).
   Future<photonv1photon.GetBalanceResponse> getBalance(
     photonv1photon.GetBalanceRequest input, {

--- a/sail_ui/lib/gen/photon/v1/photon.pb.dart
+++ b/sail_ui/lib/gen/photon/v1/photon.pb.dart
@@ -18,25 +18,23 @@ import 'package:protobuf/protobuf.dart' as $pb;
 class GetBalanceRequest extends $pb.GeneratedMessage {
   factory GetBalanceRequest() => create();
   GetBalanceRequest._() : super();
-  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceRequest clone() => GetBalanceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) => super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -45,8 +43,7 @@ class GetBalanceRequest extends $pb.GeneratedMessage {
   GetBalanceRequest createEmptyInstance() => create();
   static $pb.PbList<GetBalanceRequest> createRepeated() => $pb.PbList<GetBalanceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
+  static GetBalanceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
   static GetBalanceRequest? _defaultInstance;
 }
 
@@ -65,27 +62,25 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBalanceResponse._() : super();
-  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'totalSats')
     ..aInt64(2, _omitFieldNames ? '' : 'availableSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceResponse clone() => GetBalanceResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) => super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -94,17 +89,13 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   GetBalanceResponse createEmptyInstance() => create();
   static $pb.PbList<GetBalanceResponse> createRepeated() => $pb.PbList<GetBalanceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
+  static GetBalanceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
   static GetBalanceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get totalSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set totalSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set totalSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTotalSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -113,10 +104,7 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get availableSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set availableSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set availableSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAvailableSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -126,25 +114,23 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
 class GetBlockCountRequest extends $pb.GeneratedMessage {
   factory GetBlockCountRequest() => create();
   GetBlockCountRequest._() : super();
-  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountRequest clone() => GetBlockCountRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) => super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -153,8 +139,7 @@ class GetBlockCountRequest extends $pb.GeneratedMessage {
   GetBlockCountRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountRequest> createRepeated() => $pb.PbList<GetBlockCountRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
+  static GetBlockCountRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
   static GetBlockCountRequest? _defaultInstance;
 }
 
@@ -169,26 +154,24 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockCountResponse._() : super();
-  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'count')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountResponse clone() => GetBlockCountResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) => super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -197,17 +180,13 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
   GetBlockCountResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountResponse> createRepeated() => $pb.PbList<GetBlockCountResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
+  static GetBlockCountResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
   static GetBlockCountResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get count => $_getI64(0);
   @$pb.TagNumber(1)
-  set count($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set count($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCount() => $_has(0);
   @$pb.TagNumber(1)
@@ -217,24 +196,23 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
 class StopRequest extends $pb.GeneratedMessage {
   factory StopRequest() => create();
   StopRequest._() : super();
-  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopRequest clone() => StopRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopRequest copyWith(void Function(StopRequest) updates) =>
-      super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopRequest copyWith(void Function(StopRequest) updates) => super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -250,24 +228,23 @@ class StopRequest extends $pb.GeneratedMessage {
 class StopResponse extends $pb.GeneratedMessage {
   factory StopResponse() => create();
   StopResponse._() : super();
-  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopResponse clone() => StopResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopResponse copyWith(void Function(StopResponse) updates) =>
-      super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopResponse copyWith(void Function(StopResponse) updates) => super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -283,25 +260,23 @@ class StopResponse extends $pb.GeneratedMessage {
 class GetNewAddressRequest extends $pb.GeneratedMessage {
   factory GetNewAddressRequest() => create();
   GetNewAddressRequest._() : super();
-  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressRequest clone() => GetNewAddressRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) => super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -310,8 +285,7 @@ class GetNewAddressRequest extends $pb.GeneratedMessage {
   GetNewAddressRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressRequest> createRepeated() => $pb.PbList<GetNewAddressRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
+  static GetNewAddressRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
   static GetNewAddressRequest? _defaultInstance;
 }
 
@@ -326,26 +300,24 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewAddressResponse._() : super();
-  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressResponse clone() => GetNewAddressResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) => super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -354,17 +326,13 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
   GetNewAddressResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressResponse> createRepeated() => $pb.PbList<GetNewAddressResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
+  static GetNewAddressResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
   static GetNewAddressResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -394,29 +362,27 @@ class WithdrawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawRequest._() : super();
-  factory WithdrawRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'sideFeeSats')
     ..aInt64(4, _omitFieldNames ? '' : 'mainFeeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawRequest clone() => WithdrawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) =>
-      super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) => super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -425,17 +391,13 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   WithdrawRequest createEmptyInstance() => create();
   static $pb.PbList<WithdrawRequest> createRepeated() => $pb.PbList<WithdrawRequest>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
+  static WithdrawRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
   static WithdrawRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -444,10 +406,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -456,10 +415,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get sideFeeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set sideFeeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set sideFeeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSideFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -468,10 +424,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get mainFeeSats => $_getI64(3);
   @$pb.TagNumber(4)
-  set mainFeeSats($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set mainFeeSats($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasMainFeeSats() => $_has(3);
   @$pb.TagNumber(4)
@@ -489,26 +442,24 @@ class WithdrawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawResponse._() : super();
-  factory WithdrawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawResponse clone() => WithdrawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) =>
-      super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) => super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -517,17 +468,13 @@ class WithdrawResponse extends $pb.GeneratedMessage {
   WithdrawResponse createEmptyInstance() => create();
   static $pb.PbList<WithdrawResponse> createRepeated() => $pb.PbList<WithdrawResponse>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
+  static WithdrawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
   static WithdrawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -553,28 +500,26 @@ class TransferRequest extends $pb.GeneratedMessage {
     return $result;
   }
   TransferRequest._() : super();
-  factory TransferRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferRequest clone() => TransferRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferRequest copyWith(void Function(TransferRequest) updates) =>
-      super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferRequest copyWith(void Function(TransferRequest) updates) => super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -583,17 +528,13 @@ class TransferRequest extends $pb.GeneratedMessage {
   TransferRequest createEmptyInstance() => create();
   static $pb.PbList<TransferRequest> createRepeated() => $pb.PbList<TransferRequest>();
   @$core.pragma('dart2js:noInline')
-  static TransferRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
+  static TransferRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
   static TransferRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -602,10 +543,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -614,10 +552,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -635,26 +570,24 @@ class TransferResponse extends $pb.GeneratedMessage {
     return $result;
   }
   TransferResponse._() : super();
-  factory TransferResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferResponse clone() => TransferResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferResponse copyWith(void Function(TransferResponse) updates) =>
-      super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferResponse copyWith(void Function(TransferResponse) updates) => super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -663,17 +596,13 @@ class TransferResponse extends $pb.GeneratedMessage {
   TransferResponse createEmptyInstance() => create();
   static $pb.PbList<TransferResponse> createRepeated() => $pb.PbList<TransferResponse>();
   @$core.pragma('dart2js:noInline')
-  static TransferResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
+  static TransferResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
   static TransferResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -683,25 +612,23 @@ class TransferResponse extends $pb.GeneratedMessage {
 class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   factory GetSidechainWealthRequest() => create();
   GetSidechainWealthRequest._() : super();
-  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthRequest clone() => GetSidechainWealthRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) => super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -710,8 +637,7 @@ class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   GetSidechainWealthRequest createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthRequest> createRepeated() => $pb.PbList<GetSidechainWealthRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
+  static GetSidechainWealthRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
   static GetSidechainWealthRequest? _defaultInstance;
 }
 
@@ -726,27 +652,24 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetSidechainWealthResponse._() : super();
-  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'sats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthResponse clone() => GetSidechainWealthResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) => super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -755,17 +678,13 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
   GetSidechainWealthResponse createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthResponse> createRepeated() => $pb.PbList<GetSidechainWealthResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
+  static GetSidechainWealthResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
   static GetSidechainWealthResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get sats => $_getI64(0);
   @$pb.TagNumber(1)
-  set sats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set sats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -791,28 +710,26 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositRequest._() : super();
-  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'valueSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositRequest clone() => CreateDepositRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) => super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -821,17 +738,13 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   CreateDepositRequest createEmptyInstance() => create();
   static $pb.PbList<CreateDepositRequest> createRepeated() => $pb.PbList<CreateDepositRequest>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
+  static CreateDepositRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
   static CreateDepositRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -840,10 +753,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get valueSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set valueSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set valueSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasValueSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -852,10 +762,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -873,26 +780,24 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositResponse._() : super();
-  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositResponse clone() => CreateDepositResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) => super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -901,17 +806,13 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
   CreateDepositResponse createEmptyInstance() => create();
   static $pb.PbList<CreateDepositResponse> createRepeated() => $pb.PbList<CreateDepositResponse>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
+  static CreateDepositResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
   static CreateDepositResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -921,38 +822,32 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
 class GetPendingWithdrawalBundleRequest extends $pb.GeneratedMessage {
   factory GetPendingWithdrawalBundleRequest() => create();
   GetPendingWithdrawalBundleRequest._() : super();
-  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleRequest clone() => GetPendingWithdrawalBundleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest))
-          as GetPendingWithdrawalBundleRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest)) as GetPendingWithdrawalBundleRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleRequest create() => GetPendingWithdrawalBundleRequest._();
   GetPendingWithdrawalBundleRequest createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleRequest>();
+  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
+  static GetPendingWithdrawalBundleRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
   static GetPendingWithdrawalBundleRequest? _defaultInstance;
 }
 
@@ -967,49 +862,40 @@ class GetPendingWithdrawalBundleResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetPendingWithdrawalBundleResponse._() : super();
-  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bundleJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleResponse clone() => GetPendingWithdrawalBundleResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse))
-          as GetPendingWithdrawalBundleResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse)) as GetPendingWithdrawalBundleResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleResponse create() => GetPendingWithdrawalBundleResponse._();
   GetPendingWithdrawalBundleResponse createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleResponse>();
+  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
+  static GetPendingWithdrawalBundleResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
   static GetPendingWithdrawalBundleResponse? _defaultInstance;
 
   /// JSON string of the bundle, empty if none.
   @$pb.TagNumber(1)
   $core.String get bundleJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bundleJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bundleJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBundleJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1027,26 +913,24 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ConnectPeerRequest._() : super();
-  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerRequest clone() => ConnectPeerRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) => super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1055,17 +939,13 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
   ConnectPeerRequest createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerRequest> createRepeated() => $pb.PbList<ConnectPeerRequest>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
+  static ConnectPeerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
   static ConnectPeerRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1075,25 +955,23 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
 class ConnectPeerResponse extends $pb.GeneratedMessage {
   factory ConnectPeerResponse() => create();
   ConnectPeerResponse._() : super();
-  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerResponse clone() => ConnectPeerResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) => super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1102,8 +980,7 @@ class ConnectPeerResponse extends $pb.GeneratedMessage {
   ConnectPeerResponse createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerResponse> createRepeated() => $pb.PbList<ConnectPeerResponse>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
+  static ConnectPeerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
   static ConnectPeerResponse? _defaultInstance;
 }
 
@@ -1118,26 +995,24 @@ class ForgetPeerRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ForgetPeerRequest._() : super();
-  factory ForgetPeerRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ForgetPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ForgetPeerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ForgetPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForgetPeerRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForgetPeerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ForgetPeerRequest clone() => ForgetPeerRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ForgetPeerRequest copyWith(void Function(ForgetPeerRequest) updates) =>
-      super.copyWith((message) => updates(message as ForgetPeerRequest)) as ForgetPeerRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ForgetPeerRequest copyWith(void Function(ForgetPeerRequest) updates) => super.copyWith((message) => updates(message as ForgetPeerRequest)) as ForgetPeerRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1146,17 +1021,13 @@ class ForgetPeerRequest extends $pb.GeneratedMessage {
   ForgetPeerRequest createEmptyInstance() => create();
   static $pb.PbList<ForgetPeerRequest> createRepeated() => $pb.PbList<ForgetPeerRequest>();
   @$core.pragma('dart2js:noInline')
-  static ForgetPeerRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForgetPeerRequest>(create);
+  static ForgetPeerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForgetPeerRequest>(create);
   static ForgetPeerRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1166,25 +1037,23 @@ class ForgetPeerRequest extends $pb.GeneratedMessage {
 class ForgetPeerResponse extends $pb.GeneratedMessage {
   factory ForgetPeerResponse() => create();
   ForgetPeerResponse._() : super();
-  factory ForgetPeerResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ForgetPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ForgetPeerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ForgetPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForgetPeerResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForgetPeerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ForgetPeerResponse clone() => ForgetPeerResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ForgetPeerResponse copyWith(void Function(ForgetPeerResponse) updates) =>
-      super.copyWith((message) => updates(message as ForgetPeerResponse)) as ForgetPeerResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ForgetPeerResponse copyWith(void Function(ForgetPeerResponse) updates) => super.copyWith((message) => updates(message as ForgetPeerResponse)) as ForgetPeerResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1193,33 +1062,30 @@ class ForgetPeerResponse extends $pb.GeneratedMessage {
   ForgetPeerResponse createEmptyInstance() => create();
   static $pb.PbList<ForgetPeerResponse> createRepeated() => $pb.PbList<ForgetPeerResponse>();
   @$core.pragma('dart2js:noInline')
-  static ForgetPeerResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForgetPeerResponse>(create);
+  static ForgetPeerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForgetPeerResponse>(create);
   static ForgetPeerResponse? _defaultInstance;
 }
 
 class ListPeersRequest extends $pb.GeneratedMessage {
   factory ListPeersRequest() => create();
   ListPeersRequest._() : super();
-  factory ListPeersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersRequest clone() => ListPeersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) =>
-      super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) => super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1228,8 +1094,7 @@ class ListPeersRequest extends $pb.GeneratedMessage {
   ListPeersRequest createEmptyInstance() => create();
   static $pb.PbList<ListPeersRequest> createRepeated() => $pb.PbList<ListPeersRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
+  static ListPeersRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
   static ListPeersRequest? _defaultInstance;
 }
 
@@ -1244,26 +1109,24 @@ class ListPeersResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListPeersResponse._() : super();
-  factory ListPeersResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'peersJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersResponse clone() => ListPeersResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) =>
-      super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) => super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1272,17 +1135,13 @@ class ListPeersResponse extends $pb.GeneratedMessage {
   ListPeersResponse createEmptyInstance() => create();
   static $pb.PbList<ListPeersResponse> createRepeated() => $pb.PbList<ListPeersResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
+  static ListPeersResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
   static ListPeersResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get peersJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set peersJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set peersJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPeersJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1300,25 +1159,24 @@ class MineRequest extends $pb.GeneratedMessage {
     return $result;
   }
   MineRequest._() : super();
-  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineRequest clone() => MineRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineRequest copyWith(void Function(MineRequest) updates) =>
-      super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineRequest copyWith(void Function(MineRequest) updates) => super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1333,10 +1191,7 @@ class MineRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $fixnum.Int64 get feeSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasFeeSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -1354,25 +1209,24 @@ class MineResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MineResponse._() : super();
-  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bmmResultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineResponse clone() => MineResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineResponse copyWith(void Function(MineResponse) updates) =>
-      super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineResponse copyWith(void Function(MineResponse) updates) => super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1387,10 +1241,7 @@ class MineResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get bmmResultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bmmResultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bmmResultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBmmResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1408,26 +1259,24 @@ class GetBlockRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockRequest._() : super();
-  factory GetBlockRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockRequest clone() => GetBlockRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) => super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1436,17 +1285,13 @@ class GetBlockRequest extends $pb.GeneratedMessage {
   GetBlockRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockRequest> createRepeated() => $pb.PbList<GetBlockRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
+  static GetBlockRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
   static GetBlockRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1464,26 +1309,24 @@ class GetBlockResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockResponse._() : super();
-  factory GetBlockResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockResponse clone() => GetBlockResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) => super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1492,17 +1335,13 @@ class GetBlockResponse extends $pb.GeneratedMessage {
   GetBlockResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockResponse> createRepeated() => $pb.PbList<GetBlockResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
+  static GetBlockResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
   static GetBlockResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1512,38 +1351,32 @@ class GetBlockResponse extends $pb.GeneratedMessage {
 class GetBestMainchainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestMainchainBlockHashRequest() => create();
   GetBestMainchainBlockHashRequest._() : super();
-  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashRequest clone() => GetBestMainchainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest))
-          as GetBestMainchainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest)) as GetBestMainchainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashRequest create() => GetBestMainchainBlockHashRequest._();
   GetBestMainchainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashRequest>();
+  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() => $pb.PbList<GetBestMainchainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
+  static GetBestMainchainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
   static GetBestMainchainBlockHashRequest? _defaultInstance;
 }
 
@@ -1558,48 +1391,39 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestMainchainBlockHashResponse._() : super();
-  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashResponse clone() => GetBestMainchainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse))
-          as GetBestMainchainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse)) as GetBestMainchainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashResponse create() => GetBestMainchainBlockHashResponse._();
   GetBestMainchainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashResponse>();
+  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() => $pb.PbList<GetBestMainchainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
+  static GetBestMainchainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
   static GetBestMainchainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1609,38 +1433,32 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
 class GetBestSidechainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestSidechainBlockHashRequest() => create();
   GetBestSidechainBlockHashRequest._() : super();
-  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashRequest clone() => GetBestSidechainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest))
-          as GetBestSidechainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest)) as GetBestSidechainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashRequest create() => GetBestSidechainBlockHashRequest._();
   GetBestSidechainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashRequest>();
+  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() => $pb.PbList<GetBestSidechainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
+  static GetBestSidechainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
   static GetBestSidechainBlockHashRequest? _defaultInstance;
 }
 
@@ -1655,48 +1473,39 @@ class GetBestSidechainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestSidechainBlockHashResponse._() : super();
-  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashResponse clone() => GetBestSidechainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse))
-          as GetBestSidechainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse)) as GetBestSidechainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashResponse create() => GetBestSidechainBlockHashResponse._();
   GetBestSidechainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashResponse>();
+  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() => $pb.PbList<GetBestSidechainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
+  static GetBestSidechainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
   static GetBestSidechainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1714,26 +1523,24 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsRequest._() : super();
-  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockHash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsRequest clone() => GetBmmInclusionsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1742,17 +1549,13 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
   GetBmmInclusionsRequest createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsRequest> createRepeated() => $pb.PbList<GetBmmInclusionsRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
+  static GetBmmInclusionsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
   static GetBmmInclusionsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockHash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockHash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockHash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1770,26 +1573,24 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsResponse._() : super();
-  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'inclusions')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsResponse clone() => GetBmmInclusionsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1798,17 +1599,13 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
   GetBmmInclusionsResponse createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsResponse> createRepeated() => $pb.PbList<GetBmmInclusionsResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
+  static GetBmmInclusionsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
   static GetBmmInclusionsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get inclusions => $_getSZ(0);
   @$pb.TagNumber(1)
-  set inclusions($core.String v) {
-    $_setString(0, v);
-  }
-
+  set inclusions($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasInclusions() => $_has(0);
   @$pb.TagNumber(1)
@@ -1818,25 +1615,23 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
 class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   factory GetWalletUtxosRequest() => create();
   GetWalletUtxosRequest._() : super();
-  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosRequest clone() => GetWalletUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) => super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1845,8 +1640,7 @@ class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   GetWalletUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosRequest> createRepeated() => $pb.PbList<GetWalletUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
+  static GetWalletUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
   static GetWalletUtxosRequest? _defaultInstance;
 }
 
@@ -1861,26 +1655,24 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletUtxosResponse._() : super();
-  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosResponse clone() => GetWalletUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) => super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1889,17 +1681,13 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
   GetWalletUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosResponse> createRepeated() => $pb.PbList<GetWalletUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
+  static GetWalletUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
   static GetWalletUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1909,25 +1697,23 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
 class ListUtxosRequest extends $pb.GeneratedMessage {
   factory ListUtxosRequest() => create();
   ListUtxosRequest._() : super();
-  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosRequest clone() => ListUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) => super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1936,8 +1722,7 @@ class ListUtxosRequest extends $pb.GeneratedMessage {
   ListUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<ListUtxosRequest> createRepeated() => $pb.PbList<ListUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
+  static ListUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
   static ListUtxosRequest? _defaultInstance;
 }
 
@@ -1952,26 +1737,24 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListUtxosResponse._() : super();
-  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosResponse clone() => ListUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) => super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1980,17 +1763,13 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
   ListUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<ListUtxosResponse> createRepeated() => $pb.PbList<ListUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
+  static ListUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
   static ListUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2008,26 +1787,24 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
     return $result;
   }
   RemoveFromMempoolRequest._() : super();
-  factory RemoveFromMempoolRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFromMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFromMempoolRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFromMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveFromMempoolRequest clone() => RemoveFromMempoolRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveFromMempoolRequest copyWith(void Function(RemoveFromMempoolRequest) updates) =>
-      super.copyWith((message) => updates(message as RemoveFromMempoolRequest)) as RemoveFromMempoolRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveFromMempoolRequest copyWith(void Function(RemoveFromMempoolRequest) updates) => super.copyWith((message) => updates(message as RemoveFromMempoolRequest)) as RemoveFromMempoolRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2036,17 +1813,13 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
   RemoveFromMempoolRequest createEmptyInstance() => create();
   static $pb.PbList<RemoveFromMempoolRequest> createRepeated() => $pb.PbList<RemoveFromMempoolRequest>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFromMempoolRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolRequest>(create);
+  static RemoveFromMempoolRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolRequest>(create);
   static RemoveFromMempoolRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2056,25 +1829,23 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
 class RemoveFromMempoolResponse extends $pb.GeneratedMessage {
   factory RemoveFromMempoolResponse() => create();
   RemoveFromMempoolResponse._() : super();
-  factory RemoveFromMempoolResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFromMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFromMempoolResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFromMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveFromMempoolResponse clone() => RemoveFromMempoolResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveFromMempoolResponse copyWith(void Function(RemoveFromMempoolResponse) updates) =>
-      super.copyWith((message) => updates(message as RemoveFromMempoolResponse)) as RemoveFromMempoolResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveFromMempoolResponse copyWith(void Function(RemoveFromMempoolResponse) updates) => super.copyWith((message) => updates(message as RemoveFromMempoolResponse)) as RemoveFromMempoolResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2083,50 +1854,39 @@ class RemoveFromMempoolResponse extends $pb.GeneratedMessage {
   RemoveFromMempoolResponse createEmptyInstance() => create();
   static $pb.PbList<RemoveFromMempoolResponse> createRepeated() => $pb.PbList<RemoveFromMempoolResponse>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFromMempoolResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolResponse>(create);
+  static RemoveFromMempoolResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolResponse>(create);
   static RemoveFromMempoolResponse? _defaultInstance;
 }
 
 class GetLatestFailedWithdrawalBundleHeightRequest extends $pb.GeneratedMessage {
   factory GetLatestFailedWithdrawalBundleHeightRequest() => create();
   GetLatestFailedWithdrawalBundleHeightRequest._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'),
-      createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest clone() =>
-      GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest))
-          as GetLatestFailedWithdrawalBundleHeightRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest clone() => GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest copyWith(void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest)) as GetLatestFailedWithdrawalBundleHeightRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightRequest create() => GetLatestFailedWithdrawalBundleHeightRequest._();
   GetLatestFailedWithdrawalBundleHeightRequest createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
+  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
   static GetLatestFailedWithdrawalBundleHeightRequest? _defaultInstance;
 }
 
@@ -2141,53 +1901,40 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
     return $result;
   }
   GetLatestFailedWithdrawalBundleHeightResponse._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'height')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse clone() =>
-      GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse))
-          as GetLatestFailedWithdrawalBundleHeightResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse clone() => GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse copyWith(void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse)) as GetLatestFailedWithdrawalBundleHeightResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightResponse create() => GetLatestFailedWithdrawalBundleHeightResponse._();
   GetLatestFailedWithdrawalBundleHeightResponse createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
+  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
   static GetLatestFailedWithdrawalBundleHeightResponse? _defaultInstance;
 
   /// 0 means no failed bundle.
   @$pb.TagNumber(1)
   $fixnum.Int64 get height => $_getI64(0);
   @$pb.TagNumber(1)
-  set height($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set height($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHeight() => $_has(0);
   @$pb.TagNumber(1)
@@ -2197,25 +1944,23 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
 class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   factory GenerateMnemonicRequest() => create();
   GenerateMnemonicRequest._() : super();
-  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicRequest clone() => GenerateMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) => super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2224,8 +1969,7 @@ class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   GenerateMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicRequest> createRepeated() => $pb.PbList<GenerateMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
+  static GenerateMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
   static GenerateMnemonicRequest? _defaultInstance;
 }
 
@@ -2240,26 +1984,24 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GenerateMnemonicResponse._() : super();
-  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicResponse clone() => GenerateMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) => super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2268,17 +2010,13 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
   GenerateMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicResponse> createRepeated() => $pb.PbList<GenerateMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
+  static GenerateMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
   static GenerateMnemonicResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2296,27 +2034,24 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SetSeedFromMnemonicRequest._() : super();
-  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicRequest clone() => SetSeedFromMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2325,17 +2060,13 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
   SetSeedFromMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicRequest> createRepeated() => $pb.PbList<SetSeedFromMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
+  static SetSeedFromMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
   static SetSeedFromMnemonicRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2345,26 +2076,23 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
 class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   factory SetSeedFromMnemonicResponse() => create();
   SetSeedFromMnemonicResponse._() : super();
-  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicResponse clone() => SetSeedFromMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2373,8 +2101,7 @@ class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   SetSeedFromMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicResponse> createRepeated() => $pb.PbList<SetSeedFromMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
+  static SetSeedFromMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
   static SetSeedFromMnemonicResponse? _defaultInstance;
 }
 
@@ -2393,26 +2120,25 @@ class CallRawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawRequest._() : super();
-  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'method')
     ..aOS(2, _omitFieldNames ? '' : 'paramsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawRequest clone() => CallRawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawRequest copyWith(void Function(CallRawRequest) updates) =>
-      super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawRequest copyWith(void Function(CallRawRequest) updates) => super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2427,10 +2153,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get method => $_getSZ(0);
   @$pb.TagNumber(1)
-  set method($core.String v) {
-    $_setString(0, v);
-  }
-
+  set method($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMethod() => $_has(0);
   @$pb.TagNumber(1)
@@ -2439,10 +2162,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get paramsJson => $_getSZ(1);
   @$pb.TagNumber(2)
-  set paramsJson($core.String v) {
-    $_setString(1, v);
-  }
-
+  set paramsJson($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasParamsJson() => $_has(1);
   @$pb.TagNumber(2)
@@ -2460,26 +2180,24 @@ class CallRawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawResponse._() : super();
-  factory CallRawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'resultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawResponse clone() => CallRawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawResponse copyWith(void Function(CallRawResponse) updates) =>
-      super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawResponse copyWith(void Function(CallRawResponse) updates) => super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2488,17 +2206,13 @@ class CallRawResponse extends $pb.GeneratedMessage {
   CallRawResponse createEmptyInstance() => create();
   static $pb.PbList<CallRawResponse> createRepeated() => $pb.PbList<CallRawResponse>();
   @$core.pragma('dart2js:noInline')
-  static CallRawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
+  static CallRawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
   static CallRawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get resultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set resultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set resultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2508,25 +2222,23 @@ class CallRawResponse extends $pb.GeneratedMessage {
 class GetWalletAddressesRequest extends $pb.GeneratedMessage {
   factory GetWalletAddressesRequest() => create();
   GetWalletAddressesRequest._() : super();
-  factory GetWalletAddressesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletAddressesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletAddressesRequest clone() => GetWalletAddressesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletAddressesRequest copyWith(void Function(GetWalletAddressesRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletAddressesRequest)) as GetWalletAddressesRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletAddressesRequest copyWith(void Function(GetWalletAddressesRequest) updates) => super.copyWith((message) => updates(message as GetWalletAddressesRequest)) as GetWalletAddressesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2535,8 +2247,7 @@ class GetWalletAddressesRequest extends $pb.GeneratedMessage {
   GetWalletAddressesRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletAddressesRequest> createRepeated() => $pb.PbList<GetWalletAddressesRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletAddressesRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesRequest>(create);
+  static GetWalletAddressesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesRequest>(create);
   static GetWalletAddressesRequest? _defaultInstance;
 }
 
@@ -2551,27 +2262,24 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletAddressesResponse._() : super();
-  factory GetWalletAddressesResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletAddressesResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletAddressesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletAddressesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'photon.v1'), createEmptyInstance: create)
     ..pPS(1, _omitFieldNames ? '' : 'addresses')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletAddressesResponse clone() => GetWalletAddressesResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletAddressesResponse copyWith(void Function(GetWalletAddressesResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletAddressesResponse)) as GetWalletAddressesResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletAddressesResponse copyWith(void Function(GetWalletAddressesResponse) updates) => super.copyWith((message) => updates(message as GetWalletAddressesResponse)) as GetWalletAddressesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2580,8 +2288,7 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
   GetWalletAddressesResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletAddressesResponse> createRepeated() => $pb.PbList<GetWalletAddressesResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletAddressesResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesResponse>(create);
+  static GetWalletAddressesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesResponse>(create);
   static GetWalletAddressesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -2593,74 +2300,82 @@ class PhotonServiceApi {
   PhotonServiceApi(this._client);
 
   $async.Future<GetBalanceResponse> getBalance($pb.ClientContext? ctx, GetBalanceRequest request) =>
-      _client.invoke<GetBalanceResponse>(ctx, 'PhotonService', 'GetBalance', request, GetBalanceResponse());
+    _client.invoke<GetBalanceResponse>(ctx, 'PhotonService', 'GetBalance', request, GetBalanceResponse())
+  ;
   $async.Future<GetBlockCountResponse> getBlockCount($pb.ClientContext? ctx, GetBlockCountRequest request) =>
-      _client.invoke<GetBlockCountResponse>(ctx, 'PhotonService', 'GetBlockCount', request, GetBlockCountResponse());
+    _client.invoke<GetBlockCountResponse>(ctx, 'PhotonService', 'GetBlockCount', request, GetBlockCountResponse())
+  ;
   $async.Future<StopResponse> stop($pb.ClientContext? ctx, StopRequest request) =>
-      _client.invoke<StopResponse>(ctx, 'PhotonService', 'Stop', request, StopResponse());
+    _client.invoke<StopResponse>(ctx, 'PhotonService', 'Stop', request, StopResponse())
+  ;
   $async.Future<GetNewAddressResponse> getNewAddress($pb.ClientContext? ctx, GetNewAddressRequest request) =>
-      _client.invoke<GetNewAddressResponse>(ctx, 'PhotonService', 'GetNewAddress', request, GetNewAddressResponse());
+    _client.invoke<GetNewAddressResponse>(ctx, 'PhotonService', 'GetNewAddress', request, GetNewAddressResponse())
+  ;
   $async.Future<WithdrawResponse> withdraw($pb.ClientContext? ctx, WithdrawRequest request) =>
-      _client.invoke<WithdrawResponse>(ctx, 'PhotonService', 'Withdraw', request, WithdrawResponse());
+    _client.invoke<WithdrawResponse>(ctx, 'PhotonService', 'Withdraw', request, WithdrawResponse())
+  ;
   $async.Future<TransferResponse> transfer($pb.ClientContext? ctx, TransferRequest request) =>
-      _client.invoke<TransferResponse>(ctx, 'PhotonService', 'Transfer', request, TransferResponse());
-  $async.Future<GetSidechainWealthResponse> getSidechainWealth(
-          $pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
-      _client.invoke<GetSidechainWealthResponse>(
-          ctx, 'PhotonService', 'GetSidechainWealth', request, GetSidechainWealthResponse());
+    _client.invoke<TransferResponse>(ctx, 'PhotonService', 'Transfer', request, TransferResponse())
+  ;
+  $async.Future<GetSidechainWealthResponse> getSidechainWealth($pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
+    _client.invoke<GetSidechainWealthResponse>(ctx, 'PhotonService', 'GetSidechainWealth', request, GetSidechainWealthResponse())
+  ;
   $async.Future<CreateDepositResponse> createDeposit($pb.ClientContext? ctx, CreateDepositRequest request) =>
-      _client.invoke<CreateDepositResponse>(ctx, 'PhotonService', 'CreateDeposit', request, CreateDepositResponse());
-  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-          $pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
-      _client.invoke<GetPendingWithdrawalBundleResponse>(
-          ctx, 'PhotonService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse());
+    _client.invoke<CreateDepositResponse>(ctx, 'PhotonService', 'CreateDeposit', request, CreateDepositResponse())
+  ;
+  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
+    _client.invoke<GetPendingWithdrawalBundleResponse>(ctx, 'PhotonService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse())
+  ;
   $async.Future<ConnectPeerResponse> connectPeer($pb.ClientContext? ctx, ConnectPeerRequest request) =>
-      _client.invoke<ConnectPeerResponse>(ctx, 'PhotonService', 'ConnectPeer', request, ConnectPeerResponse());
+    _client.invoke<ConnectPeerResponse>(ctx, 'PhotonService', 'ConnectPeer', request, ConnectPeerResponse())
+  ;
   $async.Future<ForgetPeerResponse> forgetPeer($pb.ClientContext? ctx, ForgetPeerRequest request) =>
-      _client.invoke<ForgetPeerResponse>(ctx, 'PhotonService', 'ForgetPeer', request, ForgetPeerResponse());
+    _client.invoke<ForgetPeerResponse>(ctx, 'PhotonService', 'ForgetPeer', request, ForgetPeerResponse())
+  ;
   $async.Future<ListPeersResponse> listPeers($pb.ClientContext? ctx, ListPeersRequest request) =>
-      _client.invoke<ListPeersResponse>(ctx, 'PhotonService', 'ListPeers', request, ListPeersResponse());
+    _client.invoke<ListPeersResponse>(ctx, 'PhotonService', 'ListPeers', request, ListPeersResponse())
+  ;
   $async.Future<MineResponse> mine($pb.ClientContext? ctx, MineRequest request) =>
-      _client.invoke<MineResponse>(ctx, 'PhotonService', 'Mine', request, MineResponse());
+    _client.invoke<MineResponse>(ctx, 'PhotonService', 'Mine', request, MineResponse())
+  ;
   $async.Future<GetBlockResponse> getBlock($pb.ClientContext? ctx, GetBlockRequest request) =>
-      _client.invoke<GetBlockResponse>(ctx, 'PhotonService', 'GetBlock', request, GetBlockResponse());
-  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-          $pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
-      _client.invoke<GetBestMainchainBlockHashResponse>(
-          ctx, 'PhotonService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse());
-  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-          $pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
-      _client.invoke<GetBestSidechainBlockHashResponse>(
-          ctx, 'PhotonService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse());
+    _client.invoke<GetBlockResponse>(ctx, 'PhotonService', 'GetBlock', request, GetBlockResponse())
+  ;
+  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
+    _client.invoke<GetBestMainchainBlockHashResponse>(ctx, 'PhotonService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse())
+  ;
+  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
+    _client.invoke<GetBestSidechainBlockHashResponse>(ctx, 'PhotonService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse())
+  ;
   $async.Future<GetBmmInclusionsResponse> getBmmInclusions($pb.ClientContext? ctx, GetBmmInclusionsRequest request) =>
-      _client.invoke<GetBmmInclusionsResponse>(
-          ctx, 'PhotonService', 'GetBmmInclusions', request, GetBmmInclusionsResponse());
+    _client.invoke<GetBmmInclusionsResponse>(ctx, 'PhotonService', 'GetBmmInclusions', request, GetBmmInclusionsResponse())
+  ;
   $async.Future<GetWalletUtxosResponse> getWalletUtxos($pb.ClientContext? ctx, GetWalletUtxosRequest request) =>
-      _client.invoke<GetWalletUtxosResponse>(ctx, 'PhotonService', 'GetWalletUtxos', request, GetWalletUtxosResponse());
+    _client.invoke<GetWalletUtxosResponse>(ctx, 'PhotonService', 'GetWalletUtxos', request, GetWalletUtxosResponse())
+  ;
   $async.Future<ListUtxosResponse> listUtxos($pb.ClientContext? ctx, ListUtxosRequest request) =>
-      _client.invoke<ListUtxosResponse>(ctx, 'PhotonService', 'ListUtxos', request, ListUtxosResponse());
-  $async.Future<RemoveFromMempoolResponse> removeFromMempool(
-          $pb.ClientContext? ctx, RemoveFromMempoolRequest request) =>
-      _client.invoke<RemoveFromMempoolResponse>(
-          ctx, 'PhotonService', 'RemoveFromMempool', request, RemoveFromMempoolResponse());
-  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-          $pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
-      _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'PhotonService',
-          'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse());
+    _client.invoke<ListUtxosResponse>(ctx, 'PhotonService', 'ListUtxos', request, ListUtxosResponse())
+  ;
+  $async.Future<RemoveFromMempoolResponse> removeFromMempool($pb.ClientContext? ctx, RemoveFromMempoolRequest request) =>
+    _client.invoke<RemoveFromMempoolResponse>(ctx, 'PhotonService', 'RemoveFromMempool', request, RemoveFromMempoolResponse())
+  ;
+  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
+    _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'PhotonService', 'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse())
+  ;
   $async.Future<GenerateMnemonicResponse> generateMnemonic($pb.ClientContext? ctx, GenerateMnemonicRequest request) =>
-      _client.invoke<GenerateMnemonicResponse>(
-          ctx, 'PhotonService', 'GenerateMnemonic', request, GenerateMnemonicResponse());
-  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-          $pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
-      _client.invoke<SetSeedFromMnemonicResponse>(
-          ctx, 'PhotonService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse());
+    _client.invoke<GenerateMnemonicResponse>(ctx, 'PhotonService', 'GenerateMnemonic', request, GenerateMnemonicResponse())
+  ;
+  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
+    _client.invoke<SetSeedFromMnemonicResponse>(ctx, 'PhotonService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse())
+  ;
   $async.Future<CallRawResponse> callRaw($pb.ClientContext? ctx, CallRawRequest request) =>
-      _client.invoke<CallRawResponse>(ctx, 'PhotonService', 'CallRaw', request, CallRawResponse());
-  $async.Future<GetWalletAddressesResponse> getWalletAddresses(
-          $pb.ClientContext? ctx, GetWalletAddressesRequest request) =>
-      _client.invoke<GetWalletAddressesResponse>(
-          ctx, 'PhotonService', 'GetWalletAddresses', request, GetWalletAddressesResponse());
+    _client.invoke<CallRawResponse>(ctx, 'PhotonService', 'CallRaw', request, CallRawResponse())
+  ;
+  $async.Future<GetWalletAddressesResponse> getWalletAddresses($pb.ClientContext? ctx, GetWalletAddressesRequest request) =>
+    _client.invoke<GetWalletAddressesResponse>(ctx, 'PhotonService', 'GetWalletAddresses', request, GetWalletAddressesResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/photon/v1/photon.pbenum.dart
+++ b/sail_ui/lib/gen/photon/v1/photon.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/photon/v1/photon.pbjson.dart
+++ b/sail_ui/lib/gen/photon/v1/photon.pbjson.dart
@@ -19,7 +19,8 @@ const GetBalanceRequest$json = {
 };
 
 /// Descriptor for `GetBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode('ChFHZXRCYWxhbmNlUmVxdWVzdA==');
+final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode(
+    'ChFHZXRCYWxhbmNlUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBalanceResponseDescriptor instead')
 const GetBalanceResponse$json = {
@@ -31,9 +32,9 @@ const GetBalanceResponse$json = {
 };
 
 /// Descriptor for `GetBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceResponseDescriptor =
-    $convert.base64Decode('ChJHZXRCYWxhbmNlUmVzcG9uc2USHQoKdG90YWxfc2F0cxgBIAEoA1IJdG90YWxTYXRzEiUKDm'
-        'F2YWlsYWJsZV9zYXRzGAIgASgDUg1hdmFpbGFibGVTYXRz');
+final $typed_data.Uint8List getBalanceResponseDescriptor = $convert.base64Decode(
+    'ChJHZXRCYWxhbmNlUmVzcG9uc2USHQoKdG90YWxfc2F0cxgBIAEoA1IJdG90YWxTYXRzEiUKDm'
+    'F2YWlsYWJsZV9zYXRzGAIgASgDUg1hdmFpbGFibGVTYXRz');
 
 @$core.Deprecated('Use getBlockCountRequestDescriptor instead')
 const GetBlockCountRequest$json = {
@@ -41,7 +42,8 @@ const GetBlockCountRequest$json = {
 };
 
 /// Descriptor for `GetBlockCountRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode('ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
+final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
 
 @$core.Deprecated('Use getBlockCountResponseDescriptor instead')
 const GetBlockCountResponse$json = {
@@ -52,8 +54,8 @@ const GetBlockCountResponse$json = {
 };
 
 /// Descriptor for `GetBlockCountResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountResponseDescriptor =
-    $convert.base64Decode('ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
+final $typed_data.Uint8List getBlockCountResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
 
 @$core.Deprecated('Use stopRequestDescriptor instead')
 const StopRequest$json = {
@@ -61,7 +63,8 @@ const StopRequest$json = {
 };
 
 /// Descriptor for `StopRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode('CgtTdG9wUmVxdWVzdA==');
+final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode(
+    'CgtTdG9wUmVxdWVzdA==');
 
 @$core.Deprecated('Use stopResponseDescriptor instead')
 const StopResponse$json = {
@@ -69,7 +72,8 @@ const StopResponse$json = {
 };
 
 /// Descriptor for `StopResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode('CgxTdG9wUmVzcG9uc2U=');
+final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode(
+    'CgxTdG9wUmVzcG9uc2U=');
 
 @$core.Deprecated('Use getNewAddressRequestDescriptor instead')
 const GetNewAddressRequest$json = {
@@ -77,7 +81,8 @@ const GetNewAddressRequest$json = {
 };
 
 /// Descriptor for `GetNewAddressRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode('ChRHZXROZXdBZGRyZXNzUmVxdWVzdA==');
+final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode(
+    'ChRHZXROZXdBZGRyZXNzUmVxdWVzdA==');
 
 @$core.Deprecated('Use getNewAddressResponseDescriptor instead')
 const GetNewAddressResponse$json = {
@@ -88,8 +93,8 @@ const GetNewAddressResponse$json = {
 };
 
 /// Descriptor for `GetNewAddressResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressResponseDescriptor =
-    $convert.base64Decode('ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List getNewAddressResponseDescriptor = $convert.base64Decode(
+    'ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use withdrawRequestDescriptor instead')
 const WithdrawRequest$json = {
@@ -103,10 +108,10 @@ const WithdrawRequest$json = {
 };
 
 /// Descriptor for `WithdrawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawRequestDescriptor =
-    $convert.base64Decode('Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
-        'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
+final $typed_data.Uint8List withdrawRequestDescriptor = $convert.base64Decode(
+    'Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
+    'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
 
 @$core.Deprecated('Use withdrawResponseDescriptor instead')
 const WithdrawResponse$json = {
@@ -117,8 +122,8 @@ const WithdrawResponse$json = {
 };
 
 /// Descriptor for `WithdrawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawResponseDescriptor =
-    $convert.base64Decode('ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List withdrawResponseDescriptor = $convert.base64Decode(
+    'ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use transferRequestDescriptor instead')
 const TransferRequest$json = {
@@ -131,9 +136,9 @@ const TransferRequest$json = {
 };
 
 /// Descriptor for `TransferRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferRequestDescriptor =
-    $convert.base64Decode('Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List transferRequestDescriptor = $convert.base64Decode(
+    'Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use transferResponseDescriptor instead')
 const TransferResponse$json = {
@@ -144,8 +149,8 @@ const TransferResponse$json = {
 };
 
 /// Descriptor for `TransferResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferResponseDescriptor =
-    $convert.base64Decode('ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List transferResponseDescriptor = $convert.base64Decode(
+    'ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use getSidechainWealthRequestDescriptor instead')
 const GetSidechainWealthRequest$json = {
@@ -153,8 +158,8 @@ const GetSidechainWealthRequest$json = {
 };
 
 /// Descriptor for `GetSidechainWealthRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthRequestDescriptor =
-    $convert.base64Decode('ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
+final $typed_data.Uint8List getSidechainWealthRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
 
 @$core.Deprecated('Use getSidechainWealthResponseDescriptor instead')
 const GetSidechainWealthResponse$json = {
@@ -165,8 +170,8 @@ const GetSidechainWealthResponse$json = {
 };
 
 /// Descriptor for `GetSidechainWealthResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthResponseDescriptor =
-    $convert.base64Decode('ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
+final $typed_data.Uint8List getSidechainWealthResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
 
 @$core.Deprecated('Use createDepositRequestDescriptor instead')
 const CreateDepositRequest$json = {
@@ -179,9 +184,9 @@ const CreateDepositRequest$json = {
 };
 
 /// Descriptor for `CreateDepositRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositRequestDescriptor =
-    $convert.base64Decode('ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
-        'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List createDepositRequestDescriptor = $convert.base64Decode(
+    'ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
+    'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use createDepositResponseDescriptor instead')
 const CreateDepositResponse$json = {
@@ -192,8 +197,8 @@ const CreateDepositResponse$json = {
 };
 
 /// Descriptor for `CreateDepositResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositResponseDescriptor =
-    $convert.base64Decode('ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List createDepositResponseDescriptor = $convert.base64Decode(
+    'ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleRequestDescriptor instead')
 const GetPendingWithdrawalBundleRequest$json = {
@@ -201,8 +206,8 @@ const GetPendingWithdrawalBundleRequest$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor =
-    $convert.base64Decode('CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
+final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor = $convert.base64Decode(
+    'CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleResponseDescriptor instead')
 const GetPendingWithdrawalBundleResponse$json = {
@@ -213,9 +218,9 @@ const GetPendingWithdrawalBundleResponse$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor =
-    $convert.base64Decode('CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
-        'gJUgpidW5kbGVKc29u');
+final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor = $convert.base64Decode(
+    'CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
+    'gJUgpidW5kbGVKc29u');
 
 @$core.Deprecated('Use connectPeerRequestDescriptor instead')
 const ConnectPeerRequest$json = {
@@ -226,8 +231,8 @@ const ConnectPeerRequest$json = {
 };
 
 /// Descriptor for `ConnectPeerRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerRequestDescriptor =
-    $convert.base64Decode('ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List connectPeerRequestDescriptor = $convert.base64Decode(
+    'ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use connectPeerResponseDescriptor instead')
 const ConnectPeerResponse$json = {
@@ -235,7 +240,8 @@ const ConnectPeerResponse$json = {
 };
 
 /// Descriptor for `ConnectPeerResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode('ChNDb25uZWN0UGVlclJlc3BvbnNl');
+final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode(
+    'ChNDb25uZWN0UGVlclJlc3BvbnNl');
 
 @$core.Deprecated('Use forgetPeerRequestDescriptor instead')
 const ForgetPeerRequest$json = {
@@ -246,8 +252,8 @@ const ForgetPeerRequest$json = {
 };
 
 /// Descriptor for `ForgetPeerRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List forgetPeerRequestDescriptor =
-    $convert.base64Decode('ChFGb3JnZXRQZWVyUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNz');
+final $typed_data.Uint8List forgetPeerRequestDescriptor = $convert.base64Decode(
+    'ChFGb3JnZXRQZWVyUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNz');
 
 @$core.Deprecated('Use forgetPeerResponseDescriptor instead')
 const ForgetPeerResponse$json = {
@@ -255,7 +261,8 @@ const ForgetPeerResponse$json = {
 };
 
 /// Descriptor for `ForgetPeerResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List forgetPeerResponseDescriptor = $convert.base64Decode('ChJGb3JnZXRQZWVyUmVzcG9uc2U=');
+final $typed_data.Uint8List forgetPeerResponseDescriptor = $convert.base64Decode(
+    'ChJGb3JnZXRQZWVyUmVzcG9uc2U=');
 
 @$core.Deprecated('Use listPeersRequestDescriptor instead')
 const ListPeersRequest$json = {
@@ -263,7 +270,8 @@ const ListPeersRequest$json = {
 };
 
 /// Descriptor for `ListPeersRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode('ChBMaXN0UGVlcnNSZXF1ZXN0');
+final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0UGVlcnNSZXF1ZXN0');
 
 @$core.Deprecated('Use listPeersResponseDescriptor instead')
 const ListPeersResponse$json = {
@@ -274,8 +282,8 @@ const ListPeersResponse$json = {
 };
 
 /// Descriptor for `ListPeersResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
+final $typed_data.Uint8List listPeersResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
 
 @$core.Deprecated('Use mineRequestDescriptor instead')
 const MineRequest$json = {
@@ -286,8 +294,8 @@ const MineRequest$json = {
 };
 
 /// Descriptor for `MineRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineRequestDescriptor =
-    $convert.base64Decode('CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List mineRequestDescriptor = $convert.base64Decode(
+    'CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use mineResponseDescriptor instead')
 const MineResponse$json = {
@@ -298,8 +306,8 @@ const MineResponse$json = {
 };
 
 /// Descriptor for `MineResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineResponseDescriptor =
-    $convert.base64Decode('CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
+final $typed_data.Uint8List mineResponseDescriptor = $convert.base64Decode(
+    'CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
 
 @$core.Deprecated('Use getBlockRequestDescriptor instead')
 const GetBlockRequest$json = {
@@ -310,8 +318,8 @@ const GetBlockRequest$json = {
 };
 
 /// Descriptor for `GetBlockRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockRequestDescriptor =
-    $convert.base64Decode('Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
+final $typed_data.Uint8List getBlockRequestDescriptor = $convert.base64Decode(
+    'Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
 
 @$core.Deprecated('Use getBlockResponseDescriptor instead')
 const GetBlockResponse$json = {
@@ -322,8 +330,8 @@ const GetBlockResponse$json = {
 };
 
 /// Descriptor for `GetBlockResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockResponseDescriptor =
-    $convert.base64Decode('ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
+final $typed_data.Uint8List getBlockResponseDescriptor = $convert.base64Decode(
+    'ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashRequestDescriptor instead')
 const GetBestMainchainBlockHashRequest$json = {
@@ -331,8 +339,8 @@ const GetBestMainchainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashResponseDescriptor instead')
 const GetBestMainchainBlockHashResponse$json = {
@@ -343,9 +351,9 @@ const GetBestMainchainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashRequestDescriptor instead')
 const GetBestSidechainBlockHashRequest$json = {
@@ -353,8 +361,8 @@ const GetBestSidechainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashResponseDescriptor instead')
 const GetBestSidechainBlockHashResponse$json = {
@@ -365,9 +373,9 @@ const GetBestSidechainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBmmInclusionsRequestDescriptor instead')
 const GetBmmInclusionsRequest$json = {
@@ -378,9 +386,9 @@ const GetBmmInclusionsRequest$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsRequestDescriptor =
-    $convert.base64Decode('ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
-        'g=');
+final $typed_data.Uint8List getBmmInclusionsRequestDescriptor = $convert.base64Decode(
+    'ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
+    'g=');
 
 @$core.Deprecated('Use getBmmInclusionsResponseDescriptor instead')
 const GetBmmInclusionsResponse$json = {
@@ -391,9 +399,9 @@ const GetBmmInclusionsResponse$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsResponseDescriptor =
-    $convert.base64Decode('ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
-        '9ucw==');
+final $typed_data.Uint8List getBmmInclusionsResponseDescriptor = $convert.base64Decode(
+    'ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
+    '9ucw==');
 
 @$core.Deprecated('Use getWalletUtxosRequestDescriptor instead')
 const GetWalletUtxosRequest$json = {
@@ -401,7 +409,8 @@ const GetWalletUtxosRequest$json = {
 };
 
 /// Descriptor for `GetWalletUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode('ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
+final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode(
+    'ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getWalletUtxosResponseDescriptor instead')
 const GetWalletUtxosResponse$json = {
@@ -412,9 +421,9 @@ const GetWalletUtxosResponse$json = {
 };
 
 /// Descriptor for `GetWalletUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosResponseDescriptor =
-    $convert.base64Decode('ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
-        '==');
+final $typed_data.Uint8List getWalletUtxosResponseDescriptor = $convert.base64Decode(
+    'ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
+    '==');
 
 @$core.Deprecated('Use listUtxosRequestDescriptor instead')
 const ListUtxosRequest$json = {
@@ -422,7 +431,8 @@ const ListUtxosRequest$json = {
 };
 
 /// Descriptor for `ListUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode('ChBMaXN0VXR4b3NSZXF1ZXN0');
+final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0VXR4b3NSZXF1ZXN0');
 
 @$core.Deprecated('Use listUtxosResponseDescriptor instead')
 const ListUtxosResponse$json = {
@@ -433,8 +443,8 @@ const ListUtxosResponse$json = {
 };
 
 /// Descriptor for `ListUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
+final $typed_data.Uint8List listUtxosResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
 
 @$core.Deprecated('Use removeFromMempoolRequestDescriptor instead')
 const RemoveFromMempoolRequest$json = {
@@ -445,8 +455,8 @@ const RemoveFromMempoolRequest$json = {
 };
 
 /// Descriptor for `RemoveFromMempoolRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFromMempoolRequestDescriptor =
-    $convert.base64Decode('ChhSZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List removeFromMempoolRequestDescriptor = $convert.base64Decode(
+    'ChhSZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use removeFromMempoolResponseDescriptor instead')
 const RemoveFromMempoolResponse$json = {
@@ -454,8 +464,8 @@ const RemoveFromMempoolResponse$json = {
 };
 
 /// Descriptor for `RemoveFromMempoolResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFromMempoolResponseDescriptor =
-    $convert.base64Decode('ChlSZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNl');
+final $typed_data.Uint8List removeFromMempoolResponseDescriptor = $convert.base64Decode(
+    'ChlSZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNl');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightRequestDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightRequest$json = {
@@ -463,8 +473,8 @@ const GetLatestFailedWithdrawalBundleHeightRequest$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor =
-    $convert.base64Decode('CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor = $convert.base64Decode(
+    'CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightResponseDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightResponse$json = {
@@ -475,9 +485,9 @@ const GetLatestFailedWithdrawalBundleHeightResponse$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor =
-    $convert.base64Decode('Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
-        'h0GAEgASgDUgZoZWlnaHQ=');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor = $convert.base64Decode(
+    'Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
+    'h0GAEgASgDUgZoZWlnaHQ=');
 
 @$core.Deprecated('Use generateMnemonicRequestDescriptor instead')
 const GenerateMnemonicRequest$json = {
@@ -485,8 +495,8 @@ const GenerateMnemonicRequest$json = {
 };
 
 /// Descriptor for `GenerateMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicRequestDescriptor =
-    $convert.base64Decode('ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
+final $typed_data.Uint8List generateMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
 
 @$core.Deprecated('Use generateMnemonicResponseDescriptor instead')
 const GenerateMnemonicResponse$json = {
@@ -497,8 +507,8 @@ const GenerateMnemonicResponse$json = {
 };
 
 /// Descriptor for `GenerateMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicResponseDescriptor =
-    $convert.base64Decode('ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
+final $typed_data.Uint8List generateMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
 
 @$core.Deprecated('Use setSeedFromMnemonicRequestDescriptor instead')
 const SetSeedFromMnemonicRequest$json = {
@@ -509,9 +519,9 @@ const SetSeedFromMnemonicRequest$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor =
-    $convert.base64Decode('ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
-        'M=');
+final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
+    'M=');
 
 @$core.Deprecated('Use setSeedFromMnemonicResponseDescriptor instead')
 const SetSeedFromMnemonicResponse$json = {
@@ -519,8 +529,8 @@ const SetSeedFromMnemonicResponse$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor =
-    $convert.base64Decode('ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
+final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
 
 @$core.Deprecated('Use callRawRequestDescriptor instead')
 const CallRawRequest$json = {
@@ -532,9 +542,9 @@ const CallRawRequest$json = {
 };
 
 /// Descriptor for `CallRawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawRequestDescriptor =
-    $convert.base64Decode('Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
-        'gCIAEoCVIKcGFyYW1zSnNvbg==');
+final $typed_data.Uint8List callRawRequestDescriptor = $convert.base64Decode(
+    'Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
+    'gCIAEoCVIKcGFyYW1zSnNvbg==');
 
 @$core.Deprecated('Use callRawResponseDescriptor instead')
 const CallRawResponse$json = {
@@ -545,8 +555,8 @@ const CallRawResponse$json = {
 };
 
 /// Descriptor for `CallRawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawResponseDescriptor =
-    $convert.base64Decode('Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
+final $typed_data.Uint8List callRawResponseDescriptor = $convert.base64Decode(
+    'Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
 
 @$core.Deprecated('Use getWalletAddressesRequestDescriptor instead')
 const GetWalletAddressesRequest$json = {
@@ -554,8 +564,8 @@ const GetWalletAddressesRequest$json = {
 };
 
 /// Descriptor for `GetWalletAddressesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletAddressesRequestDescriptor =
-    $convert.base64Decode('ChlHZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0');
+final $typed_data.Uint8List getWalletAddressesRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0');
 
 @$core.Deprecated('Use getWalletAddressesResponseDescriptor instead')
 const GetWalletAddressesResponse$json = {
@@ -566,9 +576,9 @@ const GetWalletAddressesResponse$json = {
 };
 
 /// Descriptor for `GetWalletAddressesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletAddressesResponseDescriptor =
-    $convert.base64Decode('ChpHZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3'
-        'Nlcw==');
+final $typed_data.Uint8List getWalletAddressesResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3'
+    'Nlcw==');
 
 const $core.Map<$core.String, $core.dynamic> PhotonServiceBase$json = {
   '1': 'PhotonService',
@@ -579,53 +589,25 @@ const $core.Map<$core.String, $core.dynamic> PhotonServiceBase$json = {
     {'1': 'GetNewAddress', '2': '.photon.v1.GetNewAddressRequest', '3': '.photon.v1.GetNewAddressResponse'},
     {'1': 'Withdraw', '2': '.photon.v1.WithdrawRequest', '3': '.photon.v1.WithdrawResponse'},
     {'1': 'Transfer', '2': '.photon.v1.TransferRequest', '3': '.photon.v1.TransferResponse'},
-    {
-      '1': 'GetSidechainWealth',
-      '2': '.photon.v1.GetSidechainWealthRequest',
-      '3': '.photon.v1.GetSidechainWealthResponse'
-    },
+    {'1': 'GetSidechainWealth', '2': '.photon.v1.GetSidechainWealthRequest', '3': '.photon.v1.GetSidechainWealthResponse'},
     {'1': 'CreateDeposit', '2': '.photon.v1.CreateDepositRequest', '3': '.photon.v1.CreateDepositResponse'},
-    {
-      '1': 'GetPendingWithdrawalBundle',
-      '2': '.photon.v1.GetPendingWithdrawalBundleRequest',
-      '3': '.photon.v1.GetPendingWithdrawalBundleResponse'
-    },
+    {'1': 'GetPendingWithdrawalBundle', '2': '.photon.v1.GetPendingWithdrawalBundleRequest', '3': '.photon.v1.GetPendingWithdrawalBundleResponse'},
     {'1': 'ConnectPeer', '2': '.photon.v1.ConnectPeerRequest', '3': '.photon.v1.ConnectPeerResponse'},
     {'1': 'ForgetPeer', '2': '.photon.v1.ForgetPeerRequest', '3': '.photon.v1.ForgetPeerResponse'},
     {'1': 'ListPeers', '2': '.photon.v1.ListPeersRequest', '3': '.photon.v1.ListPeersResponse'},
     {'1': 'Mine', '2': '.photon.v1.MineRequest', '3': '.photon.v1.MineResponse'},
     {'1': 'GetBlock', '2': '.photon.v1.GetBlockRequest', '3': '.photon.v1.GetBlockResponse'},
-    {
-      '1': 'GetBestMainchainBlockHash',
-      '2': '.photon.v1.GetBestMainchainBlockHashRequest',
-      '3': '.photon.v1.GetBestMainchainBlockHashResponse'
-    },
-    {
-      '1': 'GetBestSidechainBlockHash',
-      '2': '.photon.v1.GetBestSidechainBlockHashRequest',
-      '3': '.photon.v1.GetBestSidechainBlockHashResponse'
-    },
+    {'1': 'GetBestMainchainBlockHash', '2': '.photon.v1.GetBestMainchainBlockHashRequest', '3': '.photon.v1.GetBestMainchainBlockHashResponse'},
+    {'1': 'GetBestSidechainBlockHash', '2': '.photon.v1.GetBestSidechainBlockHashRequest', '3': '.photon.v1.GetBestSidechainBlockHashResponse'},
     {'1': 'GetBmmInclusions', '2': '.photon.v1.GetBmmInclusionsRequest', '3': '.photon.v1.GetBmmInclusionsResponse'},
     {'1': 'GetWalletUtxos', '2': '.photon.v1.GetWalletUtxosRequest', '3': '.photon.v1.GetWalletUtxosResponse'},
     {'1': 'ListUtxos', '2': '.photon.v1.ListUtxosRequest', '3': '.photon.v1.ListUtxosResponse'},
     {'1': 'RemoveFromMempool', '2': '.photon.v1.RemoveFromMempoolRequest', '3': '.photon.v1.RemoveFromMempoolResponse'},
-    {
-      '1': 'GetLatestFailedWithdrawalBundleHeight',
-      '2': '.photon.v1.GetLatestFailedWithdrawalBundleHeightRequest',
-      '3': '.photon.v1.GetLatestFailedWithdrawalBundleHeightResponse'
-    },
+    {'1': 'GetLatestFailedWithdrawalBundleHeight', '2': '.photon.v1.GetLatestFailedWithdrawalBundleHeightRequest', '3': '.photon.v1.GetLatestFailedWithdrawalBundleHeightResponse'},
     {'1': 'GenerateMnemonic', '2': '.photon.v1.GenerateMnemonicRequest', '3': '.photon.v1.GenerateMnemonicResponse'},
-    {
-      '1': 'SetSeedFromMnemonic',
-      '2': '.photon.v1.SetSeedFromMnemonicRequest',
-      '3': '.photon.v1.SetSeedFromMnemonicResponse'
-    },
+    {'1': 'SetSeedFromMnemonic', '2': '.photon.v1.SetSeedFromMnemonicRequest', '3': '.photon.v1.SetSeedFromMnemonicResponse'},
     {'1': 'CallRaw', '2': '.photon.v1.CallRawRequest', '3': '.photon.v1.CallRawResponse'},
-    {
-      '1': 'GetWalletAddresses',
-      '2': '.photon.v1.GetWalletAddressesRequest',
-      '3': '.photon.v1.GetWalletAddressesResponse'
-    },
+    {'1': 'GetWalletAddresses', '2': '.photon.v1.GetWalletAddressesRequest', '3': '.photon.v1.GetWalletAddressesResponse'},
   ],
 };
 
@@ -684,44 +666,45 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> PhotonServ
 };
 
 /// Descriptor for `PhotonService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List photonServiceDescriptor =
-    $convert.base64Decode('Cg1QaG90b25TZXJ2aWNlEkkKCkdldEJhbGFuY2USHC5waG90b24udjEuR2V0QmFsYW5jZVJlcX'
-        'Vlc3QaHS5waG90b24udjEuR2V0QmFsYW5jZVJlc3BvbnNlElIKDUdldEJsb2NrQ291bnQSHy5w'
-        'aG90b24udjEuR2V0QmxvY2tDb3VudFJlcXVlc3QaIC5waG90b24udjEuR2V0QmxvY2tDb3VudF'
-        'Jlc3BvbnNlEjcKBFN0b3ASFi5waG90b24udjEuU3RvcFJlcXVlc3QaFy5waG90b24udjEuU3Rv'
-        'cFJlc3BvbnNlElIKDUdldE5ld0FkZHJlc3MSHy5waG90b24udjEuR2V0TmV3QWRkcmVzc1JlcX'
-        'Vlc3QaIC5waG90b24udjEuR2V0TmV3QWRkcmVzc1Jlc3BvbnNlEkMKCFdpdGhkcmF3EhoucGhv'
-        'dG9uLnYxLldpdGhkcmF3UmVxdWVzdBobLnBob3Rvbi52MS5XaXRoZHJhd1Jlc3BvbnNlEkMKCF'
-        'RyYW5zZmVyEhoucGhvdG9uLnYxLlRyYW5zZmVyUmVxdWVzdBobLnBob3Rvbi52MS5UcmFuc2Zl'
-        'clJlc3BvbnNlEmEKEkdldFNpZGVjaGFpbldlYWx0aBIkLnBob3Rvbi52MS5HZXRTaWRlY2hhaW'
-        '5XZWFsdGhSZXF1ZXN0GiUucGhvdG9uLnYxLkdldFNpZGVjaGFpbldlYWx0aFJlc3BvbnNlElIK'
-        'DUNyZWF0ZURlcG9zaXQSHy5waG90b24udjEuQ3JlYXRlRGVwb3NpdFJlcXVlc3QaIC5waG90b2'
-        '4udjEuQ3JlYXRlRGVwb3NpdFJlc3BvbnNlEnkKGkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxl'
-        'EiwucGhvdG9uLnYxLkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlUmVxdWVzdBotLnBob3Rvbi'
-        '52MS5HZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEkwKC0Nvbm5lY3RQZWVyEh0u'
-        'cGhvdG9uLnYxLkNvbm5lY3RQZWVyUmVxdWVzdBoeLnBob3Rvbi52MS5Db25uZWN0UGVlclJlc3'
-        'BvbnNlEkkKCkZvcmdldFBlZXISHC5waG90b24udjEuRm9yZ2V0UGVlclJlcXVlc3QaHS5waG90'
-        'b24udjEuRm9yZ2V0UGVlclJlc3BvbnNlEkYKCUxpc3RQZWVycxIbLnBob3Rvbi52MS5MaXN0UG'
-        'VlcnNSZXF1ZXN0GhwucGhvdG9uLnYxLkxpc3RQZWVyc1Jlc3BvbnNlEjcKBE1pbmUSFi5waG90'
-        'b24udjEuTWluZVJlcXVlc3QaFy5waG90b24udjEuTWluZVJlc3BvbnNlEkMKCEdldEJsb2NrEh'
-        'oucGhvdG9uLnYxLkdldEJsb2NrUmVxdWVzdBobLnBob3Rvbi52MS5HZXRCbG9ja1Jlc3BvbnNl'
-        'EnYKGUdldEJlc3RNYWluY2hhaW5CbG9ja0hhc2gSKy5waG90b24udjEuR2V0QmVzdE1haW5jaG'
-        'FpbkJsb2NrSGFzaFJlcXVlc3QaLC5waG90b24udjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFz'
-        'aFJlc3BvbnNlEnYKGUdldEJlc3RTaWRlY2hhaW5CbG9ja0hhc2gSKy5waG90b24udjEuR2V0Qm'
-        'VzdFNpZGVjaGFpbkJsb2NrSGFzaFJlcXVlc3QaLC5waG90b24udjEuR2V0QmVzdFNpZGVjaGFp'
-        'bkJsb2NrSGFzaFJlc3BvbnNlElsKEEdldEJtbUluY2x1c2lvbnMSIi5waG90b24udjEuR2V0Qm'
-        '1tSW5jbHVzaW9uc1JlcXVlc3QaIy5waG90b24udjEuR2V0Qm1tSW5jbHVzaW9uc1Jlc3BvbnNl'
-        'ElUKDkdldFdhbGxldFV0eG9zEiAucGhvdG9uLnYxLkdldFdhbGxldFV0eG9zUmVxdWVzdBohLn'
-        'Bob3Rvbi52MS5HZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEkYKCUxpc3RVdHhvcxIbLnBob3Rvbi52'
-        'MS5MaXN0VXR4b3NSZXF1ZXN0GhwucGhvdG9uLnYxLkxpc3RVdHhvc1Jlc3BvbnNlEl4KEVJlbW'
-        '92ZUZyb21NZW1wb29sEiMucGhvdG9uLnYxLlJlbW92ZUZyb21NZW1wb29sUmVxdWVzdBokLnBo'
-        'b3Rvbi52MS5SZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNlEpoBCiVHZXRMYXRlc3RGYWlsZWRXaX'
-        'RoZHJhd2FsQnVuZGxlSGVpZ2h0EjcucGhvdG9uLnYxLkdldExhdGVzdEZhaWxlZFdpdGhkcmF3'
-        'YWxCdW5kbGVIZWlnaHRSZXF1ZXN0GjgucGhvdG9uLnYxLkdldExhdGVzdEZhaWxlZFdpdGhkcm'
-        'F3YWxCdW5kbGVIZWlnaHRSZXNwb25zZRJbChBHZW5lcmF0ZU1uZW1vbmljEiIucGhvdG9uLnYx'
-        'LkdlbmVyYXRlTW5lbW9uaWNSZXF1ZXN0GiMucGhvdG9uLnYxLkdlbmVyYXRlTW5lbW9uaWNSZX'
-        'Nwb25zZRJkChNTZXRTZWVkRnJvbU1uZW1vbmljEiUucGhvdG9uLnYxLlNldFNlZWRGcm9tTW5l'
-        'bW9uaWNSZXF1ZXN0GiYucGhvdG9uLnYxLlNldFNlZWRGcm9tTW5lbW9uaWNSZXNwb25zZRJACg'
-        'dDYWxsUmF3EhkucGhvdG9uLnYxLkNhbGxSYXdSZXF1ZXN0GhoucGhvdG9uLnYxLkNhbGxSYXdS'
-        'ZXNwb25zZRJhChJHZXRXYWxsZXRBZGRyZXNzZXMSJC5waG90b24udjEuR2V0V2FsbGV0QWRkcm'
-        'Vzc2VzUmVxdWVzdBolLnBob3Rvbi52MS5HZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZQ==');
+final $typed_data.Uint8List photonServiceDescriptor = $convert.base64Decode(
+    'Cg1QaG90b25TZXJ2aWNlEkkKCkdldEJhbGFuY2USHC5waG90b24udjEuR2V0QmFsYW5jZVJlcX'
+    'Vlc3QaHS5waG90b24udjEuR2V0QmFsYW5jZVJlc3BvbnNlElIKDUdldEJsb2NrQ291bnQSHy5w'
+    'aG90b24udjEuR2V0QmxvY2tDb3VudFJlcXVlc3QaIC5waG90b24udjEuR2V0QmxvY2tDb3VudF'
+    'Jlc3BvbnNlEjcKBFN0b3ASFi5waG90b24udjEuU3RvcFJlcXVlc3QaFy5waG90b24udjEuU3Rv'
+    'cFJlc3BvbnNlElIKDUdldE5ld0FkZHJlc3MSHy5waG90b24udjEuR2V0TmV3QWRkcmVzc1JlcX'
+    'Vlc3QaIC5waG90b24udjEuR2V0TmV3QWRkcmVzc1Jlc3BvbnNlEkMKCFdpdGhkcmF3EhoucGhv'
+    'dG9uLnYxLldpdGhkcmF3UmVxdWVzdBobLnBob3Rvbi52MS5XaXRoZHJhd1Jlc3BvbnNlEkMKCF'
+    'RyYW5zZmVyEhoucGhvdG9uLnYxLlRyYW5zZmVyUmVxdWVzdBobLnBob3Rvbi52MS5UcmFuc2Zl'
+    'clJlc3BvbnNlEmEKEkdldFNpZGVjaGFpbldlYWx0aBIkLnBob3Rvbi52MS5HZXRTaWRlY2hhaW'
+    '5XZWFsdGhSZXF1ZXN0GiUucGhvdG9uLnYxLkdldFNpZGVjaGFpbldlYWx0aFJlc3BvbnNlElIK'
+    'DUNyZWF0ZURlcG9zaXQSHy5waG90b24udjEuQ3JlYXRlRGVwb3NpdFJlcXVlc3QaIC5waG90b2'
+    '4udjEuQ3JlYXRlRGVwb3NpdFJlc3BvbnNlEnkKGkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxl'
+    'EiwucGhvdG9uLnYxLkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlUmVxdWVzdBotLnBob3Rvbi'
+    '52MS5HZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEkwKC0Nvbm5lY3RQZWVyEh0u'
+    'cGhvdG9uLnYxLkNvbm5lY3RQZWVyUmVxdWVzdBoeLnBob3Rvbi52MS5Db25uZWN0UGVlclJlc3'
+    'BvbnNlEkkKCkZvcmdldFBlZXISHC5waG90b24udjEuRm9yZ2V0UGVlclJlcXVlc3QaHS5waG90'
+    'b24udjEuRm9yZ2V0UGVlclJlc3BvbnNlEkYKCUxpc3RQZWVycxIbLnBob3Rvbi52MS5MaXN0UG'
+    'VlcnNSZXF1ZXN0GhwucGhvdG9uLnYxLkxpc3RQZWVyc1Jlc3BvbnNlEjcKBE1pbmUSFi5waG90'
+    'b24udjEuTWluZVJlcXVlc3QaFy5waG90b24udjEuTWluZVJlc3BvbnNlEkMKCEdldEJsb2NrEh'
+    'oucGhvdG9uLnYxLkdldEJsb2NrUmVxdWVzdBobLnBob3Rvbi52MS5HZXRCbG9ja1Jlc3BvbnNl'
+    'EnYKGUdldEJlc3RNYWluY2hhaW5CbG9ja0hhc2gSKy5waG90b24udjEuR2V0QmVzdE1haW5jaG'
+    'FpbkJsb2NrSGFzaFJlcXVlc3QaLC5waG90b24udjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFz'
+    'aFJlc3BvbnNlEnYKGUdldEJlc3RTaWRlY2hhaW5CbG9ja0hhc2gSKy5waG90b24udjEuR2V0Qm'
+    'VzdFNpZGVjaGFpbkJsb2NrSGFzaFJlcXVlc3QaLC5waG90b24udjEuR2V0QmVzdFNpZGVjaGFp'
+    'bkJsb2NrSGFzaFJlc3BvbnNlElsKEEdldEJtbUluY2x1c2lvbnMSIi5waG90b24udjEuR2V0Qm'
+    '1tSW5jbHVzaW9uc1JlcXVlc3QaIy5waG90b24udjEuR2V0Qm1tSW5jbHVzaW9uc1Jlc3BvbnNl'
+    'ElUKDkdldFdhbGxldFV0eG9zEiAucGhvdG9uLnYxLkdldFdhbGxldFV0eG9zUmVxdWVzdBohLn'
+    'Bob3Rvbi52MS5HZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEkYKCUxpc3RVdHhvcxIbLnBob3Rvbi52'
+    'MS5MaXN0VXR4b3NSZXF1ZXN0GhwucGhvdG9uLnYxLkxpc3RVdHhvc1Jlc3BvbnNlEl4KEVJlbW'
+    '92ZUZyb21NZW1wb29sEiMucGhvdG9uLnYxLlJlbW92ZUZyb21NZW1wb29sUmVxdWVzdBokLnBo'
+    'b3Rvbi52MS5SZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNlEpoBCiVHZXRMYXRlc3RGYWlsZWRXaX'
+    'RoZHJhd2FsQnVuZGxlSGVpZ2h0EjcucGhvdG9uLnYxLkdldExhdGVzdEZhaWxlZFdpdGhkcmF3'
+    'YWxCdW5kbGVIZWlnaHRSZXF1ZXN0GjgucGhvdG9uLnYxLkdldExhdGVzdEZhaWxlZFdpdGhkcm'
+    'F3YWxCdW5kbGVIZWlnaHRSZXNwb25zZRJbChBHZW5lcmF0ZU1uZW1vbmljEiIucGhvdG9uLnYx'
+    'LkdlbmVyYXRlTW5lbW9uaWNSZXF1ZXN0GiMucGhvdG9uLnYxLkdlbmVyYXRlTW5lbW9uaWNSZX'
+    'Nwb25zZRJkChNTZXRTZWVkRnJvbU1uZW1vbmljEiUucGhvdG9uLnYxLlNldFNlZWRGcm9tTW5l'
+    'bW9uaWNSZXF1ZXN0GiYucGhvdG9uLnYxLlNldFNlZWRGcm9tTW5lbW9uaWNSZXNwb25zZRJACg'
+    'dDYWxsUmF3EhkucGhvdG9uLnYxLkNhbGxSYXdSZXF1ZXN0GhoucGhvdG9uLnYxLkNhbGxSYXdS'
+    'ZXNwb25zZRJhChJHZXRXYWxsZXRBZGRyZXNzZXMSJC5waG90b24udjEuR2V0V2FsbGV0QWRkcm'
+    'Vzc2VzUmVxdWVzdBolLnBob3Rvbi52MS5HZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZQ==');
+

--- a/sail_ui/lib/gen/photon/v1/photon.pbserver.dart
+++ b/sail_ui/lib/gen/photon/v1/photon.pbserver.dart
@@ -27,152 +27,89 @@ abstract class PhotonServiceBase extends $pb.GeneratedService {
   $async.Future<$9.GetNewAddressResponse> getNewAddress($pb.ServerContext ctx, $9.GetNewAddressRequest request);
   $async.Future<$9.WithdrawResponse> withdraw($pb.ServerContext ctx, $9.WithdrawRequest request);
   $async.Future<$9.TransferResponse> transfer($pb.ServerContext ctx, $9.TransferRequest request);
-  $async.Future<$9.GetSidechainWealthResponse> getSidechainWealth(
-      $pb.ServerContext ctx, $9.GetSidechainWealthRequest request);
+  $async.Future<$9.GetSidechainWealthResponse> getSidechainWealth($pb.ServerContext ctx, $9.GetSidechainWealthRequest request);
   $async.Future<$9.CreateDepositResponse> createDeposit($pb.ServerContext ctx, $9.CreateDepositRequest request);
-  $async.Future<$9.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-      $pb.ServerContext ctx, $9.GetPendingWithdrawalBundleRequest request);
+  $async.Future<$9.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ServerContext ctx, $9.GetPendingWithdrawalBundleRequest request);
   $async.Future<$9.ConnectPeerResponse> connectPeer($pb.ServerContext ctx, $9.ConnectPeerRequest request);
   $async.Future<$9.ForgetPeerResponse> forgetPeer($pb.ServerContext ctx, $9.ForgetPeerRequest request);
   $async.Future<$9.ListPeersResponse> listPeers($pb.ServerContext ctx, $9.ListPeersRequest request);
   $async.Future<$9.MineResponse> mine($pb.ServerContext ctx, $9.MineRequest request);
   $async.Future<$9.GetBlockResponse> getBlock($pb.ServerContext ctx, $9.GetBlockRequest request);
-  $async.Future<$9.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-      $pb.ServerContext ctx, $9.GetBestMainchainBlockHashRequest request);
-  $async.Future<$9.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-      $pb.ServerContext ctx, $9.GetBestSidechainBlockHashRequest request);
-  $async.Future<$9.GetBmmInclusionsResponse> getBmmInclusions(
-      $pb.ServerContext ctx, $9.GetBmmInclusionsRequest request);
+  $async.Future<$9.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ServerContext ctx, $9.GetBestMainchainBlockHashRequest request);
+  $async.Future<$9.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ServerContext ctx, $9.GetBestSidechainBlockHashRequest request);
+  $async.Future<$9.GetBmmInclusionsResponse> getBmmInclusions($pb.ServerContext ctx, $9.GetBmmInclusionsRequest request);
   $async.Future<$9.GetWalletUtxosResponse> getWalletUtxos($pb.ServerContext ctx, $9.GetWalletUtxosRequest request);
   $async.Future<$9.ListUtxosResponse> listUtxos($pb.ServerContext ctx, $9.ListUtxosRequest request);
-  $async.Future<$9.RemoveFromMempoolResponse> removeFromMempool(
-      $pb.ServerContext ctx, $9.RemoveFromMempoolRequest request);
-  $async.Future<$9.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-      $pb.ServerContext ctx, $9.GetLatestFailedWithdrawalBundleHeightRequest request);
-  $async.Future<$9.GenerateMnemonicResponse> generateMnemonic(
-      $pb.ServerContext ctx, $9.GenerateMnemonicRequest request);
-  $async.Future<$9.SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-      $pb.ServerContext ctx, $9.SetSeedFromMnemonicRequest request);
+  $async.Future<$9.RemoveFromMempoolResponse> removeFromMempool($pb.ServerContext ctx, $9.RemoveFromMempoolRequest request);
+  $async.Future<$9.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ServerContext ctx, $9.GetLatestFailedWithdrawalBundleHeightRequest request);
+  $async.Future<$9.GenerateMnemonicResponse> generateMnemonic($pb.ServerContext ctx, $9.GenerateMnemonicRequest request);
+  $async.Future<$9.SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ServerContext ctx, $9.SetSeedFromMnemonicRequest request);
   $async.Future<$9.CallRawResponse> callRaw($pb.ServerContext ctx, $9.CallRawRequest request);
-  $async.Future<$9.GetWalletAddressesResponse> getWalletAddresses(
-      $pb.ServerContext ctx, $9.GetWalletAddressesRequest request);
+  $async.Future<$9.GetWalletAddressesResponse> getWalletAddresses($pb.ServerContext ctx, $9.GetWalletAddressesRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetBalance':
-        return $9.GetBalanceRequest();
-      case 'GetBlockCount':
-        return $9.GetBlockCountRequest();
-      case 'Stop':
-        return $9.StopRequest();
-      case 'GetNewAddress':
-        return $9.GetNewAddressRequest();
-      case 'Withdraw':
-        return $9.WithdrawRequest();
-      case 'Transfer':
-        return $9.TransferRequest();
-      case 'GetSidechainWealth':
-        return $9.GetSidechainWealthRequest();
-      case 'CreateDeposit':
-        return $9.CreateDepositRequest();
-      case 'GetPendingWithdrawalBundle':
-        return $9.GetPendingWithdrawalBundleRequest();
-      case 'ConnectPeer':
-        return $9.ConnectPeerRequest();
-      case 'ForgetPeer':
-        return $9.ForgetPeerRequest();
-      case 'ListPeers':
-        return $9.ListPeersRequest();
-      case 'Mine':
-        return $9.MineRequest();
-      case 'GetBlock':
-        return $9.GetBlockRequest();
-      case 'GetBestMainchainBlockHash':
-        return $9.GetBestMainchainBlockHashRequest();
-      case 'GetBestSidechainBlockHash':
-        return $9.GetBestSidechainBlockHashRequest();
-      case 'GetBmmInclusions':
-        return $9.GetBmmInclusionsRequest();
-      case 'GetWalletUtxos':
-        return $9.GetWalletUtxosRequest();
-      case 'ListUtxos':
-        return $9.ListUtxosRequest();
-      case 'RemoveFromMempool':
-        return $9.RemoveFromMempoolRequest();
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return $9.GetLatestFailedWithdrawalBundleHeightRequest();
-      case 'GenerateMnemonic':
-        return $9.GenerateMnemonicRequest();
-      case 'SetSeedFromMnemonic':
-        return $9.SetSeedFromMnemonicRequest();
-      case 'CallRaw':
-        return $9.CallRawRequest();
-      case 'GetWalletAddresses':
-        return $9.GetWalletAddressesRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return $9.GetBalanceRequest();
+      case 'GetBlockCount': return $9.GetBlockCountRequest();
+      case 'Stop': return $9.StopRequest();
+      case 'GetNewAddress': return $9.GetNewAddressRequest();
+      case 'Withdraw': return $9.WithdrawRequest();
+      case 'Transfer': return $9.TransferRequest();
+      case 'GetSidechainWealth': return $9.GetSidechainWealthRequest();
+      case 'CreateDeposit': return $9.CreateDepositRequest();
+      case 'GetPendingWithdrawalBundle': return $9.GetPendingWithdrawalBundleRequest();
+      case 'ConnectPeer': return $9.ConnectPeerRequest();
+      case 'ForgetPeer': return $9.ForgetPeerRequest();
+      case 'ListPeers': return $9.ListPeersRequest();
+      case 'Mine': return $9.MineRequest();
+      case 'GetBlock': return $9.GetBlockRequest();
+      case 'GetBestMainchainBlockHash': return $9.GetBestMainchainBlockHashRequest();
+      case 'GetBestSidechainBlockHash': return $9.GetBestSidechainBlockHashRequest();
+      case 'GetBmmInclusions': return $9.GetBmmInclusionsRequest();
+      case 'GetWalletUtxos': return $9.GetWalletUtxosRequest();
+      case 'ListUtxos': return $9.ListUtxosRequest();
+      case 'RemoveFromMempool': return $9.RemoveFromMempoolRequest();
+      case 'GetLatestFailedWithdrawalBundleHeight': return $9.GetLatestFailedWithdrawalBundleHeightRequest();
+      case 'GenerateMnemonic': return $9.GenerateMnemonicRequest();
+      case 'SetSeedFromMnemonic': return $9.SetSeedFromMnemonicRequest();
+      case 'CallRaw': return $9.CallRawRequest();
+      case 'GetWalletAddresses': return $9.GetWalletAddressesRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetBalance':
-        return this.getBalance(ctx, request as $9.GetBalanceRequest);
-      case 'GetBlockCount':
-        return this.getBlockCount(ctx, request as $9.GetBlockCountRequest);
-      case 'Stop':
-        return this.stop(ctx, request as $9.StopRequest);
-      case 'GetNewAddress':
-        return this.getNewAddress(ctx, request as $9.GetNewAddressRequest);
-      case 'Withdraw':
-        return this.withdraw(ctx, request as $9.WithdrawRequest);
-      case 'Transfer':
-        return this.transfer(ctx, request as $9.TransferRequest);
-      case 'GetSidechainWealth':
-        return this.getSidechainWealth(ctx, request as $9.GetSidechainWealthRequest);
-      case 'CreateDeposit':
-        return this.createDeposit(ctx, request as $9.CreateDepositRequest);
-      case 'GetPendingWithdrawalBundle':
-        return this.getPendingWithdrawalBundle(ctx, request as $9.GetPendingWithdrawalBundleRequest);
-      case 'ConnectPeer':
-        return this.connectPeer(ctx, request as $9.ConnectPeerRequest);
-      case 'ForgetPeer':
-        return this.forgetPeer(ctx, request as $9.ForgetPeerRequest);
-      case 'ListPeers':
-        return this.listPeers(ctx, request as $9.ListPeersRequest);
-      case 'Mine':
-        return this.mine(ctx, request as $9.MineRequest);
-      case 'GetBlock':
-        return this.getBlock(ctx, request as $9.GetBlockRequest);
-      case 'GetBestMainchainBlockHash':
-        return this.getBestMainchainBlockHash(ctx, request as $9.GetBestMainchainBlockHashRequest);
-      case 'GetBestSidechainBlockHash':
-        return this.getBestSidechainBlockHash(ctx, request as $9.GetBestSidechainBlockHashRequest);
-      case 'GetBmmInclusions':
-        return this.getBmmInclusions(ctx, request as $9.GetBmmInclusionsRequest);
-      case 'GetWalletUtxos':
-        return this.getWalletUtxos(ctx, request as $9.GetWalletUtxosRequest);
-      case 'ListUtxos':
-        return this.listUtxos(ctx, request as $9.ListUtxosRequest);
-      case 'RemoveFromMempool':
-        return this.removeFromMempool(ctx, request as $9.RemoveFromMempoolRequest);
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return this
-            .getLatestFailedWithdrawalBundleHeight(ctx, request as $9.GetLatestFailedWithdrawalBundleHeightRequest);
-      case 'GenerateMnemonic':
-        return this.generateMnemonic(ctx, request as $9.GenerateMnemonicRequest);
-      case 'SetSeedFromMnemonic':
-        return this.setSeedFromMnemonic(ctx, request as $9.SetSeedFromMnemonicRequest);
-      case 'CallRaw':
-        return this.callRaw(ctx, request as $9.CallRawRequest);
-      case 'GetWalletAddresses':
-        return this.getWalletAddresses(ctx, request as $9.GetWalletAddressesRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return this.getBalance(ctx, request as $9.GetBalanceRequest);
+      case 'GetBlockCount': return this.getBlockCount(ctx, request as $9.GetBlockCountRequest);
+      case 'Stop': return this.stop(ctx, request as $9.StopRequest);
+      case 'GetNewAddress': return this.getNewAddress(ctx, request as $9.GetNewAddressRequest);
+      case 'Withdraw': return this.withdraw(ctx, request as $9.WithdrawRequest);
+      case 'Transfer': return this.transfer(ctx, request as $9.TransferRequest);
+      case 'GetSidechainWealth': return this.getSidechainWealth(ctx, request as $9.GetSidechainWealthRequest);
+      case 'CreateDeposit': return this.createDeposit(ctx, request as $9.CreateDepositRequest);
+      case 'GetPendingWithdrawalBundle': return this.getPendingWithdrawalBundle(ctx, request as $9.GetPendingWithdrawalBundleRequest);
+      case 'ConnectPeer': return this.connectPeer(ctx, request as $9.ConnectPeerRequest);
+      case 'ForgetPeer': return this.forgetPeer(ctx, request as $9.ForgetPeerRequest);
+      case 'ListPeers': return this.listPeers(ctx, request as $9.ListPeersRequest);
+      case 'Mine': return this.mine(ctx, request as $9.MineRequest);
+      case 'GetBlock': return this.getBlock(ctx, request as $9.GetBlockRequest);
+      case 'GetBestMainchainBlockHash': return this.getBestMainchainBlockHash(ctx, request as $9.GetBestMainchainBlockHashRequest);
+      case 'GetBestSidechainBlockHash': return this.getBestSidechainBlockHash(ctx, request as $9.GetBestSidechainBlockHashRequest);
+      case 'GetBmmInclusions': return this.getBmmInclusions(ctx, request as $9.GetBmmInclusionsRequest);
+      case 'GetWalletUtxos': return this.getWalletUtxos(ctx, request as $9.GetWalletUtxosRequest);
+      case 'ListUtxos': return this.listUtxos(ctx, request as $9.ListUtxosRequest);
+      case 'RemoveFromMempool': return this.removeFromMempool(ctx, request as $9.RemoveFromMempoolRequest);
+      case 'GetLatestFailedWithdrawalBundleHeight': return this.getLatestFailedWithdrawalBundleHeight(ctx, request as $9.GetLatestFailedWithdrawalBundleHeightRequest);
+      case 'GenerateMnemonic': return this.generateMnemonic(ctx, request as $9.GenerateMnemonicRequest);
+      case 'SetSeedFromMnemonic': return this.setSeedFromMnemonic(ctx, request as $9.SetSeedFromMnemonicRequest);
+      case 'CallRaw': return this.callRaw(ctx, request as $9.CallRawRequest);
+      case 'GetWalletAddresses': return this.getWalletAddresses(ctx, request as $9.GetWalletAddressesRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => PhotonServiceBase$json;
   $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => PhotonServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/thunder/v1/thunder.connect.client.dart
+++ b/sail_ui/lib/gen/thunder/v1/thunder.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "thunder.pb.dart" as thunderv1thunder;
 import "thunder.connect.spec.dart" as specs;
 
-extension type ThunderServiceClient(connect.Transport _transport) {
+extension type ThunderServiceClient (connect.Transport _transport) {
   /// Get wallet balance (total and available).
   Future<thunderv1thunder.GetBalanceResponse> getBalance(
     thunderv1thunder.GetBalanceRequest input, {

--- a/sail_ui/lib/gen/thunder/v1/thunder.pb.dart
+++ b/sail_ui/lib/gen/thunder/v1/thunder.pb.dart
@@ -18,25 +18,23 @@ import 'package:protobuf/protobuf.dart' as $pb;
 class GetBalanceRequest extends $pb.GeneratedMessage {
   factory GetBalanceRequest() => create();
   GetBalanceRequest._() : super();
-  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceRequest clone() => GetBalanceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) => super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -45,8 +43,7 @@ class GetBalanceRequest extends $pb.GeneratedMessage {
   GetBalanceRequest createEmptyInstance() => create();
   static $pb.PbList<GetBalanceRequest> createRepeated() => $pb.PbList<GetBalanceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
+  static GetBalanceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
   static GetBalanceRequest? _defaultInstance;
 }
 
@@ -65,27 +62,25 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBalanceResponse._() : super();
-  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'totalSats')
     ..aInt64(2, _omitFieldNames ? '' : 'availableSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceResponse clone() => GetBalanceResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) => super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -94,17 +89,13 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   GetBalanceResponse createEmptyInstance() => create();
   static $pb.PbList<GetBalanceResponse> createRepeated() => $pb.PbList<GetBalanceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
+  static GetBalanceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
   static GetBalanceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get totalSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set totalSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set totalSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTotalSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -113,10 +104,7 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get availableSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set availableSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set availableSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAvailableSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -126,25 +114,23 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
 class GetBlockCountRequest extends $pb.GeneratedMessage {
   factory GetBlockCountRequest() => create();
   GetBlockCountRequest._() : super();
-  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountRequest clone() => GetBlockCountRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) => super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -153,8 +139,7 @@ class GetBlockCountRequest extends $pb.GeneratedMessage {
   GetBlockCountRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountRequest> createRepeated() => $pb.PbList<GetBlockCountRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
+  static GetBlockCountRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
   static GetBlockCountRequest? _defaultInstance;
 }
 
@@ -169,26 +154,24 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockCountResponse._() : super();
-  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'count')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountResponse clone() => GetBlockCountResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) => super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -197,17 +180,13 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
   GetBlockCountResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountResponse> createRepeated() => $pb.PbList<GetBlockCountResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
+  static GetBlockCountResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
   static GetBlockCountResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get count => $_getI64(0);
   @$pb.TagNumber(1)
-  set count($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set count($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCount() => $_has(0);
   @$pb.TagNumber(1)
@@ -217,24 +196,23 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
 class StopRequest extends $pb.GeneratedMessage {
   factory StopRequest() => create();
   StopRequest._() : super();
-  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopRequest clone() => StopRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopRequest copyWith(void Function(StopRequest) updates) =>
-      super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopRequest copyWith(void Function(StopRequest) updates) => super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -250,24 +228,23 @@ class StopRequest extends $pb.GeneratedMessage {
 class StopResponse extends $pb.GeneratedMessage {
   factory StopResponse() => create();
   StopResponse._() : super();
-  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopResponse clone() => StopResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopResponse copyWith(void Function(StopResponse) updates) =>
-      super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopResponse copyWith(void Function(StopResponse) updates) => super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -283,25 +260,23 @@ class StopResponse extends $pb.GeneratedMessage {
 class GetNewAddressRequest extends $pb.GeneratedMessage {
   factory GetNewAddressRequest() => create();
   GetNewAddressRequest._() : super();
-  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressRequest clone() => GetNewAddressRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) => super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -310,8 +285,7 @@ class GetNewAddressRequest extends $pb.GeneratedMessage {
   GetNewAddressRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressRequest> createRepeated() => $pb.PbList<GetNewAddressRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
+  static GetNewAddressRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
   static GetNewAddressRequest? _defaultInstance;
 }
 
@@ -326,26 +300,24 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewAddressResponse._() : super();
-  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressResponse clone() => GetNewAddressResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) => super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -354,17 +326,13 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
   GetNewAddressResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressResponse> createRepeated() => $pb.PbList<GetNewAddressResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
+  static GetNewAddressResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
   static GetNewAddressResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -394,29 +362,27 @@ class WithdrawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawRequest._() : super();
-  factory WithdrawRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'sideFeeSats')
     ..aInt64(4, _omitFieldNames ? '' : 'mainFeeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawRequest clone() => WithdrawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) =>
-      super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) => super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -425,17 +391,13 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   WithdrawRequest createEmptyInstance() => create();
   static $pb.PbList<WithdrawRequest> createRepeated() => $pb.PbList<WithdrawRequest>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
+  static WithdrawRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
   static WithdrawRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -444,10 +406,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -456,10 +415,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get sideFeeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set sideFeeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set sideFeeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSideFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -468,10 +424,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get mainFeeSats => $_getI64(3);
   @$pb.TagNumber(4)
-  set mainFeeSats($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set mainFeeSats($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasMainFeeSats() => $_has(3);
   @$pb.TagNumber(4)
@@ -489,26 +442,24 @@ class WithdrawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawResponse._() : super();
-  factory WithdrawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawResponse clone() => WithdrawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) =>
-      super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) => super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -517,17 +468,13 @@ class WithdrawResponse extends $pb.GeneratedMessage {
   WithdrawResponse createEmptyInstance() => create();
   static $pb.PbList<WithdrawResponse> createRepeated() => $pb.PbList<WithdrawResponse>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
+  static WithdrawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
   static WithdrawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -553,28 +500,26 @@ class TransferRequest extends $pb.GeneratedMessage {
     return $result;
   }
   TransferRequest._() : super();
-  factory TransferRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferRequest clone() => TransferRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferRequest copyWith(void Function(TransferRequest) updates) =>
-      super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferRequest copyWith(void Function(TransferRequest) updates) => super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -583,17 +528,13 @@ class TransferRequest extends $pb.GeneratedMessage {
   TransferRequest createEmptyInstance() => create();
   static $pb.PbList<TransferRequest> createRepeated() => $pb.PbList<TransferRequest>();
   @$core.pragma('dart2js:noInline')
-  static TransferRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
+  static TransferRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
   static TransferRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -602,10 +543,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -614,10 +552,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -635,26 +570,24 @@ class TransferResponse extends $pb.GeneratedMessage {
     return $result;
   }
   TransferResponse._() : super();
-  factory TransferResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferResponse clone() => TransferResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferResponse copyWith(void Function(TransferResponse) updates) =>
-      super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferResponse copyWith(void Function(TransferResponse) updates) => super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -663,17 +596,13 @@ class TransferResponse extends $pb.GeneratedMessage {
   TransferResponse createEmptyInstance() => create();
   static $pb.PbList<TransferResponse> createRepeated() => $pb.PbList<TransferResponse>();
   @$core.pragma('dart2js:noInline')
-  static TransferResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
+  static TransferResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
   static TransferResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -683,25 +612,23 @@ class TransferResponse extends $pb.GeneratedMessage {
 class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   factory GetSidechainWealthRequest() => create();
   GetSidechainWealthRequest._() : super();
-  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthRequest clone() => GetSidechainWealthRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) => super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -710,8 +637,7 @@ class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   GetSidechainWealthRequest createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthRequest> createRepeated() => $pb.PbList<GetSidechainWealthRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
+  static GetSidechainWealthRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
   static GetSidechainWealthRequest? _defaultInstance;
 }
 
@@ -726,27 +652,24 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetSidechainWealthResponse._() : super();
-  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'sats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthResponse clone() => GetSidechainWealthResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) => super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -755,17 +678,13 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
   GetSidechainWealthResponse createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthResponse> createRepeated() => $pb.PbList<GetSidechainWealthResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
+  static GetSidechainWealthResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
   static GetSidechainWealthResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get sats => $_getI64(0);
   @$pb.TagNumber(1)
-  set sats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set sats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -791,28 +710,26 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositRequest._() : super();
-  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'valueSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositRequest clone() => CreateDepositRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) => super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -821,17 +738,13 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   CreateDepositRequest createEmptyInstance() => create();
   static $pb.PbList<CreateDepositRequest> createRepeated() => $pb.PbList<CreateDepositRequest>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
+  static CreateDepositRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
   static CreateDepositRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -840,10 +753,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get valueSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set valueSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set valueSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasValueSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -852,10 +762,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -873,26 +780,24 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositResponse._() : super();
-  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositResponse clone() => CreateDepositResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) => super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -901,17 +806,13 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
   CreateDepositResponse createEmptyInstance() => create();
   static $pb.PbList<CreateDepositResponse> createRepeated() => $pb.PbList<CreateDepositResponse>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
+  static CreateDepositResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
   static CreateDepositResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -921,38 +822,32 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
 class GetPendingWithdrawalBundleRequest extends $pb.GeneratedMessage {
   factory GetPendingWithdrawalBundleRequest() => create();
   GetPendingWithdrawalBundleRequest._() : super();
-  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleRequest clone() => GetPendingWithdrawalBundleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest))
-          as GetPendingWithdrawalBundleRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest)) as GetPendingWithdrawalBundleRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleRequest create() => GetPendingWithdrawalBundleRequest._();
   GetPendingWithdrawalBundleRequest createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleRequest>();
+  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
+  static GetPendingWithdrawalBundleRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
   static GetPendingWithdrawalBundleRequest? _defaultInstance;
 }
 
@@ -967,49 +862,40 @@ class GetPendingWithdrawalBundleResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetPendingWithdrawalBundleResponse._() : super();
-  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bundleJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleResponse clone() => GetPendingWithdrawalBundleResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse))
-          as GetPendingWithdrawalBundleResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse)) as GetPendingWithdrawalBundleResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleResponse create() => GetPendingWithdrawalBundleResponse._();
   GetPendingWithdrawalBundleResponse createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleResponse>();
+  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
+  static GetPendingWithdrawalBundleResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
   static GetPendingWithdrawalBundleResponse? _defaultInstance;
 
   /// JSON string of the bundle, empty if none.
   @$pb.TagNumber(1)
   $core.String get bundleJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bundleJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bundleJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBundleJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1027,26 +913,24 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ConnectPeerRequest._() : super();
-  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerRequest clone() => ConnectPeerRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) => super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1055,17 +939,13 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
   ConnectPeerRequest createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerRequest> createRepeated() => $pb.PbList<ConnectPeerRequest>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
+  static ConnectPeerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
   static ConnectPeerRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1075,25 +955,23 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
 class ConnectPeerResponse extends $pb.GeneratedMessage {
   factory ConnectPeerResponse() => create();
   ConnectPeerResponse._() : super();
-  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerResponse clone() => ConnectPeerResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) => super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1102,33 +980,30 @@ class ConnectPeerResponse extends $pb.GeneratedMessage {
   ConnectPeerResponse createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerResponse> createRepeated() => $pb.PbList<ConnectPeerResponse>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
+  static ConnectPeerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
   static ConnectPeerResponse? _defaultInstance;
 }
 
 class ListPeersRequest extends $pb.GeneratedMessage {
   factory ListPeersRequest() => create();
   ListPeersRequest._() : super();
-  factory ListPeersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersRequest clone() => ListPeersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) =>
-      super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) => super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1137,8 +1012,7 @@ class ListPeersRequest extends $pb.GeneratedMessage {
   ListPeersRequest createEmptyInstance() => create();
   static $pb.PbList<ListPeersRequest> createRepeated() => $pb.PbList<ListPeersRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
+  static ListPeersRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
   static ListPeersRequest? _defaultInstance;
 }
 
@@ -1153,26 +1027,24 @@ class ListPeersResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListPeersResponse._() : super();
-  factory ListPeersResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'peersJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersResponse clone() => ListPeersResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) =>
-      super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) => super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1181,17 +1053,13 @@ class ListPeersResponse extends $pb.GeneratedMessage {
   ListPeersResponse createEmptyInstance() => create();
   static $pb.PbList<ListPeersResponse> createRepeated() => $pb.PbList<ListPeersResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
+  static ListPeersResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
   static ListPeersResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get peersJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set peersJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set peersJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPeersJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1209,25 +1077,24 @@ class MineRequest extends $pb.GeneratedMessage {
     return $result;
   }
   MineRequest._() : super();
-  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineRequest clone() => MineRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineRequest copyWith(void Function(MineRequest) updates) =>
-      super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineRequest copyWith(void Function(MineRequest) updates) => super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1242,10 +1109,7 @@ class MineRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $fixnum.Int64 get feeSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasFeeSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -1263,25 +1127,24 @@ class MineResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MineResponse._() : super();
-  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bmmResultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineResponse clone() => MineResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineResponse copyWith(void Function(MineResponse) updates) =>
-      super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineResponse copyWith(void Function(MineResponse) updates) => super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1296,10 +1159,7 @@ class MineResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get bmmResultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bmmResultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bmmResultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBmmResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1317,26 +1177,24 @@ class GetBlockRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockRequest._() : super();
-  factory GetBlockRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockRequest clone() => GetBlockRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) => super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1345,17 +1203,13 @@ class GetBlockRequest extends $pb.GeneratedMessage {
   GetBlockRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockRequest> createRepeated() => $pb.PbList<GetBlockRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
+  static GetBlockRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
   static GetBlockRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1373,26 +1227,24 @@ class GetBlockResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockResponse._() : super();
-  factory GetBlockResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockResponse clone() => GetBlockResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) => super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1401,17 +1253,13 @@ class GetBlockResponse extends $pb.GeneratedMessage {
   GetBlockResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockResponse> createRepeated() => $pb.PbList<GetBlockResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
+  static GetBlockResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
   static GetBlockResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1421,38 +1269,32 @@ class GetBlockResponse extends $pb.GeneratedMessage {
 class GetBestMainchainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestMainchainBlockHashRequest() => create();
   GetBestMainchainBlockHashRequest._() : super();
-  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashRequest clone() => GetBestMainchainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest))
-          as GetBestMainchainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest)) as GetBestMainchainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashRequest create() => GetBestMainchainBlockHashRequest._();
   GetBestMainchainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashRequest>();
+  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() => $pb.PbList<GetBestMainchainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
+  static GetBestMainchainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
   static GetBestMainchainBlockHashRequest? _defaultInstance;
 }
 
@@ -1467,48 +1309,39 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestMainchainBlockHashResponse._() : super();
-  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashResponse clone() => GetBestMainchainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse))
-          as GetBestMainchainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse)) as GetBestMainchainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashResponse create() => GetBestMainchainBlockHashResponse._();
   GetBestMainchainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashResponse>();
+  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() => $pb.PbList<GetBestMainchainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
+  static GetBestMainchainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
   static GetBestMainchainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1518,38 +1351,32 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
 class GetBestSidechainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestSidechainBlockHashRequest() => create();
   GetBestSidechainBlockHashRequest._() : super();
-  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashRequest clone() => GetBestSidechainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest))
-          as GetBestSidechainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest)) as GetBestSidechainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashRequest create() => GetBestSidechainBlockHashRequest._();
   GetBestSidechainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashRequest>();
+  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() => $pb.PbList<GetBestSidechainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
+  static GetBestSidechainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
   static GetBestSidechainBlockHashRequest? _defaultInstance;
 }
 
@@ -1564,48 +1391,39 @@ class GetBestSidechainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestSidechainBlockHashResponse._() : super();
-  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashResponse clone() => GetBestSidechainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse))
-          as GetBestSidechainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse)) as GetBestSidechainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashResponse create() => GetBestSidechainBlockHashResponse._();
   GetBestSidechainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashResponse>();
+  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() => $pb.PbList<GetBestSidechainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
+  static GetBestSidechainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
   static GetBestSidechainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1623,26 +1441,24 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsRequest._() : super();
-  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockHash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsRequest clone() => GetBmmInclusionsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1651,17 +1467,13 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
   GetBmmInclusionsRequest createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsRequest> createRepeated() => $pb.PbList<GetBmmInclusionsRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
+  static GetBmmInclusionsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
   static GetBmmInclusionsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockHash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockHash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockHash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1679,26 +1491,24 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsResponse._() : super();
-  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'inclusions')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsResponse clone() => GetBmmInclusionsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1707,17 +1517,13 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
   GetBmmInclusionsResponse createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsResponse> createRepeated() => $pb.PbList<GetBmmInclusionsResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
+  static GetBmmInclusionsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
   static GetBmmInclusionsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get inclusions => $_getSZ(0);
   @$pb.TagNumber(1)
-  set inclusions($core.String v) {
-    $_setString(0, v);
-  }
-
+  set inclusions($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasInclusions() => $_has(0);
   @$pb.TagNumber(1)
@@ -1727,25 +1533,23 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
 class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   factory GetWalletUtxosRequest() => create();
   GetWalletUtxosRequest._() : super();
-  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosRequest clone() => GetWalletUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) => super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1754,8 +1558,7 @@ class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   GetWalletUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosRequest> createRepeated() => $pb.PbList<GetWalletUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
+  static GetWalletUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
   static GetWalletUtxosRequest? _defaultInstance;
 }
 
@@ -1770,26 +1573,24 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletUtxosResponse._() : super();
-  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosResponse clone() => GetWalletUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) => super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1798,17 +1599,13 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
   GetWalletUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosResponse> createRepeated() => $pb.PbList<GetWalletUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
+  static GetWalletUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
   static GetWalletUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1818,25 +1615,23 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
 class ListUtxosRequest extends $pb.GeneratedMessage {
   factory ListUtxosRequest() => create();
   ListUtxosRequest._() : super();
-  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosRequest clone() => ListUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) => super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1845,8 +1640,7 @@ class ListUtxosRequest extends $pb.GeneratedMessage {
   ListUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<ListUtxosRequest> createRepeated() => $pb.PbList<ListUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
+  static ListUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
   static ListUtxosRequest? _defaultInstance;
 }
 
@@ -1861,26 +1655,24 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListUtxosResponse._() : super();
-  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosResponse clone() => ListUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) => super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1889,17 +1681,13 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
   ListUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<ListUtxosResponse> createRepeated() => $pb.PbList<ListUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
+  static ListUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
   static ListUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1917,26 +1705,24 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
     return $result;
   }
   RemoveFromMempoolRequest._() : super();
-  factory RemoveFromMempoolRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFromMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFromMempoolRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFromMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveFromMempoolRequest clone() => RemoveFromMempoolRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveFromMempoolRequest copyWith(void Function(RemoveFromMempoolRequest) updates) =>
-      super.copyWith((message) => updates(message as RemoveFromMempoolRequest)) as RemoveFromMempoolRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveFromMempoolRequest copyWith(void Function(RemoveFromMempoolRequest) updates) => super.copyWith((message) => updates(message as RemoveFromMempoolRequest)) as RemoveFromMempoolRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1945,17 +1731,13 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
   RemoveFromMempoolRequest createEmptyInstance() => create();
   static $pb.PbList<RemoveFromMempoolRequest> createRepeated() => $pb.PbList<RemoveFromMempoolRequest>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFromMempoolRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolRequest>(create);
+  static RemoveFromMempoolRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolRequest>(create);
   static RemoveFromMempoolRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -1965,25 +1747,23 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
 class RemoveFromMempoolResponse extends $pb.GeneratedMessage {
   factory RemoveFromMempoolResponse() => create();
   RemoveFromMempoolResponse._() : super();
-  factory RemoveFromMempoolResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFromMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFromMempoolResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFromMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveFromMempoolResponse clone() => RemoveFromMempoolResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveFromMempoolResponse copyWith(void Function(RemoveFromMempoolResponse) updates) =>
-      super.copyWith((message) => updates(message as RemoveFromMempoolResponse)) as RemoveFromMempoolResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveFromMempoolResponse copyWith(void Function(RemoveFromMempoolResponse) updates) => super.copyWith((message) => updates(message as RemoveFromMempoolResponse)) as RemoveFromMempoolResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1992,50 +1772,39 @@ class RemoveFromMempoolResponse extends $pb.GeneratedMessage {
   RemoveFromMempoolResponse createEmptyInstance() => create();
   static $pb.PbList<RemoveFromMempoolResponse> createRepeated() => $pb.PbList<RemoveFromMempoolResponse>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFromMempoolResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolResponse>(create);
+  static RemoveFromMempoolResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolResponse>(create);
   static RemoveFromMempoolResponse? _defaultInstance;
 }
 
 class GetLatestFailedWithdrawalBundleHeightRequest extends $pb.GeneratedMessage {
   factory GetLatestFailedWithdrawalBundleHeightRequest() => create();
   GetLatestFailedWithdrawalBundleHeightRequest._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'),
-      createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest clone() =>
-      GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest))
-          as GetLatestFailedWithdrawalBundleHeightRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest clone() => GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest copyWith(void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest)) as GetLatestFailedWithdrawalBundleHeightRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightRequest create() => GetLatestFailedWithdrawalBundleHeightRequest._();
   GetLatestFailedWithdrawalBundleHeightRequest createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
+  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
   static GetLatestFailedWithdrawalBundleHeightRequest? _defaultInstance;
 }
 
@@ -2050,53 +1819,40 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
     return $result;
   }
   GetLatestFailedWithdrawalBundleHeightResponse._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'height')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse clone() =>
-      GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse))
-          as GetLatestFailedWithdrawalBundleHeightResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse clone() => GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse copyWith(void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse)) as GetLatestFailedWithdrawalBundleHeightResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightResponse create() => GetLatestFailedWithdrawalBundleHeightResponse._();
   GetLatestFailedWithdrawalBundleHeightResponse createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
+  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
   static GetLatestFailedWithdrawalBundleHeightResponse? _defaultInstance;
 
   /// 0 means no failed bundle.
   @$pb.TagNumber(1)
   $fixnum.Int64 get height => $_getI64(0);
   @$pb.TagNumber(1)
-  set height($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set height($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHeight() => $_has(0);
   @$pb.TagNumber(1)
@@ -2106,25 +1862,23 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
 class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   factory GenerateMnemonicRequest() => create();
   GenerateMnemonicRequest._() : super();
-  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicRequest clone() => GenerateMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) => super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2133,8 +1887,7 @@ class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   GenerateMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicRequest> createRepeated() => $pb.PbList<GenerateMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
+  static GenerateMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
   static GenerateMnemonicRequest? _defaultInstance;
 }
 
@@ -2149,26 +1902,24 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GenerateMnemonicResponse._() : super();
-  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicResponse clone() => GenerateMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) => super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2177,17 +1928,13 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
   GenerateMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicResponse> createRepeated() => $pb.PbList<GenerateMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
+  static GenerateMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
   static GenerateMnemonicResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2205,27 +1952,24 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SetSeedFromMnemonicRequest._() : super();
-  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicRequest clone() => SetSeedFromMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2234,17 +1978,13 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
   SetSeedFromMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicRequest> createRepeated() => $pb.PbList<SetSeedFromMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
+  static SetSeedFromMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
   static SetSeedFromMnemonicRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2254,26 +1994,23 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
 class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   factory SetSeedFromMnemonicResponse() => create();
   SetSeedFromMnemonicResponse._() : super();
-  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicResponse clone() => SetSeedFromMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2282,8 +2019,7 @@ class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   SetSeedFromMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicResponse> createRepeated() => $pb.PbList<SetSeedFromMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
+  static SetSeedFromMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
   static SetSeedFromMnemonicResponse? _defaultInstance;
 }
 
@@ -2302,26 +2038,25 @@ class CallRawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawRequest._() : super();
-  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'method')
     ..aOS(2, _omitFieldNames ? '' : 'paramsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawRequest clone() => CallRawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawRequest copyWith(void Function(CallRawRequest) updates) =>
-      super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawRequest copyWith(void Function(CallRawRequest) updates) => super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2336,10 +2071,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get method => $_getSZ(0);
   @$pb.TagNumber(1)
-  set method($core.String v) {
-    $_setString(0, v);
-  }
-
+  set method($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMethod() => $_has(0);
   @$pb.TagNumber(1)
@@ -2348,10 +2080,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get paramsJson => $_getSZ(1);
   @$pb.TagNumber(2)
-  set paramsJson($core.String v) {
-    $_setString(1, v);
-  }
-
+  set paramsJson($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasParamsJson() => $_has(1);
   @$pb.TagNumber(2)
@@ -2369,26 +2098,24 @@ class CallRawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawResponse._() : super();
-  factory CallRawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'thunder.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'resultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawResponse clone() => CallRawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawResponse copyWith(void Function(CallRawResponse) updates) =>
-      super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawResponse copyWith(void Function(CallRawResponse) updates) => super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2397,17 +2124,13 @@ class CallRawResponse extends $pb.GeneratedMessage {
   CallRawResponse createEmptyInstance() => create();
   static $pb.PbList<CallRawResponse> createRepeated() => $pb.PbList<CallRawResponse>();
   @$core.pragma('dart2js:noInline')
-  static CallRawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
+  static CallRawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
   static CallRawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get resultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set resultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set resultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2419,68 +2142,76 @@ class ThunderServiceApi {
   ThunderServiceApi(this._client);
 
   $async.Future<GetBalanceResponse> getBalance($pb.ClientContext? ctx, GetBalanceRequest request) =>
-      _client.invoke<GetBalanceResponse>(ctx, 'ThunderService', 'GetBalance', request, GetBalanceResponse());
+    _client.invoke<GetBalanceResponse>(ctx, 'ThunderService', 'GetBalance', request, GetBalanceResponse())
+  ;
   $async.Future<GetBlockCountResponse> getBlockCount($pb.ClientContext? ctx, GetBlockCountRequest request) =>
-      _client.invoke<GetBlockCountResponse>(ctx, 'ThunderService', 'GetBlockCount', request, GetBlockCountResponse());
+    _client.invoke<GetBlockCountResponse>(ctx, 'ThunderService', 'GetBlockCount', request, GetBlockCountResponse())
+  ;
   $async.Future<StopResponse> stop($pb.ClientContext? ctx, StopRequest request) =>
-      _client.invoke<StopResponse>(ctx, 'ThunderService', 'Stop', request, StopResponse());
+    _client.invoke<StopResponse>(ctx, 'ThunderService', 'Stop', request, StopResponse())
+  ;
   $async.Future<GetNewAddressResponse> getNewAddress($pb.ClientContext? ctx, GetNewAddressRequest request) =>
-      _client.invoke<GetNewAddressResponse>(ctx, 'ThunderService', 'GetNewAddress', request, GetNewAddressResponse());
+    _client.invoke<GetNewAddressResponse>(ctx, 'ThunderService', 'GetNewAddress', request, GetNewAddressResponse())
+  ;
   $async.Future<WithdrawResponse> withdraw($pb.ClientContext? ctx, WithdrawRequest request) =>
-      _client.invoke<WithdrawResponse>(ctx, 'ThunderService', 'Withdraw', request, WithdrawResponse());
+    _client.invoke<WithdrawResponse>(ctx, 'ThunderService', 'Withdraw', request, WithdrawResponse())
+  ;
   $async.Future<TransferResponse> transfer($pb.ClientContext? ctx, TransferRequest request) =>
-      _client.invoke<TransferResponse>(ctx, 'ThunderService', 'Transfer', request, TransferResponse());
-  $async.Future<GetSidechainWealthResponse> getSidechainWealth(
-          $pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
-      _client.invoke<GetSidechainWealthResponse>(
-          ctx, 'ThunderService', 'GetSidechainWealth', request, GetSidechainWealthResponse());
+    _client.invoke<TransferResponse>(ctx, 'ThunderService', 'Transfer', request, TransferResponse())
+  ;
+  $async.Future<GetSidechainWealthResponse> getSidechainWealth($pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
+    _client.invoke<GetSidechainWealthResponse>(ctx, 'ThunderService', 'GetSidechainWealth', request, GetSidechainWealthResponse())
+  ;
   $async.Future<CreateDepositResponse> createDeposit($pb.ClientContext? ctx, CreateDepositRequest request) =>
-      _client.invoke<CreateDepositResponse>(ctx, 'ThunderService', 'CreateDeposit', request, CreateDepositResponse());
-  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-          $pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
-      _client.invoke<GetPendingWithdrawalBundleResponse>(
-          ctx, 'ThunderService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse());
+    _client.invoke<CreateDepositResponse>(ctx, 'ThunderService', 'CreateDeposit', request, CreateDepositResponse())
+  ;
+  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
+    _client.invoke<GetPendingWithdrawalBundleResponse>(ctx, 'ThunderService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse())
+  ;
   $async.Future<ConnectPeerResponse> connectPeer($pb.ClientContext? ctx, ConnectPeerRequest request) =>
-      _client.invoke<ConnectPeerResponse>(ctx, 'ThunderService', 'ConnectPeer', request, ConnectPeerResponse());
+    _client.invoke<ConnectPeerResponse>(ctx, 'ThunderService', 'ConnectPeer', request, ConnectPeerResponse())
+  ;
   $async.Future<ListPeersResponse> listPeers($pb.ClientContext? ctx, ListPeersRequest request) =>
-      _client.invoke<ListPeersResponse>(ctx, 'ThunderService', 'ListPeers', request, ListPeersResponse());
+    _client.invoke<ListPeersResponse>(ctx, 'ThunderService', 'ListPeers', request, ListPeersResponse())
+  ;
   $async.Future<MineResponse> mine($pb.ClientContext? ctx, MineRequest request) =>
-      _client.invoke<MineResponse>(ctx, 'ThunderService', 'Mine', request, MineResponse());
+    _client.invoke<MineResponse>(ctx, 'ThunderService', 'Mine', request, MineResponse())
+  ;
   $async.Future<GetBlockResponse> getBlock($pb.ClientContext? ctx, GetBlockRequest request) =>
-      _client.invoke<GetBlockResponse>(ctx, 'ThunderService', 'GetBlock', request, GetBlockResponse());
-  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-          $pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
-      _client.invoke<GetBestMainchainBlockHashResponse>(
-          ctx, 'ThunderService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse());
-  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-          $pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
-      _client.invoke<GetBestSidechainBlockHashResponse>(
-          ctx, 'ThunderService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse());
+    _client.invoke<GetBlockResponse>(ctx, 'ThunderService', 'GetBlock', request, GetBlockResponse())
+  ;
+  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
+    _client.invoke<GetBestMainchainBlockHashResponse>(ctx, 'ThunderService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse())
+  ;
+  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
+    _client.invoke<GetBestSidechainBlockHashResponse>(ctx, 'ThunderService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse())
+  ;
   $async.Future<GetBmmInclusionsResponse> getBmmInclusions($pb.ClientContext? ctx, GetBmmInclusionsRequest request) =>
-      _client.invoke<GetBmmInclusionsResponse>(
-          ctx, 'ThunderService', 'GetBmmInclusions', request, GetBmmInclusionsResponse());
-  $async.Future<GetWalletUtxosResponse> getWalletUtxos($pb.ClientContext? ctx, GetWalletUtxosRequest request) => _client
-      .invoke<GetWalletUtxosResponse>(ctx, 'ThunderService', 'GetWalletUtxos', request, GetWalletUtxosResponse());
+    _client.invoke<GetBmmInclusionsResponse>(ctx, 'ThunderService', 'GetBmmInclusions', request, GetBmmInclusionsResponse())
+  ;
+  $async.Future<GetWalletUtxosResponse> getWalletUtxos($pb.ClientContext? ctx, GetWalletUtxosRequest request) =>
+    _client.invoke<GetWalletUtxosResponse>(ctx, 'ThunderService', 'GetWalletUtxos', request, GetWalletUtxosResponse())
+  ;
   $async.Future<ListUtxosResponse> listUtxos($pb.ClientContext? ctx, ListUtxosRequest request) =>
-      _client.invoke<ListUtxosResponse>(ctx, 'ThunderService', 'ListUtxos', request, ListUtxosResponse());
-  $async.Future<RemoveFromMempoolResponse> removeFromMempool(
-          $pb.ClientContext? ctx, RemoveFromMempoolRequest request) =>
-      _client.invoke<RemoveFromMempoolResponse>(
-          ctx, 'ThunderService', 'RemoveFromMempool', request, RemoveFromMempoolResponse());
-  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-          $pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
-      _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'ThunderService',
-          'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse());
+    _client.invoke<ListUtxosResponse>(ctx, 'ThunderService', 'ListUtxos', request, ListUtxosResponse())
+  ;
+  $async.Future<RemoveFromMempoolResponse> removeFromMempool($pb.ClientContext? ctx, RemoveFromMempoolRequest request) =>
+    _client.invoke<RemoveFromMempoolResponse>(ctx, 'ThunderService', 'RemoveFromMempool', request, RemoveFromMempoolResponse())
+  ;
+  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
+    _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'ThunderService', 'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse())
+  ;
   $async.Future<GenerateMnemonicResponse> generateMnemonic($pb.ClientContext? ctx, GenerateMnemonicRequest request) =>
-      _client.invoke<GenerateMnemonicResponse>(
-          ctx, 'ThunderService', 'GenerateMnemonic', request, GenerateMnemonicResponse());
-  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-          $pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
-      _client.invoke<SetSeedFromMnemonicResponse>(
-          ctx, 'ThunderService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse());
+    _client.invoke<GenerateMnemonicResponse>(ctx, 'ThunderService', 'GenerateMnemonic', request, GenerateMnemonicResponse())
+  ;
+  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
+    _client.invoke<SetSeedFromMnemonicResponse>(ctx, 'ThunderService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse())
+  ;
   $async.Future<CallRawResponse> callRaw($pb.ClientContext? ctx, CallRawRequest request) =>
-      _client.invoke<CallRawResponse>(ctx, 'ThunderService', 'CallRaw', request, CallRawResponse());
+    _client.invoke<CallRawResponse>(ctx, 'ThunderService', 'CallRaw', request, CallRawResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/thunder/v1/thunder.pbenum.dart
+++ b/sail_ui/lib/gen/thunder/v1/thunder.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/thunder/v1/thunder.pbjson.dart
+++ b/sail_ui/lib/gen/thunder/v1/thunder.pbjson.dart
@@ -19,7 +19,8 @@ const GetBalanceRequest$json = {
 };
 
 /// Descriptor for `GetBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode('ChFHZXRCYWxhbmNlUmVxdWVzdA==');
+final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode(
+    'ChFHZXRCYWxhbmNlUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBalanceResponseDescriptor instead')
 const GetBalanceResponse$json = {
@@ -31,9 +32,9 @@ const GetBalanceResponse$json = {
 };
 
 /// Descriptor for `GetBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceResponseDescriptor =
-    $convert.base64Decode('ChJHZXRCYWxhbmNlUmVzcG9uc2USHQoKdG90YWxfc2F0cxgBIAEoA1IJdG90YWxTYXRzEiUKDm'
-        'F2YWlsYWJsZV9zYXRzGAIgASgDUg1hdmFpbGFibGVTYXRz');
+final $typed_data.Uint8List getBalanceResponseDescriptor = $convert.base64Decode(
+    'ChJHZXRCYWxhbmNlUmVzcG9uc2USHQoKdG90YWxfc2F0cxgBIAEoA1IJdG90YWxTYXRzEiUKDm'
+    'F2YWlsYWJsZV9zYXRzGAIgASgDUg1hdmFpbGFibGVTYXRz');
 
 @$core.Deprecated('Use getBlockCountRequestDescriptor instead')
 const GetBlockCountRequest$json = {
@@ -41,7 +42,8 @@ const GetBlockCountRequest$json = {
 };
 
 /// Descriptor for `GetBlockCountRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode('ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
+final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
 
 @$core.Deprecated('Use getBlockCountResponseDescriptor instead')
 const GetBlockCountResponse$json = {
@@ -52,8 +54,8 @@ const GetBlockCountResponse$json = {
 };
 
 /// Descriptor for `GetBlockCountResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountResponseDescriptor =
-    $convert.base64Decode('ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
+final $typed_data.Uint8List getBlockCountResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
 
 @$core.Deprecated('Use stopRequestDescriptor instead')
 const StopRequest$json = {
@@ -61,7 +63,8 @@ const StopRequest$json = {
 };
 
 /// Descriptor for `StopRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode('CgtTdG9wUmVxdWVzdA==');
+final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode(
+    'CgtTdG9wUmVxdWVzdA==');
 
 @$core.Deprecated('Use stopResponseDescriptor instead')
 const StopResponse$json = {
@@ -69,7 +72,8 @@ const StopResponse$json = {
 };
 
 /// Descriptor for `StopResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode('CgxTdG9wUmVzcG9uc2U=');
+final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode(
+    'CgxTdG9wUmVzcG9uc2U=');
 
 @$core.Deprecated('Use getNewAddressRequestDescriptor instead')
 const GetNewAddressRequest$json = {
@@ -77,7 +81,8 @@ const GetNewAddressRequest$json = {
 };
 
 /// Descriptor for `GetNewAddressRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode('ChRHZXROZXdBZGRyZXNzUmVxdWVzdA==');
+final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode(
+    'ChRHZXROZXdBZGRyZXNzUmVxdWVzdA==');
 
 @$core.Deprecated('Use getNewAddressResponseDescriptor instead')
 const GetNewAddressResponse$json = {
@@ -88,8 +93,8 @@ const GetNewAddressResponse$json = {
 };
 
 /// Descriptor for `GetNewAddressResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressResponseDescriptor =
-    $convert.base64Decode('ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List getNewAddressResponseDescriptor = $convert.base64Decode(
+    'ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use withdrawRequestDescriptor instead')
 const WithdrawRequest$json = {
@@ -103,10 +108,10 @@ const WithdrawRequest$json = {
 };
 
 /// Descriptor for `WithdrawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawRequestDescriptor =
-    $convert.base64Decode('Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
-        'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
+final $typed_data.Uint8List withdrawRequestDescriptor = $convert.base64Decode(
+    'Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
+    'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
 
 @$core.Deprecated('Use withdrawResponseDescriptor instead')
 const WithdrawResponse$json = {
@@ -117,8 +122,8 @@ const WithdrawResponse$json = {
 };
 
 /// Descriptor for `WithdrawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawResponseDescriptor =
-    $convert.base64Decode('ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List withdrawResponseDescriptor = $convert.base64Decode(
+    'ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use transferRequestDescriptor instead')
 const TransferRequest$json = {
@@ -131,9 +136,9 @@ const TransferRequest$json = {
 };
 
 /// Descriptor for `TransferRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferRequestDescriptor =
-    $convert.base64Decode('Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List transferRequestDescriptor = $convert.base64Decode(
+    'Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use transferResponseDescriptor instead')
 const TransferResponse$json = {
@@ -144,8 +149,8 @@ const TransferResponse$json = {
 };
 
 /// Descriptor for `TransferResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferResponseDescriptor =
-    $convert.base64Decode('ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List transferResponseDescriptor = $convert.base64Decode(
+    'ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use getSidechainWealthRequestDescriptor instead')
 const GetSidechainWealthRequest$json = {
@@ -153,8 +158,8 @@ const GetSidechainWealthRequest$json = {
 };
 
 /// Descriptor for `GetSidechainWealthRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthRequestDescriptor =
-    $convert.base64Decode('ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
+final $typed_data.Uint8List getSidechainWealthRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
 
 @$core.Deprecated('Use getSidechainWealthResponseDescriptor instead')
 const GetSidechainWealthResponse$json = {
@@ -165,8 +170,8 @@ const GetSidechainWealthResponse$json = {
 };
 
 /// Descriptor for `GetSidechainWealthResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthResponseDescriptor =
-    $convert.base64Decode('ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
+final $typed_data.Uint8List getSidechainWealthResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
 
 @$core.Deprecated('Use createDepositRequestDescriptor instead')
 const CreateDepositRequest$json = {
@@ -179,9 +184,9 @@ const CreateDepositRequest$json = {
 };
 
 /// Descriptor for `CreateDepositRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositRequestDescriptor =
-    $convert.base64Decode('ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
-        'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List createDepositRequestDescriptor = $convert.base64Decode(
+    'ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
+    'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use createDepositResponseDescriptor instead')
 const CreateDepositResponse$json = {
@@ -192,8 +197,8 @@ const CreateDepositResponse$json = {
 };
 
 /// Descriptor for `CreateDepositResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositResponseDescriptor =
-    $convert.base64Decode('ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List createDepositResponseDescriptor = $convert.base64Decode(
+    'ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleRequestDescriptor instead')
 const GetPendingWithdrawalBundleRequest$json = {
@@ -201,8 +206,8 @@ const GetPendingWithdrawalBundleRequest$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor =
-    $convert.base64Decode('CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
+final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor = $convert.base64Decode(
+    'CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleResponseDescriptor instead')
 const GetPendingWithdrawalBundleResponse$json = {
@@ -213,9 +218,9 @@ const GetPendingWithdrawalBundleResponse$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor =
-    $convert.base64Decode('CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
-        'gJUgpidW5kbGVKc29u');
+final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor = $convert.base64Decode(
+    'CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
+    'gJUgpidW5kbGVKc29u');
 
 @$core.Deprecated('Use connectPeerRequestDescriptor instead')
 const ConnectPeerRequest$json = {
@@ -226,8 +231,8 @@ const ConnectPeerRequest$json = {
 };
 
 /// Descriptor for `ConnectPeerRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerRequestDescriptor =
-    $convert.base64Decode('ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List connectPeerRequestDescriptor = $convert.base64Decode(
+    'ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use connectPeerResponseDescriptor instead')
 const ConnectPeerResponse$json = {
@@ -235,7 +240,8 @@ const ConnectPeerResponse$json = {
 };
 
 /// Descriptor for `ConnectPeerResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode('ChNDb25uZWN0UGVlclJlc3BvbnNl');
+final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode(
+    'ChNDb25uZWN0UGVlclJlc3BvbnNl');
 
 @$core.Deprecated('Use listPeersRequestDescriptor instead')
 const ListPeersRequest$json = {
@@ -243,7 +249,8 @@ const ListPeersRequest$json = {
 };
 
 /// Descriptor for `ListPeersRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode('ChBMaXN0UGVlcnNSZXF1ZXN0');
+final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0UGVlcnNSZXF1ZXN0');
 
 @$core.Deprecated('Use listPeersResponseDescriptor instead')
 const ListPeersResponse$json = {
@@ -254,8 +261,8 @@ const ListPeersResponse$json = {
 };
 
 /// Descriptor for `ListPeersResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
+final $typed_data.Uint8List listPeersResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
 
 @$core.Deprecated('Use mineRequestDescriptor instead')
 const MineRequest$json = {
@@ -266,8 +273,8 @@ const MineRequest$json = {
 };
 
 /// Descriptor for `MineRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineRequestDescriptor =
-    $convert.base64Decode('CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List mineRequestDescriptor = $convert.base64Decode(
+    'CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use mineResponseDescriptor instead')
 const MineResponse$json = {
@@ -278,8 +285,8 @@ const MineResponse$json = {
 };
 
 /// Descriptor for `MineResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineResponseDescriptor =
-    $convert.base64Decode('CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
+final $typed_data.Uint8List mineResponseDescriptor = $convert.base64Decode(
+    'CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
 
 @$core.Deprecated('Use getBlockRequestDescriptor instead')
 const GetBlockRequest$json = {
@@ -290,8 +297,8 @@ const GetBlockRequest$json = {
 };
 
 /// Descriptor for `GetBlockRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockRequestDescriptor =
-    $convert.base64Decode('Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
+final $typed_data.Uint8List getBlockRequestDescriptor = $convert.base64Decode(
+    'Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
 
 @$core.Deprecated('Use getBlockResponseDescriptor instead')
 const GetBlockResponse$json = {
@@ -302,8 +309,8 @@ const GetBlockResponse$json = {
 };
 
 /// Descriptor for `GetBlockResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockResponseDescriptor =
-    $convert.base64Decode('ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
+final $typed_data.Uint8List getBlockResponseDescriptor = $convert.base64Decode(
+    'ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashRequestDescriptor instead')
 const GetBestMainchainBlockHashRequest$json = {
@@ -311,8 +318,8 @@ const GetBestMainchainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashResponseDescriptor instead')
 const GetBestMainchainBlockHashResponse$json = {
@@ -323,9 +330,9 @@ const GetBestMainchainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashRequestDescriptor instead')
 const GetBestSidechainBlockHashRequest$json = {
@@ -333,8 +340,8 @@ const GetBestSidechainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashResponseDescriptor instead')
 const GetBestSidechainBlockHashResponse$json = {
@@ -345,9 +352,9 @@ const GetBestSidechainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBmmInclusionsRequestDescriptor instead')
 const GetBmmInclusionsRequest$json = {
@@ -358,9 +365,9 @@ const GetBmmInclusionsRequest$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsRequestDescriptor =
-    $convert.base64Decode('ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
-        'g=');
+final $typed_data.Uint8List getBmmInclusionsRequestDescriptor = $convert.base64Decode(
+    'ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
+    'g=');
 
 @$core.Deprecated('Use getBmmInclusionsResponseDescriptor instead')
 const GetBmmInclusionsResponse$json = {
@@ -371,9 +378,9 @@ const GetBmmInclusionsResponse$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsResponseDescriptor =
-    $convert.base64Decode('ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
-        '9ucw==');
+final $typed_data.Uint8List getBmmInclusionsResponseDescriptor = $convert.base64Decode(
+    'ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
+    '9ucw==');
 
 @$core.Deprecated('Use getWalletUtxosRequestDescriptor instead')
 const GetWalletUtxosRequest$json = {
@@ -381,7 +388,8 @@ const GetWalletUtxosRequest$json = {
 };
 
 /// Descriptor for `GetWalletUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode('ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
+final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode(
+    'ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getWalletUtxosResponseDescriptor instead')
 const GetWalletUtxosResponse$json = {
@@ -392,9 +400,9 @@ const GetWalletUtxosResponse$json = {
 };
 
 /// Descriptor for `GetWalletUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosResponseDescriptor =
-    $convert.base64Decode('ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
-        '==');
+final $typed_data.Uint8List getWalletUtxosResponseDescriptor = $convert.base64Decode(
+    'ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
+    '==');
 
 @$core.Deprecated('Use listUtxosRequestDescriptor instead')
 const ListUtxosRequest$json = {
@@ -402,7 +410,8 @@ const ListUtxosRequest$json = {
 };
 
 /// Descriptor for `ListUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode('ChBMaXN0VXR4b3NSZXF1ZXN0');
+final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0VXR4b3NSZXF1ZXN0');
 
 @$core.Deprecated('Use listUtxosResponseDescriptor instead')
 const ListUtxosResponse$json = {
@@ -413,8 +422,8 @@ const ListUtxosResponse$json = {
 };
 
 /// Descriptor for `ListUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
+final $typed_data.Uint8List listUtxosResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
 
 @$core.Deprecated('Use removeFromMempoolRequestDescriptor instead')
 const RemoveFromMempoolRequest$json = {
@@ -425,8 +434,8 @@ const RemoveFromMempoolRequest$json = {
 };
 
 /// Descriptor for `RemoveFromMempoolRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFromMempoolRequestDescriptor =
-    $convert.base64Decode('ChhSZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List removeFromMempoolRequestDescriptor = $convert.base64Decode(
+    'ChhSZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use removeFromMempoolResponseDescriptor instead')
 const RemoveFromMempoolResponse$json = {
@@ -434,8 +443,8 @@ const RemoveFromMempoolResponse$json = {
 };
 
 /// Descriptor for `RemoveFromMempoolResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFromMempoolResponseDescriptor =
-    $convert.base64Decode('ChlSZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNl');
+final $typed_data.Uint8List removeFromMempoolResponseDescriptor = $convert.base64Decode(
+    'ChlSZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNl');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightRequestDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightRequest$json = {
@@ -443,8 +452,8 @@ const GetLatestFailedWithdrawalBundleHeightRequest$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor =
-    $convert.base64Decode('CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor = $convert.base64Decode(
+    'CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightResponseDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightResponse$json = {
@@ -455,9 +464,9 @@ const GetLatestFailedWithdrawalBundleHeightResponse$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor =
-    $convert.base64Decode('Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
-        'h0GAEgASgDUgZoZWlnaHQ=');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor = $convert.base64Decode(
+    'Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
+    'h0GAEgASgDUgZoZWlnaHQ=');
 
 @$core.Deprecated('Use generateMnemonicRequestDescriptor instead')
 const GenerateMnemonicRequest$json = {
@@ -465,8 +474,8 @@ const GenerateMnemonicRequest$json = {
 };
 
 /// Descriptor for `GenerateMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicRequestDescriptor =
-    $convert.base64Decode('ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
+final $typed_data.Uint8List generateMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
 
 @$core.Deprecated('Use generateMnemonicResponseDescriptor instead')
 const GenerateMnemonicResponse$json = {
@@ -477,8 +486,8 @@ const GenerateMnemonicResponse$json = {
 };
 
 /// Descriptor for `GenerateMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicResponseDescriptor =
-    $convert.base64Decode('ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
+final $typed_data.Uint8List generateMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
 
 @$core.Deprecated('Use setSeedFromMnemonicRequestDescriptor instead')
 const SetSeedFromMnemonicRequest$json = {
@@ -489,9 +498,9 @@ const SetSeedFromMnemonicRequest$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor =
-    $convert.base64Decode('ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
-        'M=');
+final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
+    'M=');
 
 @$core.Deprecated('Use setSeedFromMnemonicResponseDescriptor instead')
 const SetSeedFromMnemonicResponse$json = {
@@ -499,8 +508,8 @@ const SetSeedFromMnemonicResponse$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor =
-    $convert.base64Decode('ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
+final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
 
 @$core.Deprecated('Use callRawRequestDescriptor instead')
 const CallRawRequest$json = {
@@ -512,9 +521,9 @@ const CallRawRequest$json = {
 };
 
 /// Descriptor for `CallRawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawRequestDescriptor =
-    $convert.base64Decode('Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
-        'gCIAEoCVIKcGFyYW1zSnNvbg==');
+final $typed_data.Uint8List callRawRequestDescriptor = $convert.base64Decode(
+    'Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
+    'gCIAEoCVIKcGFyYW1zSnNvbg==');
 
 @$core.Deprecated('Use callRawResponseDescriptor instead')
 const CallRawResponse$json = {
@@ -525,8 +534,8 @@ const CallRawResponse$json = {
 };
 
 /// Descriptor for `CallRawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawResponseDescriptor =
-    $convert.base64Decode('Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
+final $typed_data.Uint8List callRawResponseDescriptor = $convert.base64Decode(
+    'Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
 
 const $core.Map<$core.String, $core.dynamic> ThunderServiceBase$json = {
   '1': 'ThunderService',
@@ -537,50 +546,22 @@ const $core.Map<$core.String, $core.dynamic> ThunderServiceBase$json = {
     {'1': 'GetNewAddress', '2': '.thunder.v1.GetNewAddressRequest', '3': '.thunder.v1.GetNewAddressResponse'},
     {'1': 'Withdraw', '2': '.thunder.v1.WithdrawRequest', '3': '.thunder.v1.WithdrawResponse'},
     {'1': 'Transfer', '2': '.thunder.v1.TransferRequest', '3': '.thunder.v1.TransferResponse'},
-    {
-      '1': 'GetSidechainWealth',
-      '2': '.thunder.v1.GetSidechainWealthRequest',
-      '3': '.thunder.v1.GetSidechainWealthResponse'
-    },
+    {'1': 'GetSidechainWealth', '2': '.thunder.v1.GetSidechainWealthRequest', '3': '.thunder.v1.GetSidechainWealthResponse'},
     {'1': 'CreateDeposit', '2': '.thunder.v1.CreateDepositRequest', '3': '.thunder.v1.CreateDepositResponse'},
-    {
-      '1': 'GetPendingWithdrawalBundle',
-      '2': '.thunder.v1.GetPendingWithdrawalBundleRequest',
-      '3': '.thunder.v1.GetPendingWithdrawalBundleResponse'
-    },
+    {'1': 'GetPendingWithdrawalBundle', '2': '.thunder.v1.GetPendingWithdrawalBundleRequest', '3': '.thunder.v1.GetPendingWithdrawalBundleResponse'},
     {'1': 'ConnectPeer', '2': '.thunder.v1.ConnectPeerRequest', '3': '.thunder.v1.ConnectPeerResponse'},
     {'1': 'ListPeers', '2': '.thunder.v1.ListPeersRequest', '3': '.thunder.v1.ListPeersResponse'},
     {'1': 'Mine', '2': '.thunder.v1.MineRequest', '3': '.thunder.v1.MineResponse'},
     {'1': 'GetBlock', '2': '.thunder.v1.GetBlockRequest', '3': '.thunder.v1.GetBlockResponse'},
-    {
-      '1': 'GetBestMainchainBlockHash',
-      '2': '.thunder.v1.GetBestMainchainBlockHashRequest',
-      '3': '.thunder.v1.GetBestMainchainBlockHashResponse'
-    },
-    {
-      '1': 'GetBestSidechainBlockHash',
-      '2': '.thunder.v1.GetBestSidechainBlockHashRequest',
-      '3': '.thunder.v1.GetBestSidechainBlockHashResponse'
-    },
+    {'1': 'GetBestMainchainBlockHash', '2': '.thunder.v1.GetBestMainchainBlockHashRequest', '3': '.thunder.v1.GetBestMainchainBlockHashResponse'},
+    {'1': 'GetBestSidechainBlockHash', '2': '.thunder.v1.GetBestSidechainBlockHashRequest', '3': '.thunder.v1.GetBestSidechainBlockHashResponse'},
     {'1': 'GetBmmInclusions', '2': '.thunder.v1.GetBmmInclusionsRequest', '3': '.thunder.v1.GetBmmInclusionsResponse'},
     {'1': 'GetWalletUtxos', '2': '.thunder.v1.GetWalletUtxosRequest', '3': '.thunder.v1.GetWalletUtxosResponse'},
     {'1': 'ListUtxos', '2': '.thunder.v1.ListUtxosRequest', '3': '.thunder.v1.ListUtxosResponse'},
-    {
-      '1': 'RemoveFromMempool',
-      '2': '.thunder.v1.RemoveFromMempoolRequest',
-      '3': '.thunder.v1.RemoveFromMempoolResponse'
-    },
-    {
-      '1': 'GetLatestFailedWithdrawalBundleHeight',
-      '2': '.thunder.v1.GetLatestFailedWithdrawalBundleHeightRequest',
-      '3': '.thunder.v1.GetLatestFailedWithdrawalBundleHeightResponse'
-    },
+    {'1': 'RemoveFromMempool', '2': '.thunder.v1.RemoveFromMempoolRequest', '3': '.thunder.v1.RemoveFromMempoolResponse'},
+    {'1': 'GetLatestFailedWithdrawalBundleHeight', '2': '.thunder.v1.GetLatestFailedWithdrawalBundleHeightRequest', '3': '.thunder.v1.GetLatestFailedWithdrawalBundleHeightResponse'},
     {'1': 'GenerateMnemonic', '2': '.thunder.v1.GenerateMnemonicRequest', '3': '.thunder.v1.GenerateMnemonicResponse'},
-    {
-      '1': 'SetSeedFromMnemonic',
-      '2': '.thunder.v1.SetSeedFromMnemonicRequest',
-      '3': '.thunder.v1.SetSeedFromMnemonicResponse'
-    },
+    {'1': 'SetSeedFromMnemonic', '2': '.thunder.v1.SetSeedFromMnemonicRequest', '3': '.thunder.v1.SetSeedFromMnemonicResponse'},
     {'1': 'CallRaw', '2': '.thunder.v1.CallRawRequest', '3': '.thunder.v1.CallRawResponse'},
   ],
 };
@@ -636,42 +617,43 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> ThunderSer
 };
 
 /// Descriptor for `ThunderService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List thunderServiceDescriptor =
-    $convert.base64Decode('Cg5UaHVuZGVyU2VydmljZRJLCgpHZXRCYWxhbmNlEh0udGh1bmRlci52MS5HZXRCYWxhbmNlUm'
-        'VxdWVzdBoeLnRodW5kZXIudjEuR2V0QmFsYW5jZVJlc3BvbnNlElQKDUdldEJsb2NrQ291bnQS'
-        'IC50aHVuZGVyLnYxLkdldEJsb2NrQ291bnRSZXF1ZXN0GiEudGh1bmRlci52MS5HZXRCbG9ja0'
-        'NvdW50UmVzcG9uc2USOQoEU3RvcBIXLnRodW5kZXIudjEuU3RvcFJlcXVlc3QaGC50aHVuZGVy'
-        'LnYxLlN0b3BSZXNwb25zZRJUCg1HZXROZXdBZGRyZXNzEiAudGh1bmRlci52MS5HZXROZXdBZG'
-        'RyZXNzUmVxdWVzdBohLnRodW5kZXIudjEuR2V0TmV3QWRkcmVzc1Jlc3BvbnNlEkUKCFdpdGhk'
-        'cmF3EhsudGh1bmRlci52MS5XaXRoZHJhd1JlcXVlc3QaHC50aHVuZGVyLnYxLldpdGhkcmF3Um'
-        'VzcG9uc2USRQoIVHJhbnNmZXISGy50aHVuZGVyLnYxLlRyYW5zZmVyUmVxdWVzdBocLnRodW5k'
-        'ZXIudjEuVHJhbnNmZXJSZXNwb25zZRJjChJHZXRTaWRlY2hhaW5XZWFsdGgSJS50aHVuZGVyLn'
-        'YxLkdldFNpZGVjaGFpbldlYWx0aFJlcXVlc3QaJi50aHVuZGVyLnYxLkdldFNpZGVjaGFpbldl'
-        'YWx0aFJlc3BvbnNlElQKDUNyZWF0ZURlcG9zaXQSIC50aHVuZGVyLnYxLkNyZWF0ZURlcG9zaX'
-        'RSZXF1ZXN0GiEudGh1bmRlci52MS5DcmVhdGVEZXBvc2l0UmVzcG9uc2USewoaR2V0UGVuZGlu'
-        'Z1dpdGhkcmF3YWxCdW5kbGUSLS50aHVuZGVyLnYxLkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZG'
-        'xlUmVxdWVzdBouLnRodW5kZXIudjEuR2V0UGVuZGluZ1dpdGhkcmF3YWxCdW5kbGVSZXNwb25z'
-        'ZRJOCgtDb25uZWN0UGVlchIeLnRodW5kZXIudjEuQ29ubmVjdFBlZXJSZXF1ZXN0Gh8udGh1bm'
-        'Rlci52MS5Db25uZWN0UGVlclJlc3BvbnNlEkgKCUxpc3RQZWVycxIcLnRodW5kZXIudjEuTGlz'
-        'dFBlZXJzUmVxdWVzdBodLnRodW5kZXIudjEuTGlzdFBlZXJzUmVzcG9uc2USOQoETWluZRIXLn'
-        'RodW5kZXIudjEuTWluZVJlcXVlc3QaGC50aHVuZGVyLnYxLk1pbmVSZXNwb25zZRJFCghHZXRC'
-        'bG9jaxIbLnRodW5kZXIudjEuR2V0QmxvY2tSZXF1ZXN0GhwudGh1bmRlci52MS5HZXRCbG9ja1'
-        'Jlc3BvbnNlEngKGUdldEJlc3RNYWluY2hhaW5CbG9ja0hhc2gSLC50aHVuZGVyLnYxLkdldEJl'
-        'c3RNYWluY2hhaW5CbG9ja0hhc2hSZXF1ZXN0Gi0udGh1bmRlci52MS5HZXRCZXN0TWFpbmNoYW'
-        'luQmxvY2tIYXNoUmVzcG9uc2USeAoZR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaBIsLnRodW5k'
-        'ZXIudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaFJlcXVlc3QaLS50aHVuZGVyLnYxLkdldE'
-        'Jlc3RTaWRlY2hhaW5CbG9ja0hhc2hSZXNwb25zZRJdChBHZXRCbW1JbmNsdXNpb25zEiMudGh1'
-        'bmRlci52MS5HZXRCbW1JbmNsdXNpb25zUmVxdWVzdBokLnRodW5kZXIudjEuR2V0Qm1tSW5jbH'
-        'VzaW9uc1Jlc3BvbnNlElcKDkdldFdhbGxldFV0eG9zEiEudGh1bmRlci52MS5HZXRXYWxsZXRV'
-        'dHhvc1JlcXVlc3QaIi50aHVuZGVyLnYxLkdldFdhbGxldFV0eG9zUmVzcG9uc2USSAoJTGlzdF'
-        'V0eG9zEhwudGh1bmRlci52MS5MaXN0VXR4b3NSZXF1ZXN0Gh0udGh1bmRlci52MS5MaXN0VXR4'
-        'b3NSZXNwb25zZRJgChFSZW1vdmVGcm9tTWVtcG9vbBIkLnRodW5kZXIudjEuUmVtb3ZlRnJvbU'
-        '1lbXBvb2xSZXF1ZXN0GiUudGh1bmRlci52MS5SZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNlEpwB'
-        'CiVHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0EjgudGh1bmRlci52MS5HZX'
-        'RMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdBo5LnRodW5kZXIudjEu'
-        'R2V0TGF0ZXN0RmFpbGVkV2l0aGRyYXdhbEJ1bmRsZUhlaWdodFJlc3BvbnNlEl0KEEdlbmVyYX'
-        'RlTW5lbW9uaWMSIy50aHVuZGVyLnYxLkdlbmVyYXRlTW5lbW9uaWNSZXF1ZXN0GiQudGh1bmRl'
-        'ci52MS5HZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USZgoTU2V0U2VlZEZyb21NbmVtb25pYxImLn'
-        'RodW5kZXIudjEuU2V0U2VlZEZyb21NbmVtb25pY1JlcXVlc3QaJy50aHVuZGVyLnYxLlNldFNl'
-        'ZWRGcm9tTW5lbW9uaWNSZXNwb25zZRJCCgdDYWxsUmF3EhoudGh1bmRlci52MS5DYWxsUmF3Um'
-        'VxdWVzdBobLnRodW5kZXIudjEuQ2FsbFJhd1Jlc3BvbnNl');
+final $typed_data.Uint8List thunderServiceDescriptor = $convert.base64Decode(
+    'Cg5UaHVuZGVyU2VydmljZRJLCgpHZXRCYWxhbmNlEh0udGh1bmRlci52MS5HZXRCYWxhbmNlUm'
+    'VxdWVzdBoeLnRodW5kZXIudjEuR2V0QmFsYW5jZVJlc3BvbnNlElQKDUdldEJsb2NrQ291bnQS'
+    'IC50aHVuZGVyLnYxLkdldEJsb2NrQ291bnRSZXF1ZXN0GiEudGh1bmRlci52MS5HZXRCbG9ja0'
+    'NvdW50UmVzcG9uc2USOQoEU3RvcBIXLnRodW5kZXIudjEuU3RvcFJlcXVlc3QaGC50aHVuZGVy'
+    'LnYxLlN0b3BSZXNwb25zZRJUCg1HZXROZXdBZGRyZXNzEiAudGh1bmRlci52MS5HZXROZXdBZG'
+    'RyZXNzUmVxdWVzdBohLnRodW5kZXIudjEuR2V0TmV3QWRkcmVzc1Jlc3BvbnNlEkUKCFdpdGhk'
+    'cmF3EhsudGh1bmRlci52MS5XaXRoZHJhd1JlcXVlc3QaHC50aHVuZGVyLnYxLldpdGhkcmF3Um'
+    'VzcG9uc2USRQoIVHJhbnNmZXISGy50aHVuZGVyLnYxLlRyYW5zZmVyUmVxdWVzdBocLnRodW5k'
+    'ZXIudjEuVHJhbnNmZXJSZXNwb25zZRJjChJHZXRTaWRlY2hhaW5XZWFsdGgSJS50aHVuZGVyLn'
+    'YxLkdldFNpZGVjaGFpbldlYWx0aFJlcXVlc3QaJi50aHVuZGVyLnYxLkdldFNpZGVjaGFpbldl'
+    'YWx0aFJlc3BvbnNlElQKDUNyZWF0ZURlcG9zaXQSIC50aHVuZGVyLnYxLkNyZWF0ZURlcG9zaX'
+    'RSZXF1ZXN0GiEudGh1bmRlci52MS5DcmVhdGVEZXBvc2l0UmVzcG9uc2USewoaR2V0UGVuZGlu'
+    'Z1dpdGhkcmF3YWxCdW5kbGUSLS50aHVuZGVyLnYxLkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZG'
+    'xlUmVxdWVzdBouLnRodW5kZXIudjEuR2V0UGVuZGluZ1dpdGhkcmF3YWxCdW5kbGVSZXNwb25z'
+    'ZRJOCgtDb25uZWN0UGVlchIeLnRodW5kZXIudjEuQ29ubmVjdFBlZXJSZXF1ZXN0Gh8udGh1bm'
+    'Rlci52MS5Db25uZWN0UGVlclJlc3BvbnNlEkgKCUxpc3RQZWVycxIcLnRodW5kZXIudjEuTGlz'
+    'dFBlZXJzUmVxdWVzdBodLnRodW5kZXIudjEuTGlzdFBlZXJzUmVzcG9uc2USOQoETWluZRIXLn'
+    'RodW5kZXIudjEuTWluZVJlcXVlc3QaGC50aHVuZGVyLnYxLk1pbmVSZXNwb25zZRJFCghHZXRC'
+    'bG9jaxIbLnRodW5kZXIudjEuR2V0QmxvY2tSZXF1ZXN0GhwudGh1bmRlci52MS5HZXRCbG9ja1'
+    'Jlc3BvbnNlEngKGUdldEJlc3RNYWluY2hhaW5CbG9ja0hhc2gSLC50aHVuZGVyLnYxLkdldEJl'
+    'c3RNYWluY2hhaW5CbG9ja0hhc2hSZXF1ZXN0Gi0udGh1bmRlci52MS5HZXRCZXN0TWFpbmNoYW'
+    'luQmxvY2tIYXNoUmVzcG9uc2USeAoZR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaBIsLnRodW5k'
+    'ZXIudjEuR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaFJlcXVlc3QaLS50aHVuZGVyLnYxLkdldE'
+    'Jlc3RTaWRlY2hhaW5CbG9ja0hhc2hSZXNwb25zZRJdChBHZXRCbW1JbmNsdXNpb25zEiMudGh1'
+    'bmRlci52MS5HZXRCbW1JbmNsdXNpb25zUmVxdWVzdBokLnRodW5kZXIudjEuR2V0Qm1tSW5jbH'
+    'VzaW9uc1Jlc3BvbnNlElcKDkdldFdhbGxldFV0eG9zEiEudGh1bmRlci52MS5HZXRXYWxsZXRV'
+    'dHhvc1JlcXVlc3QaIi50aHVuZGVyLnYxLkdldFdhbGxldFV0eG9zUmVzcG9uc2USSAoJTGlzdF'
+    'V0eG9zEhwudGh1bmRlci52MS5MaXN0VXR4b3NSZXF1ZXN0Gh0udGh1bmRlci52MS5MaXN0VXR4'
+    'b3NSZXNwb25zZRJgChFSZW1vdmVGcm9tTWVtcG9vbBIkLnRodW5kZXIudjEuUmVtb3ZlRnJvbU'
+    '1lbXBvb2xSZXF1ZXN0GiUudGh1bmRlci52MS5SZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNlEpwB'
+    'CiVHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0EjgudGh1bmRlci52MS5HZX'
+    'RMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdBo5LnRodW5kZXIudjEu'
+    'R2V0TGF0ZXN0RmFpbGVkV2l0aGRyYXdhbEJ1bmRsZUhlaWdodFJlc3BvbnNlEl0KEEdlbmVyYX'
+    'RlTW5lbW9uaWMSIy50aHVuZGVyLnYxLkdlbmVyYXRlTW5lbW9uaWNSZXF1ZXN0GiQudGh1bmRl'
+    'ci52MS5HZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USZgoTU2V0U2VlZEZyb21NbmVtb25pYxImLn'
+    'RodW5kZXIudjEuU2V0U2VlZEZyb21NbmVtb25pY1JlcXVlc3QaJy50aHVuZGVyLnYxLlNldFNl'
+    'ZWRGcm9tTW5lbW9uaWNSZXNwb25zZRJCCgdDYWxsUmF3EhoudGh1bmRlci52MS5DYWxsUmF3Um'
+    'VxdWVzdBobLnRodW5kZXIudjEuQ2FsbFJhd1Jlc3BvbnNl');
+

--- a/sail_ui/lib/gen/thunder/v1/thunder.pbserver.dart
+++ b/sail_ui/lib/gen/thunder/v1/thunder.pbserver.dart
@@ -27,141 +27,83 @@ abstract class ThunderServiceBase extends $pb.GeneratedService {
   $async.Future<$10.GetNewAddressResponse> getNewAddress($pb.ServerContext ctx, $10.GetNewAddressRequest request);
   $async.Future<$10.WithdrawResponse> withdraw($pb.ServerContext ctx, $10.WithdrawRequest request);
   $async.Future<$10.TransferResponse> transfer($pb.ServerContext ctx, $10.TransferRequest request);
-  $async.Future<$10.GetSidechainWealthResponse> getSidechainWealth(
-      $pb.ServerContext ctx, $10.GetSidechainWealthRequest request);
+  $async.Future<$10.GetSidechainWealthResponse> getSidechainWealth($pb.ServerContext ctx, $10.GetSidechainWealthRequest request);
   $async.Future<$10.CreateDepositResponse> createDeposit($pb.ServerContext ctx, $10.CreateDepositRequest request);
-  $async.Future<$10.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-      $pb.ServerContext ctx, $10.GetPendingWithdrawalBundleRequest request);
+  $async.Future<$10.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ServerContext ctx, $10.GetPendingWithdrawalBundleRequest request);
   $async.Future<$10.ConnectPeerResponse> connectPeer($pb.ServerContext ctx, $10.ConnectPeerRequest request);
   $async.Future<$10.ListPeersResponse> listPeers($pb.ServerContext ctx, $10.ListPeersRequest request);
   $async.Future<$10.MineResponse> mine($pb.ServerContext ctx, $10.MineRequest request);
   $async.Future<$10.GetBlockResponse> getBlock($pb.ServerContext ctx, $10.GetBlockRequest request);
-  $async.Future<$10.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-      $pb.ServerContext ctx, $10.GetBestMainchainBlockHashRequest request);
-  $async.Future<$10.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-      $pb.ServerContext ctx, $10.GetBestSidechainBlockHashRequest request);
-  $async.Future<$10.GetBmmInclusionsResponse> getBmmInclusions(
-      $pb.ServerContext ctx, $10.GetBmmInclusionsRequest request);
+  $async.Future<$10.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ServerContext ctx, $10.GetBestMainchainBlockHashRequest request);
+  $async.Future<$10.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ServerContext ctx, $10.GetBestSidechainBlockHashRequest request);
+  $async.Future<$10.GetBmmInclusionsResponse> getBmmInclusions($pb.ServerContext ctx, $10.GetBmmInclusionsRequest request);
   $async.Future<$10.GetWalletUtxosResponse> getWalletUtxos($pb.ServerContext ctx, $10.GetWalletUtxosRequest request);
   $async.Future<$10.ListUtxosResponse> listUtxos($pb.ServerContext ctx, $10.ListUtxosRequest request);
-  $async.Future<$10.RemoveFromMempoolResponse> removeFromMempool(
-      $pb.ServerContext ctx, $10.RemoveFromMempoolRequest request);
-  $async.Future<$10.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-      $pb.ServerContext ctx, $10.GetLatestFailedWithdrawalBundleHeightRequest request);
-  $async.Future<$10.GenerateMnemonicResponse> generateMnemonic(
-      $pb.ServerContext ctx, $10.GenerateMnemonicRequest request);
-  $async.Future<$10.SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-      $pb.ServerContext ctx, $10.SetSeedFromMnemonicRequest request);
+  $async.Future<$10.RemoveFromMempoolResponse> removeFromMempool($pb.ServerContext ctx, $10.RemoveFromMempoolRequest request);
+  $async.Future<$10.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ServerContext ctx, $10.GetLatestFailedWithdrawalBundleHeightRequest request);
+  $async.Future<$10.GenerateMnemonicResponse> generateMnemonic($pb.ServerContext ctx, $10.GenerateMnemonicRequest request);
+  $async.Future<$10.SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ServerContext ctx, $10.SetSeedFromMnemonicRequest request);
   $async.Future<$10.CallRawResponse> callRaw($pb.ServerContext ctx, $10.CallRawRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetBalance':
-        return $10.GetBalanceRequest();
-      case 'GetBlockCount':
-        return $10.GetBlockCountRequest();
-      case 'Stop':
-        return $10.StopRequest();
-      case 'GetNewAddress':
-        return $10.GetNewAddressRequest();
-      case 'Withdraw':
-        return $10.WithdrawRequest();
-      case 'Transfer':
-        return $10.TransferRequest();
-      case 'GetSidechainWealth':
-        return $10.GetSidechainWealthRequest();
-      case 'CreateDeposit':
-        return $10.CreateDepositRequest();
-      case 'GetPendingWithdrawalBundle':
-        return $10.GetPendingWithdrawalBundleRequest();
-      case 'ConnectPeer':
-        return $10.ConnectPeerRequest();
-      case 'ListPeers':
-        return $10.ListPeersRequest();
-      case 'Mine':
-        return $10.MineRequest();
-      case 'GetBlock':
-        return $10.GetBlockRequest();
-      case 'GetBestMainchainBlockHash':
-        return $10.GetBestMainchainBlockHashRequest();
-      case 'GetBestSidechainBlockHash':
-        return $10.GetBestSidechainBlockHashRequest();
-      case 'GetBmmInclusions':
-        return $10.GetBmmInclusionsRequest();
-      case 'GetWalletUtxos':
-        return $10.GetWalletUtxosRequest();
-      case 'ListUtxos':
-        return $10.ListUtxosRequest();
-      case 'RemoveFromMempool':
-        return $10.RemoveFromMempoolRequest();
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return $10.GetLatestFailedWithdrawalBundleHeightRequest();
-      case 'GenerateMnemonic':
-        return $10.GenerateMnemonicRequest();
-      case 'SetSeedFromMnemonic':
-        return $10.SetSeedFromMnemonicRequest();
-      case 'CallRaw':
-        return $10.CallRawRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return $10.GetBalanceRequest();
+      case 'GetBlockCount': return $10.GetBlockCountRequest();
+      case 'Stop': return $10.StopRequest();
+      case 'GetNewAddress': return $10.GetNewAddressRequest();
+      case 'Withdraw': return $10.WithdrawRequest();
+      case 'Transfer': return $10.TransferRequest();
+      case 'GetSidechainWealth': return $10.GetSidechainWealthRequest();
+      case 'CreateDeposit': return $10.CreateDepositRequest();
+      case 'GetPendingWithdrawalBundle': return $10.GetPendingWithdrawalBundleRequest();
+      case 'ConnectPeer': return $10.ConnectPeerRequest();
+      case 'ListPeers': return $10.ListPeersRequest();
+      case 'Mine': return $10.MineRequest();
+      case 'GetBlock': return $10.GetBlockRequest();
+      case 'GetBestMainchainBlockHash': return $10.GetBestMainchainBlockHashRequest();
+      case 'GetBestSidechainBlockHash': return $10.GetBestSidechainBlockHashRequest();
+      case 'GetBmmInclusions': return $10.GetBmmInclusionsRequest();
+      case 'GetWalletUtxos': return $10.GetWalletUtxosRequest();
+      case 'ListUtxos': return $10.ListUtxosRequest();
+      case 'RemoveFromMempool': return $10.RemoveFromMempoolRequest();
+      case 'GetLatestFailedWithdrawalBundleHeight': return $10.GetLatestFailedWithdrawalBundleHeightRequest();
+      case 'GenerateMnemonic': return $10.GenerateMnemonicRequest();
+      case 'SetSeedFromMnemonic': return $10.SetSeedFromMnemonicRequest();
+      case 'CallRaw': return $10.CallRawRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetBalance':
-        return this.getBalance(ctx, request as $10.GetBalanceRequest);
-      case 'GetBlockCount':
-        return this.getBlockCount(ctx, request as $10.GetBlockCountRequest);
-      case 'Stop':
-        return this.stop(ctx, request as $10.StopRequest);
-      case 'GetNewAddress':
-        return this.getNewAddress(ctx, request as $10.GetNewAddressRequest);
-      case 'Withdraw':
-        return this.withdraw(ctx, request as $10.WithdrawRequest);
-      case 'Transfer':
-        return this.transfer(ctx, request as $10.TransferRequest);
-      case 'GetSidechainWealth':
-        return this.getSidechainWealth(ctx, request as $10.GetSidechainWealthRequest);
-      case 'CreateDeposit':
-        return this.createDeposit(ctx, request as $10.CreateDepositRequest);
-      case 'GetPendingWithdrawalBundle':
-        return this.getPendingWithdrawalBundle(ctx, request as $10.GetPendingWithdrawalBundleRequest);
-      case 'ConnectPeer':
-        return this.connectPeer(ctx, request as $10.ConnectPeerRequest);
-      case 'ListPeers':
-        return this.listPeers(ctx, request as $10.ListPeersRequest);
-      case 'Mine':
-        return this.mine(ctx, request as $10.MineRequest);
-      case 'GetBlock':
-        return this.getBlock(ctx, request as $10.GetBlockRequest);
-      case 'GetBestMainchainBlockHash':
-        return this.getBestMainchainBlockHash(ctx, request as $10.GetBestMainchainBlockHashRequest);
-      case 'GetBestSidechainBlockHash':
-        return this.getBestSidechainBlockHash(ctx, request as $10.GetBestSidechainBlockHashRequest);
-      case 'GetBmmInclusions':
-        return this.getBmmInclusions(ctx, request as $10.GetBmmInclusionsRequest);
-      case 'GetWalletUtxos':
-        return this.getWalletUtxos(ctx, request as $10.GetWalletUtxosRequest);
-      case 'ListUtxos':
-        return this.listUtxos(ctx, request as $10.ListUtxosRequest);
-      case 'RemoveFromMempool':
-        return this.removeFromMempool(ctx, request as $10.RemoveFromMempoolRequest);
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return this
-            .getLatestFailedWithdrawalBundleHeight(ctx, request as $10.GetLatestFailedWithdrawalBundleHeightRequest);
-      case 'GenerateMnemonic':
-        return this.generateMnemonic(ctx, request as $10.GenerateMnemonicRequest);
-      case 'SetSeedFromMnemonic':
-        return this.setSeedFromMnemonic(ctx, request as $10.SetSeedFromMnemonicRequest);
-      case 'CallRaw':
-        return this.callRaw(ctx, request as $10.CallRawRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return this.getBalance(ctx, request as $10.GetBalanceRequest);
+      case 'GetBlockCount': return this.getBlockCount(ctx, request as $10.GetBlockCountRequest);
+      case 'Stop': return this.stop(ctx, request as $10.StopRequest);
+      case 'GetNewAddress': return this.getNewAddress(ctx, request as $10.GetNewAddressRequest);
+      case 'Withdraw': return this.withdraw(ctx, request as $10.WithdrawRequest);
+      case 'Transfer': return this.transfer(ctx, request as $10.TransferRequest);
+      case 'GetSidechainWealth': return this.getSidechainWealth(ctx, request as $10.GetSidechainWealthRequest);
+      case 'CreateDeposit': return this.createDeposit(ctx, request as $10.CreateDepositRequest);
+      case 'GetPendingWithdrawalBundle': return this.getPendingWithdrawalBundle(ctx, request as $10.GetPendingWithdrawalBundleRequest);
+      case 'ConnectPeer': return this.connectPeer(ctx, request as $10.ConnectPeerRequest);
+      case 'ListPeers': return this.listPeers(ctx, request as $10.ListPeersRequest);
+      case 'Mine': return this.mine(ctx, request as $10.MineRequest);
+      case 'GetBlock': return this.getBlock(ctx, request as $10.GetBlockRequest);
+      case 'GetBestMainchainBlockHash': return this.getBestMainchainBlockHash(ctx, request as $10.GetBestMainchainBlockHashRequest);
+      case 'GetBestSidechainBlockHash': return this.getBestSidechainBlockHash(ctx, request as $10.GetBestSidechainBlockHashRequest);
+      case 'GetBmmInclusions': return this.getBmmInclusions(ctx, request as $10.GetBmmInclusionsRequest);
+      case 'GetWalletUtxos': return this.getWalletUtxos(ctx, request as $10.GetWalletUtxosRequest);
+      case 'ListUtxos': return this.listUtxos(ctx, request as $10.ListUtxosRequest);
+      case 'RemoveFromMempool': return this.removeFromMempool(ctx, request as $10.RemoveFromMempoolRequest);
+      case 'GetLatestFailedWithdrawalBundleHeight': return this.getLatestFailedWithdrawalBundleHeight(ctx, request as $10.GetLatestFailedWithdrawalBundleHeightRequest);
+      case 'GenerateMnemonic': return this.generateMnemonic(ctx, request as $10.GenerateMnemonicRequest);
+      case 'SetSeedFromMnemonic': return this.setSeedFromMnemonic(ctx, request as $10.SetSeedFromMnemonicRequest);
+      case 'CallRaw': return this.callRaw(ctx, request as $10.CallRawRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => ThunderServiceBase$json;
   $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => ThunderServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/truthcoin/v1/truthcoin.connect.client.dart
+++ b/sail_ui/lib/gen/truthcoin/v1/truthcoin.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "truthcoin.pb.dart" as truthcoinv1truthcoin;
 import "truthcoin.connect.spec.dart" as specs;
 
-extension type TruthcoinServiceClient(connect.Transport _transport) {
+extension type TruthcoinServiceClient (connect.Transport _transport) {
   /// Get wallet balance (total and available).
   Future<truthcoinv1truthcoin.GetBalanceResponse> getBalance(
     truthcoinv1truthcoin.GetBalanceRequest input, {

--- a/sail_ui/lib/gen/truthcoin/v1/truthcoin.pb.dart
+++ b/sail_ui/lib/gen/truthcoin/v1/truthcoin.pb.dart
@@ -18,25 +18,23 @@ import 'package:protobuf/protobuf.dart' as $pb;
 class GetBalanceRequest extends $pb.GeneratedMessage {
   factory GetBalanceRequest() => create();
   GetBalanceRequest._() : super();
-  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceRequest clone() => GetBalanceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) => super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -45,8 +43,7 @@ class GetBalanceRequest extends $pb.GeneratedMessage {
   GetBalanceRequest createEmptyInstance() => create();
   static $pb.PbList<GetBalanceRequest> createRepeated() => $pb.PbList<GetBalanceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
+  static GetBalanceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
   static GetBalanceRequest? _defaultInstance;
 }
 
@@ -65,27 +62,25 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBalanceResponse._() : super();
-  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'totalSats')
     ..aInt64(2, _omitFieldNames ? '' : 'availableSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceResponse clone() => GetBalanceResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) => super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -94,17 +89,13 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   GetBalanceResponse createEmptyInstance() => create();
   static $pb.PbList<GetBalanceResponse> createRepeated() => $pb.PbList<GetBalanceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
+  static GetBalanceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
   static GetBalanceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get totalSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set totalSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set totalSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTotalSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -113,10 +104,7 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get availableSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set availableSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set availableSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAvailableSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -126,25 +114,23 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
 class GetBlockCountRequest extends $pb.GeneratedMessage {
   factory GetBlockCountRequest() => create();
   GetBlockCountRequest._() : super();
-  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountRequest clone() => GetBlockCountRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) => super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -153,8 +139,7 @@ class GetBlockCountRequest extends $pb.GeneratedMessage {
   GetBlockCountRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountRequest> createRepeated() => $pb.PbList<GetBlockCountRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
+  static GetBlockCountRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
   static GetBlockCountRequest? _defaultInstance;
 }
 
@@ -169,26 +154,24 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockCountResponse._() : super();
-  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'count')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountResponse clone() => GetBlockCountResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) => super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -197,17 +180,13 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
   GetBlockCountResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountResponse> createRepeated() => $pb.PbList<GetBlockCountResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
+  static GetBlockCountResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
   static GetBlockCountResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get count => $_getI64(0);
   @$pb.TagNumber(1)
-  set count($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set count($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCount() => $_has(0);
   @$pb.TagNumber(1)
@@ -217,24 +196,23 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
 class StopRequest extends $pb.GeneratedMessage {
   factory StopRequest() => create();
   StopRequest._() : super();
-  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopRequest clone() => StopRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopRequest copyWith(void Function(StopRequest) updates) =>
-      super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopRequest copyWith(void Function(StopRequest) updates) => super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -250,24 +228,23 @@ class StopRequest extends $pb.GeneratedMessage {
 class StopResponse extends $pb.GeneratedMessage {
   factory StopResponse() => create();
   StopResponse._() : super();
-  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopResponse clone() => StopResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopResponse copyWith(void Function(StopResponse) updates) =>
-      super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopResponse copyWith(void Function(StopResponse) updates) => super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -283,25 +260,23 @@ class StopResponse extends $pb.GeneratedMessage {
 class GetNewAddressRequest extends $pb.GeneratedMessage {
   factory GetNewAddressRequest() => create();
   GetNewAddressRequest._() : super();
-  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressRequest clone() => GetNewAddressRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) => super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -310,8 +285,7 @@ class GetNewAddressRequest extends $pb.GeneratedMessage {
   GetNewAddressRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressRequest> createRepeated() => $pb.PbList<GetNewAddressRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
+  static GetNewAddressRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
   static GetNewAddressRequest? _defaultInstance;
 }
 
@@ -326,26 +300,24 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewAddressResponse._() : super();
-  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressResponse clone() => GetNewAddressResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) => super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -354,17 +326,13 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
   GetNewAddressResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressResponse> createRepeated() => $pb.PbList<GetNewAddressResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
+  static GetNewAddressResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
   static GetNewAddressResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -394,29 +362,27 @@ class WithdrawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawRequest._() : super();
-  factory WithdrawRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'sideFeeSats')
     ..aInt64(4, _omitFieldNames ? '' : 'mainFeeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawRequest clone() => WithdrawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) =>
-      super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) => super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -425,17 +391,13 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   WithdrawRequest createEmptyInstance() => create();
   static $pb.PbList<WithdrawRequest> createRepeated() => $pb.PbList<WithdrawRequest>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
+  static WithdrawRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
   static WithdrawRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -444,10 +406,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -456,10 +415,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get sideFeeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set sideFeeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set sideFeeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSideFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -468,10 +424,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get mainFeeSats => $_getI64(3);
   @$pb.TagNumber(4)
-  set mainFeeSats($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set mainFeeSats($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasMainFeeSats() => $_has(3);
   @$pb.TagNumber(4)
@@ -489,26 +442,24 @@ class WithdrawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawResponse._() : super();
-  factory WithdrawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawResponse clone() => WithdrawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) =>
-      super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) => super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -517,17 +468,13 @@ class WithdrawResponse extends $pb.GeneratedMessage {
   WithdrawResponse createEmptyInstance() => create();
   static $pb.PbList<WithdrawResponse> createRepeated() => $pb.PbList<WithdrawResponse>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
+  static WithdrawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
   static WithdrawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -553,28 +500,26 @@ class TransferRequest extends $pb.GeneratedMessage {
     return $result;
   }
   TransferRequest._() : super();
-  factory TransferRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferRequest clone() => TransferRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferRequest copyWith(void Function(TransferRequest) updates) =>
-      super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferRequest copyWith(void Function(TransferRequest) updates) => super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -583,17 +528,13 @@ class TransferRequest extends $pb.GeneratedMessage {
   TransferRequest createEmptyInstance() => create();
   static $pb.PbList<TransferRequest> createRepeated() => $pb.PbList<TransferRequest>();
   @$core.pragma('dart2js:noInline')
-  static TransferRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
+  static TransferRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
   static TransferRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -602,10 +543,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -614,10 +552,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -635,26 +570,24 @@ class TransferResponse extends $pb.GeneratedMessage {
     return $result;
   }
   TransferResponse._() : super();
-  factory TransferResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferResponse clone() => TransferResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferResponse copyWith(void Function(TransferResponse) updates) =>
-      super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferResponse copyWith(void Function(TransferResponse) updates) => super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -663,17 +596,13 @@ class TransferResponse extends $pb.GeneratedMessage {
   TransferResponse createEmptyInstance() => create();
   static $pb.PbList<TransferResponse> createRepeated() => $pb.PbList<TransferResponse>();
   @$core.pragma('dart2js:noInline')
-  static TransferResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
+  static TransferResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
   static TransferResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -683,25 +612,23 @@ class TransferResponse extends $pb.GeneratedMessage {
 class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   factory GetSidechainWealthRequest() => create();
   GetSidechainWealthRequest._() : super();
-  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthRequest clone() => GetSidechainWealthRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) => super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -710,8 +637,7 @@ class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   GetSidechainWealthRequest createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthRequest> createRepeated() => $pb.PbList<GetSidechainWealthRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
+  static GetSidechainWealthRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
   static GetSidechainWealthRequest? _defaultInstance;
 }
 
@@ -726,27 +652,24 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetSidechainWealthResponse._() : super();
-  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'sats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthResponse clone() => GetSidechainWealthResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) => super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -755,17 +678,13 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
   GetSidechainWealthResponse createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthResponse> createRepeated() => $pb.PbList<GetSidechainWealthResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
+  static GetSidechainWealthResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
   static GetSidechainWealthResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get sats => $_getI64(0);
   @$pb.TagNumber(1)
-  set sats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set sats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -791,28 +710,26 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositRequest._() : super();
-  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'valueSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositRequest clone() => CreateDepositRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) => super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -821,17 +738,13 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   CreateDepositRequest createEmptyInstance() => create();
   static $pb.PbList<CreateDepositRequest> createRepeated() => $pb.PbList<CreateDepositRequest>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
+  static CreateDepositRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
   static CreateDepositRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -840,10 +753,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get valueSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set valueSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set valueSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasValueSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -852,10 +762,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -873,26 +780,24 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositResponse._() : super();
-  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositResponse clone() => CreateDepositResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) => super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -901,17 +806,13 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
   CreateDepositResponse createEmptyInstance() => create();
   static $pb.PbList<CreateDepositResponse> createRepeated() => $pb.PbList<CreateDepositResponse>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
+  static CreateDepositResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
   static CreateDepositResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -921,38 +822,32 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
 class GetPendingWithdrawalBundleRequest extends $pb.GeneratedMessage {
   factory GetPendingWithdrawalBundleRequest() => create();
   GetPendingWithdrawalBundleRequest._() : super();
-  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleRequest clone() => GetPendingWithdrawalBundleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest))
-          as GetPendingWithdrawalBundleRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest)) as GetPendingWithdrawalBundleRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleRequest create() => GetPendingWithdrawalBundleRequest._();
   GetPendingWithdrawalBundleRequest createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleRequest>();
+  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
+  static GetPendingWithdrawalBundleRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
   static GetPendingWithdrawalBundleRequest? _defaultInstance;
 }
 
@@ -967,49 +862,40 @@ class GetPendingWithdrawalBundleResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetPendingWithdrawalBundleResponse._() : super();
-  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bundleJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleResponse clone() => GetPendingWithdrawalBundleResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse))
-          as GetPendingWithdrawalBundleResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse)) as GetPendingWithdrawalBundleResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleResponse create() => GetPendingWithdrawalBundleResponse._();
   GetPendingWithdrawalBundleResponse createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleResponse>();
+  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
+  static GetPendingWithdrawalBundleResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
   static GetPendingWithdrawalBundleResponse? _defaultInstance;
 
   /// JSON string of the bundle, empty if none.
   @$pb.TagNumber(1)
   $core.String get bundleJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bundleJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bundleJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBundleJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1027,26 +913,24 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ConnectPeerRequest._() : super();
-  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerRequest clone() => ConnectPeerRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) => super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1055,17 +939,13 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
   ConnectPeerRequest createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerRequest> createRepeated() => $pb.PbList<ConnectPeerRequest>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
+  static ConnectPeerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
   static ConnectPeerRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1075,25 +955,23 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
 class ConnectPeerResponse extends $pb.GeneratedMessage {
   factory ConnectPeerResponse() => create();
   ConnectPeerResponse._() : super();
-  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerResponse clone() => ConnectPeerResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) => super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1102,33 +980,30 @@ class ConnectPeerResponse extends $pb.GeneratedMessage {
   ConnectPeerResponse createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerResponse> createRepeated() => $pb.PbList<ConnectPeerResponse>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
+  static ConnectPeerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
   static ConnectPeerResponse? _defaultInstance;
 }
 
 class ListPeersRequest extends $pb.GeneratedMessage {
   factory ListPeersRequest() => create();
   ListPeersRequest._() : super();
-  factory ListPeersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersRequest clone() => ListPeersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) =>
-      super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) => super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1137,8 +1012,7 @@ class ListPeersRequest extends $pb.GeneratedMessage {
   ListPeersRequest createEmptyInstance() => create();
   static $pb.PbList<ListPeersRequest> createRepeated() => $pb.PbList<ListPeersRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
+  static ListPeersRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
   static ListPeersRequest? _defaultInstance;
 }
 
@@ -1153,26 +1027,24 @@ class ListPeersResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListPeersResponse._() : super();
-  factory ListPeersResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'peersJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersResponse clone() => ListPeersResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) =>
-      super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) => super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1181,17 +1053,13 @@ class ListPeersResponse extends $pb.GeneratedMessage {
   ListPeersResponse createEmptyInstance() => create();
   static $pb.PbList<ListPeersResponse> createRepeated() => $pb.PbList<ListPeersResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
+  static ListPeersResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
   static ListPeersResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get peersJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set peersJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set peersJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPeersJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1209,25 +1077,24 @@ class MineRequest extends $pb.GeneratedMessage {
     return $result;
   }
   MineRequest._() : super();
-  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineRequest clone() => MineRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineRequest copyWith(void Function(MineRequest) updates) =>
-      super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineRequest copyWith(void Function(MineRequest) updates) => super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1242,10 +1109,7 @@ class MineRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $fixnum.Int64 get feeSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasFeeSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -1263,25 +1127,24 @@ class MineResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MineResponse._() : super();
-  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bmmResultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineResponse clone() => MineResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineResponse copyWith(void Function(MineResponse) updates) =>
-      super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineResponse copyWith(void Function(MineResponse) updates) => super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1296,10 +1159,7 @@ class MineResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get bmmResultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bmmResultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bmmResultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBmmResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1317,26 +1177,24 @@ class GetBlockRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockRequest._() : super();
-  factory GetBlockRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockRequest clone() => GetBlockRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) => super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1345,17 +1203,13 @@ class GetBlockRequest extends $pb.GeneratedMessage {
   GetBlockRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockRequest> createRepeated() => $pb.PbList<GetBlockRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
+  static GetBlockRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
   static GetBlockRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1373,26 +1227,24 @@ class GetBlockResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockResponse._() : super();
-  factory GetBlockResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockResponse clone() => GetBlockResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) => super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1401,17 +1253,13 @@ class GetBlockResponse extends $pb.GeneratedMessage {
   GetBlockResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockResponse> createRepeated() => $pb.PbList<GetBlockResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
+  static GetBlockResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
   static GetBlockResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1421,38 +1269,32 @@ class GetBlockResponse extends $pb.GeneratedMessage {
 class GetBestMainchainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestMainchainBlockHashRequest() => create();
   GetBestMainchainBlockHashRequest._() : super();
-  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashRequest clone() => GetBestMainchainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest))
-          as GetBestMainchainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest)) as GetBestMainchainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashRequest create() => GetBestMainchainBlockHashRequest._();
   GetBestMainchainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashRequest>();
+  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() => $pb.PbList<GetBestMainchainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
+  static GetBestMainchainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
   static GetBestMainchainBlockHashRequest? _defaultInstance;
 }
 
@@ -1467,48 +1309,39 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestMainchainBlockHashResponse._() : super();
-  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashResponse clone() => GetBestMainchainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse))
-          as GetBestMainchainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse)) as GetBestMainchainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashResponse create() => GetBestMainchainBlockHashResponse._();
   GetBestMainchainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashResponse>();
+  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() => $pb.PbList<GetBestMainchainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
+  static GetBestMainchainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
   static GetBestMainchainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1518,38 +1351,32 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
 class GetBestSidechainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestSidechainBlockHashRequest() => create();
   GetBestSidechainBlockHashRequest._() : super();
-  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashRequest clone() => GetBestSidechainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest))
-          as GetBestSidechainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest)) as GetBestSidechainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashRequest create() => GetBestSidechainBlockHashRequest._();
   GetBestSidechainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashRequest>();
+  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() => $pb.PbList<GetBestSidechainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
+  static GetBestSidechainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
   static GetBestSidechainBlockHashRequest? _defaultInstance;
 }
 
@@ -1564,48 +1391,39 @@ class GetBestSidechainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestSidechainBlockHashResponse._() : super();
-  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashResponse clone() => GetBestSidechainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse))
-          as GetBestSidechainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse)) as GetBestSidechainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashResponse create() => GetBestSidechainBlockHashResponse._();
   GetBestSidechainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashResponse>();
+  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() => $pb.PbList<GetBestSidechainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
+  static GetBestSidechainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
   static GetBestSidechainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1623,26 +1441,24 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsRequest._() : super();
-  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockHash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsRequest clone() => GetBmmInclusionsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1651,17 +1467,13 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
   GetBmmInclusionsRequest createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsRequest> createRepeated() => $pb.PbList<GetBmmInclusionsRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
+  static GetBmmInclusionsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
   static GetBmmInclusionsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockHash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockHash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockHash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1679,26 +1491,24 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsResponse._() : super();
-  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'inclusions')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsResponse clone() => GetBmmInclusionsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1707,17 +1517,13 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
   GetBmmInclusionsResponse createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsResponse> createRepeated() => $pb.PbList<GetBmmInclusionsResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
+  static GetBmmInclusionsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
   static GetBmmInclusionsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get inclusions => $_getSZ(0);
   @$pb.TagNumber(1)
-  set inclusions($core.String v) {
-    $_setString(0, v);
-  }
-
+  set inclusions($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasInclusions() => $_has(0);
   @$pb.TagNumber(1)
@@ -1727,25 +1533,23 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
 class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   factory GetWalletUtxosRequest() => create();
   GetWalletUtxosRequest._() : super();
-  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosRequest clone() => GetWalletUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) => super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1754,8 +1558,7 @@ class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   GetWalletUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosRequest> createRepeated() => $pb.PbList<GetWalletUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
+  static GetWalletUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
   static GetWalletUtxosRequest? _defaultInstance;
 }
 
@@ -1770,26 +1573,24 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletUtxosResponse._() : super();
-  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosResponse clone() => GetWalletUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) => super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1798,17 +1599,13 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
   GetWalletUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosResponse> createRepeated() => $pb.PbList<GetWalletUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
+  static GetWalletUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
   static GetWalletUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1818,25 +1615,23 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
 class ListUtxosRequest extends $pb.GeneratedMessage {
   factory ListUtxosRequest() => create();
   ListUtxosRequest._() : super();
-  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosRequest clone() => ListUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) => super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1845,8 +1640,7 @@ class ListUtxosRequest extends $pb.GeneratedMessage {
   ListUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<ListUtxosRequest> createRepeated() => $pb.PbList<ListUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
+  static ListUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
   static ListUtxosRequest? _defaultInstance;
 }
 
@@ -1861,26 +1655,24 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListUtxosResponse._() : super();
-  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosResponse clone() => ListUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) => super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1889,17 +1681,13 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
   ListUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<ListUtxosResponse> createRepeated() => $pb.PbList<ListUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
+  static ListUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
   static ListUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1917,26 +1705,24 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
     return $result;
   }
   RemoveFromMempoolRequest._() : super();
-  factory RemoveFromMempoolRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFromMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFromMempoolRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFromMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveFromMempoolRequest clone() => RemoveFromMempoolRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveFromMempoolRequest copyWith(void Function(RemoveFromMempoolRequest) updates) =>
-      super.copyWith((message) => updates(message as RemoveFromMempoolRequest)) as RemoveFromMempoolRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveFromMempoolRequest copyWith(void Function(RemoveFromMempoolRequest) updates) => super.copyWith((message) => updates(message as RemoveFromMempoolRequest)) as RemoveFromMempoolRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1945,17 +1731,13 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
   RemoveFromMempoolRequest createEmptyInstance() => create();
   static $pb.PbList<RemoveFromMempoolRequest> createRepeated() => $pb.PbList<RemoveFromMempoolRequest>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFromMempoolRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolRequest>(create);
+  static RemoveFromMempoolRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolRequest>(create);
   static RemoveFromMempoolRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -1965,25 +1747,23 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
 class RemoveFromMempoolResponse extends $pb.GeneratedMessage {
   factory RemoveFromMempoolResponse() => create();
   RemoveFromMempoolResponse._() : super();
-  factory RemoveFromMempoolResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFromMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFromMempoolResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFromMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveFromMempoolResponse clone() => RemoveFromMempoolResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveFromMempoolResponse copyWith(void Function(RemoveFromMempoolResponse) updates) =>
-      super.copyWith((message) => updates(message as RemoveFromMempoolResponse)) as RemoveFromMempoolResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveFromMempoolResponse copyWith(void Function(RemoveFromMempoolResponse) updates) => super.copyWith((message) => updates(message as RemoveFromMempoolResponse)) as RemoveFromMempoolResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1992,50 +1772,39 @@ class RemoveFromMempoolResponse extends $pb.GeneratedMessage {
   RemoveFromMempoolResponse createEmptyInstance() => create();
   static $pb.PbList<RemoveFromMempoolResponse> createRepeated() => $pb.PbList<RemoveFromMempoolResponse>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFromMempoolResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolResponse>(create);
+  static RemoveFromMempoolResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolResponse>(create);
   static RemoveFromMempoolResponse? _defaultInstance;
 }
 
 class GetLatestFailedWithdrawalBundleHeightRequest extends $pb.GeneratedMessage {
   factory GetLatestFailedWithdrawalBundleHeightRequest() => create();
   GetLatestFailedWithdrawalBundleHeightRequest._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'),
-      createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest clone() =>
-      GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest))
-          as GetLatestFailedWithdrawalBundleHeightRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest clone() => GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest copyWith(void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest)) as GetLatestFailedWithdrawalBundleHeightRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightRequest create() => GetLatestFailedWithdrawalBundleHeightRequest._();
   GetLatestFailedWithdrawalBundleHeightRequest createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
+  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
   static GetLatestFailedWithdrawalBundleHeightRequest? _defaultInstance;
 }
 
@@ -2050,53 +1819,40 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
     return $result;
   }
   GetLatestFailedWithdrawalBundleHeightResponse._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'height')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse clone() =>
-      GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse))
-          as GetLatestFailedWithdrawalBundleHeightResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse clone() => GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse copyWith(void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse)) as GetLatestFailedWithdrawalBundleHeightResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightResponse create() => GetLatestFailedWithdrawalBundleHeightResponse._();
   GetLatestFailedWithdrawalBundleHeightResponse createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
+  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
   static GetLatestFailedWithdrawalBundleHeightResponse? _defaultInstance;
 
   /// 0 means no failed bundle.
   @$pb.TagNumber(1)
   $fixnum.Int64 get height => $_getI64(0);
   @$pb.TagNumber(1)
-  set height($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set height($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHeight() => $_has(0);
   @$pb.TagNumber(1)
@@ -2106,25 +1862,23 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
 class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   factory GenerateMnemonicRequest() => create();
   GenerateMnemonicRequest._() : super();
-  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicRequest clone() => GenerateMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) => super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2133,8 +1887,7 @@ class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   GenerateMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicRequest> createRepeated() => $pb.PbList<GenerateMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
+  static GenerateMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
   static GenerateMnemonicRequest? _defaultInstance;
 }
 
@@ -2149,26 +1902,24 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GenerateMnemonicResponse._() : super();
-  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicResponse clone() => GenerateMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) => super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2177,17 +1928,13 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
   GenerateMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicResponse> createRepeated() => $pb.PbList<GenerateMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
+  static GenerateMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
   static GenerateMnemonicResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2205,27 +1952,24 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SetSeedFromMnemonicRequest._() : super();
-  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicRequest clone() => SetSeedFromMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2234,17 +1978,13 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
   SetSeedFromMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicRequest> createRepeated() => $pb.PbList<SetSeedFromMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
+  static SetSeedFromMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
   static SetSeedFromMnemonicRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2254,26 +1994,23 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
 class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   factory SetSeedFromMnemonicResponse() => create();
   SetSeedFromMnemonicResponse._() : super();
-  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicResponse clone() => SetSeedFromMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2282,8 +2019,7 @@ class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   SetSeedFromMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicResponse> createRepeated() => $pb.PbList<SetSeedFromMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
+  static SetSeedFromMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
   static SetSeedFromMnemonicResponse? _defaultInstance;
 }
 
@@ -2302,26 +2038,25 @@ class CallRawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawRequest._() : super();
-  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'method')
     ..aOS(2, _omitFieldNames ? '' : 'paramsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawRequest clone() => CallRawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawRequest copyWith(void Function(CallRawRequest) updates) =>
-      super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawRequest copyWith(void Function(CallRawRequest) updates) => super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2336,10 +2071,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get method => $_getSZ(0);
   @$pb.TagNumber(1)
-  set method($core.String v) {
-    $_setString(0, v);
-  }
-
+  set method($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMethod() => $_has(0);
   @$pb.TagNumber(1)
@@ -2348,10 +2080,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get paramsJson => $_getSZ(1);
   @$pb.TagNumber(2)
-  set paramsJson($core.String v) {
-    $_setString(1, v);
-  }
-
+  set paramsJson($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasParamsJson() => $_has(1);
   @$pb.TagNumber(2)
@@ -2369,26 +2098,24 @@ class CallRawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawResponse._() : super();
-  factory CallRawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'resultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawResponse clone() => CallRawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawResponse copyWith(void Function(CallRawResponse) updates) =>
-      super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawResponse copyWith(void Function(CallRawResponse) updates) => super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2397,17 +2124,13 @@ class CallRawResponse extends $pb.GeneratedMessage {
   CallRawResponse createEmptyInstance() => create();
   static $pb.PbList<CallRawResponse> createRepeated() => $pb.PbList<CallRawResponse>();
   @$core.pragma('dart2js:noInline')
-  static CallRawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
+  static CallRawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
   static CallRawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get resultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set resultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set resultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2417,25 +2140,23 @@ class CallRawResponse extends $pb.GeneratedMessage {
 class RefreshWalletRequest extends $pb.GeneratedMessage {
   factory RefreshWalletRequest() => create();
   RefreshWalletRequest._() : super();
-  factory RefreshWalletRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RefreshWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RefreshWalletRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RefreshWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RefreshWalletRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RefreshWalletRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RefreshWalletRequest clone() => RefreshWalletRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RefreshWalletRequest copyWith(void Function(RefreshWalletRequest) updates) =>
-      super.copyWith((message) => updates(message as RefreshWalletRequest)) as RefreshWalletRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RefreshWalletRequest copyWith(void Function(RefreshWalletRequest) updates) => super.copyWith((message) => updates(message as RefreshWalletRequest)) as RefreshWalletRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2444,33 +2165,30 @@ class RefreshWalletRequest extends $pb.GeneratedMessage {
   RefreshWalletRequest createEmptyInstance() => create();
   static $pb.PbList<RefreshWalletRequest> createRepeated() => $pb.PbList<RefreshWalletRequest>();
   @$core.pragma('dart2js:noInline')
-  static RefreshWalletRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RefreshWalletRequest>(create);
+  static RefreshWalletRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RefreshWalletRequest>(create);
   static RefreshWalletRequest? _defaultInstance;
 }
 
 class RefreshWalletResponse extends $pb.GeneratedMessage {
   factory RefreshWalletResponse() => create();
   RefreshWalletResponse._() : super();
-  factory RefreshWalletResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RefreshWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RefreshWalletResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RefreshWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RefreshWalletResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RefreshWalletResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RefreshWalletResponse clone() => RefreshWalletResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RefreshWalletResponse copyWith(void Function(RefreshWalletResponse) updates) =>
-      super.copyWith((message) => updates(message as RefreshWalletResponse)) as RefreshWalletResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RefreshWalletResponse copyWith(void Function(RefreshWalletResponse) updates) => super.copyWith((message) => updates(message as RefreshWalletResponse)) as RefreshWalletResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2479,8 +2197,7 @@ class RefreshWalletResponse extends $pb.GeneratedMessage {
   RefreshWalletResponse createEmptyInstance() => create();
   static $pb.PbList<RefreshWalletResponse> createRepeated() => $pb.PbList<RefreshWalletResponse>();
   @$core.pragma('dart2js:noInline')
-  static RefreshWalletResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RefreshWalletResponse>(create);
+  static RefreshWalletResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RefreshWalletResponse>(create);
   static RefreshWalletResponse? _defaultInstance;
 }
 
@@ -2495,26 +2212,24 @@ class GetTransactionRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetTransactionRequest._() : super();
-  factory GetTransactionRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetTransactionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetTransactionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTransactionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetTransactionRequest clone() => GetTransactionRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetTransactionRequest copyWith(void Function(GetTransactionRequest) updates) =>
-      super.copyWith((message) => updates(message as GetTransactionRequest)) as GetTransactionRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTransactionRequest copyWith(void Function(GetTransactionRequest) updates) => super.copyWith((message) => updates(message as GetTransactionRequest)) as GetTransactionRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2523,17 +2238,13 @@ class GetTransactionRequest extends $pb.GeneratedMessage {
   GetTransactionRequest createEmptyInstance() => create();
   static $pb.PbList<GetTransactionRequest> createRepeated() => $pb.PbList<GetTransactionRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetTransactionRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionRequest>(create);
+  static GetTransactionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionRequest>(create);
   static GetTransactionRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2551,26 +2262,24 @@ class GetTransactionResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetTransactionResponse._() : super();
-  factory GetTransactionResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetTransactionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetTransactionResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTransactionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'transactionJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetTransactionResponse clone() => GetTransactionResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetTransactionResponse copyWith(void Function(GetTransactionResponse) updates) =>
-      super.copyWith((message) => updates(message as GetTransactionResponse)) as GetTransactionResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTransactionResponse copyWith(void Function(GetTransactionResponse) updates) => super.copyWith((message) => updates(message as GetTransactionResponse)) as GetTransactionResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2579,17 +2288,13 @@ class GetTransactionResponse extends $pb.GeneratedMessage {
   GetTransactionResponse createEmptyInstance() => create();
   static $pb.PbList<GetTransactionResponse> createRepeated() => $pb.PbList<GetTransactionResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetTransactionResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionResponse>(create);
+  static GetTransactionResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionResponse>(create);
   static GetTransactionResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get transactionJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set transactionJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set transactionJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTransactionJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2607,26 +2312,24 @@ class GetTransactionInfoRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetTransactionInfoRequest._() : super();
-  factory GetTransactionInfoRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetTransactionInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetTransactionInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTransactionInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionInfoRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionInfoRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetTransactionInfoRequest clone() => GetTransactionInfoRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetTransactionInfoRequest copyWith(void Function(GetTransactionInfoRequest) updates) =>
-      super.copyWith((message) => updates(message as GetTransactionInfoRequest)) as GetTransactionInfoRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTransactionInfoRequest copyWith(void Function(GetTransactionInfoRequest) updates) => super.copyWith((message) => updates(message as GetTransactionInfoRequest)) as GetTransactionInfoRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2635,17 +2338,13 @@ class GetTransactionInfoRequest extends $pb.GeneratedMessage {
   GetTransactionInfoRequest createEmptyInstance() => create();
   static $pb.PbList<GetTransactionInfoRequest> createRepeated() => $pb.PbList<GetTransactionInfoRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetTransactionInfoRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionInfoRequest>(create);
+  static GetTransactionInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionInfoRequest>(create);
   static GetTransactionInfoRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2663,27 +2362,24 @@ class GetTransactionInfoResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetTransactionInfoResponse._() : super();
-  factory GetTransactionInfoResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetTransactionInfoResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetTransactionInfoResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTransactionInfoResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionInfoResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionInfoResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'transactionInfoJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetTransactionInfoResponse clone() => GetTransactionInfoResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetTransactionInfoResponse copyWith(void Function(GetTransactionInfoResponse) updates) =>
-      super.copyWith((message) => updates(message as GetTransactionInfoResponse)) as GetTransactionInfoResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTransactionInfoResponse copyWith(void Function(GetTransactionInfoResponse) updates) => super.copyWith((message) => updates(message as GetTransactionInfoResponse)) as GetTransactionInfoResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2692,17 +2388,13 @@ class GetTransactionInfoResponse extends $pb.GeneratedMessage {
   GetTransactionInfoResponse createEmptyInstance() => create();
   static $pb.PbList<GetTransactionInfoResponse> createRepeated() => $pb.PbList<GetTransactionInfoResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetTransactionInfoResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionInfoResponse>(create);
+  static GetTransactionInfoResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionInfoResponse>(create);
   static GetTransactionInfoResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get transactionInfoJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set transactionInfoJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set transactionInfoJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTransactionInfoJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2712,25 +2404,23 @@ class GetTransactionInfoResponse extends $pb.GeneratedMessage {
 class GetWalletAddressesRequest extends $pb.GeneratedMessage {
   factory GetWalletAddressesRequest() => create();
   GetWalletAddressesRequest._() : super();
-  factory GetWalletAddressesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletAddressesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletAddressesRequest clone() => GetWalletAddressesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletAddressesRequest copyWith(void Function(GetWalletAddressesRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletAddressesRequest)) as GetWalletAddressesRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletAddressesRequest copyWith(void Function(GetWalletAddressesRequest) updates) => super.copyWith((message) => updates(message as GetWalletAddressesRequest)) as GetWalletAddressesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2739,8 +2429,7 @@ class GetWalletAddressesRequest extends $pb.GeneratedMessage {
   GetWalletAddressesRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletAddressesRequest> createRepeated() => $pb.PbList<GetWalletAddressesRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletAddressesRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesRequest>(create);
+  static GetWalletAddressesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesRequest>(create);
   static GetWalletAddressesRequest? _defaultInstance;
 }
 
@@ -2755,27 +2444,24 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletAddressesResponse._() : super();
-  factory GetWalletAddressesResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletAddressesResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletAddressesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletAddressesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletAddressesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..pPS(1, _omitFieldNames ? '' : 'addresses')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletAddressesResponse clone() => GetWalletAddressesResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletAddressesResponse copyWith(void Function(GetWalletAddressesResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletAddressesResponse)) as GetWalletAddressesResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletAddressesResponse copyWith(void Function(GetWalletAddressesResponse) updates) => super.copyWith((message) => updates(message as GetWalletAddressesResponse)) as GetWalletAddressesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2784,8 +2470,7 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
   GetWalletAddressesResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletAddressesResponse> createRepeated() => $pb.PbList<GetWalletAddressesResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletAddressesResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesResponse>(create);
+  static GetWalletAddressesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletAddressesResponse>(create);
   static GetWalletAddressesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -2795,24 +2480,23 @@ class GetWalletAddressesResponse extends $pb.GeneratedMessage {
 class MyUtxosRequest extends $pb.GeneratedMessage {
   factory MyUtxosRequest() => create();
   MyUtxosRequest._() : super();
-  factory MyUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MyUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MyUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MyUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MyUtxosRequest clone() => MyUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MyUtxosRequest copyWith(void Function(MyUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as MyUtxosRequest)) as MyUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MyUtxosRequest copyWith(void Function(MyUtxosRequest) updates) => super.copyWith((message) => updates(message as MyUtxosRequest)) as MyUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2836,26 +2520,24 @@ class MyUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MyUtxosResponse._() : super();
-  factory MyUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MyUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MyUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MyUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MyUtxosResponse clone() => MyUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MyUtxosResponse copyWith(void Function(MyUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as MyUtxosResponse)) as MyUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MyUtxosResponse copyWith(void Function(MyUtxosResponse) updates) => super.copyWith((message) => updates(message as MyUtxosResponse)) as MyUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2864,17 +2546,13 @@ class MyUtxosResponse extends $pb.GeneratedMessage {
   MyUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<MyUtxosResponse> createRepeated() => $pb.PbList<MyUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static MyUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MyUtxosResponse>(create);
+  static MyUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MyUtxosResponse>(create);
   static MyUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2884,25 +2562,23 @@ class MyUtxosResponse extends $pb.GeneratedMessage {
 class MyUnconfirmedUtxosRequest extends $pb.GeneratedMessage {
   factory MyUnconfirmedUtxosRequest() => create();
   MyUnconfirmedUtxosRequest._() : super();
-  factory MyUnconfirmedUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MyUnconfirmedUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MyUnconfirmedUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MyUnconfirmedUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUnconfirmedUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUnconfirmedUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MyUnconfirmedUtxosRequest clone() => MyUnconfirmedUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MyUnconfirmedUtxosRequest copyWith(void Function(MyUnconfirmedUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as MyUnconfirmedUtxosRequest)) as MyUnconfirmedUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MyUnconfirmedUtxosRequest copyWith(void Function(MyUnconfirmedUtxosRequest) updates) => super.copyWith((message) => updates(message as MyUnconfirmedUtxosRequest)) as MyUnconfirmedUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2911,8 +2587,7 @@ class MyUnconfirmedUtxosRequest extends $pb.GeneratedMessage {
   MyUnconfirmedUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<MyUnconfirmedUtxosRequest> createRepeated() => $pb.PbList<MyUnconfirmedUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static MyUnconfirmedUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MyUnconfirmedUtxosRequest>(create);
+  static MyUnconfirmedUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MyUnconfirmedUtxosRequest>(create);
   static MyUnconfirmedUtxosRequest? _defaultInstance;
 }
 
@@ -2927,27 +2602,24 @@ class MyUnconfirmedUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MyUnconfirmedUtxosResponse._() : super();
-  factory MyUnconfirmedUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MyUnconfirmedUtxosResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MyUnconfirmedUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MyUnconfirmedUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUnconfirmedUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MyUnconfirmedUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MyUnconfirmedUtxosResponse clone() => MyUnconfirmedUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MyUnconfirmedUtxosResponse copyWith(void Function(MyUnconfirmedUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as MyUnconfirmedUtxosResponse)) as MyUnconfirmedUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MyUnconfirmedUtxosResponse copyWith(void Function(MyUnconfirmedUtxosResponse) updates) => super.copyWith((message) => updates(message as MyUnconfirmedUtxosResponse)) as MyUnconfirmedUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2956,17 +2628,13 @@ class MyUnconfirmedUtxosResponse extends $pb.GeneratedMessage {
   MyUnconfirmedUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<MyUnconfirmedUtxosResponse> createRepeated() => $pb.PbList<MyUnconfirmedUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static MyUnconfirmedUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MyUnconfirmedUtxosResponse>(create);
+  static MyUnconfirmedUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MyUnconfirmedUtxosResponse>(create);
   static MyUnconfirmedUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2992,50 +2660,41 @@ class CalculateInitialLiquidityRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CalculateInitialLiquidityRequest._() : super();
-  factory CalculateInitialLiquidityRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CalculateInitialLiquidityRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CalculateInitialLiquidityRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CalculateInitialLiquidityRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CalculateInitialLiquidityRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CalculateInitialLiquidityRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..a<$core.double>(1, _omitFieldNames ? '' : 'beta', $pb.PbFieldType.OD)
     ..a<$core.int>(2, _omitFieldNames ? '' : 'numOutcomes', $pb.PbFieldType.O3)
     ..aOS(3, _omitFieldNames ? '' : 'dimensions')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CalculateInitialLiquidityRequest clone() => CalculateInitialLiquidityRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CalculateInitialLiquidityRequest copyWith(void Function(CalculateInitialLiquidityRequest) updates) =>
-      super.copyWith((message) => updates(message as CalculateInitialLiquidityRequest))
-          as CalculateInitialLiquidityRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CalculateInitialLiquidityRequest copyWith(void Function(CalculateInitialLiquidityRequest) updates) => super.copyWith((message) => updates(message as CalculateInitialLiquidityRequest)) as CalculateInitialLiquidityRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static CalculateInitialLiquidityRequest create() => CalculateInitialLiquidityRequest._();
   CalculateInitialLiquidityRequest createEmptyInstance() => create();
-  static $pb.PbList<CalculateInitialLiquidityRequest> createRepeated() =>
-      $pb.PbList<CalculateInitialLiquidityRequest>();
+  static $pb.PbList<CalculateInitialLiquidityRequest> createRepeated() => $pb.PbList<CalculateInitialLiquidityRequest>();
   @$core.pragma('dart2js:noInline')
-  static CalculateInitialLiquidityRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CalculateInitialLiquidityRequest>(create);
+  static CalculateInitialLiquidityRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CalculateInitialLiquidityRequest>(create);
   static CalculateInitialLiquidityRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.double get beta => $_getN(0);
   @$pb.TagNumber(1)
-  set beta($core.double v) {
-    $_setDouble(0, v);
-  }
-
+  set beta($core.double v) { $_setDouble(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBeta() => $_has(0);
   @$pb.TagNumber(1)
@@ -3044,10 +2703,7 @@ class CalculateInitialLiquidityRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get numOutcomes => $_getIZ(1);
   @$pb.TagNumber(2)
-  set numOutcomes($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set numOutcomes($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasNumOutcomes() => $_has(1);
   @$pb.TagNumber(2)
@@ -3056,10 +2712,7 @@ class CalculateInitialLiquidityRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get dimensions => $_getSZ(2);
   @$pb.TagNumber(3)
-  set dimensions($core.String v) {
-    $_setString(2, v);
-  }
-
+  set dimensions($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasDimensions() => $_has(2);
   @$pb.TagNumber(3)
@@ -3077,48 +2730,39 @@ class CalculateInitialLiquidityResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CalculateInitialLiquidityResponse._() : super();
-  factory CalculateInitialLiquidityResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CalculateInitialLiquidityResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CalculateInitialLiquidityResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CalculateInitialLiquidityResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CalculateInitialLiquidityResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CalculateInitialLiquidityResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'resultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CalculateInitialLiquidityResponse clone() => CalculateInitialLiquidityResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CalculateInitialLiquidityResponse copyWith(void Function(CalculateInitialLiquidityResponse) updates) =>
-      super.copyWith((message) => updates(message as CalculateInitialLiquidityResponse))
-          as CalculateInitialLiquidityResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CalculateInitialLiquidityResponse copyWith(void Function(CalculateInitialLiquidityResponse) updates) => super.copyWith((message) => updates(message as CalculateInitialLiquidityResponse)) as CalculateInitialLiquidityResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static CalculateInitialLiquidityResponse create() => CalculateInitialLiquidityResponse._();
   CalculateInitialLiquidityResponse createEmptyInstance() => create();
-  static $pb.PbList<CalculateInitialLiquidityResponse> createRepeated() =>
-      $pb.PbList<CalculateInitialLiquidityResponse>();
+  static $pb.PbList<CalculateInitialLiquidityResponse> createRepeated() => $pb.PbList<CalculateInitialLiquidityResponse>();
   @$core.pragma('dart2js:noInline')
-  static CalculateInitialLiquidityResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CalculateInitialLiquidityResponse>(create);
+  static CalculateInitialLiquidityResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CalculateInitialLiquidityResponse>(create);
   static CalculateInitialLiquidityResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get resultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set resultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set resultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -3172,14 +2816,10 @@ class MarketCreateRequest extends $pb.GeneratedMessage {
     return $result;
   }
   MarketCreateRequest._() : super();
-  factory MarketCreateRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MarketCreateRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MarketCreateRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MarketCreateRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketCreateRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketCreateRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'title')
     ..aOS(2, _omitFieldNames ? '' : 'description')
     ..aOS(3, _omitFieldNames ? '' : 'dimensions')
@@ -3190,17 +2830,19 @@ class MarketCreateRequest extends $pb.GeneratedMessage {
     ..pPS(8, _omitFieldNames ? '' : 'tags')
     ..pPS(9, _omitFieldNames ? '' : 'categoryTxids')
     ..pPS(10, _omitFieldNames ? '' : 'residualNames')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MarketCreateRequest clone() => MarketCreateRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MarketCreateRequest copyWith(void Function(MarketCreateRequest) updates) =>
-      super.copyWith((message) => updates(message as MarketCreateRequest)) as MarketCreateRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MarketCreateRequest copyWith(void Function(MarketCreateRequest) updates) => super.copyWith((message) => updates(message as MarketCreateRequest)) as MarketCreateRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3209,17 +2851,13 @@ class MarketCreateRequest extends $pb.GeneratedMessage {
   MarketCreateRequest createEmptyInstance() => create();
   static $pb.PbList<MarketCreateRequest> createRepeated() => $pb.PbList<MarketCreateRequest>();
   @$core.pragma('dart2js:noInline')
-  static MarketCreateRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketCreateRequest>(create);
+  static MarketCreateRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketCreateRequest>(create);
   static MarketCreateRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get title => $_getSZ(0);
   @$pb.TagNumber(1)
-  set title($core.String v) {
-    $_setString(0, v);
-  }
-
+  set title($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTitle() => $_has(0);
   @$pb.TagNumber(1)
@@ -3228,10 +2866,7 @@ class MarketCreateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get description => $_getSZ(1);
   @$pb.TagNumber(2)
-  set description($core.String v) {
-    $_setString(1, v);
-  }
-
+  set description($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasDescription() => $_has(1);
   @$pb.TagNumber(2)
@@ -3240,10 +2875,7 @@ class MarketCreateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get dimensions => $_getSZ(2);
   @$pb.TagNumber(3)
-  set dimensions($core.String v) {
-    $_setString(2, v);
-  }
-
+  set dimensions($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasDimensions() => $_has(2);
   @$pb.TagNumber(3)
@@ -3252,10 +2884,7 @@ class MarketCreateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get feeSats => $_getI64(3);
   @$pb.TagNumber(4)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasFeeSats() => $_has(3);
   @$pb.TagNumber(4)
@@ -3264,10 +2893,7 @@ class MarketCreateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.double get beta => $_getN(4);
   @$pb.TagNumber(5)
-  set beta($core.double v) {
-    $_setDouble(4, v);
-  }
-
+  set beta($core.double v) { $_setDouble(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasBeta() => $_has(4);
   @$pb.TagNumber(5)
@@ -3276,10 +2902,7 @@ class MarketCreateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get initialLiquidity => $_getI64(5);
   @$pb.TagNumber(6)
-  set initialLiquidity($fixnum.Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set initialLiquidity($fixnum.Int64 v) { $_setInt64(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasInitialLiquidity() => $_has(5);
   @$pb.TagNumber(6)
@@ -3288,10 +2911,7 @@ class MarketCreateRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.double get tradingFee => $_getN(6);
   @$pb.TagNumber(7)
-  set tradingFee($core.double v) {
-    $_setDouble(6, v);
-  }
-
+  set tradingFee($core.double v) { $_setDouble(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasTradingFee() => $_has(6);
   @$pb.TagNumber(7)
@@ -3318,26 +2938,24 @@ class MarketCreateResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MarketCreateResponse._() : super();
-  factory MarketCreateResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MarketCreateResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MarketCreateResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MarketCreateResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketCreateResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketCreateResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MarketCreateResponse clone() => MarketCreateResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MarketCreateResponse copyWith(void Function(MarketCreateResponse) updates) =>
-      super.copyWith((message) => updates(message as MarketCreateResponse)) as MarketCreateResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MarketCreateResponse copyWith(void Function(MarketCreateResponse) updates) => super.copyWith((message) => updates(message as MarketCreateResponse)) as MarketCreateResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3346,17 +2964,13 @@ class MarketCreateResponse extends $pb.GeneratedMessage {
   MarketCreateResponse createEmptyInstance() => create();
   static $pb.PbList<MarketCreateResponse> createRepeated() => $pb.PbList<MarketCreateResponse>();
   @$core.pragma('dart2js:noInline')
-  static MarketCreateResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketCreateResponse>(create);
+  static MarketCreateResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketCreateResponse>(create);
   static MarketCreateResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -3366,25 +2980,23 @@ class MarketCreateResponse extends $pb.GeneratedMessage {
 class MarketListRequest extends $pb.GeneratedMessage {
   factory MarketListRequest() => create();
   MarketListRequest._() : super();
-  factory MarketListRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MarketListRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MarketListRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MarketListRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketListRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketListRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MarketListRequest clone() => MarketListRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MarketListRequest copyWith(void Function(MarketListRequest) updates) =>
-      super.copyWith((message) => updates(message as MarketListRequest)) as MarketListRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MarketListRequest copyWith(void Function(MarketListRequest) updates) => super.copyWith((message) => updates(message as MarketListRequest)) as MarketListRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3393,8 +3005,7 @@ class MarketListRequest extends $pb.GeneratedMessage {
   MarketListRequest createEmptyInstance() => create();
   static $pb.PbList<MarketListRequest> createRepeated() => $pb.PbList<MarketListRequest>();
   @$core.pragma('dart2js:noInline')
-  static MarketListRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketListRequest>(create);
+  static MarketListRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketListRequest>(create);
   static MarketListRequest? _defaultInstance;
 }
 
@@ -3409,26 +3020,24 @@ class MarketListResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MarketListResponse._() : super();
-  factory MarketListResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MarketListResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MarketListResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MarketListResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketListResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketListResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'marketsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MarketListResponse clone() => MarketListResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MarketListResponse copyWith(void Function(MarketListResponse) updates) =>
-      super.copyWith((message) => updates(message as MarketListResponse)) as MarketListResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MarketListResponse copyWith(void Function(MarketListResponse) updates) => super.copyWith((message) => updates(message as MarketListResponse)) as MarketListResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3437,17 +3046,13 @@ class MarketListResponse extends $pb.GeneratedMessage {
   MarketListResponse createEmptyInstance() => create();
   static $pb.PbList<MarketListResponse> createRepeated() => $pb.PbList<MarketListResponse>();
   @$core.pragma('dart2js:noInline')
-  static MarketListResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketListResponse>(create);
+  static MarketListResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketListResponse>(create);
   static MarketListResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get marketsJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set marketsJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set marketsJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMarketsJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -3465,26 +3070,24 @@ class MarketGetRequest extends $pb.GeneratedMessage {
     return $result;
   }
   MarketGetRequest._() : super();
-  factory MarketGetRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MarketGetRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MarketGetRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MarketGetRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketGetRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketGetRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'marketId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MarketGetRequest clone() => MarketGetRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MarketGetRequest copyWith(void Function(MarketGetRequest) updates) =>
-      super.copyWith((message) => updates(message as MarketGetRequest)) as MarketGetRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MarketGetRequest copyWith(void Function(MarketGetRequest) updates) => super.copyWith((message) => updates(message as MarketGetRequest)) as MarketGetRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3493,17 +3096,13 @@ class MarketGetRequest extends $pb.GeneratedMessage {
   MarketGetRequest createEmptyInstance() => create();
   static $pb.PbList<MarketGetRequest> createRepeated() => $pb.PbList<MarketGetRequest>();
   @$core.pragma('dart2js:noInline')
-  static MarketGetRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketGetRequest>(create);
+  static MarketGetRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketGetRequest>(create);
   static MarketGetRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get marketId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set marketId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set marketId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMarketId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3521,26 +3120,24 @@ class MarketGetResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MarketGetResponse._() : super();
-  factory MarketGetResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MarketGetResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MarketGetResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MarketGetResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketGetResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketGetResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'marketJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MarketGetResponse clone() => MarketGetResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MarketGetResponse copyWith(void Function(MarketGetResponse) updates) =>
-      super.copyWith((message) => updates(message as MarketGetResponse)) as MarketGetResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MarketGetResponse copyWith(void Function(MarketGetResponse) updates) => super.copyWith((message) => updates(message as MarketGetResponse)) as MarketGetResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3549,17 +3146,13 @@ class MarketGetResponse extends $pb.GeneratedMessage {
   MarketGetResponse createEmptyInstance() => create();
   static $pb.PbList<MarketGetResponse> createRepeated() => $pb.PbList<MarketGetResponse>();
   @$core.pragma('dart2js:noInline')
-  static MarketGetResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketGetResponse>(create);
+  static MarketGetResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketGetResponse>(create);
   static MarketGetResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get marketJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set marketJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set marketJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMarketJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -3597,31 +3190,29 @@ class MarketBuyRequest extends $pb.GeneratedMessage {
     return $result;
   }
   MarketBuyRequest._() : super();
-  factory MarketBuyRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MarketBuyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MarketBuyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MarketBuyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketBuyRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketBuyRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'marketId')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'outcomeIndex', $pb.PbFieldType.O3)
     ..a<$core.double>(3, _omitFieldNames ? '' : 'sharesAmount', $pb.PbFieldType.OD)
     ..aOB(4, _omitFieldNames ? '' : 'dryRun')
     ..aInt64(5, _omitFieldNames ? '' : 'feeSats')
     ..aInt64(6, _omitFieldNames ? '' : 'maxCost')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MarketBuyRequest clone() => MarketBuyRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MarketBuyRequest copyWith(void Function(MarketBuyRequest) updates) =>
-      super.copyWith((message) => updates(message as MarketBuyRequest)) as MarketBuyRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MarketBuyRequest copyWith(void Function(MarketBuyRequest) updates) => super.copyWith((message) => updates(message as MarketBuyRequest)) as MarketBuyRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3630,17 +3221,13 @@ class MarketBuyRequest extends $pb.GeneratedMessage {
   MarketBuyRequest createEmptyInstance() => create();
   static $pb.PbList<MarketBuyRequest> createRepeated() => $pb.PbList<MarketBuyRequest>();
   @$core.pragma('dart2js:noInline')
-  static MarketBuyRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketBuyRequest>(create);
+  static MarketBuyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketBuyRequest>(create);
   static MarketBuyRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get marketId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set marketId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set marketId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMarketId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3649,10 +3236,7 @@ class MarketBuyRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get outcomeIndex => $_getIZ(1);
   @$pb.TagNumber(2)
-  set outcomeIndex($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set outcomeIndex($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasOutcomeIndex() => $_has(1);
   @$pb.TagNumber(2)
@@ -3661,10 +3245,7 @@ class MarketBuyRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.double get sharesAmount => $_getN(2);
   @$pb.TagNumber(3)
-  set sharesAmount($core.double v) {
-    $_setDouble(2, v);
-  }
-
+  set sharesAmount($core.double v) { $_setDouble(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSharesAmount() => $_has(2);
   @$pb.TagNumber(3)
@@ -3673,10 +3254,7 @@ class MarketBuyRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get dryRun => $_getBF(3);
   @$pb.TagNumber(4)
-  set dryRun($core.bool v) {
-    $_setBool(3, v);
-  }
-
+  set dryRun($core.bool v) { $_setBool(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasDryRun() => $_has(3);
   @$pb.TagNumber(4)
@@ -3685,10 +3263,7 @@ class MarketBuyRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get feeSats => $_getI64(4);
   @$pb.TagNumber(5)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasFeeSats() => $_has(4);
   @$pb.TagNumber(5)
@@ -3697,10 +3272,7 @@ class MarketBuyRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get maxCost => $_getI64(5);
   @$pb.TagNumber(6)
-  set maxCost($fixnum.Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set maxCost($fixnum.Int64 v) { $_setInt64(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasMaxCost() => $_has(5);
   @$pb.TagNumber(6)
@@ -3718,26 +3290,24 @@ class MarketBuyResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MarketBuyResponse._() : super();
-  factory MarketBuyResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MarketBuyResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MarketBuyResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MarketBuyResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketBuyResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketBuyResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'resultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MarketBuyResponse clone() => MarketBuyResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MarketBuyResponse copyWith(void Function(MarketBuyResponse) updates) =>
-      super.copyWith((message) => updates(message as MarketBuyResponse)) as MarketBuyResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MarketBuyResponse copyWith(void Function(MarketBuyResponse) updates) => super.copyWith((message) => updates(message as MarketBuyResponse)) as MarketBuyResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3746,17 +3316,13 @@ class MarketBuyResponse extends $pb.GeneratedMessage {
   MarketBuyResponse createEmptyInstance() => create();
   static $pb.PbList<MarketBuyResponse> createRepeated() => $pb.PbList<MarketBuyResponse>();
   @$core.pragma('dart2js:noInline')
-  static MarketBuyResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketBuyResponse>(create);
+  static MarketBuyResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketBuyResponse>(create);
   static MarketBuyResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get resultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set resultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set resultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -3798,14 +3364,10 @@ class MarketSellRequest extends $pb.GeneratedMessage {
     return $result;
   }
   MarketSellRequest._() : super();
-  factory MarketSellRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MarketSellRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MarketSellRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MarketSellRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketSellRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketSellRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'marketId')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'outcomeIndex', $pb.PbFieldType.O3)
     ..aInt64(3, _omitFieldNames ? '' : 'sharesAmount')
@@ -3813,17 +3375,19 @@ class MarketSellRequest extends $pb.GeneratedMessage {
     ..aOB(5, _omitFieldNames ? '' : 'dryRun')
     ..aInt64(6, _omitFieldNames ? '' : 'feeSats')
     ..aInt64(7, _omitFieldNames ? '' : 'minProceeds')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MarketSellRequest clone() => MarketSellRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MarketSellRequest copyWith(void Function(MarketSellRequest) updates) =>
-      super.copyWith((message) => updates(message as MarketSellRequest)) as MarketSellRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MarketSellRequest copyWith(void Function(MarketSellRequest) updates) => super.copyWith((message) => updates(message as MarketSellRequest)) as MarketSellRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3832,17 +3396,13 @@ class MarketSellRequest extends $pb.GeneratedMessage {
   MarketSellRequest createEmptyInstance() => create();
   static $pb.PbList<MarketSellRequest> createRepeated() => $pb.PbList<MarketSellRequest>();
   @$core.pragma('dart2js:noInline')
-  static MarketSellRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketSellRequest>(create);
+  static MarketSellRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketSellRequest>(create);
   static MarketSellRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get marketId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set marketId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set marketId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMarketId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3851,10 +3411,7 @@ class MarketSellRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get outcomeIndex => $_getIZ(1);
   @$pb.TagNumber(2)
-  set outcomeIndex($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set outcomeIndex($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasOutcomeIndex() => $_has(1);
   @$pb.TagNumber(2)
@@ -3863,10 +3420,7 @@ class MarketSellRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get sharesAmount => $_getI64(2);
   @$pb.TagNumber(3)
-  set sharesAmount($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set sharesAmount($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSharesAmount() => $_has(2);
   @$pb.TagNumber(3)
@@ -3875,10 +3429,7 @@ class MarketSellRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get sellerAddress => $_getSZ(3);
   @$pb.TagNumber(4)
-  set sellerAddress($core.String v) {
-    $_setString(3, v);
-  }
-
+  set sellerAddress($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasSellerAddress() => $_has(3);
   @$pb.TagNumber(4)
@@ -3887,10 +3438,7 @@ class MarketSellRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.bool get dryRun => $_getBF(4);
   @$pb.TagNumber(5)
-  set dryRun($core.bool v) {
-    $_setBool(4, v);
-  }
-
+  set dryRun($core.bool v) { $_setBool(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasDryRun() => $_has(4);
   @$pb.TagNumber(5)
@@ -3899,10 +3447,7 @@ class MarketSellRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get feeSats => $_getI64(5);
   @$pb.TagNumber(6)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasFeeSats() => $_has(5);
   @$pb.TagNumber(6)
@@ -3911,10 +3456,7 @@ class MarketSellRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get minProceeds => $_getI64(6);
   @$pb.TagNumber(7)
-  set minProceeds($fixnum.Int64 v) {
-    $_setInt64(6, v);
-  }
-
+  set minProceeds($fixnum.Int64 v) { $_setInt64(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasMinProceeds() => $_has(6);
   @$pb.TagNumber(7)
@@ -3932,26 +3474,24 @@ class MarketSellResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MarketSellResponse._() : super();
-  factory MarketSellResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MarketSellResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MarketSellResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MarketSellResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketSellResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketSellResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'resultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MarketSellResponse clone() => MarketSellResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MarketSellResponse copyWith(void Function(MarketSellResponse) updates) =>
-      super.copyWith((message) => updates(message as MarketSellResponse)) as MarketSellResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MarketSellResponse copyWith(void Function(MarketSellResponse) updates) => super.copyWith((message) => updates(message as MarketSellResponse)) as MarketSellResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3960,17 +3500,13 @@ class MarketSellResponse extends $pb.GeneratedMessage {
   MarketSellResponse createEmptyInstance() => create();
   static $pb.PbList<MarketSellResponse> createRepeated() => $pb.PbList<MarketSellResponse>();
   @$core.pragma('dart2js:noInline')
-  static MarketSellResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketSellResponse>(create);
+  static MarketSellResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketSellResponse>(create);
   static MarketSellResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get resultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set resultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set resultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -3992,27 +3528,25 @@ class MarketPositionsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   MarketPositionsRequest._() : super();
-  factory MarketPositionsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MarketPositionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MarketPositionsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MarketPositionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketPositionsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketPositionsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aOS(2, _omitFieldNames ? '' : 'marketId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MarketPositionsRequest clone() => MarketPositionsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MarketPositionsRequest copyWith(void Function(MarketPositionsRequest) updates) =>
-      super.copyWith((message) => updates(message as MarketPositionsRequest)) as MarketPositionsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MarketPositionsRequest copyWith(void Function(MarketPositionsRequest) updates) => super.copyWith((message) => updates(message as MarketPositionsRequest)) as MarketPositionsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4021,17 +3555,13 @@ class MarketPositionsRequest extends $pb.GeneratedMessage {
   MarketPositionsRequest createEmptyInstance() => create();
   static $pb.PbList<MarketPositionsRequest> createRepeated() => $pb.PbList<MarketPositionsRequest>();
   @$core.pragma('dart2js:noInline')
-  static MarketPositionsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketPositionsRequest>(create);
+  static MarketPositionsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketPositionsRequest>(create);
   static MarketPositionsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -4040,10 +3570,7 @@ class MarketPositionsRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get marketId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set marketId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set marketId($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasMarketId() => $_has(1);
   @$pb.TagNumber(2)
@@ -4061,26 +3588,24 @@ class MarketPositionsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MarketPositionsResponse._() : super();
-  factory MarketPositionsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MarketPositionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MarketPositionsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MarketPositionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketPositionsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MarketPositionsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'positionsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MarketPositionsResponse clone() => MarketPositionsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MarketPositionsResponse copyWith(void Function(MarketPositionsResponse) updates) =>
-      super.copyWith((message) => updates(message as MarketPositionsResponse)) as MarketPositionsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MarketPositionsResponse copyWith(void Function(MarketPositionsResponse) updates) => super.copyWith((message) => updates(message as MarketPositionsResponse)) as MarketPositionsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4089,17 +3614,13 @@ class MarketPositionsResponse extends $pb.GeneratedMessage {
   MarketPositionsResponse createEmptyInstance() => create();
   static $pb.PbList<MarketPositionsResponse> createRepeated() => $pb.PbList<MarketPositionsResponse>();
   @$core.pragma('dart2js:noInline')
-  static MarketPositionsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketPositionsResponse>(create);
+  static MarketPositionsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MarketPositionsResponse>(create);
   static MarketPositionsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get positionsJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set positionsJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set positionsJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPositionsJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -4109,25 +3630,23 @@ class MarketPositionsResponse extends $pb.GeneratedMessage {
 class SlotStatusRequest extends $pb.GeneratedMessage {
   factory SlotStatusRequest() => create();
   SlotStatusRequest._() : super();
-  factory SlotStatusRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SlotStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SlotStatusRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SlotStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotStatusRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotStatusRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SlotStatusRequest clone() => SlotStatusRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SlotStatusRequest copyWith(void Function(SlotStatusRequest) updates) =>
-      super.copyWith((message) => updates(message as SlotStatusRequest)) as SlotStatusRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SlotStatusRequest copyWith(void Function(SlotStatusRequest) updates) => super.copyWith((message) => updates(message as SlotStatusRequest)) as SlotStatusRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4136,8 +3655,7 @@ class SlotStatusRequest extends $pb.GeneratedMessage {
   SlotStatusRequest createEmptyInstance() => create();
   static $pb.PbList<SlotStatusRequest> createRepeated() => $pb.PbList<SlotStatusRequest>();
   @$core.pragma('dart2js:noInline')
-  static SlotStatusRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotStatusRequest>(create);
+  static SlotStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotStatusRequest>(create);
   static SlotStatusRequest? _defaultInstance;
 }
 
@@ -4152,26 +3670,24 @@ class SlotStatusResponse extends $pb.GeneratedMessage {
     return $result;
   }
   SlotStatusResponse._() : super();
-  factory SlotStatusResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SlotStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SlotStatusResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SlotStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotStatusResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotStatusResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'statusJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SlotStatusResponse clone() => SlotStatusResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SlotStatusResponse copyWith(void Function(SlotStatusResponse) updates) =>
-      super.copyWith((message) => updates(message as SlotStatusResponse)) as SlotStatusResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SlotStatusResponse copyWith(void Function(SlotStatusResponse) updates) => super.copyWith((message) => updates(message as SlotStatusResponse)) as SlotStatusResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4180,17 +3696,13 @@ class SlotStatusResponse extends $pb.GeneratedMessage {
   SlotStatusResponse createEmptyInstance() => create();
   static $pb.PbList<SlotStatusResponse> createRepeated() => $pb.PbList<SlotStatusResponse>();
   @$core.pragma('dart2js:noInline')
-  static SlotStatusResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotStatusResponse>(create);
+  static SlotStatusResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotStatusResponse>(create);
   static SlotStatusResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get statusJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set statusJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set statusJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasStatusJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -4212,27 +3724,25 @@ class SlotListRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SlotListRequest._() : super();
-  factory SlotListRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SlotListRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SlotListRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SlotListRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotListRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotListRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'period', $pb.PbFieldType.O3)
     ..aOS(2, _omitFieldNames ? '' : 'status')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SlotListRequest clone() => SlotListRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SlotListRequest copyWith(void Function(SlotListRequest) updates) =>
-      super.copyWith((message) => updates(message as SlotListRequest)) as SlotListRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SlotListRequest copyWith(void Function(SlotListRequest) updates) => super.copyWith((message) => updates(message as SlotListRequest)) as SlotListRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4241,17 +3751,13 @@ class SlotListRequest extends $pb.GeneratedMessage {
   SlotListRequest createEmptyInstance() => create();
   static $pb.PbList<SlotListRequest> createRepeated() => $pb.PbList<SlotListRequest>();
   @$core.pragma('dart2js:noInline')
-  static SlotListRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotListRequest>(create);
+  static SlotListRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotListRequest>(create);
   static SlotListRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get period => $_getIZ(0);
   @$pb.TagNumber(1)
-  set period($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set period($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPeriod() => $_has(0);
   @$pb.TagNumber(1)
@@ -4260,10 +3766,7 @@ class SlotListRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get status => $_getSZ(1);
   @$pb.TagNumber(2)
-  set status($core.String v) {
-    $_setString(1, v);
-  }
-
+  set status($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasStatus() => $_has(1);
   @$pb.TagNumber(2)
@@ -4281,26 +3784,24 @@ class SlotListResponse extends $pb.GeneratedMessage {
     return $result;
   }
   SlotListResponse._() : super();
-  factory SlotListResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SlotListResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SlotListResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SlotListResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotListResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotListResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'slotsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SlotListResponse clone() => SlotListResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SlotListResponse copyWith(void Function(SlotListResponse) updates) =>
-      super.copyWith((message) => updates(message as SlotListResponse)) as SlotListResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SlotListResponse copyWith(void Function(SlotListResponse) updates) => super.copyWith((message) => updates(message as SlotListResponse)) as SlotListResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4309,17 +3810,13 @@ class SlotListResponse extends $pb.GeneratedMessage {
   SlotListResponse createEmptyInstance() => create();
   static $pb.PbList<SlotListResponse> createRepeated() => $pb.PbList<SlotListResponse>();
   @$core.pragma('dart2js:noInline')
-  static SlotListResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotListResponse>(create);
+  static SlotListResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotListResponse>(create);
   static SlotListResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get slotsJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set slotsJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set slotsJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSlotsJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -4337,25 +3834,24 @@ class SlotGetRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SlotGetRequest._() : super();
-  factory SlotGetRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SlotGetRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SlotGetRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SlotGetRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotGetRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotGetRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'slotId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SlotGetRequest clone() => SlotGetRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SlotGetRequest copyWith(void Function(SlotGetRequest) updates) =>
-      super.copyWith((message) => updates(message as SlotGetRequest)) as SlotGetRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SlotGetRequest copyWith(void Function(SlotGetRequest) updates) => super.copyWith((message) => updates(message as SlotGetRequest)) as SlotGetRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4370,10 +3866,7 @@ class SlotGetRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get slotId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set slotId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set slotId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSlotId() => $_has(0);
   @$pb.TagNumber(1)
@@ -4391,26 +3884,24 @@ class SlotGetResponse extends $pb.GeneratedMessage {
     return $result;
   }
   SlotGetResponse._() : super();
-  factory SlotGetResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SlotGetResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SlotGetResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SlotGetResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotGetResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotGetResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'slotJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SlotGetResponse clone() => SlotGetResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SlotGetResponse copyWith(void Function(SlotGetResponse) updates) =>
-      super.copyWith((message) => updates(message as SlotGetResponse)) as SlotGetResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SlotGetResponse copyWith(void Function(SlotGetResponse) updates) => super.copyWith((message) => updates(message as SlotGetResponse)) as SlotGetResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4419,17 +3910,13 @@ class SlotGetResponse extends $pb.GeneratedMessage {
   SlotGetResponse createEmptyInstance() => create();
   static $pb.PbList<SlotGetResponse> createRepeated() => $pb.PbList<SlotGetResponse>();
   @$core.pragma('dart2js:noInline')
-  static SlotGetResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotGetResponse>(create);
+  static SlotGetResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotGetResponse>(create);
   static SlotGetResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get slotJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set slotJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set slotJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSlotJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -4475,14 +3962,10 @@ class SlotClaimRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SlotClaimRequest._() : super();
-  factory SlotClaimRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SlotClaimRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SlotClaimRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SlotClaimRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotClaimRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotClaimRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'feeSats')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'periodIndex', $pb.PbFieldType.O3)
     ..a<$core.int>(3, _omitFieldNames ? '' : 'slotIndex', $pb.PbFieldType.O3)
@@ -4491,17 +3974,19 @@ class SlotClaimRequest extends $pb.GeneratedMessage {
     ..aOB(6, _omitFieldNames ? '' : 'isScaled')
     ..a<$core.int>(7, _omitFieldNames ? '' : 'min', $pb.PbFieldType.O3)
     ..a<$core.int>(8, _omitFieldNames ? '' : 'max', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SlotClaimRequest clone() => SlotClaimRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SlotClaimRequest copyWith(void Function(SlotClaimRequest) updates) =>
-      super.copyWith((message) => updates(message as SlotClaimRequest)) as SlotClaimRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SlotClaimRequest copyWith(void Function(SlotClaimRequest) updates) => super.copyWith((message) => updates(message as SlotClaimRequest)) as SlotClaimRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4510,17 +3995,13 @@ class SlotClaimRequest extends $pb.GeneratedMessage {
   SlotClaimRequest createEmptyInstance() => create();
   static $pb.PbList<SlotClaimRequest> createRepeated() => $pb.PbList<SlotClaimRequest>();
   @$core.pragma('dart2js:noInline')
-  static SlotClaimRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotClaimRequest>(create);
+  static SlotClaimRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotClaimRequest>(create);
   static SlotClaimRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get feeSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasFeeSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -4529,10 +4010,7 @@ class SlotClaimRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get periodIndex => $_getIZ(1);
   @$pb.TagNumber(2)
-  set periodIndex($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set periodIndex($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasPeriodIndex() => $_has(1);
   @$pb.TagNumber(2)
@@ -4541,10 +4019,7 @@ class SlotClaimRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get slotIndex => $_getIZ(2);
   @$pb.TagNumber(3)
-  set slotIndex($core.int v) {
-    $_setSignedInt32(2, v);
-  }
-
+  set slotIndex($core.int v) { $_setSignedInt32(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSlotIndex() => $_has(2);
   @$pb.TagNumber(3)
@@ -4553,10 +4028,7 @@ class SlotClaimRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get question => $_getSZ(3);
   @$pb.TagNumber(4)
-  set question($core.String v) {
-    $_setString(3, v);
-  }
-
+  set question($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasQuestion() => $_has(3);
   @$pb.TagNumber(4)
@@ -4565,10 +4037,7 @@ class SlotClaimRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.bool get isStandard => $_getBF(4);
   @$pb.TagNumber(5)
-  set isStandard($core.bool v) {
-    $_setBool(4, v);
-  }
-
+  set isStandard($core.bool v) { $_setBool(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasIsStandard() => $_has(4);
   @$pb.TagNumber(5)
@@ -4577,10 +4046,7 @@ class SlotClaimRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.bool get isScaled => $_getBF(5);
   @$pb.TagNumber(6)
-  set isScaled($core.bool v) {
-    $_setBool(5, v);
-  }
-
+  set isScaled($core.bool v) { $_setBool(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasIsScaled() => $_has(5);
   @$pb.TagNumber(6)
@@ -4589,10 +4055,7 @@ class SlotClaimRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.int get min => $_getIZ(6);
   @$pb.TagNumber(7)
-  set min($core.int v) {
-    $_setSignedInt32(6, v);
-  }
-
+  set min($core.int v) { $_setSignedInt32(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasMin() => $_has(6);
   @$pb.TagNumber(7)
@@ -4601,10 +4064,7 @@ class SlotClaimRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.int get max => $_getIZ(7);
   @$pb.TagNumber(8)
-  set max($core.int v) {
-    $_setSignedInt32(7, v);
-  }
-
+  set max($core.int v) { $_setSignedInt32(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasMax() => $_has(7);
   @$pb.TagNumber(8)
@@ -4622,26 +4082,24 @@ class SlotClaimResponse extends $pb.GeneratedMessage {
     return $result;
   }
   SlotClaimResponse._() : super();
-  factory SlotClaimResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SlotClaimResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SlotClaimResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SlotClaimResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotClaimResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotClaimResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SlotClaimResponse clone() => SlotClaimResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SlotClaimResponse copyWith(void Function(SlotClaimResponse) updates) =>
-      super.copyWith((message) => updates(message as SlotClaimResponse)) as SlotClaimResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SlotClaimResponse copyWith(void Function(SlotClaimResponse) updates) => super.copyWith((message) => updates(message as SlotClaimResponse)) as SlotClaimResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4650,17 +4108,13 @@ class SlotClaimResponse extends $pb.GeneratedMessage {
   SlotClaimResponse createEmptyInstance() => create();
   static $pb.PbList<SlotClaimResponse> createRepeated() => $pb.PbList<SlotClaimResponse>();
   @$core.pragma('dart2js:noInline')
-  static SlotClaimResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotClaimResponse>(create);
+  static SlotClaimResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotClaimResponse>(create);
   static SlotClaimResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -4686,28 +4140,26 @@ class SlotClaimCategoryRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SlotClaimCategoryRequest._() : super();
-  factory SlotClaimCategoryRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SlotClaimCategoryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SlotClaimCategoryRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SlotClaimCategoryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotClaimCategoryRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotClaimCategoryRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'slotsJson')
     ..aOB(2, _omitFieldNames ? '' : 'isStandard')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SlotClaimCategoryRequest clone() => SlotClaimCategoryRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SlotClaimCategoryRequest copyWith(void Function(SlotClaimCategoryRequest) updates) =>
-      super.copyWith((message) => updates(message as SlotClaimCategoryRequest)) as SlotClaimCategoryRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SlotClaimCategoryRequest copyWith(void Function(SlotClaimCategoryRequest) updates) => super.copyWith((message) => updates(message as SlotClaimCategoryRequest)) as SlotClaimCategoryRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4716,17 +4168,13 @@ class SlotClaimCategoryRequest extends $pb.GeneratedMessage {
   SlotClaimCategoryRequest createEmptyInstance() => create();
   static $pb.PbList<SlotClaimCategoryRequest> createRepeated() => $pb.PbList<SlotClaimCategoryRequest>();
   @$core.pragma('dart2js:noInline')
-  static SlotClaimCategoryRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotClaimCategoryRequest>(create);
+  static SlotClaimCategoryRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotClaimCategoryRequest>(create);
   static SlotClaimCategoryRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get slotsJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set slotsJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set slotsJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSlotsJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -4735,10 +4183,7 @@ class SlotClaimCategoryRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get isStandard => $_getBF(1);
   @$pb.TagNumber(2)
-  set isStandard($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set isStandard($core.bool v) { $_setBool(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasIsStandard() => $_has(1);
   @$pb.TagNumber(2)
@@ -4747,10 +4192,7 @@ class SlotClaimCategoryRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -4768,26 +4210,24 @@ class SlotClaimCategoryResponse extends $pb.GeneratedMessage {
     return $result;
   }
   SlotClaimCategoryResponse._() : super();
-  factory SlotClaimCategoryResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SlotClaimCategoryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SlotClaimCategoryResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SlotClaimCategoryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotClaimCategoryResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SlotClaimCategoryResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SlotClaimCategoryResponse clone() => SlotClaimCategoryResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SlotClaimCategoryResponse copyWith(void Function(SlotClaimCategoryResponse) updates) =>
-      super.copyWith((message) => updates(message as SlotClaimCategoryResponse)) as SlotClaimCategoryResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SlotClaimCategoryResponse copyWith(void Function(SlotClaimCategoryResponse) updates) => super.copyWith((message) => updates(message as SlotClaimCategoryResponse)) as SlotClaimCategoryResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4796,17 +4236,13 @@ class SlotClaimCategoryResponse extends $pb.GeneratedMessage {
   SlotClaimCategoryResponse createEmptyInstance() => create();
   static $pb.PbList<SlotClaimCategoryResponse> createRepeated() => $pb.PbList<SlotClaimCategoryResponse>();
   @$core.pragma('dart2js:noInline')
-  static SlotClaimCategoryResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotClaimCategoryResponse>(create);
+  static SlotClaimCategoryResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SlotClaimCategoryResponse>(create);
   static SlotClaimCategoryResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -4828,27 +4264,25 @@ class VoteRegisterRequest extends $pb.GeneratedMessage {
     return $result;
   }
   VoteRegisterRequest._() : super();
-  factory VoteRegisterRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VoteRegisterRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VoteRegisterRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VoteRegisterRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteRegisterRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteRegisterRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'feeSats')
     ..aInt64(2, _omitFieldNames ? '' : 'reputationBondSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VoteRegisterRequest clone() => VoteRegisterRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VoteRegisterRequest copyWith(void Function(VoteRegisterRequest) updates) =>
-      super.copyWith((message) => updates(message as VoteRegisterRequest)) as VoteRegisterRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VoteRegisterRequest copyWith(void Function(VoteRegisterRequest) updates) => super.copyWith((message) => updates(message as VoteRegisterRequest)) as VoteRegisterRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4857,17 +4291,13 @@ class VoteRegisterRequest extends $pb.GeneratedMessage {
   VoteRegisterRequest createEmptyInstance() => create();
   static $pb.PbList<VoteRegisterRequest> createRepeated() => $pb.PbList<VoteRegisterRequest>();
   @$core.pragma('dart2js:noInline')
-  static VoteRegisterRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteRegisterRequest>(create);
+  static VoteRegisterRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteRegisterRequest>(create);
   static VoteRegisterRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get feeSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasFeeSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -4876,10 +4306,7 @@ class VoteRegisterRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get reputationBondSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set reputationBondSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set reputationBondSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasReputationBondSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -4897,26 +4324,24 @@ class VoteRegisterResponse extends $pb.GeneratedMessage {
     return $result;
   }
   VoteRegisterResponse._() : super();
-  factory VoteRegisterResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VoteRegisterResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VoteRegisterResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VoteRegisterResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteRegisterResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteRegisterResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VoteRegisterResponse clone() => VoteRegisterResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VoteRegisterResponse copyWith(void Function(VoteRegisterResponse) updates) =>
-      super.copyWith((message) => updates(message as VoteRegisterResponse)) as VoteRegisterResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VoteRegisterResponse copyWith(void Function(VoteRegisterResponse) updates) => super.copyWith((message) => updates(message as VoteRegisterResponse)) as VoteRegisterResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4925,17 +4350,13 @@ class VoteRegisterResponse extends $pb.GeneratedMessage {
   VoteRegisterResponse createEmptyInstance() => create();
   static $pb.PbList<VoteRegisterResponse> createRepeated() => $pb.PbList<VoteRegisterResponse>();
   @$core.pragma('dart2js:noInline')
-  static VoteRegisterResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteRegisterResponse>(create);
+  static VoteRegisterResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteRegisterResponse>(create);
   static VoteRegisterResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -4953,26 +4374,24 @@ class VoteVoterRequest extends $pb.GeneratedMessage {
     return $result;
   }
   VoteVoterRequest._() : super();
-  factory VoteVoterRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VoteVoterRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VoteVoterRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VoteVoterRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteVoterRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteVoterRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VoteVoterRequest clone() => VoteVoterRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VoteVoterRequest copyWith(void Function(VoteVoterRequest) updates) =>
-      super.copyWith((message) => updates(message as VoteVoterRequest)) as VoteVoterRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VoteVoterRequest copyWith(void Function(VoteVoterRequest) updates) => super.copyWith((message) => updates(message as VoteVoterRequest)) as VoteVoterRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4981,17 +4400,13 @@ class VoteVoterRequest extends $pb.GeneratedMessage {
   VoteVoterRequest createEmptyInstance() => create();
   static $pb.PbList<VoteVoterRequest> createRepeated() => $pb.PbList<VoteVoterRequest>();
   @$core.pragma('dart2js:noInline')
-  static VoteVoterRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteVoterRequest>(create);
+  static VoteVoterRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteVoterRequest>(create);
   static VoteVoterRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -5009,26 +4424,24 @@ class VoteVoterResponse extends $pb.GeneratedMessage {
     return $result;
   }
   VoteVoterResponse._() : super();
-  factory VoteVoterResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VoteVoterResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VoteVoterResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VoteVoterResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteVoterResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteVoterResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'voterJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VoteVoterResponse clone() => VoteVoterResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VoteVoterResponse copyWith(void Function(VoteVoterResponse) updates) =>
-      super.copyWith((message) => updates(message as VoteVoterResponse)) as VoteVoterResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VoteVoterResponse copyWith(void Function(VoteVoterResponse) updates) => super.copyWith((message) => updates(message as VoteVoterResponse)) as VoteVoterResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5037,17 +4450,13 @@ class VoteVoterResponse extends $pb.GeneratedMessage {
   VoteVoterResponse createEmptyInstance() => create();
   static $pb.PbList<VoteVoterResponse> createRepeated() => $pb.PbList<VoteVoterResponse>();
   @$core.pragma('dart2js:noInline')
-  static VoteVoterResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteVoterResponse>(create);
+  static VoteVoterResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteVoterResponse>(create);
   static VoteVoterResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get voterJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set voterJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set voterJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasVoterJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -5057,25 +4466,23 @@ class VoteVoterResponse extends $pb.GeneratedMessage {
 class VoteVotersRequest extends $pb.GeneratedMessage {
   factory VoteVotersRequest() => create();
   VoteVotersRequest._() : super();
-  factory VoteVotersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VoteVotersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VoteVotersRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VoteVotersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteVotersRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteVotersRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VoteVotersRequest clone() => VoteVotersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VoteVotersRequest copyWith(void Function(VoteVotersRequest) updates) =>
-      super.copyWith((message) => updates(message as VoteVotersRequest)) as VoteVotersRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VoteVotersRequest copyWith(void Function(VoteVotersRequest) updates) => super.copyWith((message) => updates(message as VoteVotersRequest)) as VoteVotersRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5084,8 +4491,7 @@ class VoteVotersRequest extends $pb.GeneratedMessage {
   VoteVotersRequest createEmptyInstance() => create();
   static $pb.PbList<VoteVotersRequest> createRepeated() => $pb.PbList<VoteVotersRequest>();
   @$core.pragma('dart2js:noInline')
-  static VoteVotersRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteVotersRequest>(create);
+  static VoteVotersRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteVotersRequest>(create);
   static VoteVotersRequest? _defaultInstance;
 }
 
@@ -5100,26 +4506,24 @@ class VoteVotersResponse extends $pb.GeneratedMessage {
     return $result;
   }
   VoteVotersResponse._() : super();
-  factory VoteVotersResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VoteVotersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VoteVotersResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VoteVotersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteVotersResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteVotersResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'votersJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VoteVotersResponse clone() => VoteVotersResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VoteVotersResponse copyWith(void Function(VoteVotersResponse) updates) =>
-      super.copyWith((message) => updates(message as VoteVotersResponse)) as VoteVotersResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VoteVotersResponse copyWith(void Function(VoteVotersResponse) updates) => super.copyWith((message) => updates(message as VoteVotersResponse)) as VoteVotersResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5128,17 +4532,13 @@ class VoteVotersResponse extends $pb.GeneratedMessage {
   VoteVotersResponse createEmptyInstance() => create();
   static $pb.PbList<VoteVotersResponse> createRepeated() => $pb.PbList<VoteVotersResponse>();
   @$core.pragma('dart2js:noInline')
-  static VoteVotersResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteVotersResponse>(create);
+  static VoteVotersResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteVotersResponse>(create);
   static VoteVotersResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get votersJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set votersJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set votersJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasVotersJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -5160,27 +4560,25 @@ class VoteSubmitRequest extends $pb.GeneratedMessage {
     return $result;
   }
   VoteSubmitRequest._() : super();
-  factory VoteSubmitRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VoteSubmitRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VoteSubmitRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VoteSubmitRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteSubmitRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteSubmitRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'votesJson')
     ..aInt64(2, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VoteSubmitRequest clone() => VoteSubmitRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VoteSubmitRequest copyWith(void Function(VoteSubmitRequest) updates) =>
-      super.copyWith((message) => updates(message as VoteSubmitRequest)) as VoteSubmitRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VoteSubmitRequest copyWith(void Function(VoteSubmitRequest) updates) => super.copyWith((message) => updates(message as VoteSubmitRequest)) as VoteSubmitRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5189,17 +4587,13 @@ class VoteSubmitRequest extends $pb.GeneratedMessage {
   VoteSubmitRequest createEmptyInstance() => create();
   static $pb.PbList<VoteSubmitRequest> createRepeated() => $pb.PbList<VoteSubmitRequest>();
   @$core.pragma('dart2js:noInline')
-  static VoteSubmitRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteSubmitRequest>(create);
+  static VoteSubmitRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteSubmitRequest>(create);
   static VoteSubmitRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get votesJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set votesJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set votesJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasVotesJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -5208,10 +4602,7 @@ class VoteSubmitRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get feeSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasFeeSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -5229,26 +4620,24 @@ class VoteSubmitResponse extends $pb.GeneratedMessage {
     return $result;
   }
   VoteSubmitResponse._() : super();
-  factory VoteSubmitResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VoteSubmitResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VoteSubmitResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VoteSubmitResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteSubmitResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteSubmitResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VoteSubmitResponse clone() => VoteSubmitResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VoteSubmitResponse copyWith(void Function(VoteSubmitResponse) updates) =>
-      super.copyWith((message) => updates(message as VoteSubmitResponse)) as VoteSubmitResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VoteSubmitResponse copyWith(void Function(VoteSubmitResponse) updates) => super.copyWith((message) => updates(message as VoteSubmitResponse)) as VoteSubmitResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5257,17 +4646,13 @@ class VoteSubmitResponse extends $pb.GeneratedMessage {
   VoteSubmitResponse createEmptyInstance() => create();
   static $pb.PbList<VoteSubmitResponse> createRepeated() => $pb.PbList<VoteSubmitResponse>();
   @$core.pragma('dart2js:noInline')
-  static VoteSubmitResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteSubmitResponse>(create);
+  static VoteSubmitResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteSubmitResponse>(create);
   static VoteSubmitResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -5293,28 +4678,26 @@ class VoteListRequest extends $pb.GeneratedMessage {
     return $result;
   }
   VoteListRequest._() : super();
-  factory VoteListRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VoteListRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VoteListRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VoteListRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteListRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteListRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'voter')
     ..aOS(2, _omitFieldNames ? '' : 'decisionId')
     ..a<$core.int>(3, _omitFieldNames ? '' : 'periodId', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VoteListRequest clone() => VoteListRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VoteListRequest copyWith(void Function(VoteListRequest) updates) =>
-      super.copyWith((message) => updates(message as VoteListRequest)) as VoteListRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VoteListRequest copyWith(void Function(VoteListRequest) updates) => super.copyWith((message) => updates(message as VoteListRequest)) as VoteListRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5323,17 +4706,13 @@ class VoteListRequest extends $pb.GeneratedMessage {
   VoteListRequest createEmptyInstance() => create();
   static $pb.PbList<VoteListRequest> createRepeated() => $pb.PbList<VoteListRequest>();
   @$core.pragma('dart2js:noInline')
-  static VoteListRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteListRequest>(create);
+  static VoteListRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteListRequest>(create);
   static VoteListRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get voter => $_getSZ(0);
   @$pb.TagNumber(1)
-  set voter($core.String v) {
-    $_setString(0, v);
-  }
-
+  set voter($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasVoter() => $_has(0);
   @$pb.TagNumber(1)
@@ -5342,10 +4721,7 @@ class VoteListRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get decisionId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set decisionId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set decisionId($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasDecisionId() => $_has(1);
   @$pb.TagNumber(2)
@@ -5354,10 +4730,7 @@ class VoteListRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get periodId => $_getIZ(2);
   @$pb.TagNumber(3)
-  set periodId($core.int v) {
-    $_setSignedInt32(2, v);
-  }
-
+  set periodId($core.int v) { $_setSignedInt32(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasPeriodId() => $_has(2);
   @$pb.TagNumber(3)
@@ -5375,26 +4748,24 @@ class VoteListResponse extends $pb.GeneratedMessage {
     return $result;
   }
   VoteListResponse._() : super();
-  factory VoteListResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VoteListResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VoteListResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VoteListResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteListResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VoteListResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'votesJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VoteListResponse clone() => VoteListResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VoteListResponse copyWith(void Function(VoteListResponse) updates) =>
-      super.copyWith((message) => updates(message as VoteListResponse)) as VoteListResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VoteListResponse copyWith(void Function(VoteListResponse) updates) => super.copyWith((message) => updates(message as VoteListResponse)) as VoteListResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5403,17 +4774,13 @@ class VoteListResponse extends $pb.GeneratedMessage {
   VoteListResponse createEmptyInstance() => create();
   static $pb.PbList<VoteListResponse> createRepeated() => $pb.PbList<VoteListResponse>();
   @$core.pragma('dart2js:noInline')
-  static VoteListResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteListResponse>(create);
+  static VoteListResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VoteListResponse>(create);
   static VoteListResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get votesJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set votesJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set votesJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasVotesJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -5431,26 +4798,24 @@ class VotePeriodRequest extends $pb.GeneratedMessage {
     return $result;
   }
   VotePeriodRequest._() : super();
-  factory VotePeriodRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VotePeriodRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VotePeriodRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VotePeriodRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VotePeriodRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VotePeriodRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'periodId', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VotePeriodRequest clone() => VotePeriodRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VotePeriodRequest copyWith(void Function(VotePeriodRequest) updates) =>
-      super.copyWith((message) => updates(message as VotePeriodRequest)) as VotePeriodRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VotePeriodRequest copyWith(void Function(VotePeriodRequest) updates) => super.copyWith((message) => updates(message as VotePeriodRequest)) as VotePeriodRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5459,17 +4824,13 @@ class VotePeriodRequest extends $pb.GeneratedMessage {
   VotePeriodRequest createEmptyInstance() => create();
   static $pb.PbList<VotePeriodRequest> createRepeated() => $pb.PbList<VotePeriodRequest>();
   @$core.pragma('dart2js:noInline')
-  static VotePeriodRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VotePeriodRequest>(create);
+  static VotePeriodRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VotePeriodRequest>(create);
   static VotePeriodRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get periodId => $_getIZ(0);
   @$pb.TagNumber(1)
-  set periodId($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set periodId($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPeriodId() => $_has(0);
   @$pb.TagNumber(1)
@@ -5487,26 +4848,24 @@ class VotePeriodResponse extends $pb.GeneratedMessage {
     return $result;
   }
   VotePeriodResponse._() : super();
-  factory VotePeriodResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VotePeriodResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VotePeriodResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VotePeriodResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VotePeriodResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VotePeriodResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'periodJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VotePeriodResponse clone() => VotePeriodResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VotePeriodResponse copyWith(void Function(VotePeriodResponse) updates) =>
-      super.copyWith((message) => updates(message as VotePeriodResponse)) as VotePeriodResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VotePeriodResponse copyWith(void Function(VotePeriodResponse) updates) => super.copyWith((message) => updates(message as VotePeriodResponse)) as VotePeriodResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5515,17 +4874,13 @@ class VotePeriodResponse extends $pb.GeneratedMessage {
   VotePeriodResponse createEmptyInstance() => create();
   static $pb.PbList<VotePeriodResponse> createRepeated() => $pb.PbList<VotePeriodResponse>();
   @$core.pragma('dart2js:noInline')
-  static VotePeriodResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VotePeriodResponse>(create);
+  static VotePeriodResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VotePeriodResponse>(create);
   static VotePeriodResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get periodJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set periodJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set periodJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPeriodJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -5555,29 +4910,27 @@ class VotecoinTransferRequest extends $pb.GeneratedMessage {
     return $result;
   }
   VotecoinTransferRequest._() : super();
-  factory VotecoinTransferRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VotecoinTransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VotecoinTransferRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VotecoinTransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VotecoinTransferRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VotecoinTransferRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'dest')
     ..aInt64(2, _omitFieldNames ? '' : 'amount')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
     ..aOS(4, _omitFieldNames ? '' : 'memo')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VotecoinTransferRequest clone() => VotecoinTransferRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VotecoinTransferRequest copyWith(void Function(VotecoinTransferRequest) updates) =>
-      super.copyWith((message) => updates(message as VotecoinTransferRequest)) as VotecoinTransferRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VotecoinTransferRequest copyWith(void Function(VotecoinTransferRequest) updates) => super.copyWith((message) => updates(message as VotecoinTransferRequest)) as VotecoinTransferRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5586,17 +4939,13 @@ class VotecoinTransferRequest extends $pb.GeneratedMessage {
   VotecoinTransferRequest createEmptyInstance() => create();
   static $pb.PbList<VotecoinTransferRequest> createRepeated() => $pb.PbList<VotecoinTransferRequest>();
   @$core.pragma('dart2js:noInline')
-  static VotecoinTransferRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VotecoinTransferRequest>(create);
+  static VotecoinTransferRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VotecoinTransferRequest>(create);
   static VotecoinTransferRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get dest => $_getSZ(0);
   @$pb.TagNumber(1)
-  set dest($core.String v) {
-    $_setString(0, v);
-  }
-
+  set dest($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDest() => $_has(0);
   @$pb.TagNumber(1)
@@ -5605,10 +4954,7 @@ class VotecoinTransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amount => $_getI64(1);
   @$pb.TagNumber(2)
-  set amount($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -5617,10 +4963,7 @@ class VotecoinTransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -5629,10 +4972,7 @@ class VotecoinTransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get memo => $_getSZ(3);
   @$pb.TagNumber(4)
-  set memo($core.String v) {
-    $_setString(3, v);
-  }
-
+  set memo($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasMemo() => $_has(3);
   @$pb.TagNumber(4)
@@ -5650,26 +4990,24 @@ class VotecoinTransferResponse extends $pb.GeneratedMessage {
     return $result;
   }
   VotecoinTransferResponse._() : super();
-  factory VotecoinTransferResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VotecoinTransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VotecoinTransferResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VotecoinTransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VotecoinTransferResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VotecoinTransferResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VotecoinTransferResponse clone() => VotecoinTransferResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VotecoinTransferResponse copyWith(void Function(VotecoinTransferResponse) updates) =>
-      super.copyWith((message) => updates(message as VotecoinTransferResponse)) as VotecoinTransferResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VotecoinTransferResponse copyWith(void Function(VotecoinTransferResponse) updates) => super.copyWith((message) => updates(message as VotecoinTransferResponse)) as VotecoinTransferResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5678,17 +5016,13 @@ class VotecoinTransferResponse extends $pb.GeneratedMessage {
   VotecoinTransferResponse createEmptyInstance() => create();
   static $pb.PbList<VotecoinTransferResponse> createRepeated() => $pb.PbList<VotecoinTransferResponse>();
   @$core.pragma('dart2js:noInline')
-  static VotecoinTransferResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VotecoinTransferResponse>(create);
+  static VotecoinTransferResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VotecoinTransferResponse>(create);
   static VotecoinTransferResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -5706,26 +5040,24 @@ class VotecoinBalanceRequest extends $pb.GeneratedMessage {
     return $result;
   }
   VotecoinBalanceRequest._() : super();
-  factory VotecoinBalanceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VotecoinBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VotecoinBalanceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VotecoinBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VotecoinBalanceRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VotecoinBalanceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VotecoinBalanceRequest clone() => VotecoinBalanceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VotecoinBalanceRequest copyWith(void Function(VotecoinBalanceRequest) updates) =>
-      super.copyWith((message) => updates(message as VotecoinBalanceRequest)) as VotecoinBalanceRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VotecoinBalanceRequest copyWith(void Function(VotecoinBalanceRequest) updates) => super.copyWith((message) => updates(message as VotecoinBalanceRequest)) as VotecoinBalanceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5734,17 +5066,13 @@ class VotecoinBalanceRequest extends $pb.GeneratedMessage {
   VotecoinBalanceRequest createEmptyInstance() => create();
   static $pb.PbList<VotecoinBalanceRequest> createRepeated() => $pb.PbList<VotecoinBalanceRequest>();
   @$core.pragma('dart2js:noInline')
-  static VotecoinBalanceRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VotecoinBalanceRequest>(create);
+  static VotecoinBalanceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VotecoinBalanceRequest>(create);
   static VotecoinBalanceRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -5762,26 +5090,24 @@ class VotecoinBalanceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   VotecoinBalanceResponse._() : super();
-  factory VotecoinBalanceResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VotecoinBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VotecoinBalanceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VotecoinBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VotecoinBalanceResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VotecoinBalanceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'balance')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VotecoinBalanceResponse clone() => VotecoinBalanceResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VotecoinBalanceResponse copyWith(void Function(VotecoinBalanceResponse) updates) =>
-      super.copyWith((message) => updates(message as VotecoinBalanceResponse)) as VotecoinBalanceResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VotecoinBalanceResponse copyWith(void Function(VotecoinBalanceResponse) updates) => super.copyWith((message) => updates(message as VotecoinBalanceResponse)) as VotecoinBalanceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5790,17 +5116,13 @@ class VotecoinBalanceResponse extends $pb.GeneratedMessage {
   VotecoinBalanceResponse createEmptyInstance() => create();
   static $pb.PbList<VotecoinBalanceResponse> createRepeated() => $pb.PbList<VotecoinBalanceResponse>();
   @$core.pragma('dart2js:noInline')
-  static VotecoinBalanceResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VotecoinBalanceResponse>(create);
+  static VotecoinBalanceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VotecoinBalanceResponse>(create);
   static VotecoinBalanceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get balance => $_getI64(0);
   @$pb.TagNumber(1)
-  set balance($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set balance($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBalance() => $_has(0);
   @$pb.TagNumber(1)
@@ -5830,29 +5152,27 @@ class TransferVotecoinRequest extends $pb.GeneratedMessage {
     return $result;
   }
   TransferVotecoinRequest._() : super();
-  factory TransferVotecoinRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferVotecoinRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferVotecoinRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferVotecoinRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferVotecoinRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferVotecoinRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'dest')
     ..aInt64(2, _omitFieldNames ? '' : 'amount')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
     ..aOS(4, _omitFieldNames ? '' : 'memo')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferVotecoinRequest clone() => TransferVotecoinRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferVotecoinRequest copyWith(void Function(TransferVotecoinRequest) updates) =>
-      super.copyWith((message) => updates(message as TransferVotecoinRequest)) as TransferVotecoinRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferVotecoinRequest copyWith(void Function(TransferVotecoinRequest) updates) => super.copyWith((message) => updates(message as TransferVotecoinRequest)) as TransferVotecoinRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5861,17 +5181,13 @@ class TransferVotecoinRequest extends $pb.GeneratedMessage {
   TransferVotecoinRequest createEmptyInstance() => create();
   static $pb.PbList<TransferVotecoinRequest> createRepeated() => $pb.PbList<TransferVotecoinRequest>();
   @$core.pragma('dart2js:noInline')
-  static TransferVotecoinRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferVotecoinRequest>(create);
+  static TransferVotecoinRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferVotecoinRequest>(create);
   static TransferVotecoinRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get dest => $_getSZ(0);
   @$pb.TagNumber(1)
-  set dest($core.String v) {
-    $_setString(0, v);
-  }
-
+  set dest($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDest() => $_has(0);
   @$pb.TagNumber(1)
@@ -5880,10 +5196,7 @@ class TransferVotecoinRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amount => $_getI64(1);
   @$pb.TagNumber(2)
-  set amount($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -5892,10 +5205,7 @@ class TransferVotecoinRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -5904,10 +5214,7 @@ class TransferVotecoinRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get memo => $_getSZ(3);
   @$pb.TagNumber(4)
-  set memo($core.String v) {
-    $_setString(3, v);
-  }
-
+  set memo($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasMemo() => $_has(3);
   @$pb.TagNumber(4)
@@ -5925,26 +5232,24 @@ class TransferVotecoinResponse extends $pb.GeneratedMessage {
     return $result;
   }
   TransferVotecoinResponse._() : super();
-  factory TransferVotecoinResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferVotecoinResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferVotecoinResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferVotecoinResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferVotecoinResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferVotecoinResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferVotecoinResponse clone() => TransferVotecoinResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferVotecoinResponse copyWith(void Function(TransferVotecoinResponse) updates) =>
-      super.copyWith((message) => updates(message as TransferVotecoinResponse)) as TransferVotecoinResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferVotecoinResponse copyWith(void Function(TransferVotecoinResponse) updates) => super.copyWith((message) => updates(message as TransferVotecoinResponse)) as TransferVotecoinResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5953,17 +5258,13 @@ class TransferVotecoinResponse extends $pb.GeneratedMessage {
   TransferVotecoinResponse createEmptyInstance() => create();
   static $pb.PbList<TransferVotecoinResponse> createRepeated() => $pb.PbList<TransferVotecoinResponse>();
   @$core.pragma('dart2js:noInline')
-  static TransferVotecoinResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferVotecoinResponse>(create);
+  static TransferVotecoinResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferVotecoinResponse>(create);
   static TransferVotecoinResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -5973,26 +5274,23 @@ class TransferVotecoinResponse extends $pb.GeneratedMessage {
 class GetNewEncryptionKeyRequest extends $pb.GeneratedMessage {
   factory GetNewEncryptionKeyRequest() => create();
   GetNewEncryptionKeyRequest._() : super();
-  factory GetNewEncryptionKeyRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewEncryptionKeyRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewEncryptionKeyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewEncryptionKeyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewEncryptionKeyRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewEncryptionKeyRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewEncryptionKeyRequest clone() => GetNewEncryptionKeyRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewEncryptionKeyRequest copyWith(void Function(GetNewEncryptionKeyRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewEncryptionKeyRequest)) as GetNewEncryptionKeyRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewEncryptionKeyRequest copyWith(void Function(GetNewEncryptionKeyRequest) updates) => super.copyWith((message) => updates(message as GetNewEncryptionKeyRequest)) as GetNewEncryptionKeyRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6001,8 +5299,7 @@ class GetNewEncryptionKeyRequest extends $pb.GeneratedMessage {
   GetNewEncryptionKeyRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewEncryptionKeyRequest> createRepeated() => $pb.PbList<GetNewEncryptionKeyRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewEncryptionKeyRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewEncryptionKeyRequest>(create);
+  static GetNewEncryptionKeyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewEncryptionKeyRequest>(create);
   static GetNewEncryptionKeyRequest? _defaultInstance;
 }
 
@@ -6017,27 +5314,24 @@ class GetNewEncryptionKeyResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewEncryptionKeyResponse._() : super();
-  factory GetNewEncryptionKeyResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewEncryptionKeyResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewEncryptionKeyResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewEncryptionKeyResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewEncryptionKeyResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewEncryptionKeyResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'key')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewEncryptionKeyResponse clone() => GetNewEncryptionKeyResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewEncryptionKeyResponse copyWith(void Function(GetNewEncryptionKeyResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewEncryptionKeyResponse)) as GetNewEncryptionKeyResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewEncryptionKeyResponse copyWith(void Function(GetNewEncryptionKeyResponse) updates) => super.copyWith((message) => updates(message as GetNewEncryptionKeyResponse)) as GetNewEncryptionKeyResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6046,17 +5340,13 @@ class GetNewEncryptionKeyResponse extends $pb.GeneratedMessage {
   GetNewEncryptionKeyResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewEncryptionKeyResponse> createRepeated() => $pb.PbList<GetNewEncryptionKeyResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewEncryptionKeyResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewEncryptionKeyResponse>(create);
+  static GetNewEncryptionKeyResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewEncryptionKeyResponse>(create);
   static GetNewEncryptionKeyResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get key => $_getSZ(0);
   @$pb.TagNumber(1)
-  set key($core.String v) {
-    $_setString(0, v);
-  }
-
+  set key($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasKey() => $_has(0);
   @$pb.TagNumber(1)
@@ -6066,25 +5356,23 @@ class GetNewEncryptionKeyResponse extends $pb.GeneratedMessage {
 class GetNewVerifyingKeyRequest extends $pb.GeneratedMessage {
   factory GetNewVerifyingKeyRequest() => create();
   GetNewVerifyingKeyRequest._() : super();
-  factory GetNewVerifyingKeyRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewVerifyingKeyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewVerifyingKeyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewVerifyingKeyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewVerifyingKeyRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewVerifyingKeyRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewVerifyingKeyRequest clone() => GetNewVerifyingKeyRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewVerifyingKeyRequest copyWith(void Function(GetNewVerifyingKeyRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewVerifyingKeyRequest)) as GetNewVerifyingKeyRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewVerifyingKeyRequest copyWith(void Function(GetNewVerifyingKeyRequest) updates) => super.copyWith((message) => updates(message as GetNewVerifyingKeyRequest)) as GetNewVerifyingKeyRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6093,8 +5381,7 @@ class GetNewVerifyingKeyRequest extends $pb.GeneratedMessage {
   GetNewVerifyingKeyRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewVerifyingKeyRequest> createRepeated() => $pb.PbList<GetNewVerifyingKeyRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewVerifyingKeyRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewVerifyingKeyRequest>(create);
+  static GetNewVerifyingKeyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewVerifyingKeyRequest>(create);
   static GetNewVerifyingKeyRequest? _defaultInstance;
 }
 
@@ -6109,27 +5396,24 @@ class GetNewVerifyingKeyResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewVerifyingKeyResponse._() : super();
-  factory GetNewVerifyingKeyResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewVerifyingKeyResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewVerifyingKeyResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewVerifyingKeyResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewVerifyingKeyResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewVerifyingKeyResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'key')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewVerifyingKeyResponse clone() => GetNewVerifyingKeyResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewVerifyingKeyResponse copyWith(void Function(GetNewVerifyingKeyResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewVerifyingKeyResponse)) as GetNewVerifyingKeyResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewVerifyingKeyResponse copyWith(void Function(GetNewVerifyingKeyResponse) updates) => super.copyWith((message) => updates(message as GetNewVerifyingKeyResponse)) as GetNewVerifyingKeyResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6138,17 +5422,13 @@ class GetNewVerifyingKeyResponse extends $pb.GeneratedMessage {
   GetNewVerifyingKeyResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewVerifyingKeyResponse> createRepeated() => $pb.PbList<GetNewVerifyingKeyResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewVerifyingKeyResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewVerifyingKeyResponse>(create);
+  static GetNewVerifyingKeyResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewVerifyingKeyResponse>(create);
   static GetNewVerifyingKeyResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get key => $_getSZ(0);
   @$pb.TagNumber(1)
-  set key($core.String v) {
-    $_setString(0, v);
-  }
-
+  set key($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasKey() => $_has(0);
   @$pb.TagNumber(1)
@@ -6170,27 +5450,25 @@ class EncryptMsgRequest extends $pb.GeneratedMessage {
     return $result;
   }
   EncryptMsgRequest._() : super();
-  factory EncryptMsgRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory EncryptMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory EncryptMsgRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EncryptMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptMsgRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptMsgRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'msg')
     ..aOS(2, _omitFieldNames ? '' : 'encryptionPubkey')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   EncryptMsgRequest clone() => EncryptMsgRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  EncryptMsgRequest copyWith(void Function(EncryptMsgRequest) updates) =>
-      super.copyWith((message) => updates(message as EncryptMsgRequest)) as EncryptMsgRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EncryptMsgRequest copyWith(void Function(EncryptMsgRequest) updates) => super.copyWith((message) => updates(message as EncryptMsgRequest)) as EncryptMsgRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6199,17 +5477,13 @@ class EncryptMsgRequest extends $pb.GeneratedMessage {
   EncryptMsgRequest createEmptyInstance() => create();
   static $pb.PbList<EncryptMsgRequest> createRepeated() => $pb.PbList<EncryptMsgRequest>();
   @$core.pragma('dart2js:noInline')
-  static EncryptMsgRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptMsgRequest>(create);
+  static EncryptMsgRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptMsgRequest>(create);
   static EncryptMsgRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get msg => $_getSZ(0);
   @$pb.TagNumber(1)
-  set msg($core.String v) {
-    $_setString(0, v);
-  }
-
+  set msg($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMsg() => $_has(0);
   @$pb.TagNumber(1)
@@ -6218,10 +5492,7 @@ class EncryptMsgRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get encryptionPubkey => $_getSZ(1);
   @$pb.TagNumber(2)
-  set encryptionPubkey($core.String v) {
-    $_setString(1, v);
-  }
-
+  set encryptionPubkey($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasEncryptionPubkey() => $_has(1);
   @$pb.TagNumber(2)
@@ -6239,26 +5510,24 @@ class EncryptMsgResponse extends $pb.GeneratedMessage {
     return $result;
   }
   EncryptMsgResponse._() : super();
-  factory EncryptMsgResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory EncryptMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory EncryptMsgResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EncryptMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptMsgResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptMsgResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'ciphertext')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   EncryptMsgResponse clone() => EncryptMsgResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  EncryptMsgResponse copyWith(void Function(EncryptMsgResponse) updates) =>
-      super.copyWith((message) => updates(message as EncryptMsgResponse)) as EncryptMsgResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EncryptMsgResponse copyWith(void Function(EncryptMsgResponse) updates) => super.copyWith((message) => updates(message as EncryptMsgResponse)) as EncryptMsgResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6267,17 +5536,13 @@ class EncryptMsgResponse extends $pb.GeneratedMessage {
   EncryptMsgResponse createEmptyInstance() => create();
   static $pb.PbList<EncryptMsgResponse> createRepeated() => $pb.PbList<EncryptMsgResponse>();
   @$core.pragma('dart2js:noInline')
-  static EncryptMsgResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptMsgResponse>(create);
+  static EncryptMsgResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptMsgResponse>(create);
   static EncryptMsgResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get ciphertext => $_getSZ(0);
   @$pb.TagNumber(1)
-  set ciphertext($core.String v) {
-    $_setString(0, v);
-  }
-
+  set ciphertext($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCiphertext() => $_has(0);
   @$pb.TagNumber(1)
@@ -6299,27 +5564,25 @@ class DecryptMsgRequest extends $pb.GeneratedMessage {
     return $result;
   }
   DecryptMsgRequest._() : super();
-  factory DecryptMsgRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DecryptMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DecryptMsgRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DecryptMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecryptMsgRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecryptMsgRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'ciphertext')
     ..aOS(2, _omitFieldNames ? '' : 'encryptionPubkey')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DecryptMsgRequest clone() => DecryptMsgRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DecryptMsgRequest copyWith(void Function(DecryptMsgRequest) updates) =>
-      super.copyWith((message) => updates(message as DecryptMsgRequest)) as DecryptMsgRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DecryptMsgRequest copyWith(void Function(DecryptMsgRequest) updates) => super.copyWith((message) => updates(message as DecryptMsgRequest)) as DecryptMsgRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6328,17 +5591,13 @@ class DecryptMsgRequest extends $pb.GeneratedMessage {
   DecryptMsgRequest createEmptyInstance() => create();
   static $pb.PbList<DecryptMsgRequest> createRepeated() => $pb.PbList<DecryptMsgRequest>();
   @$core.pragma('dart2js:noInline')
-  static DecryptMsgRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecryptMsgRequest>(create);
+  static DecryptMsgRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecryptMsgRequest>(create);
   static DecryptMsgRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get ciphertext => $_getSZ(0);
   @$pb.TagNumber(1)
-  set ciphertext($core.String v) {
-    $_setString(0, v);
-  }
-
+  set ciphertext($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCiphertext() => $_has(0);
   @$pb.TagNumber(1)
@@ -6347,10 +5606,7 @@ class DecryptMsgRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get encryptionPubkey => $_getSZ(1);
   @$pb.TagNumber(2)
-  set encryptionPubkey($core.String v) {
-    $_setString(1, v);
-  }
-
+  set encryptionPubkey($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasEncryptionPubkey() => $_has(1);
   @$pb.TagNumber(2)
@@ -6368,26 +5624,24 @@ class DecryptMsgResponse extends $pb.GeneratedMessage {
     return $result;
   }
   DecryptMsgResponse._() : super();
-  factory DecryptMsgResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DecryptMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DecryptMsgResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DecryptMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecryptMsgResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecryptMsgResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'plaintext')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DecryptMsgResponse clone() => DecryptMsgResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DecryptMsgResponse copyWith(void Function(DecryptMsgResponse) updates) =>
-      super.copyWith((message) => updates(message as DecryptMsgResponse)) as DecryptMsgResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DecryptMsgResponse copyWith(void Function(DecryptMsgResponse) updates) => super.copyWith((message) => updates(message as DecryptMsgResponse)) as DecryptMsgResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6396,17 +5650,13 @@ class DecryptMsgResponse extends $pb.GeneratedMessage {
   DecryptMsgResponse createEmptyInstance() => create();
   static $pb.PbList<DecryptMsgResponse> createRepeated() => $pb.PbList<DecryptMsgResponse>();
   @$core.pragma('dart2js:noInline')
-  static DecryptMsgResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecryptMsgResponse>(create);
+  static DecryptMsgResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecryptMsgResponse>(create);
   static DecryptMsgResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get plaintext => $_getSZ(0);
   @$pb.TagNumber(1)
-  set plaintext($core.String v) {
-    $_setString(0, v);
-  }
-
+  set plaintext($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPlaintext() => $_has(0);
   @$pb.TagNumber(1)
@@ -6428,27 +5678,25 @@ class SignArbitraryMsgRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SignArbitraryMsgRequest._() : super();
-  factory SignArbitraryMsgRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SignArbitraryMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SignArbitraryMsgRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignArbitraryMsgRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'msg')
     ..aOS(2, _omitFieldNames ? '' : 'verifyingKey')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SignArbitraryMsgRequest clone() => SignArbitraryMsgRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SignArbitraryMsgRequest copyWith(void Function(SignArbitraryMsgRequest) updates) =>
-      super.copyWith((message) => updates(message as SignArbitraryMsgRequest)) as SignArbitraryMsgRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignArbitraryMsgRequest copyWith(void Function(SignArbitraryMsgRequest) updates) => super.copyWith((message) => updates(message as SignArbitraryMsgRequest)) as SignArbitraryMsgRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6457,17 +5705,13 @@ class SignArbitraryMsgRequest extends $pb.GeneratedMessage {
   SignArbitraryMsgRequest createEmptyInstance() => create();
   static $pb.PbList<SignArbitraryMsgRequest> createRepeated() => $pb.PbList<SignArbitraryMsgRequest>();
   @$core.pragma('dart2js:noInline')
-  static SignArbitraryMsgRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgRequest>(create);
+  static SignArbitraryMsgRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgRequest>(create);
   static SignArbitraryMsgRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get msg => $_getSZ(0);
   @$pb.TagNumber(1)
-  set msg($core.String v) {
-    $_setString(0, v);
-  }
-
+  set msg($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMsg() => $_has(0);
   @$pb.TagNumber(1)
@@ -6476,10 +5720,7 @@ class SignArbitraryMsgRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get verifyingKey => $_getSZ(1);
   @$pb.TagNumber(2)
-  set verifyingKey($core.String v) {
-    $_setString(1, v);
-  }
-
+  set verifyingKey($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasVerifyingKey() => $_has(1);
   @$pb.TagNumber(2)
@@ -6497,26 +5738,24 @@ class SignArbitraryMsgResponse extends $pb.GeneratedMessage {
     return $result;
   }
   SignArbitraryMsgResponse._() : super();
-  factory SignArbitraryMsgResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SignArbitraryMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SignArbitraryMsgResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignArbitraryMsgResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'signature')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SignArbitraryMsgResponse clone() => SignArbitraryMsgResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SignArbitraryMsgResponse copyWith(void Function(SignArbitraryMsgResponse) updates) =>
-      super.copyWith((message) => updates(message as SignArbitraryMsgResponse)) as SignArbitraryMsgResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignArbitraryMsgResponse copyWith(void Function(SignArbitraryMsgResponse) updates) => super.copyWith((message) => updates(message as SignArbitraryMsgResponse)) as SignArbitraryMsgResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6525,17 +5764,13 @@ class SignArbitraryMsgResponse extends $pb.GeneratedMessage {
   SignArbitraryMsgResponse createEmptyInstance() => create();
   static $pb.PbList<SignArbitraryMsgResponse> createRepeated() => $pb.PbList<SignArbitraryMsgResponse>();
   @$core.pragma('dart2js:noInline')
-  static SignArbitraryMsgResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgResponse>(create);
+  static SignArbitraryMsgResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgResponse>(create);
   static SignArbitraryMsgResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get signature => $_getSZ(0);
   @$pb.TagNumber(1)
-  set signature($core.String v) {
-    $_setString(0, v);
-  }
-
+  set signature($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSignature() => $_has(0);
   @$pb.TagNumber(1)
@@ -6557,28 +5792,25 @@ class SignArbitraryMsgAsAddrRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SignArbitraryMsgAsAddrRequest._() : super();
-  factory SignArbitraryMsgAsAddrRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SignArbitraryMsgAsAddrRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SignArbitraryMsgAsAddrRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignArbitraryMsgAsAddrRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgAsAddrRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgAsAddrRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'msg')
     ..aOS(2, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SignArbitraryMsgAsAddrRequest clone() => SignArbitraryMsgAsAddrRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SignArbitraryMsgAsAddrRequest copyWith(void Function(SignArbitraryMsgAsAddrRequest) updates) =>
-      super.copyWith((message) => updates(message as SignArbitraryMsgAsAddrRequest)) as SignArbitraryMsgAsAddrRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignArbitraryMsgAsAddrRequest copyWith(void Function(SignArbitraryMsgAsAddrRequest) updates) => super.copyWith((message) => updates(message as SignArbitraryMsgAsAddrRequest)) as SignArbitraryMsgAsAddrRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6587,17 +5819,13 @@ class SignArbitraryMsgAsAddrRequest extends $pb.GeneratedMessage {
   SignArbitraryMsgAsAddrRequest createEmptyInstance() => create();
   static $pb.PbList<SignArbitraryMsgAsAddrRequest> createRepeated() => $pb.PbList<SignArbitraryMsgAsAddrRequest>();
   @$core.pragma('dart2js:noInline')
-  static SignArbitraryMsgAsAddrRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgAsAddrRequest>(create);
+  static SignArbitraryMsgAsAddrRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgAsAddrRequest>(create);
   static SignArbitraryMsgAsAddrRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get msg => $_getSZ(0);
   @$pb.TagNumber(1)
-  set msg($core.String v) {
-    $_setString(0, v);
-  }
-
+  set msg($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMsg() => $_has(0);
   @$pb.TagNumber(1)
@@ -6606,10 +5834,7 @@ class SignArbitraryMsgAsAddrRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get address => $_getSZ(1);
   @$pb.TagNumber(2)
-  set address($core.String v) {
-    $_setString(1, v);
-  }
-
+  set address($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAddress() => $_has(1);
   @$pb.TagNumber(2)
@@ -6631,28 +5856,25 @@ class SignArbitraryMsgAsAddrResponse extends $pb.GeneratedMessage {
     return $result;
   }
   SignArbitraryMsgAsAddrResponse._() : super();
-  factory SignArbitraryMsgAsAddrResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SignArbitraryMsgAsAddrResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SignArbitraryMsgAsAddrResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignArbitraryMsgAsAddrResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgAsAddrResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignArbitraryMsgAsAddrResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'verifyingKey')
     ..aOS(2, _omitFieldNames ? '' : 'signature')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SignArbitraryMsgAsAddrResponse clone() => SignArbitraryMsgAsAddrResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SignArbitraryMsgAsAddrResponse copyWith(void Function(SignArbitraryMsgAsAddrResponse) updates) =>
-      super.copyWith((message) => updates(message as SignArbitraryMsgAsAddrResponse)) as SignArbitraryMsgAsAddrResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignArbitraryMsgAsAddrResponse copyWith(void Function(SignArbitraryMsgAsAddrResponse) updates) => super.copyWith((message) => updates(message as SignArbitraryMsgAsAddrResponse)) as SignArbitraryMsgAsAddrResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6661,17 +5883,13 @@ class SignArbitraryMsgAsAddrResponse extends $pb.GeneratedMessage {
   SignArbitraryMsgAsAddrResponse createEmptyInstance() => create();
   static $pb.PbList<SignArbitraryMsgAsAddrResponse> createRepeated() => $pb.PbList<SignArbitraryMsgAsAddrResponse>();
   @$core.pragma('dart2js:noInline')
-  static SignArbitraryMsgAsAddrResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgAsAddrResponse>(create);
+  static SignArbitraryMsgAsAddrResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignArbitraryMsgAsAddrResponse>(create);
   static SignArbitraryMsgAsAddrResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get verifyingKey => $_getSZ(0);
   @$pb.TagNumber(1)
-  set verifyingKey($core.String v) {
-    $_setString(0, v);
-  }
-
+  set verifyingKey($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasVerifyingKey() => $_has(0);
   @$pb.TagNumber(1)
@@ -6680,10 +5898,7 @@ class SignArbitraryMsgAsAddrResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get signature => $_getSZ(1);
   @$pb.TagNumber(2)
-  set signature($core.String v) {
-    $_setString(1, v);
-  }
-
+  set signature($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasSignature() => $_has(1);
   @$pb.TagNumber(2)
@@ -6713,29 +5928,27 @@ class VerifySignatureRequest extends $pb.GeneratedMessage {
     return $result;
   }
   VerifySignatureRequest._() : super();
-  factory VerifySignatureRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VerifySignatureRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VerifySignatureRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VerifySignatureRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VerifySignatureRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VerifySignatureRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'msg')
     ..aOS(2, _omitFieldNames ? '' : 'signature')
     ..aOS(3, _omitFieldNames ? '' : 'verifyingKey')
     ..aOS(4, _omitFieldNames ? '' : 'dst')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VerifySignatureRequest clone() => VerifySignatureRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VerifySignatureRequest copyWith(void Function(VerifySignatureRequest) updates) =>
-      super.copyWith((message) => updates(message as VerifySignatureRequest)) as VerifySignatureRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VerifySignatureRequest copyWith(void Function(VerifySignatureRequest) updates) => super.copyWith((message) => updates(message as VerifySignatureRequest)) as VerifySignatureRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6744,17 +5957,13 @@ class VerifySignatureRequest extends $pb.GeneratedMessage {
   VerifySignatureRequest createEmptyInstance() => create();
   static $pb.PbList<VerifySignatureRequest> createRepeated() => $pb.PbList<VerifySignatureRequest>();
   @$core.pragma('dart2js:noInline')
-  static VerifySignatureRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VerifySignatureRequest>(create);
+  static VerifySignatureRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VerifySignatureRequest>(create);
   static VerifySignatureRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get msg => $_getSZ(0);
   @$pb.TagNumber(1)
-  set msg($core.String v) {
-    $_setString(0, v);
-  }
-
+  set msg($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMsg() => $_has(0);
   @$pb.TagNumber(1)
@@ -6763,10 +5972,7 @@ class VerifySignatureRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get signature => $_getSZ(1);
   @$pb.TagNumber(2)
-  set signature($core.String v) {
-    $_setString(1, v);
-  }
-
+  set signature($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasSignature() => $_has(1);
   @$pb.TagNumber(2)
@@ -6775,10 +5981,7 @@ class VerifySignatureRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get verifyingKey => $_getSZ(2);
   @$pb.TagNumber(3)
-  set verifyingKey($core.String v) {
-    $_setString(2, v);
-  }
-
+  set verifyingKey($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasVerifyingKey() => $_has(2);
   @$pb.TagNumber(3)
@@ -6787,10 +5990,7 @@ class VerifySignatureRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get dst => $_getSZ(3);
   @$pb.TagNumber(4)
-  set dst($core.String v) {
-    $_setString(3, v);
-  }
-
+  set dst($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasDst() => $_has(3);
   @$pb.TagNumber(4)
@@ -6808,26 +6008,24 @@ class VerifySignatureResponse extends $pb.GeneratedMessage {
     return $result;
   }
   VerifySignatureResponse._() : super();
-  factory VerifySignatureResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VerifySignatureResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VerifySignatureResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VerifySignatureResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VerifySignatureResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'VerifySignatureResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'truthcoin.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'valid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VerifySignatureResponse clone() => VerifySignatureResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  VerifySignatureResponse copyWith(void Function(VerifySignatureResponse) updates) =>
-      super.copyWith((message) => updates(message as VerifySignatureResponse)) as VerifySignatureResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VerifySignatureResponse copyWith(void Function(VerifySignatureResponse) updates) => super.copyWith((message) => updates(message as VerifySignatureResponse)) as VerifySignatureResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -6836,17 +6034,13 @@ class VerifySignatureResponse extends $pb.GeneratedMessage {
   VerifySignatureResponse createEmptyInstance() => create();
   static $pb.PbList<VerifySignatureResponse> createRepeated() => $pb.PbList<VerifySignatureResponse>();
   @$core.pragma('dart2js:noInline')
-  static VerifySignatureResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VerifySignatureResponse>(create);
+  static VerifySignatureResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VerifySignatureResponse>(create);
   static VerifySignatureResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get valid => $_getBF(0);
   @$pb.TagNumber(1)
-  set valid($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set valid($core.bool v) { $_setBool(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasValid() => $_has(0);
   @$pb.TagNumber(1)
@@ -6858,158 +6052,178 @@ class TruthcoinServiceApi {
   TruthcoinServiceApi(this._client);
 
   $async.Future<GetBalanceResponse> getBalance($pb.ClientContext? ctx, GetBalanceRequest request) =>
-      _client.invoke<GetBalanceResponse>(ctx, 'TruthcoinService', 'GetBalance', request, GetBalanceResponse());
+    _client.invoke<GetBalanceResponse>(ctx, 'TruthcoinService', 'GetBalance', request, GetBalanceResponse())
+  ;
   $async.Future<GetBlockCountResponse> getBlockCount($pb.ClientContext? ctx, GetBlockCountRequest request) =>
-      _client.invoke<GetBlockCountResponse>(ctx, 'TruthcoinService', 'GetBlockCount', request, GetBlockCountResponse());
+    _client.invoke<GetBlockCountResponse>(ctx, 'TruthcoinService', 'GetBlockCount', request, GetBlockCountResponse())
+  ;
   $async.Future<StopResponse> stop($pb.ClientContext? ctx, StopRequest request) =>
-      _client.invoke<StopResponse>(ctx, 'TruthcoinService', 'Stop', request, StopResponse());
+    _client.invoke<StopResponse>(ctx, 'TruthcoinService', 'Stop', request, StopResponse())
+  ;
   $async.Future<GetNewAddressResponse> getNewAddress($pb.ClientContext? ctx, GetNewAddressRequest request) =>
-      _client.invoke<GetNewAddressResponse>(ctx, 'TruthcoinService', 'GetNewAddress', request, GetNewAddressResponse());
+    _client.invoke<GetNewAddressResponse>(ctx, 'TruthcoinService', 'GetNewAddress', request, GetNewAddressResponse())
+  ;
   $async.Future<WithdrawResponse> withdraw($pb.ClientContext? ctx, WithdrawRequest request) =>
-      _client.invoke<WithdrawResponse>(ctx, 'TruthcoinService', 'Withdraw', request, WithdrawResponse());
+    _client.invoke<WithdrawResponse>(ctx, 'TruthcoinService', 'Withdraw', request, WithdrawResponse())
+  ;
   $async.Future<TransferResponse> transfer($pb.ClientContext? ctx, TransferRequest request) =>
-      _client.invoke<TransferResponse>(ctx, 'TruthcoinService', 'Transfer', request, TransferResponse());
-  $async.Future<GetSidechainWealthResponse> getSidechainWealth(
-          $pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
-      _client.invoke<GetSidechainWealthResponse>(
-          ctx, 'TruthcoinService', 'GetSidechainWealth', request, GetSidechainWealthResponse());
+    _client.invoke<TransferResponse>(ctx, 'TruthcoinService', 'Transfer', request, TransferResponse())
+  ;
+  $async.Future<GetSidechainWealthResponse> getSidechainWealth($pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
+    _client.invoke<GetSidechainWealthResponse>(ctx, 'TruthcoinService', 'GetSidechainWealth', request, GetSidechainWealthResponse())
+  ;
   $async.Future<CreateDepositResponse> createDeposit($pb.ClientContext? ctx, CreateDepositRequest request) =>
-      _client.invoke<CreateDepositResponse>(ctx, 'TruthcoinService', 'CreateDeposit', request, CreateDepositResponse());
-  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-          $pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
-      _client.invoke<GetPendingWithdrawalBundleResponse>(
-          ctx, 'TruthcoinService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse());
+    _client.invoke<CreateDepositResponse>(ctx, 'TruthcoinService', 'CreateDeposit', request, CreateDepositResponse())
+  ;
+  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
+    _client.invoke<GetPendingWithdrawalBundleResponse>(ctx, 'TruthcoinService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse())
+  ;
   $async.Future<ConnectPeerResponse> connectPeer($pb.ClientContext? ctx, ConnectPeerRequest request) =>
-      _client.invoke<ConnectPeerResponse>(ctx, 'TruthcoinService', 'ConnectPeer', request, ConnectPeerResponse());
+    _client.invoke<ConnectPeerResponse>(ctx, 'TruthcoinService', 'ConnectPeer', request, ConnectPeerResponse())
+  ;
   $async.Future<ListPeersResponse> listPeers($pb.ClientContext? ctx, ListPeersRequest request) =>
-      _client.invoke<ListPeersResponse>(ctx, 'TruthcoinService', 'ListPeers', request, ListPeersResponse());
+    _client.invoke<ListPeersResponse>(ctx, 'TruthcoinService', 'ListPeers', request, ListPeersResponse())
+  ;
   $async.Future<MineResponse> mine($pb.ClientContext? ctx, MineRequest request) =>
-      _client.invoke<MineResponse>(ctx, 'TruthcoinService', 'Mine', request, MineResponse());
+    _client.invoke<MineResponse>(ctx, 'TruthcoinService', 'Mine', request, MineResponse())
+  ;
   $async.Future<GetBlockResponse> getBlock($pb.ClientContext? ctx, GetBlockRequest request) =>
-      _client.invoke<GetBlockResponse>(ctx, 'TruthcoinService', 'GetBlock', request, GetBlockResponse());
-  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-          $pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
-      _client.invoke<GetBestMainchainBlockHashResponse>(
-          ctx, 'TruthcoinService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse());
-  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-          $pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
-      _client.invoke<GetBestSidechainBlockHashResponse>(
-          ctx, 'TruthcoinService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse());
+    _client.invoke<GetBlockResponse>(ctx, 'TruthcoinService', 'GetBlock', request, GetBlockResponse())
+  ;
+  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
+    _client.invoke<GetBestMainchainBlockHashResponse>(ctx, 'TruthcoinService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse())
+  ;
+  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
+    _client.invoke<GetBestSidechainBlockHashResponse>(ctx, 'TruthcoinService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse())
+  ;
   $async.Future<GetBmmInclusionsResponse> getBmmInclusions($pb.ClientContext? ctx, GetBmmInclusionsRequest request) =>
-      _client.invoke<GetBmmInclusionsResponse>(
-          ctx, 'TruthcoinService', 'GetBmmInclusions', request, GetBmmInclusionsResponse());
-  $async.Future<GetWalletUtxosResponse> getWalletUtxos($pb.ClientContext? ctx, GetWalletUtxosRequest request) => _client
-      .invoke<GetWalletUtxosResponse>(ctx, 'TruthcoinService', 'GetWalletUtxos', request, GetWalletUtxosResponse());
+    _client.invoke<GetBmmInclusionsResponse>(ctx, 'TruthcoinService', 'GetBmmInclusions', request, GetBmmInclusionsResponse())
+  ;
+  $async.Future<GetWalletUtxosResponse> getWalletUtxos($pb.ClientContext? ctx, GetWalletUtxosRequest request) =>
+    _client.invoke<GetWalletUtxosResponse>(ctx, 'TruthcoinService', 'GetWalletUtxos', request, GetWalletUtxosResponse())
+  ;
   $async.Future<ListUtxosResponse> listUtxos($pb.ClientContext? ctx, ListUtxosRequest request) =>
-      _client.invoke<ListUtxosResponse>(ctx, 'TruthcoinService', 'ListUtxos', request, ListUtxosResponse());
-  $async.Future<RemoveFromMempoolResponse> removeFromMempool(
-          $pb.ClientContext? ctx, RemoveFromMempoolRequest request) =>
-      _client.invoke<RemoveFromMempoolResponse>(
-          ctx, 'TruthcoinService', 'RemoveFromMempool', request, RemoveFromMempoolResponse());
-  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-          $pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
-      _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'TruthcoinService',
-          'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse());
+    _client.invoke<ListUtxosResponse>(ctx, 'TruthcoinService', 'ListUtxos', request, ListUtxosResponse())
+  ;
+  $async.Future<RemoveFromMempoolResponse> removeFromMempool($pb.ClientContext? ctx, RemoveFromMempoolRequest request) =>
+    _client.invoke<RemoveFromMempoolResponse>(ctx, 'TruthcoinService', 'RemoveFromMempool', request, RemoveFromMempoolResponse())
+  ;
+  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
+    _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'TruthcoinService', 'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse())
+  ;
   $async.Future<GenerateMnemonicResponse> generateMnemonic($pb.ClientContext? ctx, GenerateMnemonicRequest request) =>
-      _client.invoke<GenerateMnemonicResponse>(
-          ctx, 'TruthcoinService', 'GenerateMnemonic', request, GenerateMnemonicResponse());
-  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-          $pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
-      _client.invoke<SetSeedFromMnemonicResponse>(
-          ctx, 'TruthcoinService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse());
+    _client.invoke<GenerateMnemonicResponse>(ctx, 'TruthcoinService', 'GenerateMnemonic', request, GenerateMnemonicResponse())
+  ;
+  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
+    _client.invoke<SetSeedFromMnemonicResponse>(ctx, 'TruthcoinService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse())
+  ;
   $async.Future<CallRawResponse> callRaw($pb.ClientContext? ctx, CallRawRequest request) =>
-      _client.invoke<CallRawResponse>(ctx, 'TruthcoinService', 'CallRaw', request, CallRawResponse());
+    _client.invoke<CallRawResponse>(ctx, 'TruthcoinService', 'CallRaw', request, CallRawResponse())
+  ;
   $async.Future<RefreshWalletResponse> refreshWallet($pb.ClientContext? ctx, RefreshWalletRequest request) =>
-      _client.invoke<RefreshWalletResponse>(ctx, 'TruthcoinService', 'RefreshWallet', request, RefreshWalletResponse());
-  $async.Future<GetTransactionResponse> getTransaction($pb.ClientContext? ctx, GetTransactionRequest request) => _client
-      .invoke<GetTransactionResponse>(ctx, 'TruthcoinService', 'GetTransaction', request, GetTransactionResponse());
-  $async.Future<GetTransactionInfoResponse> getTransactionInfo(
-          $pb.ClientContext? ctx, GetTransactionInfoRequest request) =>
-      _client.invoke<GetTransactionInfoResponse>(
-          ctx, 'TruthcoinService', 'GetTransactionInfo', request, GetTransactionInfoResponse());
-  $async.Future<GetWalletAddressesResponse> getWalletAddresses(
-          $pb.ClientContext? ctx, GetWalletAddressesRequest request) =>
-      _client.invoke<GetWalletAddressesResponse>(
-          ctx, 'TruthcoinService', 'GetWalletAddresses', request, GetWalletAddressesResponse());
+    _client.invoke<RefreshWalletResponse>(ctx, 'TruthcoinService', 'RefreshWallet', request, RefreshWalletResponse())
+  ;
+  $async.Future<GetTransactionResponse> getTransaction($pb.ClientContext? ctx, GetTransactionRequest request) =>
+    _client.invoke<GetTransactionResponse>(ctx, 'TruthcoinService', 'GetTransaction', request, GetTransactionResponse())
+  ;
+  $async.Future<GetTransactionInfoResponse> getTransactionInfo($pb.ClientContext? ctx, GetTransactionInfoRequest request) =>
+    _client.invoke<GetTransactionInfoResponse>(ctx, 'TruthcoinService', 'GetTransactionInfo', request, GetTransactionInfoResponse())
+  ;
+  $async.Future<GetWalletAddressesResponse> getWalletAddresses($pb.ClientContext? ctx, GetWalletAddressesRequest request) =>
+    _client.invoke<GetWalletAddressesResponse>(ctx, 'TruthcoinService', 'GetWalletAddresses', request, GetWalletAddressesResponse())
+  ;
   $async.Future<MyUtxosResponse> myUtxos($pb.ClientContext? ctx, MyUtxosRequest request) =>
-      _client.invoke<MyUtxosResponse>(ctx, 'TruthcoinService', 'MyUtxos', request, MyUtxosResponse());
-  $async.Future<MyUnconfirmedUtxosResponse> myUnconfirmedUtxos(
-          $pb.ClientContext? ctx, MyUnconfirmedUtxosRequest request) =>
-      _client.invoke<MyUnconfirmedUtxosResponse>(
-          ctx, 'TruthcoinService', 'MyUnconfirmedUtxos', request, MyUnconfirmedUtxosResponse());
-  $async.Future<CalculateInitialLiquidityResponse> calculateInitialLiquidity(
-          $pb.ClientContext? ctx, CalculateInitialLiquidityRequest request) =>
-      _client.invoke<CalculateInitialLiquidityResponse>(
-          ctx, 'TruthcoinService', 'CalculateInitialLiquidity', request, CalculateInitialLiquidityResponse());
+    _client.invoke<MyUtxosResponse>(ctx, 'TruthcoinService', 'MyUtxos', request, MyUtxosResponse())
+  ;
+  $async.Future<MyUnconfirmedUtxosResponse> myUnconfirmedUtxos($pb.ClientContext? ctx, MyUnconfirmedUtxosRequest request) =>
+    _client.invoke<MyUnconfirmedUtxosResponse>(ctx, 'TruthcoinService', 'MyUnconfirmedUtxos', request, MyUnconfirmedUtxosResponse())
+  ;
+  $async.Future<CalculateInitialLiquidityResponse> calculateInitialLiquidity($pb.ClientContext? ctx, CalculateInitialLiquidityRequest request) =>
+    _client.invoke<CalculateInitialLiquidityResponse>(ctx, 'TruthcoinService', 'CalculateInitialLiquidity', request, CalculateInitialLiquidityResponse())
+  ;
   $async.Future<MarketCreateResponse> marketCreate($pb.ClientContext? ctx, MarketCreateRequest request) =>
-      _client.invoke<MarketCreateResponse>(ctx, 'TruthcoinService', 'MarketCreate', request, MarketCreateResponse());
+    _client.invoke<MarketCreateResponse>(ctx, 'TruthcoinService', 'MarketCreate', request, MarketCreateResponse())
+  ;
   $async.Future<MarketListResponse> marketList($pb.ClientContext? ctx, MarketListRequest request) =>
-      _client.invoke<MarketListResponse>(ctx, 'TruthcoinService', 'MarketList', request, MarketListResponse());
+    _client.invoke<MarketListResponse>(ctx, 'TruthcoinService', 'MarketList', request, MarketListResponse())
+  ;
   $async.Future<MarketGetResponse> marketGet($pb.ClientContext? ctx, MarketGetRequest request) =>
-      _client.invoke<MarketGetResponse>(ctx, 'TruthcoinService', 'MarketGet', request, MarketGetResponse());
+    _client.invoke<MarketGetResponse>(ctx, 'TruthcoinService', 'MarketGet', request, MarketGetResponse())
+  ;
   $async.Future<MarketBuyResponse> marketBuy($pb.ClientContext? ctx, MarketBuyRequest request) =>
-      _client.invoke<MarketBuyResponse>(ctx, 'TruthcoinService', 'MarketBuy', request, MarketBuyResponse());
+    _client.invoke<MarketBuyResponse>(ctx, 'TruthcoinService', 'MarketBuy', request, MarketBuyResponse())
+  ;
   $async.Future<MarketSellResponse> marketSell($pb.ClientContext? ctx, MarketSellRequest request) =>
-      _client.invoke<MarketSellResponse>(ctx, 'TruthcoinService', 'MarketSell', request, MarketSellResponse());
+    _client.invoke<MarketSellResponse>(ctx, 'TruthcoinService', 'MarketSell', request, MarketSellResponse())
+  ;
   $async.Future<MarketPositionsResponse> marketPositions($pb.ClientContext? ctx, MarketPositionsRequest request) =>
-      _client.invoke<MarketPositionsResponse>(
-          ctx, 'TruthcoinService', 'MarketPositions', request, MarketPositionsResponse());
+    _client.invoke<MarketPositionsResponse>(ctx, 'TruthcoinService', 'MarketPositions', request, MarketPositionsResponse())
+  ;
   $async.Future<SlotStatusResponse> slotStatus($pb.ClientContext? ctx, SlotStatusRequest request) =>
-      _client.invoke<SlotStatusResponse>(ctx, 'TruthcoinService', 'SlotStatus', request, SlotStatusResponse());
+    _client.invoke<SlotStatusResponse>(ctx, 'TruthcoinService', 'SlotStatus', request, SlotStatusResponse())
+  ;
   $async.Future<SlotListResponse> slotList($pb.ClientContext? ctx, SlotListRequest request) =>
-      _client.invoke<SlotListResponse>(ctx, 'TruthcoinService', 'SlotList', request, SlotListResponse());
+    _client.invoke<SlotListResponse>(ctx, 'TruthcoinService', 'SlotList', request, SlotListResponse())
+  ;
   $async.Future<SlotGetResponse> slotGet($pb.ClientContext? ctx, SlotGetRequest request) =>
-      _client.invoke<SlotGetResponse>(ctx, 'TruthcoinService', 'SlotGet', request, SlotGetResponse());
+    _client.invoke<SlotGetResponse>(ctx, 'TruthcoinService', 'SlotGet', request, SlotGetResponse())
+  ;
   $async.Future<SlotClaimResponse> slotClaim($pb.ClientContext? ctx, SlotClaimRequest request) =>
-      _client.invoke<SlotClaimResponse>(ctx, 'TruthcoinService', 'SlotClaim', request, SlotClaimResponse());
-  $async.Future<SlotClaimCategoryResponse> slotClaimCategory(
-          $pb.ClientContext? ctx, SlotClaimCategoryRequest request) =>
-      _client.invoke<SlotClaimCategoryResponse>(
-          ctx, 'TruthcoinService', 'SlotClaimCategory', request, SlotClaimCategoryResponse());
+    _client.invoke<SlotClaimResponse>(ctx, 'TruthcoinService', 'SlotClaim', request, SlotClaimResponse())
+  ;
+  $async.Future<SlotClaimCategoryResponse> slotClaimCategory($pb.ClientContext? ctx, SlotClaimCategoryRequest request) =>
+    _client.invoke<SlotClaimCategoryResponse>(ctx, 'TruthcoinService', 'SlotClaimCategory', request, SlotClaimCategoryResponse())
+  ;
   $async.Future<VoteRegisterResponse> voteRegister($pb.ClientContext? ctx, VoteRegisterRequest request) =>
-      _client.invoke<VoteRegisterResponse>(ctx, 'TruthcoinService', 'VoteRegister', request, VoteRegisterResponse());
+    _client.invoke<VoteRegisterResponse>(ctx, 'TruthcoinService', 'VoteRegister', request, VoteRegisterResponse())
+  ;
   $async.Future<VoteVoterResponse> voteVoter($pb.ClientContext? ctx, VoteVoterRequest request) =>
-      _client.invoke<VoteVoterResponse>(ctx, 'TruthcoinService', 'VoteVoter', request, VoteVoterResponse());
+    _client.invoke<VoteVoterResponse>(ctx, 'TruthcoinService', 'VoteVoter', request, VoteVoterResponse())
+  ;
   $async.Future<VoteVotersResponse> voteVoters($pb.ClientContext? ctx, VoteVotersRequest request) =>
-      _client.invoke<VoteVotersResponse>(ctx, 'TruthcoinService', 'VoteVoters', request, VoteVotersResponse());
+    _client.invoke<VoteVotersResponse>(ctx, 'TruthcoinService', 'VoteVoters', request, VoteVotersResponse())
+  ;
   $async.Future<VoteSubmitResponse> voteSubmit($pb.ClientContext? ctx, VoteSubmitRequest request) =>
-      _client.invoke<VoteSubmitResponse>(ctx, 'TruthcoinService', 'VoteSubmit', request, VoteSubmitResponse());
+    _client.invoke<VoteSubmitResponse>(ctx, 'TruthcoinService', 'VoteSubmit', request, VoteSubmitResponse())
+  ;
   $async.Future<VoteListResponse> voteList($pb.ClientContext? ctx, VoteListRequest request) =>
-      _client.invoke<VoteListResponse>(ctx, 'TruthcoinService', 'VoteList', request, VoteListResponse());
+    _client.invoke<VoteListResponse>(ctx, 'TruthcoinService', 'VoteList', request, VoteListResponse())
+  ;
   $async.Future<VotePeriodResponse> votePeriod($pb.ClientContext? ctx, VotePeriodRequest request) =>
-      _client.invoke<VotePeriodResponse>(ctx, 'TruthcoinService', 'VotePeriod', request, VotePeriodResponse());
+    _client.invoke<VotePeriodResponse>(ctx, 'TruthcoinService', 'VotePeriod', request, VotePeriodResponse())
+  ;
   $async.Future<VotecoinTransferResponse> votecoinTransfer($pb.ClientContext? ctx, VotecoinTransferRequest request) =>
-      _client.invoke<VotecoinTransferResponse>(
-          ctx, 'TruthcoinService', 'VotecoinTransfer', request, VotecoinTransferResponse());
+    _client.invoke<VotecoinTransferResponse>(ctx, 'TruthcoinService', 'VotecoinTransfer', request, VotecoinTransferResponse())
+  ;
   $async.Future<VotecoinBalanceResponse> votecoinBalance($pb.ClientContext? ctx, VotecoinBalanceRequest request) =>
-      _client.invoke<VotecoinBalanceResponse>(
-          ctx, 'TruthcoinService', 'VotecoinBalance', request, VotecoinBalanceResponse());
+    _client.invoke<VotecoinBalanceResponse>(ctx, 'TruthcoinService', 'VotecoinBalance', request, VotecoinBalanceResponse())
+  ;
   $async.Future<TransferVotecoinResponse> transferVotecoin($pb.ClientContext? ctx, TransferVotecoinRequest request) =>
-      _client.invoke<TransferVotecoinResponse>(
-          ctx, 'TruthcoinService', 'TransferVotecoin', request, TransferVotecoinResponse());
-  $async.Future<GetNewEncryptionKeyResponse> getNewEncryptionKey(
-          $pb.ClientContext? ctx, GetNewEncryptionKeyRequest request) =>
-      _client.invoke<GetNewEncryptionKeyResponse>(
-          ctx, 'TruthcoinService', 'GetNewEncryptionKey', request, GetNewEncryptionKeyResponse());
-  $async.Future<GetNewVerifyingKeyResponse> getNewVerifyingKey(
-          $pb.ClientContext? ctx, GetNewVerifyingKeyRequest request) =>
-      _client.invoke<GetNewVerifyingKeyResponse>(
-          ctx, 'TruthcoinService', 'GetNewVerifyingKey', request, GetNewVerifyingKeyResponse());
+    _client.invoke<TransferVotecoinResponse>(ctx, 'TruthcoinService', 'TransferVotecoin', request, TransferVotecoinResponse())
+  ;
+  $async.Future<GetNewEncryptionKeyResponse> getNewEncryptionKey($pb.ClientContext? ctx, GetNewEncryptionKeyRequest request) =>
+    _client.invoke<GetNewEncryptionKeyResponse>(ctx, 'TruthcoinService', 'GetNewEncryptionKey', request, GetNewEncryptionKeyResponse())
+  ;
+  $async.Future<GetNewVerifyingKeyResponse> getNewVerifyingKey($pb.ClientContext? ctx, GetNewVerifyingKeyRequest request) =>
+    _client.invoke<GetNewVerifyingKeyResponse>(ctx, 'TruthcoinService', 'GetNewVerifyingKey', request, GetNewVerifyingKeyResponse())
+  ;
   $async.Future<EncryptMsgResponse> encryptMsg($pb.ClientContext? ctx, EncryptMsgRequest request) =>
-      _client.invoke<EncryptMsgResponse>(ctx, 'TruthcoinService', 'EncryptMsg', request, EncryptMsgResponse());
+    _client.invoke<EncryptMsgResponse>(ctx, 'TruthcoinService', 'EncryptMsg', request, EncryptMsgResponse())
+  ;
   $async.Future<DecryptMsgResponse> decryptMsg($pb.ClientContext? ctx, DecryptMsgRequest request) =>
-      _client.invoke<DecryptMsgResponse>(ctx, 'TruthcoinService', 'DecryptMsg', request, DecryptMsgResponse());
+    _client.invoke<DecryptMsgResponse>(ctx, 'TruthcoinService', 'DecryptMsg', request, DecryptMsgResponse())
+  ;
   $async.Future<SignArbitraryMsgResponse> signArbitraryMsg($pb.ClientContext? ctx, SignArbitraryMsgRequest request) =>
-      _client.invoke<SignArbitraryMsgResponse>(
-          ctx, 'TruthcoinService', 'SignArbitraryMsg', request, SignArbitraryMsgResponse());
-  $async.Future<SignArbitraryMsgAsAddrResponse> signArbitraryMsgAsAddr(
-          $pb.ClientContext? ctx, SignArbitraryMsgAsAddrRequest request) =>
-      _client.invoke<SignArbitraryMsgAsAddrResponse>(
-          ctx, 'TruthcoinService', 'SignArbitraryMsgAsAddr', request, SignArbitraryMsgAsAddrResponse());
+    _client.invoke<SignArbitraryMsgResponse>(ctx, 'TruthcoinService', 'SignArbitraryMsg', request, SignArbitraryMsgResponse())
+  ;
+  $async.Future<SignArbitraryMsgAsAddrResponse> signArbitraryMsgAsAddr($pb.ClientContext? ctx, SignArbitraryMsgAsAddrRequest request) =>
+    _client.invoke<SignArbitraryMsgAsAddrResponse>(ctx, 'TruthcoinService', 'SignArbitraryMsgAsAddr', request, SignArbitraryMsgAsAddrResponse())
+  ;
   $async.Future<VerifySignatureResponse> verifySignature($pb.ClientContext? ctx, VerifySignatureRequest request) =>
-      _client.invoke<VerifySignatureResponse>(
-          ctx, 'TruthcoinService', 'VerifySignature', request, VerifySignatureResponse());
+    _client.invoke<VerifySignatureResponse>(ctx, 'TruthcoinService', 'VerifySignature', request, VerifySignatureResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/truthcoin/v1/truthcoin.pbenum.dart
+++ b/sail_ui/lib/gen/truthcoin/v1/truthcoin.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/truthcoin/v1/truthcoin.pbjson.dart
+++ b/sail_ui/lib/gen/truthcoin/v1/truthcoin.pbjson.dart
@@ -19,7 +19,8 @@ const GetBalanceRequest$json = {
 };
 
 /// Descriptor for `GetBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode('ChFHZXRCYWxhbmNlUmVxdWVzdA==');
+final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode(
+    'ChFHZXRCYWxhbmNlUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBalanceResponseDescriptor instead')
 const GetBalanceResponse$json = {
@@ -31,9 +32,9 @@ const GetBalanceResponse$json = {
 };
 
 /// Descriptor for `GetBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceResponseDescriptor =
-    $convert.base64Decode('ChJHZXRCYWxhbmNlUmVzcG9uc2USHQoKdG90YWxfc2F0cxgBIAEoA1IJdG90YWxTYXRzEiUKDm'
-        'F2YWlsYWJsZV9zYXRzGAIgASgDUg1hdmFpbGFibGVTYXRz');
+final $typed_data.Uint8List getBalanceResponseDescriptor = $convert.base64Decode(
+    'ChJHZXRCYWxhbmNlUmVzcG9uc2USHQoKdG90YWxfc2F0cxgBIAEoA1IJdG90YWxTYXRzEiUKDm'
+    'F2YWlsYWJsZV9zYXRzGAIgASgDUg1hdmFpbGFibGVTYXRz');
 
 @$core.Deprecated('Use getBlockCountRequestDescriptor instead')
 const GetBlockCountRequest$json = {
@@ -41,7 +42,8 @@ const GetBlockCountRequest$json = {
 };
 
 /// Descriptor for `GetBlockCountRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode('ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
+final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
 
 @$core.Deprecated('Use getBlockCountResponseDescriptor instead')
 const GetBlockCountResponse$json = {
@@ -52,8 +54,8 @@ const GetBlockCountResponse$json = {
 };
 
 /// Descriptor for `GetBlockCountResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountResponseDescriptor =
-    $convert.base64Decode('ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
+final $typed_data.Uint8List getBlockCountResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
 
 @$core.Deprecated('Use stopRequestDescriptor instead')
 const StopRequest$json = {
@@ -61,7 +63,8 @@ const StopRequest$json = {
 };
 
 /// Descriptor for `StopRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode('CgtTdG9wUmVxdWVzdA==');
+final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode(
+    'CgtTdG9wUmVxdWVzdA==');
 
 @$core.Deprecated('Use stopResponseDescriptor instead')
 const StopResponse$json = {
@@ -69,7 +72,8 @@ const StopResponse$json = {
 };
 
 /// Descriptor for `StopResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode('CgxTdG9wUmVzcG9uc2U=');
+final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode(
+    'CgxTdG9wUmVzcG9uc2U=');
 
 @$core.Deprecated('Use getNewAddressRequestDescriptor instead')
 const GetNewAddressRequest$json = {
@@ -77,7 +81,8 @@ const GetNewAddressRequest$json = {
 };
 
 /// Descriptor for `GetNewAddressRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode('ChRHZXROZXdBZGRyZXNzUmVxdWVzdA==');
+final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode(
+    'ChRHZXROZXdBZGRyZXNzUmVxdWVzdA==');
 
 @$core.Deprecated('Use getNewAddressResponseDescriptor instead')
 const GetNewAddressResponse$json = {
@@ -88,8 +93,8 @@ const GetNewAddressResponse$json = {
 };
 
 /// Descriptor for `GetNewAddressResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressResponseDescriptor =
-    $convert.base64Decode('ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List getNewAddressResponseDescriptor = $convert.base64Decode(
+    'ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use withdrawRequestDescriptor instead')
 const WithdrawRequest$json = {
@@ -103,10 +108,10 @@ const WithdrawRequest$json = {
 };
 
 /// Descriptor for `WithdrawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawRequestDescriptor =
-    $convert.base64Decode('Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
-        'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
+final $typed_data.Uint8List withdrawRequestDescriptor = $convert.base64Decode(
+    'Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
+    'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
 
 @$core.Deprecated('Use withdrawResponseDescriptor instead')
 const WithdrawResponse$json = {
@@ -117,8 +122,8 @@ const WithdrawResponse$json = {
 };
 
 /// Descriptor for `WithdrawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawResponseDescriptor =
-    $convert.base64Decode('ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List withdrawResponseDescriptor = $convert.base64Decode(
+    'ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use transferRequestDescriptor instead')
 const TransferRequest$json = {
@@ -131,9 +136,9 @@ const TransferRequest$json = {
 };
 
 /// Descriptor for `TransferRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferRequestDescriptor =
-    $convert.base64Decode('Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List transferRequestDescriptor = $convert.base64Decode(
+    'Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use transferResponseDescriptor instead')
 const TransferResponse$json = {
@@ -144,8 +149,8 @@ const TransferResponse$json = {
 };
 
 /// Descriptor for `TransferResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferResponseDescriptor =
-    $convert.base64Decode('ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List transferResponseDescriptor = $convert.base64Decode(
+    'ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use getSidechainWealthRequestDescriptor instead')
 const GetSidechainWealthRequest$json = {
@@ -153,8 +158,8 @@ const GetSidechainWealthRequest$json = {
 };
 
 /// Descriptor for `GetSidechainWealthRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthRequestDescriptor =
-    $convert.base64Decode('ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
+final $typed_data.Uint8List getSidechainWealthRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
 
 @$core.Deprecated('Use getSidechainWealthResponseDescriptor instead')
 const GetSidechainWealthResponse$json = {
@@ -165,8 +170,8 @@ const GetSidechainWealthResponse$json = {
 };
 
 /// Descriptor for `GetSidechainWealthResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthResponseDescriptor =
-    $convert.base64Decode('ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
+final $typed_data.Uint8List getSidechainWealthResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
 
 @$core.Deprecated('Use createDepositRequestDescriptor instead')
 const CreateDepositRequest$json = {
@@ -179,9 +184,9 @@ const CreateDepositRequest$json = {
 };
 
 /// Descriptor for `CreateDepositRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositRequestDescriptor =
-    $convert.base64Decode('ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
-        'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List createDepositRequestDescriptor = $convert.base64Decode(
+    'ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
+    'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use createDepositResponseDescriptor instead')
 const CreateDepositResponse$json = {
@@ -192,8 +197,8 @@ const CreateDepositResponse$json = {
 };
 
 /// Descriptor for `CreateDepositResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositResponseDescriptor =
-    $convert.base64Decode('ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List createDepositResponseDescriptor = $convert.base64Decode(
+    'ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleRequestDescriptor instead')
 const GetPendingWithdrawalBundleRequest$json = {
@@ -201,8 +206,8 @@ const GetPendingWithdrawalBundleRequest$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor =
-    $convert.base64Decode('CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
+final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor = $convert.base64Decode(
+    'CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleResponseDescriptor instead')
 const GetPendingWithdrawalBundleResponse$json = {
@@ -213,9 +218,9 @@ const GetPendingWithdrawalBundleResponse$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor =
-    $convert.base64Decode('CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
-        'gJUgpidW5kbGVKc29u');
+final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor = $convert.base64Decode(
+    'CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
+    'gJUgpidW5kbGVKc29u');
 
 @$core.Deprecated('Use connectPeerRequestDescriptor instead')
 const ConnectPeerRequest$json = {
@@ -226,8 +231,8 @@ const ConnectPeerRequest$json = {
 };
 
 /// Descriptor for `ConnectPeerRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerRequestDescriptor =
-    $convert.base64Decode('ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List connectPeerRequestDescriptor = $convert.base64Decode(
+    'ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use connectPeerResponseDescriptor instead')
 const ConnectPeerResponse$json = {
@@ -235,7 +240,8 @@ const ConnectPeerResponse$json = {
 };
 
 /// Descriptor for `ConnectPeerResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode('ChNDb25uZWN0UGVlclJlc3BvbnNl');
+final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode(
+    'ChNDb25uZWN0UGVlclJlc3BvbnNl');
 
 @$core.Deprecated('Use listPeersRequestDescriptor instead')
 const ListPeersRequest$json = {
@@ -243,7 +249,8 @@ const ListPeersRequest$json = {
 };
 
 /// Descriptor for `ListPeersRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode('ChBMaXN0UGVlcnNSZXF1ZXN0');
+final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0UGVlcnNSZXF1ZXN0');
 
 @$core.Deprecated('Use listPeersResponseDescriptor instead')
 const ListPeersResponse$json = {
@@ -254,8 +261,8 @@ const ListPeersResponse$json = {
 };
 
 /// Descriptor for `ListPeersResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
+final $typed_data.Uint8List listPeersResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
 
 @$core.Deprecated('Use mineRequestDescriptor instead')
 const MineRequest$json = {
@@ -266,8 +273,8 @@ const MineRequest$json = {
 };
 
 /// Descriptor for `MineRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineRequestDescriptor =
-    $convert.base64Decode('CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List mineRequestDescriptor = $convert.base64Decode(
+    'CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use mineResponseDescriptor instead')
 const MineResponse$json = {
@@ -278,8 +285,8 @@ const MineResponse$json = {
 };
 
 /// Descriptor for `MineResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineResponseDescriptor =
-    $convert.base64Decode('CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
+final $typed_data.Uint8List mineResponseDescriptor = $convert.base64Decode(
+    'CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
 
 @$core.Deprecated('Use getBlockRequestDescriptor instead')
 const GetBlockRequest$json = {
@@ -290,8 +297,8 @@ const GetBlockRequest$json = {
 };
 
 /// Descriptor for `GetBlockRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockRequestDescriptor =
-    $convert.base64Decode('Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
+final $typed_data.Uint8List getBlockRequestDescriptor = $convert.base64Decode(
+    'Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
 
 @$core.Deprecated('Use getBlockResponseDescriptor instead')
 const GetBlockResponse$json = {
@@ -302,8 +309,8 @@ const GetBlockResponse$json = {
 };
 
 /// Descriptor for `GetBlockResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockResponseDescriptor =
-    $convert.base64Decode('ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
+final $typed_data.Uint8List getBlockResponseDescriptor = $convert.base64Decode(
+    'ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashRequestDescriptor instead')
 const GetBestMainchainBlockHashRequest$json = {
@@ -311,8 +318,8 @@ const GetBestMainchainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashResponseDescriptor instead')
 const GetBestMainchainBlockHashResponse$json = {
@@ -323,9 +330,9 @@ const GetBestMainchainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashRequestDescriptor instead')
 const GetBestSidechainBlockHashRequest$json = {
@@ -333,8 +340,8 @@ const GetBestSidechainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashResponseDescriptor instead')
 const GetBestSidechainBlockHashResponse$json = {
@@ -345,9 +352,9 @@ const GetBestSidechainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBmmInclusionsRequestDescriptor instead')
 const GetBmmInclusionsRequest$json = {
@@ -358,9 +365,9 @@ const GetBmmInclusionsRequest$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsRequestDescriptor =
-    $convert.base64Decode('ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
-        'g=');
+final $typed_data.Uint8List getBmmInclusionsRequestDescriptor = $convert.base64Decode(
+    'ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
+    'g=');
 
 @$core.Deprecated('Use getBmmInclusionsResponseDescriptor instead')
 const GetBmmInclusionsResponse$json = {
@@ -371,9 +378,9 @@ const GetBmmInclusionsResponse$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsResponseDescriptor =
-    $convert.base64Decode('ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
-        '9ucw==');
+final $typed_data.Uint8List getBmmInclusionsResponseDescriptor = $convert.base64Decode(
+    'ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
+    '9ucw==');
 
 @$core.Deprecated('Use getWalletUtxosRequestDescriptor instead')
 const GetWalletUtxosRequest$json = {
@@ -381,7 +388,8 @@ const GetWalletUtxosRequest$json = {
 };
 
 /// Descriptor for `GetWalletUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode('ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
+final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode(
+    'ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getWalletUtxosResponseDescriptor instead')
 const GetWalletUtxosResponse$json = {
@@ -392,9 +400,9 @@ const GetWalletUtxosResponse$json = {
 };
 
 /// Descriptor for `GetWalletUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosResponseDescriptor =
-    $convert.base64Decode('ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
-        '==');
+final $typed_data.Uint8List getWalletUtxosResponseDescriptor = $convert.base64Decode(
+    'ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
+    '==');
 
 @$core.Deprecated('Use listUtxosRequestDescriptor instead')
 const ListUtxosRequest$json = {
@@ -402,7 +410,8 @@ const ListUtxosRequest$json = {
 };
 
 /// Descriptor for `ListUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode('ChBMaXN0VXR4b3NSZXF1ZXN0');
+final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0VXR4b3NSZXF1ZXN0');
 
 @$core.Deprecated('Use listUtxosResponseDescriptor instead')
 const ListUtxosResponse$json = {
@@ -413,8 +422,8 @@ const ListUtxosResponse$json = {
 };
 
 /// Descriptor for `ListUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
+final $typed_data.Uint8List listUtxosResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
 
 @$core.Deprecated('Use removeFromMempoolRequestDescriptor instead')
 const RemoveFromMempoolRequest$json = {
@@ -425,8 +434,8 @@ const RemoveFromMempoolRequest$json = {
 };
 
 /// Descriptor for `RemoveFromMempoolRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFromMempoolRequestDescriptor =
-    $convert.base64Decode('ChhSZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List removeFromMempoolRequestDescriptor = $convert.base64Decode(
+    'ChhSZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use removeFromMempoolResponseDescriptor instead')
 const RemoveFromMempoolResponse$json = {
@@ -434,8 +443,8 @@ const RemoveFromMempoolResponse$json = {
 };
 
 /// Descriptor for `RemoveFromMempoolResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFromMempoolResponseDescriptor =
-    $convert.base64Decode('ChlSZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNl');
+final $typed_data.Uint8List removeFromMempoolResponseDescriptor = $convert.base64Decode(
+    'ChlSZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNl');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightRequestDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightRequest$json = {
@@ -443,8 +452,8 @@ const GetLatestFailedWithdrawalBundleHeightRequest$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor =
-    $convert.base64Decode('CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor = $convert.base64Decode(
+    'CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightResponseDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightResponse$json = {
@@ -455,9 +464,9 @@ const GetLatestFailedWithdrawalBundleHeightResponse$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor =
-    $convert.base64Decode('Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
-        'h0GAEgASgDUgZoZWlnaHQ=');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor = $convert.base64Decode(
+    'Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
+    'h0GAEgASgDUgZoZWlnaHQ=');
 
 @$core.Deprecated('Use generateMnemonicRequestDescriptor instead')
 const GenerateMnemonicRequest$json = {
@@ -465,8 +474,8 @@ const GenerateMnemonicRequest$json = {
 };
 
 /// Descriptor for `GenerateMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicRequestDescriptor =
-    $convert.base64Decode('ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
+final $typed_data.Uint8List generateMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
 
 @$core.Deprecated('Use generateMnemonicResponseDescriptor instead')
 const GenerateMnemonicResponse$json = {
@@ -477,8 +486,8 @@ const GenerateMnemonicResponse$json = {
 };
 
 /// Descriptor for `GenerateMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicResponseDescriptor =
-    $convert.base64Decode('ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
+final $typed_data.Uint8List generateMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
 
 @$core.Deprecated('Use setSeedFromMnemonicRequestDescriptor instead')
 const SetSeedFromMnemonicRequest$json = {
@@ -489,9 +498,9 @@ const SetSeedFromMnemonicRequest$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor =
-    $convert.base64Decode('ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
-        'M=');
+final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
+    'M=');
 
 @$core.Deprecated('Use setSeedFromMnemonicResponseDescriptor instead')
 const SetSeedFromMnemonicResponse$json = {
@@ -499,8 +508,8 @@ const SetSeedFromMnemonicResponse$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor =
-    $convert.base64Decode('ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
+final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
 
 @$core.Deprecated('Use callRawRequestDescriptor instead')
 const CallRawRequest$json = {
@@ -512,9 +521,9 @@ const CallRawRequest$json = {
 };
 
 /// Descriptor for `CallRawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawRequestDescriptor =
-    $convert.base64Decode('Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
-        'gCIAEoCVIKcGFyYW1zSnNvbg==');
+final $typed_data.Uint8List callRawRequestDescriptor = $convert.base64Decode(
+    'Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
+    'gCIAEoCVIKcGFyYW1zSnNvbg==');
 
 @$core.Deprecated('Use callRawResponseDescriptor instead')
 const CallRawResponse$json = {
@@ -525,8 +534,8 @@ const CallRawResponse$json = {
 };
 
 /// Descriptor for `CallRawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawResponseDescriptor =
-    $convert.base64Decode('Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
+final $typed_data.Uint8List callRawResponseDescriptor = $convert.base64Decode(
+    'Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
 
 @$core.Deprecated('Use refreshWalletRequestDescriptor instead')
 const RefreshWalletRequest$json = {
@@ -534,7 +543,8 @@ const RefreshWalletRequest$json = {
 };
 
 /// Descriptor for `RefreshWalletRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List refreshWalletRequestDescriptor = $convert.base64Decode('ChRSZWZyZXNoV2FsbGV0UmVxdWVzdA==');
+final $typed_data.Uint8List refreshWalletRequestDescriptor = $convert.base64Decode(
+    'ChRSZWZyZXNoV2FsbGV0UmVxdWVzdA==');
 
 @$core.Deprecated('Use refreshWalletResponseDescriptor instead')
 const RefreshWalletResponse$json = {
@@ -542,7 +552,8 @@ const RefreshWalletResponse$json = {
 };
 
 /// Descriptor for `RefreshWalletResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List refreshWalletResponseDescriptor = $convert.base64Decode('ChVSZWZyZXNoV2FsbGV0UmVzcG9uc2U=');
+final $typed_data.Uint8List refreshWalletResponseDescriptor = $convert.base64Decode(
+    'ChVSZWZyZXNoV2FsbGV0UmVzcG9uc2U=');
 
 @$core.Deprecated('Use getTransactionRequestDescriptor instead')
 const GetTransactionRequest$json = {
@@ -553,8 +564,8 @@ const GetTransactionRequest$json = {
 };
 
 /// Descriptor for `GetTransactionRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getTransactionRequestDescriptor =
-    $convert.base64Decode('ChVHZXRUcmFuc2FjdGlvblJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List getTransactionRequestDescriptor = $convert.base64Decode(
+    'ChVHZXRUcmFuc2FjdGlvblJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use getTransactionResponseDescriptor instead')
 const GetTransactionResponse$json = {
@@ -565,9 +576,9 @@ const GetTransactionResponse$json = {
 };
 
 /// Descriptor for `GetTransactionResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getTransactionResponseDescriptor =
-    $convert.base64Decode('ChZHZXRUcmFuc2FjdGlvblJlc3BvbnNlEikKEHRyYW5zYWN0aW9uX2pzb24YASABKAlSD3RyYW'
-        '5zYWN0aW9uSnNvbg==');
+final $typed_data.Uint8List getTransactionResponseDescriptor = $convert.base64Decode(
+    'ChZHZXRUcmFuc2FjdGlvblJlc3BvbnNlEikKEHRyYW5zYWN0aW9uX2pzb24YASABKAlSD3RyYW'
+    '5zYWN0aW9uSnNvbg==');
 
 @$core.Deprecated('Use getTransactionInfoRequestDescriptor instead')
 const GetTransactionInfoRequest$json = {
@@ -578,8 +589,8 @@ const GetTransactionInfoRequest$json = {
 };
 
 /// Descriptor for `GetTransactionInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getTransactionInfoRequestDescriptor =
-    $convert.base64Decode('ChlHZXRUcmFuc2FjdGlvbkluZm9SZXF1ZXN0EhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List getTransactionInfoRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRUcmFuc2FjdGlvbkluZm9SZXF1ZXN0EhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use getTransactionInfoResponseDescriptor instead')
 const GetTransactionInfoResponse$json = {
@@ -590,9 +601,9 @@ const GetTransactionInfoResponse$json = {
 };
 
 /// Descriptor for `GetTransactionInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getTransactionInfoResponseDescriptor =
-    $convert.base64Decode('ChpHZXRUcmFuc2FjdGlvbkluZm9SZXNwb25zZRIyChV0cmFuc2FjdGlvbl9pbmZvX2pzb24YAS'
-        'ABKAlSE3RyYW5zYWN0aW9uSW5mb0pzb24=');
+final $typed_data.Uint8List getTransactionInfoResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRUcmFuc2FjdGlvbkluZm9SZXNwb25zZRIyChV0cmFuc2FjdGlvbl9pbmZvX2pzb24YAS'
+    'ABKAlSE3RyYW5zYWN0aW9uSW5mb0pzb24=');
 
 @$core.Deprecated('Use getWalletAddressesRequestDescriptor instead')
 const GetWalletAddressesRequest$json = {
@@ -600,8 +611,8 @@ const GetWalletAddressesRequest$json = {
 };
 
 /// Descriptor for `GetWalletAddressesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletAddressesRequestDescriptor =
-    $convert.base64Decode('ChlHZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0');
+final $typed_data.Uint8List getWalletAddressesRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0');
 
 @$core.Deprecated('Use getWalletAddressesResponseDescriptor instead')
 const GetWalletAddressesResponse$json = {
@@ -612,9 +623,9 @@ const GetWalletAddressesResponse$json = {
 };
 
 /// Descriptor for `GetWalletAddressesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletAddressesResponseDescriptor =
-    $convert.base64Decode('ChpHZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3'
-        'Nlcw==');
+final $typed_data.Uint8List getWalletAddressesResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3'
+    'Nlcw==');
 
 @$core.Deprecated('Use myUtxosRequestDescriptor instead')
 const MyUtxosRequest$json = {
@@ -622,7 +633,8 @@ const MyUtxosRequest$json = {
 };
 
 /// Descriptor for `MyUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List myUtxosRequestDescriptor = $convert.base64Decode('Cg5NeVV0eG9zUmVxdWVzdA==');
+final $typed_data.Uint8List myUtxosRequestDescriptor = $convert.base64Decode(
+    'Cg5NeVV0eG9zUmVxdWVzdA==');
 
 @$core.Deprecated('Use myUtxosResponseDescriptor instead')
 const MyUtxosResponse$json = {
@@ -633,8 +645,8 @@ const MyUtxosResponse$json = {
 };
 
 /// Descriptor for `MyUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List myUtxosResponseDescriptor =
-    $convert.base64Decode('Cg9NeVV0eG9zUmVzcG9uc2USHQoKdXR4b3NfanNvbhgBIAEoCVIJdXR4b3NKc29u');
+final $typed_data.Uint8List myUtxosResponseDescriptor = $convert.base64Decode(
+    'Cg9NeVV0eG9zUmVzcG9uc2USHQoKdXR4b3NfanNvbhgBIAEoCVIJdXR4b3NKc29u');
 
 @$core.Deprecated('Use myUnconfirmedUtxosRequestDescriptor instead')
 const MyUnconfirmedUtxosRequest$json = {
@@ -642,8 +654,8 @@ const MyUnconfirmedUtxosRequest$json = {
 };
 
 /// Descriptor for `MyUnconfirmedUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List myUnconfirmedUtxosRequestDescriptor =
-    $convert.base64Decode('ChlNeVVuY29uZmlybWVkVXR4b3NSZXF1ZXN0');
+final $typed_data.Uint8List myUnconfirmedUtxosRequestDescriptor = $convert.base64Decode(
+    'ChlNeVVuY29uZmlybWVkVXR4b3NSZXF1ZXN0');
 
 @$core.Deprecated('Use myUnconfirmedUtxosResponseDescriptor instead')
 const MyUnconfirmedUtxosResponse$json = {
@@ -654,9 +666,9 @@ const MyUnconfirmedUtxosResponse$json = {
 };
 
 /// Descriptor for `MyUnconfirmedUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List myUnconfirmedUtxosResponseDescriptor =
-    $convert.base64Decode('ChpNeVVuY29uZmlybWVkVXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0'
-        'pzb24=');
+final $typed_data.Uint8List myUnconfirmedUtxosResponseDescriptor = $convert.base64Decode(
+    'ChpNeVVuY29uZmlybWVkVXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0'
+    'pzb24=');
 
 @$core.Deprecated('Use calculateInitialLiquidityRequestDescriptor instead')
 const CalculateInitialLiquidityRequest$json = {
@@ -673,10 +685,10 @@ const CalculateInitialLiquidityRequest$json = {
 };
 
 /// Descriptor for `CalculateInitialLiquidityRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List calculateInitialLiquidityRequestDescriptor =
-    $convert.base64Decode('CiBDYWxjdWxhdGVJbml0aWFsTGlxdWlkaXR5UmVxdWVzdBISCgRiZXRhGAEgASgBUgRiZXRhEi'
-        'YKDG51bV9vdXRjb21lcxgCIAEoBUgAUgtudW1PdXRjb21lc4gBARIjCgpkaW1lbnNpb25zGAMg'
-        'ASgJSAFSCmRpbWVuc2lvbnOIAQFCDwoNX251bV9vdXRjb21lc0INCgtfZGltZW5zaW9ucw==');
+final $typed_data.Uint8List calculateInitialLiquidityRequestDescriptor = $convert.base64Decode(
+    'CiBDYWxjdWxhdGVJbml0aWFsTGlxdWlkaXR5UmVxdWVzdBISCgRiZXRhGAEgASgBUgRiZXRhEi'
+    'YKDG51bV9vdXRjb21lcxgCIAEoBUgAUgtudW1PdXRjb21lc4gBARIjCgpkaW1lbnNpb25zGAMg'
+    'ASgJSAFSCmRpbWVuc2lvbnOIAQFCDwoNX251bV9vdXRjb21lc0INCgtfZGltZW5zaW9ucw==');
 
 @$core.Deprecated('Use calculateInitialLiquidityResponseDescriptor instead')
 const CalculateInitialLiquidityResponse$json = {
@@ -687,9 +699,9 @@ const CalculateInitialLiquidityResponse$json = {
 };
 
 /// Descriptor for `CalculateInitialLiquidityResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List calculateInitialLiquidityResponseDescriptor =
-    $convert.base64Decode('CiFDYWxjdWxhdGVJbml0aWFsTGlxdWlkaXR5UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKA'
-        'lSCnJlc3VsdEpzb24=');
+final $typed_data.Uint8List calculateInitialLiquidityResponseDescriptor = $convert.base64Decode(
+    'CiFDYWxjdWxhdGVJbml0aWFsTGlxdWlkaXR5UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKA'
+    'lSCnJlc3VsdEpzb24=');
 
 @$core.Deprecated('Use marketCreateRequestDescriptor instead')
 const MarketCreateRequest$json = {
@@ -714,15 +726,15 @@ const MarketCreateRequest$json = {
 };
 
 /// Descriptor for `MarketCreateRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List marketCreateRequestDescriptor =
-    $convert.base64Decode('ChNNYXJrZXRDcmVhdGVSZXF1ZXN0EhQKBXRpdGxlGAEgASgJUgV0aXRsZRIgCgtkZXNjcmlwdG'
-        'lvbhgCIAEoCVILZGVzY3JpcHRpb24SHgoKZGltZW5zaW9ucxgDIAEoCVIKZGltZW5zaW9ucxIZ'
-        'CghmZWVfc2F0cxgEIAEoA1IHZmVlU2F0cxIXCgRiZXRhGAUgASgBSABSBGJldGGIAQESMAoRaW'
-        '5pdGlhbF9saXF1aWRpdHkYBiABKANIAVIQaW5pdGlhbExpcXVpZGl0eYgBARIkCgt0cmFkaW5n'
-        'X2ZlZRgHIAEoAUgCUgp0cmFkaW5nRmVliAEBEhIKBHRhZ3MYCCADKAlSBHRhZ3MSJQoOY2F0ZW'
-        'dvcnlfdHhpZHMYCSADKAlSDWNhdGVnb3J5VHhpZHMSJQoOcmVzaWR1YWxfbmFtZXMYCiADKAlS'
-        'DXJlc2lkdWFsTmFtZXNCBwoFX2JldGFCFAoSX2luaXRpYWxfbGlxdWlkaXR5Qg4KDF90cmFkaW'
-        '5nX2ZlZQ==');
+final $typed_data.Uint8List marketCreateRequestDescriptor = $convert.base64Decode(
+    'ChNNYXJrZXRDcmVhdGVSZXF1ZXN0EhQKBXRpdGxlGAEgASgJUgV0aXRsZRIgCgtkZXNjcmlwdG'
+    'lvbhgCIAEoCVILZGVzY3JpcHRpb24SHgoKZGltZW5zaW9ucxgDIAEoCVIKZGltZW5zaW9ucxIZ'
+    'CghmZWVfc2F0cxgEIAEoA1IHZmVlU2F0cxIXCgRiZXRhGAUgASgBSABSBGJldGGIAQESMAoRaW'
+    '5pdGlhbF9saXF1aWRpdHkYBiABKANIAVIQaW5pdGlhbExpcXVpZGl0eYgBARIkCgt0cmFkaW5n'
+    'X2ZlZRgHIAEoAUgCUgp0cmFkaW5nRmVliAEBEhIKBHRhZ3MYCCADKAlSBHRhZ3MSJQoOY2F0ZW'
+    'dvcnlfdHhpZHMYCSADKAlSDWNhdGVnb3J5VHhpZHMSJQoOcmVzaWR1YWxfbmFtZXMYCiADKAlS'
+    'DXJlc2lkdWFsTmFtZXNCBwoFX2JldGFCFAoSX2luaXRpYWxfbGlxdWlkaXR5Qg4KDF90cmFkaW'
+    '5nX2ZlZQ==');
 
 @$core.Deprecated('Use marketCreateResponseDescriptor instead')
 const MarketCreateResponse$json = {
@@ -733,8 +745,8 @@ const MarketCreateResponse$json = {
 };
 
 /// Descriptor for `MarketCreateResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List marketCreateResponseDescriptor =
-    $convert.base64Decode('ChRNYXJrZXRDcmVhdGVSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
+final $typed_data.Uint8List marketCreateResponseDescriptor = $convert.base64Decode(
+    'ChRNYXJrZXRDcmVhdGVSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
 
 @$core.Deprecated('Use marketListRequestDescriptor instead')
 const MarketListRequest$json = {
@@ -742,7 +754,8 @@ const MarketListRequest$json = {
 };
 
 /// Descriptor for `MarketListRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List marketListRequestDescriptor = $convert.base64Decode('ChFNYXJrZXRMaXN0UmVxdWVzdA==');
+final $typed_data.Uint8List marketListRequestDescriptor = $convert.base64Decode(
+    'ChFNYXJrZXRMaXN0UmVxdWVzdA==');
 
 @$core.Deprecated('Use marketListResponseDescriptor instead')
 const MarketListResponse$json = {
@@ -753,9 +766,9 @@ const MarketListResponse$json = {
 };
 
 /// Descriptor for `MarketListResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List marketListResponseDescriptor =
-    $convert.base64Decode('ChJNYXJrZXRMaXN0UmVzcG9uc2USIQoMbWFya2V0c19qc29uGAEgASgJUgttYXJrZXRzSnNvbg'
-        '==');
+final $typed_data.Uint8List marketListResponseDescriptor = $convert.base64Decode(
+    'ChJNYXJrZXRMaXN0UmVzcG9uc2USIQoMbWFya2V0c19qc29uGAEgASgJUgttYXJrZXRzSnNvbg'
+    '==');
 
 @$core.Deprecated('Use marketGetRequestDescriptor instead')
 const MarketGetRequest$json = {
@@ -766,8 +779,8 @@ const MarketGetRequest$json = {
 };
 
 /// Descriptor for `MarketGetRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List marketGetRequestDescriptor =
-    $convert.base64Decode('ChBNYXJrZXRHZXRSZXF1ZXN0EhsKCW1hcmtldF9pZBgBIAEoCVIIbWFya2V0SWQ=');
+final $typed_data.Uint8List marketGetRequestDescriptor = $convert.base64Decode(
+    'ChBNYXJrZXRHZXRSZXF1ZXN0EhsKCW1hcmtldF9pZBgBIAEoCVIIbWFya2V0SWQ=');
 
 @$core.Deprecated('Use marketGetResponseDescriptor instead')
 const MarketGetResponse$json = {
@@ -778,8 +791,8 @@ const MarketGetResponse$json = {
 };
 
 /// Descriptor for `MarketGetResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List marketGetResponseDescriptor =
-    $convert.base64Decode('ChFNYXJrZXRHZXRSZXNwb25zZRIfCgttYXJrZXRfanNvbhgBIAEoCVIKbWFya2V0SnNvbg==');
+final $typed_data.Uint8List marketGetResponseDescriptor = $convert.base64Decode(
+    'ChFNYXJrZXRHZXRSZXNwb25zZRIfCgttYXJrZXRfanNvbhgBIAEoCVIKbWFya2V0SnNvbg==');
 
 @$core.Deprecated('Use marketBuyRequestDescriptor instead')
 const MarketBuyRequest$json = {
@@ -800,12 +813,12 @@ const MarketBuyRequest$json = {
 };
 
 /// Descriptor for `MarketBuyRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List marketBuyRequestDescriptor =
-    $convert.base64Decode('ChBNYXJrZXRCdXlSZXF1ZXN0EhsKCW1hcmtldF9pZBgBIAEoCVIIbWFya2V0SWQSIwoNb3V0Y2'
-        '9tZV9pbmRleBgCIAEoBVIMb3V0Y29tZUluZGV4EiMKDXNoYXJlc19hbW91bnQYAyABKAFSDHNo'
-        'YXJlc0Ftb3VudBIcCgdkcnlfcnVuGAQgASgISABSBmRyeVJ1bogBARIeCghmZWVfc2F0cxgFIA'
-        'EoA0gBUgdmZWVTYXRziAEBEh4KCG1heF9jb3N0GAYgASgDSAJSB21heENvc3SIAQFCCgoIX2Ry'
-        'eV9ydW5CCwoJX2ZlZV9zYXRzQgsKCV9tYXhfY29zdA==');
+final $typed_data.Uint8List marketBuyRequestDescriptor = $convert.base64Decode(
+    'ChBNYXJrZXRCdXlSZXF1ZXN0EhsKCW1hcmtldF9pZBgBIAEoCVIIbWFya2V0SWQSIwoNb3V0Y2'
+    '9tZV9pbmRleBgCIAEoBVIMb3V0Y29tZUluZGV4EiMKDXNoYXJlc19hbW91bnQYAyABKAFSDHNo'
+    'YXJlc0Ftb3VudBIcCgdkcnlfcnVuGAQgASgISABSBmRyeVJ1bogBARIeCghmZWVfc2F0cxgFIA'
+    'EoA0gBUgdmZWVTYXRziAEBEh4KCG1heF9jb3N0GAYgASgDSAJSB21heENvc3SIAQFCCgoIX2Ry'
+    'eV9ydW5CCwoJX2ZlZV9zYXRzQgsKCV9tYXhfY29zdA==');
 
 @$core.Deprecated('Use marketBuyResponseDescriptor instead')
 const MarketBuyResponse$json = {
@@ -816,8 +829,8 @@ const MarketBuyResponse$json = {
 };
 
 /// Descriptor for `MarketBuyResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List marketBuyResponseDescriptor =
-    $convert.base64Decode('ChFNYXJrZXRCdXlSZXNwb25zZRIfCgtyZXN1bHRfanNvbhgBIAEoCVIKcmVzdWx0SnNvbg==');
+final $typed_data.Uint8List marketBuyResponseDescriptor = $convert.base64Decode(
+    'ChFNYXJrZXRCdXlSZXNwb25zZRIfCgtyZXN1bHRfanNvbhgBIAEoCVIKcmVzdWx0SnNvbg==');
 
 @$core.Deprecated('Use marketSellRequestDescriptor instead')
 const MarketSellRequest$json = {
@@ -839,13 +852,13 @@ const MarketSellRequest$json = {
 };
 
 /// Descriptor for `MarketSellRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List marketSellRequestDescriptor =
-    $convert.base64Decode('ChFNYXJrZXRTZWxsUmVxdWVzdBIbCgltYXJrZXRfaWQYASABKAlSCG1hcmtldElkEiMKDW91dG'
-        'NvbWVfaW5kZXgYAiABKAVSDG91dGNvbWVJbmRleBIjCg1zaGFyZXNfYW1vdW50GAMgASgDUgxz'
-        'aGFyZXNBbW91bnQSJQoOc2VsbGVyX2FkZHJlc3MYBCABKAlSDXNlbGxlckFkZHJlc3MSHAoHZH'
-        'J5X3J1bhgFIAEoCEgAUgZkcnlSdW6IAQESHgoIZmVlX3NhdHMYBiABKANIAVIHZmVlU2F0c4gB'
-        'ARImCgxtaW5fcHJvY2VlZHMYByABKANIAlILbWluUHJvY2VlZHOIAQFCCgoIX2RyeV9ydW5CCw'
-        'oJX2ZlZV9zYXRzQg8KDV9taW5fcHJvY2VlZHM=');
+final $typed_data.Uint8List marketSellRequestDescriptor = $convert.base64Decode(
+    'ChFNYXJrZXRTZWxsUmVxdWVzdBIbCgltYXJrZXRfaWQYASABKAlSCG1hcmtldElkEiMKDW91dG'
+    'NvbWVfaW5kZXgYAiABKAVSDG91dGNvbWVJbmRleBIjCg1zaGFyZXNfYW1vdW50GAMgASgDUgxz'
+    'aGFyZXNBbW91bnQSJQoOc2VsbGVyX2FkZHJlc3MYBCABKAlSDXNlbGxlckFkZHJlc3MSHAoHZH'
+    'J5X3J1bhgFIAEoCEgAUgZkcnlSdW6IAQESHgoIZmVlX3NhdHMYBiABKANIAVIHZmVlU2F0c4gB'
+    'ARImCgxtaW5fcHJvY2VlZHMYByABKANIAlILbWluUHJvY2VlZHOIAQFCCgoIX2RyeV9ydW5CCw'
+    'oJX2ZlZV9zYXRzQg8KDV9taW5fcHJvY2VlZHM=');
 
 @$core.Deprecated('Use marketSellResponseDescriptor instead')
 const MarketSellResponse$json = {
@@ -856,8 +869,8 @@ const MarketSellResponse$json = {
 };
 
 /// Descriptor for `MarketSellResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List marketSellResponseDescriptor =
-    $convert.base64Decode('ChJNYXJrZXRTZWxsUmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
+final $typed_data.Uint8List marketSellResponseDescriptor = $convert.base64Decode(
+    'ChJNYXJrZXRTZWxsUmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
 
 @$core.Deprecated('Use marketPositionsRequestDescriptor instead')
 const MarketPositionsRequest$json = {
@@ -873,10 +886,10 @@ const MarketPositionsRequest$json = {
 };
 
 /// Descriptor for `MarketPositionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List marketPositionsRequestDescriptor =
-    $convert.base64Decode('ChZNYXJrZXRQb3NpdGlvbnNSZXF1ZXN0Eh0KB2FkZHJlc3MYASABKAlIAFIHYWRkcmVzc4gBAR'
-        'IgCgltYXJrZXRfaWQYAiABKAlIAVIIbWFya2V0SWSIAQFCCgoIX2FkZHJlc3NCDAoKX21hcmtl'
-        'dF9pZA==');
+final $typed_data.Uint8List marketPositionsRequestDescriptor = $convert.base64Decode(
+    'ChZNYXJrZXRQb3NpdGlvbnNSZXF1ZXN0Eh0KB2FkZHJlc3MYASABKAlIAFIHYWRkcmVzc4gBAR'
+    'IgCgltYXJrZXRfaWQYAiABKAlIAVIIbWFya2V0SWSIAQFCCgoIX2FkZHJlc3NCDAoKX21hcmtl'
+    'dF9pZA==');
 
 @$core.Deprecated('Use marketPositionsResponseDescriptor instead')
 const MarketPositionsResponse$json = {
@@ -887,9 +900,9 @@ const MarketPositionsResponse$json = {
 };
 
 /// Descriptor for `MarketPositionsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List marketPositionsResponseDescriptor =
-    $convert.base64Decode('ChdNYXJrZXRQb3NpdGlvbnNSZXNwb25zZRIlCg5wb3NpdGlvbnNfanNvbhgBIAEoCVINcG9zaX'
-        'Rpb25zSnNvbg==');
+final $typed_data.Uint8List marketPositionsResponseDescriptor = $convert.base64Decode(
+    'ChdNYXJrZXRQb3NpdGlvbnNSZXNwb25zZRIlCg5wb3NpdGlvbnNfanNvbhgBIAEoCVINcG9zaX'
+    'Rpb25zSnNvbg==');
 
 @$core.Deprecated('Use slotStatusRequestDescriptor instead')
 const SlotStatusRequest$json = {
@@ -897,7 +910,8 @@ const SlotStatusRequest$json = {
 };
 
 /// Descriptor for `SlotStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List slotStatusRequestDescriptor = $convert.base64Decode('ChFTbG90U3RhdHVzUmVxdWVzdA==');
+final $typed_data.Uint8List slotStatusRequestDescriptor = $convert.base64Decode(
+    'ChFTbG90U3RhdHVzUmVxdWVzdA==');
 
 @$core.Deprecated('Use slotStatusResponseDescriptor instead')
 const SlotStatusResponse$json = {
@@ -908,8 +922,8 @@ const SlotStatusResponse$json = {
 };
 
 /// Descriptor for `SlotStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List slotStatusResponseDescriptor =
-    $convert.base64Decode('ChJTbG90U3RhdHVzUmVzcG9uc2USHwoLc3RhdHVzX2pzb24YASABKAlSCnN0YXR1c0pzb24=');
+final $typed_data.Uint8List slotStatusResponseDescriptor = $convert.base64Decode(
+    'ChJTbG90U3RhdHVzUmVzcG9uc2USHwoLc3RhdHVzX2pzb24YASABKAlSCnN0YXR1c0pzb24=');
 
 @$core.Deprecated('Use slotListRequestDescriptor instead')
 const SlotListRequest$json = {
@@ -925,9 +939,9 @@ const SlotListRequest$json = {
 };
 
 /// Descriptor for `SlotListRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List slotListRequestDescriptor =
-    $convert.base64Decode('Cg9TbG90TGlzdFJlcXVlc3QSGwoGcGVyaW9kGAEgASgFSABSBnBlcmlvZIgBARIbCgZzdGF0dX'
-        'MYAiABKAlIAVIGc3RhdHVziAEBQgkKB19wZXJpb2RCCQoHX3N0YXR1cw==');
+final $typed_data.Uint8List slotListRequestDescriptor = $convert.base64Decode(
+    'Cg9TbG90TGlzdFJlcXVlc3QSGwoGcGVyaW9kGAEgASgFSABSBnBlcmlvZIgBARIbCgZzdGF0dX'
+    'MYAiABKAlIAVIGc3RhdHVziAEBQgkKB19wZXJpb2RCCQoHX3N0YXR1cw==');
 
 @$core.Deprecated('Use slotListResponseDescriptor instead')
 const SlotListResponse$json = {
@@ -938,8 +952,8 @@ const SlotListResponse$json = {
 };
 
 /// Descriptor for `SlotListResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List slotListResponseDescriptor =
-    $convert.base64Decode('ChBTbG90TGlzdFJlc3BvbnNlEh0KCnNsb3RzX2pzb24YASABKAlSCXNsb3RzSnNvbg==');
+final $typed_data.Uint8List slotListResponseDescriptor = $convert.base64Decode(
+    'ChBTbG90TGlzdFJlc3BvbnNlEh0KCnNsb3RzX2pzb24YASABKAlSCXNsb3RzSnNvbg==');
 
 @$core.Deprecated('Use slotGetRequestDescriptor instead')
 const SlotGetRequest$json = {
@@ -950,8 +964,8 @@ const SlotGetRequest$json = {
 };
 
 /// Descriptor for `SlotGetRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List slotGetRequestDescriptor =
-    $convert.base64Decode('Cg5TbG90R2V0UmVxdWVzdBIXCgdzbG90X2lkGAEgASgJUgZzbG90SWQ=');
+final $typed_data.Uint8List slotGetRequestDescriptor = $convert.base64Decode(
+    'Cg5TbG90R2V0UmVxdWVzdBIXCgdzbG90X2lkGAEgASgJUgZzbG90SWQ=');
 
 @$core.Deprecated('Use slotGetResponseDescriptor instead')
 const SlotGetResponse$json = {
@@ -962,8 +976,8 @@ const SlotGetResponse$json = {
 };
 
 /// Descriptor for `SlotGetResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List slotGetResponseDescriptor =
-    $convert.base64Decode('Cg9TbG90R2V0UmVzcG9uc2USGwoJc2xvdF9qc29uGAEgASgJUghzbG90SnNvbg==');
+final $typed_data.Uint8List slotGetResponseDescriptor = $convert.base64Decode(
+    'Cg9TbG90R2V0UmVzcG9uc2USGwoJc2xvdF9qc29uGAEgASgJUghzbG90SnNvbg==');
 
 @$core.Deprecated('Use slotClaimRequestDescriptor instead')
 const SlotClaimRequest$json = {
@@ -986,13 +1000,13 @@ const SlotClaimRequest$json = {
 };
 
 /// Descriptor for `SlotClaimRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List slotClaimRequestDescriptor =
-    $convert.base64Decode('ChBTbG90Q2xhaW1SZXF1ZXN0EhkKCGZlZV9zYXRzGAEgASgDUgdmZWVTYXRzEiEKDHBlcmlvZF'
-        '9pbmRleBgCIAEoBVILcGVyaW9kSW5kZXgSHQoKc2xvdF9pbmRleBgDIAEoBVIJc2xvdEluZGV4'
-        'EhoKCHF1ZXN0aW9uGAQgASgJUghxdWVzdGlvbhIfCgtpc19zdGFuZGFyZBgFIAEoCFIKaXNTdG'
-        'FuZGFyZBIgCglpc19zY2FsZWQYBiABKAhIAFIIaXNTY2FsZWSIAQESFQoDbWluGAcgASgFSAFS'
-        'A21pbogBARIVCgNtYXgYCCABKAVIAlIDbWF4iAEBQgwKCl9pc19zY2FsZWRCBgoEX21pbkIGCg'
-        'RfbWF4');
+final $typed_data.Uint8List slotClaimRequestDescriptor = $convert.base64Decode(
+    'ChBTbG90Q2xhaW1SZXF1ZXN0EhkKCGZlZV9zYXRzGAEgASgDUgdmZWVTYXRzEiEKDHBlcmlvZF'
+    '9pbmRleBgCIAEoBVILcGVyaW9kSW5kZXgSHQoKc2xvdF9pbmRleBgDIAEoBVIJc2xvdEluZGV4'
+    'EhoKCHF1ZXN0aW9uGAQgASgJUghxdWVzdGlvbhIfCgtpc19zdGFuZGFyZBgFIAEoCFIKaXNTdG'
+    'FuZGFyZBIgCglpc19zY2FsZWQYBiABKAhIAFIIaXNTY2FsZWSIAQESFQoDbWluGAcgASgFSAFS'
+    'A21pbogBARIVCgNtYXgYCCABKAVIAlIDbWF4iAEBQgwKCl9pc19zY2FsZWRCBgoEX21pbkIGCg'
+    'RfbWF4');
 
 @$core.Deprecated('Use slotClaimResponseDescriptor instead')
 const SlotClaimResponse$json = {
@@ -1003,8 +1017,8 @@ const SlotClaimResponse$json = {
 };
 
 /// Descriptor for `SlotClaimResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List slotClaimResponseDescriptor =
-    $convert.base64Decode('ChFTbG90Q2xhaW1SZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
+final $typed_data.Uint8List slotClaimResponseDescriptor = $convert.base64Decode(
+    'ChFTbG90Q2xhaW1SZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
 
 @$core.Deprecated('Use slotClaimCategoryRequestDescriptor instead')
 const SlotClaimCategoryRequest$json = {
@@ -1017,10 +1031,10 @@ const SlotClaimCategoryRequest$json = {
 };
 
 /// Descriptor for `SlotClaimCategoryRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List slotClaimCategoryRequestDescriptor =
-    $convert.base64Decode('ChhTbG90Q2xhaW1DYXRlZ29yeVJlcXVlc3QSHQoKc2xvdHNfanNvbhgBIAEoCVIJc2xvdHNKc2'
-        '9uEh8KC2lzX3N0YW5kYXJkGAIgASgIUgppc1N0YW5kYXJkEhkKCGZlZV9zYXRzGAMgASgDUgdm'
-        'ZWVTYXRz');
+final $typed_data.Uint8List slotClaimCategoryRequestDescriptor = $convert.base64Decode(
+    'ChhTbG90Q2xhaW1DYXRlZ29yeVJlcXVlc3QSHQoKc2xvdHNfanNvbhgBIAEoCVIJc2xvdHNKc2'
+    '9uEh8KC2lzX3N0YW5kYXJkGAIgASgIUgppc1N0YW5kYXJkEhkKCGZlZV9zYXRzGAMgASgDUgdm'
+    'ZWVTYXRz');
 
 @$core.Deprecated('Use slotClaimCategoryResponseDescriptor instead')
 const SlotClaimCategoryResponse$json = {
@@ -1031,8 +1045,8 @@ const SlotClaimCategoryResponse$json = {
 };
 
 /// Descriptor for `SlotClaimCategoryResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List slotClaimCategoryResponseDescriptor =
-    $convert.base64Decode('ChlTbG90Q2xhaW1DYXRlZ29yeVJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List slotClaimCategoryResponseDescriptor = $convert.base64Decode(
+    'ChlTbG90Q2xhaW1DYXRlZ29yeVJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use voteRegisterRequestDescriptor instead')
 const VoteRegisterRequest$json = {
@@ -1047,10 +1061,10 @@ const VoteRegisterRequest$json = {
 };
 
 /// Descriptor for `VoteRegisterRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List voteRegisterRequestDescriptor =
-    $convert.base64Decode('ChNWb3RlUmVnaXN0ZXJSZXF1ZXN0EhkKCGZlZV9zYXRzGAEgASgDUgdmZWVTYXRzEjUKFHJlcH'
-        'V0YXRpb25fYm9uZF9zYXRzGAIgASgDSABSEnJlcHV0YXRpb25Cb25kU2F0c4gBAUIXChVfcmVw'
-        'dXRhdGlvbl9ib25kX3NhdHM=');
+final $typed_data.Uint8List voteRegisterRequestDescriptor = $convert.base64Decode(
+    'ChNWb3RlUmVnaXN0ZXJSZXF1ZXN0EhkKCGZlZV9zYXRzGAEgASgDUgdmZWVTYXRzEjUKFHJlcH'
+    'V0YXRpb25fYm9uZF9zYXRzGAIgASgDSABSEnJlcHV0YXRpb25Cb25kU2F0c4gBAUIXChVfcmVw'
+    'dXRhdGlvbl9ib25kX3NhdHM=');
 
 @$core.Deprecated('Use voteRegisterResponseDescriptor instead')
 const VoteRegisterResponse$json = {
@@ -1061,8 +1075,8 @@ const VoteRegisterResponse$json = {
 };
 
 /// Descriptor for `VoteRegisterResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List voteRegisterResponseDescriptor =
-    $convert.base64Decode('ChRWb3RlUmVnaXN0ZXJSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
+final $typed_data.Uint8List voteRegisterResponseDescriptor = $convert.base64Decode(
+    'ChRWb3RlUmVnaXN0ZXJSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
 
 @$core.Deprecated('Use voteVoterRequestDescriptor instead')
 const VoteVoterRequest$json = {
@@ -1073,8 +1087,8 @@ const VoteVoterRequest$json = {
 };
 
 /// Descriptor for `VoteVoterRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List voteVoterRequestDescriptor =
-    $convert.base64Decode('ChBWb3RlVm90ZXJSZXF1ZXN0EhgKB2FkZHJlc3MYASABKAlSB2FkZHJlc3M=');
+final $typed_data.Uint8List voteVoterRequestDescriptor = $convert.base64Decode(
+    'ChBWb3RlVm90ZXJSZXF1ZXN0EhgKB2FkZHJlc3MYASABKAlSB2FkZHJlc3M=');
 
 @$core.Deprecated('Use voteVoterResponseDescriptor instead')
 const VoteVoterResponse$json = {
@@ -1085,8 +1099,8 @@ const VoteVoterResponse$json = {
 };
 
 /// Descriptor for `VoteVoterResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List voteVoterResponseDescriptor =
-    $convert.base64Decode('ChFWb3RlVm90ZXJSZXNwb25zZRIdCgp2b3Rlcl9qc29uGAEgASgJUgl2b3Rlckpzb24=');
+final $typed_data.Uint8List voteVoterResponseDescriptor = $convert.base64Decode(
+    'ChFWb3RlVm90ZXJSZXNwb25zZRIdCgp2b3Rlcl9qc29uGAEgASgJUgl2b3Rlckpzb24=');
 
 @$core.Deprecated('Use voteVotersRequestDescriptor instead')
 const VoteVotersRequest$json = {
@@ -1094,7 +1108,8 @@ const VoteVotersRequest$json = {
 };
 
 /// Descriptor for `VoteVotersRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List voteVotersRequestDescriptor = $convert.base64Decode('ChFWb3RlVm90ZXJzUmVxdWVzdA==');
+final $typed_data.Uint8List voteVotersRequestDescriptor = $convert.base64Decode(
+    'ChFWb3RlVm90ZXJzUmVxdWVzdA==');
 
 @$core.Deprecated('Use voteVotersResponseDescriptor instead')
 const VoteVotersResponse$json = {
@@ -1105,8 +1120,8 @@ const VoteVotersResponse$json = {
 };
 
 /// Descriptor for `VoteVotersResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List voteVotersResponseDescriptor =
-    $convert.base64Decode('ChJWb3RlVm90ZXJzUmVzcG9uc2USHwoLdm90ZXJzX2pzb24YASABKAlSCnZvdGVyc0pzb24=');
+final $typed_data.Uint8List voteVotersResponseDescriptor = $convert.base64Decode(
+    'ChJWb3RlVm90ZXJzUmVzcG9uc2USHwoLdm90ZXJzX2pzb24YASABKAlSCnZvdGVyc0pzb24=');
 
 @$core.Deprecated('Use voteSubmitRequestDescriptor instead')
 const VoteSubmitRequest$json = {
@@ -1118,9 +1133,9 @@ const VoteSubmitRequest$json = {
 };
 
 /// Descriptor for `VoteSubmitRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List voteSubmitRequestDescriptor =
-    $convert.base64Decode('ChFWb3RlU3VibWl0UmVxdWVzdBIdCgp2b3Rlc19qc29uGAEgASgJUgl2b3Rlc0pzb24SGQoIZm'
-        'VlX3NhdHMYAiABKANSB2ZlZVNhdHM=');
+final $typed_data.Uint8List voteSubmitRequestDescriptor = $convert.base64Decode(
+    'ChFWb3RlU3VibWl0UmVxdWVzdBIdCgp2b3Rlc19qc29uGAEgASgJUgl2b3Rlc0pzb24SGQoIZm'
+    'VlX3NhdHMYAiABKANSB2ZlZVNhdHM=');
 
 @$core.Deprecated('Use voteSubmitResponseDescriptor instead')
 const VoteSubmitResponse$json = {
@@ -1131,8 +1146,8 @@ const VoteSubmitResponse$json = {
 };
 
 /// Descriptor for `VoteSubmitResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List voteSubmitResponseDescriptor =
-    $convert.base64Decode('ChJWb3RlU3VibWl0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List voteSubmitResponseDescriptor = $convert.base64Decode(
+    'ChJWb3RlU3VibWl0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use voteListRequestDescriptor instead')
 const VoteListRequest$json = {
@@ -1150,10 +1165,10 @@ const VoteListRequest$json = {
 };
 
 /// Descriptor for `VoteListRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List voteListRequestDescriptor =
-    $convert.base64Decode('Cg9Wb3RlTGlzdFJlcXVlc3QSGQoFdm90ZXIYASABKAlIAFIFdm90ZXKIAQESJAoLZGVjaXNpb2'
-        '5faWQYAiABKAlIAVIKZGVjaXNpb25JZIgBARIgCglwZXJpb2RfaWQYAyABKAVIAlIIcGVyaW9k'
-        'SWSIAQFCCAoGX3ZvdGVyQg4KDF9kZWNpc2lvbl9pZEIMCgpfcGVyaW9kX2lk');
+final $typed_data.Uint8List voteListRequestDescriptor = $convert.base64Decode(
+    'Cg9Wb3RlTGlzdFJlcXVlc3QSGQoFdm90ZXIYASABKAlIAFIFdm90ZXKIAQESJAoLZGVjaXNpb2'
+    '5faWQYAiABKAlIAVIKZGVjaXNpb25JZIgBARIgCglwZXJpb2RfaWQYAyABKAVIAlIIcGVyaW9k'
+    'SWSIAQFCCAoGX3ZvdGVyQg4KDF9kZWNpc2lvbl9pZEIMCgpfcGVyaW9kX2lk');
 
 @$core.Deprecated('Use voteListResponseDescriptor instead')
 const VoteListResponse$json = {
@@ -1164,8 +1179,8 @@ const VoteListResponse$json = {
 };
 
 /// Descriptor for `VoteListResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List voteListResponseDescriptor =
-    $convert.base64Decode('ChBWb3RlTGlzdFJlc3BvbnNlEh0KCnZvdGVzX2pzb24YASABKAlSCXZvdGVzSnNvbg==');
+final $typed_data.Uint8List voteListResponseDescriptor = $convert.base64Decode(
+    'ChBWb3RlTGlzdFJlc3BvbnNlEh0KCnZvdGVzX2pzb24YASABKAlSCXZvdGVzSnNvbg==');
 
 @$core.Deprecated('Use votePeriodRequestDescriptor instead')
 const VotePeriodRequest$json = {
@@ -1179,9 +1194,9 @@ const VotePeriodRequest$json = {
 };
 
 /// Descriptor for `VotePeriodRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List votePeriodRequestDescriptor =
-    $convert.base64Decode('ChFWb3RlUGVyaW9kUmVxdWVzdBIgCglwZXJpb2RfaWQYASABKAVIAFIIcGVyaW9kSWSIAQFCDA'
-        'oKX3BlcmlvZF9pZA==');
+final $typed_data.Uint8List votePeriodRequestDescriptor = $convert.base64Decode(
+    'ChFWb3RlUGVyaW9kUmVxdWVzdBIgCglwZXJpb2RfaWQYASABKAVIAFIIcGVyaW9kSWSIAQFCDA'
+    'oKX3BlcmlvZF9pZA==');
 
 @$core.Deprecated('Use votePeriodResponseDescriptor instead')
 const VotePeriodResponse$json = {
@@ -1192,8 +1207,8 @@ const VotePeriodResponse$json = {
 };
 
 /// Descriptor for `VotePeriodResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List votePeriodResponseDescriptor =
-    $convert.base64Decode('ChJWb3RlUGVyaW9kUmVzcG9uc2USHwoLcGVyaW9kX2pzb24YASABKAlSCnBlcmlvZEpzb24=');
+final $typed_data.Uint8List votePeriodResponseDescriptor = $convert.base64Decode(
+    'ChJWb3RlUGVyaW9kUmVzcG9uc2USHwoLcGVyaW9kX2pzb24YASABKAlSCnBlcmlvZEpzb24=');
 
 @$core.Deprecated('Use votecoinTransferRequestDescriptor instead')
 const VotecoinTransferRequest$json = {
@@ -1210,10 +1225,10 @@ const VotecoinTransferRequest$json = {
 };
 
 /// Descriptor for `VotecoinTransferRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List votecoinTransferRequestDescriptor =
-    $convert.base64Decode('ChdWb3RlY29pblRyYW5zZmVyUmVxdWVzdBISCgRkZXN0GAEgASgJUgRkZXN0EhYKBmFtb3VudB'
-        'gCIAEoA1IGYW1vdW50EhkKCGZlZV9zYXRzGAMgASgDUgdmZWVTYXRzEhcKBG1lbW8YBCABKAlI'
-        'AFIEbWVtb4gBAUIHCgVfbWVtbw==');
+final $typed_data.Uint8List votecoinTransferRequestDescriptor = $convert.base64Decode(
+    'ChdWb3RlY29pblRyYW5zZmVyUmVxdWVzdBISCgRkZXN0GAEgASgJUgRkZXN0EhYKBmFtb3VudB'
+    'gCIAEoA1IGYW1vdW50EhkKCGZlZV9zYXRzGAMgASgDUgdmZWVTYXRzEhcKBG1lbW8YBCABKAlI'
+    'AFIEbWVtb4gBAUIHCgVfbWVtbw==');
 
 @$core.Deprecated('Use votecoinTransferResponseDescriptor instead')
 const VotecoinTransferResponse$json = {
@@ -1224,8 +1239,8 @@ const VotecoinTransferResponse$json = {
 };
 
 /// Descriptor for `VotecoinTransferResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List votecoinTransferResponseDescriptor =
-    $convert.base64Decode('ChhWb3RlY29pblRyYW5zZmVyUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List votecoinTransferResponseDescriptor = $convert.base64Decode(
+    'ChhWb3RlY29pblRyYW5zZmVyUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use votecoinBalanceRequestDescriptor instead')
 const VotecoinBalanceRequest$json = {
@@ -1236,8 +1251,8 @@ const VotecoinBalanceRequest$json = {
 };
 
 /// Descriptor for `VotecoinBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List votecoinBalanceRequestDescriptor =
-    $convert.base64Decode('ChZWb3RlY29pbkJhbGFuY2VSZXF1ZXN0EhgKB2FkZHJlc3MYASABKAlSB2FkZHJlc3M=');
+final $typed_data.Uint8List votecoinBalanceRequestDescriptor = $convert.base64Decode(
+    'ChZWb3RlY29pbkJhbGFuY2VSZXF1ZXN0EhgKB2FkZHJlc3MYASABKAlSB2FkZHJlc3M=');
 
 @$core.Deprecated('Use votecoinBalanceResponseDescriptor instead')
 const VotecoinBalanceResponse$json = {
@@ -1248,8 +1263,8 @@ const VotecoinBalanceResponse$json = {
 };
 
 /// Descriptor for `VotecoinBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List votecoinBalanceResponseDescriptor =
-    $convert.base64Decode('ChdWb3RlY29pbkJhbGFuY2VSZXNwb25zZRIYCgdiYWxhbmNlGAEgASgDUgdiYWxhbmNl');
+final $typed_data.Uint8List votecoinBalanceResponseDescriptor = $convert.base64Decode(
+    'ChdWb3RlY29pbkJhbGFuY2VSZXNwb25zZRIYCgdiYWxhbmNlGAEgASgDUgdiYWxhbmNl');
 
 @$core.Deprecated('Use transferVotecoinRequestDescriptor instead')
 const TransferVotecoinRequest$json = {
@@ -1266,10 +1281,10 @@ const TransferVotecoinRequest$json = {
 };
 
 /// Descriptor for `TransferVotecoinRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferVotecoinRequestDescriptor =
-    $convert.base64Decode('ChdUcmFuc2ZlclZvdGVjb2luUmVxdWVzdBISCgRkZXN0GAEgASgJUgRkZXN0EhYKBmFtb3VudB'
-        'gCIAEoA1IGYW1vdW50EhkKCGZlZV9zYXRzGAMgASgDUgdmZWVTYXRzEhcKBG1lbW8YBCABKAlI'
-        'AFIEbWVtb4gBAUIHCgVfbWVtbw==');
+final $typed_data.Uint8List transferVotecoinRequestDescriptor = $convert.base64Decode(
+    'ChdUcmFuc2ZlclZvdGVjb2luUmVxdWVzdBISCgRkZXN0GAEgASgJUgRkZXN0EhYKBmFtb3VudB'
+    'gCIAEoA1IGYW1vdW50EhkKCGZlZV9zYXRzGAMgASgDUgdmZWVTYXRzEhcKBG1lbW8YBCABKAlI'
+    'AFIEbWVtb4gBAUIHCgVfbWVtbw==');
 
 @$core.Deprecated('Use transferVotecoinResponseDescriptor instead')
 const TransferVotecoinResponse$json = {
@@ -1280,8 +1295,8 @@ const TransferVotecoinResponse$json = {
 };
 
 /// Descriptor for `TransferVotecoinResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferVotecoinResponseDescriptor =
-    $convert.base64Decode('ChhUcmFuc2ZlclZvdGVjb2luUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List transferVotecoinResponseDescriptor = $convert.base64Decode(
+    'ChhUcmFuc2ZlclZvdGVjb2luUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use getNewEncryptionKeyRequestDescriptor instead')
 const GetNewEncryptionKeyRequest$json = {
@@ -1289,8 +1304,8 @@ const GetNewEncryptionKeyRequest$json = {
 };
 
 /// Descriptor for `GetNewEncryptionKeyRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewEncryptionKeyRequestDescriptor =
-    $convert.base64Decode('ChpHZXROZXdFbmNyeXB0aW9uS2V5UmVxdWVzdA==');
+final $typed_data.Uint8List getNewEncryptionKeyRequestDescriptor = $convert.base64Decode(
+    'ChpHZXROZXdFbmNyeXB0aW9uS2V5UmVxdWVzdA==');
 
 @$core.Deprecated('Use getNewEncryptionKeyResponseDescriptor instead')
 const GetNewEncryptionKeyResponse$json = {
@@ -1301,8 +1316,8 @@ const GetNewEncryptionKeyResponse$json = {
 };
 
 /// Descriptor for `GetNewEncryptionKeyResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewEncryptionKeyResponseDescriptor =
-    $convert.base64Decode('ChtHZXROZXdFbmNyeXB0aW9uS2V5UmVzcG9uc2USEAoDa2V5GAEgASgJUgNrZXk=');
+final $typed_data.Uint8List getNewEncryptionKeyResponseDescriptor = $convert.base64Decode(
+    'ChtHZXROZXdFbmNyeXB0aW9uS2V5UmVzcG9uc2USEAoDa2V5GAEgASgJUgNrZXk=');
 
 @$core.Deprecated('Use getNewVerifyingKeyRequestDescriptor instead')
 const GetNewVerifyingKeyRequest$json = {
@@ -1310,8 +1325,8 @@ const GetNewVerifyingKeyRequest$json = {
 };
 
 /// Descriptor for `GetNewVerifyingKeyRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewVerifyingKeyRequestDescriptor =
-    $convert.base64Decode('ChlHZXROZXdWZXJpZnlpbmdLZXlSZXF1ZXN0');
+final $typed_data.Uint8List getNewVerifyingKeyRequestDescriptor = $convert.base64Decode(
+    'ChlHZXROZXdWZXJpZnlpbmdLZXlSZXF1ZXN0');
 
 @$core.Deprecated('Use getNewVerifyingKeyResponseDescriptor instead')
 const GetNewVerifyingKeyResponse$json = {
@@ -1322,8 +1337,8 @@ const GetNewVerifyingKeyResponse$json = {
 };
 
 /// Descriptor for `GetNewVerifyingKeyResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewVerifyingKeyResponseDescriptor =
-    $convert.base64Decode('ChpHZXROZXdWZXJpZnlpbmdLZXlSZXNwb25zZRIQCgNrZXkYASABKAlSA2tleQ==');
+final $typed_data.Uint8List getNewVerifyingKeyResponseDescriptor = $convert.base64Decode(
+    'ChpHZXROZXdWZXJpZnlpbmdLZXlSZXNwb25zZRIQCgNrZXkYASABKAlSA2tleQ==');
 
 @$core.Deprecated('Use encryptMsgRequestDescriptor instead')
 const EncryptMsgRequest$json = {
@@ -1335,9 +1350,9 @@ const EncryptMsgRequest$json = {
 };
 
 /// Descriptor for `EncryptMsgRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List encryptMsgRequestDescriptor =
-    $convert.base64Decode('ChFFbmNyeXB0TXNnUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIrChFlbmNyeXB0aW9uX3B1Ym'
-        'tleRgCIAEoCVIQZW5jcnlwdGlvblB1YmtleQ==');
+final $typed_data.Uint8List encryptMsgRequestDescriptor = $convert.base64Decode(
+    'ChFFbmNyeXB0TXNnUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIrChFlbmNyeXB0aW9uX3B1Ym'
+    'tleRgCIAEoCVIQZW5jcnlwdGlvblB1YmtleQ==');
 
 @$core.Deprecated('Use encryptMsgResponseDescriptor instead')
 const EncryptMsgResponse$json = {
@@ -1348,8 +1363,8 @@ const EncryptMsgResponse$json = {
 };
 
 /// Descriptor for `EncryptMsgResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List encryptMsgResponseDescriptor =
-    $convert.base64Decode('ChJFbmNyeXB0TXNnUmVzcG9uc2USHgoKY2lwaGVydGV4dBgBIAEoCVIKY2lwaGVydGV4dA==');
+final $typed_data.Uint8List encryptMsgResponseDescriptor = $convert.base64Decode(
+    'ChJFbmNyeXB0TXNnUmVzcG9uc2USHgoKY2lwaGVydGV4dBgBIAEoCVIKY2lwaGVydGV4dA==');
 
 @$core.Deprecated('Use decryptMsgRequestDescriptor instead')
 const DecryptMsgRequest$json = {
@@ -1361,9 +1376,9 @@ const DecryptMsgRequest$json = {
 };
 
 /// Descriptor for `DecryptMsgRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List decryptMsgRequestDescriptor =
-    $convert.base64Decode('ChFEZWNyeXB0TXNnUmVxdWVzdBIeCgpjaXBoZXJ0ZXh0GAEgASgJUgpjaXBoZXJ0ZXh0EisKEW'
-        'VuY3J5cHRpb25fcHVia2V5GAIgASgJUhBlbmNyeXB0aW9uUHVia2V5');
+final $typed_data.Uint8List decryptMsgRequestDescriptor = $convert.base64Decode(
+    'ChFEZWNyeXB0TXNnUmVxdWVzdBIeCgpjaXBoZXJ0ZXh0GAEgASgJUgpjaXBoZXJ0ZXh0EisKEW'
+    'VuY3J5cHRpb25fcHVia2V5GAIgASgJUhBlbmNyeXB0aW9uUHVia2V5');
 
 @$core.Deprecated('Use decryptMsgResponseDescriptor instead')
 const DecryptMsgResponse$json = {
@@ -1374,8 +1389,8 @@ const DecryptMsgResponse$json = {
 };
 
 /// Descriptor for `DecryptMsgResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List decryptMsgResponseDescriptor =
-    $convert.base64Decode('ChJEZWNyeXB0TXNnUmVzcG9uc2USHAoJcGxhaW50ZXh0GAEgASgJUglwbGFpbnRleHQ=');
+final $typed_data.Uint8List decryptMsgResponseDescriptor = $convert.base64Decode(
+    'ChJEZWNyeXB0TXNnUmVzcG9uc2USHAoJcGxhaW50ZXh0GAEgASgJUglwbGFpbnRleHQ=');
 
 @$core.Deprecated('Use signArbitraryMsgRequestDescriptor instead')
 const SignArbitraryMsgRequest$json = {
@@ -1387,9 +1402,9 @@ const SignArbitraryMsgRequest$json = {
 };
 
 /// Descriptor for `SignArbitraryMsgRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signArbitraryMsgRequestDescriptor =
-    $convert.base64Decode('ChdTaWduQXJiaXRyYXJ5TXNnUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIjCg12ZXJpZnlpbm'
-        'dfa2V5GAIgASgJUgx2ZXJpZnlpbmdLZXk=');
+final $typed_data.Uint8List signArbitraryMsgRequestDescriptor = $convert.base64Decode(
+    'ChdTaWduQXJiaXRyYXJ5TXNnUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIjCg12ZXJpZnlpbm'
+    'dfa2V5GAIgASgJUgx2ZXJpZnlpbmdLZXk=');
 
 @$core.Deprecated('Use signArbitraryMsgResponseDescriptor instead')
 const SignArbitraryMsgResponse$json = {
@@ -1400,9 +1415,9 @@ const SignArbitraryMsgResponse$json = {
 };
 
 /// Descriptor for `SignArbitraryMsgResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signArbitraryMsgResponseDescriptor =
-    $convert.base64Decode('ChhTaWduQXJiaXRyYXJ5TXNnUmVzcG9uc2USHAoJc2lnbmF0dXJlGAEgASgJUglzaWduYXR1cm'
-        'U=');
+final $typed_data.Uint8List signArbitraryMsgResponseDescriptor = $convert.base64Decode(
+    'ChhTaWduQXJiaXRyYXJ5TXNnUmVzcG9uc2USHAoJc2lnbmF0dXJlGAEgASgJUglzaWduYXR1cm'
+    'U=');
 
 @$core.Deprecated('Use signArbitraryMsgAsAddrRequestDescriptor instead')
 const SignArbitraryMsgAsAddrRequest$json = {
@@ -1414,9 +1429,9 @@ const SignArbitraryMsgAsAddrRequest$json = {
 };
 
 /// Descriptor for `SignArbitraryMsgAsAddrRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signArbitraryMsgAsAddrRequestDescriptor =
-    $convert.base64Decode('Ch1TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIYCgdhZG'
-        'RyZXNzGAIgASgJUgdhZGRyZXNz');
+final $typed_data.Uint8List signArbitraryMsgAsAddrRequestDescriptor = $convert.base64Decode(
+    'Ch1TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVxdWVzdBIQCgNtc2cYASABKAlSA21zZxIYCgdhZG'
+    'RyZXNzGAIgASgJUgdhZGRyZXNz');
 
 @$core.Deprecated('Use signArbitraryMsgAsAddrResponseDescriptor instead')
 const SignArbitraryMsgAsAddrResponse$json = {
@@ -1428,9 +1443,9 @@ const SignArbitraryMsgAsAddrResponse$json = {
 };
 
 /// Descriptor for `SignArbitraryMsgAsAddrResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signArbitraryMsgAsAddrResponseDescriptor =
-    $convert.base64Decode('Ch5TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVzcG9uc2USIwoNdmVyaWZ5aW5nX2tleRgBIAEoCV'
-        'IMdmVyaWZ5aW5nS2V5EhwKCXNpZ25hdHVyZRgCIAEoCVIJc2lnbmF0dXJl');
+final $typed_data.Uint8List signArbitraryMsgAsAddrResponseDescriptor = $convert.base64Decode(
+    'Ch5TaWduQXJiaXRyYXJ5TXNnQXNBZGRyUmVzcG9uc2USIwoNdmVyaWZ5aW5nX2tleRgBIAEoCV'
+    'IMdmVyaWZ5aW5nS2V5EhwKCXNpZ25hdHVyZRgCIAEoCVIJc2lnbmF0dXJl');
 
 @$core.Deprecated('Use verifySignatureRequestDescriptor instead')
 const VerifySignatureRequest$json = {
@@ -1444,10 +1459,10 @@ const VerifySignatureRequest$json = {
 };
 
 /// Descriptor for `VerifySignatureRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List verifySignatureRequestDescriptor =
-    $convert.base64Decode('ChZWZXJpZnlTaWduYXR1cmVSZXF1ZXN0EhAKA21zZxgBIAEoCVIDbXNnEhwKCXNpZ25hdHVyZR'
-        'gCIAEoCVIJc2lnbmF0dXJlEiMKDXZlcmlmeWluZ19rZXkYAyABKAlSDHZlcmlmeWluZ0tleRIQ'
-        'CgNkc3QYBCABKAlSA2RzdA==');
+final $typed_data.Uint8List verifySignatureRequestDescriptor = $convert.base64Decode(
+    'ChZWZXJpZnlTaWduYXR1cmVSZXF1ZXN0EhAKA21zZxgBIAEoCVIDbXNnEhwKCXNpZ25hdHVyZR'
+    'gCIAEoCVIJc2lnbmF0dXJlEiMKDXZlcmlmeWluZ19rZXkYAyABKAlSDHZlcmlmeWluZ0tleRIQ'
+    'CgNkc3QYBCABKAlSA2RzdA==');
 
 @$core.Deprecated('Use verifySignatureResponseDescriptor instead')
 const VerifySignatureResponse$json = {
@@ -1458,8 +1473,8 @@ const VerifySignatureResponse$json = {
 };
 
 /// Descriptor for `VerifySignatureResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List verifySignatureResponseDescriptor =
-    $convert.base64Decode('ChdWZXJpZnlTaWduYXR1cmVSZXNwb25zZRIUCgV2YWxpZBgBIAEoCFIFdmFsaWQ=');
+final $typed_data.Uint8List verifySignatureResponseDescriptor = $convert.base64Decode(
+    'ChdWZXJpZnlTaWduYXR1cmVSZXNwb25zZRIUCgV2YWxpZBgBIAEoCFIFdmFsaWQ=');
 
 const $core.Map<$core.String, $core.dynamic> TruthcoinServiceBase$json = {
   '1': 'TruthcoinService',
@@ -1470,82 +1485,30 @@ const $core.Map<$core.String, $core.dynamic> TruthcoinServiceBase$json = {
     {'1': 'GetNewAddress', '2': '.truthcoin.v1.GetNewAddressRequest', '3': '.truthcoin.v1.GetNewAddressResponse'},
     {'1': 'Withdraw', '2': '.truthcoin.v1.WithdrawRequest', '3': '.truthcoin.v1.WithdrawResponse'},
     {'1': 'Transfer', '2': '.truthcoin.v1.TransferRequest', '3': '.truthcoin.v1.TransferResponse'},
-    {
-      '1': 'GetSidechainWealth',
-      '2': '.truthcoin.v1.GetSidechainWealthRequest',
-      '3': '.truthcoin.v1.GetSidechainWealthResponse'
-    },
+    {'1': 'GetSidechainWealth', '2': '.truthcoin.v1.GetSidechainWealthRequest', '3': '.truthcoin.v1.GetSidechainWealthResponse'},
     {'1': 'CreateDeposit', '2': '.truthcoin.v1.CreateDepositRequest', '3': '.truthcoin.v1.CreateDepositResponse'},
-    {
-      '1': 'GetPendingWithdrawalBundle',
-      '2': '.truthcoin.v1.GetPendingWithdrawalBundleRequest',
-      '3': '.truthcoin.v1.GetPendingWithdrawalBundleResponse'
-    },
+    {'1': 'GetPendingWithdrawalBundle', '2': '.truthcoin.v1.GetPendingWithdrawalBundleRequest', '3': '.truthcoin.v1.GetPendingWithdrawalBundleResponse'},
     {'1': 'ConnectPeer', '2': '.truthcoin.v1.ConnectPeerRequest', '3': '.truthcoin.v1.ConnectPeerResponse'},
     {'1': 'ListPeers', '2': '.truthcoin.v1.ListPeersRequest', '3': '.truthcoin.v1.ListPeersResponse'},
     {'1': 'Mine', '2': '.truthcoin.v1.MineRequest', '3': '.truthcoin.v1.MineResponse'},
     {'1': 'GetBlock', '2': '.truthcoin.v1.GetBlockRequest', '3': '.truthcoin.v1.GetBlockResponse'},
-    {
-      '1': 'GetBestMainchainBlockHash',
-      '2': '.truthcoin.v1.GetBestMainchainBlockHashRequest',
-      '3': '.truthcoin.v1.GetBestMainchainBlockHashResponse'
-    },
-    {
-      '1': 'GetBestSidechainBlockHash',
-      '2': '.truthcoin.v1.GetBestSidechainBlockHashRequest',
-      '3': '.truthcoin.v1.GetBestSidechainBlockHashResponse'
-    },
-    {
-      '1': 'GetBmmInclusions',
-      '2': '.truthcoin.v1.GetBmmInclusionsRequest',
-      '3': '.truthcoin.v1.GetBmmInclusionsResponse'
-    },
+    {'1': 'GetBestMainchainBlockHash', '2': '.truthcoin.v1.GetBestMainchainBlockHashRequest', '3': '.truthcoin.v1.GetBestMainchainBlockHashResponse'},
+    {'1': 'GetBestSidechainBlockHash', '2': '.truthcoin.v1.GetBestSidechainBlockHashRequest', '3': '.truthcoin.v1.GetBestSidechainBlockHashResponse'},
+    {'1': 'GetBmmInclusions', '2': '.truthcoin.v1.GetBmmInclusionsRequest', '3': '.truthcoin.v1.GetBmmInclusionsResponse'},
     {'1': 'GetWalletUtxos', '2': '.truthcoin.v1.GetWalletUtxosRequest', '3': '.truthcoin.v1.GetWalletUtxosResponse'},
     {'1': 'ListUtxos', '2': '.truthcoin.v1.ListUtxosRequest', '3': '.truthcoin.v1.ListUtxosResponse'},
-    {
-      '1': 'RemoveFromMempool',
-      '2': '.truthcoin.v1.RemoveFromMempoolRequest',
-      '3': '.truthcoin.v1.RemoveFromMempoolResponse'
-    },
-    {
-      '1': 'GetLatestFailedWithdrawalBundleHeight',
-      '2': '.truthcoin.v1.GetLatestFailedWithdrawalBundleHeightRequest',
-      '3': '.truthcoin.v1.GetLatestFailedWithdrawalBundleHeightResponse'
-    },
-    {
-      '1': 'GenerateMnemonic',
-      '2': '.truthcoin.v1.GenerateMnemonicRequest',
-      '3': '.truthcoin.v1.GenerateMnemonicResponse'
-    },
-    {
-      '1': 'SetSeedFromMnemonic',
-      '2': '.truthcoin.v1.SetSeedFromMnemonicRequest',
-      '3': '.truthcoin.v1.SetSeedFromMnemonicResponse'
-    },
+    {'1': 'RemoveFromMempool', '2': '.truthcoin.v1.RemoveFromMempoolRequest', '3': '.truthcoin.v1.RemoveFromMempoolResponse'},
+    {'1': 'GetLatestFailedWithdrawalBundleHeight', '2': '.truthcoin.v1.GetLatestFailedWithdrawalBundleHeightRequest', '3': '.truthcoin.v1.GetLatestFailedWithdrawalBundleHeightResponse'},
+    {'1': 'GenerateMnemonic', '2': '.truthcoin.v1.GenerateMnemonicRequest', '3': '.truthcoin.v1.GenerateMnemonicResponse'},
+    {'1': 'SetSeedFromMnemonic', '2': '.truthcoin.v1.SetSeedFromMnemonicRequest', '3': '.truthcoin.v1.SetSeedFromMnemonicResponse'},
     {'1': 'CallRaw', '2': '.truthcoin.v1.CallRawRequest', '3': '.truthcoin.v1.CallRawResponse'},
     {'1': 'RefreshWallet', '2': '.truthcoin.v1.RefreshWalletRequest', '3': '.truthcoin.v1.RefreshWalletResponse'},
     {'1': 'GetTransaction', '2': '.truthcoin.v1.GetTransactionRequest', '3': '.truthcoin.v1.GetTransactionResponse'},
-    {
-      '1': 'GetTransactionInfo',
-      '2': '.truthcoin.v1.GetTransactionInfoRequest',
-      '3': '.truthcoin.v1.GetTransactionInfoResponse'
-    },
-    {
-      '1': 'GetWalletAddresses',
-      '2': '.truthcoin.v1.GetWalletAddressesRequest',
-      '3': '.truthcoin.v1.GetWalletAddressesResponse'
-    },
+    {'1': 'GetTransactionInfo', '2': '.truthcoin.v1.GetTransactionInfoRequest', '3': '.truthcoin.v1.GetTransactionInfoResponse'},
+    {'1': 'GetWalletAddresses', '2': '.truthcoin.v1.GetWalletAddressesRequest', '3': '.truthcoin.v1.GetWalletAddressesResponse'},
     {'1': 'MyUtxos', '2': '.truthcoin.v1.MyUtxosRequest', '3': '.truthcoin.v1.MyUtxosResponse'},
-    {
-      '1': 'MyUnconfirmedUtxos',
-      '2': '.truthcoin.v1.MyUnconfirmedUtxosRequest',
-      '3': '.truthcoin.v1.MyUnconfirmedUtxosResponse'
-    },
-    {
-      '1': 'CalculateInitialLiquidity',
-      '2': '.truthcoin.v1.CalculateInitialLiquidityRequest',
-      '3': '.truthcoin.v1.CalculateInitialLiquidityResponse'
-    },
+    {'1': 'MyUnconfirmedUtxos', '2': '.truthcoin.v1.MyUnconfirmedUtxosRequest', '3': '.truthcoin.v1.MyUnconfirmedUtxosResponse'},
+    {'1': 'CalculateInitialLiquidity', '2': '.truthcoin.v1.CalculateInitialLiquidityRequest', '3': '.truthcoin.v1.CalculateInitialLiquidityResponse'},
     {'1': 'MarketCreate', '2': '.truthcoin.v1.MarketCreateRequest', '3': '.truthcoin.v1.MarketCreateResponse'},
     {'1': 'MarketList', '2': '.truthcoin.v1.MarketListRequest', '3': '.truthcoin.v1.MarketListResponse'},
     {'1': 'MarketGet', '2': '.truthcoin.v1.MarketGetRequest', '3': '.truthcoin.v1.MarketGetResponse'},
@@ -1556,50 +1519,22 @@ const $core.Map<$core.String, $core.dynamic> TruthcoinServiceBase$json = {
     {'1': 'SlotList', '2': '.truthcoin.v1.SlotListRequest', '3': '.truthcoin.v1.SlotListResponse'},
     {'1': 'SlotGet', '2': '.truthcoin.v1.SlotGetRequest', '3': '.truthcoin.v1.SlotGetResponse'},
     {'1': 'SlotClaim', '2': '.truthcoin.v1.SlotClaimRequest', '3': '.truthcoin.v1.SlotClaimResponse'},
-    {
-      '1': 'SlotClaimCategory',
-      '2': '.truthcoin.v1.SlotClaimCategoryRequest',
-      '3': '.truthcoin.v1.SlotClaimCategoryResponse'
-    },
+    {'1': 'SlotClaimCategory', '2': '.truthcoin.v1.SlotClaimCategoryRequest', '3': '.truthcoin.v1.SlotClaimCategoryResponse'},
     {'1': 'VoteRegister', '2': '.truthcoin.v1.VoteRegisterRequest', '3': '.truthcoin.v1.VoteRegisterResponse'},
     {'1': 'VoteVoter', '2': '.truthcoin.v1.VoteVoterRequest', '3': '.truthcoin.v1.VoteVoterResponse'},
     {'1': 'VoteVoters', '2': '.truthcoin.v1.VoteVotersRequest', '3': '.truthcoin.v1.VoteVotersResponse'},
     {'1': 'VoteSubmit', '2': '.truthcoin.v1.VoteSubmitRequest', '3': '.truthcoin.v1.VoteSubmitResponse'},
     {'1': 'VoteList', '2': '.truthcoin.v1.VoteListRequest', '3': '.truthcoin.v1.VoteListResponse'},
     {'1': 'VotePeriod', '2': '.truthcoin.v1.VotePeriodRequest', '3': '.truthcoin.v1.VotePeriodResponse'},
-    {
-      '1': 'VotecoinTransfer',
-      '2': '.truthcoin.v1.VotecoinTransferRequest',
-      '3': '.truthcoin.v1.VotecoinTransferResponse'
-    },
+    {'1': 'VotecoinTransfer', '2': '.truthcoin.v1.VotecoinTransferRequest', '3': '.truthcoin.v1.VotecoinTransferResponse'},
     {'1': 'VotecoinBalance', '2': '.truthcoin.v1.VotecoinBalanceRequest', '3': '.truthcoin.v1.VotecoinBalanceResponse'},
-    {
-      '1': 'TransferVotecoin',
-      '2': '.truthcoin.v1.TransferVotecoinRequest',
-      '3': '.truthcoin.v1.TransferVotecoinResponse'
-    },
-    {
-      '1': 'GetNewEncryptionKey',
-      '2': '.truthcoin.v1.GetNewEncryptionKeyRequest',
-      '3': '.truthcoin.v1.GetNewEncryptionKeyResponse'
-    },
-    {
-      '1': 'GetNewVerifyingKey',
-      '2': '.truthcoin.v1.GetNewVerifyingKeyRequest',
-      '3': '.truthcoin.v1.GetNewVerifyingKeyResponse'
-    },
+    {'1': 'TransferVotecoin', '2': '.truthcoin.v1.TransferVotecoinRequest', '3': '.truthcoin.v1.TransferVotecoinResponse'},
+    {'1': 'GetNewEncryptionKey', '2': '.truthcoin.v1.GetNewEncryptionKeyRequest', '3': '.truthcoin.v1.GetNewEncryptionKeyResponse'},
+    {'1': 'GetNewVerifyingKey', '2': '.truthcoin.v1.GetNewVerifyingKeyRequest', '3': '.truthcoin.v1.GetNewVerifyingKeyResponse'},
     {'1': 'EncryptMsg', '2': '.truthcoin.v1.EncryptMsgRequest', '3': '.truthcoin.v1.EncryptMsgResponse'},
     {'1': 'DecryptMsg', '2': '.truthcoin.v1.DecryptMsgRequest', '3': '.truthcoin.v1.DecryptMsgResponse'},
-    {
-      '1': 'SignArbitraryMsg',
-      '2': '.truthcoin.v1.SignArbitraryMsgRequest',
-      '3': '.truthcoin.v1.SignArbitraryMsgResponse'
-    },
-    {
-      '1': 'SignArbitraryMsgAsAddr',
-      '2': '.truthcoin.v1.SignArbitraryMsgAsAddrRequest',
-      '3': '.truthcoin.v1.SignArbitraryMsgAsAddrResponse'
-    },
+    {'1': 'SignArbitraryMsg', '2': '.truthcoin.v1.SignArbitraryMsgRequest', '3': '.truthcoin.v1.SignArbitraryMsgResponse'},
+    {'1': 'SignArbitraryMsgAsAddr', '2': '.truthcoin.v1.SignArbitraryMsgAsAddrRequest', '3': '.truthcoin.v1.SignArbitraryMsgAsAddrResponse'},
     {'1': 'VerifySignature', '2': '.truthcoin.v1.VerifySignatureRequest', '3': '.truthcoin.v1.VerifySignatureResponse'},
   ],
 };
@@ -1723,99 +1658,100 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TruthcoinS
 };
 
 /// Descriptor for `TruthcoinService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List truthcoinServiceDescriptor =
-    $convert.base64Decode('ChBUcnV0aGNvaW5TZXJ2aWNlEk8KCkdldEJhbGFuY2USHy50cnV0aGNvaW4udjEuR2V0QmFsYW'
-        '5jZVJlcXVlc3QaIC50cnV0aGNvaW4udjEuR2V0QmFsYW5jZVJlc3BvbnNlElgKDUdldEJsb2Nr'
-        'Q291bnQSIi50cnV0aGNvaW4udjEuR2V0QmxvY2tDb3VudFJlcXVlc3QaIy50cnV0aGNvaW4udj'
-        'EuR2V0QmxvY2tDb3VudFJlc3BvbnNlEj0KBFN0b3ASGS50cnV0aGNvaW4udjEuU3RvcFJlcXVl'
-        'c3QaGi50cnV0aGNvaW4udjEuU3RvcFJlc3BvbnNlElgKDUdldE5ld0FkZHJlc3MSIi50cnV0aG'
-        'NvaW4udjEuR2V0TmV3QWRkcmVzc1JlcXVlc3QaIy50cnV0aGNvaW4udjEuR2V0TmV3QWRkcmVz'
-        'c1Jlc3BvbnNlEkkKCFdpdGhkcmF3Eh0udHJ1dGhjb2luLnYxLldpdGhkcmF3UmVxdWVzdBoeLn'
-        'RydXRoY29pbi52MS5XaXRoZHJhd1Jlc3BvbnNlEkkKCFRyYW5zZmVyEh0udHJ1dGhjb2luLnYx'
-        'LlRyYW5zZmVyUmVxdWVzdBoeLnRydXRoY29pbi52MS5UcmFuc2ZlclJlc3BvbnNlEmcKEkdldF'
-        'NpZGVjaGFpbldlYWx0aBInLnRydXRoY29pbi52MS5HZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0'
-        'GigudHJ1dGhjb2luLnYxLkdldFNpZGVjaGFpbldlYWx0aFJlc3BvbnNlElgKDUNyZWF0ZURlcG'
-        '9zaXQSIi50cnV0aGNvaW4udjEuQ3JlYXRlRGVwb3NpdFJlcXVlc3QaIy50cnV0aGNvaW4udjEu'
-        'Q3JlYXRlRGVwb3NpdFJlc3BvbnNlEn8KGkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlEi8udH'
-        'J1dGhjb2luLnYxLkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlUmVxdWVzdBowLnRydXRoY29p'
-        'bi52MS5HZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlElIKC0Nvbm5lY3RQZWVyEi'
-        'AudHJ1dGhjb2luLnYxLkNvbm5lY3RQZWVyUmVxdWVzdBohLnRydXRoY29pbi52MS5Db25uZWN0'
-        'UGVlclJlc3BvbnNlEkwKCUxpc3RQZWVycxIeLnRydXRoY29pbi52MS5MaXN0UGVlcnNSZXF1ZX'
-        'N0Gh8udHJ1dGhjb2luLnYxLkxpc3RQZWVyc1Jlc3BvbnNlEj0KBE1pbmUSGS50cnV0aGNvaW4u'
-        'djEuTWluZVJlcXVlc3QaGi50cnV0aGNvaW4udjEuTWluZVJlc3BvbnNlEkkKCEdldEJsb2NrEh'
-        '0udHJ1dGhjb2luLnYxLkdldEJsb2NrUmVxdWVzdBoeLnRydXRoY29pbi52MS5HZXRCbG9ja1Jl'
-        'c3BvbnNlEnwKGUdldEJlc3RNYWluY2hhaW5CbG9ja0hhc2gSLi50cnV0aGNvaW4udjEuR2V0Qm'
-        'VzdE1haW5jaGFpbkJsb2NrSGFzaFJlcXVlc3QaLy50cnV0aGNvaW4udjEuR2V0QmVzdE1haW5j'
-        'aGFpbkJsb2NrSGFzaFJlc3BvbnNlEnwKGUdldEJlc3RTaWRlY2hhaW5CbG9ja0hhc2gSLi50cn'
-        'V0aGNvaW4udjEuR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaFJlcXVlc3QaLy50cnV0aGNvaW4u'
-        'djEuR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaFJlc3BvbnNlEmEKEEdldEJtbUluY2x1c2lvbn'
-        'MSJS50cnV0aGNvaW4udjEuR2V0Qm1tSW5jbHVzaW9uc1JlcXVlc3QaJi50cnV0aGNvaW4udjEu'
-        'R2V0Qm1tSW5jbHVzaW9uc1Jlc3BvbnNlElsKDkdldFdhbGxldFV0eG9zEiMudHJ1dGhjb2luLn'
-        'YxLkdldFdhbGxldFV0eG9zUmVxdWVzdBokLnRydXRoY29pbi52MS5HZXRXYWxsZXRVdHhvc1Jl'
-        'c3BvbnNlEkwKCUxpc3RVdHhvcxIeLnRydXRoY29pbi52MS5MaXN0VXR4b3NSZXF1ZXN0Gh8udH'
-        'J1dGhjb2luLnYxLkxpc3RVdHhvc1Jlc3BvbnNlEmQKEVJlbW92ZUZyb21NZW1wb29sEiYudHJ1'
-        'dGhjb2luLnYxLlJlbW92ZUZyb21NZW1wb29sUmVxdWVzdBonLnRydXRoY29pbi52MS5SZW1vdm'
-        'VGcm9tTWVtcG9vbFJlc3BvbnNlEqABCiVHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxl'
-        'SGVpZ2h0EjoudHJ1dGhjb2luLnYxLkdldExhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZW'
-        'lnaHRSZXF1ZXN0GjsudHJ1dGhjb2luLnYxLkdldExhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5k'
-        'bGVIZWlnaHRSZXNwb25zZRJhChBHZW5lcmF0ZU1uZW1vbmljEiUudHJ1dGhjb2luLnYxLkdlbm'
-        'VyYXRlTW5lbW9uaWNSZXF1ZXN0GiYudHJ1dGhjb2luLnYxLkdlbmVyYXRlTW5lbW9uaWNSZXNw'
-        'b25zZRJqChNTZXRTZWVkRnJvbU1uZW1vbmljEigudHJ1dGhjb2luLnYxLlNldFNlZWRGcm9tTW'
-        '5lbW9uaWNSZXF1ZXN0GikudHJ1dGhjb2luLnYxLlNldFNlZWRGcm9tTW5lbW9uaWNSZXNwb25z'
-        'ZRJGCgdDYWxsUmF3EhwudHJ1dGhjb2luLnYxLkNhbGxSYXdSZXF1ZXN0Gh0udHJ1dGhjb2luLn'
-        'YxLkNhbGxSYXdSZXNwb25zZRJYCg1SZWZyZXNoV2FsbGV0EiIudHJ1dGhjb2luLnYxLlJlZnJl'
-        'c2hXYWxsZXRSZXF1ZXN0GiMudHJ1dGhjb2luLnYxLlJlZnJlc2hXYWxsZXRSZXNwb25zZRJbCg'
-        '5HZXRUcmFuc2FjdGlvbhIjLnRydXRoY29pbi52MS5HZXRUcmFuc2FjdGlvblJlcXVlc3QaJC50'
-        'cnV0aGNvaW4udjEuR2V0VHJhbnNhY3Rpb25SZXNwb25zZRJnChJHZXRUcmFuc2FjdGlvbkluZm'
-        '8SJy50cnV0aGNvaW4udjEuR2V0VHJhbnNhY3Rpb25JbmZvUmVxdWVzdBooLnRydXRoY29pbi52'
-        'MS5HZXRUcmFuc2FjdGlvbkluZm9SZXNwb25zZRJnChJHZXRXYWxsZXRBZGRyZXNzZXMSJy50cn'
-        'V0aGNvaW4udjEuR2V0V2FsbGV0QWRkcmVzc2VzUmVxdWVzdBooLnRydXRoY29pbi52MS5HZXRX'
-        'YWxsZXRBZGRyZXNzZXNSZXNwb25zZRJGCgdNeVV0eG9zEhwudHJ1dGhjb2luLnYxLk15VXR4b3'
-        'NSZXF1ZXN0Gh0udHJ1dGhjb2luLnYxLk15VXR4b3NSZXNwb25zZRJnChJNeVVuY29uZmlybWVk'
-        'VXR4b3MSJy50cnV0aGNvaW4udjEuTXlVbmNvbmZpcm1lZFV0eG9zUmVxdWVzdBooLnRydXRoY2'
-        '9pbi52MS5NeVVuY29uZmlybWVkVXR4b3NSZXNwb25zZRJ8ChlDYWxjdWxhdGVJbml0aWFsTGlx'
-        'dWlkaXR5Ei4udHJ1dGhjb2luLnYxLkNhbGN1bGF0ZUluaXRpYWxMaXF1aWRpdHlSZXF1ZXN0Gi'
-        '8udHJ1dGhjb2luLnYxLkNhbGN1bGF0ZUluaXRpYWxMaXF1aWRpdHlSZXNwb25zZRJVCgxNYXJr'
-        'ZXRDcmVhdGUSIS50cnV0aGNvaW4udjEuTWFya2V0Q3JlYXRlUmVxdWVzdBoiLnRydXRoY29pbi'
-        '52MS5NYXJrZXRDcmVhdGVSZXNwb25zZRJPCgpNYXJrZXRMaXN0Eh8udHJ1dGhjb2luLnYxLk1h'
-        'cmtldExpc3RSZXF1ZXN0GiAudHJ1dGhjb2luLnYxLk1hcmtldExpc3RSZXNwb25zZRJMCglNYX'
-        'JrZXRHZXQSHi50cnV0aGNvaW4udjEuTWFya2V0R2V0UmVxdWVzdBofLnRydXRoY29pbi52MS5N'
-        'YXJrZXRHZXRSZXNwb25zZRJMCglNYXJrZXRCdXkSHi50cnV0aGNvaW4udjEuTWFya2V0QnV5Um'
-        'VxdWVzdBofLnRydXRoY29pbi52MS5NYXJrZXRCdXlSZXNwb25zZRJPCgpNYXJrZXRTZWxsEh8u'
-        'dHJ1dGhjb2luLnYxLk1hcmtldFNlbGxSZXF1ZXN0GiAudHJ1dGhjb2luLnYxLk1hcmtldFNlbG'
-        'xSZXNwb25zZRJeCg9NYXJrZXRQb3NpdGlvbnMSJC50cnV0aGNvaW4udjEuTWFya2V0UG9zaXRp'
-        'b25zUmVxdWVzdBolLnRydXRoY29pbi52MS5NYXJrZXRQb3NpdGlvbnNSZXNwb25zZRJPCgpTbG'
-        '90U3RhdHVzEh8udHJ1dGhjb2luLnYxLlNsb3RTdGF0dXNSZXF1ZXN0GiAudHJ1dGhjb2luLnYx'
-        'LlNsb3RTdGF0dXNSZXNwb25zZRJJCghTbG90TGlzdBIdLnRydXRoY29pbi52MS5TbG90TGlzdF'
-        'JlcXVlc3QaHi50cnV0aGNvaW4udjEuU2xvdExpc3RSZXNwb25zZRJGCgdTbG90R2V0EhwudHJ1'
-        'dGhjb2luLnYxLlNsb3RHZXRSZXF1ZXN0Gh0udHJ1dGhjb2luLnYxLlNsb3RHZXRSZXNwb25zZR'
-        'JMCglTbG90Q2xhaW0SHi50cnV0aGNvaW4udjEuU2xvdENsYWltUmVxdWVzdBofLnRydXRoY29p'
-        'bi52MS5TbG90Q2xhaW1SZXNwb25zZRJkChFTbG90Q2xhaW1DYXRlZ29yeRImLnRydXRoY29pbi'
-        '52MS5TbG90Q2xhaW1DYXRlZ29yeVJlcXVlc3QaJy50cnV0aGNvaW4udjEuU2xvdENsYWltQ2F0'
-        'ZWdvcnlSZXNwb25zZRJVCgxWb3RlUmVnaXN0ZXISIS50cnV0aGNvaW4udjEuVm90ZVJlZ2lzdG'
-        'VyUmVxdWVzdBoiLnRydXRoY29pbi52MS5Wb3RlUmVnaXN0ZXJSZXNwb25zZRJMCglWb3RlVm90'
-        'ZXISHi50cnV0aGNvaW4udjEuVm90ZVZvdGVyUmVxdWVzdBofLnRydXRoY29pbi52MS5Wb3RlVm'
-        '90ZXJSZXNwb25zZRJPCgpWb3RlVm90ZXJzEh8udHJ1dGhjb2luLnYxLlZvdGVWb3RlcnNSZXF1'
-        'ZXN0GiAudHJ1dGhjb2luLnYxLlZvdGVWb3RlcnNSZXNwb25zZRJPCgpWb3RlU3VibWl0Eh8udH'
-        'J1dGhjb2luLnYxLlZvdGVTdWJtaXRSZXF1ZXN0GiAudHJ1dGhjb2luLnYxLlZvdGVTdWJtaXRS'
-        'ZXNwb25zZRJJCghWb3RlTGlzdBIdLnRydXRoY29pbi52MS5Wb3RlTGlzdFJlcXVlc3QaHi50cn'
-        'V0aGNvaW4udjEuVm90ZUxpc3RSZXNwb25zZRJPCgpWb3RlUGVyaW9kEh8udHJ1dGhjb2luLnYx'
-        'LlZvdGVQZXJpb2RSZXF1ZXN0GiAudHJ1dGhjb2luLnYxLlZvdGVQZXJpb2RSZXNwb25zZRJhCh'
-        'BWb3RlY29pblRyYW5zZmVyEiUudHJ1dGhjb2luLnYxLlZvdGVjb2luVHJhbnNmZXJSZXF1ZXN0'
-        'GiYudHJ1dGhjb2luLnYxLlZvdGVjb2luVHJhbnNmZXJSZXNwb25zZRJeCg9Wb3RlY29pbkJhbG'
-        'FuY2USJC50cnV0aGNvaW4udjEuVm90ZWNvaW5CYWxhbmNlUmVxdWVzdBolLnRydXRoY29pbi52'
-        'MS5Wb3RlY29pbkJhbGFuY2VSZXNwb25zZRJhChBUcmFuc2ZlclZvdGVjb2luEiUudHJ1dGhjb2'
-        'luLnYxLlRyYW5zZmVyVm90ZWNvaW5SZXF1ZXN0GiYudHJ1dGhjb2luLnYxLlRyYW5zZmVyVm90'
-        'ZWNvaW5SZXNwb25zZRJqChNHZXROZXdFbmNyeXB0aW9uS2V5EigudHJ1dGhjb2luLnYxLkdldE'
-        '5ld0VuY3J5cHRpb25LZXlSZXF1ZXN0GikudHJ1dGhjb2luLnYxLkdldE5ld0VuY3J5cHRpb25L'
-        'ZXlSZXNwb25zZRJnChJHZXROZXdWZXJpZnlpbmdLZXkSJy50cnV0aGNvaW4udjEuR2V0TmV3Vm'
-        'VyaWZ5aW5nS2V5UmVxdWVzdBooLnRydXRoY29pbi52MS5HZXROZXdWZXJpZnlpbmdLZXlSZXNw'
-        'b25zZRJPCgpFbmNyeXB0TXNnEh8udHJ1dGhjb2luLnYxLkVuY3J5cHRNc2dSZXF1ZXN0GiAudH'
-        'J1dGhjb2luLnYxLkVuY3J5cHRNc2dSZXNwb25zZRJPCgpEZWNyeXB0TXNnEh8udHJ1dGhjb2lu'
-        'LnYxLkRlY3J5cHRNc2dSZXF1ZXN0GiAudHJ1dGhjb2luLnYxLkRlY3J5cHRNc2dSZXNwb25zZR'
-        'JhChBTaWduQXJiaXRyYXJ5TXNnEiUudHJ1dGhjb2luLnYxLlNpZ25BcmJpdHJhcnlNc2dSZXF1'
-        'ZXN0GiYudHJ1dGhjb2luLnYxLlNpZ25BcmJpdHJhcnlNc2dSZXNwb25zZRJzChZTaWduQXJiaX'
-        'RyYXJ5TXNnQXNBZGRyEisudHJ1dGhjb2luLnYxLlNpZ25BcmJpdHJhcnlNc2dBc0FkZHJSZXF1'
-        'ZXN0GiwudHJ1dGhjb2luLnYxLlNpZ25BcmJpdHJhcnlNc2dBc0FkZHJSZXNwb25zZRJeCg9WZX'
-        'JpZnlTaWduYXR1cmUSJC50cnV0aGNvaW4udjEuVmVyaWZ5U2lnbmF0dXJlUmVxdWVzdBolLnRy'
-        'dXRoY29pbi52MS5WZXJpZnlTaWduYXR1cmVSZXNwb25zZQ==');
+final $typed_data.Uint8List truthcoinServiceDescriptor = $convert.base64Decode(
+    'ChBUcnV0aGNvaW5TZXJ2aWNlEk8KCkdldEJhbGFuY2USHy50cnV0aGNvaW4udjEuR2V0QmFsYW'
+    '5jZVJlcXVlc3QaIC50cnV0aGNvaW4udjEuR2V0QmFsYW5jZVJlc3BvbnNlElgKDUdldEJsb2Nr'
+    'Q291bnQSIi50cnV0aGNvaW4udjEuR2V0QmxvY2tDb3VudFJlcXVlc3QaIy50cnV0aGNvaW4udj'
+    'EuR2V0QmxvY2tDb3VudFJlc3BvbnNlEj0KBFN0b3ASGS50cnV0aGNvaW4udjEuU3RvcFJlcXVl'
+    'c3QaGi50cnV0aGNvaW4udjEuU3RvcFJlc3BvbnNlElgKDUdldE5ld0FkZHJlc3MSIi50cnV0aG'
+    'NvaW4udjEuR2V0TmV3QWRkcmVzc1JlcXVlc3QaIy50cnV0aGNvaW4udjEuR2V0TmV3QWRkcmVz'
+    'c1Jlc3BvbnNlEkkKCFdpdGhkcmF3Eh0udHJ1dGhjb2luLnYxLldpdGhkcmF3UmVxdWVzdBoeLn'
+    'RydXRoY29pbi52MS5XaXRoZHJhd1Jlc3BvbnNlEkkKCFRyYW5zZmVyEh0udHJ1dGhjb2luLnYx'
+    'LlRyYW5zZmVyUmVxdWVzdBoeLnRydXRoY29pbi52MS5UcmFuc2ZlclJlc3BvbnNlEmcKEkdldF'
+    'NpZGVjaGFpbldlYWx0aBInLnRydXRoY29pbi52MS5HZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0'
+    'GigudHJ1dGhjb2luLnYxLkdldFNpZGVjaGFpbldlYWx0aFJlc3BvbnNlElgKDUNyZWF0ZURlcG'
+    '9zaXQSIi50cnV0aGNvaW4udjEuQ3JlYXRlRGVwb3NpdFJlcXVlc3QaIy50cnV0aGNvaW4udjEu'
+    'Q3JlYXRlRGVwb3NpdFJlc3BvbnNlEn8KGkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlEi8udH'
+    'J1dGhjb2luLnYxLkdldFBlbmRpbmdXaXRoZHJhd2FsQnVuZGxlUmVxdWVzdBowLnRydXRoY29p'
+    'bi52MS5HZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlElIKC0Nvbm5lY3RQZWVyEi'
+    'AudHJ1dGhjb2luLnYxLkNvbm5lY3RQZWVyUmVxdWVzdBohLnRydXRoY29pbi52MS5Db25uZWN0'
+    'UGVlclJlc3BvbnNlEkwKCUxpc3RQZWVycxIeLnRydXRoY29pbi52MS5MaXN0UGVlcnNSZXF1ZX'
+    'N0Gh8udHJ1dGhjb2luLnYxLkxpc3RQZWVyc1Jlc3BvbnNlEj0KBE1pbmUSGS50cnV0aGNvaW4u'
+    'djEuTWluZVJlcXVlc3QaGi50cnV0aGNvaW4udjEuTWluZVJlc3BvbnNlEkkKCEdldEJsb2NrEh'
+    '0udHJ1dGhjb2luLnYxLkdldEJsb2NrUmVxdWVzdBoeLnRydXRoY29pbi52MS5HZXRCbG9ja1Jl'
+    'c3BvbnNlEnwKGUdldEJlc3RNYWluY2hhaW5CbG9ja0hhc2gSLi50cnV0aGNvaW4udjEuR2V0Qm'
+    'VzdE1haW5jaGFpbkJsb2NrSGFzaFJlcXVlc3QaLy50cnV0aGNvaW4udjEuR2V0QmVzdE1haW5j'
+    'aGFpbkJsb2NrSGFzaFJlc3BvbnNlEnwKGUdldEJlc3RTaWRlY2hhaW5CbG9ja0hhc2gSLi50cn'
+    'V0aGNvaW4udjEuR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaFJlcXVlc3QaLy50cnV0aGNvaW4u'
+    'djEuR2V0QmVzdFNpZGVjaGFpbkJsb2NrSGFzaFJlc3BvbnNlEmEKEEdldEJtbUluY2x1c2lvbn'
+    'MSJS50cnV0aGNvaW4udjEuR2V0Qm1tSW5jbHVzaW9uc1JlcXVlc3QaJi50cnV0aGNvaW4udjEu'
+    'R2V0Qm1tSW5jbHVzaW9uc1Jlc3BvbnNlElsKDkdldFdhbGxldFV0eG9zEiMudHJ1dGhjb2luLn'
+    'YxLkdldFdhbGxldFV0eG9zUmVxdWVzdBokLnRydXRoY29pbi52MS5HZXRXYWxsZXRVdHhvc1Jl'
+    'c3BvbnNlEkwKCUxpc3RVdHhvcxIeLnRydXRoY29pbi52MS5MaXN0VXR4b3NSZXF1ZXN0Gh8udH'
+    'J1dGhjb2luLnYxLkxpc3RVdHhvc1Jlc3BvbnNlEmQKEVJlbW92ZUZyb21NZW1wb29sEiYudHJ1'
+    'dGhjb2luLnYxLlJlbW92ZUZyb21NZW1wb29sUmVxdWVzdBonLnRydXRoY29pbi52MS5SZW1vdm'
+    'VGcm9tTWVtcG9vbFJlc3BvbnNlEqABCiVHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxl'
+    'SGVpZ2h0EjoudHJ1dGhjb2luLnYxLkdldExhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZW'
+    'lnaHRSZXF1ZXN0GjsudHJ1dGhjb2luLnYxLkdldExhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5k'
+    'bGVIZWlnaHRSZXNwb25zZRJhChBHZW5lcmF0ZU1uZW1vbmljEiUudHJ1dGhjb2luLnYxLkdlbm'
+    'VyYXRlTW5lbW9uaWNSZXF1ZXN0GiYudHJ1dGhjb2luLnYxLkdlbmVyYXRlTW5lbW9uaWNSZXNw'
+    'b25zZRJqChNTZXRTZWVkRnJvbU1uZW1vbmljEigudHJ1dGhjb2luLnYxLlNldFNlZWRGcm9tTW'
+    '5lbW9uaWNSZXF1ZXN0GikudHJ1dGhjb2luLnYxLlNldFNlZWRGcm9tTW5lbW9uaWNSZXNwb25z'
+    'ZRJGCgdDYWxsUmF3EhwudHJ1dGhjb2luLnYxLkNhbGxSYXdSZXF1ZXN0Gh0udHJ1dGhjb2luLn'
+    'YxLkNhbGxSYXdSZXNwb25zZRJYCg1SZWZyZXNoV2FsbGV0EiIudHJ1dGhjb2luLnYxLlJlZnJl'
+    'c2hXYWxsZXRSZXF1ZXN0GiMudHJ1dGhjb2luLnYxLlJlZnJlc2hXYWxsZXRSZXNwb25zZRJbCg'
+    '5HZXRUcmFuc2FjdGlvbhIjLnRydXRoY29pbi52MS5HZXRUcmFuc2FjdGlvblJlcXVlc3QaJC50'
+    'cnV0aGNvaW4udjEuR2V0VHJhbnNhY3Rpb25SZXNwb25zZRJnChJHZXRUcmFuc2FjdGlvbkluZm'
+    '8SJy50cnV0aGNvaW4udjEuR2V0VHJhbnNhY3Rpb25JbmZvUmVxdWVzdBooLnRydXRoY29pbi52'
+    'MS5HZXRUcmFuc2FjdGlvbkluZm9SZXNwb25zZRJnChJHZXRXYWxsZXRBZGRyZXNzZXMSJy50cn'
+    'V0aGNvaW4udjEuR2V0V2FsbGV0QWRkcmVzc2VzUmVxdWVzdBooLnRydXRoY29pbi52MS5HZXRX'
+    'YWxsZXRBZGRyZXNzZXNSZXNwb25zZRJGCgdNeVV0eG9zEhwudHJ1dGhjb2luLnYxLk15VXR4b3'
+    'NSZXF1ZXN0Gh0udHJ1dGhjb2luLnYxLk15VXR4b3NSZXNwb25zZRJnChJNeVVuY29uZmlybWVk'
+    'VXR4b3MSJy50cnV0aGNvaW4udjEuTXlVbmNvbmZpcm1lZFV0eG9zUmVxdWVzdBooLnRydXRoY2'
+    '9pbi52MS5NeVVuY29uZmlybWVkVXR4b3NSZXNwb25zZRJ8ChlDYWxjdWxhdGVJbml0aWFsTGlx'
+    'dWlkaXR5Ei4udHJ1dGhjb2luLnYxLkNhbGN1bGF0ZUluaXRpYWxMaXF1aWRpdHlSZXF1ZXN0Gi'
+    '8udHJ1dGhjb2luLnYxLkNhbGN1bGF0ZUluaXRpYWxMaXF1aWRpdHlSZXNwb25zZRJVCgxNYXJr'
+    'ZXRDcmVhdGUSIS50cnV0aGNvaW4udjEuTWFya2V0Q3JlYXRlUmVxdWVzdBoiLnRydXRoY29pbi'
+    '52MS5NYXJrZXRDcmVhdGVSZXNwb25zZRJPCgpNYXJrZXRMaXN0Eh8udHJ1dGhjb2luLnYxLk1h'
+    'cmtldExpc3RSZXF1ZXN0GiAudHJ1dGhjb2luLnYxLk1hcmtldExpc3RSZXNwb25zZRJMCglNYX'
+    'JrZXRHZXQSHi50cnV0aGNvaW4udjEuTWFya2V0R2V0UmVxdWVzdBofLnRydXRoY29pbi52MS5N'
+    'YXJrZXRHZXRSZXNwb25zZRJMCglNYXJrZXRCdXkSHi50cnV0aGNvaW4udjEuTWFya2V0QnV5Um'
+    'VxdWVzdBofLnRydXRoY29pbi52MS5NYXJrZXRCdXlSZXNwb25zZRJPCgpNYXJrZXRTZWxsEh8u'
+    'dHJ1dGhjb2luLnYxLk1hcmtldFNlbGxSZXF1ZXN0GiAudHJ1dGhjb2luLnYxLk1hcmtldFNlbG'
+    'xSZXNwb25zZRJeCg9NYXJrZXRQb3NpdGlvbnMSJC50cnV0aGNvaW4udjEuTWFya2V0UG9zaXRp'
+    'b25zUmVxdWVzdBolLnRydXRoY29pbi52MS5NYXJrZXRQb3NpdGlvbnNSZXNwb25zZRJPCgpTbG'
+    '90U3RhdHVzEh8udHJ1dGhjb2luLnYxLlNsb3RTdGF0dXNSZXF1ZXN0GiAudHJ1dGhjb2luLnYx'
+    'LlNsb3RTdGF0dXNSZXNwb25zZRJJCghTbG90TGlzdBIdLnRydXRoY29pbi52MS5TbG90TGlzdF'
+    'JlcXVlc3QaHi50cnV0aGNvaW4udjEuU2xvdExpc3RSZXNwb25zZRJGCgdTbG90R2V0EhwudHJ1'
+    'dGhjb2luLnYxLlNsb3RHZXRSZXF1ZXN0Gh0udHJ1dGhjb2luLnYxLlNsb3RHZXRSZXNwb25zZR'
+    'JMCglTbG90Q2xhaW0SHi50cnV0aGNvaW4udjEuU2xvdENsYWltUmVxdWVzdBofLnRydXRoY29p'
+    'bi52MS5TbG90Q2xhaW1SZXNwb25zZRJkChFTbG90Q2xhaW1DYXRlZ29yeRImLnRydXRoY29pbi'
+    '52MS5TbG90Q2xhaW1DYXRlZ29yeVJlcXVlc3QaJy50cnV0aGNvaW4udjEuU2xvdENsYWltQ2F0'
+    'ZWdvcnlSZXNwb25zZRJVCgxWb3RlUmVnaXN0ZXISIS50cnV0aGNvaW4udjEuVm90ZVJlZ2lzdG'
+    'VyUmVxdWVzdBoiLnRydXRoY29pbi52MS5Wb3RlUmVnaXN0ZXJSZXNwb25zZRJMCglWb3RlVm90'
+    'ZXISHi50cnV0aGNvaW4udjEuVm90ZVZvdGVyUmVxdWVzdBofLnRydXRoY29pbi52MS5Wb3RlVm'
+    '90ZXJSZXNwb25zZRJPCgpWb3RlVm90ZXJzEh8udHJ1dGhjb2luLnYxLlZvdGVWb3RlcnNSZXF1'
+    'ZXN0GiAudHJ1dGhjb2luLnYxLlZvdGVWb3RlcnNSZXNwb25zZRJPCgpWb3RlU3VibWl0Eh8udH'
+    'J1dGhjb2luLnYxLlZvdGVTdWJtaXRSZXF1ZXN0GiAudHJ1dGhjb2luLnYxLlZvdGVTdWJtaXRS'
+    'ZXNwb25zZRJJCghWb3RlTGlzdBIdLnRydXRoY29pbi52MS5Wb3RlTGlzdFJlcXVlc3QaHi50cn'
+    'V0aGNvaW4udjEuVm90ZUxpc3RSZXNwb25zZRJPCgpWb3RlUGVyaW9kEh8udHJ1dGhjb2luLnYx'
+    'LlZvdGVQZXJpb2RSZXF1ZXN0GiAudHJ1dGhjb2luLnYxLlZvdGVQZXJpb2RSZXNwb25zZRJhCh'
+    'BWb3RlY29pblRyYW5zZmVyEiUudHJ1dGhjb2luLnYxLlZvdGVjb2luVHJhbnNmZXJSZXF1ZXN0'
+    'GiYudHJ1dGhjb2luLnYxLlZvdGVjb2luVHJhbnNmZXJSZXNwb25zZRJeCg9Wb3RlY29pbkJhbG'
+    'FuY2USJC50cnV0aGNvaW4udjEuVm90ZWNvaW5CYWxhbmNlUmVxdWVzdBolLnRydXRoY29pbi52'
+    'MS5Wb3RlY29pbkJhbGFuY2VSZXNwb25zZRJhChBUcmFuc2ZlclZvdGVjb2luEiUudHJ1dGhjb2'
+    'luLnYxLlRyYW5zZmVyVm90ZWNvaW5SZXF1ZXN0GiYudHJ1dGhjb2luLnYxLlRyYW5zZmVyVm90'
+    'ZWNvaW5SZXNwb25zZRJqChNHZXROZXdFbmNyeXB0aW9uS2V5EigudHJ1dGhjb2luLnYxLkdldE'
+    '5ld0VuY3J5cHRpb25LZXlSZXF1ZXN0GikudHJ1dGhjb2luLnYxLkdldE5ld0VuY3J5cHRpb25L'
+    'ZXlSZXNwb25zZRJnChJHZXROZXdWZXJpZnlpbmdLZXkSJy50cnV0aGNvaW4udjEuR2V0TmV3Vm'
+    'VyaWZ5aW5nS2V5UmVxdWVzdBooLnRydXRoY29pbi52MS5HZXROZXdWZXJpZnlpbmdLZXlSZXNw'
+    'b25zZRJPCgpFbmNyeXB0TXNnEh8udHJ1dGhjb2luLnYxLkVuY3J5cHRNc2dSZXF1ZXN0GiAudH'
+    'J1dGhjb2luLnYxLkVuY3J5cHRNc2dSZXNwb25zZRJPCgpEZWNyeXB0TXNnEh8udHJ1dGhjb2lu'
+    'LnYxLkRlY3J5cHRNc2dSZXF1ZXN0GiAudHJ1dGhjb2luLnYxLkRlY3J5cHRNc2dSZXNwb25zZR'
+    'JhChBTaWduQXJiaXRyYXJ5TXNnEiUudHJ1dGhjb2luLnYxLlNpZ25BcmJpdHJhcnlNc2dSZXF1'
+    'ZXN0GiYudHJ1dGhjb2luLnYxLlNpZ25BcmJpdHJhcnlNc2dSZXNwb25zZRJzChZTaWduQXJiaX'
+    'RyYXJ5TXNnQXNBZGRyEisudHJ1dGhjb2luLnYxLlNpZ25BcmJpdHJhcnlNc2dBc0FkZHJSZXF1'
+    'ZXN0GiwudHJ1dGhjb2luLnYxLlNpZ25BcmJpdHJhcnlNc2dBc0FkZHJSZXNwb25zZRJeCg9WZX'
+    'JpZnlTaWduYXR1cmUSJC50cnV0aGNvaW4udjEuVmVyaWZ5U2lnbmF0dXJlUmVxdWVzdBolLnRy'
+    'dXRoY29pbi52MS5WZXJpZnlTaWduYXR1cmVSZXNwb25zZQ==');
+

--- a/sail_ui/lib/gen/truthcoin/v1/truthcoin.pbserver.dart
+++ b/sail_ui/lib/gen/truthcoin/v1/truthcoin.pbserver.dart
@@ -27,43 +27,30 @@ abstract class TruthcoinServiceBase extends $pb.GeneratedService {
   $async.Future<$11.GetNewAddressResponse> getNewAddress($pb.ServerContext ctx, $11.GetNewAddressRequest request);
   $async.Future<$11.WithdrawResponse> withdraw($pb.ServerContext ctx, $11.WithdrawRequest request);
   $async.Future<$11.TransferResponse> transfer($pb.ServerContext ctx, $11.TransferRequest request);
-  $async.Future<$11.GetSidechainWealthResponse> getSidechainWealth(
-      $pb.ServerContext ctx, $11.GetSidechainWealthRequest request);
+  $async.Future<$11.GetSidechainWealthResponse> getSidechainWealth($pb.ServerContext ctx, $11.GetSidechainWealthRequest request);
   $async.Future<$11.CreateDepositResponse> createDeposit($pb.ServerContext ctx, $11.CreateDepositRequest request);
-  $async.Future<$11.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-      $pb.ServerContext ctx, $11.GetPendingWithdrawalBundleRequest request);
+  $async.Future<$11.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ServerContext ctx, $11.GetPendingWithdrawalBundleRequest request);
   $async.Future<$11.ConnectPeerResponse> connectPeer($pb.ServerContext ctx, $11.ConnectPeerRequest request);
   $async.Future<$11.ListPeersResponse> listPeers($pb.ServerContext ctx, $11.ListPeersRequest request);
   $async.Future<$11.MineResponse> mine($pb.ServerContext ctx, $11.MineRequest request);
   $async.Future<$11.GetBlockResponse> getBlock($pb.ServerContext ctx, $11.GetBlockRequest request);
-  $async.Future<$11.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-      $pb.ServerContext ctx, $11.GetBestMainchainBlockHashRequest request);
-  $async.Future<$11.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-      $pb.ServerContext ctx, $11.GetBestSidechainBlockHashRequest request);
-  $async.Future<$11.GetBmmInclusionsResponse> getBmmInclusions(
-      $pb.ServerContext ctx, $11.GetBmmInclusionsRequest request);
+  $async.Future<$11.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ServerContext ctx, $11.GetBestMainchainBlockHashRequest request);
+  $async.Future<$11.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ServerContext ctx, $11.GetBestSidechainBlockHashRequest request);
+  $async.Future<$11.GetBmmInclusionsResponse> getBmmInclusions($pb.ServerContext ctx, $11.GetBmmInclusionsRequest request);
   $async.Future<$11.GetWalletUtxosResponse> getWalletUtxos($pb.ServerContext ctx, $11.GetWalletUtxosRequest request);
   $async.Future<$11.ListUtxosResponse> listUtxos($pb.ServerContext ctx, $11.ListUtxosRequest request);
-  $async.Future<$11.RemoveFromMempoolResponse> removeFromMempool(
-      $pb.ServerContext ctx, $11.RemoveFromMempoolRequest request);
-  $async.Future<$11.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-      $pb.ServerContext ctx, $11.GetLatestFailedWithdrawalBundleHeightRequest request);
-  $async.Future<$11.GenerateMnemonicResponse> generateMnemonic(
-      $pb.ServerContext ctx, $11.GenerateMnemonicRequest request);
-  $async.Future<$11.SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-      $pb.ServerContext ctx, $11.SetSeedFromMnemonicRequest request);
+  $async.Future<$11.RemoveFromMempoolResponse> removeFromMempool($pb.ServerContext ctx, $11.RemoveFromMempoolRequest request);
+  $async.Future<$11.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ServerContext ctx, $11.GetLatestFailedWithdrawalBundleHeightRequest request);
+  $async.Future<$11.GenerateMnemonicResponse> generateMnemonic($pb.ServerContext ctx, $11.GenerateMnemonicRequest request);
+  $async.Future<$11.SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ServerContext ctx, $11.SetSeedFromMnemonicRequest request);
   $async.Future<$11.CallRawResponse> callRaw($pb.ServerContext ctx, $11.CallRawRequest request);
   $async.Future<$11.RefreshWalletResponse> refreshWallet($pb.ServerContext ctx, $11.RefreshWalletRequest request);
   $async.Future<$11.GetTransactionResponse> getTransaction($pb.ServerContext ctx, $11.GetTransactionRequest request);
-  $async.Future<$11.GetTransactionInfoResponse> getTransactionInfo(
-      $pb.ServerContext ctx, $11.GetTransactionInfoRequest request);
-  $async.Future<$11.GetWalletAddressesResponse> getWalletAddresses(
-      $pb.ServerContext ctx, $11.GetWalletAddressesRequest request);
+  $async.Future<$11.GetTransactionInfoResponse> getTransactionInfo($pb.ServerContext ctx, $11.GetTransactionInfoRequest request);
+  $async.Future<$11.GetWalletAddressesResponse> getWalletAddresses($pb.ServerContext ctx, $11.GetWalletAddressesRequest request);
   $async.Future<$11.MyUtxosResponse> myUtxos($pb.ServerContext ctx, $11.MyUtxosRequest request);
-  $async.Future<$11.MyUnconfirmedUtxosResponse> myUnconfirmedUtxos(
-      $pb.ServerContext ctx, $11.MyUnconfirmedUtxosRequest request);
-  $async.Future<$11.CalculateInitialLiquidityResponse> calculateInitialLiquidity(
-      $pb.ServerContext ctx, $11.CalculateInitialLiquidityRequest request);
+  $async.Future<$11.MyUnconfirmedUtxosResponse> myUnconfirmedUtxos($pb.ServerContext ctx, $11.MyUnconfirmedUtxosRequest request);
+  $async.Future<$11.CalculateInitialLiquidityResponse> calculateInitialLiquidity($pb.ServerContext ctx, $11.CalculateInitialLiquidityRequest request);
   $async.Future<$11.MarketCreateResponse> marketCreate($pb.ServerContext ctx, $11.MarketCreateRequest request);
   $async.Future<$11.MarketListResponse> marketList($pb.ServerContext ctx, $11.MarketListRequest request);
   $async.Future<$11.MarketGetResponse> marketGet($pb.ServerContext ctx, $11.MarketGetRequest request);
@@ -74,275 +61,151 @@ abstract class TruthcoinServiceBase extends $pb.GeneratedService {
   $async.Future<$11.SlotListResponse> slotList($pb.ServerContext ctx, $11.SlotListRequest request);
   $async.Future<$11.SlotGetResponse> slotGet($pb.ServerContext ctx, $11.SlotGetRequest request);
   $async.Future<$11.SlotClaimResponse> slotClaim($pb.ServerContext ctx, $11.SlotClaimRequest request);
-  $async.Future<$11.SlotClaimCategoryResponse> slotClaimCategory(
-      $pb.ServerContext ctx, $11.SlotClaimCategoryRequest request);
+  $async.Future<$11.SlotClaimCategoryResponse> slotClaimCategory($pb.ServerContext ctx, $11.SlotClaimCategoryRequest request);
   $async.Future<$11.VoteRegisterResponse> voteRegister($pb.ServerContext ctx, $11.VoteRegisterRequest request);
   $async.Future<$11.VoteVoterResponse> voteVoter($pb.ServerContext ctx, $11.VoteVoterRequest request);
   $async.Future<$11.VoteVotersResponse> voteVoters($pb.ServerContext ctx, $11.VoteVotersRequest request);
   $async.Future<$11.VoteSubmitResponse> voteSubmit($pb.ServerContext ctx, $11.VoteSubmitRequest request);
   $async.Future<$11.VoteListResponse> voteList($pb.ServerContext ctx, $11.VoteListRequest request);
   $async.Future<$11.VotePeriodResponse> votePeriod($pb.ServerContext ctx, $11.VotePeriodRequest request);
-  $async.Future<$11.VotecoinTransferResponse> votecoinTransfer(
-      $pb.ServerContext ctx, $11.VotecoinTransferRequest request);
+  $async.Future<$11.VotecoinTransferResponse> votecoinTransfer($pb.ServerContext ctx, $11.VotecoinTransferRequest request);
   $async.Future<$11.VotecoinBalanceResponse> votecoinBalance($pb.ServerContext ctx, $11.VotecoinBalanceRequest request);
-  $async.Future<$11.TransferVotecoinResponse> transferVotecoin(
-      $pb.ServerContext ctx, $11.TransferVotecoinRequest request);
-  $async.Future<$11.GetNewEncryptionKeyResponse> getNewEncryptionKey(
-      $pb.ServerContext ctx, $11.GetNewEncryptionKeyRequest request);
-  $async.Future<$11.GetNewVerifyingKeyResponse> getNewVerifyingKey(
-      $pb.ServerContext ctx, $11.GetNewVerifyingKeyRequest request);
+  $async.Future<$11.TransferVotecoinResponse> transferVotecoin($pb.ServerContext ctx, $11.TransferVotecoinRequest request);
+  $async.Future<$11.GetNewEncryptionKeyResponse> getNewEncryptionKey($pb.ServerContext ctx, $11.GetNewEncryptionKeyRequest request);
+  $async.Future<$11.GetNewVerifyingKeyResponse> getNewVerifyingKey($pb.ServerContext ctx, $11.GetNewVerifyingKeyRequest request);
   $async.Future<$11.EncryptMsgResponse> encryptMsg($pb.ServerContext ctx, $11.EncryptMsgRequest request);
   $async.Future<$11.DecryptMsgResponse> decryptMsg($pb.ServerContext ctx, $11.DecryptMsgRequest request);
-  $async.Future<$11.SignArbitraryMsgResponse> signArbitraryMsg(
-      $pb.ServerContext ctx, $11.SignArbitraryMsgRequest request);
-  $async.Future<$11.SignArbitraryMsgAsAddrResponse> signArbitraryMsgAsAddr(
-      $pb.ServerContext ctx, $11.SignArbitraryMsgAsAddrRequest request);
+  $async.Future<$11.SignArbitraryMsgResponse> signArbitraryMsg($pb.ServerContext ctx, $11.SignArbitraryMsgRequest request);
+  $async.Future<$11.SignArbitraryMsgAsAddrResponse> signArbitraryMsgAsAddr($pb.ServerContext ctx, $11.SignArbitraryMsgAsAddrRequest request);
   $async.Future<$11.VerifySignatureResponse> verifySignature($pb.ServerContext ctx, $11.VerifySignatureRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetBalance':
-        return $11.GetBalanceRequest();
-      case 'GetBlockCount':
-        return $11.GetBlockCountRequest();
-      case 'Stop':
-        return $11.StopRequest();
-      case 'GetNewAddress':
-        return $11.GetNewAddressRequest();
-      case 'Withdraw':
-        return $11.WithdrawRequest();
-      case 'Transfer':
-        return $11.TransferRequest();
-      case 'GetSidechainWealth':
-        return $11.GetSidechainWealthRequest();
-      case 'CreateDeposit':
-        return $11.CreateDepositRequest();
-      case 'GetPendingWithdrawalBundle':
-        return $11.GetPendingWithdrawalBundleRequest();
-      case 'ConnectPeer':
-        return $11.ConnectPeerRequest();
-      case 'ListPeers':
-        return $11.ListPeersRequest();
-      case 'Mine':
-        return $11.MineRequest();
-      case 'GetBlock':
-        return $11.GetBlockRequest();
-      case 'GetBestMainchainBlockHash':
-        return $11.GetBestMainchainBlockHashRequest();
-      case 'GetBestSidechainBlockHash':
-        return $11.GetBestSidechainBlockHashRequest();
-      case 'GetBmmInclusions':
-        return $11.GetBmmInclusionsRequest();
-      case 'GetWalletUtxos':
-        return $11.GetWalletUtxosRequest();
-      case 'ListUtxos':
-        return $11.ListUtxosRequest();
-      case 'RemoveFromMempool':
-        return $11.RemoveFromMempoolRequest();
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return $11.GetLatestFailedWithdrawalBundleHeightRequest();
-      case 'GenerateMnemonic':
-        return $11.GenerateMnemonicRequest();
-      case 'SetSeedFromMnemonic':
-        return $11.SetSeedFromMnemonicRequest();
-      case 'CallRaw':
-        return $11.CallRawRequest();
-      case 'RefreshWallet':
-        return $11.RefreshWalletRequest();
-      case 'GetTransaction':
-        return $11.GetTransactionRequest();
-      case 'GetTransactionInfo':
-        return $11.GetTransactionInfoRequest();
-      case 'GetWalletAddresses':
-        return $11.GetWalletAddressesRequest();
-      case 'MyUtxos':
-        return $11.MyUtxosRequest();
-      case 'MyUnconfirmedUtxos':
-        return $11.MyUnconfirmedUtxosRequest();
-      case 'CalculateInitialLiquidity':
-        return $11.CalculateInitialLiquidityRequest();
-      case 'MarketCreate':
-        return $11.MarketCreateRequest();
-      case 'MarketList':
-        return $11.MarketListRequest();
-      case 'MarketGet':
-        return $11.MarketGetRequest();
-      case 'MarketBuy':
-        return $11.MarketBuyRequest();
-      case 'MarketSell':
-        return $11.MarketSellRequest();
-      case 'MarketPositions':
-        return $11.MarketPositionsRequest();
-      case 'SlotStatus':
-        return $11.SlotStatusRequest();
-      case 'SlotList':
-        return $11.SlotListRequest();
-      case 'SlotGet':
-        return $11.SlotGetRequest();
-      case 'SlotClaim':
-        return $11.SlotClaimRequest();
-      case 'SlotClaimCategory':
-        return $11.SlotClaimCategoryRequest();
-      case 'VoteRegister':
-        return $11.VoteRegisterRequest();
-      case 'VoteVoter':
-        return $11.VoteVoterRequest();
-      case 'VoteVoters':
-        return $11.VoteVotersRequest();
-      case 'VoteSubmit':
-        return $11.VoteSubmitRequest();
-      case 'VoteList':
-        return $11.VoteListRequest();
-      case 'VotePeriod':
-        return $11.VotePeriodRequest();
-      case 'VotecoinTransfer':
-        return $11.VotecoinTransferRequest();
-      case 'VotecoinBalance':
-        return $11.VotecoinBalanceRequest();
-      case 'TransferVotecoin':
-        return $11.TransferVotecoinRequest();
-      case 'GetNewEncryptionKey':
-        return $11.GetNewEncryptionKeyRequest();
-      case 'GetNewVerifyingKey':
-        return $11.GetNewVerifyingKeyRequest();
-      case 'EncryptMsg':
-        return $11.EncryptMsgRequest();
-      case 'DecryptMsg':
-        return $11.DecryptMsgRequest();
-      case 'SignArbitraryMsg':
-        return $11.SignArbitraryMsgRequest();
-      case 'SignArbitraryMsgAsAddr':
-        return $11.SignArbitraryMsgAsAddrRequest();
-      case 'VerifySignature':
-        return $11.VerifySignatureRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return $11.GetBalanceRequest();
+      case 'GetBlockCount': return $11.GetBlockCountRequest();
+      case 'Stop': return $11.StopRequest();
+      case 'GetNewAddress': return $11.GetNewAddressRequest();
+      case 'Withdraw': return $11.WithdrawRequest();
+      case 'Transfer': return $11.TransferRequest();
+      case 'GetSidechainWealth': return $11.GetSidechainWealthRequest();
+      case 'CreateDeposit': return $11.CreateDepositRequest();
+      case 'GetPendingWithdrawalBundle': return $11.GetPendingWithdrawalBundleRequest();
+      case 'ConnectPeer': return $11.ConnectPeerRequest();
+      case 'ListPeers': return $11.ListPeersRequest();
+      case 'Mine': return $11.MineRequest();
+      case 'GetBlock': return $11.GetBlockRequest();
+      case 'GetBestMainchainBlockHash': return $11.GetBestMainchainBlockHashRequest();
+      case 'GetBestSidechainBlockHash': return $11.GetBestSidechainBlockHashRequest();
+      case 'GetBmmInclusions': return $11.GetBmmInclusionsRequest();
+      case 'GetWalletUtxos': return $11.GetWalletUtxosRequest();
+      case 'ListUtxos': return $11.ListUtxosRequest();
+      case 'RemoveFromMempool': return $11.RemoveFromMempoolRequest();
+      case 'GetLatestFailedWithdrawalBundleHeight': return $11.GetLatestFailedWithdrawalBundleHeightRequest();
+      case 'GenerateMnemonic': return $11.GenerateMnemonicRequest();
+      case 'SetSeedFromMnemonic': return $11.SetSeedFromMnemonicRequest();
+      case 'CallRaw': return $11.CallRawRequest();
+      case 'RefreshWallet': return $11.RefreshWalletRequest();
+      case 'GetTransaction': return $11.GetTransactionRequest();
+      case 'GetTransactionInfo': return $11.GetTransactionInfoRequest();
+      case 'GetWalletAddresses': return $11.GetWalletAddressesRequest();
+      case 'MyUtxos': return $11.MyUtxosRequest();
+      case 'MyUnconfirmedUtxos': return $11.MyUnconfirmedUtxosRequest();
+      case 'CalculateInitialLiquidity': return $11.CalculateInitialLiquidityRequest();
+      case 'MarketCreate': return $11.MarketCreateRequest();
+      case 'MarketList': return $11.MarketListRequest();
+      case 'MarketGet': return $11.MarketGetRequest();
+      case 'MarketBuy': return $11.MarketBuyRequest();
+      case 'MarketSell': return $11.MarketSellRequest();
+      case 'MarketPositions': return $11.MarketPositionsRequest();
+      case 'SlotStatus': return $11.SlotStatusRequest();
+      case 'SlotList': return $11.SlotListRequest();
+      case 'SlotGet': return $11.SlotGetRequest();
+      case 'SlotClaim': return $11.SlotClaimRequest();
+      case 'SlotClaimCategory': return $11.SlotClaimCategoryRequest();
+      case 'VoteRegister': return $11.VoteRegisterRequest();
+      case 'VoteVoter': return $11.VoteVoterRequest();
+      case 'VoteVoters': return $11.VoteVotersRequest();
+      case 'VoteSubmit': return $11.VoteSubmitRequest();
+      case 'VoteList': return $11.VoteListRequest();
+      case 'VotePeriod': return $11.VotePeriodRequest();
+      case 'VotecoinTransfer': return $11.VotecoinTransferRequest();
+      case 'VotecoinBalance': return $11.VotecoinBalanceRequest();
+      case 'TransferVotecoin': return $11.TransferVotecoinRequest();
+      case 'GetNewEncryptionKey': return $11.GetNewEncryptionKeyRequest();
+      case 'GetNewVerifyingKey': return $11.GetNewVerifyingKeyRequest();
+      case 'EncryptMsg': return $11.EncryptMsgRequest();
+      case 'DecryptMsg': return $11.DecryptMsgRequest();
+      case 'SignArbitraryMsg': return $11.SignArbitraryMsgRequest();
+      case 'SignArbitraryMsgAsAddr': return $11.SignArbitraryMsgAsAddrRequest();
+      case 'VerifySignature': return $11.VerifySignatureRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetBalance':
-        return this.getBalance(ctx, request as $11.GetBalanceRequest);
-      case 'GetBlockCount':
-        return this.getBlockCount(ctx, request as $11.GetBlockCountRequest);
-      case 'Stop':
-        return this.stop(ctx, request as $11.StopRequest);
-      case 'GetNewAddress':
-        return this.getNewAddress(ctx, request as $11.GetNewAddressRequest);
-      case 'Withdraw':
-        return this.withdraw(ctx, request as $11.WithdrawRequest);
-      case 'Transfer':
-        return this.transfer(ctx, request as $11.TransferRequest);
-      case 'GetSidechainWealth':
-        return this.getSidechainWealth(ctx, request as $11.GetSidechainWealthRequest);
-      case 'CreateDeposit':
-        return this.createDeposit(ctx, request as $11.CreateDepositRequest);
-      case 'GetPendingWithdrawalBundle':
-        return this.getPendingWithdrawalBundle(ctx, request as $11.GetPendingWithdrawalBundleRequest);
-      case 'ConnectPeer':
-        return this.connectPeer(ctx, request as $11.ConnectPeerRequest);
-      case 'ListPeers':
-        return this.listPeers(ctx, request as $11.ListPeersRequest);
-      case 'Mine':
-        return this.mine(ctx, request as $11.MineRequest);
-      case 'GetBlock':
-        return this.getBlock(ctx, request as $11.GetBlockRequest);
-      case 'GetBestMainchainBlockHash':
-        return this.getBestMainchainBlockHash(ctx, request as $11.GetBestMainchainBlockHashRequest);
-      case 'GetBestSidechainBlockHash':
-        return this.getBestSidechainBlockHash(ctx, request as $11.GetBestSidechainBlockHashRequest);
-      case 'GetBmmInclusions':
-        return this.getBmmInclusions(ctx, request as $11.GetBmmInclusionsRequest);
-      case 'GetWalletUtxos':
-        return this.getWalletUtxos(ctx, request as $11.GetWalletUtxosRequest);
-      case 'ListUtxos':
-        return this.listUtxos(ctx, request as $11.ListUtxosRequest);
-      case 'RemoveFromMempool':
-        return this.removeFromMempool(ctx, request as $11.RemoveFromMempoolRequest);
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return this
-            .getLatestFailedWithdrawalBundleHeight(ctx, request as $11.GetLatestFailedWithdrawalBundleHeightRequest);
-      case 'GenerateMnemonic':
-        return this.generateMnemonic(ctx, request as $11.GenerateMnemonicRequest);
-      case 'SetSeedFromMnemonic':
-        return this.setSeedFromMnemonic(ctx, request as $11.SetSeedFromMnemonicRequest);
-      case 'CallRaw':
-        return this.callRaw(ctx, request as $11.CallRawRequest);
-      case 'RefreshWallet':
-        return this.refreshWallet(ctx, request as $11.RefreshWalletRequest);
-      case 'GetTransaction':
-        return this.getTransaction(ctx, request as $11.GetTransactionRequest);
-      case 'GetTransactionInfo':
-        return this.getTransactionInfo(ctx, request as $11.GetTransactionInfoRequest);
-      case 'GetWalletAddresses':
-        return this.getWalletAddresses(ctx, request as $11.GetWalletAddressesRequest);
-      case 'MyUtxos':
-        return this.myUtxos(ctx, request as $11.MyUtxosRequest);
-      case 'MyUnconfirmedUtxos':
-        return this.myUnconfirmedUtxos(ctx, request as $11.MyUnconfirmedUtxosRequest);
-      case 'CalculateInitialLiquidity':
-        return this.calculateInitialLiquidity(ctx, request as $11.CalculateInitialLiquidityRequest);
-      case 'MarketCreate':
-        return this.marketCreate(ctx, request as $11.MarketCreateRequest);
-      case 'MarketList':
-        return this.marketList(ctx, request as $11.MarketListRequest);
-      case 'MarketGet':
-        return this.marketGet(ctx, request as $11.MarketGetRequest);
-      case 'MarketBuy':
-        return this.marketBuy(ctx, request as $11.MarketBuyRequest);
-      case 'MarketSell':
-        return this.marketSell(ctx, request as $11.MarketSellRequest);
-      case 'MarketPositions':
-        return this.marketPositions(ctx, request as $11.MarketPositionsRequest);
-      case 'SlotStatus':
-        return this.slotStatus(ctx, request as $11.SlotStatusRequest);
-      case 'SlotList':
-        return this.slotList(ctx, request as $11.SlotListRequest);
-      case 'SlotGet':
-        return this.slotGet(ctx, request as $11.SlotGetRequest);
-      case 'SlotClaim':
-        return this.slotClaim(ctx, request as $11.SlotClaimRequest);
-      case 'SlotClaimCategory':
-        return this.slotClaimCategory(ctx, request as $11.SlotClaimCategoryRequest);
-      case 'VoteRegister':
-        return this.voteRegister(ctx, request as $11.VoteRegisterRequest);
-      case 'VoteVoter':
-        return this.voteVoter(ctx, request as $11.VoteVoterRequest);
-      case 'VoteVoters':
-        return this.voteVoters(ctx, request as $11.VoteVotersRequest);
-      case 'VoteSubmit':
-        return this.voteSubmit(ctx, request as $11.VoteSubmitRequest);
-      case 'VoteList':
-        return this.voteList(ctx, request as $11.VoteListRequest);
-      case 'VotePeriod':
-        return this.votePeriod(ctx, request as $11.VotePeriodRequest);
-      case 'VotecoinTransfer':
-        return this.votecoinTransfer(ctx, request as $11.VotecoinTransferRequest);
-      case 'VotecoinBalance':
-        return this.votecoinBalance(ctx, request as $11.VotecoinBalanceRequest);
-      case 'TransferVotecoin':
-        return this.transferVotecoin(ctx, request as $11.TransferVotecoinRequest);
-      case 'GetNewEncryptionKey':
-        return this.getNewEncryptionKey(ctx, request as $11.GetNewEncryptionKeyRequest);
-      case 'GetNewVerifyingKey':
-        return this.getNewVerifyingKey(ctx, request as $11.GetNewVerifyingKeyRequest);
-      case 'EncryptMsg':
-        return this.encryptMsg(ctx, request as $11.EncryptMsgRequest);
-      case 'DecryptMsg':
-        return this.decryptMsg(ctx, request as $11.DecryptMsgRequest);
-      case 'SignArbitraryMsg':
-        return this.signArbitraryMsg(ctx, request as $11.SignArbitraryMsgRequest);
-      case 'SignArbitraryMsgAsAddr':
-        return this.signArbitraryMsgAsAddr(ctx, request as $11.SignArbitraryMsgAsAddrRequest);
-      case 'VerifySignature':
-        return this.verifySignature(ctx, request as $11.VerifySignatureRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return this.getBalance(ctx, request as $11.GetBalanceRequest);
+      case 'GetBlockCount': return this.getBlockCount(ctx, request as $11.GetBlockCountRequest);
+      case 'Stop': return this.stop(ctx, request as $11.StopRequest);
+      case 'GetNewAddress': return this.getNewAddress(ctx, request as $11.GetNewAddressRequest);
+      case 'Withdraw': return this.withdraw(ctx, request as $11.WithdrawRequest);
+      case 'Transfer': return this.transfer(ctx, request as $11.TransferRequest);
+      case 'GetSidechainWealth': return this.getSidechainWealth(ctx, request as $11.GetSidechainWealthRequest);
+      case 'CreateDeposit': return this.createDeposit(ctx, request as $11.CreateDepositRequest);
+      case 'GetPendingWithdrawalBundle': return this.getPendingWithdrawalBundle(ctx, request as $11.GetPendingWithdrawalBundleRequest);
+      case 'ConnectPeer': return this.connectPeer(ctx, request as $11.ConnectPeerRequest);
+      case 'ListPeers': return this.listPeers(ctx, request as $11.ListPeersRequest);
+      case 'Mine': return this.mine(ctx, request as $11.MineRequest);
+      case 'GetBlock': return this.getBlock(ctx, request as $11.GetBlockRequest);
+      case 'GetBestMainchainBlockHash': return this.getBestMainchainBlockHash(ctx, request as $11.GetBestMainchainBlockHashRequest);
+      case 'GetBestSidechainBlockHash': return this.getBestSidechainBlockHash(ctx, request as $11.GetBestSidechainBlockHashRequest);
+      case 'GetBmmInclusions': return this.getBmmInclusions(ctx, request as $11.GetBmmInclusionsRequest);
+      case 'GetWalletUtxos': return this.getWalletUtxos(ctx, request as $11.GetWalletUtxosRequest);
+      case 'ListUtxos': return this.listUtxos(ctx, request as $11.ListUtxosRequest);
+      case 'RemoveFromMempool': return this.removeFromMempool(ctx, request as $11.RemoveFromMempoolRequest);
+      case 'GetLatestFailedWithdrawalBundleHeight': return this.getLatestFailedWithdrawalBundleHeight(ctx, request as $11.GetLatestFailedWithdrawalBundleHeightRequest);
+      case 'GenerateMnemonic': return this.generateMnemonic(ctx, request as $11.GenerateMnemonicRequest);
+      case 'SetSeedFromMnemonic': return this.setSeedFromMnemonic(ctx, request as $11.SetSeedFromMnemonicRequest);
+      case 'CallRaw': return this.callRaw(ctx, request as $11.CallRawRequest);
+      case 'RefreshWallet': return this.refreshWallet(ctx, request as $11.RefreshWalletRequest);
+      case 'GetTransaction': return this.getTransaction(ctx, request as $11.GetTransactionRequest);
+      case 'GetTransactionInfo': return this.getTransactionInfo(ctx, request as $11.GetTransactionInfoRequest);
+      case 'GetWalletAddresses': return this.getWalletAddresses(ctx, request as $11.GetWalletAddressesRequest);
+      case 'MyUtxos': return this.myUtxos(ctx, request as $11.MyUtxosRequest);
+      case 'MyUnconfirmedUtxos': return this.myUnconfirmedUtxos(ctx, request as $11.MyUnconfirmedUtxosRequest);
+      case 'CalculateInitialLiquidity': return this.calculateInitialLiquidity(ctx, request as $11.CalculateInitialLiquidityRequest);
+      case 'MarketCreate': return this.marketCreate(ctx, request as $11.MarketCreateRequest);
+      case 'MarketList': return this.marketList(ctx, request as $11.MarketListRequest);
+      case 'MarketGet': return this.marketGet(ctx, request as $11.MarketGetRequest);
+      case 'MarketBuy': return this.marketBuy(ctx, request as $11.MarketBuyRequest);
+      case 'MarketSell': return this.marketSell(ctx, request as $11.MarketSellRequest);
+      case 'MarketPositions': return this.marketPositions(ctx, request as $11.MarketPositionsRequest);
+      case 'SlotStatus': return this.slotStatus(ctx, request as $11.SlotStatusRequest);
+      case 'SlotList': return this.slotList(ctx, request as $11.SlotListRequest);
+      case 'SlotGet': return this.slotGet(ctx, request as $11.SlotGetRequest);
+      case 'SlotClaim': return this.slotClaim(ctx, request as $11.SlotClaimRequest);
+      case 'SlotClaimCategory': return this.slotClaimCategory(ctx, request as $11.SlotClaimCategoryRequest);
+      case 'VoteRegister': return this.voteRegister(ctx, request as $11.VoteRegisterRequest);
+      case 'VoteVoter': return this.voteVoter(ctx, request as $11.VoteVoterRequest);
+      case 'VoteVoters': return this.voteVoters(ctx, request as $11.VoteVotersRequest);
+      case 'VoteSubmit': return this.voteSubmit(ctx, request as $11.VoteSubmitRequest);
+      case 'VoteList': return this.voteList(ctx, request as $11.VoteListRequest);
+      case 'VotePeriod': return this.votePeriod(ctx, request as $11.VotePeriodRequest);
+      case 'VotecoinTransfer': return this.votecoinTransfer(ctx, request as $11.VotecoinTransferRequest);
+      case 'VotecoinBalance': return this.votecoinBalance(ctx, request as $11.VotecoinBalanceRequest);
+      case 'TransferVotecoin': return this.transferVotecoin(ctx, request as $11.TransferVotecoinRequest);
+      case 'GetNewEncryptionKey': return this.getNewEncryptionKey(ctx, request as $11.GetNewEncryptionKeyRequest);
+      case 'GetNewVerifyingKey': return this.getNewVerifyingKey(ctx, request as $11.GetNewVerifyingKeyRequest);
+      case 'EncryptMsg': return this.encryptMsg(ctx, request as $11.EncryptMsgRequest);
+      case 'DecryptMsg': return this.decryptMsg(ctx, request as $11.DecryptMsgRequest);
+      case 'SignArbitraryMsg': return this.signArbitraryMsg(ctx, request as $11.SignArbitraryMsgRequest);
+      case 'SignArbitraryMsgAsAddr': return this.signArbitraryMsgAsAddr(ctx, request as $11.SignArbitraryMsgAsAddrRequest);
+      case 'VerifySignature': return this.verifySignature(ctx, request as $11.VerifySignatureRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => TruthcoinServiceBase$json;
   $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => TruthcoinServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.connect.client.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.connect.client.dart
@@ -8,7 +8,7 @@ import "walletmanager.pb.dart" as walletmanagerv1walletmanager;
 import "walletmanager.connect.spec.dart" as specs;
 import "../../google/protobuf/empty.pb.dart" as googleprotobufempty;
 
-extension type WalletManagerServiceClient(connect.Transport _transport) {
+extension type WalletManagerServiceClient (connect.Transport _transport) {
   /// Wallet lifecycle
   Future<walletmanagerv1walletmanager.GetWalletStatusResponse> getWalletStatus(
     walletmanagerv1walletmanager.GetWalletStatusRequest input, {

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -20,25 +20,23 @@ import '../../google/protobuf/empty.pb.dart' as $12;
 class GetWalletStatusRequest extends $pb.GeneratedMessage {
   factory GetWalletStatusRequest() => create();
   GetWalletStatusRequest._() : super();
-  factory GetWalletStatusRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletStatusRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletStatusRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletStatusRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletStatusRequest clone() => GetWalletStatusRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletStatusRequest copyWith(void Function(GetWalletStatusRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletStatusRequest)) as GetWalletStatusRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletStatusRequest copyWith(void Function(GetWalletStatusRequest) updates) => super.copyWith((message) => updates(message as GetWalletStatusRequest)) as GetWalletStatusRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -47,8 +45,7 @@ class GetWalletStatusRequest extends $pb.GeneratedMessage {
   GetWalletStatusRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletStatusRequest> createRepeated() => $pb.PbList<GetWalletStatusRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletStatusRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletStatusRequest>(create);
+  static GetWalletStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletStatusRequest>(create);
   static GetWalletStatusRequest? _defaultInstance;
 }
 
@@ -79,30 +76,28 @@ class GetWalletStatusResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletStatusResponse._() : super();
-  factory GetWalletStatusResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletStatusResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletStatusResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletStatusResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'hasWallet')
     ..aOB(2, _omitFieldNames ? '' : 'encrypted')
     ..aOB(3, _omitFieldNames ? '' : 'unlocked')
     ..aOS(4, _omitFieldNames ? '' : 'activeWalletId')
     ..aOS(5, _omitFieldNames ? '' : 'activeWalletName')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletStatusResponse clone() => GetWalletStatusResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletStatusResponse copyWith(void Function(GetWalletStatusResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletStatusResponse)) as GetWalletStatusResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletStatusResponse copyWith(void Function(GetWalletStatusResponse) updates) => super.copyWith((message) => updates(message as GetWalletStatusResponse)) as GetWalletStatusResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -111,17 +106,13 @@ class GetWalletStatusResponse extends $pb.GeneratedMessage {
   GetWalletStatusResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletStatusResponse> createRepeated() => $pb.PbList<GetWalletStatusResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletStatusResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletStatusResponse>(create);
+  static GetWalletStatusResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletStatusResponse>(create);
   static GetWalletStatusResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get hasWallet => $_getBF(0);
   @$pb.TagNumber(1)
-  set hasWallet($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set hasWallet($core.bool v) { $_setBool(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHasWallet() => $_has(0);
   @$pb.TagNumber(1)
@@ -130,10 +121,7 @@ class GetWalletStatusResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get encrypted => $_getBF(1);
   @$pb.TagNumber(2)
-  set encrypted($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set encrypted($core.bool v) { $_setBool(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasEncrypted() => $_has(1);
   @$pb.TagNumber(2)
@@ -142,10 +130,7 @@ class GetWalletStatusResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get unlocked => $_getBF(2);
   @$pb.TagNumber(3)
-  set unlocked($core.bool v) {
-    $_setBool(2, v);
-  }
-
+  set unlocked($core.bool v) { $_setBool(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasUnlocked() => $_has(2);
   @$pb.TagNumber(3)
@@ -154,10 +139,7 @@ class GetWalletStatusResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get activeWalletId => $_getSZ(3);
   @$pb.TagNumber(4)
-  set activeWalletId($core.String v) {
-    $_setString(3, v);
-  }
-
+  set activeWalletId($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasActiveWalletId() => $_has(3);
   @$pb.TagNumber(4)
@@ -166,10 +148,7 @@ class GetWalletStatusResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get activeWalletName => $_getSZ(4);
   @$pb.TagNumber(5)
-  set activeWalletName($core.String v) {
-    $_setString(4, v);
-  }
-
+  set activeWalletName($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasActiveWalletName() => $_has(4);
   @$pb.TagNumber(5)
@@ -195,28 +174,26 @@ class GenerateWalletRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GenerateWalletRequest._() : super();
-  factory GenerateWalletRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateWalletRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateWalletRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateWalletRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOS(2, _omitFieldNames ? '' : 'customMnemonic')
     ..aOS(3, _omitFieldNames ? '' : 'passphrase')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateWalletRequest clone() => GenerateWalletRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateWalletRequest copyWith(void Function(GenerateWalletRequest) updates) =>
-      super.copyWith((message) => updates(message as GenerateWalletRequest)) as GenerateWalletRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateWalletRequest copyWith(void Function(GenerateWalletRequest) updates) => super.copyWith((message) => updates(message as GenerateWalletRequest)) as GenerateWalletRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -225,17 +202,13 @@ class GenerateWalletRequest extends $pb.GeneratedMessage {
   GenerateWalletRequest createEmptyInstance() => create();
   static $pb.PbList<GenerateWalletRequest> createRepeated() => $pb.PbList<GenerateWalletRequest>();
   @$core.pragma('dart2js:noInline')
-  static GenerateWalletRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateWalletRequest>(create);
+  static GenerateWalletRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateWalletRequest>(create);
   static GenerateWalletRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -244,10 +217,7 @@ class GenerateWalletRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get customMnemonic => $_getSZ(1);
   @$pb.TagNumber(2)
-  set customMnemonic($core.String v) {
-    $_setString(1, v);
-  }
-
+  set customMnemonic($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasCustomMnemonic() => $_has(1);
   @$pb.TagNumber(2)
@@ -256,10 +226,7 @@ class GenerateWalletRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get passphrase => $_getSZ(2);
   @$pb.TagNumber(3)
-  set passphrase($core.String v) {
-    $_setString(2, v);
-  }
-
+  set passphrase($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasPassphrase() => $_has(2);
   @$pb.TagNumber(3)
@@ -281,27 +248,25 @@ class GenerateWalletResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GenerateWalletResponse._() : super();
-  factory GenerateWalletResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateWalletResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateWalletResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateWalletResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
     ..aOS(2, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateWalletResponse clone() => GenerateWalletResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateWalletResponse copyWith(void Function(GenerateWalletResponse) updates) =>
-      super.copyWith((message) => updates(message as GenerateWalletResponse)) as GenerateWalletResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateWalletResponse copyWith(void Function(GenerateWalletResponse) updates) => super.copyWith((message) => updates(message as GenerateWalletResponse)) as GenerateWalletResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -310,17 +275,13 @@ class GenerateWalletResponse extends $pb.GeneratedMessage {
   GenerateWalletResponse createEmptyInstance() => create();
   static $pb.PbList<GenerateWalletResponse> createRepeated() => $pb.PbList<GenerateWalletResponse>();
   @$core.pragma('dart2js:noInline')
-  static GenerateWalletResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateWalletResponse>(create);
+  static GenerateWalletResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateWalletResponse>(create);
   static GenerateWalletResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -329,10 +290,7 @@ class GenerateWalletResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get mnemonic => $_getSZ(1);
   @$pb.TagNumber(2)
-  set mnemonic($core.String v) {
-    $_setString(1, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasMnemonic() => $_has(1);
   @$pb.TagNumber(2)
@@ -350,26 +308,24 @@ class UnlockWalletRequest extends $pb.GeneratedMessage {
     return $result;
   }
   UnlockWalletRequest._() : super();
-  factory UnlockWalletRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UnlockWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory UnlockWalletRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UnlockWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnlockWalletRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnlockWalletRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'password')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   UnlockWalletRequest clone() => UnlockWalletRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  UnlockWalletRequest copyWith(void Function(UnlockWalletRequest) updates) =>
-      super.copyWith((message) => updates(message as UnlockWalletRequest)) as UnlockWalletRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UnlockWalletRequest copyWith(void Function(UnlockWalletRequest) updates) => super.copyWith((message) => updates(message as UnlockWalletRequest)) as UnlockWalletRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -378,17 +334,13 @@ class UnlockWalletRequest extends $pb.GeneratedMessage {
   UnlockWalletRequest createEmptyInstance() => create();
   static $pb.PbList<UnlockWalletRequest> createRepeated() => $pb.PbList<UnlockWalletRequest>();
   @$core.pragma('dart2js:noInline')
-  static UnlockWalletRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnlockWalletRequest>(create);
+  static UnlockWalletRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnlockWalletRequest>(create);
   static UnlockWalletRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get password => $_getSZ(0);
   @$pb.TagNumber(1)
-  set password($core.String v) {
-    $_setString(0, v);
-  }
-
+  set password($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPassword() => $_has(0);
   @$pb.TagNumber(1)
@@ -398,25 +350,23 @@ class UnlockWalletRequest extends $pb.GeneratedMessage {
 class UnlockWalletResponse extends $pb.GeneratedMessage {
   factory UnlockWalletResponse() => create();
   UnlockWalletResponse._() : super();
-  factory UnlockWalletResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UnlockWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory UnlockWalletResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UnlockWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnlockWalletResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnlockWalletResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   UnlockWalletResponse clone() => UnlockWalletResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  UnlockWalletResponse copyWith(void Function(UnlockWalletResponse) updates) =>
-      super.copyWith((message) => updates(message as UnlockWalletResponse)) as UnlockWalletResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UnlockWalletResponse copyWith(void Function(UnlockWalletResponse) updates) => super.copyWith((message) => updates(message as UnlockWalletResponse)) as UnlockWalletResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -425,33 +375,30 @@ class UnlockWalletResponse extends $pb.GeneratedMessage {
   UnlockWalletResponse createEmptyInstance() => create();
   static $pb.PbList<UnlockWalletResponse> createRepeated() => $pb.PbList<UnlockWalletResponse>();
   @$core.pragma('dart2js:noInline')
-  static UnlockWalletResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnlockWalletResponse>(create);
+  static UnlockWalletResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnlockWalletResponse>(create);
   static UnlockWalletResponse? _defaultInstance;
 }
 
 class LockWalletRequest extends $pb.GeneratedMessage {
   factory LockWalletRequest() => create();
   LockWalletRequest._() : super();
-  factory LockWalletRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LockWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory LockWalletRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LockWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'LockWalletRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'LockWalletRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   LockWalletRequest clone() => LockWalletRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  LockWalletRequest copyWith(void Function(LockWalletRequest) updates) =>
-      super.copyWith((message) => updates(message as LockWalletRequest)) as LockWalletRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  LockWalletRequest copyWith(void Function(LockWalletRequest) updates) => super.copyWith((message) => updates(message as LockWalletRequest)) as LockWalletRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -460,33 +407,30 @@ class LockWalletRequest extends $pb.GeneratedMessage {
   LockWalletRequest createEmptyInstance() => create();
   static $pb.PbList<LockWalletRequest> createRepeated() => $pb.PbList<LockWalletRequest>();
   @$core.pragma('dart2js:noInline')
-  static LockWalletRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LockWalletRequest>(create);
+  static LockWalletRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LockWalletRequest>(create);
   static LockWalletRequest? _defaultInstance;
 }
 
 class LockWalletResponse extends $pb.GeneratedMessage {
   factory LockWalletResponse() => create();
   LockWalletResponse._() : super();
-  factory LockWalletResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LockWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory LockWalletResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LockWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'LockWalletResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'LockWalletResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   LockWalletResponse clone() => LockWalletResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  LockWalletResponse copyWith(void Function(LockWalletResponse) updates) =>
-      super.copyWith((message) => updates(message as LockWalletResponse)) as LockWalletResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  LockWalletResponse copyWith(void Function(LockWalletResponse) updates) => super.copyWith((message) => updates(message as LockWalletResponse)) as LockWalletResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -495,8 +439,7 @@ class LockWalletResponse extends $pb.GeneratedMessage {
   LockWalletResponse createEmptyInstance() => create();
   static $pb.PbList<LockWalletResponse> createRepeated() => $pb.PbList<LockWalletResponse>();
   @$core.pragma('dart2js:noInline')
-  static LockWalletResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LockWalletResponse>(create);
+  static LockWalletResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LockWalletResponse>(create);
   static LockWalletResponse? _defaultInstance;
 }
 
@@ -511,26 +454,24 @@ class EncryptWalletRequest extends $pb.GeneratedMessage {
     return $result;
   }
   EncryptWalletRequest._() : super();
-  factory EncryptWalletRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory EncryptWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory EncryptWalletRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EncryptWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptWalletRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptWalletRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'password')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   EncryptWalletRequest clone() => EncryptWalletRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  EncryptWalletRequest copyWith(void Function(EncryptWalletRequest) updates) =>
-      super.copyWith((message) => updates(message as EncryptWalletRequest)) as EncryptWalletRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EncryptWalletRequest copyWith(void Function(EncryptWalletRequest) updates) => super.copyWith((message) => updates(message as EncryptWalletRequest)) as EncryptWalletRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -539,17 +480,13 @@ class EncryptWalletRequest extends $pb.GeneratedMessage {
   EncryptWalletRequest createEmptyInstance() => create();
   static $pb.PbList<EncryptWalletRequest> createRepeated() => $pb.PbList<EncryptWalletRequest>();
   @$core.pragma('dart2js:noInline')
-  static EncryptWalletRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptWalletRequest>(create);
+  static EncryptWalletRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptWalletRequest>(create);
   static EncryptWalletRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get password => $_getSZ(0);
   @$pb.TagNumber(1)
-  set password($core.String v) {
-    $_setString(0, v);
-  }
-
+  set password($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPassword() => $_has(0);
   @$pb.TagNumber(1)
@@ -559,25 +496,23 @@ class EncryptWalletRequest extends $pb.GeneratedMessage {
 class EncryptWalletResponse extends $pb.GeneratedMessage {
   factory EncryptWalletResponse() => create();
   EncryptWalletResponse._() : super();
-  factory EncryptWalletResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory EncryptWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory EncryptWalletResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EncryptWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptWalletResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncryptWalletResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   EncryptWalletResponse clone() => EncryptWalletResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  EncryptWalletResponse copyWith(void Function(EncryptWalletResponse) updates) =>
-      super.copyWith((message) => updates(message as EncryptWalletResponse)) as EncryptWalletResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EncryptWalletResponse copyWith(void Function(EncryptWalletResponse) updates) => super.copyWith((message) => updates(message as EncryptWalletResponse)) as EncryptWalletResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -586,8 +521,7 @@ class EncryptWalletResponse extends $pb.GeneratedMessage {
   EncryptWalletResponse createEmptyInstance() => create();
   static $pb.PbList<EncryptWalletResponse> createRepeated() => $pb.PbList<EncryptWalletResponse>();
   @$core.pragma('dart2js:noInline')
-  static EncryptWalletResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptWalletResponse>(create);
+  static EncryptWalletResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncryptWalletResponse>(create);
   static EncryptWalletResponse? _defaultInstance;
 }
 
@@ -606,27 +540,25 @@ class ChangePasswordRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ChangePasswordRequest._() : super();
-  factory ChangePasswordRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChangePasswordRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ChangePasswordRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ChangePasswordRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ChangePasswordRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ChangePasswordRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'oldPassword')
     ..aOS(2, _omitFieldNames ? '' : 'newPassword')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ChangePasswordRequest clone() => ChangePasswordRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ChangePasswordRequest copyWith(void Function(ChangePasswordRequest) updates) =>
-      super.copyWith((message) => updates(message as ChangePasswordRequest)) as ChangePasswordRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ChangePasswordRequest copyWith(void Function(ChangePasswordRequest) updates) => super.copyWith((message) => updates(message as ChangePasswordRequest)) as ChangePasswordRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -635,17 +567,13 @@ class ChangePasswordRequest extends $pb.GeneratedMessage {
   ChangePasswordRequest createEmptyInstance() => create();
   static $pb.PbList<ChangePasswordRequest> createRepeated() => $pb.PbList<ChangePasswordRequest>();
   @$core.pragma('dart2js:noInline')
-  static ChangePasswordRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChangePasswordRequest>(create);
+  static ChangePasswordRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChangePasswordRequest>(create);
   static ChangePasswordRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get oldPassword => $_getSZ(0);
   @$pb.TagNumber(1)
-  set oldPassword($core.String v) {
-    $_setString(0, v);
-  }
-
+  set oldPassword($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasOldPassword() => $_has(0);
   @$pb.TagNumber(1)
@@ -654,10 +582,7 @@ class ChangePasswordRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get newPassword => $_getSZ(1);
   @$pb.TagNumber(2)
-  set newPassword($core.String v) {
-    $_setString(1, v);
-  }
-
+  set newPassword($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasNewPassword() => $_has(1);
   @$pb.TagNumber(2)
@@ -667,25 +592,23 @@ class ChangePasswordRequest extends $pb.GeneratedMessage {
 class ChangePasswordResponse extends $pb.GeneratedMessage {
   factory ChangePasswordResponse() => create();
   ChangePasswordResponse._() : super();
-  factory ChangePasswordResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChangePasswordResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ChangePasswordResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ChangePasswordResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ChangePasswordResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ChangePasswordResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ChangePasswordResponse clone() => ChangePasswordResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ChangePasswordResponse copyWith(void Function(ChangePasswordResponse) updates) =>
-      super.copyWith((message) => updates(message as ChangePasswordResponse)) as ChangePasswordResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ChangePasswordResponse copyWith(void Function(ChangePasswordResponse) updates) => super.copyWith((message) => updates(message as ChangePasswordResponse)) as ChangePasswordResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -694,8 +617,7 @@ class ChangePasswordResponse extends $pb.GeneratedMessage {
   ChangePasswordResponse createEmptyInstance() => create();
   static $pb.PbList<ChangePasswordResponse> createRepeated() => $pb.PbList<ChangePasswordResponse>();
   @$core.pragma('dart2js:noInline')
-  static ChangePasswordResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChangePasswordResponse>(create);
+  static ChangePasswordResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChangePasswordResponse>(create);
   static ChangePasswordResponse? _defaultInstance;
 }
 
@@ -710,26 +632,24 @@ class RemoveEncryptionRequest extends $pb.GeneratedMessage {
     return $result;
   }
   RemoveEncryptionRequest._() : super();
-  factory RemoveEncryptionRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveEncryptionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveEncryptionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveEncryptionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveEncryptionRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveEncryptionRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'password')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveEncryptionRequest clone() => RemoveEncryptionRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveEncryptionRequest copyWith(void Function(RemoveEncryptionRequest) updates) =>
-      super.copyWith((message) => updates(message as RemoveEncryptionRequest)) as RemoveEncryptionRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveEncryptionRequest copyWith(void Function(RemoveEncryptionRequest) updates) => super.copyWith((message) => updates(message as RemoveEncryptionRequest)) as RemoveEncryptionRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -738,17 +658,13 @@ class RemoveEncryptionRequest extends $pb.GeneratedMessage {
   RemoveEncryptionRequest createEmptyInstance() => create();
   static $pb.PbList<RemoveEncryptionRequest> createRepeated() => $pb.PbList<RemoveEncryptionRequest>();
   @$core.pragma('dart2js:noInline')
-  static RemoveEncryptionRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveEncryptionRequest>(create);
+  static RemoveEncryptionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveEncryptionRequest>(create);
   static RemoveEncryptionRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get password => $_getSZ(0);
   @$pb.TagNumber(1)
-  set password($core.String v) {
-    $_setString(0, v);
-  }
-
+  set password($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPassword() => $_has(0);
   @$pb.TagNumber(1)
@@ -758,25 +674,23 @@ class RemoveEncryptionRequest extends $pb.GeneratedMessage {
 class RemoveEncryptionResponse extends $pb.GeneratedMessage {
   factory RemoveEncryptionResponse() => create();
   RemoveEncryptionResponse._() : super();
-  factory RemoveEncryptionResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveEncryptionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveEncryptionResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveEncryptionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveEncryptionResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveEncryptionResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveEncryptionResponse clone() => RemoveEncryptionResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveEncryptionResponse copyWith(void Function(RemoveEncryptionResponse) updates) =>
-      super.copyWith((message) => updates(message as RemoveEncryptionResponse)) as RemoveEncryptionResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveEncryptionResponse copyWith(void Function(RemoveEncryptionResponse) updates) => super.copyWith((message) => updates(message as RemoveEncryptionResponse)) as RemoveEncryptionResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -785,8 +699,7 @@ class RemoveEncryptionResponse extends $pb.GeneratedMessage {
   RemoveEncryptionResponse createEmptyInstance() => create();
   static $pb.PbList<RemoveEncryptionResponse> createRepeated() => $pb.PbList<RemoveEncryptionResponse>();
   @$core.pragma('dart2js:noInline')
-  static RemoveEncryptionResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveEncryptionResponse>(create);
+  static RemoveEncryptionResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveEncryptionResponse>(create);
   static RemoveEncryptionResponse? _defaultInstance;
 }
 
@@ -833,13 +746,10 @@ class WalletMetadata extends $pb.GeneratedMessage {
     return $result;
   }
   WalletMetadata._() : super();
-  factory WalletMetadata.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WalletMetadata.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WalletMetadata.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WalletMetadata.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WalletMetadata',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WalletMetadata', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'id')
     ..aOS(2, _omitFieldNames ? '' : 'name')
     ..aOS(3, _omitFieldNames ? '' : 'walletType')
@@ -848,19 +758,20 @@ class WalletMetadata extends $pb.GeneratedMessage {
     ..aOS(6, _omitFieldNames ? '' : 'bip47PaymentCode')
     ..aOS(7, _omitFieldNames ? '' : 'masterMnemonic')
     ..aOS(8, _omitFieldNames ? '' : 'l1Mnemonic')
-    ..pc<SidechainStarter>(9, _omitFieldNames ? '' : 'sidechains', $pb.PbFieldType.PM,
-        subBuilder: SidechainStarter.create)
-    ..hasRequiredFields = false;
+    ..pc<SidechainStarter>(9, _omitFieldNames ? '' : 'sidechains', $pb.PbFieldType.PM, subBuilder: SidechainStarter.create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WalletMetadata clone() => WalletMetadata()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WalletMetadata copyWith(void Function(WalletMetadata) updates) =>
-      super.copyWith((message) => updates(message as WalletMetadata)) as WalletMetadata;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WalletMetadata copyWith(void Function(WalletMetadata) updates) => super.copyWith((message) => updates(message as WalletMetadata)) as WalletMetadata;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -875,10 +786,7 @@ class WalletMetadata extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
@@ -887,10 +795,7 @@ class WalletMetadata extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get name => $_getSZ(1);
   @$pb.TagNumber(2)
-  set name($core.String v) {
-    $_setString(1, v);
-  }
-
+  set name($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasName() => $_has(1);
   @$pb.TagNumber(2)
@@ -899,10 +804,7 @@ class WalletMetadata extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get walletType => $_getSZ(2);
   @$pb.TagNumber(3)
-  set walletType($core.String v) {
-    $_setString(2, v);
-  }
-
+  set walletType($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasWalletType() => $_has(2);
   @$pb.TagNumber(3)
@@ -911,10 +813,7 @@ class WalletMetadata extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get gradientJson => $_getSZ(3);
   @$pb.TagNumber(4)
-  set gradientJson($core.String v) {
-    $_setString(3, v);
-  }
-
+  set gradientJson($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasGradientJson() => $_has(3);
   @$pb.TagNumber(4)
@@ -923,10 +822,7 @@ class WalletMetadata extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get createdAt => $_getSZ(4);
   @$pb.TagNumber(5)
-  set createdAt($core.String v) {
-    $_setString(4, v);
-  }
-
+  set createdAt($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasCreatedAt() => $_has(4);
   @$pb.TagNumber(5)
@@ -937,10 +833,7 @@ class WalletMetadata extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get bip47PaymentCode => $_getSZ(5);
   @$pb.TagNumber(6)
-  set bip47PaymentCode($core.String v) {
-    $_setString(5, v);
-  }
-
+  set bip47PaymentCode($core.String v) { $_setString(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasBip47PaymentCode() => $_has(5);
   @$pb.TagNumber(6)
@@ -952,10 +845,7 @@ class WalletMetadata extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get masterMnemonic => $_getSZ(6);
   @$pb.TagNumber(7)
-  set masterMnemonic($core.String v) {
-    $_setString(6, v);
-  }
-
+  set masterMnemonic($core.String v) { $_setString(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasMasterMnemonic() => $_has(6);
   @$pb.TagNumber(7)
@@ -964,10 +854,7 @@ class WalletMetadata extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get l1Mnemonic => $_getSZ(7);
   @$pb.TagNumber(8)
-  set l1Mnemonic($core.String v) {
-    $_setString(7, v);
-  }
-
+  set l1Mnemonic($core.String v) { $_setString(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasL1Mnemonic() => $_has(7);
   @$pb.TagNumber(8)
@@ -996,28 +883,26 @@ class SidechainStarter extends $pb.GeneratedMessage {
     return $result;
   }
   SidechainStarter._() : super();
-  factory SidechainStarter.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SidechainStarter.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SidechainStarter.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SidechainStarter.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SidechainStarter',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SidechainStarter', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'slot', $pb.PbFieldType.O3)
     ..aOS(2, _omitFieldNames ? '' : 'name')
     ..aOS(3, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SidechainStarter clone() => SidechainStarter()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SidechainStarter copyWith(void Function(SidechainStarter) updates) =>
-      super.copyWith((message) => updates(message as SidechainStarter)) as SidechainStarter;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SidechainStarter copyWith(void Function(SidechainStarter) updates) => super.copyWith((message) => updates(message as SidechainStarter)) as SidechainStarter;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1026,17 +911,13 @@ class SidechainStarter extends $pb.GeneratedMessage {
   SidechainStarter createEmptyInstance() => create();
   static $pb.PbList<SidechainStarter> createRepeated() => $pb.PbList<SidechainStarter>();
   @$core.pragma('dart2js:noInline')
-  static SidechainStarter getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SidechainStarter>(create);
+  static SidechainStarter getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SidechainStarter>(create);
   static SidechainStarter? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get slot => $_getIZ(0);
   @$pb.TagNumber(1)
-  set slot($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set slot($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSlot() => $_has(0);
   @$pb.TagNumber(1)
@@ -1045,10 +926,7 @@ class SidechainStarter extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get name => $_getSZ(1);
   @$pb.TagNumber(2)
-  set name($core.String v) {
-    $_setString(1, v);
-  }
-
+  set name($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasName() => $_has(1);
   @$pb.TagNumber(2)
@@ -1057,10 +935,7 @@ class SidechainStarter extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get mnemonic => $_getSZ(2);
   @$pb.TagNumber(3)
-  set mnemonic($core.String v) {
-    $_setString(2, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasMnemonic() => $_has(2);
   @$pb.TagNumber(3)
@@ -1070,25 +945,23 @@ class SidechainStarter extends $pb.GeneratedMessage {
 class ListWalletsRequest extends $pb.GeneratedMessage {
   factory ListWalletsRequest() => create();
   ListWalletsRequest._() : super();
-  factory ListWalletsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListWalletsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListWalletsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListWalletsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListWalletsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListWalletsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListWalletsRequest clone() => ListWalletsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListWalletsRequest copyWith(void Function(ListWalletsRequest) updates) =>
-      super.copyWith((message) => updates(message as ListWalletsRequest)) as ListWalletsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListWalletsRequest copyWith(void Function(ListWalletsRequest) updates) => super.copyWith((message) => updates(message as ListWalletsRequest)) as ListWalletsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1097,8 +970,7 @@ class ListWalletsRequest extends $pb.GeneratedMessage {
   ListWalletsRequest createEmptyInstance() => create();
   static $pb.PbList<ListWalletsRequest> createRepeated() => $pb.PbList<ListWalletsRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListWalletsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListWalletsRequest>(create);
+  static ListWalletsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListWalletsRequest>(create);
   static ListWalletsRequest? _defaultInstance;
 }
 
@@ -1117,27 +989,25 @@ class ListWalletsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListWalletsResponse._() : super();
-  factory ListWalletsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListWalletsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListWalletsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListWalletsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListWalletsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListWalletsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..pc<WalletMetadata>(1, _omitFieldNames ? '' : 'wallets', $pb.PbFieldType.PM, subBuilder: WalletMetadata.create)
     ..aOS(2, _omitFieldNames ? '' : 'activeWalletId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListWalletsResponse clone() => ListWalletsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListWalletsResponse copyWith(void Function(ListWalletsResponse) updates) =>
-      super.copyWith((message) => updates(message as ListWalletsResponse)) as ListWalletsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListWalletsResponse copyWith(void Function(ListWalletsResponse) updates) => super.copyWith((message) => updates(message as ListWalletsResponse)) as ListWalletsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1146,8 +1016,7 @@ class ListWalletsResponse extends $pb.GeneratedMessage {
   ListWalletsResponse createEmptyInstance() => create();
   static $pb.PbList<ListWalletsResponse> createRepeated() => $pb.PbList<ListWalletsResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListWalletsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListWalletsResponse>(create);
+  static ListWalletsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListWalletsResponse>(create);
   static ListWalletsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -1156,10 +1025,7 @@ class ListWalletsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get activeWalletId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set activeWalletId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set activeWalletId($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasActiveWalletId() => $_has(1);
   @$pb.TagNumber(2)
@@ -1177,26 +1043,24 @@ class SwitchWalletRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SwitchWalletRequest._() : super();
-  factory SwitchWalletRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SwitchWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SwitchWalletRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SwitchWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SwitchWalletRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SwitchWalletRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SwitchWalletRequest clone() => SwitchWalletRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SwitchWalletRequest copyWith(void Function(SwitchWalletRequest) updates) =>
-      super.copyWith((message) => updates(message as SwitchWalletRequest)) as SwitchWalletRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SwitchWalletRequest copyWith(void Function(SwitchWalletRequest) updates) => super.copyWith((message) => updates(message as SwitchWalletRequest)) as SwitchWalletRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1205,17 +1069,13 @@ class SwitchWalletRequest extends $pb.GeneratedMessage {
   SwitchWalletRequest createEmptyInstance() => create();
   static $pb.PbList<SwitchWalletRequest> createRepeated() => $pb.PbList<SwitchWalletRequest>();
   @$core.pragma('dart2js:noInline')
-  static SwitchWalletRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SwitchWalletRequest>(create);
+  static SwitchWalletRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SwitchWalletRequest>(create);
   static SwitchWalletRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1225,25 +1085,23 @@ class SwitchWalletRequest extends $pb.GeneratedMessage {
 class SwitchWalletResponse extends $pb.GeneratedMessage {
   factory SwitchWalletResponse() => create();
   SwitchWalletResponse._() : super();
-  factory SwitchWalletResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SwitchWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SwitchWalletResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SwitchWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SwitchWalletResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SwitchWalletResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SwitchWalletResponse clone() => SwitchWalletResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SwitchWalletResponse copyWith(void Function(SwitchWalletResponse) updates) =>
-      super.copyWith((message) => updates(message as SwitchWalletResponse)) as SwitchWalletResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SwitchWalletResponse copyWith(void Function(SwitchWalletResponse) updates) => super.copyWith((message) => updates(message as SwitchWalletResponse)) as SwitchWalletResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1252,8 +1110,7 @@ class SwitchWalletResponse extends $pb.GeneratedMessage {
   SwitchWalletResponse createEmptyInstance() => create();
   static $pb.PbList<SwitchWalletResponse> createRepeated() => $pb.PbList<SwitchWalletResponse>();
   @$core.pragma('dart2js:noInline')
-  static SwitchWalletResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SwitchWalletResponse>(create);
+  static SwitchWalletResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SwitchWalletResponse>(create);
   static SwitchWalletResponse? _defaultInstance;
 }
 
@@ -1276,29 +1133,26 @@ class UpdateWalletMetadataRequest extends $pb.GeneratedMessage {
     return $result;
   }
   UpdateWalletMetadataRequest._() : super();
-  factory UpdateWalletMetadataRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UpdateWalletMetadataRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory UpdateWalletMetadataRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UpdateWalletMetadataRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UpdateWalletMetadataRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UpdateWalletMetadataRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
     ..aOS(2, _omitFieldNames ? '' : 'name')
     ..aOS(3, _omitFieldNames ? '' : 'gradientJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   UpdateWalletMetadataRequest clone() => UpdateWalletMetadataRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  UpdateWalletMetadataRequest copyWith(void Function(UpdateWalletMetadataRequest) updates) =>
-      super.copyWith((message) => updates(message as UpdateWalletMetadataRequest)) as UpdateWalletMetadataRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UpdateWalletMetadataRequest copyWith(void Function(UpdateWalletMetadataRequest) updates) => super.copyWith((message) => updates(message as UpdateWalletMetadataRequest)) as UpdateWalletMetadataRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1307,17 +1161,13 @@ class UpdateWalletMetadataRequest extends $pb.GeneratedMessage {
   UpdateWalletMetadataRequest createEmptyInstance() => create();
   static $pb.PbList<UpdateWalletMetadataRequest> createRepeated() => $pb.PbList<UpdateWalletMetadataRequest>();
   @$core.pragma('dart2js:noInline')
-  static UpdateWalletMetadataRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UpdateWalletMetadataRequest>(create);
+  static UpdateWalletMetadataRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UpdateWalletMetadataRequest>(create);
   static UpdateWalletMetadataRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1326,10 +1176,7 @@ class UpdateWalletMetadataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get name => $_getSZ(1);
   @$pb.TagNumber(2)
-  set name($core.String v) {
-    $_setString(1, v);
-  }
-
+  set name($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasName() => $_has(1);
   @$pb.TagNumber(2)
@@ -1338,10 +1185,7 @@ class UpdateWalletMetadataRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get gradientJson => $_getSZ(2);
   @$pb.TagNumber(3)
-  set gradientJson($core.String v) {
-    $_setString(2, v);
-  }
-
+  set gradientJson($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasGradientJson() => $_has(2);
   @$pb.TagNumber(3)
@@ -1351,26 +1195,23 @@ class UpdateWalletMetadataRequest extends $pb.GeneratedMessage {
 class UpdateWalletMetadataResponse extends $pb.GeneratedMessage {
   factory UpdateWalletMetadataResponse() => create();
   UpdateWalletMetadataResponse._() : super();
-  factory UpdateWalletMetadataResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UpdateWalletMetadataResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory UpdateWalletMetadataResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UpdateWalletMetadataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UpdateWalletMetadataResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UpdateWalletMetadataResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   UpdateWalletMetadataResponse clone() => UpdateWalletMetadataResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  UpdateWalletMetadataResponse copyWith(void Function(UpdateWalletMetadataResponse) updates) =>
-      super.copyWith((message) => updates(message as UpdateWalletMetadataResponse)) as UpdateWalletMetadataResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UpdateWalletMetadataResponse copyWith(void Function(UpdateWalletMetadataResponse) updates) => super.copyWith((message) => updates(message as UpdateWalletMetadataResponse)) as UpdateWalletMetadataResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1379,8 +1220,7 @@ class UpdateWalletMetadataResponse extends $pb.GeneratedMessage {
   UpdateWalletMetadataResponse createEmptyInstance() => create();
   static $pb.PbList<UpdateWalletMetadataResponse> createRepeated() => $pb.PbList<UpdateWalletMetadataResponse>();
   @$core.pragma('dart2js:noInline')
-  static UpdateWalletMetadataResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UpdateWalletMetadataResponse>(create);
+  static UpdateWalletMetadataResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UpdateWalletMetadataResponse>(create);
   static UpdateWalletMetadataResponse? _defaultInstance;
 }
 
@@ -1395,26 +1235,24 @@ class DeleteWalletRequest extends $pb.GeneratedMessage {
     return $result;
   }
   DeleteWalletRequest._() : super();
-  factory DeleteWalletRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeleteWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DeleteWalletRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DeleteWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DeleteWalletRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DeleteWalletRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DeleteWalletRequest clone() => DeleteWalletRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DeleteWalletRequest copyWith(void Function(DeleteWalletRequest) updates) =>
-      super.copyWith((message) => updates(message as DeleteWalletRequest)) as DeleteWalletRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DeleteWalletRequest copyWith(void Function(DeleteWalletRequest) updates) => super.copyWith((message) => updates(message as DeleteWalletRequest)) as DeleteWalletRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1423,17 +1261,13 @@ class DeleteWalletRequest extends $pb.GeneratedMessage {
   DeleteWalletRequest createEmptyInstance() => create();
   static $pb.PbList<DeleteWalletRequest> createRepeated() => $pb.PbList<DeleteWalletRequest>();
   @$core.pragma('dart2js:noInline')
-  static DeleteWalletRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeleteWalletRequest>(create);
+  static DeleteWalletRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeleteWalletRequest>(create);
   static DeleteWalletRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1443,25 +1277,23 @@ class DeleteWalletRequest extends $pb.GeneratedMessage {
 class DeleteWalletResponse extends $pb.GeneratedMessage {
   factory DeleteWalletResponse() => create();
   DeleteWalletResponse._() : super();
-  factory DeleteWalletResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeleteWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DeleteWalletResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DeleteWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DeleteWalletResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DeleteWalletResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DeleteWalletResponse clone() => DeleteWalletResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DeleteWalletResponse copyWith(void Function(DeleteWalletResponse) updates) =>
-      super.copyWith((message) => updates(message as DeleteWalletResponse)) as DeleteWalletResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DeleteWalletResponse copyWith(void Function(DeleteWalletResponse) updates) => super.copyWith((message) => updates(message as DeleteWalletResponse)) as DeleteWalletResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1470,33 +1302,30 @@ class DeleteWalletResponse extends $pb.GeneratedMessage {
   DeleteWalletResponse createEmptyInstance() => create();
   static $pb.PbList<DeleteWalletResponse> createRepeated() => $pb.PbList<DeleteWalletResponse>();
   @$core.pragma('dart2js:noInline')
-  static DeleteWalletResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeleteWalletResponse>(create);
+  static DeleteWalletResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeleteWalletResponse>(create);
   static DeleteWalletResponse? _defaultInstance;
 }
 
 class DeleteAllWalletsRequest extends $pb.GeneratedMessage {
   factory DeleteAllWalletsRequest() => create();
   DeleteAllWalletsRequest._() : super();
-  factory DeleteAllWalletsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeleteAllWalletsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DeleteAllWalletsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DeleteAllWalletsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DeleteAllWalletsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DeleteAllWalletsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DeleteAllWalletsRequest clone() => DeleteAllWalletsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DeleteAllWalletsRequest copyWith(void Function(DeleteAllWalletsRequest) updates) =>
-      super.copyWith((message) => updates(message as DeleteAllWalletsRequest)) as DeleteAllWalletsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DeleteAllWalletsRequest copyWith(void Function(DeleteAllWalletsRequest) updates) => super.copyWith((message) => updates(message as DeleteAllWalletsRequest)) as DeleteAllWalletsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1505,33 +1334,30 @@ class DeleteAllWalletsRequest extends $pb.GeneratedMessage {
   DeleteAllWalletsRequest createEmptyInstance() => create();
   static $pb.PbList<DeleteAllWalletsRequest> createRepeated() => $pb.PbList<DeleteAllWalletsRequest>();
   @$core.pragma('dart2js:noInline')
-  static DeleteAllWalletsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeleteAllWalletsRequest>(create);
+  static DeleteAllWalletsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeleteAllWalletsRequest>(create);
   static DeleteAllWalletsRequest? _defaultInstance;
 }
 
 class DeleteAllWalletsResponse extends $pb.GeneratedMessage {
   factory DeleteAllWalletsResponse() => create();
   DeleteAllWalletsResponse._() : super();
-  factory DeleteAllWalletsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeleteAllWalletsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DeleteAllWalletsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DeleteAllWalletsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DeleteAllWalletsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DeleteAllWalletsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DeleteAllWalletsResponse clone() => DeleteAllWalletsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DeleteAllWalletsResponse copyWith(void Function(DeleteAllWalletsResponse) updates) =>
-      super.copyWith((message) => updates(message as DeleteAllWalletsResponse)) as DeleteAllWalletsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DeleteAllWalletsResponse copyWith(void Function(DeleteAllWalletsResponse) updates) => super.copyWith((message) => updates(message as DeleteAllWalletsResponse)) as DeleteAllWalletsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1540,8 +1366,7 @@ class DeleteAllWalletsResponse extends $pb.GeneratedMessage {
   DeleteAllWalletsResponse createEmptyInstance() => create();
   static $pb.PbList<DeleteAllWalletsResponse> createRepeated() => $pb.PbList<DeleteAllWalletsResponse>();
   @$core.pragma('dart2js:noInline')
-  static DeleteAllWalletsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeleteAllWalletsResponse>(create);
+  static DeleteAllWalletsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeleteAllWalletsResponse>(create);
   static DeleteAllWalletsResponse? _defaultInstance;
 }
 
@@ -1564,29 +1389,26 @@ class CreateWatchOnlyWalletRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CreateWatchOnlyWalletRequest._() : super();
-  factory CreateWatchOnlyWalletRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateWatchOnlyWalletRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateWatchOnlyWalletRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateWatchOnlyWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateWatchOnlyWalletRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateWatchOnlyWalletRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOS(2, _omitFieldNames ? '' : 'xpubOrDescriptor')
     ..aOS(3, _omitFieldNames ? '' : 'gradientJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateWatchOnlyWalletRequest clone() => CreateWatchOnlyWalletRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateWatchOnlyWalletRequest copyWith(void Function(CreateWatchOnlyWalletRequest) updates) =>
-      super.copyWith((message) => updates(message as CreateWatchOnlyWalletRequest)) as CreateWatchOnlyWalletRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateWatchOnlyWalletRequest copyWith(void Function(CreateWatchOnlyWalletRequest) updates) => super.copyWith((message) => updates(message as CreateWatchOnlyWalletRequest)) as CreateWatchOnlyWalletRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1595,17 +1417,13 @@ class CreateWatchOnlyWalletRequest extends $pb.GeneratedMessage {
   CreateWatchOnlyWalletRequest createEmptyInstance() => create();
   static $pb.PbList<CreateWatchOnlyWalletRequest> createRepeated() => $pb.PbList<CreateWatchOnlyWalletRequest>();
   @$core.pragma('dart2js:noInline')
-  static CreateWatchOnlyWalletRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateWatchOnlyWalletRequest>(create);
+  static CreateWatchOnlyWalletRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateWatchOnlyWalletRequest>(create);
   static CreateWatchOnlyWalletRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -1614,10 +1432,7 @@ class CreateWatchOnlyWalletRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get xpubOrDescriptor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set xpubOrDescriptor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set xpubOrDescriptor($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasXpubOrDescriptor() => $_has(1);
   @$pb.TagNumber(2)
@@ -1626,10 +1441,7 @@ class CreateWatchOnlyWalletRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get gradientJson => $_getSZ(2);
   @$pb.TagNumber(3)
-  set gradientJson($core.String v) {
-    $_setString(2, v);
-  }
-
+  set gradientJson($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasGradientJson() => $_has(2);
   @$pb.TagNumber(3)
@@ -1647,27 +1459,24 @@ class CreateWatchOnlyWalletResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CreateWatchOnlyWalletResponse._() : super();
-  factory CreateWatchOnlyWalletResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateWatchOnlyWalletResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateWatchOnlyWalletResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateWatchOnlyWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateWatchOnlyWalletResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateWatchOnlyWalletResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateWatchOnlyWalletResponse clone() => CreateWatchOnlyWalletResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateWatchOnlyWalletResponse copyWith(void Function(CreateWatchOnlyWalletResponse) updates) =>
-      super.copyWith((message) => updates(message as CreateWatchOnlyWalletResponse)) as CreateWatchOnlyWalletResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateWatchOnlyWalletResponse copyWith(void Function(CreateWatchOnlyWalletResponse) updates) => super.copyWith((message) => updates(message as CreateWatchOnlyWalletResponse)) as CreateWatchOnlyWalletResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1676,17 +1485,13 @@ class CreateWatchOnlyWalletResponse extends $pb.GeneratedMessage {
   CreateWatchOnlyWalletResponse createEmptyInstance() => create();
   static $pb.PbList<CreateWatchOnlyWalletResponse> createRepeated() => $pb.PbList<CreateWatchOnlyWalletResponse>();
   @$core.pragma('dart2js:noInline')
-  static CreateWatchOnlyWalletResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateWatchOnlyWalletResponse>(create);
+  static CreateWatchOnlyWalletResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateWatchOnlyWalletResponse>(create);
   static CreateWatchOnlyWalletResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1704,27 +1509,24 @@ class CreateBitcoinCoreWalletRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CreateBitcoinCoreWalletRequest._() : super();
-  factory CreateBitcoinCoreWalletRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateBitcoinCoreWalletRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateBitcoinCoreWalletRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateBitcoinCoreWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateBitcoinCoreWalletRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateBitcoinCoreWalletRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateBitcoinCoreWalletRequest clone() => CreateBitcoinCoreWalletRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateBitcoinCoreWalletRequest copyWith(void Function(CreateBitcoinCoreWalletRequest) updates) =>
-      super.copyWith((message) => updates(message as CreateBitcoinCoreWalletRequest)) as CreateBitcoinCoreWalletRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateBitcoinCoreWalletRequest copyWith(void Function(CreateBitcoinCoreWalletRequest) updates) => super.copyWith((message) => updates(message as CreateBitcoinCoreWalletRequest)) as CreateBitcoinCoreWalletRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1733,17 +1535,13 @@ class CreateBitcoinCoreWalletRequest extends $pb.GeneratedMessage {
   CreateBitcoinCoreWalletRequest createEmptyInstance() => create();
   static $pb.PbList<CreateBitcoinCoreWalletRequest> createRepeated() => $pb.PbList<CreateBitcoinCoreWalletRequest>();
   @$core.pragma('dart2js:noInline')
-  static CreateBitcoinCoreWalletRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateBitcoinCoreWalletRequest>(create);
+  static CreateBitcoinCoreWalletRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateBitcoinCoreWalletRequest>(create);
   static CreateBitcoinCoreWalletRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1761,28 +1559,24 @@ class CreateBitcoinCoreWalletResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CreateBitcoinCoreWalletResponse._() : super();
-  factory CreateBitcoinCoreWalletResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateBitcoinCoreWalletResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateBitcoinCoreWalletResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateBitcoinCoreWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateBitcoinCoreWalletResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateBitcoinCoreWalletResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'coreWalletName')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateBitcoinCoreWalletResponse clone() => CreateBitcoinCoreWalletResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateBitcoinCoreWalletResponse copyWith(void Function(CreateBitcoinCoreWalletResponse) updates) =>
-      super.copyWith((message) => updates(message as CreateBitcoinCoreWalletResponse))
-          as CreateBitcoinCoreWalletResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateBitcoinCoreWalletResponse copyWith(void Function(CreateBitcoinCoreWalletResponse) updates) => super.copyWith((message) => updates(message as CreateBitcoinCoreWalletResponse)) as CreateBitcoinCoreWalletResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1791,17 +1585,13 @@ class CreateBitcoinCoreWalletResponse extends $pb.GeneratedMessage {
   CreateBitcoinCoreWalletResponse createEmptyInstance() => create();
   static $pb.PbList<CreateBitcoinCoreWalletResponse> createRepeated() => $pb.PbList<CreateBitcoinCoreWalletResponse>();
   @$core.pragma('dart2js:noInline')
-  static CreateBitcoinCoreWalletResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateBitcoinCoreWalletResponse>(create);
+  static CreateBitcoinCoreWalletResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateBitcoinCoreWalletResponse>(create);
   static CreateBitcoinCoreWalletResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get coreWalletName => $_getSZ(0);
   @$pb.TagNumber(1)
-  set coreWalletName($core.String v) {
-    $_setString(0, v);
-  }
-
+  set coreWalletName($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCoreWalletName() => $_has(0);
   @$pb.TagNumber(1)
@@ -1811,25 +1601,23 @@ class CreateBitcoinCoreWalletResponse extends $pb.GeneratedMessage {
 class EnsureCoreWalletsRequest extends $pb.GeneratedMessage {
   factory EnsureCoreWalletsRequest() => create();
   EnsureCoreWalletsRequest._() : super();
-  factory EnsureCoreWalletsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory EnsureCoreWalletsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory EnsureCoreWalletsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EnsureCoreWalletsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EnsureCoreWalletsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EnsureCoreWalletsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   EnsureCoreWalletsRequest clone() => EnsureCoreWalletsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  EnsureCoreWalletsRequest copyWith(void Function(EnsureCoreWalletsRequest) updates) =>
-      super.copyWith((message) => updates(message as EnsureCoreWalletsRequest)) as EnsureCoreWalletsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EnsureCoreWalletsRequest copyWith(void Function(EnsureCoreWalletsRequest) updates) => super.copyWith((message) => updates(message as EnsureCoreWalletsRequest)) as EnsureCoreWalletsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1838,8 +1626,7 @@ class EnsureCoreWalletsRequest extends $pb.GeneratedMessage {
   EnsureCoreWalletsRequest createEmptyInstance() => create();
   static $pb.PbList<EnsureCoreWalletsRequest> createRepeated() => $pb.PbList<EnsureCoreWalletsRequest>();
   @$core.pragma('dart2js:noInline')
-  static EnsureCoreWalletsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EnsureCoreWalletsRequest>(create);
+  static EnsureCoreWalletsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EnsureCoreWalletsRequest>(create);
   static EnsureCoreWalletsRequest? _defaultInstance;
 }
 
@@ -1854,26 +1641,24 @@ class EnsureCoreWalletsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   EnsureCoreWalletsResponse._() : super();
-  factory EnsureCoreWalletsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory EnsureCoreWalletsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory EnsureCoreWalletsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EnsureCoreWalletsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EnsureCoreWalletsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EnsureCoreWalletsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'syncedCount', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   EnsureCoreWalletsResponse clone() => EnsureCoreWalletsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  EnsureCoreWalletsResponse copyWith(void Function(EnsureCoreWalletsResponse) updates) =>
-      super.copyWith((message) => updates(message as EnsureCoreWalletsResponse)) as EnsureCoreWalletsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EnsureCoreWalletsResponse copyWith(void Function(EnsureCoreWalletsResponse) updates) => super.copyWith((message) => updates(message as EnsureCoreWalletsResponse)) as EnsureCoreWalletsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1882,17 +1667,13 @@ class EnsureCoreWalletsResponse extends $pb.GeneratedMessage {
   EnsureCoreWalletsResponse createEmptyInstance() => create();
   static $pb.PbList<EnsureCoreWalletsResponse> createRepeated() => $pb.PbList<EnsureCoreWalletsResponse>();
   @$core.pragma('dart2js:noInline')
-  static EnsureCoreWalletsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EnsureCoreWalletsResponse>(create);
+  static EnsureCoreWalletsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EnsureCoreWalletsResponse>(create);
   static EnsureCoreWalletsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get syncedCount => $_getIZ(0);
   @$pb.TagNumber(1)
-  set syncedCount($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set syncedCount($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSyncedCount() => $_has(0);
   @$pb.TagNumber(1)
@@ -1910,26 +1691,24 @@ class GetBalanceRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBalanceRequest._() : super();
-  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceRequest clone() => GetBalanceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) => super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1938,17 +1717,13 @@ class GetBalanceRequest extends $pb.GeneratedMessage {
   GetBalanceRequest createEmptyInstance() => create();
   static $pb.PbList<GetBalanceRequest> createRepeated() => $pb.PbList<GetBalanceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
+  static GetBalanceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
   static GetBalanceRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1970,27 +1745,25 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBalanceResponse._() : super();
-  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..a<$core.double>(1, _omitFieldNames ? '' : 'confirmedSats', $pb.PbFieldType.OD)
     ..a<$core.double>(2, _omitFieldNames ? '' : 'unconfirmedSats', $pb.PbFieldType.OD)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceResponse clone() => GetBalanceResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) => super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1999,17 +1772,13 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   GetBalanceResponse createEmptyInstance() => create();
   static $pb.PbList<GetBalanceResponse> createRepeated() => $pb.PbList<GetBalanceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
+  static GetBalanceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
   static GetBalanceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.double get confirmedSats => $_getN(0);
   @$pb.TagNumber(1)
-  set confirmedSats($core.double v) {
-    $_setDouble(0, v);
-  }
-
+  set confirmedSats($core.double v) { $_setDouble(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasConfirmedSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -2018,10 +1787,7 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.double get unconfirmedSats => $_getN(1);
   @$pb.TagNumber(2)
-  set unconfirmedSats($core.double v) {
-    $_setDouble(1, v);
-  }
-
+  set unconfirmedSats($core.double v) { $_setDouble(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasUnconfirmedSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -2039,26 +1805,24 @@ class GetNewAddressRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewAddressRequest._() : super();
-  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressRequest clone() => GetNewAddressRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) => super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2067,17 +1831,13 @@ class GetNewAddressRequest extends $pb.GeneratedMessage {
   GetNewAddressRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressRequest> createRepeated() => $pb.PbList<GetNewAddressRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
+  static GetNewAddressRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
   static GetNewAddressRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -2099,27 +1859,25 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewAddressResponse._() : super();
-  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'index', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewAddressResponse clone() => GetNewAddressResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) => super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2128,17 +1886,13 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
   GetNewAddressResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewAddressResponse> createRepeated() => $pb.PbList<GetNewAddressResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewAddressResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
+  static GetNewAddressResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
   static GetNewAddressResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -2147,10 +1901,7 @@ class GetNewAddressResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get index => $_getIZ(1);
   @$pb.TagNumber(2)
-  set index($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set index($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasIndex() => $_has(1);
   @$pb.TagNumber(2)
@@ -2192,37 +1943,30 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SendTransactionRequest._() : super();
-  factory SendTransactionRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SendTransactionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SendTransactionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SendTransactionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SendTransactionRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SendTransactionRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
-    ..m<$core.String, $fixnum.Int64>(2, _omitFieldNames ? '' : 'destinations',
-        entryClassName: 'SendTransactionRequest.DestinationsEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.O6,
-        packageName: const $pb.PackageName('walletmanager.v1'))
+    ..m<$core.String, $fixnum.Int64>(2, _omitFieldNames ? '' : 'destinations', entryClassName: 'SendTransactionRequest.DestinationsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.O6, packageName: const $pb.PackageName('walletmanager.v1'))
     ..aInt64(3, _omitFieldNames ? '' : 'feeRateSatPerVbyte')
     ..aOB(4, _omitFieldNames ? '' : 'subtractFeeFromAmount')
     ..aOS(5, _omitFieldNames ? '' : 'opReturnHex')
     ..aInt64(6, _omitFieldNames ? '' : 'fixedFeeSats')
-    ..pc<UnspentOutput>(7, _omitFieldNames ? '' : 'requiredInputs', $pb.PbFieldType.PM,
-        subBuilder: UnspentOutput.create)
-    ..hasRequiredFields = false;
+    ..pc<UnspentOutput>(7, _omitFieldNames ? '' : 'requiredInputs', $pb.PbFieldType.PM, subBuilder: UnspentOutput.create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SendTransactionRequest clone() => SendTransactionRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SendTransactionRequest copyWith(void Function(SendTransactionRequest) updates) =>
-      super.copyWith((message) => updates(message as SendTransactionRequest)) as SendTransactionRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SendTransactionRequest copyWith(void Function(SendTransactionRequest) updates) => super.copyWith((message) => updates(message as SendTransactionRequest)) as SendTransactionRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2231,17 +1975,13 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
   SendTransactionRequest createEmptyInstance() => create();
   static $pb.PbList<SendTransactionRequest> createRepeated() => $pb.PbList<SendTransactionRequest>();
   @$core.pragma('dart2js:noInline')
-  static SendTransactionRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SendTransactionRequest>(create);
+  static SendTransactionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SendTransactionRequest>(create);
   static SendTransactionRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -2253,10 +1993,7 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeRateSatPerVbyte => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeRateSatPerVbyte($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeRateSatPerVbyte($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeRateSatPerVbyte() => $_has(2);
   @$pb.TagNumber(3)
@@ -2265,10 +2002,7 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.bool get subtractFeeFromAmount => $_getBF(3);
   @$pb.TagNumber(4)
-  set subtractFeeFromAmount($core.bool v) {
-    $_setBool(3, v);
-  }
-
+  set subtractFeeFromAmount($core.bool v) { $_setBool(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasSubtractFeeFromAmount() => $_has(3);
   @$pb.TagNumber(4)
@@ -2278,10 +2012,7 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get opReturnHex => $_getSZ(4);
   @$pb.TagNumber(5)
-  set opReturnHex($core.String v) {
-    $_setString(4, v);
-  }
-
+  set opReturnHex($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasOpReturnHex() => $_has(4);
   @$pb.TagNumber(5)
@@ -2291,10 +2022,7 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get fixedFeeSats => $_getI64(5);
   @$pb.TagNumber(6)
-  set fixedFeeSats($fixnum.Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set fixedFeeSats($fixnum.Int64 v) { $_setInt64(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasFixedFeeSats() => $_has(5);
   @$pb.TagNumber(6)
@@ -2316,26 +2044,24 @@ class SendTransactionResponse extends $pb.GeneratedMessage {
     return $result;
   }
   SendTransactionResponse._() : super();
-  factory SendTransactionResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SendTransactionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SendTransactionResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SendTransactionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SendTransactionResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SendTransactionResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SendTransactionResponse clone() => SendTransactionResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SendTransactionResponse copyWith(void Function(SendTransactionResponse) updates) =>
-      super.copyWith((message) => updates(message as SendTransactionResponse)) as SendTransactionResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SendTransactionResponse copyWith(void Function(SendTransactionResponse) updates) => super.copyWith((message) => updates(message as SendTransactionResponse)) as SendTransactionResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2344,17 +2070,13 @@ class SendTransactionResponse extends $pb.GeneratedMessage {
   SendTransactionResponse createEmptyInstance() => create();
   static $pb.PbList<SendTransactionResponse> createRepeated() => $pb.PbList<SendTransactionResponse>();
   @$core.pragma('dart2js:noInline')
-  static SendTransactionResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SendTransactionResponse>(create);
+  static SendTransactionResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SendTransactionResponse>(create);
   static SendTransactionResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2376,27 +2098,25 @@ class ListTransactionsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ListTransactionsRequest._() : super();
-  factory ListTransactionsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListTransactionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListTransactionsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListTransactionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListTransactionsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListTransactionsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'count', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListTransactionsRequest clone() => ListTransactionsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListTransactionsRequest copyWith(void Function(ListTransactionsRequest) updates) =>
-      super.copyWith((message) => updates(message as ListTransactionsRequest)) as ListTransactionsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListTransactionsRequest copyWith(void Function(ListTransactionsRequest) updates) => super.copyWith((message) => updates(message as ListTransactionsRequest)) as ListTransactionsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2405,17 +2125,13 @@ class ListTransactionsRequest extends $pb.GeneratedMessage {
   ListTransactionsRequest createEmptyInstance() => create();
   static $pb.PbList<ListTransactionsRequest> createRepeated() => $pb.PbList<ListTransactionsRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListTransactionsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListTransactionsRequest>(create);
+  static ListTransactionsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListTransactionsRequest>(create);
   static ListTransactionsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -2424,10 +2140,7 @@ class ListTransactionsRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get count => $_getIZ(1);
   @$pb.TagNumber(2)
-  set count($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set count($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasCount() => $_has(1);
   @$pb.TagNumber(2)
@@ -2493,14 +2206,10 @@ class TransactionEntry extends $pb.GeneratedMessage {
     return $result;
   }
   TransactionEntry._() : super();
-  factory TransactionEntry.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransactionEntry.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransactionEntry.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransactionEntry.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransactionEntry',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransactionEntry', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'vout', $pb.PbFieldType.O3)
     ..aOS(3, _omitFieldNames ? '' : 'address')
@@ -2514,17 +2223,19 @@ class TransactionEntry extends $pb.GeneratedMessage {
     ..a<$core.double>(11, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.OD)
     ..aOB(12, _omitFieldNames ? '' : 'replacedByTxid')
     ..aOS(13, _omitFieldNames ? '' : 'walletId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransactionEntry clone() => TransactionEntry()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransactionEntry copyWith(void Function(TransactionEntry) updates) =>
-      super.copyWith((message) => updates(message as TransactionEntry)) as TransactionEntry;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransactionEntry copyWith(void Function(TransactionEntry) updates) => super.copyWith((message) => updates(message as TransactionEntry)) as TransactionEntry;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2533,17 +2244,13 @@ class TransactionEntry extends $pb.GeneratedMessage {
   TransactionEntry createEmptyInstance() => create();
   static $pb.PbList<TransactionEntry> createRepeated() => $pb.PbList<TransactionEntry>();
   @$core.pragma('dart2js:noInline')
-  static TransactionEntry getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransactionEntry>(create);
+  static TransactionEntry getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransactionEntry>(create);
   static TransactionEntry? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2552,10 +2259,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get vout => $_getIZ(1);
   @$pb.TagNumber(2)
-  set vout($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set vout($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasVout() => $_has(1);
   @$pb.TagNumber(2)
@@ -2564,10 +2268,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get address => $_getSZ(2);
   @$pb.TagNumber(3)
-  set address($core.String v) {
-    $_setString(2, v);
-  }
-
+  set address($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasAddress() => $_has(2);
   @$pb.TagNumber(3)
@@ -2576,10 +2277,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get category => $_getSZ(3);
   @$pb.TagNumber(4)
-  set category($core.String v) {
-    $_setString(3, v);
-  }
-
+  set category($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasCategory() => $_has(3);
   @$pb.TagNumber(4)
@@ -2588,10 +2286,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.double get amount => $_getN(4);
   @$pb.TagNumber(5)
-  set amount($core.double v) {
-    $_setDouble(4, v);
-  }
-
+  set amount($core.double v) { $_setDouble(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasAmount() => $_has(4);
   @$pb.TagNumber(5)
@@ -2600,10 +2295,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get amountSats => $_getI64(5);
   @$pb.TagNumber(6)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasAmountSats() => $_has(5);
   @$pb.TagNumber(6)
@@ -2612,10 +2304,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.int get confirmations => $_getIZ(6);
   @$pb.TagNumber(7)
-  set confirmations($core.int v) {
-    $_setSignedInt32(6, v);
-  }
-
+  set confirmations($core.int v) { $_setSignedInt32(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasConfirmations() => $_has(6);
   @$pb.TagNumber(7)
@@ -2624,10 +2313,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $fixnum.Int64 get blockTime => $_getI64(7);
   @$pb.TagNumber(8)
-  set blockTime($fixnum.Int64 v) {
-    $_setInt64(7, v);
-  }
-
+  set blockTime($fixnum.Int64 v) { $_setInt64(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasBlockTime() => $_has(7);
   @$pb.TagNumber(8)
@@ -2636,10 +2322,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $fixnum.Int64 get time => $_getI64(8);
   @$pb.TagNumber(9)
-  set time($fixnum.Int64 v) {
-    $_setInt64(8, v);
-  }
-
+  set time($fixnum.Int64 v) { $_setInt64(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasTime() => $_has(8);
   @$pb.TagNumber(9)
@@ -2648,10 +2331,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.String get label => $_getSZ(9);
   @$pb.TagNumber(10)
-  set label($core.String v) {
-    $_setString(9, v);
-  }
-
+  set label($core.String v) { $_setString(9, v); }
   @$pb.TagNumber(10)
   $core.bool hasLabel() => $_has(9);
   @$pb.TagNumber(10)
@@ -2660,10 +2340,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $core.double get fee => $_getN(10);
   @$pb.TagNumber(11)
-  set fee($core.double v) {
-    $_setDouble(10, v);
-  }
-
+  set fee($core.double v) { $_setDouble(10, v); }
   @$pb.TagNumber(11)
   $core.bool hasFee() => $_has(10);
   @$pb.TagNumber(11)
@@ -2672,10 +2349,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $core.bool get replacedByTxid => $_getBF(11);
   @$pb.TagNumber(12)
-  set replacedByTxid($core.bool v) {
-    $_setBool(11, v);
-  }
-
+  set replacedByTxid($core.bool v) { $_setBool(11, v); }
   @$pb.TagNumber(12)
   $core.bool hasReplacedByTxid() => $_has(11);
   @$pb.TagNumber(12)
@@ -2684,10 +2358,7 @@ class TransactionEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(13)
   $core.String get walletId => $_getSZ(12);
   @$pb.TagNumber(13)
-  set walletId($core.String v) {
-    $_setString(12, v);
-  }
-
+  set walletId($core.String v) { $_setString(12, v); }
   @$pb.TagNumber(13)
   $core.bool hasWalletId() => $_has(12);
   @$pb.TagNumber(13)
@@ -2705,27 +2376,24 @@ class ListTransactionsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListTransactionsResponse._() : super();
-  factory ListTransactionsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListTransactionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListTransactionsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListTransactionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListTransactionsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..pc<TransactionEntry>(1, _omitFieldNames ? '' : 'transactions', $pb.PbFieldType.PM,
-        subBuilder: TransactionEntry.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListTransactionsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..pc<TransactionEntry>(1, _omitFieldNames ? '' : 'transactions', $pb.PbFieldType.PM, subBuilder: TransactionEntry.create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListTransactionsResponse clone() => ListTransactionsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListTransactionsResponse copyWith(void Function(ListTransactionsResponse) updates) =>
-      super.copyWith((message) => updates(message as ListTransactionsResponse)) as ListTransactionsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListTransactionsResponse copyWith(void Function(ListTransactionsResponse) updates) => super.copyWith((message) => updates(message as ListTransactionsResponse)) as ListTransactionsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2734,8 +2402,7 @@ class ListTransactionsResponse extends $pb.GeneratedMessage {
   ListTransactionsResponse createEmptyInstance() => create();
   static $pb.PbList<ListTransactionsResponse> createRepeated() => $pb.PbList<ListTransactionsResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListTransactionsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListTransactionsResponse>(create);
+  static ListTransactionsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListTransactionsResponse>(create);
   static ListTransactionsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -2753,26 +2420,24 @@ class ListUnspentRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ListUnspentRequest._() : super();
-  factory ListUnspentRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUnspentRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUnspentRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUnspentRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUnspentRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUnspentRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUnspentRequest clone() => ListUnspentRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUnspentRequest copyWith(void Function(ListUnspentRequest) updates) =>
-      super.copyWith((message) => updates(message as ListUnspentRequest)) as ListUnspentRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUnspentRequest copyWith(void Function(ListUnspentRequest) updates) => super.copyWith((message) => updates(message as ListUnspentRequest)) as ListUnspentRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2781,17 +2446,13 @@ class ListUnspentRequest extends $pb.GeneratedMessage {
   ListUnspentRequest createEmptyInstance() => create();
   static $pb.PbList<ListUnspentRequest> createRepeated() => $pb.PbList<ListUnspentRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListUnspentRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUnspentRequest>(create);
+  static ListUnspentRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUnspentRequest>(create);
   static ListUnspentRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -2845,13 +2506,10 @@ class UnspentOutput extends $pb.GeneratedMessage {
     return $result;
   }
   UnspentOutput._() : super();
-  factory UnspentOutput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UnspentOutput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory UnspentOutput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UnspentOutput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnspentOutput',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnspentOutput', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'vout', $pb.PbFieldType.O3)
     ..aOS(3, _omitFieldNames ? '' : 'address')
@@ -2862,17 +2520,19 @@ class UnspentOutput extends $pb.GeneratedMessage {
     ..aOB(8, _omitFieldNames ? '' : 'spendable')
     ..aOB(9, _omitFieldNames ? '' : 'solvable')
     ..aOS(10, _omitFieldNames ? '' : 'walletId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   UnspentOutput clone() => UnspentOutput()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  UnspentOutput copyWith(void Function(UnspentOutput) updates) =>
-      super.copyWith((message) => updates(message as UnspentOutput)) as UnspentOutput;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UnspentOutput copyWith(void Function(UnspentOutput) updates) => super.copyWith((message) => updates(message as UnspentOutput)) as UnspentOutput;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2887,10 +2547,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2899,10 +2556,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get vout => $_getIZ(1);
   @$pb.TagNumber(2)
-  set vout($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set vout($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasVout() => $_has(1);
   @$pb.TagNumber(2)
@@ -2911,10 +2565,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get address => $_getSZ(2);
   @$pb.TagNumber(3)
-  set address($core.String v) {
-    $_setString(2, v);
-  }
-
+  set address($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasAddress() => $_has(2);
   @$pb.TagNumber(3)
@@ -2923,10 +2574,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.double get amount => $_getN(3);
   @$pb.TagNumber(4)
-  set amount($core.double v) {
-    $_setDouble(3, v);
-  }
-
+  set amount($core.double v) { $_setDouble(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasAmount() => $_has(3);
   @$pb.TagNumber(4)
@@ -2935,10 +2583,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get amountSats => $_getI64(4);
   @$pb.TagNumber(5)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasAmountSats() => $_has(4);
   @$pb.TagNumber(5)
@@ -2947,10 +2592,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get confirmations => $_getIZ(5);
   @$pb.TagNumber(6)
-  set confirmations($core.int v) {
-    $_setSignedInt32(5, v);
-  }
-
+  set confirmations($core.int v) { $_setSignedInt32(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasConfirmations() => $_has(5);
   @$pb.TagNumber(6)
@@ -2959,10 +2601,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get label => $_getSZ(6);
   @$pb.TagNumber(7)
-  set label($core.String v) {
-    $_setString(6, v);
-  }
-
+  set label($core.String v) { $_setString(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasLabel() => $_has(6);
   @$pb.TagNumber(7)
@@ -2971,10 +2610,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.bool get spendable => $_getBF(7);
   @$pb.TagNumber(8)
-  set spendable($core.bool v) {
-    $_setBool(7, v);
-  }
-
+  set spendable($core.bool v) { $_setBool(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasSpendable() => $_has(7);
   @$pb.TagNumber(8)
@@ -2983,10 +2619,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.bool get solvable => $_getBF(8);
   @$pb.TagNumber(9)
-  set solvable($core.bool v) {
-    $_setBool(8, v);
-  }
-
+  set solvable($core.bool v) { $_setBool(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasSolvable() => $_has(8);
   @$pb.TagNumber(9)
@@ -2995,10 +2628,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.String get walletId => $_getSZ(9);
   @$pb.TagNumber(10)
-  set walletId($core.String v) {
-    $_setString(9, v);
-  }
-
+  set walletId($core.String v) { $_setString(9, v); }
   @$pb.TagNumber(10)
   $core.bool hasWalletId() => $_has(9);
   @$pb.TagNumber(10)
@@ -3016,26 +2646,24 @@ class ListUnspentResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListUnspentResponse._() : super();
-  factory ListUnspentResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUnspentResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUnspentResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUnspentResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUnspentResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUnspentResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..pc<UnspentOutput>(1, _omitFieldNames ? '' : 'utxos', $pb.PbFieldType.PM, subBuilder: UnspentOutput.create)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUnspentResponse clone() => ListUnspentResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUnspentResponse copyWith(void Function(ListUnspentResponse) updates) =>
-      super.copyWith((message) => updates(message as ListUnspentResponse)) as ListUnspentResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUnspentResponse copyWith(void Function(ListUnspentResponse) updates) => super.copyWith((message) => updates(message as ListUnspentResponse)) as ListUnspentResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3044,8 +2672,7 @@ class ListUnspentResponse extends $pb.GeneratedMessage {
   ListUnspentResponse createEmptyInstance() => create();
   static $pb.PbList<ListUnspentResponse> createRepeated() => $pb.PbList<ListUnspentResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListUnspentResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUnspentResponse>(create);
+  static ListUnspentResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUnspentResponse>(create);
   static ListUnspentResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -3063,27 +2690,24 @@ class ListReceiveAddressesRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ListReceiveAddressesRequest._() : super();
-  factory ListReceiveAddressesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListReceiveAddressesRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListReceiveAddressesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListReceiveAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListReceiveAddressesRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListReceiveAddressesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListReceiveAddressesRequest clone() => ListReceiveAddressesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListReceiveAddressesRequest copyWith(void Function(ListReceiveAddressesRequest) updates) =>
-      super.copyWith((message) => updates(message as ListReceiveAddressesRequest)) as ListReceiveAddressesRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListReceiveAddressesRequest copyWith(void Function(ListReceiveAddressesRequest) updates) => super.copyWith((message) => updates(message as ListReceiveAddressesRequest)) as ListReceiveAddressesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3092,17 +2716,13 @@ class ListReceiveAddressesRequest extends $pb.GeneratedMessage {
   ListReceiveAddressesRequest createEmptyInstance() => create();
   static $pb.PbList<ListReceiveAddressesRequest> createRepeated() => $pb.PbList<ListReceiveAddressesRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListReceiveAddressesRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListReceiveAddressesRequest>(create);
+  static ListReceiveAddressesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListReceiveAddressesRequest>(create);
   static ListReceiveAddressesRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3136,29 +2756,28 @@ class ReceiveAddress extends $pb.GeneratedMessage {
     return $result;
   }
   ReceiveAddress._() : super();
-  factory ReceiveAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReceiveAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ReceiveAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReceiveAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReceiveAddress',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ReceiveAddress', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..a<$core.double>(2, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.OD)
     ..aInt64(3, _omitFieldNames ? '' : 'amountSats')
     ..aOS(4, _omitFieldNames ? '' : 'label')
     ..a<$core.int>(5, _omitFieldNames ? '' : 'txCount', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ReceiveAddress clone() => ReceiveAddress()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ReceiveAddress copyWith(void Function(ReceiveAddress) updates) =>
-      super.copyWith((message) => updates(message as ReceiveAddress)) as ReceiveAddress;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ReceiveAddress copyWith(void Function(ReceiveAddress) updates) => super.copyWith((message) => updates(message as ReceiveAddress)) as ReceiveAddress;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3173,10 +2792,7 @@ class ReceiveAddress extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -3185,10 +2801,7 @@ class ReceiveAddress extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.double get amount => $_getN(1);
   @$pb.TagNumber(2)
-  set amount($core.double v) {
-    $_setDouble(1, v);
-  }
-
+  set amount($core.double v) { $_setDouble(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -3197,10 +2810,7 @@ class ReceiveAddress extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get amountSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasAmountSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -3209,10 +2819,7 @@ class ReceiveAddress extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get label => $_getSZ(3);
   @$pb.TagNumber(4)
-  set label($core.String v) {
-    $_setString(3, v);
-  }
-
+  set label($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasLabel() => $_has(3);
   @$pb.TagNumber(4)
@@ -3221,10 +2828,7 @@ class ReceiveAddress extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.int get txCount => $_getIZ(4);
   @$pb.TagNumber(5)
-  set txCount($core.int v) {
-    $_setSignedInt32(4, v);
-  }
-
+  set txCount($core.int v) { $_setSignedInt32(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasTxCount() => $_has(4);
   @$pb.TagNumber(5)
@@ -3242,27 +2846,24 @@ class ListReceiveAddressesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListReceiveAddressesResponse._() : super();
-  factory ListReceiveAddressesResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListReceiveAddressesResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListReceiveAddressesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListReceiveAddressesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListReceiveAddressesResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListReceiveAddressesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..pc<ReceiveAddress>(1, _omitFieldNames ? '' : 'addresses', $pb.PbFieldType.PM, subBuilder: ReceiveAddress.create)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListReceiveAddressesResponse clone() => ListReceiveAddressesResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListReceiveAddressesResponse copyWith(void Function(ListReceiveAddressesResponse) updates) =>
-      super.copyWith((message) => updates(message as ListReceiveAddressesResponse)) as ListReceiveAddressesResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListReceiveAddressesResponse copyWith(void Function(ListReceiveAddressesResponse) updates) => super.copyWith((message) => updates(message as ListReceiveAddressesResponse)) as ListReceiveAddressesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3271,8 +2872,7 @@ class ListReceiveAddressesResponse extends $pb.GeneratedMessage {
   ListReceiveAddressesResponse createEmptyInstance() => create();
   static $pb.PbList<ListReceiveAddressesResponse> createRepeated() => $pb.PbList<ListReceiveAddressesResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListReceiveAddressesResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListReceiveAddressesResponse>(create);
+  static ListReceiveAddressesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListReceiveAddressesResponse>(create);
   static ListReceiveAddressesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -3294,28 +2894,25 @@ class GetTransactionDetailsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetTransactionDetailsRequest._() : super();
-  factory GetTransactionDetailsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetTransactionDetailsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetTransactionDetailsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTransactionDetailsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionDetailsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionDetailsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
     ..aOS(2, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetTransactionDetailsRequest clone() => GetTransactionDetailsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetTransactionDetailsRequest copyWith(void Function(GetTransactionDetailsRequest) updates) =>
-      super.copyWith((message) => updates(message as GetTransactionDetailsRequest)) as GetTransactionDetailsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTransactionDetailsRequest copyWith(void Function(GetTransactionDetailsRequest) updates) => super.copyWith((message) => updates(message as GetTransactionDetailsRequest)) as GetTransactionDetailsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3324,17 +2921,13 @@ class GetTransactionDetailsRequest extends $pb.GeneratedMessage {
   GetTransactionDetailsRequest createEmptyInstance() => create();
   static $pb.PbList<GetTransactionDetailsRequest> createRepeated() => $pb.PbList<GetTransactionDetailsRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetTransactionDetailsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionDetailsRequest>(create);
+  static GetTransactionDetailsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionDetailsRequest>(create);
   static GetTransactionDetailsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3343,10 +2936,7 @@ class GetTransactionDetailsRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get txid => $_getSZ(1);
   @$pb.TagNumber(2)
-  set txid($core.String v) {
-    $_setString(1, v);
-  }
-
+  set txid($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasTxid() => $_has(1);
   @$pb.TagNumber(2)
@@ -3424,15 +3014,10 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetTransactionDetailsResponse._() : super();
-  factory GetTransactionDetailsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetTransactionDetailsResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetTransactionDetailsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTransactionDetailsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionDetailsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionDetailsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOM<TransactionEntry>(1, _omitFieldNames ? '' : 'transaction', subBuilder: TransactionEntry.create)
     ..aOS(2, _omitFieldNames ? '' : 'rawHex')
     ..aOS(3, _omitFieldNames ? '' : 'blockhash')
@@ -3447,20 +3032,21 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
     ..a<$core.double>(12, _omitFieldNames ? '' : 'feeRateSatVb', $pb.PbFieldType.OD)
     ..pc<TransactionInput>(13, _omitFieldNames ? '' : 'inputs', $pb.PbFieldType.PM, subBuilder: TransactionInput.create)
     ..aInt64(14, _omitFieldNames ? '' : 'totalInputSats')
-    ..pc<TransactionOutput>(15, _omitFieldNames ? '' : 'outputs', $pb.PbFieldType.PM,
-        subBuilder: TransactionOutput.create)
+    ..pc<TransactionOutput>(15, _omitFieldNames ? '' : 'outputs', $pb.PbFieldType.PM, subBuilder: TransactionOutput.create)
     ..aInt64(16, _omitFieldNames ? '' : 'totalOutputSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetTransactionDetailsResponse clone() => GetTransactionDetailsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetTransactionDetailsResponse copyWith(void Function(GetTransactionDetailsResponse) updates) =>
-      super.copyWith((message) => updates(message as GetTransactionDetailsResponse)) as GetTransactionDetailsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTransactionDetailsResponse copyWith(void Function(GetTransactionDetailsResponse) updates) => super.copyWith((message) => updates(message as GetTransactionDetailsResponse)) as GetTransactionDetailsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3469,17 +3055,13 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   GetTransactionDetailsResponse createEmptyInstance() => create();
   static $pb.PbList<GetTransactionDetailsResponse> createRepeated() => $pb.PbList<GetTransactionDetailsResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetTransactionDetailsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionDetailsResponse>(create);
+  static GetTransactionDetailsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionDetailsResponse>(create);
   static GetTransactionDetailsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   TransactionEntry get transaction => $_getN(0);
   @$pb.TagNumber(1)
-  set transaction(TransactionEntry v) {
-    setField(1, v);
-  }
-
+  set transaction(TransactionEntry v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasTransaction() => $_has(0);
   @$pb.TagNumber(1)
@@ -3490,10 +3072,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get rawHex => $_getSZ(1);
   @$pb.TagNumber(2)
-  set rawHex($core.String v) {
-    $_setString(1, v);
-  }
-
+  set rawHex($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasRawHex() => $_has(1);
   @$pb.TagNumber(2)
@@ -3502,10 +3081,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get blockhash => $_getSZ(2);
   @$pb.TagNumber(3)
-  set blockhash($core.String v) {
-    $_setString(2, v);
-  }
-
+  set blockhash($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasBlockhash() => $_has(2);
   @$pb.TagNumber(3)
@@ -3514,10 +3090,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.int get confirmations => $_getIZ(3);
   @$pb.TagNumber(4)
-  set confirmations($core.int v) {
-    $_setSignedInt32(3, v);
-  }
-
+  set confirmations($core.int v) { $_setSignedInt32(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasConfirmations() => $_has(3);
   @$pb.TagNumber(4)
@@ -3526,10 +3099,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get blockTime => $_getI64(4);
   @$pb.TagNumber(5)
-  set blockTime($fixnum.Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set blockTime($fixnum.Int64 v) { $_setInt64(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasBlockTime() => $_has(4);
   @$pb.TagNumber(5)
@@ -3538,10 +3108,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get version => $_getIZ(5);
   @$pb.TagNumber(6)
-  set version($core.int v) {
-    $_setSignedInt32(5, v);
-  }
-
+  set version($core.int v) { $_setSignedInt32(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasVersion() => $_has(5);
   @$pb.TagNumber(6)
@@ -3550,10 +3117,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.int get locktime => $_getIZ(6);
   @$pb.TagNumber(7)
-  set locktime($core.int v) {
-    $_setSignedInt32(6, v);
-  }
-
+  set locktime($core.int v) { $_setSignedInt32(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasLocktime() => $_has(6);
   @$pb.TagNumber(7)
@@ -3562,10 +3126,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.int get sizeBytes => $_getIZ(7);
   @$pb.TagNumber(8)
-  set sizeBytes($core.int v) {
-    $_setSignedInt32(7, v);
-  }
-
+  set sizeBytes($core.int v) { $_setSignedInt32(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasSizeBytes() => $_has(7);
   @$pb.TagNumber(8)
@@ -3574,10 +3135,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.int get vsizeVbytes => $_getIZ(8);
   @$pb.TagNumber(9)
-  set vsizeVbytes($core.int v) {
-    $_setSignedInt32(8, v);
-  }
-
+  set vsizeVbytes($core.int v) { $_setSignedInt32(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasVsizeVbytes() => $_has(8);
   @$pb.TagNumber(9)
@@ -3586,10 +3144,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.int get weightWu => $_getIZ(9);
   @$pb.TagNumber(10)
-  set weightWu($core.int v) {
-    $_setSignedInt32(9, v);
-  }
-
+  set weightWu($core.int v) { $_setSignedInt32(9, v); }
   @$pb.TagNumber(10)
   $core.bool hasWeightWu() => $_has(9);
   @$pb.TagNumber(10)
@@ -3598,10 +3153,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $fixnum.Int64 get feeSats => $_getI64(10);
   @$pb.TagNumber(11)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(10, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(10, v); }
   @$pb.TagNumber(11)
   $core.bool hasFeeSats() => $_has(10);
   @$pb.TagNumber(11)
@@ -3610,10 +3162,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $core.double get feeRateSatVb => $_getN(11);
   @$pb.TagNumber(12)
-  set feeRateSatVb($core.double v) {
-    $_setDouble(11, v);
-  }
-
+  set feeRateSatVb($core.double v) { $_setDouble(11, v); }
   @$pb.TagNumber(12)
   $core.bool hasFeeRateSatVb() => $_has(11);
   @$pb.TagNumber(12)
@@ -3625,10 +3174,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(14)
   $fixnum.Int64 get totalInputSats => $_getI64(13);
   @$pb.TagNumber(14)
-  set totalInputSats($fixnum.Int64 v) {
-    $_setInt64(13, v);
-  }
-
+  set totalInputSats($fixnum.Int64 v) { $_setInt64(13, v); }
   @$pb.TagNumber(14)
   $core.bool hasTotalInputSats() => $_has(13);
   @$pb.TagNumber(14)
@@ -3640,10 +3186,7 @@ class GetTransactionDetailsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(16)
   $fixnum.Int64 get totalOutputSats => $_getI64(15);
   @$pb.TagNumber(16)
-  set totalOutputSats($fixnum.Int64 v) {
-    $_setInt64(15, v);
-  }
-
+  set totalOutputSats($fixnum.Int64 v) { $_setInt64(15, v); }
   @$pb.TagNumber(16)
   $core.bool hasTotalOutputSats() => $_has(15);
   @$pb.TagNumber(16)
@@ -3697,14 +3240,10 @@ class TransactionInput extends $pb.GeneratedMessage {
     return $result;
   }
   TransactionInput._() : super();
-  factory TransactionInput.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransactionInput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransactionInput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransactionInput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransactionInput',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransactionInput', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'index', $pb.PbFieldType.O3)
     ..aOS(2, _omitFieldNames ? '' : 'prevTxid')
     ..a<$core.int>(3, _omitFieldNames ? '' : 'prevVout', $pb.PbFieldType.O3)
@@ -3715,17 +3254,19 @@ class TransactionInput extends $pb.GeneratedMessage {
     ..pPS(8, _omitFieldNames ? '' : 'witness')
     ..aInt64(9, _omitFieldNames ? '' : 'sequence')
     ..aOB(10, _omitFieldNames ? '' : 'isCoinbase')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransactionInput clone() => TransactionInput()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransactionInput copyWith(void Function(TransactionInput) updates) =>
-      super.copyWith((message) => updates(message as TransactionInput)) as TransactionInput;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransactionInput copyWith(void Function(TransactionInput) updates) => super.copyWith((message) => updates(message as TransactionInput)) as TransactionInput;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3734,17 +3275,13 @@ class TransactionInput extends $pb.GeneratedMessage {
   TransactionInput createEmptyInstance() => create();
   static $pb.PbList<TransactionInput> createRepeated() => $pb.PbList<TransactionInput>();
   @$core.pragma('dart2js:noInline')
-  static TransactionInput getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransactionInput>(create);
+  static TransactionInput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransactionInput>(create);
   static TransactionInput? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get index => $_getIZ(0);
   @$pb.TagNumber(1)
-  set index($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set index($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasIndex() => $_has(0);
   @$pb.TagNumber(1)
@@ -3753,10 +3290,7 @@ class TransactionInput extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get prevTxid => $_getSZ(1);
   @$pb.TagNumber(2)
-  set prevTxid($core.String v) {
-    $_setString(1, v);
-  }
-
+  set prevTxid($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasPrevTxid() => $_has(1);
   @$pb.TagNumber(2)
@@ -3765,10 +3299,7 @@ class TransactionInput extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get prevVout => $_getIZ(2);
   @$pb.TagNumber(3)
-  set prevVout($core.int v) {
-    $_setSignedInt32(2, v);
-  }
-
+  set prevVout($core.int v) { $_setSignedInt32(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasPrevVout() => $_has(2);
   @$pb.TagNumber(3)
@@ -3777,10 +3308,7 @@ class TransactionInput extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get address => $_getSZ(3);
   @$pb.TagNumber(4)
-  set address($core.String v) {
-    $_setString(3, v);
-  }
-
+  set address($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasAddress() => $_has(3);
   @$pb.TagNumber(4)
@@ -3789,10 +3317,7 @@ class TransactionInput extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get valueSats => $_getI64(4);
   @$pb.TagNumber(5)
-  set valueSats($fixnum.Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set valueSats($fixnum.Int64 v) { $_setInt64(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasValueSats() => $_has(4);
   @$pb.TagNumber(5)
@@ -3801,10 +3326,7 @@ class TransactionInput extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get scriptSigAsm => $_getSZ(5);
   @$pb.TagNumber(6)
-  set scriptSigAsm($core.String v) {
-    $_setString(5, v);
-  }
-
+  set scriptSigAsm($core.String v) { $_setString(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasScriptSigAsm() => $_has(5);
   @$pb.TagNumber(6)
@@ -3813,10 +3335,7 @@ class TransactionInput extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get scriptSigHex => $_getSZ(6);
   @$pb.TagNumber(7)
-  set scriptSigHex($core.String v) {
-    $_setString(6, v);
-  }
-
+  set scriptSigHex($core.String v) { $_setString(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasScriptSigHex() => $_has(6);
   @$pb.TagNumber(7)
@@ -3828,10 +3347,7 @@ class TransactionInput extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $fixnum.Int64 get sequence => $_getI64(8);
   @$pb.TagNumber(9)
-  set sequence($fixnum.Int64 v) {
-    $_setInt64(8, v);
-  }
-
+  set sequence($fixnum.Int64 v) { $_setInt64(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasSequence() => $_has(8);
   @$pb.TagNumber(9)
@@ -3840,10 +3356,7 @@ class TransactionInput extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.bool get isCoinbase => $_getBF(9);
   @$pb.TagNumber(10)
-  set isCoinbase($core.bool v) {
-    $_setBool(9, v);
-  }
-
+  set isCoinbase($core.bool v) { $_setBool(9, v); }
   @$pb.TagNumber(10)
   $core.bool hasIsCoinbase() => $_has(9);
   @$pb.TagNumber(10)
@@ -3881,31 +3394,29 @@ class TransactionOutput extends $pb.GeneratedMessage {
     return $result;
   }
   TransactionOutput._() : super();
-  factory TransactionOutput.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransactionOutput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransactionOutput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransactionOutput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransactionOutput',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransactionOutput', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'index', $pb.PbFieldType.O3)
     ..aInt64(2, _omitFieldNames ? '' : 'valueSats')
     ..aOS(3, _omitFieldNames ? '' : 'address')
     ..aOS(4, _omitFieldNames ? '' : 'scriptType')
     ..aOS(5, _omitFieldNames ? '' : 'scriptPubkeyAsm')
     ..aOS(6, _omitFieldNames ? '' : 'scriptPubkeyHex')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransactionOutput clone() => TransactionOutput()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransactionOutput copyWith(void Function(TransactionOutput) updates) =>
-      super.copyWith((message) => updates(message as TransactionOutput)) as TransactionOutput;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransactionOutput copyWith(void Function(TransactionOutput) updates) => super.copyWith((message) => updates(message as TransactionOutput)) as TransactionOutput;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3914,17 +3425,13 @@ class TransactionOutput extends $pb.GeneratedMessage {
   TransactionOutput createEmptyInstance() => create();
   static $pb.PbList<TransactionOutput> createRepeated() => $pb.PbList<TransactionOutput>();
   @$core.pragma('dart2js:noInline')
-  static TransactionOutput getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransactionOutput>(create);
+  static TransactionOutput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransactionOutput>(create);
   static TransactionOutput? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get index => $_getIZ(0);
   @$pb.TagNumber(1)
-  set index($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set index($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasIndex() => $_has(0);
   @$pb.TagNumber(1)
@@ -3933,10 +3440,7 @@ class TransactionOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get valueSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set valueSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set valueSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasValueSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -3945,10 +3449,7 @@ class TransactionOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get address => $_getSZ(2);
   @$pb.TagNumber(3)
-  set address($core.String v) {
-    $_setString(2, v);
-  }
-
+  set address($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasAddress() => $_has(2);
   @$pb.TagNumber(3)
@@ -3957,10 +3458,7 @@ class TransactionOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get scriptType => $_getSZ(3);
   @$pb.TagNumber(4)
-  set scriptType($core.String v) {
-    $_setString(3, v);
-  }
-
+  set scriptType($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasScriptType() => $_has(3);
   @$pb.TagNumber(4)
@@ -3969,10 +3467,7 @@ class TransactionOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get scriptPubkeyAsm => $_getSZ(4);
   @$pb.TagNumber(5)
-  set scriptPubkeyAsm($core.String v) {
-    $_setString(4, v);
-  }
-
+  set scriptPubkeyAsm($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasScriptPubkeyAsm() => $_has(4);
   @$pb.TagNumber(5)
@@ -3981,10 +3476,7 @@ class TransactionOutput extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get scriptPubkeyHex => $_getSZ(5);
   @$pb.TagNumber(6)
-  set scriptPubkeyHex($core.String v) {
-    $_setString(5, v);
-  }
-
+  set scriptPubkeyHex($core.String v) { $_setString(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasScriptPubkeyHex() => $_has(5);
   @$pb.TagNumber(6)
@@ -4010,27 +3502,26 @@ class BumpFeeRequest extends $pb.GeneratedMessage {
     return $result;
   }
   BumpFeeRequest._() : super();
-  factory BumpFeeRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory BumpFeeRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory BumpFeeRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BumpFeeRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BumpFeeRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BumpFeeRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
     ..aOS(2, _omitFieldNames ? '' : 'txid')
     ..aInt64(3, _omitFieldNames ? '' : 'newFeeRate')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   BumpFeeRequest clone() => BumpFeeRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  BumpFeeRequest copyWith(void Function(BumpFeeRequest) updates) =>
-      super.copyWith((message) => updates(message as BumpFeeRequest)) as BumpFeeRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BumpFeeRequest copyWith(void Function(BumpFeeRequest) updates) => super.copyWith((message) => updates(message as BumpFeeRequest)) as BumpFeeRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4045,10 +3536,7 @@ class BumpFeeRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -4057,10 +3545,7 @@ class BumpFeeRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get txid => $_getSZ(1);
   @$pb.TagNumber(2)
-  set txid($core.String v) {
-    $_setString(1, v);
-  }
-
+  set txid($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasTxid() => $_has(1);
   @$pb.TagNumber(2)
@@ -4069,10 +3554,7 @@ class BumpFeeRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get newFeeRate => $_getI64(2);
   @$pb.TagNumber(3)
-  set newFeeRate($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set newFeeRate($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasNewFeeRate() => $_has(2);
   @$pb.TagNumber(3)
@@ -4090,26 +3572,24 @@ class BumpFeeResponse extends $pb.GeneratedMessage {
     return $result;
   }
   BumpFeeResponse._() : super();
-  factory BumpFeeResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory BumpFeeResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory BumpFeeResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BumpFeeResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BumpFeeResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BumpFeeResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'newTxid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   BumpFeeResponse clone() => BumpFeeResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  BumpFeeResponse copyWith(void Function(BumpFeeResponse) updates) =>
-      super.copyWith((message) => updates(message as BumpFeeResponse)) as BumpFeeResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BumpFeeResponse copyWith(void Function(BumpFeeResponse) updates) => super.copyWith((message) => updates(message as BumpFeeResponse)) as BumpFeeResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4118,17 +3598,13 @@ class BumpFeeResponse extends $pb.GeneratedMessage {
   BumpFeeResponse createEmptyInstance() => create();
   static $pb.PbList<BumpFeeResponse> createRepeated() => $pb.PbList<BumpFeeResponse>();
   @$core.pragma('dart2js:noInline')
-  static BumpFeeResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BumpFeeResponse>(create);
+  static BumpFeeResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BumpFeeResponse>(create);
   static BumpFeeResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get newTxid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set newTxid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set newTxid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasNewTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -4154,28 +3630,26 @@ class DeriveAddressesRequest extends $pb.GeneratedMessage {
     return $result;
   }
   DeriveAddressesRequest._() : super();
-  factory DeriveAddressesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeriveAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DeriveAddressesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DeriveAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DeriveAddressesRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DeriveAddressesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'startIndex', $pb.PbFieldType.O3)
     ..a<$core.int>(3, _omitFieldNames ? '' : 'count', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DeriveAddressesRequest clone() => DeriveAddressesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DeriveAddressesRequest copyWith(void Function(DeriveAddressesRequest) updates) =>
-      super.copyWith((message) => updates(message as DeriveAddressesRequest)) as DeriveAddressesRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DeriveAddressesRequest copyWith(void Function(DeriveAddressesRequest) updates) => super.copyWith((message) => updates(message as DeriveAddressesRequest)) as DeriveAddressesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4184,17 +3658,13 @@ class DeriveAddressesRequest extends $pb.GeneratedMessage {
   DeriveAddressesRequest createEmptyInstance() => create();
   static $pb.PbList<DeriveAddressesRequest> createRepeated() => $pb.PbList<DeriveAddressesRequest>();
   @$core.pragma('dart2js:noInline')
-  static DeriveAddressesRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeriveAddressesRequest>(create);
+  static DeriveAddressesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeriveAddressesRequest>(create);
   static DeriveAddressesRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -4203,10 +3673,7 @@ class DeriveAddressesRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get startIndex => $_getIZ(1);
   @$pb.TagNumber(2)
-  set startIndex($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set startIndex($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasStartIndex() => $_has(1);
   @$pb.TagNumber(2)
@@ -4215,10 +3682,7 @@ class DeriveAddressesRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get count => $_getIZ(2);
   @$pb.TagNumber(3)
-  set count($core.int v) {
-    $_setSignedInt32(2, v);
-  }
-
+  set count($core.int v) { $_setSignedInt32(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasCount() => $_has(2);
   @$pb.TagNumber(3)
@@ -4236,26 +3700,24 @@ class DeriveAddressesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   DeriveAddressesResponse._() : super();
-  factory DeriveAddressesResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeriveAddressesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DeriveAddressesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DeriveAddressesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DeriveAddressesResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DeriveAddressesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..pPS(1, _omitFieldNames ? '' : 'addresses')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DeriveAddressesResponse clone() => DeriveAddressesResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DeriveAddressesResponse copyWith(void Function(DeriveAddressesResponse) updates) =>
-      super.copyWith((message) => updates(message as DeriveAddressesResponse)) as DeriveAddressesResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DeriveAddressesResponse copyWith(void Function(DeriveAddressesResponse) updates) => super.copyWith((message) => updates(message as DeriveAddressesResponse)) as DeriveAddressesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4264,8 +3726,7 @@ class DeriveAddressesResponse extends $pb.GeneratedMessage {
   DeriveAddressesResponse createEmptyInstance() => create();
   static $pb.PbList<DeriveAddressesResponse> createRepeated() => $pb.PbList<DeriveAddressesResponse>();
   @$core.pragma('dart2js:noInline')
-  static DeriveAddressesResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeriveAddressesResponse>(create);
+  static DeriveAddressesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeriveAddressesResponse>(create);
   static DeriveAddressesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -4283,26 +3744,24 @@ class GetWalletSeedRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletSeedRequest._() : super();
-  factory GetWalletSeedRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletSeedRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletSeedRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletSeedRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletSeedRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletSeedRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletSeedRequest clone() => GetWalletSeedRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletSeedRequest copyWith(void Function(GetWalletSeedRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletSeedRequest)) as GetWalletSeedRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletSeedRequest copyWith(void Function(GetWalletSeedRequest) updates) => super.copyWith((message) => updates(message as GetWalletSeedRequest)) as GetWalletSeedRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4311,17 +3770,13 @@ class GetWalletSeedRequest extends $pb.GeneratedMessage {
   GetWalletSeedRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletSeedRequest> createRepeated() => $pb.PbList<GetWalletSeedRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletSeedRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletSeedRequest>(create);
+  static GetWalletSeedRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletSeedRequest>(create);
   static GetWalletSeedRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get walletId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set walletId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set walletId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWalletId() => $_has(0);
   @$pb.TagNumber(1)
@@ -4343,27 +3798,25 @@ class GetWalletSeedResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletSeedResponse._() : super();
-  factory GetWalletSeedResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletSeedResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletSeedResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletSeedResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletSeedResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletSeedResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'seedHex')
     ..aOS(2, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletSeedResponse clone() => GetWalletSeedResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletSeedResponse copyWith(void Function(GetWalletSeedResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletSeedResponse)) as GetWalletSeedResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletSeedResponse copyWith(void Function(GetWalletSeedResponse) updates) => super.copyWith((message) => updates(message as GetWalletSeedResponse)) as GetWalletSeedResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4372,17 +3825,13 @@ class GetWalletSeedResponse extends $pb.GeneratedMessage {
   GetWalletSeedResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletSeedResponse> createRepeated() => $pb.PbList<GetWalletSeedResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletSeedResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletSeedResponse>(create);
+  static GetWalletSeedResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletSeedResponse>(create);
   static GetWalletSeedResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get seedHex => $_getSZ(0);
   @$pb.TagNumber(1)
-  set seedHex($core.String v) {
-    $_setString(0, v);
-  }
-
+  set seedHex($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSeedHex() => $_has(0);
   @$pb.TagNumber(1)
@@ -4392,10 +3841,7 @@ class GetWalletSeedResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get mnemonic => $_getSZ(1);
   @$pb.TagNumber(2)
-  set mnemonic($core.String v) {
-    $_setString(1, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasMnemonic() => $_has(1);
   @$pb.TagNumber(2)
@@ -4405,25 +3851,23 @@ class GetWalletSeedResponse extends $pb.GeneratedMessage {
 class ListCoreVariantsRequest extends $pb.GeneratedMessage {
   factory ListCoreVariantsRequest() => create();
   ListCoreVariantsRequest._() : super();
-  factory ListCoreVariantsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListCoreVariantsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListCoreVariantsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListCoreVariantsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListCoreVariantsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListCoreVariantsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListCoreVariantsRequest clone() => ListCoreVariantsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListCoreVariantsRequest copyWith(void Function(ListCoreVariantsRequest) updates) =>
-      super.copyWith((message) => updates(message as ListCoreVariantsRequest)) as ListCoreVariantsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListCoreVariantsRequest copyWith(void Function(ListCoreVariantsRequest) updates) => super.copyWith((message) => updates(message as ListCoreVariantsRequest)) as ListCoreVariantsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4432,8 +3876,7 @@ class ListCoreVariantsRequest extends $pb.GeneratedMessage {
   ListCoreVariantsRequest createEmptyInstance() => create();
   static $pb.PbList<ListCoreVariantsRequest> createRepeated() => $pb.PbList<ListCoreVariantsRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListCoreVariantsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListCoreVariantsRequest>(create);
+  static ListCoreVariantsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListCoreVariantsRequest>(create);
   static ListCoreVariantsRequest? _defaultInstance;
 }
 
@@ -4456,27 +3899,26 @@ class CoreVariant extends $pb.GeneratedMessage {
     return $result;
   }
   CoreVariant._() : super();
-  factory CoreVariant.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CoreVariant.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CoreVariant.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CoreVariant.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CoreVariant',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CoreVariant', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'id')
     ..aOS(2, _omitFieldNames ? '' : 'displayName')
     ..aOB(3, _omitFieldNames ? '' : 'installed')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CoreVariant clone() => CoreVariant()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CoreVariant copyWith(void Function(CoreVariant) updates) =>
-      super.copyWith((message) => updates(message as CoreVariant)) as CoreVariant;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CoreVariant copyWith(void Function(CoreVariant) updates) => super.copyWith((message) => updates(message as CoreVariant)) as CoreVariant;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4491,10 +3933,7 @@ class CoreVariant extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
@@ -4503,10 +3942,7 @@ class CoreVariant extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get displayName => $_getSZ(1);
   @$pb.TagNumber(2)
-  set displayName($core.String v) {
-    $_setString(1, v);
-  }
-
+  set displayName($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasDisplayName() => $_has(1);
   @$pb.TagNumber(2)
@@ -4515,10 +3951,7 @@ class CoreVariant extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get installed => $_getBF(2);
   @$pb.TagNumber(3)
-  set installed($core.bool v) {
-    $_setBool(2, v);
-  }
-
+  set installed($core.bool v) { $_setBool(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasInstalled() => $_has(2);
   @$pb.TagNumber(3)
@@ -4540,27 +3973,25 @@ class ListCoreVariantsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListCoreVariantsResponse._() : super();
-  factory ListCoreVariantsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListCoreVariantsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListCoreVariantsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListCoreVariantsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListCoreVariantsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListCoreVariantsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..pc<CoreVariant>(1, _omitFieldNames ? '' : 'variants', $pb.PbFieldType.PM, subBuilder: CoreVariant.create)
     ..aOS(2, _omitFieldNames ? '' : 'activeId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListCoreVariantsResponse clone() => ListCoreVariantsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListCoreVariantsResponse copyWith(void Function(ListCoreVariantsResponse) updates) =>
-      super.copyWith((message) => updates(message as ListCoreVariantsResponse)) as ListCoreVariantsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListCoreVariantsResponse copyWith(void Function(ListCoreVariantsResponse) updates) => super.copyWith((message) => updates(message as ListCoreVariantsResponse)) as ListCoreVariantsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4569,8 +4000,7 @@ class ListCoreVariantsResponse extends $pb.GeneratedMessage {
   ListCoreVariantsResponse createEmptyInstance() => create();
   static $pb.PbList<ListCoreVariantsResponse> createRepeated() => $pb.PbList<ListCoreVariantsResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListCoreVariantsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListCoreVariantsResponse>(create);
+  static ListCoreVariantsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListCoreVariantsResponse>(create);
   static ListCoreVariantsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -4579,10 +4009,7 @@ class ListCoreVariantsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get activeId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set activeId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set activeId($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasActiveId() => $_has(1);
   @$pb.TagNumber(2)
@@ -4592,25 +4019,23 @@ class ListCoreVariantsResponse extends $pb.GeneratedMessage {
 class GetCoreVariantRequest extends $pb.GeneratedMessage {
   factory GetCoreVariantRequest() => create();
   GetCoreVariantRequest._() : super();
-  factory GetCoreVariantRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetCoreVariantRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetCoreVariantRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetCoreVariantRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetCoreVariantRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetCoreVariantRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetCoreVariantRequest clone() => GetCoreVariantRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetCoreVariantRequest copyWith(void Function(GetCoreVariantRequest) updates) =>
-      super.copyWith((message) => updates(message as GetCoreVariantRequest)) as GetCoreVariantRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetCoreVariantRequest copyWith(void Function(GetCoreVariantRequest) updates) => super.copyWith((message) => updates(message as GetCoreVariantRequest)) as GetCoreVariantRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4619,8 +4044,7 @@ class GetCoreVariantRequest extends $pb.GeneratedMessage {
   GetCoreVariantRequest createEmptyInstance() => create();
   static $pb.PbList<GetCoreVariantRequest> createRepeated() => $pb.PbList<GetCoreVariantRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetCoreVariantRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCoreVariantRequest>(create);
+  static GetCoreVariantRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCoreVariantRequest>(create);
   static GetCoreVariantRequest? _defaultInstance;
 }
 
@@ -4635,26 +4059,24 @@ class GetCoreVariantResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetCoreVariantResponse._() : super();
-  factory GetCoreVariantResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetCoreVariantResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetCoreVariantResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetCoreVariantResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetCoreVariantResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetCoreVariantResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'id')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetCoreVariantResponse clone() => GetCoreVariantResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetCoreVariantResponse copyWith(void Function(GetCoreVariantResponse) updates) =>
-      super.copyWith((message) => updates(message as GetCoreVariantResponse)) as GetCoreVariantResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetCoreVariantResponse copyWith(void Function(GetCoreVariantResponse) updates) => super.copyWith((message) => updates(message as GetCoreVariantResponse)) as GetCoreVariantResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4663,17 +4085,13 @@ class GetCoreVariantResponse extends $pb.GeneratedMessage {
   GetCoreVariantResponse createEmptyInstance() => create();
   static $pb.PbList<GetCoreVariantResponse> createRepeated() => $pb.PbList<GetCoreVariantResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetCoreVariantResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCoreVariantResponse>(create);
+  static GetCoreVariantResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCoreVariantResponse>(create);
   static GetCoreVariantResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
@@ -4691,26 +4109,24 @@ class SetCoreVariantRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SetCoreVariantRequest._() : super();
-  factory SetCoreVariantRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetCoreVariantRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetCoreVariantRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetCoreVariantRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetCoreVariantRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetCoreVariantRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'id')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetCoreVariantRequest clone() => SetCoreVariantRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetCoreVariantRequest copyWith(void Function(SetCoreVariantRequest) updates) =>
-      super.copyWith((message) => updates(message as SetCoreVariantRequest)) as SetCoreVariantRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetCoreVariantRequest copyWith(void Function(SetCoreVariantRequest) updates) => super.copyWith((message) => updates(message as SetCoreVariantRequest)) as SetCoreVariantRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4719,17 +4135,13 @@ class SetCoreVariantRequest extends $pb.GeneratedMessage {
   SetCoreVariantRequest createEmptyInstance() => create();
   static $pb.PbList<SetCoreVariantRequest> createRepeated() => $pb.PbList<SetCoreVariantRequest>();
   @$core.pragma('dart2js:noInline')
-  static SetCoreVariantRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetCoreVariantRequest>(create);
+  static SetCoreVariantRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetCoreVariantRequest>(create);
   static SetCoreVariantRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
@@ -4739,25 +4151,23 @@ class SetCoreVariantRequest extends $pb.GeneratedMessage {
 class SetCoreVariantResponse extends $pb.GeneratedMessage {
   factory SetCoreVariantResponse() => create();
   SetCoreVariantResponse._() : super();
-  factory SetCoreVariantResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetCoreVariantResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetCoreVariantResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetCoreVariantResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetCoreVariantResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetCoreVariantResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetCoreVariantResponse clone() => SetCoreVariantResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetCoreVariantResponse copyWith(void Function(SetCoreVariantResponse) updates) =>
-      super.copyWith((message) => updates(message as SetCoreVariantResponse)) as SetCoreVariantResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetCoreVariantResponse copyWith(void Function(SetCoreVariantResponse) updates) => super.copyWith((message) => updates(message as SetCoreVariantResponse)) as SetCoreVariantResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4766,33 +4176,30 @@ class SetCoreVariantResponse extends $pb.GeneratedMessage {
   SetCoreVariantResponse createEmptyInstance() => create();
   static $pb.PbList<SetCoreVariantResponse> createRepeated() => $pb.PbList<SetCoreVariantResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetCoreVariantResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetCoreVariantResponse>(create);
+  static SetCoreVariantResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetCoreVariantResponse>(create);
   static SetCoreVariantResponse? _defaultInstance;
 }
 
 class GetTestSidechainsRequest extends $pb.GeneratedMessage {
   factory GetTestSidechainsRequest() => create();
   GetTestSidechainsRequest._() : super();
-  factory GetTestSidechainsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetTestSidechainsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetTestSidechainsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTestSidechainsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTestSidechainsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTestSidechainsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetTestSidechainsRequest clone() => GetTestSidechainsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetTestSidechainsRequest copyWith(void Function(GetTestSidechainsRequest) updates) =>
-      super.copyWith((message) => updates(message as GetTestSidechainsRequest)) as GetTestSidechainsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTestSidechainsRequest copyWith(void Function(GetTestSidechainsRequest) updates) => super.copyWith((message) => updates(message as GetTestSidechainsRequest)) as GetTestSidechainsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4801,8 +4208,7 @@ class GetTestSidechainsRequest extends $pb.GeneratedMessage {
   GetTestSidechainsRequest createEmptyInstance() => create();
   static $pb.PbList<GetTestSidechainsRequest> createRepeated() => $pb.PbList<GetTestSidechainsRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetTestSidechainsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTestSidechainsRequest>(create);
+  static GetTestSidechainsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTestSidechainsRequest>(create);
   static GetTestSidechainsRequest? _defaultInstance;
 }
 
@@ -4817,26 +4223,24 @@ class GetTestSidechainsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetTestSidechainsResponse._() : super();
-  factory GetTestSidechainsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetTestSidechainsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetTestSidechainsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTestSidechainsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTestSidechainsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTestSidechainsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'enabled')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetTestSidechainsResponse clone() => GetTestSidechainsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetTestSidechainsResponse copyWith(void Function(GetTestSidechainsResponse) updates) =>
-      super.copyWith((message) => updates(message as GetTestSidechainsResponse)) as GetTestSidechainsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTestSidechainsResponse copyWith(void Function(GetTestSidechainsResponse) updates) => super.copyWith((message) => updates(message as GetTestSidechainsResponse)) as GetTestSidechainsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4845,17 +4249,13 @@ class GetTestSidechainsResponse extends $pb.GeneratedMessage {
   GetTestSidechainsResponse createEmptyInstance() => create();
   static $pb.PbList<GetTestSidechainsResponse> createRepeated() => $pb.PbList<GetTestSidechainsResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetTestSidechainsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTestSidechainsResponse>(create);
+  static GetTestSidechainsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTestSidechainsResponse>(create);
   static GetTestSidechainsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get enabled => $_getBF(0);
   @$pb.TagNumber(1)
-  set enabled($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set enabled($core.bool v) { $_setBool(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasEnabled() => $_has(0);
   @$pb.TagNumber(1)
@@ -4873,26 +4273,24 @@ class SetTestSidechainsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SetTestSidechainsRequest._() : super();
-  factory SetTestSidechainsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetTestSidechainsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetTestSidechainsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetTestSidechainsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetTestSidechainsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetTestSidechainsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'enabled')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetTestSidechainsRequest clone() => SetTestSidechainsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetTestSidechainsRequest copyWith(void Function(SetTestSidechainsRequest) updates) =>
-      super.copyWith((message) => updates(message as SetTestSidechainsRequest)) as SetTestSidechainsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetTestSidechainsRequest copyWith(void Function(SetTestSidechainsRequest) updates) => super.copyWith((message) => updates(message as SetTestSidechainsRequest)) as SetTestSidechainsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4901,17 +4299,13 @@ class SetTestSidechainsRequest extends $pb.GeneratedMessage {
   SetTestSidechainsRequest createEmptyInstance() => create();
   static $pb.PbList<SetTestSidechainsRequest> createRepeated() => $pb.PbList<SetTestSidechainsRequest>();
   @$core.pragma('dart2js:noInline')
-  static SetTestSidechainsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetTestSidechainsRequest>(create);
+  static SetTestSidechainsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetTestSidechainsRequest>(create);
   static SetTestSidechainsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get enabled => $_getBF(0);
   @$pb.TagNumber(1)
-  set enabled($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set enabled($core.bool v) { $_setBool(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasEnabled() => $_has(0);
   @$pb.TagNumber(1)
@@ -4921,25 +4315,23 @@ class SetTestSidechainsRequest extends $pb.GeneratedMessage {
 class SetTestSidechainsResponse extends $pb.GeneratedMessage {
   factory SetTestSidechainsResponse() => create();
   SetTestSidechainsResponse._() : super();
-  factory SetTestSidechainsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetTestSidechainsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetTestSidechainsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetTestSidechainsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetTestSidechainsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetTestSidechainsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetTestSidechainsResponse clone() => SetTestSidechainsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetTestSidechainsResponse copyWith(void Function(SetTestSidechainsResponse) updates) =>
-      super.copyWith((message) => updates(message as SetTestSidechainsResponse)) as SetTestSidechainsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetTestSidechainsResponse copyWith(void Function(SetTestSidechainsResponse) updates) => super.copyWith((message) => updates(message as SetTestSidechainsResponse)) as SetTestSidechainsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -4948,8 +4340,7 @@ class SetTestSidechainsResponse extends $pb.GeneratedMessage {
   SetTestSidechainsResponse createEmptyInstance() => create();
   static $pb.PbList<SetTestSidechainsResponse> createRepeated() => $pb.PbList<SetTestSidechainsResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetTestSidechainsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetTestSidechainsResponse>(create);
+  static SetTestSidechainsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetTestSidechainsResponse>(create);
   static SetTestSidechainsResponse? _defaultInstance;
 }
 
@@ -4996,14 +4387,10 @@ class WatchWalletDataResponse extends $pb.GeneratedMessage {
     return $result;
   }
   WatchWalletDataResponse._() : super();
-  factory WatchWalletDataResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WatchWalletDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WatchWalletDataResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WatchWalletDataResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WatchWalletDataResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WatchWalletDataResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOB(1, _omitFieldNames ? '' : 'hasWallet')
     ..aOB(2, _omitFieldNames ? '' : 'encrypted')
     ..aOB(3, _omitFieldNames ? '' : 'unlocked')
@@ -5013,17 +4400,19 @@ class WatchWalletDataResponse extends $pb.GeneratedMessage {
     ..a<$core.double>(7, _omitFieldNames ? '' : 'unconfirmedSats', $pb.PbFieldType.OD)
     ..aInt64(8, _omitFieldNames ? '' : 'seq')
     ..aOB(9, _omitFieldNames ? '' : 'heartbeat')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WatchWalletDataResponse clone() => WatchWalletDataResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WatchWalletDataResponse copyWith(void Function(WatchWalletDataResponse) updates) =>
-      super.copyWith((message) => updates(message as WatchWalletDataResponse)) as WatchWalletDataResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WatchWalletDataResponse copyWith(void Function(WatchWalletDataResponse) updates) => super.copyWith((message) => updates(message as WatchWalletDataResponse)) as WatchWalletDataResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -5032,18 +4421,14 @@ class WatchWalletDataResponse extends $pb.GeneratedMessage {
   WatchWalletDataResponse createEmptyInstance() => create();
   static $pb.PbList<WatchWalletDataResponse> createRepeated() => $pb.PbList<WatchWalletDataResponse>();
   @$core.pragma('dart2js:noInline')
-  static WatchWalletDataResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WatchWalletDataResponse>(create);
+  static WatchWalletDataResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WatchWalletDataResponse>(create);
   static WatchWalletDataResponse? _defaultInstance;
 
   /// Wallet status
   @$pb.TagNumber(1)
   $core.bool get hasWallet => $_getBF(0);
   @$pb.TagNumber(1)
-  set hasWallet($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set hasWallet($core.bool v) { $_setBool(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHasWallet() => $_has(0);
   @$pb.TagNumber(1)
@@ -5052,10 +4437,7 @@ class WatchWalletDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get encrypted => $_getBF(1);
   @$pb.TagNumber(2)
-  set encrypted($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set encrypted($core.bool v) { $_setBool(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasEncrypted() => $_has(1);
   @$pb.TagNumber(2)
@@ -5064,10 +4446,7 @@ class WatchWalletDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get unlocked => $_getBF(2);
   @$pb.TagNumber(3)
-  set unlocked($core.bool v) {
-    $_setBool(2, v);
-  }
-
+  set unlocked($core.bool v) { $_setBool(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasUnlocked() => $_has(2);
   @$pb.TagNumber(3)
@@ -5076,10 +4455,7 @@ class WatchWalletDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get activeWalletId => $_getSZ(3);
   @$pb.TagNumber(4)
-  set activeWalletId($core.String v) {
-    $_setString(3, v);
-  }
-
+  set activeWalletId($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasActiveWalletId() => $_has(3);
   @$pb.TagNumber(4)
@@ -5093,10 +4469,7 @@ class WatchWalletDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.double get confirmedSats => $_getN(5);
   @$pb.TagNumber(6)
-  set confirmedSats($core.double v) {
-    $_setDouble(5, v);
-  }
-
+  set confirmedSats($core.double v) { $_setDouble(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasConfirmedSats() => $_has(5);
   @$pb.TagNumber(6)
@@ -5105,10 +4478,7 @@ class WatchWalletDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.double get unconfirmedSats => $_getN(6);
   @$pb.TagNumber(7)
-  set unconfirmedSats($core.double v) {
-    $_setDouble(6, v);
-  }
-
+  set unconfirmedSats($core.double v) { $_setDouble(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasUnconfirmedSats() => $_has(6);
   @$pb.TagNumber(7)
@@ -5119,10 +4489,7 @@ class WatchWalletDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $fixnum.Int64 get seq => $_getI64(7);
   @$pb.TagNumber(8)
-  set seq($fixnum.Int64 v) {
-    $_setInt64(7, v);
-  }
-
+  set seq($fixnum.Int64 v) { $_setInt64(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasSeq() => $_has(7);
   @$pb.TagNumber(8)
@@ -5134,10 +4501,7 @@ class WatchWalletDataResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.bool get heartbeat => $_getBF(8);
   @$pb.TagNumber(9)
-  set heartbeat($core.bool v) {
-    $_setBool(8, v);
-  }
-
+  set heartbeat($core.bool v) { $_setBool(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasHeartbeat() => $_has(8);
   @$pb.TagNumber(9)
@@ -5149,92 +4513,100 @@ class WalletManagerServiceApi {
   WalletManagerServiceApi(this._client);
 
   $async.Future<GetWalletStatusResponse> getWalletStatus($pb.ClientContext? ctx, GetWalletStatusRequest request) =>
-      _client.invoke<GetWalletStatusResponse>(
-          ctx, 'WalletManagerService', 'GetWalletStatus', request, GetWalletStatusResponse());
-  $async.Future<GenerateWalletResponse> generateWallet($pb.ClientContext? ctx, GenerateWalletRequest request) => _client
-      .invoke<GenerateWalletResponse>(ctx, 'WalletManagerService', 'GenerateWallet', request, GenerateWalletResponse());
-  $async.Future<UnlockWalletResponse> unlockWallet($pb.ClientContext? ctx, UnlockWalletRequest request) => _client
-      .invoke<UnlockWalletResponse>(ctx, 'WalletManagerService', 'UnlockWallet', request, UnlockWalletResponse());
+    _client.invoke<GetWalletStatusResponse>(ctx, 'WalletManagerService', 'GetWalletStatus', request, GetWalletStatusResponse())
+  ;
+  $async.Future<GenerateWalletResponse> generateWallet($pb.ClientContext? ctx, GenerateWalletRequest request) =>
+    _client.invoke<GenerateWalletResponse>(ctx, 'WalletManagerService', 'GenerateWallet', request, GenerateWalletResponse())
+  ;
+  $async.Future<UnlockWalletResponse> unlockWallet($pb.ClientContext? ctx, UnlockWalletRequest request) =>
+    _client.invoke<UnlockWalletResponse>(ctx, 'WalletManagerService', 'UnlockWallet', request, UnlockWalletResponse())
+  ;
   $async.Future<LockWalletResponse> lockWallet($pb.ClientContext? ctx, LockWalletRequest request) =>
-      _client.invoke<LockWalletResponse>(ctx, 'WalletManagerService', 'LockWallet', request, LockWalletResponse());
-  $async.Future<EncryptWalletResponse> encryptWallet($pb.ClientContext? ctx, EncryptWalletRequest request) => _client
-      .invoke<EncryptWalletResponse>(ctx, 'WalletManagerService', 'EncryptWallet', request, EncryptWalletResponse());
-  $async.Future<ChangePasswordResponse> changePassword($pb.ClientContext? ctx, ChangePasswordRequest request) => _client
-      .invoke<ChangePasswordResponse>(ctx, 'WalletManagerService', 'ChangePassword', request, ChangePasswordResponse());
+    _client.invoke<LockWalletResponse>(ctx, 'WalletManagerService', 'LockWallet', request, LockWalletResponse())
+  ;
+  $async.Future<EncryptWalletResponse> encryptWallet($pb.ClientContext? ctx, EncryptWalletRequest request) =>
+    _client.invoke<EncryptWalletResponse>(ctx, 'WalletManagerService', 'EncryptWallet', request, EncryptWalletResponse())
+  ;
+  $async.Future<ChangePasswordResponse> changePassword($pb.ClientContext? ctx, ChangePasswordRequest request) =>
+    _client.invoke<ChangePasswordResponse>(ctx, 'WalletManagerService', 'ChangePassword', request, ChangePasswordResponse())
+  ;
   $async.Future<RemoveEncryptionResponse> removeEncryption($pb.ClientContext? ctx, RemoveEncryptionRequest request) =>
-      _client.invoke<RemoveEncryptionResponse>(
-          ctx, 'WalletManagerService', 'RemoveEncryption', request, RemoveEncryptionResponse());
+    _client.invoke<RemoveEncryptionResponse>(ctx, 'WalletManagerService', 'RemoveEncryption', request, RemoveEncryptionResponse())
+  ;
   $async.Future<ListWalletsResponse> listWallets($pb.ClientContext? ctx, ListWalletsRequest request) =>
-      _client.invoke<ListWalletsResponse>(ctx, 'WalletManagerService', 'ListWallets', request, ListWalletsResponse());
-  $async.Future<SwitchWalletResponse> switchWallet($pb.ClientContext? ctx, SwitchWalletRequest request) => _client
-      .invoke<SwitchWalletResponse>(ctx, 'WalletManagerService', 'SwitchWallet', request, SwitchWalletResponse());
-  $async.Future<UpdateWalletMetadataResponse> updateWalletMetadata(
-          $pb.ClientContext? ctx, UpdateWalletMetadataRequest request) =>
-      _client.invoke<UpdateWalletMetadataResponse>(
-          ctx, 'WalletManagerService', 'UpdateWalletMetadata', request, UpdateWalletMetadataResponse());
-  $async.Future<DeleteWalletResponse> deleteWallet($pb.ClientContext? ctx, DeleteWalletRequest request) => _client
-      .invoke<DeleteWalletResponse>(ctx, 'WalletManagerService', 'DeleteWallet', request, DeleteWalletResponse());
+    _client.invoke<ListWalletsResponse>(ctx, 'WalletManagerService', 'ListWallets', request, ListWalletsResponse())
+  ;
+  $async.Future<SwitchWalletResponse> switchWallet($pb.ClientContext? ctx, SwitchWalletRequest request) =>
+    _client.invoke<SwitchWalletResponse>(ctx, 'WalletManagerService', 'SwitchWallet', request, SwitchWalletResponse())
+  ;
+  $async.Future<UpdateWalletMetadataResponse> updateWalletMetadata($pb.ClientContext? ctx, UpdateWalletMetadataRequest request) =>
+    _client.invoke<UpdateWalletMetadataResponse>(ctx, 'WalletManagerService', 'UpdateWalletMetadata', request, UpdateWalletMetadataResponse())
+  ;
+  $async.Future<DeleteWalletResponse> deleteWallet($pb.ClientContext? ctx, DeleteWalletRequest request) =>
+    _client.invoke<DeleteWalletResponse>(ctx, 'WalletManagerService', 'DeleteWallet', request, DeleteWalletResponse())
+  ;
   $async.Future<DeleteAllWalletsResponse> deleteAllWallets($pb.ClientContext? ctx, DeleteAllWalletsRequest request) =>
-      _client.invoke<DeleteAllWalletsResponse>(
-          ctx, 'WalletManagerService', 'DeleteAllWallets', request, DeleteAllWalletsResponse());
-  $async.Future<CreateWatchOnlyWalletResponse> createWatchOnlyWallet(
-          $pb.ClientContext? ctx, CreateWatchOnlyWalletRequest request) =>
-      _client.invoke<CreateWatchOnlyWalletResponse>(
-          ctx, 'WalletManagerService', 'CreateWatchOnlyWallet', request, CreateWatchOnlyWalletResponse());
-  $async.Future<CreateBitcoinCoreWalletResponse> createBitcoinCoreWallet(
-          $pb.ClientContext? ctx, CreateBitcoinCoreWalletRequest request) =>
-      _client.invoke<CreateBitcoinCoreWalletResponse>(
-          ctx, 'WalletManagerService', 'CreateBitcoinCoreWallet', request, CreateBitcoinCoreWalletResponse());
-  $async.Future<EnsureCoreWalletsResponse> ensureCoreWallets(
-          $pb.ClientContext? ctx, EnsureCoreWalletsRequest request) =>
-      _client.invoke<EnsureCoreWalletsResponse>(
-          ctx, 'WalletManagerService', 'EnsureCoreWallets', request, EnsureCoreWalletsResponse());
+    _client.invoke<DeleteAllWalletsResponse>(ctx, 'WalletManagerService', 'DeleteAllWallets', request, DeleteAllWalletsResponse())
+  ;
+  $async.Future<CreateWatchOnlyWalletResponse> createWatchOnlyWallet($pb.ClientContext? ctx, CreateWatchOnlyWalletRequest request) =>
+    _client.invoke<CreateWatchOnlyWalletResponse>(ctx, 'WalletManagerService', 'CreateWatchOnlyWallet', request, CreateWatchOnlyWalletResponse())
+  ;
+  $async.Future<CreateBitcoinCoreWalletResponse> createBitcoinCoreWallet($pb.ClientContext? ctx, CreateBitcoinCoreWalletRequest request) =>
+    _client.invoke<CreateBitcoinCoreWalletResponse>(ctx, 'WalletManagerService', 'CreateBitcoinCoreWallet', request, CreateBitcoinCoreWalletResponse())
+  ;
+  $async.Future<EnsureCoreWalletsResponse> ensureCoreWallets($pb.ClientContext? ctx, EnsureCoreWalletsRequest request) =>
+    _client.invoke<EnsureCoreWalletsResponse>(ctx, 'WalletManagerService', 'EnsureCoreWallets', request, EnsureCoreWalletsResponse())
+  ;
   $async.Future<GetBalanceResponse> getBalance($pb.ClientContext? ctx, GetBalanceRequest request) =>
-      _client.invoke<GetBalanceResponse>(ctx, 'WalletManagerService', 'GetBalance', request, GetBalanceResponse());
-  $async.Future<GetNewAddressResponse> getNewAddress($pb.ClientContext? ctx, GetNewAddressRequest request) => _client
-      .invoke<GetNewAddressResponse>(ctx, 'WalletManagerService', 'GetNewAddress', request, GetNewAddressResponse());
+    _client.invoke<GetBalanceResponse>(ctx, 'WalletManagerService', 'GetBalance', request, GetBalanceResponse())
+  ;
+  $async.Future<GetNewAddressResponse> getNewAddress($pb.ClientContext? ctx, GetNewAddressRequest request) =>
+    _client.invoke<GetNewAddressResponse>(ctx, 'WalletManagerService', 'GetNewAddress', request, GetNewAddressResponse())
+  ;
   $async.Future<SendTransactionResponse> sendTransaction($pb.ClientContext? ctx, SendTransactionRequest request) =>
-      _client.invoke<SendTransactionResponse>(
-          ctx, 'WalletManagerService', 'SendTransaction', request, SendTransactionResponse());
+    _client.invoke<SendTransactionResponse>(ctx, 'WalletManagerService', 'SendTransaction', request, SendTransactionResponse())
+  ;
   $async.Future<ListTransactionsResponse> listTransactions($pb.ClientContext? ctx, ListTransactionsRequest request) =>
-      _client.invoke<ListTransactionsResponse>(
-          ctx, 'WalletManagerService', 'ListTransactions', request, ListTransactionsResponse());
+    _client.invoke<ListTransactionsResponse>(ctx, 'WalletManagerService', 'ListTransactions', request, ListTransactionsResponse())
+  ;
   $async.Future<ListUnspentResponse> listUnspent($pb.ClientContext? ctx, ListUnspentRequest request) =>
-      _client.invoke<ListUnspentResponse>(ctx, 'WalletManagerService', 'ListUnspent', request, ListUnspentResponse());
-  $async.Future<ListReceiveAddressesResponse> listReceiveAddresses(
-          $pb.ClientContext? ctx, ListReceiveAddressesRequest request) =>
-      _client.invoke<ListReceiveAddressesResponse>(
-          ctx, 'WalletManagerService', 'ListReceiveAddresses', request, ListReceiveAddressesResponse());
-  $async.Future<GetTransactionDetailsResponse> getTransactionDetails(
-          $pb.ClientContext? ctx, GetTransactionDetailsRequest request) =>
-      _client.invoke<GetTransactionDetailsResponse>(
-          ctx, 'WalletManagerService', 'GetTransactionDetails', request, GetTransactionDetailsResponse());
+    _client.invoke<ListUnspentResponse>(ctx, 'WalletManagerService', 'ListUnspent', request, ListUnspentResponse())
+  ;
+  $async.Future<ListReceiveAddressesResponse> listReceiveAddresses($pb.ClientContext? ctx, ListReceiveAddressesRequest request) =>
+    _client.invoke<ListReceiveAddressesResponse>(ctx, 'WalletManagerService', 'ListReceiveAddresses', request, ListReceiveAddressesResponse())
+  ;
+  $async.Future<GetTransactionDetailsResponse> getTransactionDetails($pb.ClientContext? ctx, GetTransactionDetailsRequest request) =>
+    _client.invoke<GetTransactionDetailsResponse>(ctx, 'WalletManagerService', 'GetTransactionDetails', request, GetTransactionDetailsResponse())
+  ;
   $async.Future<BumpFeeResponse> bumpFee($pb.ClientContext? ctx, BumpFeeRequest request) =>
-      _client.invoke<BumpFeeResponse>(ctx, 'WalletManagerService', 'BumpFee', request, BumpFeeResponse());
+    _client.invoke<BumpFeeResponse>(ctx, 'WalletManagerService', 'BumpFee', request, BumpFeeResponse())
+  ;
   $async.Future<DeriveAddressesResponse> deriveAddresses($pb.ClientContext? ctx, DeriveAddressesRequest request) =>
-      _client.invoke<DeriveAddressesResponse>(
-          ctx, 'WalletManagerService', 'DeriveAddresses', request, DeriveAddressesResponse());
-  $async.Future<GetWalletSeedResponse> getWalletSeed($pb.ClientContext? ctx, GetWalletSeedRequest request) => _client
-      .invoke<GetWalletSeedResponse>(ctx, 'WalletManagerService', 'GetWalletSeed', request, GetWalletSeedResponse());
+    _client.invoke<DeriveAddressesResponse>(ctx, 'WalletManagerService', 'DeriveAddresses', request, DeriveAddressesResponse())
+  ;
+  $async.Future<GetWalletSeedResponse> getWalletSeed($pb.ClientContext? ctx, GetWalletSeedRequest request) =>
+    _client.invoke<GetWalletSeedResponse>(ctx, 'WalletManagerService', 'GetWalletSeed', request, GetWalletSeedResponse())
+  ;
   $async.Future<ListCoreVariantsResponse> listCoreVariants($pb.ClientContext? ctx, ListCoreVariantsRequest request) =>
-      _client.invoke<ListCoreVariantsResponse>(
-          ctx, 'WalletManagerService', 'ListCoreVariants', request, ListCoreVariantsResponse());
-  $async.Future<GetCoreVariantResponse> getCoreVariant($pb.ClientContext? ctx, GetCoreVariantRequest request) => _client
-      .invoke<GetCoreVariantResponse>(ctx, 'WalletManagerService', 'GetCoreVariant', request, GetCoreVariantResponse());
-  $async.Future<SetCoreVariantResponse> setCoreVariant($pb.ClientContext? ctx, SetCoreVariantRequest request) => _client
-      .invoke<SetCoreVariantResponse>(ctx, 'WalletManagerService', 'SetCoreVariant', request, SetCoreVariantResponse());
-  $async.Future<GetTestSidechainsResponse> getTestSidechains(
-          $pb.ClientContext? ctx, GetTestSidechainsRequest request) =>
-      _client.invoke<GetTestSidechainsResponse>(
-          ctx, 'WalletManagerService', 'GetTestSidechains', request, GetTestSidechainsResponse());
-  $async.Future<SetTestSidechainsResponse> setTestSidechains(
-          $pb.ClientContext? ctx, SetTestSidechainsRequest request) =>
-      _client.invoke<SetTestSidechainsResponse>(
-          ctx, 'WalletManagerService', 'SetTestSidechains', request, SetTestSidechainsResponse());
+    _client.invoke<ListCoreVariantsResponse>(ctx, 'WalletManagerService', 'ListCoreVariants', request, ListCoreVariantsResponse())
+  ;
+  $async.Future<GetCoreVariantResponse> getCoreVariant($pb.ClientContext? ctx, GetCoreVariantRequest request) =>
+    _client.invoke<GetCoreVariantResponse>(ctx, 'WalletManagerService', 'GetCoreVariant', request, GetCoreVariantResponse())
+  ;
+  $async.Future<SetCoreVariantResponse> setCoreVariant($pb.ClientContext? ctx, SetCoreVariantRequest request) =>
+    _client.invoke<SetCoreVariantResponse>(ctx, 'WalletManagerService', 'SetCoreVariant', request, SetCoreVariantResponse())
+  ;
+  $async.Future<GetTestSidechainsResponse> getTestSidechains($pb.ClientContext? ctx, GetTestSidechainsRequest request) =>
+    _client.invoke<GetTestSidechainsResponse>(ctx, 'WalletManagerService', 'GetTestSidechains', request, GetTestSidechainsResponse())
+  ;
+  $async.Future<SetTestSidechainsResponse> setTestSidechains($pb.ClientContext? ctx, SetTestSidechainsRequest request) =>
+    _client.invoke<SetTestSidechainsResponse>(ctx, 'WalletManagerService', 'SetTestSidechains', request, SetTestSidechainsResponse())
+  ;
   $async.Future<WatchWalletDataResponse> watchWalletData($pb.ClientContext? ctx, $12.Empty request) =>
-      _client.invoke<WatchWalletDataResponse>(
-          ctx, 'WalletManagerService', 'WatchWalletData', request, WatchWalletDataResponse());
+    _client.invoke<WatchWalletDataResponse>(ctx, 'WalletManagerService', 'WatchWalletData', request, WatchWalletDataResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbenum.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -21,8 +21,8 @@ const GetWalletStatusRequest$json = {
 };
 
 /// Descriptor for `GetWalletStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletStatusRequestDescriptor =
-    $convert.base64Decode('ChZHZXRXYWxsZXRTdGF0dXNSZXF1ZXN0');
+final $typed_data.Uint8List getWalletStatusRequestDescriptor = $convert.base64Decode(
+    'ChZHZXRXYWxsZXRTdGF0dXNSZXF1ZXN0');
 
 @$core.Deprecated('Use getWalletStatusResponseDescriptor instead')
 const GetWalletStatusResponse$json = {
@@ -37,11 +37,11 @@ const GetWalletStatusResponse$json = {
 };
 
 /// Descriptor for `GetWalletStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletStatusResponseDescriptor =
-    $convert.base64Decode('ChdHZXRXYWxsZXRTdGF0dXNSZXNwb25zZRIdCgpoYXNfd2FsbGV0GAEgASgIUgloYXNXYWxsZX'
-        'QSHAoJZW5jcnlwdGVkGAIgASgIUgllbmNyeXB0ZWQSGgoIdW5sb2NrZWQYAyABKAhSCHVubG9j'
-        'a2VkEigKEGFjdGl2ZV93YWxsZXRfaWQYBCABKAlSDmFjdGl2ZVdhbGxldElkEiwKEmFjdGl2ZV'
-        '93YWxsZXRfbmFtZRgFIAEoCVIQYWN0aXZlV2FsbGV0TmFtZQ==');
+final $typed_data.Uint8List getWalletStatusResponseDescriptor = $convert.base64Decode(
+    'ChdHZXRXYWxsZXRTdGF0dXNSZXNwb25zZRIdCgpoYXNfd2FsbGV0GAEgASgIUgloYXNXYWxsZX'
+    'QSHAoJZW5jcnlwdGVkGAIgASgIUgllbmNyeXB0ZWQSGgoIdW5sb2NrZWQYAyABKAhSCHVubG9j'
+    'a2VkEigKEGFjdGl2ZV93YWxsZXRfaWQYBCABKAlSDmFjdGl2ZVdhbGxldElkEiwKEmFjdGl2ZV'
+    '93YWxsZXRfbmFtZRgFIAEoCVIQYWN0aXZlV2FsbGV0TmFtZQ==');
 
 @$core.Deprecated('Use generateWalletRequestDescriptor instead')
 const GenerateWalletRequest$json = {
@@ -54,10 +54,10 @@ const GenerateWalletRequest$json = {
 };
 
 /// Descriptor for `GenerateWalletRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateWalletRequestDescriptor =
-    $convert.base64Decode('ChVHZW5lcmF0ZVdhbGxldFJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRInCg9jdXN0b21fbW'
-        '5lbW9uaWMYAiABKAlSDmN1c3RvbU1uZW1vbmljEh4KCnBhc3NwaHJhc2UYAyABKAlSCnBhc3Nw'
-        'aHJhc2U=');
+final $typed_data.Uint8List generateWalletRequestDescriptor = $convert.base64Decode(
+    'ChVHZW5lcmF0ZVdhbGxldFJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRInCg9jdXN0b21fbW'
+    '5lbW9uaWMYAiABKAlSDmN1c3RvbU1uZW1vbmljEh4KCnBhc3NwaHJhc2UYAyABKAlSCnBhc3Nw'
+    'aHJhc2U=');
 
 @$core.Deprecated('Use generateWalletResponseDescriptor instead')
 const GenerateWalletResponse$json = {
@@ -69,9 +69,9 @@ const GenerateWalletResponse$json = {
 };
 
 /// Descriptor for `GenerateWalletResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateWalletResponseDescriptor =
-    $convert.base64Decode('ChZHZW5lcmF0ZVdhbGxldFJlc3BvbnNlEhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQSGg'
-        'oIbW5lbW9uaWMYAiABKAlSCG1uZW1vbmlj');
+final $typed_data.Uint8List generateWalletResponseDescriptor = $convert.base64Decode(
+    'ChZHZW5lcmF0ZVdhbGxldFJlc3BvbnNlEhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQSGg'
+    'oIbW5lbW9uaWMYAiABKAlSCG1uZW1vbmlj');
 
 @$core.Deprecated('Use unlockWalletRequestDescriptor instead')
 const UnlockWalletRequest$json = {
@@ -82,8 +82,8 @@ const UnlockWalletRequest$json = {
 };
 
 /// Descriptor for `UnlockWalletRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List unlockWalletRequestDescriptor =
-    $convert.base64Decode('ChNVbmxvY2tXYWxsZXRSZXF1ZXN0EhoKCHBhc3N3b3JkGAEgASgJUghwYXNzd29yZA==');
+final $typed_data.Uint8List unlockWalletRequestDescriptor = $convert.base64Decode(
+    'ChNVbmxvY2tXYWxsZXRSZXF1ZXN0EhoKCHBhc3N3b3JkGAEgASgJUghwYXNzd29yZA==');
 
 @$core.Deprecated('Use unlockWalletResponseDescriptor instead')
 const UnlockWalletResponse$json = {
@@ -91,7 +91,8 @@ const UnlockWalletResponse$json = {
 };
 
 /// Descriptor for `UnlockWalletResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List unlockWalletResponseDescriptor = $convert.base64Decode('ChRVbmxvY2tXYWxsZXRSZXNwb25zZQ==');
+final $typed_data.Uint8List unlockWalletResponseDescriptor = $convert.base64Decode(
+    'ChRVbmxvY2tXYWxsZXRSZXNwb25zZQ==');
 
 @$core.Deprecated('Use lockWalletRequestDescriptor instead')
 const LockWalletRequest$json = {
@@ -99,7 +100,8 @@ const LockWalletRequest$json = {
 };
 
 /// Descriptor for `LockWalletRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lockWalletRequestDescriptor = $convert.base64Decode('ChFMb2NrV2FsbGV0UmVxdWVzdA==');
+final $typed_data.Uint8List lockWalletRequestDescriptor = $convert.base64Decode(
+    'ChFMb2NrV2FsbGV0UmVxdWVzdA==');
 
 @$core.Deprecated('Use lockWalletResponseDescriptor instead')
 const LockWalletResponse$json = {
@@ -107,7 +109,8 @@ const LockWalletResponse$json = {
 };
 
 /// Descriptor for `LockWalletResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lockWalletResponseDescriptor = $convert.base64Decode('ChJMb2NrV2FsbGV0UmVzcG9uc2U=');
+final $typed_data.Uint8List lockWalletResponseDescriptor = $convert.base64Decode(
+    'ChJMb2NrV2FsbGV0UmVzcG9uc2U=');
 
 @$core.Deprecated('Use encryptWalletRequestDescriptor instead')
 const EncryptWalletRequest$json = {
@@ -118,8 +121,8 @@ const EncryptWalletRequest$json = {
 };
 
 /// Descriptor for `EncryptWalletRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List encryptWalletRequestDescriptor =
-    $convert.base64Decode('ChRFbmNyeXB0V2FsbGV0UmVxdWVzdBIaCghwYXNzd29yZBgBIAEoCVIIcGFzc3dvcmQ=');
+final $typed_data.Uint8List encryptWalletRequestDescriptor = $convert.base64Decode(
+    'ChRFbmNyeXB0V2FsbGV0UmVxdWVzdBIaCghwYXNzd29yZBgBIAEoCVIIcGFzc3dvcmQ=');
 
 @$core.Deprecated('Use encryptWalletResponseDescriptor instead')
 const EncryptWalletResponse$json = {
@@ -127,7 +130,8 @@ const EncryptWalletResponse$json = {
 };
 
 /// Descriptor for `EncryptWalletResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List encryptWalletResponseDescriptor = $convert.base64Decode('ChVFbmNyeXB0V2FsbGV0UmVzcG9uc2U=');
+final $typed_data.Uint8List encryptWalletResponseDescriptor = $convert.base64Decode(
+    'ChVFbmNyeXB0V2FsbGV0UmVzcG9uc2U=');
 
 @$core.Deprecated('Use changePasswordRequestDescriptor instead')
 const ChangePasswordRequest$json = {
@@ -139,9 +143,9 @@ const ChangePasswordRequest$json = {
 };
 
 /// Descriptor for `ChangePasswordRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List changePasswordRequestDescriptor =
-    $convert.base64Decode('ChVDaGFuZ2VQYXNzd29yZFJlcXVlc3QSIQoMb2xkX3Bhc3N3b3JkGAEgASgJUgtvbGRQYXNzd2'
-        '9yZBIhCgxuZXdfcGFzc3dvcmQYAiABKAlSC25ld1Bhc3N3b3Jk');
+final $typed_data.Uint8List changePasswordRequestDescriptor = $convert.base64Decode(
+    'ChVDaGFuZ2VQYXNzd29yZFJlcXVlc3QSIQoMb2xkX3Bhc3N3b3JkGAEgASgJUgtvbGRQYXNzd2'
+    '9yZBIhCgxuZXdfcGFzc3dvcmQYAiABKAlSC25ld1Bhc3N3b3Jk');
 
 @$core.Deprecated('Use changePasswordResponseDescriptor instead')
 const ChangePasswordResponse$json = {
@@ -149,8 +153,8 @@ const ChangePasswordResponse$json = {
 };
 
 /// Descriptor for `ChangePasswordResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List changePasswordResponseDescriptor =
-    $convert.base64Decode('ChZDaGFuZ2VQYXNzd29yZFJlc3BvbnNl');
+final $typed_data.Uint8List changePasswordResponseDescriptor = $convert.base64Decode(
+    'ChZDaGFuZ2VQYXNzd29yZFJlc3BvbnNl');
 
 @$core.Deprecated('Use removeEncryptionRequestDescriptor instead')
 const RemoveEncryptionRequest$json = {
@@ -161,8 +165,8 @@ const RemoveEncryptionRequest$json = {
 };
 
 /// Descriptor for `RemoveEncryptionRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeEncryptionRequestDescriptor =
-    $convert.base64Decode('ChdSZW1vdmVFbmNyeXB0aW9uUmVxdWVzdBIaCghwYXNzd29yZBgBIAEoCVIIcGFzc3dvcmQ=');
+final $typed_data.Uint8List removeEncryptionRequestDescriptor = $convert.base64Decode(
+    'ChdSZW1vdmVFbmNyeXB0aW9uUmVxdWVzdBIaCghwYXNzd29yZBgBIAEoCVIIcGFzc3dvcmQ=');
 
 @$core.Deprecated('Use removeEncryptionResponseDescriptor instead')
 const RemoveEncryptionResponse$json = {
@@ -170,8 +174,8 @@ const RemoveEncryptionResponse$json = {
 };
 
 /// Descriptor for `RemoveEncryptionResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeEncryptionResponseDescriptor =
-    $convert.base64Decode('ChhSZW1vdmVFbmNyeXB0aW9uUmVzcG9uc2U=');
+final $typed_data.Uint8List removeEncryptionResponseDescriptor = $convert.base64Decode(
+    'ChhSZW1vdmVFbmNyeXB0aW9uUmVzcG9uc2U=');
 
 @$core.Deprecated('Use walletMetadataDescriptor instead')
 const WalletMetadata$json = {
@@ -190,14 +194,14 @@ const WalletMetadata$json = {
 };
 
 /// Descriptor for `WalletMetadata`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List walletMetadataDescriptor =
-    $convert.base64Decode('Cg5XYWxsZXRNZXRhZGF0YRIOCgJpZBgBIAEoCVICaWQSEgoEbmFtZRgCIAEoCVIEbmFtZRIfCg'
-        't3YWxsZXRfdHlwZRgDIAEoCVIKd2FsbGV0VHlwZRIjCg1ncmFkaWVudF9qc29uGAQgASgJUgxn'
-        'cmFkaWVudEpzb24SHQoKY3JlYXRlZF9hdBgFIAEoCVIJY3JlYXRlZEF0EiwKEmJpcDQ3X3BheW'
-        '1lbnRfY29kZRgGIAEoCVIQYmlwNDdQYXltZW50Q29kZRInCg9tYXN0ZXJfbW5lbW9uaWMYByAB'
-        'KAlSDm1hc3Rlck1uZW1vbmljEh8KC2wxX21uZW1vbmljGAggASgJUgpsMU1uZW1vbmljEkIKCn'
-        'NpZGVjaGFpbnMYCSADKAsyIi53YWxsZXRtYW5hZ2VyLnYxLlNpZGVjaGFpblN0YXJ0ZXJSCnNp'
-        'ZGVjaGFpbnM=');
+final $typed_data.Uint8List walletMetadataDescriptor = $convert.base64Decode(
+    'Cg5XYWxsZXRNZXRhZGF0YRIOCgJpZBgBIAEoCVICaWQSEgoEbmFtZRgCIAEoCVIEbmFtZRIfCg'
+    't3YWxsZXRfdHlwZRgDIAEoCVIKd2FsbGV0VHlwZRIjCg1ncmFkaWVudF9qc29uGAQgASgJUgxn'
+    'cmFkaWVudEpzb24SHQoKY3JlYXRlZF9hdBgFIAEoCVIJY3JlYXRlZEF0EiwKEmJpcDQ3X3BheW'
+    '1lbnRfY29kZRgGIAEoCVIQYmlwNDdQYXltZW50Q29kZRInCg9tYXN0ZXJfbW5lbW9uaWMYByAB'
+    'KAlSDm1hc3Rlck1uZW1vbmljEh8KC2wxX21uZW1vbmljGAggASgJUgpsMU1uZW1vbmljEkIKCn'
+    'NpZGVjaGFpbnMYCSADKAsyIi53YWxsZXRtYW5hZ2VyLnYxLlNpZGVjaGFpblN0YXJ0ZXJSCnNp'
+    'ZGVjaGFpbnM=');
 
 @$core.Deprecated('Use sidechainStarterDescriptor instead')
 const SidechainStarter$json = {
@@ -210,9 +214,9 @@ const SidechainStarter$json = {
 };
 
 /// Descriptor for `SidechainStarter`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List sidechainStarterDescriptor =
-    $convert.base64Decode('ChBTaWRlY2hhaW5TdGFydGVyEhIKBHNsb3QYASABKAVSBHNsb3QSEgoEbmFtZRgCIAEoCVIEbm'
-        'FtZRIaCghtbmVtb25pYxgDIAEoCVIIbW5lbW9uaWM=');
+final $typed_data.Uint8List sidechainStarterDescriptor = $convert.base64Decode(
+    'ChBTaWRlY2hhaW5TdGFydGVyEhIKBHNsb3QYASABKAVSBHNsb3QSEgoEbmFtZRgCIAEoCVIEbm'
+    'FtZRIaCghtbmVtb25pYxgDIAEoCVIIbW5lbW9uaWM=');
 
 @$core.Deprecated('Use listWalletsRequestDescriptor instead')
 const ListWalletsRequest$json = {
@@ -220,7 +224,8 @@ const ListWalletsRequest$json = {
 };
 
 /// Descriptor for `ListWalletsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listWalletsRequestDescriptor = $convert.base64Decode('ChJMaXN0V2FsbGV0c1JlcXVlc3Q=');
+final $typed_data.Uint8List listWalletsRequestDescriptor = $convert.base64Decode(
+    'ChJMaXN0V2FsbGV0c1JlcXVlc3Q=');
 
 @$core.Deprecated('Use listWalletsResponseDescriptor instead')
 const ListWalletsResponse$json = {
@@ -232,10 +237,10 @@ const ListWalletsResponse$json = {
 };
 
 /// Descriptor for `ListWalletsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listWalletsResponseDescriptor =
-    $convert.base64Decode('ChNMaXN0V2FsbGV0c1Jlc3BvbnNlEjoKB3dhbGxldHMYASADKAsyIC53YWxsZXRtYW5hZ2VyLn'
-        'YxLldhbGxldE1ldGFkYXRhUgd3YWxsZXRzEigKEGFjdGl2ZV93YWxsZXRfaWQYAiABKAlSDmFj'
-        'dGl2ZVdhbGxldElk');
+final $typed_data.Uint8List listWalletsResponseDescriptor = $convert.base64Decode(
+    'ChNMaXN0V2FsbGV0c1Jlc3BvbnNlEjoKB3dhbGxldHMYASADKAsyIC53YWxsZXRtYW5hZ2VyLn'
+    'YxLldhbGxldE1ldGFkYXRhUgd3YWxsZXRzEigKEGFjdGl2ZV93YWxsZXRfaWQYAiABKAlSDmFj'
+    'dGl2ZVdhbGxldElk');
 
 @$core.Deprecated('Use switchWalletRequestDescriptor instead')
 const SwitchWalletRequest$json = {
@@ -246,8 +251,8 @@ const SwitchWalletRequest$json = {
 };
 
 /// Descriptor for `SwitchWalletRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List switchWalletRequestDescriptor =
-    $convert.base64Decode('ChNTd2l0Y2hXYWxsZXRSZXF1ZXN0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQ=');
+final $typed_data.Uint8List switchWalletRequestDescriptor = $convert.base64Decode(
+    'ChNTd2l0Y2hXYWxsZXRSZXF1ZXN0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQ=');
 
 @$core.Deprecated('Use switchWalletResponseDescriptor instead')
 const SwitchWalletResponse$json = {
@@ -255,7 +260,8 @@ const SwitchWalletResponse$json = {
 };
 
 /// Descriptor for `SwitchWalletResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List switchWalletResponseDescriptor = $convert.base64Decode('ChRTd2l0Y2hXYWxsZXRSZXNwb25zZQ==');
+final $typed_data.Uint8List switchWalletResponseDescriptor = $convert.base64Decode(
+    'ChRTd2l0Y2hXYWxsZXRSZXNwb25zZQ==');
 
 @$core.Deprecated('Use updateWalletMetadataRequestDescriptor instead')
 const UpdateWalletMetadataRequest$json = {
@@ -268,10 +274,10 @@ const UpdateWalletMetadataRequest$json = {
 };
 
 /// Descriptor for `UpdateWalletMetadataRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List updateWalletMetadataRequestDescriptor =
-    $convert.base64Decode('ChtVcGRhdGVXYWxsZXRNZXRhZGF0YVJlcXVlc3QSGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZX'
-        'RJZBISCgRuYW1lGAIgASgJUgRuYW1lEiMKDWdyYWRpZW50X2pzb24YAyABKAlSDGdyYWRpZW50'
-        'SnNvbg==');
+final $typed_data.Uint8List updateWalletMetadataRequestDescriptor = $convert.base64Decode(
+    'ChtVcGRhdGVXYWxsZXRNZXRhZGF0YVJlcXVlc3QSGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZX'
+    'RJZBISCgRuYW1lGAIgASgJUgRuYW1lEiMKDWdyYWRpZW50X2pzb24YAyABKAlSDGdyYWRpZW50'
+    'SnNvbg==');
 
 @$core.Deprecated('Use updateWalletMetadataResponseDescriptor instead')
 const UpdateWalletMetadataResponse$json = {
@@ -279,8 +285,8 @@ const UpdateWalletMetadataResponse$json = {
 };
 
 /// Descriptor for `UpdateWalletMetadataResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List updateWalletMetadataResponseDescriptor =
-    $convert.base64Decode('ChxVcGRhdGVXYWxsZXRNZXRhZGF0YVJlc3BvbnNl');
+final $typed_data.Uint8List updateWalletMetadataResponseDescriptor = $convert.base64Decode(
+    'ChxVcGRhdGVXYWxsZXRNZXRhZGF0YVJlc3BvbnNl');
 
 @$core.Deprecated('Use deleteWalletRequestDescriptor instead')
 const DeleteWalletRequest$json = {
@@ -291,8 +297,8 @@ const DeleteWalletRequest$json = {
 };
 
 /// Descriptor for `DeleteWalletRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List deleteWalletRequestDescriptor =
-    $convert.base64Decode('ChNEZWxldGVXYWxsZXRSZXF1ZXN0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQ=');
+final $typed_data.Uint8List deleteWalletRequestDescriptor = $convert.base64Decode(
+    'ChNEZWxldGVXYWxsZXRSZXF1ZXN0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQ=');
 
 @$core.Deprecated('Use deleteWalletResponseDescriptor instead')
 const DeleteWalletResponse$json = {
@@ -300,7 +306,8 @@ const DeleteWalletResponse$json = {
 };
 
 /// Descriptor for `DeleteWalletResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List deleteWalletResponseDescriptor = $convert.base64Decode('ChREZWxldGVXYWxsZXRSZXNwb25zZQ==');
+final $typed_data.Uint8List deleteWalletResponseDescriptor = $convert.base64Decode(
+    'ChREZWxldGVXYWxsZXRSZXNwb25zZQ==');
 
 @$core.Deprecated('Use deleteAllWalletsRequestDescriptor instead')
 const DeleteAllWalletsRequest$json = {
@@ -308,8 +315,8 @@ const DeleteAllWalletsRequest$json = {
 };
 
 /// Descriptor for `DeleteAllWalletsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List deleteAllWalletsRequestDescriptor =
-    $convert.base64Decode('ChdEZWxldGVBbGxXYWxsZXRzUmVxdWVzdA==');
+final $typed_data.Uint8List deleteAllWalletsRequestDescriptor = $convert.base64Decode(
+    'ChdEZWxldGVBbGxXYWxsZXRzUmVxdWVzdA==');
 
 @$core.Deprecated('Use deleteAllWalletsResponseDescriptor instead')
 const DeleteAllWalletsResponse$json = {
@@ -317,8 +324,8 @@ const DeleteAllWalletsResponse$json = {
 };
 
 /// Descriptor for `DeleteAllWalletsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List deleteAllWalletsResponseDescriptor =
-    $convert.base64Decode('ChhEZWxldGVBbGxXYWxsZXRzUmVzcG9uc2U=');
+final $typed_data.Uint8List deleteAllWalletsResponseDescriptor = $convert.base64Decode(
+    'ChhEZWxldGVBbGxXYWxsZXRzUmVzcG9uc2U=');
 
 @$core.Deprecated('Use createWatchOnlyWalletRequestDescriptor instead')
 const CreateWatchOnlyWalletRequest$json = {
@@ -331,10 +338,10 @@ const CreateWatchOnlyWalletRequest$json = {
 };
 
 /// Descriptor for `CreateWatchOnlyWalletRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createWatchOnlyWalletRequestDescriptor =
-    $convert.base64Decode('ChxDcmVhdGVXYXRjaE9ubHlXYWxsZXRSZXF1ZXN0EhIKBG5hbWUYASABKAlSBG5hbWUSLAoSeH'
-        'B1Yl9vcl9kZXNjcmlwdG9yGAIgASgJUhB4cHViT3JEZXNjcmlwdG9yEiMKDWdyYWRpZW50X2pz'
-        'b24YAyABKAlSDGdyYWRpZW50SnNvbg==');
+final $typed_data.Uint8List createWatchOnlyWalletRequestDescriptor = $convert.base64Decode(
+    'ChxDcmVhdGVXYXRjaE9ubHlXYWxsZXRSZXF1ZXN0EhIKBG5hbWUYASABKAlSBG5hbWUSLAoSeH'
+    'B1Yl9vcl9kZXNjcmlwdG9yGAIgASgJUhB4cHViT3JEZXNjcmlwdG9yEiMKDWdyYWRpZW50X2pz'
+    'b24YAyABKAlSDGdyYWRpZW50SnNvbg==');
 
 @$core.Deprecated('Use createWatchOnlyWalletResponseDescriptor instead')
 const CreateWatchOnlyWalletResponse$json = {
@@ -345,9 +352,9 @@ const CreateWatchOnlyWalletResponse$json = {
 };
 
 /// Descriptor for `CreateWatchOnlyWalletResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createWatchOnlyWalletResponseDescriptor =
-    $convert.base64Decode('Ch1DcmVhdGVXYXRjaE9ubHlXYWxsZXRSZXNwb25zZRIbCgl3YWxsZXRfaWQYASABKAlSCHdhbG'
-        'xldElk');
+final $typed_data.Uint8List createWatchOnlyWalletResponseDescriptor = $convert.base64Decode(
+    'Ch1DcmVhdGVXYXRjaE9ubHlXYWxsZXRSZXNwb25zZRIbCgl3YWxsZXRfaWQYASABKAlSCHdhbG'
+    'xldElk');
 
 @$core.Deprecated('Use createBitcoinCoreWalletRequestDescriptor instead')
 const CreateBitcoinCoreWalletRequest$json = {
@@ -358,9 +365,9 @@ const CreateBitcoinCoreWalletRequest$json = {
 };
 
 /// Descriptor for `CreateBitcoinCoreWalletRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createBitcoinCoreWalletRequestDescriptor =
-    $convert.base64Decode('Ch5DcmVhdGVCaXRjb2luQ29yZVdhbGxldFJlcXVlc3QSGwoJd2FsbGV0X2lkGAEgASgJUgh3YW'
-        'xsZXRJZA==');
+final $typed_data.Uint8List createBitcoinCoreWalletRequestDescriptor = $convert.base64Decode(
+    'Ch5DcmVhdGVCaXRjb2luQ29yZVdhbGxldFJlcXVlc3QSGwoJd2FsbGV0X2lkGAEgASgJUgh3YW'
+    'xsZXRJZA==');
 
 @$core.Deprecated('Use createBitcoinCoreWalletResponseDescriptor instead')
 const CreateBitcoinCoreWalletResponse$json = {
@@ -371,9 +378,9 @@ const CreateBitcoinCoreWalletResponse$json = {
 };
 
 /// Descriptor for `CreateBitcoinCoreWalletResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createBitcoinCoreWalletResponseDescriptor =
-    $convert.base64Decode('Ch9DcmVhdGVCaXRjb2luQ29yZVdhbGxldFJlc3BvbnNlEigKEGNvcmVfd2FsbGV0X25hbWUYAS'
-        'ABKAlSDmNvcmVXYWxsZXROYW1l');
+final $typed_data.Uint8List createBitcoinCoreWalletResponseDescriptor = $convert.base64Decode(
+    'Ch9DcmVhdGVCaXRjb2luQ29yZVdhbGxldFJlc3BvbnNlEigKEGNvcmVfd2FsbGV0X25hbWUYAS'
+    'ABKAlSDmNvcmVXYWxsZXROYW1l');
 
 @$core.Deprecated('Use ensureCoreWalletsRequestDescriptor instead')
 const EnsureCoreWalletsRequest$json = {
@@ -381,8 +388,8 @@ const EnsureCoreWalletsRequest$json = {
 };
 
 /// Descriptor for `EnsureCoreWalletsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ensureCoreWalletsRequestDescriptor =
-    $convert.base64Decode('ChhFbnN1cmVDb3JlV2FsbGV0c1JlcXVlc3Q=');
+final $typed_data.Uint8List ensureCoreWalletsRequestDescriptor = $convert.base64Decode(
+    'ChhFbnN1cmVDb3JlV2FsbGV0c1JlcXVlc3Q=');
 
 @$core.Deprecated('Use ensureCoreWalletsResponseDescriptor instead')
 const EnsureCoreWalletsResponse$json = {
@@ -393,9 +400,9 @@ const EnsureCoreWalletsResponse$json = {
 };
 
 /// Descriptor for `EnsureCoreWalletsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ensureCoreWalletsResponseDescriptor =
-    $convert.base64Decode('ChlFbnN1cmVDb3JlV2FsbGV0c1Jlc3BvbnNlEiEKDHN5bmNlZF9jb3VudBgBIAEoBVILc3luY2'
-        'VkQ291bnQ=');
+final $typed_data.Uint8List ensureCoreWalletsResponseDescriptor = $convert.base64Decode(
+    'ChlFbnN1cmVDb3JlV2FsbGV0c1Jlc3BvbnNlEiEKDHN5bmNlZF9jb3VudBgBIAEoBVILc3luY2'
+    'VkQ291bnQ=');
 
 @$core.Deprecated('Use getBalanceRequestDescriptor instead')
 const GetBalanceRequest$json = {
@@ -406,8 +413,8 @@ const GetBalanceRequest$json = {
 };
 
 /// Descriptor for `GetBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceRequestDescriptor =
-    $convert.base64Decode('ChFHZXRCYWxhbmNlUmVxdWVzdBIbCgl3YWxsZXRfaWQYASABKAlSCHdhbGxldElk');
+final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode(
+    'ChFHZXRCYWxhbmNlUmVxdWVzdBIbCgl3YWxsZXRfaWQYASABKAlSCHdhbGxldElk');
 
 @$core.Deprecated('Use getBalanceResponseDescriptor instead')
 const GetBalanceResponse$json = {
@@ -419,9 +426,9 @@ const GetBalanceResponse$json = {
 };
 
 /// Descriptor for `GetBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceResponseDescriptor =
-    $convert.base64Decode('ChJHZXRCYWxhbmNlUmVzcG9uc2USJQoOY29uZmlybWVkX3NhdHMYASABKAFSDWNvbmZpcm1lZF'
-        'NhdHMSKQoQdW5jb25maXJtZWRfc2F0cxgCIAEoAVIPdW5jb25maXJtZWRTYXRz');
+final $typed_data.Uint8List getBalanceResponseDescriptor = $convert.base64Decode(
+    'ChJHZXRCYWxhbmNlUmVzcG9uc2USJQoOY29uZmlybWVkX3NhdHMYASABKAFSDWNvbmZpcm1lZF'
+    'NhdHMSKQoQdW5jb25maXJtZWRfc2F0cxgCIAEoAVIPdW5jb25maXJtZWRTYXRz');
 
 @$core.Deprecated('Use getNewAddressRequestDescriptor instead')
 const GetNewAddressRequest$json = {
@@ -432,8 +439,8 @@ const GetNewAddressRequest$json = {
 };
 
 /// Descriptor for `GetNewAddressRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressRequestDescriptor =
-    $convert.base64Decode('ChRHZXROZXdBZGRyZXNzUmVxdWVzdBIbCgl3YWxsZXRfaWQYASABKAlSCHdhbGxldElk');
+final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode(
+    'ChRHZXROZXdBZGRyZXNzUmVxdWVzdBIbCgl3YWxsZXRfaWQYASABKAlSCHdhbGxldElk');
 
 @$core.Deprecated('Use getNewAddressResponseDescriptor instead')
 const GetNewAddressResponse$json = {
@@ -445,23 +452,16 @@ const GetNewAddressResponse$json = {
 };
 
 /// Descriptor for `GetNewAddressResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewAddressResponseDescriptor =
-    $convert.base64Decode('ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIUCgVpbm'
-        'RleBgCIAEoBVIFaW5kZXg=');
+final $typed_data.Uint8List getNewAddressResponseDescriptor = $convert.base64Decode(
+    'ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIUCgVpbm'
+    'RleBgCIAEoBVIFaW5kZXg=');
 
 @$core.Deprecated('Use sendTransactionRequestDescriptor instead')
 const SendTransactionRequest$json = {
   '1': 'SendTransactionRequest',
   '2': [
     {'1': 'wallet_id', '3': 1, '4': 1, '5': 9, '10': 'walletId'},
-    {
-      '1': 'destinations',
-      '3': 2,
-      '4': 3,
-      '5': 11,
-      '6': '.walletmanager.v1.SendTransactionRequest.DestinationsEntry',
-      '10': 'destinations'
-    },
+    {'1': 'destinations', '3': 2, '4': 3, '5': 11, '6': '.walletmanager.v1.SendTransactionRequest.DestinationsEntry', '10': 'destinations'},
     {'1': 'fee_rate_sat_per_vbyte', '3': 3, '4': 1, '5': 3, '10': 'feeRateSatPerVbyte'},
     {'1': 'subtract_fee_from_amount', '3': 4, '4': 1, '5': 8, '10': 'subtractFeeFromAmount'},
     {'1': 'op_return_hex', '3': 5, '4': 1, '5': 9, '10': 'opReturnHex'},
@@ -482,16 +482,16 @@ const SendTransactionRequest_DestinationsEntry$json = {
 };
 
 /// Descriptor for `SendTransactionRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List sendTransactionRequestDescriptor =
-    $convert.base64Decode('ChZTZW5kVHJhbnNhY3Rpb25SZXF1ZXN0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQSXg'
-        'oMZGVzdGluYXRpb25zGAIgAygLMjoud2FsbGV0bWFuYWdlci52MS5TZW5kVHJhbnNhY3Rpb25S'
-        'ZXF1ZXN0LkRlc3RpbmF0aW9uc0VudHJ5UgxkZXN0aW5hdGlvbnMSMgoWZmVlX3JhdGVfc2F0X3'
-        'Blcl92Ynl0ZRgDIAEoA1ISZmVlUmF0ZVNhdFBlclZieXRlEjcKGHN1YnRyYWN0X2ZlZV9mcm9t'
-        'X2Ftb3VudBgEIAEoCFIVc3VidHJhY3RGZWVGcm9tQW1vdW50EiIKDW9wX3JldHVybl9oZXgYBS'
-        'ABKAlSC29wUmV0dXJuSGV4EiQKDmZpeGVkX2ZlZV9zYXRzGAYgASgDUgxmaXhlZEZlZVNhdHMS'
-        'SAoPcmVxdWlyZWRfaW5wdXRzGAcgAygLMh8ud2FsbGV0bWFuYWdlci52MS5VbnNwZW50T3V0cH'
-        'V0Ug5yZXF1aXJlZElucHV0cxo/ChFEZXN0aW5hdGlvbnNFbnRyeRIQCgNrZXkYASABKAlSA2tl'
-        'eRIUCgV2YWx1ZRgCIAEoA1IFdmFsdWU6AjgB');
+final $typed_data.Uint8List sendTransactionRequestDescriptor = $convert.base64Decode(
+    'ChZTZW5kVHJhbnNhY3Rpb25SZXF1ZXN0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQSXg'
+    'oMZGVzdGluYXRpb25zGAIgAygLMjoud2FsbGV0bWFuYWdlci52MS5TZW5kVHJhbnNhY3Rpb25S'
+    'ZXF1ZXN0LkRlc3RpbmF0aW9uc0VudHJ5UgxkZXN0aW5hdGlvbnMSMgoWZmVlX3JhdGVfc2F0X3'
+    'Blcl92Ynl0ZRgDIAEoA1ISZmVlUmF0ZVNhdFBlclZieXRlEjcKGHN1YnRyYWN0X2ZlZV9mcm9t'
+    'X2Ftb3VudBgEIAEoCFIVc3VidHJhY3RGZWVGcm9tQW1vdW50EiIKDW9wX3JldHVybl9oZXgYBS'
+    'ABKAlSC29wUmV0dXJuSGV4EiQKDmZpeGVkX2ZlZV9zYXRzGAYgASgDUgxmaXhlZEZlZVNhdHMS'
+    'SAoPcmVxdWlyZWRfaW5wdXRzGAcgAygLMh8ud2FsbGV0bWFuYWdlci52MS5VbnNwZW50T3V0cH'
+    'V0Ug5yZXF1aXJlZElucHV0cxo/ChFEZXN0aW5hdGlvbnNFbnRyeRIQCgNrZXkYASABKAlSA2tl'
+    'eRIUCgV2YWx1ZRgCIAEoA1IFdmFsdWU6AjgB');
 
 @$core.Deprecated('Use sendTransactionResponseDescriptor instead')
 const SendTransactionResponse$json = {
@@ -502,8 +502,8 @@ const SendTransactionResponse$json = {
 };
 
 /// Descriptor for `SendTransactionResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List sendTransactionResponseDescriptor =
-    $convert.base64Decode('ChdTZW5kVHJhbnNhY3Rpb25SZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
+final $typed_data.Uint8List sendTransactionResponseDescriptor = $convert.base64Decode(
+    'ChdTZW5kVHJhbnNhY3Rpb25SZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
 
 @$core.Deprecated('Use listTransactionsRequestDescriptor instead')
 const ListTransactionsRequest$json = {
@@ -515,9 +515,9 @@ const ListTransactionsRequest$json = {
 };
 
 /// Descriptor for `ListTransactionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listTransactionsRequestDescriptor =
-    $convert.base64Decode('ChdMaXN0VHJhbnNhY3Rpb25zUmVxdWVzdBIbCgl3YWxsZXRfaWQYASABKAlSCHdhbGxldElkEh'
-        'QKBWNvdW50GAIgASgFUgVjb3VudA==');
+final $typed_data.Uint8List listTransactionsRequestDescriptor = $convert.base64Decode(
+    'ChdMaXN0VHJhbnNhY3Rpb25zUmVxdWVzdBIbCgl3YWxsZXRfaWQYASABKAlSCHdhbGxldElkEh'
+    'QKBWNvdW50GAIgASgFUgVjb3VudA==');
 
 @$core.Deprecated('Use transactionEntryDescriptor instead')
 const TransactionEntry$json = {
@@ -540,14 +540,14 @@ const TransactionEntry$json = {
 };
 
 /// Descriptor for `TransactionEntry`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transactionEntryDescriptor =
-    $convert.base64Decode('ChBUcmFuc2FjdGlvbkVudHJ5EhIKBHR4aWQYASABKAlSBHR4aWQSEgoEdm91dBgCIAEoBVIEdm'
-        '91dBIYCgdhZGRyZXNzGAMgASgJUgdhZGRyZXNzEhoKCGNhdGVnb3J5GAQgASgJUghjYXRlZ29y'
-        'eRIWCgZhbW91bnQYBSABKAFSBmFtb3VudBIfCgthbW91bnRfc2F0cxgGIAEoA1IKYW1vdW50U2'
-        'F0cxIkCg1jb25maXJtYXRpb25zGAcgASgFUg1jb25maXJtYXRpb25zEh0KCmJsb2NrX3RpbWUY'
-        'CCABKANSCWJsb2NrVGltZRISCgR0aW1lGAkgASgDUgR0aW1lEhQKBWxhYmVsGAogASgJUgVsYW'
-        'JlbBIQCgNmZWUYCyABKAFSA2ZlZRIoChByZXBsYWNlZF9ieV90eGlkGAwgASgIUg5yZXBsYWNl'
-        'ZEJ5VHhpZBIbCgl3YWxsZXRfaWQYDSABKAlSCHdhbGxldElk');
+final $typed_data.Uint8List transactionEntryDescriptor = $convert.base64Decode(
+    'ChBUcmFuc2FjdGlvbkVudHJ5EhIKBHR4aWQYASABKAlSBHR4aWQSEgoEdm91dBgCIAEoBVIEdm'
+    '91dBIYCgdhZGRyZXNzGAMgASgJUgdhZGRyZXNzEhoKCGNhdGVnb3J5GAQgASgJUghjYXRlZ29y'
+    'eRIWCgZhbW91bnQYBSABKAFSBmFtb3VudBIfCgthbW91bnRfc2F0cxgGIAEoA1IKYW1vdW50U2'
+    'F0cxIkCg1jb25maXJtYXRpb25zGAcgASgFUg1jb25maXJtYXRpb25zEh0KCmJsb2NrX3RpbWUY'
+    'CCABKANSCWJsb2NrVGltZRISCgR0aW1lGAkgASgDUgR0aW1lEhQKBWxhYmVsGAogASgJUgVsYW'
+    'JlbBIQCgNmZWUYCyABKAFSA2ZlZRIoChByZXBsYWNlZF9ieV90eGlkGAwgASgIUg5yZXBsYWNl'
+    'ZEJ5VHhpZBIbCgl3YWxsZXRfaWQYDSABKAlSCHdhbGxldElk');
 
 @$core.Deprecated('Use listTransactionsResponseDescriptor instead')
 const ListTransactionsResponse$json = {
@@ -558,9 +558,9 @@ const ListTransactionsResponse$json = {
 };
 
 /// Descriptor for `ListTransactionsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listTransactionsResponseDescriptor =
-    $convert.base64Decode('ChhMaXN0VHJhbnNhY3Rpb25zUmVzcG9uc2USRgoMdHJhbnNhY3Rpb25zGAEgAygLMiIud2FsbG'
-        'V0bWFuYWdlci52MS5UcmFuc2FjdGlvbkVudHJ5Ugx0cmFuc2FjdGlvbnM=');
+final $typed_data.Uint8List listTransactionsResponseDescriptor = $convert.base64Decode(
+    'ChhMaXN0VHJhbnNhY3Rpb25zUmVzcG9uc2USRgoMdHJhbnNhY3Rpb25zGAEgAygLMiIud2FsbG'
+    'V0bWFuYWdlci52MS5UcmFuc2FjdGlvbkVudHJ5Ugx0cmFuc2FjdGlvbnM=');
 
 @$core.Deprecated('Use listUnspentRequestDescriptor instead')
 const ListUnspentRequest$json = {
@@ -571,8 +571,8 @@ const ListUnspentRequest$json = {
 };
 
 /// Descriptor for `ListUnspentRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUnspentRequestDescriptor =
-    $convert.base64Decode('ChJMaXN0VW5zcGVudFJlcXVlc3QSGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZXRJZA==');
+final $typed_data.Uint8List listUnspentRequestDescriptor = $convert.base64Decode(
+    'ChJMaXN0VW5zcGVudFJlcXVlc3QSGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZXRJZA==');
 
 @$core.Deprecated('Use unspentOutputDescriptor instead')
 const UnspentOutput$json = {
@@ -592,13 +592,13 @@ const UnspentOutput$json = {
 };
 
 /// Descriptor for `UnspentOutput`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List unspentOutputDescriptor =
-    $convert.base64Decode('Cg1VbnNwZW50T3V0cHV0EhIKBHR4aWQYASABKAlSBHR4aWQSEgoEdm91dBgCIAEoBVIEdm91dB'
-        'IYCgdhZGRyZXNzGAMgASgJUgdhZGRyZXNzEhYKBmFtb3VudBgEIAEoAVIGYW1vdW50Eh8KC2Ft'
-        'b3VudF9zYXRzGAUgASgDUgphbW91bnRTYXRzEiQKDWNvbmZpcm1hdGlvbnMYBiABKAVSDWNvbm'
-        'Zpcm1hdGlvbnMSFAoFbGFiZWwYByABKAlSBWxhYmVsEhwKCXNwZW5kYWJsZRgIIAEoCFIJc3Bl'
-        'bmRhYmxlEhoKCHNvbHZhYmxlGAkgASgIUghzb2x2YWJsZRIbCgl3YWxsZXRfaWQYCiABKAlSCH'
-        'dhbGxldElk');
+final $typed_data.Uint8List unspentOutputDescriptor = $convert.base64Decode(
+    'Cg1VbnNwZW50T3V0cHV0EhIKBHR4aWQYASABKAlSBHR4aWQSEgoEdm91dBgCIAEoBVIEdm91dB'
+    'IYCgdhZGRyZXNzGAMgASgJUgdhZGRyZXNzEhYKBmFtb3VudBgEIAEoAVIGYW1vdW50Eh8KC2Ft'
+    'b3VudF9zYXRzGAUgASgDUgphbW91bnRTYXRzEiQKDWNvbmZpcm1hdGlvbnMYBiABKAVSDWNvbm'
+    'Zpcm1hdGlvbnMSFAoFbGFiZWwYByABKAlSBWxhYmVsEhwKCXNwZW5kYWJsZRgIIAEoCFIJc3Bl'
+    'bmRhYmxlEhoKCHNvbHZhYmxlGAkgASgIUghzb2x2YWJsZRIbCgl3YWxsZXRfaWQYCiABKAlSCH'
+    'dhbGxldElk');
 
 @$core.Deprecated('Use listUnspentResponseDescriptor instead')
 const ListUnspentResponse$json = {
@@ -609,9 +609,9 @@ const ListUnspentResponse$json = {
 };
 
 /// Descriptor for `ListUnspentResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUnspentResponseDescriptor =
-    $convert.base64Decode('ChNMaXN0VW5zcGVudFJlc3BvbnNlEjUKBXV0eG9zGAEgAygLMh8ud2FsbGV0bWFuYWdlci52MS'
-        '5VbnNwZW50T3V0cHV0UgV1dHhvcw==');
+final $typed_data.Uint8List listUnspentResponseDescriptor = $convert.base64Decode(
+    'ChNMaXN0VW5zcGVudFJlc3BvbnNlEjUKBXV0eG9zGAEgAygLMh8ud2FsbGV0bWFuYWdlci52MS'
+    '5VbnNwZW50T3V0cHV0UgV1dHhvcw==');
 
 @$core.Deprecated('Use listReceiveAddressesRequestDescriptor instead')
 const ListReceiveAddressesRequest$json = {
@@ -622,9 +622,9 @@ const ListReceiveAddressesRequest$json = {
 };
 
 /// Descriptor for `ListReceiveAddressesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listReceiveAddressesRequestDescriptor =
-    $convert.base64Decode('ChtMaXN0UmVjZWl2ZUFkZHJlc3Nlc1JlcXVlc3QSGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZX'
-        'RJZA==');
+final $typed_data.Uint8List listReceiveAddressesRequestDescriptor = $convert.base64Decode(
+    'ChtMaXN0UmVjZWl2ZUFkZHJlc3Nlc1JlcXVlc3QSGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZX'
+    'RJZA==');
 
 @$core.Deprecated('Use receiveAddressDescriptor instead')
 const ReceiveAddress$json = {
@@ -639,10 +639,10 @@ const ReceiveAddress$json = {
 };
 
 /// Descriptor for `ReceiveAddress`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List receiveAddressDescriptor =
-    $convert.base64Decode('Cg5SZWNlaXZlQWRkcmVzcxIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEhYKBmFtb3VudBgCIA'
-        'EoAVIGYW1vdW50Eh8KC2Ftb3VudF9zYXRzGAMgASgDUgphbW91bnRTYXRzEhQKBWxhYmVsGAQg'
-        'ASgJUgVsYWJlbBIZCgh0eF9jb3VudBgFIAEoBVIHdHhDb3VudA==');
+final $typed_data.Uint8List receiveAddressDescriptor = $convert.base64Decode(
+    'Cg5SZWNlaXZlQWRkcmVzcxIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEhYKBmFtb3VudBgCIA'
+    'EoAVIGYW1vdW50Eh8KC2Ftb3VudF9zYXRzGAMgASgDUgphbW91bnRTYXRzEhQKBWxhYmVsGAQg'
+    'ASgJUgVsYWJlbBIZCgh0eF9jb3VudBgFIAEoBVIHdHhDb3VudA==');
 
 @$core.Deprecated('Use listReceiveAddressesResponseDescriptor instead')
 const ListReceiveAddressesResponse$json = {
@@ -653,9 +653,9 @@ const ListReceiveAddressesResponse$json = {
 };
 
 /// Descriptor for `ListReceiveAddressesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listReceiveAddressesResponseDescriptor =
-    $convert.base64Decode('ChxMaXN0UmVjZWl2ZUFkZHJlc3Nlc1Jlc3BvbnNlEj4KCWFkZHJlc3NlcxgBIAMoCzIgLndhbG'
-        'xldG1hbmFnZXIudjEuUmVjZWl2ZUFkZHJlc3NSCWFkZHJlc3Nlcw==');
+final $typed_data.Uint8List listReceiveAddressesResponseDescriptor = $convert.base64Decode(
+    'ChxMaXN0UmVjZWl2ZUFkZHJlc3Nlc1Jlc3BvbnNlEj4KCWFkZHJlc3NlcxgBIAMoCzIgLndhbG'
+    'xldG1hbmFnZXIudjEuUmVjZWl2ZUFkZHJlc3NSCWFkZHJlc3Nlcw==');
 
 @$core.Deprecated('Use getTransactionDetailsRequestDescriptor instead')
 const GetTransactionDetailsRequest$json = {
@@ -667,9 +667,9 @@ const GetTransactionDetailsRequest$json = {
 };
 
 /// Descriptor for `GetTransactionDetailsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getTransactionDetailsRequestDescriptor =
-    $convert.base64Decode('ChxHZXRUcmFuc2FjdGlvbkRldGFpbHNSZXF1ZXN0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbG'
-        'V0SWQSEgoEdHhpZBgCIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List getTransactionDetailsRequestDescriptor = $convert.base64Decode(
+    'ChxHZXRUcmFuc2FjdGlvbkRldGFpbHNSZXF1ZXN0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbG'
+    'V0SWQSEgoEdHhpZBgCIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use getTransactionDetailsResponseDescriptor instead')
 const GetTransactionDetailsResponse$json = {
@@ -695,19 +695,19 @@ const GetTransactionDetailsResponse$json = {
 };
 
 /// Descriptor for `GetTransactionDetailsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getTransactionDetailsResponseDescriptor =
-    $convert.base64Decode('Ch1HZXRUcmFuc2FjdGlvbkRldGFpbHNSZXNwb25zZRJECgt0cmFuc2FjdGlvbhgBIAEoCzIiLn'
-        'dhbGxldG1hbmFnZXIudjEuVHJhbnNhY3Rpb25FbnRyeVILdHJhbnNhY3Rpb24SFwoHcmF3X2hl'
-        'eBgCIAEoCVIGcmF3SGV4EhwKCWJsb2NraGFzaBgDIAEoCVIJYmxvY2toYXNoEiQKDWNvbmZpcm'
-        '1hdGlvbnMYBCABKAVSDWNvbmZpcm1hdGlvbnMSHQoKYmxvY2tfdGltZRgFIAEoA1IJYmxvY2tU'
-        'aW1lEhgKB3ZlcnNpb24YBiABKAVSB3ZlcnNpb24SGgoIbG9ja3RpbWUYByABKAVSCGxvY2t0aW'
-        '1lEh0KCnNpemVfYnl0ZXMYCCABKAVSCXNpemVCeXRlcxIhCgx2c2l6ZV92Ynl0ZXMYCSABKAVS'
-        'C3ZzaXplVmJ5dGVzEhsKCXdlaWdodF93dRgKIAEoBVIId2VpZ2h0V3USGQoIZmVlX3NhdHMYCy'
-        'ABKANSB2ZlZVNhdHMSJQoPZmVlX3JhdGVfc2F0X3ZiGAwgASgBUgxmZWVSYXRlU2F0VmISOgoG'
-        'aW5wdXRzGA0gAygLMiIud2FsbGV0bWFuYWdlci52MS5UcmFuc2FjdGlvbklucHV0UgZpbnB1dH'
-        'MSKAoQdG90YWxfaW5wdXRfc2F0cxgOIAEoA1IOdG90YWxJbnB1dFNhdHMSPQoHb3V0cHV0cxgP'
-        'IAMoCzIjLndhbGxldG1hbmFnZXIudjEuVHJhbnNhY3Rpb25PdXRwdXRSB291dHB1dHMSKgoRdG'
-        '90YWxfb3V0cHV0X3NhdHMYECABKANSD3RvdGFsT3V0cHV0U2F0cw==');
+final $typed_data.Uint8List getTransactionDetailsResponseDescriptor = $convert.base64Decode(
+    'Ch1HZXRUcmFuc2FjdGlvbkRldGFpbHNSZXNwb25zZRJECgt0cmFuc2FjdGlvbhgBIAEoCzIiLn'
+    'dhbGxldG1hbmFnZXIudjEuVHJhbnNhY3Rpb25FbnRyeVILdHJhbnNhY3Rpb24SFwoHcmF3X2hl'
+    'eBgCIAEoCVIGcmF3SGV4EhwKCWJsb2NraGFzaBgDIAEoCVIJYmxvY2toYXNoEiQKDWNvbmZpcm'
+    '1hdGlvbnMYBCABKAVSDWNvbmZpcm1hdGlvbnMSHQoKYmxvY2tfdGltZRgFIAEoA1IJYmxvY2tU'
+    'aW1lEhgKB3ZlcnNpb24YBiABKAVSB3ZlcnNpb24SGgoIbG9ja3RpbWUYByABKAVSCGxvY2t0aW'
+    '1lEh0KCnNpemVfYnl0ZXMYCCABKAVSCXNpemVCeXRlcxIhCgx2c2l6ZV92Ynl0ZXMYCSABKAVS'
+    'C3ZzaXplVmJ5dGVzEhsKCXdlaWdodF93dRgKIAEoBVIId2VpZ2h0V3USGQoIZmVlX3NhdHMYCy'
+    'ABKANSB2ZlZVNhdHMSJQoPZmVlX3JhdGVfc2F0X3ZiGAwgASgBUgxmZWVSYXRlU2F0VmISOgoG'
+    'aW5wdXRzGA0gAygLMiIud2FsbGV0bWFuYWdlci52MS5UcmFuc2FjdGlvbklucHV0UgZpbnB1dH'
+    'MSKAoQdG90YWxfaW5wdXRfc2F0cxgOIAEoA1IOdG90YWxJbnB1dFNhdHMSPQoHb3V0cHV0cxgP'
+    'IAMoCzIjLndhbGxldG1hbmFnZXIudjEuVHJhbnNhY3Rpb25PdXRwdXRSB291dHB1dHMSKgoRdG'
+    '90YWxfb3V0cHV0X3NhdHMYECABKANSD3RvdGFsT3V0cHV0U2F0cw==');
 
 @$core.Deprecated('Use transactionInputDescriptor instead')
 const TransactionInput$json = {
@@ -727,13 +727,13 @@ const TransactionInput$json = {
 };
 
 /// Descriptor for `TransactionInput`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transactionInputDescriptor =
-    $convert.base64Decode('ChBUcmFuc2FjdGlvbklucHV0EhQKBWluZGV4GAEgASgFUgVpbmRleBIbCglwcmV2X3R4aWQYAi'
-        'ABKAlSCHByZXZUeGlkEhsKCXByZXZfdm91dBgDIAEoBVIIcHJldlZvdXQSGAoHYWRkcmVzcxgE'
-        'IAEoCVIHYWRkcmVzcxIdCgp2YWx1ZV9zYXRzGAUgASgDUgl2YWx1ZVNhdHMSJAoOc2NyaXB0X3'
-        'NpZ19hc20YBiABKAlSDHNjcmlwdFNpZ0FzbRIkCg5zY3JpcHRfc2lnX2hleBgHIAEoCVIMc2Ny'
-        'aXB0U2lnSGV4EhgKB3dpdG5lc3MYCCADKAlSB3dpdG5lc3MSGgoIc2VxdWVuY2UYCSABKANSCH'
-        'NlcXVlbmNlEh8KC2lzX2NvaW5iYXNlGAogASgIUgppc0NvaW5iYXNl');
+final $typed_data.Uint8List transactionInputDescriptor = $convert.base64Decode(
+    'ChBUcmFuc2FjdGlvbklucHV0EhQKBWluZGV4GAEgASgFUgVpbmRleBIbCglwcmV2X3R4aWQYAi'
+    'ABKAlSCHByZXZUeGlkEhsKCXByZXZfdm91dBgDIAEoBVIIcHJldlZvdXQSGAoHYWRkcmVzcxgE'
+    'IAEoCVIHYWRkcmVzcxIdCgp2YWx1ZV9zYXRzGAUgASgDUgl2YWx1ZVNhdHMSJAoOc2NyaXB0X3'
+    'NpZ19hc20YBiABKAlSDHNjcmlwdFNpZ0FzbRIkCg5zY3JpcHRfc2lnX2hleBgHIAEoCVIMc2Ny'
+    'aXB0U2lnSGV4EhgKB3dpdG5lc3MYCCADKAlSB3dpdG5lc3MSGgoIc2VxdWVuY2UYCSABKANSCH'
+    'NlcXVlbmNlEh8KC2lzX2NvaW5iYXNlGAogASgIUgppc0NvaW5iYXNl');
 
 @$core.Deprecated('Use transactionOutputDescriptor instead')
 const TransactionOutput$json = {
@@ -749,11 +749,11 @@ const TransactionOutput$json = {
 };
 
 /// Descriptor for `TransactionOutput`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transactionOutputDescriptor =
-    $convert.base64Decode('ChFUcmFuc2FjdGlvbk91dHB1dBIUCgVpbmRleBgBIAEoBVIFaW5kZXgSHQoKdmFsdWVfc2F0cx'
-        'gCIAEoA1IJdmFsdWVTYXRzEhgKB2FkZHJlc3MYAyABKAlSB2FkZHJlc3MSHwoLc2NyaXB0X3R5'
-        'cGUYBCABKAlSCnNjcmlwdFR5cGUSKgoRc2NyaXB0X3B1YmtleV9hc20YBSABKAlSD3NjcmlwdF'
-        'B1YmtleUFzbRIqChFzY3JpcHRfcHVia2V5X2hleBgGIAEoCVIPc2NyaXB0UHVia2V5SGV4');
+final $typed_data.Uint8List transactionOutputDescriptor = $convert.base64Decode(
+    'ChFUcmFuc2FjdGlvbk91dHB1dBIUCgVpbmRleBgBIAEoBVIFaW5kZXgSHQoKdmFsdWVfc2F0cx'
+    'gCIAEoA1IJdmFsdWVTYXRzEhgKB2FkZHJlc3MYAyABKAlSB2FkZHJlc3MSHwoLc2NyaXB0X3R5'
+    'cGUYBCABKAlSCnNjcmlwdFR5cGUSKgoRc2NyaXB0X3B1YmtleV9hc20YBSABKAlSD3NjcmlwdF'
+    'B1YmtleUFzbRIqChFzY3JpcHRfcHVia2V5X2hleBgGIAEoCVIPc2NyaXB0UHVia2V5SGV4');
 
 @$core.Deprecated('Use bumpFeeRequestDescriptor instead')
 const BumpFeeRequest$json = {
@@ -766,9 +766,9 @@ const BumpFeeRequest$json = {
 };
 
 /// Descriptor for `BumpFeeRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List bumpFeeRequestDescriptor =
-    $convert.base64Decode('Cg5CdW1wRmVlUmVxdWVzdBIbCgl3YWxsZXRfaWQYASABKAlSCHdhbGxldElkEhIKBHR4aWQYAi'
-        'ABKAlSBHR4aWQSIAoMbmV3X2ZlZV9yYXRlGAMgASgDUgpuZXdGZWVSYXRl');
+final $typed_data.Uint8List bumpFeeRequestDescriptor = $convert.base64Decode(
+    'Cg5CdW1wRmVlUmVxdWVzdBIbCgl3YWxsZXRfaWQYASABKAlSCHdhbGxldElkEhIKBHR4aWQYAi'
+    'ABKAlSBHR4aWQSIAoMbmV3X2ZlZV9yYXRlGAMgASgDUgpuZXdGZWVSYXRl');
 
 @$core.Deprecated('Use bumpFeeResponseDescriptor instead')
 const BumpFeeResponse$json = {
@@ -779,8 +779,8 @@ const BumpFeeResponse$json = {
 };
 
 /// Descriptor for `BumpFeeResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List bumpFeeResponseDescriptor =
-    $convert.base64Decode('Cg9CdW1wRmVlUmVzcG9uc2USGQoIbmV3X3R4aWQYASABKAlSB25ld1R4aWQ=');
+final $typed_data.Uint8List bumpFeeResponseDescriptor = $convert.base64Decode(
+    'Cg9CdW1wRmVlUmVzcG9uc2USGQoIbmV3X3R4aWQYASABKAlSB25ld1R4aWQ=');
 
 @$core.Deprecated('Use deriveAddressesRequestDescriptor instead')
 const DeriveAddressesRequest$json = {
@@ -793,9 +793,9 @@ const DeriveAddressesRequest$json = {
 };
 
 /// Descriptor for `DeriveAddressesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List deriveAddressesRequestDescriptor =
-    $convert.base64Decode('ChZEZXJpdmVBZGRyZXNzZXNSZXF1ZXN0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQSHw'
-        'oLc3RhcnRfaW5kZXgYAiABKAVSCnN0YXJ0SW5kZXgSFAoFY291bnQYAyABKAVSBWNvdW50');
+final $typed_data.Uint8List deriveAddressesRequestDescriptor = $convert.base64Decode(
+    'ChZEZXJpdmVBZGRyZXNzZXNSZXF1ZXN0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SWQSHw'
+    'oLc3RhcnRfaW5kZXgYAiABKAVSCnN0YXJ0SW5kZXgSFAoFY291bnQYAyABKAVSBWNvdW50');
 
 @$core.Deprecated('Use deriveAddressesResponseDescriptor instead')
 const DeriveAddressesResponse$json = {
@@ -806,9 +806,9 @@ const DeriveAddressesResponse$json = {
 };
 
 /// Descriptor for `DeriveAddressesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List deriveAddressesResponseDescriptor =
-    $convert.base64Decode('ChdEZXJpdmVBZGRyZXNzZXNSZXNwb25zZRIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3Nlcw'
-        '==');
+final $typed_data.Uint8List deriveAddressesResponseDescriptor = $convert.base64Decode(
+    'ChdEZXJpdmVBZGRyZXNzZXNSZXNwb25zZRIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3Nlcw'
+    '==');
 
 @$core.Deprecated('Use getWalletSeedRequestDescriptor instead')
 const GetWalletSeedRequest$json = {
@@ -819,8 +819,8 @@ const GetWalletSeedRequest$json = {
 };
 
 /// Descriptor for `GetWalletSeedRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletSeedRequestDescriptor =
-    $convert.base64Decode('ChRHZXRXYWxsZXRTZWVkUmVxdWVzdBIbCgl3YWxsZXRfaWQYASABKAlSCHdhbGxldElk');
+final $typed_data.Uint8List getWalletSeedRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRXYWxsZXRTZWVkUmVxdWVzdBIbCgl3YWxsZXRfaWQYASABKAlSCHdhbGxldElk');
 
 @$core.Deprecated('Use getWalletSeedResponseDescriptor instead')
 const GetWalletSeedResponse$json = {
@@ -832,9 +832,9 @@ const GetWalletSeedResponse$json = {
 };
 
 /// Descriptor for `GetWalletSeedResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletSeedResponseDescriptor =
-    $convert.base64Decode('ChVHZXRXYWxsZXRTZWVkUmVzcG9uc2USGQoIc2VlZF9oZXgYASABKAlSB3NlZWRIZXgSGgoIbW'
-        '5lbW9uaWMYAiABKAlSCG1uZW1vbmlj');
+final $typed_data.Uint8List getWalletSeedResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRXYWxsZXRTZWVkUmVzcG9uc2USGQoIc2VlZF9oZXgYASABKAlSB3NlZWRIZXgSGgoIbW'
+    '5lbW9uaWMYAiABKAlSCG1uZW1vbmlj');
 
 @$core.Deprecated('Use listCoreVariantsRequestDescriptor instead')
 const ListCoreVariantsRequest$json = {
@@ -842,8 +842,8 @@ const ListCoreVariantsRequest$json = {
 };
 
 /// Descriptor for `ListCoreVariantsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listCoreVariantsRequestDescriptor =
-    $convert.base64Decode('ChdMaXN0Q29yZVZhcmlhbnRzUmVxdWVzdA==');
+final $typed_data.Uint8List listCoreVariantsRequestDescriptor = $convert.base64Decode(
+    'ChdMaXN0Q29yZVZhcmlhbnRzUmVxdWVzdA==');
 
 @$core.Deprecated('Use coreVariantDescriptor instead')
 const CoreVariant$json = {
@@ -856,9 +856,9 @@ const CoreVariant$json = {
 };
 
 /// Descriptor for `CoreVariant`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List coreVariantDescriptor =
-    $convert.base64Decode('CgtDb3JlVmFyaWFudBIOCgJpZBgBIAEoCVICaWQSIQoMZGlzcGxheV9uYW1lGAIgASgJUgtkaX'
-        'NwbGF5TmFtZRIcCglpbnN0YWxsZWQYAyABKAhSCWluc3RhbGxlZA==');
+final $typed_data.Uint8List coreVariantDescriptor = $convert.base64Decode(
+    'CgtDb3JlVmFyaWFudBIOCgJpZBgBIAEoCVICaWQSIQoMZGlzcGxheV9uYW1lGAIgASgJUgtkaX'
+    'NwbGF5TmFtZRIcCglpbnN0YWxsZWQYAyABKAhSCWluc3RhbGxlZA==');
 
 @$core.Deprecated('Use listCoreVariantsResponseDescriptor instead')
 const ListCoreVariantsResponse$json = {
@@ -870,10 +870,10 @@ const ListCoreVariantsResponse$json = {
 };
 
 /// Descriptor for `ListCoreVariantsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listCoreVariantsResponseDescriptor =
-    $convert.base64Decode('ChhMaXN0Q29yZVZhcmlhbnRzUmVzcG9uc2USOQoIdmFyaWFudHMYASADKAsyHS53YWxsZXRtYW'
-        '5hZ2VyLnYxLkNvcmVWYXJpYW50Ugh2YXJpYW50cxIbCglhY3RpdmVfaWQYAiABKAlSCGFjdGl2'
-        'ZUlk');
+final $typed_data.Uint8List listCoreVariantsResponseDescriptor = $convert.base64Decode(
+    'ChhMaXN0Q29yZVZhcmlhbnRzUmVzcG9uc2USOQoIdmFyaWFudHMYASADKAsyHS53YWxsZXRtYW'
+    '5hZ2VyLnYxLkNvcmVWYXJpYW50Ugh2YXJpYW50cxIbCglhY3RpdmVfaWQYAiABKAlSCGFjdGl2'
+    'ZUlk');
 
 @$core.Deprecated('Use getCoreVariantRequestDescriptor instead')
 const GetCoreVariantRequest$json = {
@@ -881,7 +881,8 @@ const GetCoreVariantRequest$json = {
 };
 
 /// Descriptor for `GetCoreVariantRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getCoreVariantRequestDescriptor = $convert.base64Decode('ChVHZXRDb3JlVmFyaWFudFJlcXVlc3Q=');
+final $typed_data.Uint8List getCoreVariantRequestDescriptor = $convert.base64Decode(
+    'ChVHZXRDb3JlVmFyaWFudFJlcXVlc3Q=');
 
 @$core.Deprecated('Use getCoreVariantResponseDescriptor instead')
 const GetCoreVariantResponse$json = {
@@ -892,8 +893,8 @@ const GetCoreVariantResponse$json = {
 };
 
 /// Descriptor for `GetCoreVariantResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getCoreVariantResponseDescriptor =
-    $convert.base64Decode('ChZHZXRDb3JlVmFyaWFudFJlc3BvbnNlEg4KAmlkGAEgASgJUgJpZA==');
+final $typed_data.Uint8List getCoreVariantResponseDescriptor = $convert.base64Decode(
+    'ChZHZXRDb3JlVmFyaWFudFJlc3BvbnNlEg4KAmlkGAEgASgJUgJpZA==');
 
 @$core.Deprecated('Use setCoreVariantRequestDescriptor instead')
 const SetCoreVariantRequest$json = {
@@ -904,8 +905,8 @@ const SetCoreVariantRequest$json = {
 };
 
 /// Descriptor for `SetCoreVariantRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setCoreVariantRequestDescriptor =
-    $convert.base64Decode('ChVTZXRDb3JlVmFyaWFudFJlcXVlc3QSDgoCaWQYASABKAlSAmlk');
+final $typed_data.Uint8List setCoreVariantRequestDescriptor = $convert.base64Decode(
+    'ChVTZXRDb3JlVmFyaWFudFJlcXVlc3QSDgoCaWQYASABKAlSAmlk');
 
 @$core.Deprecated('Use setCoreVariantResponseDescriptor instead')
 const SetCoreVariantResponse$json = {
@@ -913,8 +914,8 @@ const SetCoreVariantResponse$json = {
 };
 
 /// Descriptor for `SetCoreVariantResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setCoreVariantResponseDescriptor =
-    $convert.base64Decode('ChZTZXRDb3JlVmFyaWFudFJlc3BvbnNl');
+final $typed_data.Uint8List setCoreVariantResponseDescriptor = $convert.base64Decode(
+    'ChZTZXRDb3JlVmFyaWFudFJlc3BvbnNl');
 
 @$core.Deprecated('Use getTestSidechainsRequestDescriptor instead')
 const GetTestSidechainsRequest$json = {
@@ -922,8 +923,8 @@ const GetTestSidechainsRequest$json = {
 };
 
 /// Descriptor for `GetTestSidechainsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getTestSidechainsRequestDescriptor =
-    $convert.base64Decode('ChhHZXRUZXN0U2lkZWNoYWluc1JlcXVlc3Q=');
+final $typed_data.Uint8List getTestSidechainsRequestDescriptor = $convert.base64Decode(
+    'ChhHZXRUZXN0U2lkZWNoYWluc1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getTestSidechainsResponseDescriptor instead')
 const GetTestSidechainsResponse$json = {
@@ -934,8 +935,8 @@ const GetTestSidechainsResponse$json = {
 };
 
 /// Descriptor for `GetTestSidechainsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getTestSidechainsResponseDescriptor =
-    $convert.base64Decode('ChlHZXRUZXN0U2lkZWNoYWluc1Jlc3BvbnNlEhgKB2VuYWJsZWQYASABKAhSB2VuYWJsZWQ=');
+final $typed_data.Uint8List getTestSidechainsResponseDescriptor = $convert.base64Decode(
+    'ChlHZXRUZXN0U2lkZWNoYWluc1Jlc3BvbnNlEhgKB2VuYWJsZWQYASABKAhSB2VuYWJsZWQ=');
 
 @$core.Deprecated('Use setTestSidechainsRequestDescriptor instead')
 const SetTestSidechainsRequest$json = {
@@ -946,8 +947,8 @@ const SetTestSidechainsRequest$json = {
 };
 
 /// Descriptor for `SetTestSidechainsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setTestSidechainsRequestDescriptor =
-    $convert.base64Decode('ChhTZXRUZXN0U2lkZWNoYWluc1JlcXVlc3QSGAoHZW5hYmxlZBgBIAEoCFIHZW5hYmxlZA==');
+final $typed_data.Uint8List setTestSidechainsRequestDescriptor = $convert.base64Decode(
+    'ChhTZXRUZXN0U2lkZWNoYWluc1JlcXVlc3QSGAoHZW5hYmxlZBgBIAEoCFIHZW5hYmxlZA==');
 
 @$core.Deprecated('Use setTestSidechainsResponseDescriptor instead')
 const SetTestSidechainsResponse$json = {
@@ -955,8 +956,8 @@ const SetTestSidechainsResponse$json = {
 };
 
 /// Descriptor for `SetTestSidechainsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setTestSidechainsResponseDescriptor =
-    $convert.base64Decode('ChlTZXRUZXN0U2lkZWNoYWluc1Jlc3BvbnNl');
+final $typed_data.Uint8List setTestSidechainsResponseDescriptor = $convert.base64Decode(
+    'ChlTZXRUZXN0U2lkZWNoYWluc1Jlc3BvbnNl');
 
 @$core.Deprecated('Use watchWalletDataResponseDescriptor instead')
 const WatchWalletDataResponse$json = {
@@ -975,142 +976,49 @@ const WatchWalletDataResponse$json = {
 };
 
 /// Descriptor for `WatchWalletDataResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List watchWalletDataResponseDescriptor =
-    $convert.base64Decode('ChdXYXRjaFdhbGxldERhdGFSZXNwb25zZRIdCgpoYXNfd2FsbGV0GAEgASgIUgloYXNXYWxsZX'
-        'QSHAoJZW5jcnlwdGVkGAIgASgIUgllbmNyeXB0ZWQSGgoIdW5sb2NrZWQYAyABKAhSCHVubG9j'
-        'a2VkEigKEGFjdGl2ZV93YWxsZXRfaWQYBCABKAlSDmFjdGl2ZVdhbGxldElkEjoKB3dhbGxldH'
-        'MYBSADKAsyIC53YWxsZXRtYW5hZ2VyLnYxLldhbGxldE1ldGFkYXRhUgd3YWxsZXRzEiUKDmNv'
-        'bmZpcm1lZF9zYXRzGAYgASgBUg1jb25maXJtZWRTYXRzEikKEHVuY29uZmlybWVkX3NhdHMYBy'
-        'ABKAFSD3VuY29uZmlybWVkU2F0cxIQCgNzZXEYCCABKANSA3NlcRIcCgloZWFydGJlYXQYCSAB'
-        'KAhSCWhlYXJ0YmVhdA==');
+final $typed_data.Uint8List watchWalletDataResponseDescriptor = $convert.base64Decode(
+    'ChdXYXRjaFdhbGxldERhdGFSZXNwb25zZRIdCgpoYXNfd2FsbGV0GAEgASgIUgloYXNXYWxsZX'
+    'QSHAoJZW5jcnlwdGVkGAIgASgIUgllbmNyeXB0ZWQSGgoIdW5sb2NrZWQYAyABKAhSCHVubG9j'
+    'a2VkEigKEGFjdGl2ZV93YWxsZXRfaWQYBCABKAlSDmFjdGl2ZVdhbGxldElkEjoKB3dhbGxldH'
+    'MYBSADKAsyIC53YWxsZXRtYW5hZ2VyLnYxLldhbGxldE1ldGFkYXRhUgd3YWxsZXRzEiUKDmNv'
+    'bmZpcm1lZF9zYXRzGAYgASgBUg1jb25maXJtZWRTYXRzEikKEHVuY29uZmlybWVkX3NhdHMYBy'
+    'ABKAFSD3VuY29uZmlybWVkU2F0cxIQCgNzZXEYCCABKANSA3NlcRIcCgloZWFydGJlYXQYCSAB'
+    'KAhSCWhlYXJ0YmVhdA==');
 
 const $core.Map<$core.String, $core.dynamic> WalletManagerServiceBase$json = {
   '1': 'WalletManagerService',
   '2': [
-    {
-      '1': 'GetWalletStatus',
-      '2': '.walletmanager.v1.GetWalletStatusRequest',
-      '3': '.walletmanager.v1.GetWalletStatusResponse'
-    },
-    {
-      '1': 'GenerateWallet',
-      '2': '.walletmanager.v1.GenerateWalletRequest',
-      '3': '.walletmanager.v1.GenerateWalletResponse'
-    },
+    {'1': 'GetWalletStatus', '2': '.walletmanager.v1.GetWalletStatusRequest', '3': '.walletmanager.v1.GetWalletStatusResponse'},
+    {'1': 'GenerateWallet', '2': '.walletmanager.v1.GenerateWalletRequest', '3': '.walletmanager.v1.GenerateWalletResponse'},
     {'1': 'UnlockWallet', '2': '.walletmanager.v1.UnlockWalletRequest', '3': '.walletmanager.v1.UnlockWalletResponse'},
     {'1': 'LockWallet', '2': '.walletmanager.v1.LockWalletRequest', '3': '.walletmanager.v1.LockWalletResponse'},
-    {
-      '1': 'EncryptWallet',
-      '2': '.walletmanager.v1.EncryptWalletRequest',
-      '3': '.walletmanager.v1.EncryptWalletResponse'
-    },
-    {
-      '1': 'ChangePassword',
-      '2': '.walletmanager.v1.ChangePasswordRequest',
-      '3': '.walletmanager.v1.ChangePasswordResponse'
-    },
-    {
-      '1': 'RemoveEncryption',
-      '2': '.walletmanager.v1.RemoveEncryptionRequest',
-      '3': '.walletmanager.v1.RemoveEncryptionResponse'
-    },
+    {'1': 'EncryptWallet', '2': '.walletmanager.v1.EncryptWalletRequest', '3': '.walletmanager.v1.EncryptWalletResponse'},
+    {'1': 'ChangePassword', '2': '.walletmanager.v1.ChangePasswordRequest', '3': '.walletmanager.v1.ChangePasswordResponse'},
+    {'1': 'RemoveEncryption', '2': '.walletmanager.v1.RemoveEncryptionRequest', '3': '.walletmanager.v1.RemoveEncryptionResponse'},
     {'1': 'ListWallets', '2': '.walletmanager.v1.ListWalletsRequest', '3': '.walletmanager.v1.ListWalletsResponse'},
     {'1': 'SwitchWallet', '2': '.walletmanager.v1.SwitchWalletRequest', '3': '.walletmanager.v1.SwitchWalletResponse'},
-    {
-      '1': 'UpdateWalletMetadata',
-      '2': '.walletmanager.v1.UpdateWalletMetadataRequest',
-      '3': '.walletmanager.v1.UpdateWalletMetadataResponse'
-    },
+    {'1': 'UpdateWalletMetadata', '2': '.walletmanager.v1.UpdateWalletMetadataRequest', '3': '.walletmanager.v1.UpdateWalletMetadataResponse'},
     {'1': 'DeleteWallet', '2': '.walletmanager.v1.DeleteWalletRequest', '3': '.walletmanager.v1.DeleteWalletResponse'},
-    {
-      '1': 'DeleteAllWallets',
-      '2': '.walletmanager.v1.DeleteAllWalletsRequest',
-      '3': '.walletmanager.v1.DeleteAllWalletsResponse'
-    },
-    {
-      '1': 'CreateWatchOnlyWallet',
-      '2': '.walletmanager.v1.CreateWatchOnlyWalletRequest',
-      '3': '.walletmanager.v1.CreateWatchOnlyWalletResponse'
-    },
-    {
-      '1': 'CreateBitcoinCoreWallet',
-      '2': '.walletmanager.v1.CreateBitcoinCoreWalletRequest',
-      '3': '.walletmanager.v1.CreateBitcoinCoreWalletResponse'
-    },
-    {
-      '1': 'EnsureCoreWallets',
-      '2': '.walletmanager.v1.EnsureCoreWalletsRequest',
-      '3': '.walletmanager.v1.EnsureCoreWalletsResponse'
-    },
+    {'1': 'DeleteAllWallets', '2': '.walletmanager.v1.DeleteAllWalletsRequest', '3': '.walletmanager.v1.DeleteAllWalletsResponse'},
+    {'1': 'CreateWatchOnlyWallet', '2': '.walletmanager.v1.CreateWatchOnlyWalletRequest', '3': '.walletmanager.v1.CreateWatchOnlyWalletResponse'},
+    {'1': 'CreateBitcoinCoreWallet', '2': '.walletmanager.v1.CreateBitcoinCoreWalletRequest', '3': '.walletmanager.v1.CreateBitcoinCoreWalletResponse'},
+    {'1': 'EnsureCoreWallets', '2': '.walletmanager.v1.EnsureCoreWalletsRequest', '3': '.walletmanager.v1.EnsureCoreWalletsResponse'},
     {'1': 'GetBalance', '2': '.walletmanager.v1.GetBalanceRequest', '3': '.walletmanager.v1.GetBalanceResponse'},
-    {
-      '1': 'GetNewAddress',
-      '2': '.walletmanager.v1.GetNewAddressRequest',
-      '3': '.walletmanager.v1.GetNewAddressResponse'
-    },
-    {
-      '1': 'SendTransaction',
-      '2': '.walletmanager.v1.SendTransactionRequest',
-      '3': '.walletmanager.v1.SendTransactionResponse'
-    },
-    {
-      '1': 'ListTransactions',
-      '2': '.walletmanager.v1.ListTransactionsRequest',
-      '3': '.walletmanager.v1.ListTransactionsResponse'
-    },
+    {'1': 'GetNewAddress', '2': '.walletmanager.v1.GetNewAddressRequest', '3': '.walletmanager.v1.GetNewAddressResponse'},
+    {'1': 'SendTransaction', '2': '.walletmanager.v1.SendTransactionRequest', '3': '.walletmanager.v1.SendTransactionResponse'},
+    {'1': 'ListTransactions', '2': '.walletmanager.v1.ListTransactionsRequest', '3': '.walletmanager.v1.ListTransactionsResponse'},
     {'1': 'ListUnspent', '2': '.walletmanager.v1.ListUnspentRequest', '3': '.walletmanager.v1.ListUnspentResponse'},
-    {
-      '1': 'ListReceiveAddresses',
-      '2': '.walletmanager.v1.ListReceiveAddressesRequest',
-      '3': '.walletmanager.v1.ListReceiveAddressesResponse'
-    },
-    {
-      '1': 'GetTransactionDetails',
-      '2': '.walletmanager.v1.GetTransactionDetailsRequest',
-      '3': '.walletmanager.v1.GetTransactionDetailsResponse'
-    },
+    {'1': 'ListReceiveAddresses', '2': '.walletmanager.v1.ListReceiveAddressesRequest', '3': '.walletmanager.v1.ListReceiveAddressesResponse'},
+    {'1': 'GetTransactionDetails', '2': '.walletmanager.v1.GetTransactionDetailsRequest', '3': '.walletmanager.v1.GetTransactionDetailsResponse'},
     {'1': 'BumpFee', '2': '.walletmanager.v1.BumpFeeRequest', '3': '.walletmanager.v1.BumpFeeResponse'},
-    {
-      '1': 'DeriveAddresses',
-      '2': '.walletmanager.v1.DeriveAddressesRequest',
-      '3': '.walletmanager.v1.DeriveAddressesResponse'
-    },
-    {
-      '1': 'GetWalletSeed',
-      '2': '.walletmanager.v1.GetWalletSeedRequest',
-      '3': '.walletmanager.v1.GetWalletSeedResponse'
-    },
-    {
-      '1': 'ListCoreVariants',
-      '2': '.walletmanager.v1.ListCoreVariantsRequest',
-      '3': '.walletmanager.v1.ListCoreVariantsResponse'
-    },
-    {
-      '1': 'GetCoreVariant',
-      '2': '.walletmanager.v1.GetCoreVariantRequest',
-      '3': '.walletmanager.v1.GetCoreVariantResponse'
-    },
-    {
-      '1': 'SetCoreVariant',
-      '2': '.walletmanager.v1.SetCoreVariantRequest',
-      '3': '.walletmanager.v1.SetCoreVariantResponse'
-    },
-    {
-      '1': 'GetTestSidechains',
-      '2': '.walletmanager.v1.GetTestSidechainsRequest',
-      '3': '.walletmanager.v1.GetTestSidechainsResponse'
-    },
-    {
-      '1': 'SetTestSidechains',
-      '2': '.walletmanager.v1.SetTestSidechainsRequest',
-      '3': '.walletmanager.v1.SetTestSidechainsResponse'
-    },
-    {
-      '1': 'WatchWalletData',
-      '2': '.google.protobuf.Empty',
-      '3': '.walletmanager.v1.WatchWalletDataResponse',
-      '6': true
-    },
+    {'1': 'DeriveAddresses', '2': '.walletmanager.v1.DeriveAddressesRequest', '3': '.walletmanager.v1.DeriveAddressesResponse'},
+    {'1': 'GetWalletSeed', '2': '.walletmanager.v1.GetWalletSeedRequest', '3': '.walletmanager.v1.GetWalletSeedResponse'},
+    {'1': 'ListCoreVariants', '2': '.walletmanager.v1.ListCoreVariantsRequest', '3': '.walletmanager.v1.ListCoreVariantsResponse'},
+    {'1': 'GetCoreVariant', '2': '.walletmanager.v1.GetCoreVariantRequest', '3': '.walletmanager.v1.GetCoreVariantResponse'},
+    {'1': 'SetCoreVariant', '2': '.walletmanager.v1.SetCoreVariantRequest', '3': '.walletmanager.v1.SetCoreVariantResponse'},
+    {'1': 'GetTestSidechains', '2': '.walletmanager.v1.GetTestSidechainsRequest', '3': '.walletmanager.v1.GetTestSidechainsResponse'},
+    {'1': 'SetTestSidechains', '2': '.walletmanager.v1.SetTestSidechainsRequest', '3': '.walletmanager.v1.SetTestSidechainsResponse'},
+    {'1': 'WatchWalletData', '2': '.google.protobuf.Empty', '3': '.walletmanager.v1.WatchWalletDataResponse', '6': true},
   ],
 };
 
@@ -1190,62 +1098,63 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> WalletMana
 };
 
 /// Descriptor for `WalletManagerService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List walletManagerServiceDescriptor =
-    $convert.base64Decode('ChRXYWxsZXRNYW5hZ2VyU2VydmljZRJmCg9HZXRXYWxsZXRTdGF0dXMSKC53YWxsZXRtYW5hZ2'
-        'VyLnYxLkdldFdhbGxldFN0YXR1c1JlcXVlc3QaKS53YWxsZXRtYW5hZ2VyLnYxLkdldFdhbGxl'
-        'dFN0YXR1c1Jlc3BvbnNlEmMKDkdlbmVyYXRlV2FsbGV0Eicud2FsbGV0bWFuYWdlci52MS5HZW'
-        '5lcmF0ZVdhbGxldFJlcXVlc3QaKC53YWxsZXRtYW5hZ2VyLnYxLkdlbmVyYXRlV2FsbGV0UmVz'
-        'cG9uc2USXQoMVW5sb2NrV2FsbGV0EiUud2FsbGV0bWFuYWdlci52MS5VbmxvY2tXYWxsZXRSZX'
-        'F1ZXN0GiYud2FsbGV0bWFuYWdlci52MS5VbmxvY2tXYWxsZXRSZXNwb25zZRJXCgpMb2NrV2Fs'
-        'bGV0EiMud2FsbGV0bWFuYWdlci52MS5Mb2NrV2FsbGV0UmVxdWVzdBokLndhbGxldG1hbmFnZX'
-        'IudjEuTG9ja1dhbGxldFJlc3BvbnNlEmAKDUVuY3J5cHRXYWxsZXQSJi53YWxsZXRtYW5hZ2Vy'
-        'LnYxLkVuY3J5cHRXYWxsZXRSZXF1ZXN0Gicud2FsbGV0bWFuYWdlci52MS5FbmNyeXB0V2FsbG'
-        'V0UmVzcG9uc2USYwoOQ2hhbmdlUGFzc3dvcmQSJy53YWxsZXRtYW5hZ2VyLnYxLkNoYW5nZVBh'
-        'c3N3b3JkUmVxdWVzdBooLndhbGxldG1hbmFnZXIudjEuQ2hhbmdlUGFzc3dvcmRSZXNwb25zZR'
-        'JpChBSZW1vdmVFbmNyeXB0aW9uEikud2FsbGV0bWFuYWdlci52MS5SZW1vdmVFbmNyeXB0aW9u'
-        'UmVxdWVzdBoqLndhbGxldG1hbmFnZXIudjEuUmVtb3ZlRW5jcnlwdGlvblJlc3BvbnNlEloKC0'
-        'xpc3RXYWxsZXRzEiQud2FsbGV0bWFuYWdlci52MS5MaXN0V2FsbGV0c1JlcXVlc3QaJS53YWxs'
-        'ZXRtYW5hZ2VyLnYxLkxpc3RXYWxsZXRzUmVzcG9uc2USXQoMU3dpdGNoV2FsbGV0EiUud2FsbG'
-        'V0bWFuYWdlci52MS5Td2l0Y2hXYWxsZXRSZXF1ZXN0GiYud2FsbGV0bWFuYWdlci52MS5Td2l0'
-        'Y2hXYWxsZXRSZXNwb25zZRJ1ChRVcGRhdGVXYWxsZXRNZXRhZGF0YRItLndhbGxldG1hbmFnZX'
-        'IudjEuVXBkYXRlV2FsbGV0TWV0YWRhdGFSZXF1ZXN0Gi4ud2FsbGV0bWFuYWdlci52MS5VcGRh'
-        'dGVXYWxsZXRNZXRhZGF0YVJlc3BvbnNlEl0KDERlbGV0ZVdhbGxldBIlLndhbGxldG1hbmFnZX'
-        'IudjEuRGVsZXRlV2FsbGV0UmVxdWVzdBomLndhbGxldG1hbmFnZXIudjEuRGVsZXRlV2FsbGV0'
-        'UmVzcG9uc2USaQoQRGVsZXRlQWxsV2FsbGV0cxIpLndhbGxldG1hbmFnZXIudjEuRGVsZXRlQW'
-        'xsV2FsbGV0c1JlcXVlc3QaKi53YWxsZXRtYW5hZ2VyLnYxLkRlbGV0ZUFsbFdhbGxldHNSZXNw'
-        'b25zZRJ4ChVDcmVhdGVXYXRjaE9ubHlXYWxsZXQSLi53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZV'
-        'dhdGNoT25seVdhbGxldFJlcXVlc3QaLy53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZVdhdGNoT25s'
-        'eVdhbGxldFJlc3BvbnNlEn4KF0NyZWF0ZUJpdGNvaW5Db3JlV2FsbGV0EjAud2FsbGV0bWFuYW'
-        'dlci52MS5DcmVhdGVCaXRjb2luQ29yZVdhbGxldFJlcXVlc3QaMS53YWxsZXRtYW5hZ2VyLnYx'
-        'LkNyZWF0ZUJpdGNvaW5Db3JlV2FsbGV0UmVzcG9uc2USbAoRRW5zdXJlQ29yZVdhbGxldHMSKi'
-        '53YWxsZXRtYW5hZ2VyLnYxLkVuc3VyZUNvcmVXYWxsZXRzUmVxdWVzdBorLndhbGxldG1hbmFn'
-        'ZXIudjEuRW5zdXJlQ29yZVdhbGxldHNSZXNwb25zZRJXCgpHZXRCYWxhbmNlEiMud2FsbGV0bW'
-        'FuYWdlci52MS5HZXRCYWxhbmNlUmVxdWVzdBokLndhbGxldG1hbmFnZXIudjEuR2V0QmFsYW5j'
-        'ZVJlc3BvbnNlEmAKDUdldE5ld0FkZHJlc3MSJi53YWxsZXRtYW5hZ2VyLnYxLkdldE5ld0FkZH'
-        'Jlc3NSZXF1ZXN0Gicud2FsbGV0bWFuYWdlci52MS5HZXROZXdBZGRyZXNzUmVzcG9uc2USZgoP'
-        'U2VuZFRyYW5zYWN0aW9uEigud2FsbGV0bWFuYWdlci52MS5TZW5kVHJhbnNhY3Rpb25SZXF1ZX'
-        'N0Gikud2FsbGV0bWFuYWdlci52MS5TZW5kVHJhbnNhY3Rpb25SZXNwb25zZRJpChBMaXN0VHJh'
-        'bnNhY3Rpb25zEikud2FsbGV0bWFuYWdlci52MS5MaXN0VHJhbnNhY3Rpb25zUmVxdWVzdBoqLn'
-        'dhbGxldG1hbmFnZXIudjEuTGlzdFRyYW5zYWN0aW9uc1Jlc3BvbnNlEloKC0xpc3RVbnNwZW50'
-        'EiQud2FsbGV0bWFuYWdlci52MS5MaXN0VW5zcGVudFJlcXVlc3QaJS53YWxsZXRtYW5hZ2VyLn'
-        'YxLkxpc3RVbnNwZW50UmVzcG9uc2USdQoUTGlzdFJlY2VpdmVBZGRyZXNzZXMSLS53YWxsZXRt'
-        'YW5hZ2VyLnYxLkxpc3RSZWNlaXZlQWRkcmVzc2VzUmVxdWVzdBouLndhbGxldG1hbmFnZXIudj'
-        'EuTGlzdFJlY2VpdmVBZGRyZXNzZXNSZXNwb25zZRJ4ChVHZXRUcmFuc2FjdGlvbkRldGFpbHMS'
-        'Li53YWxsZXRtYW5hZ2VyLnYxLkdldFRyYW5zYWN0aW9uRGV0YWlsc1JlcXVlc3QaLy53YWxsZX'
-        'RtYW5hZ2VyLnYxLkdldFRyYW5zYWN0aW9uRGV0YWlsc1Jlc3BvbnNlEk4KB0J1bXBGZWUSIC53'
-        'YWxsZXRtYW5hZ2VyLnYxLkJ1bXBGZWVSZXF1ZXN0GiEud2FsbGV0bWFuYWdlci52MS5CdW1wRm'
-        'VlUmVzcG9uc2USZgoPRGVyaXZlQWRkcmVzc2VzEigud2FsbGV0bWFuYWdlci52MS5EZXJpdmVB'
-        'ZGRyZXNzZXNSZXF1ZXN0Gikud2FsbGV0bWFuYWdlci52MS5EZXJpdmVBZGRyZXNzZXNSZXNwb2'
-        '5zZRJgCg1HZXRXYWxsZXRTZWVkEiYud2FsbGV0bWFuYWdlci52MS5HZXRXYWxsZXRTZWVkUmVx'
-        'dWVzdBonLndhbGxldG1hbmFnZXIudjEuR2V0V2FsbGV0U2VlZFJlc3BvbnNlEmkKEExpc3RDb3'
-        'JlVmFyaWFudHMSKS53YWxsZXRtYW5hZ2VyLnYxLkxpc3RDb3JlVmFyaWFudHNSZXF1ZXN0Giou'
-        'd2FsbGV0bWFuYWdlci52MS5MaXN0Q29yZVZhcmlhbnRzUmVzcG9uc2USYwoOR2V0Q29yZVZhcm'
-        'lhbnQSJy53YWxsZXRtYW5hZ2VyLnYxLkdldENvcmVWYXJpYW50UmVxdWVzdBooLndhbGxldG1h'
-        'bmFnZXIudjEuR2V0Q29yZVZhcmlhbnRSZXNwb25zZRJjCg5TZXRDb3JlVmFyaWFudBInLndhbG'
-        'xldG1hbmFnZXIudjEuU2V0Q29yZVZhcmlhbnRSZXF1ZXN0Gigud2FsbGV0bWFuYWdlci52MS5T'
-        'ZXRDb3JlVmFyaWFudFJlc3BvbnNlEmwKEUdldFRlc3RTaWRlY2hhaW5zEioud2FsbGV0bWFuYW'
-        'dlci52MS5HZXRUZXN0U2lkZWNoYWluc1JlcXVlc3QaKy53YWxsZXRtYW5hZ2VyLnYxLkdldFRl'
-        'c3RTaWRlY2hhaW5zUmVzcG9uc2USbAoRU2V0VGVzdFNpZGVjaGFpbnMSKi53YWxsZXRtYW5hZ2'
-        'VyLnYxLlNldFRlc3RTaWRlY2hhaW5zUmVxdWVzdBorLndhbGxldG1hbmFnZXIudjEuU2V0VGVz'
-        'dFNpZGVjaGFpbnNSZXNwb25zZRJWCg9XYXRjaFdhbGxldERhdGESFi5nb29nbGUucHJvdG9idW'
-        'YuRW1wdHkaKS53YWxsZXRtYW5hZ2VyLnYxLldhdGNoV2FsbGV0RGF0YVJlc3BvbnNlMAE=');
+final $typed_data.Uint8List walletManagerServiceDescriptor = $convert.base64Decode(
+    'ChRXYWxsZXRNYW5hZ2VyU2VydmljZRJmCg9HZXRXYWxsZXRTdGF0dXMSKC53YWxsZXRtYW5hZ2'
+    'VyLnYxLkdldFdhbGxldFN0YXR1c1JlcXVlc3QaKS53YWxsZXRtYW5hZ2VyLnYxLkdldFdhbGxl'
+    'dFN0YXR1c1Jlc3BvbnNlEmMKDkdlbmVyYXRlV2FsbGV0Eicud2FsbGV0bWFuYWdlci52MS5HZW'
+    '5lcmF0ZVdhbGxldFJlcXVlc3QaKC53YWxsZXRtYW5hZ2VyLnYxLkdlbmVyYXRlV2FsbGV0UmVz'
+    'cG9uc2USXQoMVW5sb2NrV2FsbGV0EiUud2FsbGV0bWFuYWdlci52MS5VbmxvY2tXYWxsZXRSZX'
+    'F1ZXN0GiYud2FsbGV0bWFuYWdlci52MS5VbmxvY2tXYWxsZXRSZXNwb25zZRJXCgpMb2NrV2Fs'
+    'bGV0EiMud2FsbGV0bWFuYWdlci52MS5Mb2NrV2FsbGV0UmVxdWVzdBokLndhbGxldG1hbmFnZX'
+    'IudjEuTG9ja1dhbGxldFJlc3BvbnNlEmAKDUVuY3J5cHRXYWxsZXQSJi53YWxsZXRtYW5hZ2Vy'
+    'LnYxLkVuY3J5cHRXYWxsZXRSZXF1ZXN0Gicud2FsbGV0bWFuYWdlci52MS5FbmNyeXB0V2FsbG'
+    'V0UmVzcG9uc2USYwoOQ2hhbmdlUGFzc3dvcmQSJy53YWxsZXRtYW5hZ2VyLnYxLkNoYW5nZVBh'
+    'c3N3b3JkUmVxdWVzdBooLndhbGxldG1hbmFnZXIudjEuQ2hhbmdlUGFzc3dvcmRSZXNwb25zZR'
+    'JpChBSZW1vdmVFbmNyeXB0aW9uEikud2FsbGV0bWFuYWdlci52MS5SZW1vdmVFbmNyeXB0aW9u'
+    'UmVxdWVzdBoqLndhbGxldG1hbmFnZXIudjEuUmVtb3ZlRW5jcnlwdGlvblJlc3BvbnNlEloKC0'
+    'xpc3RXYWxsZXRzEiQud2FsbGV0bWFuYWdlci52MS5MaXN0V2FsbGV0c1JlcXVlc3QaJS53YWxs'
+    'ZXRtYW5hZ2VyLnYxLkxpc3RXYWxsZXRzUmVzcG9uc2USXQoMU3dpdGNoV2FsbGV0EiUud2FsbG'
+    'V0bWFuYWdlci52MS5Td2l0Y2hXYWxsZXRSZXF1ZXN0GiYud2FsbGV0bWFuYWdlci52MS5Td2l0'
+    'Y2hXYWxsZXRSZXNwb25zZRJ1ChRVcGRhdGVXYWxsZXRNZXRhZGF0YRItLndhbGxldG1hbmFnZX'
+    'IudjEuVXBkYXRlV2FsbGV0TWV0YWRhdGFSZXF1ZXN0Gi4ud2FsbGV0bWFuYWdlci52MS5VcGRh'
+    'dGVXYWxsZXRNZXRhZGF0YVJlc3BvbnNlEl0KDERlbGV0ZVdhbGxldBIlLndhbGxldG1hbmFnZX'
+    'IudjEuRGVsZXRlV2FsbGV0UmVxdWVzdBomLndhbGxldG1hbmFnZXIudjEuRGVsZXRlV2FsbGV0'
+    'UmVzcG9uc2USaQoQRGVsZXRlQWxsV2FsbGV0cxIpLndhbGxldG1hbmFnZXIudjEuRGVsZXRlQW'
+    'xsV2FsbGV0c1JlcXVlc3QaKi53YWxsZXRtYW5hZ2VyLnYxLkRlbGV0ZUFsbFdhbGxldHNSZXNw'
+    'b25zZRJ4ChVDcmVhdGVXYXRjaE9ubHlXYWxsZXQSLi53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZV'
+    'dhdGNoT25seVdhbGxldFJlcXVlc3QaLy53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZVdhdGNoT25s'
+    'eVdhbGxldFJlc3BvbnNlEn4KF0NyZWF0ZUJpdGNvaW5Db3JlV2FsbGV0EjAud2FsbGV0bWFuYW'
+    'dlci52MS5DcmVhdGVCaXRjb2luQ29yZVdhbGxldFJlcXVlc3QaMS53YWxsZXRtYW5hZ2VyLnYx'
+    'LkNyZWF0ZUJpdGNvaW5Db3JlV2FsbGV0UmVzcG9uc2USbAoRRW5zdXJlQ29yZVdhbGxldHMSKi'
+    '53YWxsZXRtYW5hZ2VyLnYxLkVuc3VyZUNvcmVXYWxsZXRzUmVxdWVzdBorLndhbGxldG1hbmFn'
+    'ZXIudjEuRW5zdXJlQ29yZVdhbGxldHNSZXNwb25zZRJXCgpHZXRCYWxhbmNlEiMud2FsbGV0bW'
+    'FuYWdlci52MS5HZXRCYWxhbmNlUmVxdWVzdBokLndhbGxldG1hbmFnZXIudjEuR2V0QmFsYW5j'
+    'ZVJlc3BvbnNlEmAKDUdldE5ld0FkZHJlc3MSJi53YWxsZXRtYW5hZ2VyLnYxLkdldE5ld0FkZH'
+    'Jlc3NSZXF1ZXN0Gicud2FsbGV0bWFuYWdlci52MS5HZXROZXdBZGRyZXNzUmVzcG9uc2USZgoP'
+    'U2VuZFRyYW5zYWN0aW9uEigud2FsbGV0bWFuYWdlci52MS5TZW5kVHJhbnNhY3Rpb25SZXF1ZX'
+    'N0Gikud2FsbGV0bWFuYWdlci52MS5TZW5kVHJhbnNhY3Rpb25SZXNwb25zZRJpChBMaXN0VHJh'
+    'bnNhY3Rpb25zEikud2FsbGV0bWFuYWdlci52MS5MaXN0VHJhbnNhY3Rpb25zUmVxdWVzdBoqLn'
+    'dhbGxldG1hbmFnZXIudjEuTGlzdFRyYW5zYWN0aW9uc1Jlc3BvbnNlEloKC0xpc3RVbnNwZW50'
+    'EiQud2FsbGV0bWFuYWdlci52MS5MaXN0VW5zcGVudFJlcXVlc3QaJS53YWxsZXRtYW5hZ2VyLn'
+    'YxLkxpc3RVbnNwZW50UmVzcG9uc2USdQoUTGlzdFJlY2VpdmVBZGRyZXNzZXMSLS53YWxsZXRt'
+    'YW5hZ2VyLnYxLkxpc3RSZWNlaXZlQWRkcmVzc2VzUmVxdWVzdBouLndhbGxldG1hbmFnZXIudj'
+    'EuTGlzdFJlY2VpdmVBZGRyZXNzZXNSZXNwb25zZRJ4ChVHZXRUcmFuc2FjdGlvbkRldGFpbHMS'
+    'Li53YWxsZXRtYW5hZ2VyLnYxLkdldFRyYW5zYWN0aW9uRGV0YWlsc1JlcXVlc3QaLy53YWxsZX'
+    'RtYW5hZ2VyLnYxLkdldFRyYW5zYWN0aW9uRGV0YWlsc1Jlc3BvbnNlEk4KB0J1bXBGZWUSIC53'
+    'YWxsZXRtYW5hZ2VyLnYxLkJ1bXBGZWVSZXF1ZXN0GiEud2FsbGV0bWFuYWdlci52MS5CdW1wRm'
+    'VlUmVzcG9uc2USZgoPRGVyaXZlQWRkcmVzc2VzEigud2FsbGV0bWFuYWdlci52MS5EZXJpdmVB'
+    'ZGRyZXNzZXNSZXF1ZXN0Gikud2FsbGV0bWFuYWdlci52MS5EZXJpdmVBZGRyZXNzZXNSZXNwb2'
+    '5zZRJgCg1HZXRXYWxsZXRTZWVkEiYud2FsbGV0bWFuYWdlci52MS5HZXRXYWxsZXRTZWVkUmVx'
+    'dWVzdBonLndhbGxldG1hbmFnZXIudjEuR2V0V2FsbGV0U2VlZFJlc3BvbnNlEmkKEExpc3RDb3'
+    'JlVmFyaWFudHMSKS53YWxsZXRtYW5hZ2VyLnYxLkxpc3RDb3JlVmFyaWFudHNSZXF1ZXN0Giou'
+    'd2FsbGV0bWFuYWdlci52MS5MaXN0Q29yZVZhcmlhbnRzUmVzcG9uc2USYwoOR2V0Q29yZVZhcm'
+    'lhbnQSJy53YWxsZXRtYW5hZ2VyLnYxLkdldENvcmVWYXJpYW50UmVxdWVzdBooLndhbGxldG1h'
+    'bmFnZXIudjEuR2V0Q29yZVZhcmlhbnRSZXNwb25zZRJjCg5TZXRDb3JlVmFyaWFudBInLndhbG'
+    'xldG1hbmFnZXIudjEuU2V0Q29yZVZhcmlhbnRSZXF1ZXN0Gigud2FsbGV0bWFuYWdlci52MS5T'
+    'ZXRDb3JlVmFyaWFudFJlc3BvbnNlEmwKEUdldFRlc3RTaWRlY2hhaW5zEioud2FsbGV0bWFuYW'
+    'dlci52MS5HZXRUZXN0U2lkZWNoYWluc1JlcXVlc3QaKy53YWxsZXRtYW5hZ2VyLnYxLkdldFRl'
+    'c3RTaWRlY2hhaW5zUmVzcG9uc2USbAoRU2V0VGVzdFNpZGVjaGFpbnMSKi53YWxsZXRtYW5hZ2'
+    'VyLnYxLlNldFRlc3RTaWRlY2hhaW5zUmVxdWVzdBorLndhbGxldG1hbmFnZXIudjEuU2V0VGVz'
+    'dFNpZGVjaGFpbnNSZXNwb25zZRJWCg9XYXRjaFdhbGxldERhdGESFi5nb29nbGUucHJvdG9idW'
+    'YuRW1wdHkaKS53YWxsZXRtYW5hZ2VyLnYxLldhdGNoV2FsbGV0RGF0YVJlc3BvbnNlMAE=');
+

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbserver.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbserver.dart
@@ -28,184 +28,107 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
   $async.Future<$13.LockWalletResponse> lockWallet($pb.ServerContext ctx, $13.LockWalletRequest request);
   $async.Future<$13.EncryptWalletResponse> encryptWallet($pb.ServerContext ctx, $13.EncryptWalletRequest request);
   $async.Future<$13.ChangePasswordResponse> changePassword($pb.ServerContext ctx, $13.ChangePasswordRequest request);
-  $async.Future<$13.RemoveEncryptionResponse> removeEncryption(
-      $pb.ServerContext ctx, $13.RemoveEncryptionRequest request);
+  $async.Future<$13.RemoveEncryptionResponse> removeEncryption($pb.ServerContext ctx, $13.RemoveEncryptionRequest request);
   $async.Future<$13.ListWalletsResponse> listWallets($pb.ServerContext ctx, $13.ListWalletsRequest request);
   $async.Future<$13.SwitchWalletResponse> switchWallet($pb.ServerContext ctx, $13.SwitchWalletRequest request);
-  $async.Future<$13.UpdateWalletMetadataResponse> updateWalletMetadata(
-      $pb.ServerContext ctx, $13.UpdateWalletMetadataRequest request);
+  $async.Future<$13.UpdateWalletMetadataResponse> updateWalletMetadata($pb.ServerContext ctx, $13.UpdateWalletMetadataRequest request);
   $async.Future<$13.DeleteWalletResponse> deleteWallet($pb.ServerContext ctx, $13.DeleteWalletRequest request);
-  $async.Future<$13.DeleteAllWalletsResponse> deleteAllWallets(
-      $pb.ServerContext ctx, $13.DeleteAllWalletsRequest request);
-  $async.Future<$13.CreateWatchOnlyWalletResponse> createWatchOnlyWallet(
-      $pb.ServerContext ctx, $13.CreateWatchOnlyWalletRequest request);
-  $async.Future<$13.CreateBitcoinCoreWalletResponse> createBitcoinCoreWallet(
-      $pb.ServerContext ctx, $13.CreateBitcoinCoreWalletRequest request);
-  $async.Future<$13.EnsureCoreWalletsResponse> ensureCoreWallets(
-      $pb.ServerContext ctx, $13.EnsureCoreWalletsRequest request);
+  $async.Future<$13.DeleteAllWalletsResponse> deleteAllWallets($pb.ServerContext ctx, $13.DeleteAllWalletsRequest request);
+  $async.Future<$13.CreateWatchOnlyWalletResponse> createWatchOnlyWallet($pb.ServerContext ctx, $13.CreateWatchOnlyWalletRequest request);
+  $async.Future<$13.CreateBitcoinCoreWalletResponse> createBitcoinCoreWallet($pb.ServerContext ctx, $13.CreateBitcoinCoreWalletRequest request);
+  $async.Future<$13.EnsureCoreWalletsResponse> ensureCoreWallets($pb.ServerContext ctx, $13.EnsureCoreWalletsRequest request);
   $async.Future<$13.GetBalanceResponse> getBalance($pb.ServerContext ctx, $13.GetBalanceRequest request);
   $async.Future<$13.GetNewAddressResponse> getNewAddress($pb.ServerContext ctx, $13.GetNewAddressRequest request);
   $async.Future<$13.SendTransactionResponse> sendTransaction($pb.ServerContext ctx, $13.SendTransactionRequest request);
-  $async.Future<$13.ListTransactionsResponse> listTransactions(
-      $pb.ServerContext ctx, $13.ListTransactionsRequest request);
+  $async.Future<$13.ListTransactionsResponse> listTransactions($pb.ServerContext ctx, $13.ListTransactionsRequest request);
   $async.Future<$13.ListUnspentResponse> listUnspent($pb.ServerContext ctx, $13.ListUnspentRequest request);
-  $async.Future<$13.ListReceiveAddressesResponse> listReceiveAddresses(
-      $pb.ServerContext ctx, $13.ListReceiveAddressesRequest request);
-  $async.Future<$13.GetTransactionDetailsResponse> getTransactionDetails(
-      $pb.ServerContext ctx, $13.GetTransactionDetailsRequest request);
+  $async.Future<$13.ListReceiveAddressesResponse> listReceiveAddresses($pb.ServerContext ctx, $13.ListReceiveAddressesRequest request);
+  $async.Future<$13.GetTransactionDetailsResponse> getTransactionDetails($pb.ServerContext ctx, $13.GetTransactionDetailsRequest request);
   $async.Future<$13.BumpFeeResponse> bumpFee($pb.ServerContext ctx, $13.BumpFeeRequest request);
   $async.Future<$13.DeriveAddressesResponse> deriveAddresses($pb.ServerContext ctx, $13.DeriveAddressesRequest request);
   $async.Future<$13.GetWalletSeedResponse> getWalletSeed($pb.ServerContext ctx, $13.GetWalletSeedRequest request);
-  $async.Future<$13.ListCoreVariantsResponse> listCoreVariants(
-      $pb.ServerContext ctx, $13.ListCoreVariantsRequest request);
+  $async.Future<$13.ListCoreVariantsResponse> listCoreVariants($pb.ServerContext ctx, $13.ListCoreVariantsRequest request);
   $async.Future<$13.GetCoreVariantResponse> getCoreVariant($pb.ServerContext ctx, $13.GetCoreVariantRequest request);
   $async.Future<$13.SetCoreVariantResponse> setCoreVariant($pb.ServerContext ctx, $13.SetCoreVariantRequest request);
-  $async.Future<$13.GetTestSidechainsResponse> getTestSidechains(
-      $pb.ServerContext ctx, $13.GetTestSidechainsRequest request);
-  $async.Future<$13.SetTestSidechainsResponse> setTestSidechains(
-      $pb.ServerContext ctx, $13.SetTestSidechainsRequest request);
+  $async.Future<$13.GetTestSidechainsResponse> getTestSidechains($pb.ServerContext ctx, $13.GetTestSidechainsRequest request);
+  $async.Future<$13.SetTestSidechainsResponse> setTestSidechains($pb.ServerContext ctx, $13.SetTestSidechainsRequest request);
   $async.Future<$13.WatchWalletDataResponse> watchWalletData($pb.ServerContext ctx, $12.Empty request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetWalletStatus':
-        return $13.GetWalletStatusRequest();
-      case 'GenerateWallet':
-        return $13.GenerateWalletRequest();
-      case 'UnlockWallet':
-        return $13.UnlockWalletRequest();
-      case 'LockWallet':
-        return $13.LockWalletRequest();
-      case 'EncryptWallet':
-        return $13.EncryptWalletRequest();
-      case 'ChangePassword':
-        return $13.ChangePasswordRequest();
-      case 'RemoveEncryption':
-        return $13.RemoveEncryptionRequest();
-      case 'ListWallets':
-        return $13.ListWalletsRequest();
-      case 'SwitchWallet':
-        return $13.SwitchWalletRequest();
-      case 'UpdateWalletMetadata':
-        return $13.UpdateWalletMetadataRequest();
-      case 'DeleteWallet':
-        return $13.DeleteWalletRequest();
-      case 'DeleteAllWallets':
-        return $13.DeleteAllWalletsRequest();
-      case 'CreateWatchOnlyWallet':
-        return $13.CreateWatchOnlyWalletRequest();
-      case 'CreateBitcoinCoreWallet':
-        return $13.CreateBitcoinCoreWalletRequest();
-      case 'EnsureCoreWallets':
-        return $13.EnsureCoreWalletsRequest();
-      case 'GetBalance':
-        return $13.GetBalanceRequest();
-      case 'GetNewAddress':
-        return $13.GetNewAddressRequest();
-      case 'SendTransaction':
-        return $13.SendTransactionRequest();
-      case 'ListTransactions':
-        return $13.ListTransactionsRequest();
-      case 'ListUnspent':
-        return $13.ListUnspentRequest();
-      case 'ListReceiveAddresses':
-        return $13.ListReceiveAddressesRequest();
-      case 'GetTransactionDetails':
-        return $13.GetTransactionDetailsRequest();
-      case 'BumpFee':
-        return $13.BumpFeeRequest();
-      case 'DeriveAddresses':
-        return $13.DeriveAddressesRequest();
-      case 'GetWalletSeed':
-        return $13.GetWalletSeedRequest();
-      case 'ListCoreVariants':
-        return $13.ListCoreVariantsRequest();
-      case 'GetCoreVariant':
-        return $13.GetCoreVariantRequest();
-      case 'SetCoreVariant':
-        return $13.SetCoreVariantRequest();
-      case 'GetTestSidechains':
-        return $13.GetTestSidechainsRequest();
-      case 'SetTestSidechains':
-        return $13.SetTestSidechainsRequest();
-      case 'WatchWalletData':
-        return $12.Empty();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetWalletStatus': return $13.GetWalletStatusRequest();
+      case 'GenerateWallet': return $13.GenerateWalletRequest();
+      case 'UnlockWallet': return $13.UnlockWalletRequest();
+      case 'LockWallet': return $13.LockWalletRequest();
+      case 'EncryptWallet': return $13.EncryptWalletRequest();
+      case 'ChangePassword': return $13.ChangePasswordRequest();
+      case 'RemoveEncryption': return $13.RemoveEncryptionRequest();
+      case 'ListWallets': return $13.ListWalletsRequest();
+      case 'SwitchWallet': return $13.SwitchWalletRequest();
+      case 'UpdateWalletMetadata': return $13.UpdateWalletMetadataRequest();
+      case 'DeleteWallet': return $13.DeleteWalletRequest();
+      case 'DeleteAllWallets': return $13.DeleteAllWalletsRequest();
+      case 'CreateWatchOnlyWallet': return $13.CreateWatchOnlyWalletRequest();
+      case 'CreateBitcoinCoreWallet': return $13.CreateBitcoinCoreWalletRequest();
+      case 'EnsureCoreWallets': return $13.EnsureCoreWalletsRequest();
+      case 'GetBalance': return $13.GetBalanceRequest();
+      case 'GetNewAddress': return $13.GetNewAddressRequest();
+      case 'SendTransaction': return $13.SendTransactionRequest();
+      case 'ListTransactions': return $13.ListTransactionsRequest();
+      case 'ListUnspent': return $13.ListUnspentRequest();
+      case 'ListReceiveAddresses': return $13.ListReceiveAddressesRequest();
+      case 'GetTransactionDetails': return $13.GetTransactionDetailsRequest();
+      case 'BumpFee': return $13.BumpFeeRequest();
+      case 'DeriveAddresses': return $13.DeriveAddressesRequest();
+      case 'GetWalletSeed': return $13.GetWalletSeedRequest();
+      case 'ListCoreVariants': return $13.ListCoreVariantsRequest();
+      case 'GetCoreVariant': return $13.GetCoreVariantRequest();
+      case 'SetCoreVariant': return $13.SetCoreVariantRequest();
+      case 'GetTestSidechains': return $13.GetTestSidechainsRequest();
+      case 'SetTestSidechains': return $13.SetTestSidechainsRequest();
+      case 'WatchWalletData': return $12.Empty();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetWalletStatus':
-        return this.getWalletStatus(ctx, request as $13.GetWalletStatusRequest);
-      case 'GenerateWallet':
-        return this.generateWallet(ctx, request as $13.GenerateWalletRequest);
-      case 'UnlockWallet':
-        return this.unlockWallet(ctx, request as $13.UnlockWalletRequest);
-      case 'LockWallet':
-        return this.lockWallet(ctx, request as $13.LockWalletRequest);
-      case 'EncryptWallet':
-        return this.encryptWallet(ctx, request as $13.EncryptWalletRequest);
-      case 'ChangePassword':
-        return this.changePassword(ctx, request as $13.ChangePasswordRequest);
-      case 'RemoveEncryption':
-        return this.removeEncryption(ctx, request as $13.RemoveEncryptionRequest);
-      case 'ListWallets':
-        return this.listWallets(ctx, request as $13.ListWalletsRequest);
-      case 'SwitchWallet':
-        return this.switchWallet(ctx, request as $13.SwitchWalletRequest);
-      case 'UpdateWalletMetadata':
-        return this.updateWalletMetadata(ctx, request as $13.UpdateWalletMetadataRequest);
-      case 'DeleteWallet':
-        return this.deleteWallet(ctx, request as $13.DeleteWalletRequest);
-      case 'DeleteAllWallets':
-        return this.deleteAllWallets(ctx, request as $13.DeleteAllWalletsRequest);
-      case 'CreateWatchOnlyWallet':
-        return this.createWatchOnlyWallet(ctx, request as $13.CreateWatchOnlyWalletRequest);
-      case 'CreateBitcoinCoreWallet':
-        return this.createBitcoinCoreWallet(ctx, request as $13.CreateBitcoinCoreWalletRequest);
-      case 'EnsureCoreWallets':
-        return this.ensureCoreWallets(ctx, request as $13.EnsureCoreWalletsRequest);
-      case 'GetBalance':
-        return this.getBalance(ctx, request as $13.GetBalanceRequest);
-      case 'GetNewAddress':
-        return this.getNewAddress(ctx, request as $13.GetNewAddressRequest);
-      case 'SendTransaction':
-        return this.sendTransaction(ctx, request as $13.SendTransactionRequest);
-      case 'ListTransactions':
-        return this.listTransactions(ctx, request as $13.ListTransactionsRequest);
-      case 'ListUnspent':
-        return this.listUnspent(ctx, request as $13.ListUnspentRequest);
-      case 'ListReceiveAddresses':
-        return this.listReceiveAddresses(ctx, request as $13.ListReceiveAddressesRequest);
-      case 'GetTransactionDetails':
-        return this.getTransactionDetails(ctx, request as $13.GetTransactionDetailsRequest);
-      case 'BumpFee':
-        return this.bumpFee(ctx, request as $13.BumpFeeRequest);
-      case 'DeriveAddresses':
-        return this.deriveAddresses(ctx, request as $13.DeriveAddressesRequest);
-      case 'GetWalletSeed':
-        return this.getWalletSeed(ctx, request as $13.GetWalletSeedRequest);
-      case 'ListCoreVariants':
-        return this.listCoreVariants(ctx, request as $13.ListCoreVariantsRequest);
-      case 'GetCoreVariant':
-        return this.getCoreVariant(ctx, request as $13.GetCoreVariantRequest);
-      case 'SetCoreVariant':
-        return this.setCoreVariant(ctx, request as $13.SetCoreVariantRequest);
-      case 'GetTestSidechains':
-        return this.getTestSidechains(ctx, request as $13.GetTestSidechainsRequest);
-      case 'SetTestSidechains':
-        return this.setTestSidechains(ctx, request as $13.SetTestSidechainsRequest);
-      case 'WatchWalletData':
-        return this.watchWalletData(ctx, request as $12.Empty);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetWalletStatus': return this.getWalletStatus(ctx, request as $13.GetWalletStatusRequest);
+      case 'GenerateWallet': return this.generateWallet(ctx, request as $13.GenerateWalletRequest);
+      case 'UnlockWallet': return this.unlockWallet(ctx, request as $13.UnlockWalletRequest);
+      case 'LockWallet': return this.lockWallet(ctx, request as $13.LockWalletRequest);
+      case 'EncryptWallet': return this.encryptWallet(ctx, request as $13.EncryptWalletRequest);
+      case 'ChangePassword': return this.changePassword(ctx, request as $13.ChangePasswordRequest);
+      case 'RemoveEncryption': return this.removeEncryption(ctx, request as $13.RemoveEncryptionRequest);
+      case 'ListWallets': return this.listWallets(ctx, request as $13.ListWalletsRequest);
+      case 'SwitchWallet': return this.switchWallet(ctx, request as $13.SwitchWalletRequest);
+      case 'UpdateWalletMetadata': return this.updateWalletMetadata(ctx, request as $13.UpdateWalletMetadataRequest);
+      case 'DeleteWallet': return this.deleteWallet(ctx, request as $13.DeleteWalletRequest);
+      case 'DeleteAllWallets': return this.deleteAllWallets(ctx, request as $13.DeleteAllWalletsRequest);
+      case 'CreateWatchOnlyWallet': return this.createWatchOnlyWallet(ctx, request as $13.CreateWatchOnlyWalletRequest);
+      case 'CreateBitcoinCoreWallet': return this.createBitcoinCoreWallet(ctx, request as $13.CreateBitcoinCoreWalletRequest);
+      case 'EnsureCoreWallets': return this.ensureCoreWallets(ctx, request as $13.EnsureCoreWalletsRequest);
+      case 'GetBalance': return this.getBalance(ctx, request as $13.GetBalanceRequest);
+      case 'GetNewAddress': return this.getNewAddress(ctx, request as $13.GetNewAddressRequest);
+      case 'SendTransaction': return this.sendTransaction(ctx, request as $13.SendTransactionRequest);
+      case 'ListTransactions': return this.listTransactions(ctx, request as $13.ListTransactionsRequest);
+      case 'ListUnspent': return this.listUnspent(ctx, request as $13.ListUnspentRequest);
+      case 'ListReceiveAddresses': return this.listReceiveAddresses(ctx, request as $13.ListReceiveAddressesRequest);
+      case 'GetTransactionDetails': return this.getTransactionDetails(ctx, request as $13.GetTransactionDetailsRequest);
+      case 'BumpFee': return this.bumpFee(ctx, request as $13.BumpFeeRequest);
+      case 'DeriveAddresses': return this.deriveAddresses(ctx, request as $13.DeriveAddressesRequest);
+      case 'GetWalletSeed': return this.getWalletSeed(ctx, request as $13.GetWalletSeedRequest);
+      case 'ListCoreVariants': return this.listCoreVariants(ctx, request as $13.ListCoreVariantsRequest);
+      case 'GetCoreVariant': return this.getCoreVariant(ctx, request as $13.GetCoreVariantRequest);
+      case 'SetCoreVariant': return this.setCoreVariant(ctx, request as $13.SetCoreVariantRequest);
+      case 'GetTestSidechains': return this.getTestSidechains(ctx, request as $13.GetTestSidechainsRequest);
+      case 'SetTestSidechains': return this.setTestSidechains(ctx, request as $13.SetTestSidechainsRequest);
+      case 'WatchWalletData': return this.watchWalletData(ctx, request as $12.Empty);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => WalletManagerServiceBase$json;
-  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson =>
-      WalletManagerServiceBase$messageJson;
+  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => WalletManagerServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/gen/zside/v1/zside.connect.client.dart
+++ b/sail_ui/lib/gen/zside/v1/zside.connect.client.dart
@@ -7,7 +7,7 @@ import "package:connectrpc/connect.dart" as connect;
 import "zside.pb.dart" as zsidev1zside;
 import "zside.connect.spec.dart" as specs;
 
-extension type ZSideServiceClient(connect.Transport _transport) {
+extension type ZSideServiceClient (connect.Transport _transport) {
   /// Get wallet balance (total and available, both transparent and shielded).
   Future<zsidev1zside.GetBalanceResponse> getBalance(
     zsidev1zside.GetBalanceRequest input, {

--- a/sail_ui/lib/gen/zside/v1/zside.pb.dart
+++ b/sail_ui/lib/gen/zside/v1/zside.pb.dart
@@ -18,25 +18,23 @@ import 'package:protobuf/protobuf.dart' as $pb;
 class GetBalanceRequest extends $pb.GeneratedMessage {
   factory GetBalanceRequest() => create();
   GetBalanceRequest._() : super();
-  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceRequest clone() => GetBalanceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceRequest copyWith(void Function(GetBalanceRequest) updates) => super.copyWith((message) => updates(message as GetBalanceRequest)) as GetBalanceRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -45,8 +43,7 @@ class GetBalanceRequest extends $pb.GeneratedMessage {
   GetBalanceRequest createEmptyInstance() => create();
   static $pb.PbList<GetBalanceRequest> createRepeated() => $pb.PbList<GetBalanceRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
+  static GetBalanceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceRequest>(create);
   static GetBalanceRequest? _defaultInstance;
 }
 
@@ -73,29 +70,27 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBalanceResponse._() : super();
-  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBalanceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalanceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalanceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'totalShieldedSats')
     ..aInt64(2, _omitFieldNames ? '' : 'totalTransparentSats')
     ..aInt64(3, _omitFieldNames ? '' : 'availableShieldedSats')
     ..aInt64(4, _omitFieldNames ? '' : 'availableTransparentSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBalanceResponse clone() => GetBalanceResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalanceResponse copyWith(void Function(GetBalanceResponse) updates) => super.copyWith((message) => updates(message as GetBalanceResponse)) as GetBalanceResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -104,17 +99,13 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   GetBalanceResponse createEmptyInstance() => create();
   static $pb.PbList<GetBalanceResponse> createRepeated() => $pb.PbList<GetBalanceResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBalanceResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
+  static GetBalanceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalanceResponse>(create);
   static GetBalanceResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get totalShieldedSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set totalShieldedSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set totalShieldedSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTotalShieldedSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -123,10 +114,7 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get totalTransparentSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set totalTransparentSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set totalTransparentSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasTotalTransparentSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -135,10 +123,7 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get availableShieldedSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set availableShieldedSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set availableShieldedSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasAvailableShieldedSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -147,10 +132,7 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get availableTransparentSats => $_getI64(3);
   @$pb.TagNumber(4)
-  set availableTransparentSats($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set availableTransparentSats($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasAvailableTransparentSats() => $_has(3);
   @$pb.TagNumber(4)
@@ -160,25 +142,23 @@ class GetBalanceResponse extends $pb.GeneratedMessage {
 class GetBlockCountRequest extends $pb.GeneratedMessage {
   factory GetBlockCountRequest() => create();
   GetBlockCountRequest._() : super();
-  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountRequest clone() => GetBlockCountRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountRequest copyWith(void Function(GetBlockCountRequest) updates) => super.copyWith((message) => updates(message as GetBlockCountRequest)) as GetBlockCountRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -187,8 +167,7 @@ class GetBlockCountRequest extends $pb.GeneratedMessage {
   GetBlockCountRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountRequest> createRepeated() => $pb.PbList<GetBlockCountRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
+  static GetBlockCountRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountRequest>(create);
   static GetBlockCountRequest? _defaultInstance;
 }
 
@@ -203,26 +182,24 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockCountResponse._() : super();
-  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockCountResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockCountResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockCountResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'count')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockCountResponse clone() => GetBlockCountResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockCountResponse copyWith(void Function(GetBlockCountResponse) updates) => super.copyWith((message) => updates(message as GetBlockCountResponse)) as GetBlockCountResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -231,17 +208,13 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
   GetBlockCountResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockCountResponse> createRepeated() => $pb.PbList<GetBlockCountResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockCountResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
+  static GetBlockCountResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockCountResponse>(create);
   static GetBlockCountResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get count => $_getI64(0);
   @$pb.TagNumber(1)
-  set count($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set count($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCount() => $_has(0);
   @$pb.TagNumber(1)
@@ -251,24 +224,23 @@ class GetBlockCountResponse extends $pb.GeneratedMessage {
 class StopRequest extends $pb.GeneratedMessage {
   factory StopRequest() => create();
   StopRequest._() : super();
-  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopRequest clone() => StopRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopRequest copyWith(void Function(StopRequest) updates) =>
-      super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopRequest copyWith(void Function(StopRequest) updates) => super.copyWith((message) => updates(message as StopRequest)) as StopRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -284,24 +256,23 @@ class StopRequest extends $pb.GeneratedMessage {
 class StopResponse extends $pb.GeneratedMessage {
   factory StopResponse() => create();
   StopResponse._() : super();
-  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory StopResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StopResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StopResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   StopResponse clone() => StopResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StopResponse copyWith(void Function(StopResponse) updates) =>
-      super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StopResponse copyWith(void Function(StopResponse) updates) => super.copyWith((message) => updates(message as StopResponse)) as StopResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -337,29 +308,27 @@ class WithdrawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawRequest._() : super();
-  factory WithdrawRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'sideFeeSats')
     ..aInt64(4, _omitFieldNames ? '' : 'mainFeeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawRequest clone() => WithdrawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) =>
-      super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawRequest copyWith(void Function(WithdrawRequest) updates) => super.copyWith((message) => updates(message as WithdrawRequest)) as WithdrawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -368,17 +337,13 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   WithdrawRequest createEmptyInstance() => create();
   static $pb.PbList<WithdrawRequest> createRepeated() => $pb.PbList<WithdrawRequest>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
+  static WithdrawRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawRequest>(create);
   static WithdrawRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -387,10 +352,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -399,10 +361,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get sideFeeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set sideFeeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set sideFeeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSideFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -411,10 +370,7 @@ class WithdrawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get mainFeeSats => $_getI64(3);
   @$pb.TagNumber(4)
-  set mainFeeSats($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set mainFeeSats($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasMainFeeSats() => $_has(3);
   @$pb.TagNumber(4)
@@ -432,26 +388,24 @@ class WithdrawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   WithdrawResponse._() : super();
-  factory WithdrawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory WithdrawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WithdrawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WithdrawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   WithdrawResponse clone() => WithdrawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) =>
-      super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WithdrawResponse copyWith(void Function(WithdrawResponse) updates) => super.copyWith((message) => updates(message as WithdrawResponse)) as WithdrawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -460,17 +414,13 @@ class WithdrawResponse extends $pb.GeneratedMessage {
   WithdrawResponse createEmptyInstance() => create();
   static $pb.PbList<WithdrawResponse> createRepeated() => $pb.PbList<WithdrawResponse>();
   @$core.pragma('dart2js:noInline')
-  static WithdrawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
+  static WithdrawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WithdrawResponse>(create);
   static WithdrawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -496,28 +446,26 @@ class TransferRequest extends $pb.GeneratedMessage {
     return $result;
   }
   TransferRequest._() : super();
-  factory TransferRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferRequest clone() => TransferRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferRequest copyWith(void Function(TransferRequest) updates) =>
-      super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferRequest copyWith(void Function(TransferRequest) updates) => super.copyWith((message) => updates(message as TransferRequest)) as TransferRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -526,17 +474,13 @@ class TransferRequest extends $pb.GeneratedMessage {
   TransferRequest createEmptyInstance() => create();
   static $pb.PbList<TransferRequest> createRepeated() => $pb.PbList<TransferRequest>();
   @$core.pragma('dart2js:noInline')
-  static TransferRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
+  static TransferRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferRequest>(create);
   static TransferRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -545,10 +489,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -557,10 +498,7 @@ class TransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -578,26 +516,24 @@ class TransferResponse extends $pb.GeneratedMessage {
     return $result;
   }
   TransferResponse._() : super();
-  factory TransferResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransferResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransferResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransferResponse clone() => TransferResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransferResponse copyWith(void Function(TransferResponse) updates) =>
-      super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransferResponse copyWith(void Function(TransferResponse) updates) => super.copyWith((message) => updates(message as TransferResponse)) as TransferResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -606,17 +542,13 @@ class TransferResponse extends $pb.GeneratedMessage {
   TransferResponse createEmptyInstance() => create();
   static $pb.PbList<TransferResponse> createRepeated() => $pb.PbList<TransferResponse>();
   @$core.pragma('dart2js:noInline')
-  static TransferResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
+  static TransferResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransferResponse>(create);
   static TransferResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -626,25 +558,23 @@ class TransferResponse extends $pb.GeneratedMessage {
 class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   factory GetSidechainWealthRequest() => create();
   GetSidechainWealthRequest._() : super();
-  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthRequest clone() => GetSidechainWealthRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthRequest copyWith(void Function(GetSidechainWealthRequest) updates) => super.copyWith((message) => updates(message as GetSidechainWealthRequest)) as GetSidechainWealthRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -653,8 +583,7 @@ class GetSidechainWealthRequest extends $pb.GeneratedMessage {
   GetSidechainWealthRequest createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthRequest> createRepeated() => $pb.PbList<GetSidechainWealthRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
+  static GetSidechainWealthRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthRequest>(create);
   static GetSidechainWealthRequest? _defaultInstance;
 }
 
@@ -669,27 +598,24 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetSidechainWealthResponse._() : super();
-  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSidechainWealthResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetSidechainWealthResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetSidechainWealthResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetSidechainWealthResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'sats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetSidechainWealthResponse clone() => GetSidechainWealthResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) =>
-      super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetSidechainWealthResponse copyWith(void Function(GetSidechainWealthResponse) updates) => super.copyWith((message) => updates(message as GetSidechainWealthResponse)) as GetSidechainWealthResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -698,17 +624,13 @@ class GetSidechainWealthResponse extends $pb.GeneratedMessage {
   GetSidechainWealthResponse createEmptyInstance() => create();
   static $pb.PbList<GetSidechainWealthResponse> createRepeated() => $pb.PbList<GetSidechainWealthResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetSidechainWealthResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
+  static GetSidechainWealthResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSidechainWealthResponse>(create);
   static GetSidechainWealthResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get sats => $_getI64(0);
   @$pb.TagNumber(1)
-  set sats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set sats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -734,28 +656,26 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositRequest._() : super();
-  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'valueSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositRequest clone() => CreateDepositRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositRequest copyWith(void Function(CreateDepositRequest) updates) => super.copyWith((message) => updates(message as CreateDepositRequest)) as CreateDepositRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -764,17 +684,13 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   CreateDepositRequest createEmptyInstance() => create();
   static $pb.PbList<CreateDepositRequest> createRepeated() => $pb.PbList<CreateDepositRequest>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
+  static CreateDepositRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositRequest>(create);
   static CreateDepositRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -783,10 +699,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get valueSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set valueSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set valueSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasValueSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -795,10 +708,7 @@ class CreateDepositRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -816,26 +726,24 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CreateDepositResponse._() : super();
-  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CreateDepositResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateDepositResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CreateDepositResponse clone() => CreateDepositResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) =>
-      super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateDepositResponse copyWith(void Function(CreateDepositResponse) updates) => super.copyWith((message) => updates(message as CreateDepositResponse)) as CreateDepositResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -844,17 +752,13 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
   CreateDepositResponse createEmptyInstance() => create();
   static $pb.PbList<CreateDepositResponse> createRepeated() => $pb.PbList<CreateDepositResponse>();
   @$core.pragma('dart2js:noInline')
-  static CreateDepositResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
+  static CreateDepositResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateDepositResponse>(create);
   static CreateDepositResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -864,38 +768,32 @@ class CreateDepositResponse extends $pb.GeneratedMessage {
 class GetPendingWithdrawalBundleRequest extends $pb.GeneratedMessage {
   factory GetPendingWithdrawalBundleRequest() => create();
   GetPendingWithdrawalBundleRequest._() : super();
-  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleRequest clone() => GetPendingWithdrawalBundleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest))
-          as GetPendingWithdrawalBundleRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleRequest copyWith(void Function(GetPendingWithdrawalBundleRequest) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleRequest)) as GetPendingWithdrawalBundleRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleRequest create() => GetPendingWithdrawalBundleRequest._();
   GetPendingWithdrawalBundleRequest createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleRequest>();
+  static $pb.PbList<GetPendingWithdrawalBundleRequest> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
+  static GetPendingWithdrawalBundleRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleRequest>(create);
   static GetPendingWithdrawalBundleRequest? _defaultInstance;
 }
 
@@ -910,49 +808,40 @@ class GetPendingWithdrawalBundleResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetPendingWithdrawalBundleResponse._() : super();
-  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetPendingWithdrawalBundleResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetPendingWithdrawalBundleResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bundleJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetPendingWithdrawalBundleResponse clone() => GetPendingWithdrawalBundleResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) =>
-      super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse))
-          as GetPendingWithdrawalBundleResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetPendingWithdrawalBundleResponse copyWith(void Function(GetPendingWithdrawalBundleResponse) updates) => super.copyWith((message) => updates(message as GetPendingWithdrawalBundleResponse)) as GetPendingWithdrawalBundleResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetPendingWithdrawalBundleResponse create() => GetPendingWithdrawalBundleResponse._();
   GetPendingWithdrawalBundleResponse createEmptyInstance() => create();
-  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() =>
-      $pb.PbList<GetPendingWithdrawalBundleResponse>();
+  static $pb.PbList<GetPendingWithdrawalBundleResponse> createRepeated() => $pb.PbList<GetPendingWithdrawalBundleResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetPendingWithdrawalBundleResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
+  static GetPendingWithdrawalBundleResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetPendingWithdrawalBundleResponse>(create);
   static GetPendingWithdrawalBundleResponse? _defaultInstance;
 
   /// JSON string of the bundle, empty if none.
   @$pb.TagNumber(1)
   $core.String get bundleJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bundleJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bundleJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBundleJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -970,26 +859,24 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ConnectPeerRequest._() : super();
-  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerRequest clone() => ConnectPeerRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerRequest copyWith(void Function(ConnectPeerRequest) updates) => super.copyWith((message) => updates(message as ConnectPeerRequest)) as ConnectPeerRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -998,17 +885,13 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
   ConnectPeerRequest createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerRequest> createRepeated() => $pb.PbList<ConnectPeerRequest>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
+  static ConnectPeerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerRequest>(create);
   static ConnectPeerRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1018,25 +901,23 @@ class ConnectPeerRequest extends $pb.GeneratedMessage {
 class ConnectPeerResponse extends $pb.GeneratedMessage {
   factory ConnectPeerResponse() => create();
   ConnectPeerResponse._() : super();
-  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConnectPeerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectPeerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ConnectPeerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConnectPeerResponse clone() => ConnectPeerResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) =>
-      super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectPeerResponse copyWith(void Function(ConnectPeerResponse) updates) => super.copyWith((message) => updates(message as ConnectPeerResponse)) as ConnectPeerResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1045,33 +926,30 @@ class ConnectPeerResponse extends $pb.GeneratedMessage {
   ConnectPeerResponse createEmptyInstance() => create();
   static $pb.PbList<ConnectPeerResponse> createRepeated() => $pb.PbList<ConnectPeerResponse>();
   @$core.pragma('dart2js:noInline')
-  static ConnectPeerResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
+  static ConnectPeerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectPeerResponse>(create);
   static ConnectPeerResponse? _defaultInstance;
 }
 
 class ListPeersRequest extends $pb.GeneratedMessage {
   factory ListPeersRequest() => create();
   ListPeersRequest._() : super();
-  factory ListPeersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersRequest clone() => ListPeersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) =>
-      super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersRequest copyWith(void Function(ListPeersRequest) updates) => super.copyWith((message) => updates(message as ListPeersRequest)) as ListPeersRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1080,8 +958,7 @@ class ListPeersRequest extends $pb.GeneratedMessage {
   ListPeersRequest createEmptyInstance() => create();
   static $pb.PbList<ListPeersRequest> createRepeated() => $pb.PbList<ListPeersRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
+  static ListPeersRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersRequest>(create);
   static ListPeersRequest? _defaultInstance;
 }
 
@@ -1096,26 +973,24 @@ class ListPeersResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListPeersResponse._() : super();
-  factory ListPeersResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListPeersResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListPeersResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListPeersResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'peersJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListPeersResponse clone() => ListPeersResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) =>
-      super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListPeersResponse copyWith(void Function(ListPeersResponse) updates) => super.copyWith((message) => updates(message as ListPeersResponse)) as ListPeersResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1124,17 +999,13 @@ class ListPeersResponse extends $pb.GeneratedMessage {
   ListPeersResponse createEmptyInstance() => create();
   static $pb.PbList<ListPeersResponse> createRepeated() => $pb.PbList<ListPeersResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListPeersResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
+  static ListPeersResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPeersResponse>(create);
   static ListPeersResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get peersJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set peersJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set peersJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPeersJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1152,25 +1023,24 @@ class MineRequest extends $pb.GeneratedMessage {
     return $result;
   }
   MineRequest._() : super();
-  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineRequest clone() => MineRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineRequest copyWith(void Function(MineRequest) updates) =>
-      super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineRequest copyWith(void Function(MineRequest) updates) => super.copyWith((message) => updates(message as MineRequest)) as MineRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1185,10 +1055,7 @@ class MineRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $fixnum.Int64 get feeSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasFeeSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -1206,25 +1073,24 @@ class MineResponse extends $pb.GeneratedMessage {
     return $result;
   }
   MineResponse._() : super();
-  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory MineResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MineResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'bmmResultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   MineResponse clone() => MineResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  MineResponse copyWith(void Function(MineResponse) updates) =>
-      super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MineResponse copyWith(void Function(MineResponse) updates) => super.copyWith((message) => updates(message as MineResponse)) as MineResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1239,10 +1105,7 @@ class MineResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get bmmResultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set bmmResultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set bmmResultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBmmResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1260,26 +1123,24 @@ class GetBlockRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockRequest._() : super();
-  factory GetBlockRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockRequest clone() => GetBlockRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) => super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1288,17 +1149,13 @@ class GetBlockRequest extends $pb.GeneratedMessage {
   GetBlockRequest createEmptyInstance() => create();
   static $pb.PbList<GetBlockRequest> createRepeated() => $pb.PbList<GetBlockRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
+  static GetBlockRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
   static GetBlockRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1316,26 +1173,24 @@ class GetBlockResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBlockResponse._() : super();
-  factory GetBlockResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBlockResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBlockResponse clone() => GetBlockResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) => super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1344,17 +1199,13 @@ class GetBlockResponse extends $pb.GeneratedMessage {
   GetBlockResponse createEmptyInstance() => create();
   static $pb.PbList<GetBlockResponse> createRepeated() => $pb.PbList<GetBlockResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBlockResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
+  static GetBlockResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
   static GetBlockResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1364,38 +1215,32 @@ class GetBlockResponse extends $pb.GeneratedMessage {
 class GetBestMainchainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestMainchainBlockHashRequest() => create();
   GetBestMainchainBlockHashRequest._() : super();
-  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashRequest clone() => GetBestMainchainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest))
-          as GetBestMainchainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashRequest copyWith(void Function(GetBestMainchainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashRequest)) as GetBestMainchainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashRequest create() => GetBestMainchainBlockHashRequest._();
   GetBestMainchainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashRequest>();
+  static $pb.PbList<GetBestMainchainBlockHashRequest> createRepeated() => $pb.PbList<GetBestMainchainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
+  static GetBestMainchainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashRequest>(create);
   static GetBestMainchainBlockHashRequest? _defaultInstance;
 }
 
@@ -1410,48 +1255,39 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestMainchainBlockHashResponse._() : super();
-  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestMainchainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestMainchainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestMainchainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestMainchainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestMainchainBlockHashResponse clone() => GetBestMainchainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse))
-          as GetBestMainchainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestMainchainBlockHashResponse copyWith(void Function(GetBestMainchainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestMainchainBlockHashResponse)) as GetBestMainchainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestMainchainBlockHashResponse create() => GetBestMainchainBlockHashResponse._();
   GetBestMainchainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestMainchainBlockHashResponse>();
+  static $pb.PbList<GetBestMainchainBlockHashResponse> createRepeated() => $pb.PbList<GetBestMainchainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestMainchainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
+  static GetBestMainchainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestMainchainBlockHashResponse>(create);
   static GetBestMainchainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1461,38 +1297,32 @@ class GetBestMainchainBlockHashResponse extends $pb.GeneratedMessage {
 class GetBestSidechainBlockHashRequest extends $pb.GeneratedMessage {
   factory GetBestSidechainBlockHashRequest() => create();
   GetBestSidechainBlockHashRequest._() : super();
-  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashRequest clone() => GetBestSidechainBlockHashRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest))
-          as GetBestSidechainBlockHashRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashRequest copyWith(void Function(GetBestSidechainBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashRequest)) as GetBestSidechainBlockHashRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashRequest create() => GetBestSidechainBlockHashRequest._();
   GetBestSidechainBlockHashRequest createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashRequest>();
+  static $pb.PbList<GetBestSidechainBlockHashRequest> createRepeated() => $pb.PbList<GetBestSidechainBlockHashRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
+  static GetBestSidechainBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashRequest>(create);
   static GetBestSidechainBlockHashRequest? _defaultInstance;
 }
 
@@ -1507,48 +1337,39 @@ class GetBestSidechainBlockHashResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBestSidechainBlockHashResponse._() : super();
-  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBestSidechainBlockHashResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBestSidechainBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBestSidechainBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBestSidechainBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'hash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBestSidechainBlockHashResponse clone() => GetBestSidechainBlockHashResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse))
-          as GetBestSidechainBlockHashResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBestSidechainBlockHashResponse copyWith(void Function(GetBestSidechainBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBestSidechainBlockHashResponse)) as GetBestSidechainBlockHashResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetBestSidechainBlockHashResponse create() => GetBestSidechainBlockHashResponse._();
   GetBestSidechainBlockHashResponse createEmptyInstance() => create();
-  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() =>
-      $pb.PbList<GetBestSidechainBlockHashResponse>();
+  static $pb.PbList<GetBestSidechainBlockHashResponse> createRepeated() => $pb.PbList<GetBestSidechainBlockHashResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBestSidechainBlockHashResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
+  static GetBestSidechainBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBestSidechainBlockHashResponse>(create);
   static GetBestSidechainBlockHashResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1566,26 +1387,24 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsRequest._() : super();
-  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'blockHash')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsRequest clone() => GetBmmInclusionsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsRequest copyWith(void Function(GetBmmInclusionsRequest) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsRequest)) as GetBmmInclusionsRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1594,17 +1413,13 @@ class GetBmmInclusionsRequest extends $pb.GeneratedMessage {
   GetBmmInclusionsRequest createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsRequest> createRepeated() => $pb.PbList<GetBmmInclusionsRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
+  static GetBmmInclusionsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsRequest>(create);
   static GetBmmInclusionsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get blockHash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set blockHash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set blockHash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1622,26 +1437,24 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetBmmInclusionsResponse._() : super();
-  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetBmmInclusionsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBmmInclusionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBmmInclusionsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'inclusions')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetBmmInclusionsResponse clone() => GetBmmInclusionsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) =>
-      super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBmmInclusionsResponse copyWith(void Function(GetBmmInclusionsResponse) updates) => super.copyWith((message) => updates(message as GetBmmInclusionsResponse)) as GetBmmInclusionsResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1650,17 +1463,13 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
   GetBmmInclusionsResponse createEmptyInstance() => create();
   static $pb.PbList<GetBmmInclusionsResponse> createRepeated() => $pb.PbList<GetBmmInclusionsResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetBmmInclusionsResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
+  static GetBmmInclusionsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBmmInclusionsResponse>(create);
   static GetBmmInclusionsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get inclusions => $_getSZ(0);
   @$pb.TagNumber(1)
-  set inclusions($core.String v) {
-    $_setString(0, v);
-  }
-
+  set inclusions($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasInclusions() => $_has(0);
   @$pb.TagNumber(1)
@@ -1670,25 +1479,23 @@ class GetBmmInclusionsResponse extends $pb.GeneratedMessage {
 class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   factory GetWalletUtxosRequest() => create();
   GetWalletUtxosRequest._() : super();
-  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosRequest clone() => GetWalletUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosRequest copyWith(void Function(GetWalletUtxosRequest) updates) => super.copyWith((message) => updates(message as GetWalletUtxosRequest)) as GetWalletUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1697,8 +1504,7 @@ class GetWalletUtxosRequest extends $pb.GeneratedMessage {
   GetWalletUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosRequest> createRepeated() => $pb.PbList<GetWalletUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
+  static GetWalletUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosRequest>(create);
   static GetWalletUtxosRequest? _defaultInstance;
 }
 
@@ -1713,26 +1519,24 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetWalletUtxosResponse._() : super();
-  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetWalletUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetWalletUtxosResponse clone() => GetWalletUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletUtxosResponse copyWith(void Function(GetWalletUtxosResponse) updates) => super.copyWith((message) => updates(message as GetWalletUtxosResponse)) as GetWalletUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1741,17 +1545,13 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
   GetWalletUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<GetWalletUtxosResponse> createRepeated() => $pb.PbList<GetWalletUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetWalletUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
+  static GetWalletUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletUtxosResponse>(create);
   static GetWalletUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1761,25 +1561,23 @@ class GetWalletUtxosResponse extends $pb.GeneratedMessage {
 class ListUtxosRequest extends $pb.GeneratedMessage {
   factory ListUtxosRequest() => create();
   ListUtxosRequest._() : super();
-  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosRequest clone() => ListUtxosRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosRequest copyWith(void Function(ListUtxosRequest) updates) => super.copyWith((message) => updates(message as ListUtxosRequest)) as ListUtxosRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1788,8 +1586,7 @@ class ListUtxosRequest extends $pb.GeneratedMessage {
   ListUtxosRequest createEmptyInstance() => create();
   static $pb.PbList<ListUtxosRequest> createRepeated() => $pb.PbList<ListUtxosRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
+  static ListUtxosRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosRequest>(create);
   static ListUtxosRequest? _defaultInstance;
 }
 
@@ -1804,26 +1601,24 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ListUtxosResponse._() : super();
-  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListUtxosResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListUtxosResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListUtxosResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'utxosJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListUtxosResponse clone() => ListUtxosResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) =>
-      super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListUtxosResponse copyWith(void Function(ListUtxosResponse) updates) => super.copyWith((message) => updates(message as ListUtxosResponse)) as ListUtxosResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1832,17 +1627,13 @@ class ListUtxosResponse extends $pb.GeneratedMessage {
   ListUtxosResponse createEmptyInstance() => create();
   static $pb.PbList<ListUtxosResponse> createRepeated() => $pb.PbList<ListUtxosResponse>();
   @$core.pragma('dart2js:noInline')
-  static ListUtxosResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
+  static ListUtxosResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListUtxosResponse>(create);
   static ListUtxosResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get utxosJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set utxosJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set utxosJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasUtxosJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -1860,26 +1651,24 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
     return $result;
   }
   RemoveFromMempoolRequest._() : super();
-  factory RemoveFromMempoolRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFromMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFromMempoolRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFromMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveFromMempoolRequest clone() => RemoveFromMempoolRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveFromMempoolRequest copyWith(void Function(RemoveFromMempoolRequest) updates) =>
-      super.copyWith((message) => updates(message as RemoveFromMempoolRequest)) as RemoveFromMempoolRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveFromMempoolRequest copyWith(void Function(RemoveFromMempoolRequest) updates) => super.copyWith((message) => updates(message as RemoveFromMempoolRequest)) as RemoveFromMempoolRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1888,17 +1677,13 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
   RemoveFromMempoolRequest createEmptyInstance() => create();
   static $pb.PbList<RemoveFromMempoolRequest> createRepeated() => $pb.PbList<RemoveFromMempoolRequest>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFromMempoolRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolRequest>(create);
+  static RemoveFromMempoolRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolRequest>(create);
   static RemoveFromMempoolRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -1908,25 +1693,23 @@ class RemoveFromMempoolRequest extends $pb.GeneratedMessage {
 class RemoveFromMempoolResponse extends $pb.GeneratedMessage {
   factory RemoveFromMempoolResponse() => create();
   RemoveFromMempoolResponse._() : super();
-  factory RemoveFromMempoolResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFromMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFromMempoolResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFromMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RemoveFromMempoolResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   RemoveFromMempoolResponse clone() => RemoveFromMempoolResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  RemoveFromMempoolResponse copyWith(void Function(RemoveFromMempoolResponse) updates) =>
-      super.copyWith((message) => updates(message as RemoveFromMempoolResponse)) as RemoveFromMempoolResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RemoveFromMempoolResponse copyWith(void Function(RemoveFromMempoolResponse) updates) => super.copyWith((message) => updates(message as RemoveFromMempoolResponse)) as RemoveFromMempoolResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1935,50 +1718,39 @@ class RemoveFromMempoolResponse extends $pb.GeneratedMessage {
   RemoveFromMempoolResponse createEmptyInstance() => create();
   static $pb.PbList<RemoveFromMempoolResponse> createRepeated() => $pb.PbList<RemoveFromMempoolResponse>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFromMempoolResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolResponse>(create);
+  static RemoveFromMempoolResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFromMempoolResponse>(create);
   static RemoveFromMempoolResponse? _defaultInstance;
 }
 
 class GetLatestFailedWithdrawalBundleHeightRequest extends $pb.GeneratedMessage {
   factory GetLatestFailedWithdrawalBundleHeightRequest() => create();
   GetLatestFailedWithdrawalBundleHeightRequest._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'),
-      createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest clone() =>
-      GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightRequest copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest))
-          as GetLatestFailedWithdrawalBundleHeightRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest clone() => GetLatestFailedWithdrawalBundleHeightRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightRequest copyWith(void Function(GetLatestFailedWithdrawalBundleHeightRequest) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightRequest)) as GetLatestFailedWithdrawalBundleHeightRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightRequest create() => GetLatestFailedWithdrawalBundleHeightRequest._();
   GetLatestFailedWithdrawalBundleHeightRequest createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
+  static GetLatestFailedWithdrawalBundleHeightRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightRequest>(create);
   static GetLatestFailedWithdrawalBundleHeightRequest? _defaultInstance;
 }
 
@@ -1993,53 +1765,40 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
     return $result;
   }
   GetLatestFailedWithdrawalBundleHeightResponse._() : super();
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetLatestFailedWithdrawalBundleHeightResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetLatestFailedWithdrawalBundleHeightResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'height')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse clone() =>
-      GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetLatestFailedWithdrawalBundleHeightResponse copyWith(
-          void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) =>
-      super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse))
-          as GetLatestFailedWithdrawalBundleHeightResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse clone() => GetLatestFailedWithdrawalBundleHeightResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetLatestFailedWithdrawalBundleHeightResponse copyWith(void Function(GetLatestFailedWithdrawalBundleHeightResponse) updates) => super.copyWith((message) => updates(message as GetLatestFailedWithdrawalBundleHeightResponse)) as GetLatestFailedWithdrawalBundleHeightResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetLatestFailedWithdrawalBundleHeightResponse create() => GetLatestFailedWithdrawalBundleHeightResponse._();
   GetLatestFailedWithdrawalBundleHeightResponse createEmptyInstance() => create();
-  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() =>
-      $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
+  static $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse> createRepeated() => $pb.PbList<GetLatestFailedWithdrawalBundleHeightResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
+  static GetLatestFailedWithdrawalBundleHeightResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetLatestFailedWithdrawalBundleHeightResponse>(create);
   static GetLatestFailedWithdrawalBundleHeightResponse? _defaultInstance;
 
   /// 0 means no failed bundle.
   @$pb.TagNumber(1)
   $fixnum.Int64 get height => $_getI64(0);
   @$pb.TagNumber(1)
-  set height($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set height($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHeight() => $_has(0);
   @$pb.TagNumber(1)
@@ -2049,25 +1808,23 @@ class GetLatestFailedWithdrawalBundleHeightResponse extends $pb.GeneratedMessage
 class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   factory GenerateMnemonicRequest() => create();
   GenerateMnemonicRequest._() : super();
-  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicRequest clone() => GenerateMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicRequest copyWith(void Function(GenerateMnemonicRequest) updates) => super.copyWith((message) => updates(message as GenerateMnemonicRequest)) as GenerateMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2076,8 +1833,7 @@ class GenerateMnemonicRequest extends $pb.GeneratedMessage {
   GenerateMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicRequest> createRepeated() => $pb.PbList<GenerateMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
+  static GenerateMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicRequest>(create);
   static GenerateMnemonicRequest? _defaultInstance;
 }
 
@@ -2092,26 +1848,24 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GenerateMnemonicResponse._() : super();
-  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GenerateMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenerateMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GenerateMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenerateMnemonicResponse clone() => GenerateMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenerateMnemonicResponse copyWith(void Function(GenerateMnemonicResponse) updates) => super.copyWith((message) => updates(message as GenerateMnemonicResponse)) as GenerateMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2120,17 +1874,13 @@ class GenerateMnemonicResponse extends $pb.GeneratedMessage {
   GenerateMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<GenerateMnemonicResponse> createRepeated() => $pb.PbList<GenerateMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static GenerateMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
+  static GenerateMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenerateMnemonicResponse>(create);
   static GenerateMnemonicResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2148,27 +1898,24 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
     return $result;
   }
   SetSeedFromMnemonicRequest._() : super();
-  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'mnemonic')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicRequest clone() => SetSeedFromMnemonicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicRequest copyWith(void Function(SetSeedFromMnemonicRequest) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicRequest)) as SetSeedFromMnemonicRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2177,17 +1924,13 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
   SetSeedFromMnemonicRequest createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicRequest> createRepeated() => $pb.PbList<SetSeedFromMnemonicRequest>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
+  static SetSeedFromMnemonicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicRequest>(create);
   static SetSeedFromMnemonicRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get mnemonic => $_getSZ(0);
   @$pb.TagNumber(1)
-  set mnemonic($core.String v) {
-    $_setString(0, v);
-  }
-
+  set mnemonic($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMnemonic() => $_has(0);
   @$pb.TagNumber(1)
@@ -2197,26 +1940,23 @@ class SetSeedFromMnemonicRequest extends $pb.GeneratedMessage {
 class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   factory SetSeedFromMnemonicResponse() => create();
   SetSeedFromMnemonicResponse._() : super();
-  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SetSeedFromMnemonicResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SetSeedFromMnemonicResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SetSeedFromMnemonicResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SetSeedFromMnemonicResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SetSeedFromMnemonicResponse clone() => SetSeedFromMnemonicResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) =>
-      super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SetSeedFromMnemonicResponse copyWith(void Function(SetSeedFromMnemonicResponse) updates) => super.copyWith((message) => updates(message as SetSeedFromMnemonicResponse)) as SetSeedFromMnemonicResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2225,8 +1965,7 @@ class SetSeedFromMnemonicResponse extends $pb.GeneratedMessage {
   SetSeedFromMnemonicResponse createEmptyInstance() => create();
   static $pb.PbList<SetSeedFromMnemonicResponse> createRepeated() => $pb.PbList<SetSeedFromMnemonicResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetSeedFromMnemonicResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
+  static SetSeedFromMnemonicResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetSeedFromMnemonicResponse>(create);
   static SetSeedFromMnemonicResponse? _defaultInstance;
 }
 
@@ -2245,26 +1984,25 @@ class CallRawRequest extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawRequest._() : super();
-  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'method')
     ..aOS(2, _omitFieldNames ? '' : 'paramsJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawRequest clone() => CallRawRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawRequest copyWith(void Function(CallRawRequest) updates) =>
-      super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawRequest copyWith(void Function(CallRawRequest) updates) => super.copyWith((message) => updates(message as CallRawRequest)) as CallRawRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2279,10 +2017,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get method => $_getSZ(0);
   @$pb.TagNumber(1)
-  set method($core.String v) {
-    $_setString(0, v);
-  }
-
+  set method($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMethod() => $_has(0);
   @$pb.TagNumber(1)
@@ -2291,10 +2026,7 @@ class CallRawRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get paramsJson => $_getSZ(1);
   @$pb.TagNumber(2)
-  set paramsJson($core.String v) {
-    $_setString(1, v);
-  }
-
+  set paramsJson($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasParamsJson() => $_has(1);
   @$pb.TagNumber(2)
@@ -2312,26 +2044,24 @@ class CallRawResponse extends $pb.GeneratedMessage {
     return $result;
   }
   CallRawResponse._() : super();
-  factory CallRawResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CallRawResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CallRawResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CallRawResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'resultJson')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CallRawResponse clone() => CallRawResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CallRawResponse copyWith(void Function(CallRawResponse) updates) =>
-      super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CallRawResponse copyWith(void Function(CallRawResponse) updates) => super.copyWith((message) => updates(message as CallRawResponse)) as CallRawResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2340,17 +2070,13 @@ class CallRawResponse extends $pb.GeneratedMessage {
   CallRawResponse createEmptyInstance() => create();
   static $pb.PbList<CallRawResponse> createRepeated() => $pb.PbList<CallRawResponse>();
   @$core.pragma('dart2js:noInline')
-  static CallRawResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
+  static CallRawResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CallRawResponse>(create);
   static CallRawResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get resultJson => $_getSZ(0);
   @$pb.TagNumber(1)
-  set resultJson($core.String v) {
-    $_setString(0, v);
-  }
-
+  set resultJson($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResultJson() => $_has(0);
   @$pb.TagNumber(1)
@@ -2360,26 +2086,23 @@ class CallRawResponse extends $pb.GeneratedMessage {
 class GetNewShieldedAddressRequest extends $pb.GeneratedMessage {
   factory GetNewShieldedAddressRequest() => create();
   GetNewShieldedAddressRequest._() : super();
-  factory GetNewShieldedAddressRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewShieldedAddressRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewShieldedAddressRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewShieldedAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewShieldedAddressRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewShieldedAddressRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewShieldedAddressRequest clone() => GetNewShieldedAddressRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewShieldedAddressRequest copyWith(void Function(GetNewShieldedAddressRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewShieldedAddressRequest)) as GetNewShieldedAddressRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewShieldedAddressRequest copyWith(void Function(GetNewShieldedAddressRequest) updates) => super.copyWith((message) => updates(message as GetNewShieldedAddressRequest)) as GetNewShieldedAddressRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2388,8 +2111,7 @@ class GetNewShieldedAddressRequest extends $pb.GeneratedMessage {
   GetNewShieldedAddressRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewShieldedAddressRequest> createRepeated() => $pb.PbList<GetNewShieldedAddressRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewShieldedAddressRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewShieldedAddressRequest>(create);
+  static GetNewShieldedAddressRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewShieldedAddressRequest>(create);
   static GetNewShieldedAddressRequest? _defaultInstance;
 }
 
@@ -2404,27 +2126,24 @@ class GetNewShieldedAddressResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewShieldedAddressResponse._() : super();
-  factory GetNewShieldedAddressResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewShieldedAddressResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewShieldedAddressResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewShieldedAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewShieldedAddressResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewShieldedAddressResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewShieldedAddressResponse clone() => GetNewShieldedAddressResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewShieldedAddressResponse copyWith(void Function(GetNewShieldedAddressResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewShieldedAddressResponse)) as GetNewShieldedAddressResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewShieldedAddressResponse copyWith(void Function(GetNewShieldedAddressResponse) updates) => super.copyWith((message) => updates(message as GetNewShieldedAddressResponse)) as GetNewShieldedAddressResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2433,17 +2152,13 @@ class GetNewShieldedAddressResponse extends $pb.GeneratedMessage {
   GetNewShieldedAddressResponse createEmptyInstance() => create();
   static $pb.PbList<GetNewShieldedAddressResponse> createRepeated() => $pb.PbList<GetNewShieldedAddressResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewShieldedAddressResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewShieldedAddressResponse>(create);
+  static GetNewShieldedAddressResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewShieldedAddressResponse>(create);
   static GetNewShieldedAddressResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -2453,27 +2168,23 @@ class GetNewShieldedAddressResponse extends $pb.GeneratedMessage {
 class GetNewTransparentAddressRequest extends $pb.GeneratedMessage {
   factory GetNewTransparentAddressRequest() => create();
   GetNewTransparentAddressRequest._() : super();
-  factory GetNewTransparentAddressRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewTransparentAddressRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewTransparentAddressRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewTransparentAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewTransparentAddressRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewTransparentAddressRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewTransparentAddressRequest clone() => GetNewTransparentAddressRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewTransparentAddressRequest copyWith(void Function(GetNewTransparentAddressRequest) updates) =>
-      super.copyWith((message) => updates(message as GetNewTransparentAddressRequest))
-          as GetNewTransparentAddressRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewTransparentAddressRequest copyWith(void Function(GetNewTransparentAddressRequest) updates) => super.copyWith((message) => updates(message as GetNewTransparentAddressRequest)) as GetNewTransparentAddressRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2482,8 +2193,7 @@ class GetNewTransparentAddressRequest extends $pb.GeneratedMessage {
   GetNewTransparentAddressRequest createEmptyInstance() => create();
   static $pb.PbList<GetNewTransparentAddressRequest> createRepeated() => $pb.PbList<GetNewTransparentAddressRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNewTransparentAddressRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewTransparentAddressRequest>(create);
+  static GetNewTransparentAddressRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewTransparentAddressRequest>(create);
   static GetNewTransparentAddressRequest? _defaultInstance;
 }
 
@@ -2498,48 +2208,39 @@ class GetNewTransparentAddressResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetNewTransparentAddressResponse._() : super();
-  factory GetNewTransparentAddressResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetNewTransparentAddressResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetNewTransparentAddressResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewTransparentAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewTransparentAddressResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewTransparentAddressResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetNewTransparentAddressResponse clone() => GetNewTransparentAddressResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetNewTransparentAddressResponse copyWith(void Function(GetNewTransparentAddressResponse) updates) =>
-      super.copyWith((message) => updates(message as GetNewTransparentAddressResponse))
-          as GetNewTransparentAddressResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewTransparentAddressResponse copyWith(void Function(GetNewTransparentAddressResponse) updates) => super.copyWith((message) => updates(message as GetNewTransparentAddressResponse)) as GetNewTransparentAddressResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetNewTransparentAddressResponse create() => GetNewTransparentAddressResponse._();
   GetNewTransparentAddressResponse createEmptyInstance() => create();
-  static $pb.PbList<GetNewTransparentAddressResponse> createRepeated() =>
-      $pb.PbList<GetNewTransparentAddressResponse>();
+  static $pb.PbList<GetNewTransparentAddressResponse> createRepeated() => $pb.PbList<GetNewTransparentAddressResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNewTransparentAddressResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewTransparentAddressResponse>(create);
+  static GetNewTransparentAddressResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewTransparentAddressResponse>(create);
   static GetNewTransparentAddressResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -2549,38 +2250,32 @@ class GetNewTransparentAddressResponse extends $pb.GeneratedMessage {
 class GetShieldedWalletAddressesRequest extends $pb.GeneratedMessage {
   factory GetShieldedWalletAddressesRequest() => create();
   GetShieldedWalletAddressesRequest._() : super();
-  factory GetShieldedWalletAddressesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetShieldedWalletAddressesRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetShieldedWalletAddressesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetShieldedWalletAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetShieldedWalletAddressesRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetShieldedWalletAddressesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetShieldedWalletAddressesRequest clone() => GetShieldedWalletAddressesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetShieldedWalletAddressesRequest copyWith(void Function(GetShieldedWalletAddressesRequest) updates) =>
-      super.copyWith((message) => updates(message as GetShieldedWalletAddressesRequest))
-          as GetShieldedWalletAddressesRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetShieldedWalletAddressesRequest copyWith(void Function(GetShieldedWalletAddressesRequest) updates) => super.copyWith((message) => updates(message as GetShieldedWalletAddressesRequest)) as GetShieldedWalletAddressesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetShieldedWalletAddressesRequest create() => GetShieldedWalletAddressesRequest._();
   GetShieldedWalletAddressesRequest createEmptyInstance() => create();
-  static $pb.PbList<GetShieldedWalletAddressesRequest> createRepeated() =>
-      $pb.PbList<GetShieldedWalletAddressesRequest>();
+  static $pb.PbList<GetShieldedWalletAddressesRequest> createRepeated() => $pb.PbList<GetShieldedWalletAddressesRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetShieldedWalletAddressesRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetShieldedWalletAddressesRequest>(create);
+  static GetShieldedWalletAddressesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetShieldedWalletAddressesRequest>(create);
   static GetShieldedWalletAddressesRequest? _defaultInstance;
 }
 
@@ -2595,39 +2290,33 @@ class GetShieldedWalletAddressesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetShieldedWalletAddressesResponse._() : super();
-  factory GetShieldedWalletAddressesResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetShieldedWalletAddressesResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetShieldedWalletAddressesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetShieldedWalletAddressesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetShieldedWalletAddressesResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetShieldedWalletAddressesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..pPS(1, _omitFieldNames ? '' : 'addresses')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetShieldedWalletAddressesResponse clone() => GetShieldedWalletAddressesResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetShieldedWalletAddressesResponse copyWith(void Function(GetShieldedWalletAddressesResponse) updates) =>
-      super.copyWith((message) => updates(message as GetShieldedWalletAddressesResponse))
-          as GetShieldedWalletAddressesResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetShieldedWalletAddressesResponse copyWith(void Function(GetShieldedWalletAddressesResponse) updates) => super.copyWith((message) => updates(message as GetShieldedWalletAddressesResponse)) as GetShieldedWalletAddressesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetShieldedWalletAddressesResponse create() => GetShieldedWalletAddressesResponse._();
   GetShieldedWalletAddressesResponse createEmptyInstance() => create();
-  static $pb.PbList<GetShieldedWalletAddressesResponse> createRepeated() =>
-      $pb.PbList<GetShieldedWalletAddressesResponse>();
+  static $pb.PbList<GetShieldedWalletAddressesResponse> createRepeated() => $pb.PbList<GetShieldedWalletAddressesResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetShieldedWalletAddressesResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetShieldedWalletAddressesResponse>(create);
+  static GetShieldedWalletAddressesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetShieldedWalletAddressesResponse>(create);
   static GetShieldedWalletAddressesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -2637,38 +2326,32 @@ class GetShieldedWalletAddressesResponse extends $pb.GeneratedMessage {
 class GetTransparentWalletAddressesRequest extends $pb.GeneratedMessage {
   factory GetTransparentWalletAddressesRequest() => create();
   GetTransparentWalletAddressesRequest._() : super();
-  factory GetTransparentWalletAddressesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetTransparentWalletAddressesRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetTransparentWalletAddressesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTransparentWalletAddressesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransparentWalletAddressesRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransparentWalletAddressesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetTransparentWalletAddressesRequest clone() => GetTransparentWalletAddressesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetTransparentWalletAddressesRequest copyWith(void Function(GetTransparentWalletAddressesRequest) updates) =>
-      super.copyWith((message) => updates(message as GetTransparentWalletAddressesRequest))
-          as GetTransparentWalletAddressesRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTransparentWalletAddressesRequest copyWith(void Function(GetTransparentWalletAddressesRequest) updates) => super.copyWith((message) => updates(message as GetTransparentWalletAddressesRequest)) as GetTransparentWalletAddressesRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetTransparentWalletAddressesRequest create() => GetTransparentWalletAddressesRequest._();
   GetTransparentWalletAddressesRequest createEmptyInstance() => create();
-  static $pb.PbList<GetTransparentWalletAddressesRequest> createRepeated() =>
-      $pb.PbList<GetTransparentWalletAddressesRequest>();
+  static $pb.PbList<GetTransparentWalletAddressesRequest> createRepeated() => $pb.PbList<GetTransparentWalletAddressesRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetTransparentWalletAddressesRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransparentWalletAddressesRequest>(create);
+  static GetTransparentWalletAddressesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransparentWalletAddressesRequest>(create);
   static GetTransparentWalletAddressesRequest? _defaultInstance;
 }
 
@@ -2683,39 +2366,33 @@ class GetTransparentWalletAddressesResponse extends $pb.GeneratedMessage {
     return $result;
   }
   GetTransparentWalletAddressesResponse._() : super();
-  factory GetTransparentWalletAddressesResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetTransparentWalletAddressesResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetTransparentWalletAddressesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTransparentWalletAddressesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransparentWalletAddressesResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransparentWalletAddressesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..pPS(1, _omitFieldNames ? '' : 'addresses')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetTransparentWalletAddressesResponse clone() => GetTransparentWalletAddressesResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetTransparentWalletAddressesResponse copyWith(void Function(GetTransparentWalletAddressesResponse) updates) =>
-      super.copyWith((message) => updates(message as GetTransparentWalletAddressesResponse))
-          as GetTransparentWalletAddressesResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTransparentWalletAddressesResponse copyWith(void Function(GetTransparentWalletAddressesResponse) updates) => super.copyWith((message) => updates(message as GetTransparentWalletAddressesResponse)) as GetTransparentWalletAddressesResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetTransparentWalletAddressesResponse create() => GetTransparentWalletAddressesResponse._();
   GetTransparentWalletAddressesResponse createEmptyInstance() => create();
-  static $pb.PbList<GetTransparentWalletAddressesResponse> createRepeated() =>
-      $pb.PbList<GetTransparentWalletAddressesResponse>();
+  static $pb.PbList<GetTransparentWalletAddressesResponse> createRepeated() => $pb.PbList<GetTransparentWalletAddressesResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetTransparentWalletAddressesResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransparentWalletAddressesResponse>(create);
+  static GetTransparentWalletAddressesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransparentWalletAddressesResponse>(create);
   static GetTransparentWalletAddressesResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -2737,26 +2414,25 @@ class ShieldRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ShieldRequest._() : super();
-  factory ShieldRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ShieldRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ShieldRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ShieldRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShieldRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShieldRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(2, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ShieldRequest clone() => ShieldRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ShieldRequest copyWith(void Function(ShieldRequest) updates) =>
-      super.copyWith((message) => updates(message as ShieldRequest)) as ShieldRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ShieldRequest copyWith(void Function(ShieldRequest) updates) => super.copyWith((message) => updates(message as ShieldRequest)) as ShieldRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2771,10 +2447,7 @@ class ShieldRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $fixnum.Int64 get amountSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAmountSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -2783,10 +2456,7 @@ class ShieldRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get feeSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasFeeSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -2804,25 +2474,24 @@ class ShieldResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ShieldResponse._() : super();
-  factory ShieldResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ShieldResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ShieldResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ShieldResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShieldResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShieldResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ShieldResponse clone() => ShieldResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ShieldResponse copyWith(void Function(ShieldResponse) updates) =>
-      super.copyWith((message) => updates(message as ShieldResponse)) as ShieldResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ShieldResponse copyWith(void Function(ShieldResponse) updates) => super.copyWith((message) => updates(message as ShieldResponse)) as ShieldResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2837,10 +2506,7 @@ class ShieldResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2862,27 +2528,25 @@ class UnshieldRequest extends $pb.GeneratedMessage {
     return $result;
   }
   UnshieldRequest._() : super();
-  factory UnshieldRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UnshieldRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory UnshieldRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UnshieldRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnshieldRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnshieldRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aInt64(1, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(2, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   UnshieldRequest clone() => UnshieldRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  UnshieldRequest copyWith(void Function(UnshieldRequest) updates) =>
-      super.copyWith((message) => updates(message as UnshieldRequest)) as UnshieldRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UnshieldRequest copyWith(void Function(UnshieldRequest) updates) => super.copyWith((message) => updates(message as UnshieldRequest)) as UnshieldRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2891,17 +2555,13 @@ class UnshieldRequest extends $pb.GeneratedMessage {
   UnshieldRequest createEmptyInstance() => create();
   static $pb.PbList<UnshieldRequest> createRepeated() => $pb.PbList<UnshieldRequest>();
   @$core.pragma('dart2js:noInline')
-  static UnshieldRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnshieldRequest>(create);
+  static UnshieldRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnshieldRequest>(create);
   static UnshieldRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get amountSats => $_getI64(0);
   @$pb.TagNumber(1)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAmountSats() => $_has(0);
   @$pb.TagNumber(1)
@@ -2910,10 +2570,7 @@ class UnshieldRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get feeSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasFeeSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -2931,26 +2588,24 @@ class UnshieldResponse extends $pb.GeneratedMessage {
     return $result;
   }
   UnshieldResponse._() : super();
-  factory UnshieldResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UnshieldResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory UnshieldResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UnshieldResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnshieldResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UnshieldResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   UnshieldResponse clone() => UnshieldResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  UnshieldResponse copyWith(void Function(UnshieldResponse) updates) =>
-      super.copyWith((message) => updates(message as UnshieldResponse)) as UnshieldResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UnshieldResponse copyWith(void Function(UnshieldResponse) updates) => super.copyWith((message) => updates(message as UnshieldResponse)) as UnshieldResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2959,17 +2614,13 @@ class UnshieldResponse extends $pb.GeneratedMessage {
   UnshieldResponse createEmptyInstance() => create();
   static $pb.PbList<UnshieldResponse> createRepeated() => $pb.PbList<UnshieldResponse>();
   @$core.pragma('dart2js:noInline')
-  static UnshieldResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnshieldResponse>(create);
+  static UnshieldResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnshieldResponse>(create);
   static UnshieldResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2995,28 +2646,26 @@ class ShieldedTransferRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ShieldedTransferRequest._() : super();
-  factory ShieldedTransferRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ShieldedTransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ShieldedTransferRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ShieldedTransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShieldedTransferRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShieldedTransferRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ShieldedTransferRequest clone() => ShieldedTransferRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ShieldedTransferRequest copyWith(void Function(ShieldedTransferRequest) updates) =>
-      super.copyWith((message) => updates(message as ShieldedTransferRequest)) as ShieldedTransferRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ShieldedTransferRequest copyWith(void Function(ShieldedTransferRequest) updates) => super.copyWith((message) => updates(message as ShieldedTransferRequest)) as ShieldedTransferRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3025,17 +2674,13 @@ class ShieldedTransferRequest extends $pb.GeneratedMessage {
   ShieldedTransferRequest createEmptyInstance() => create();
   static $pb.PbList<ShieldedTransferRequest> createRepeated() => $pb.PbList<ShieldedTransferRequest>();
   @$core.pragma('dart2js:noInline')
-  static ShieldedTransferRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShieldedTransferRequest>(create);
+  static ShieldedTransferRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShieldedTransferRequest>(create);
   static ShieldedTransferRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -3044,10 +2689,7 @@ class ShieldedTransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -3056,10 +2698,7 @@ class ShieldedTransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -3077,26 +2716,24 @@ class ShieldedTransferResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ShieldedTransferResponse._() : super();
-  factory ShieldedTransferResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ShieldedTransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ShieldedTransferResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ShieldedTransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShieldedTransferResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ShieldedTransferResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ShieldedTransferResponse clone() => ShieldedTransferResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ShieldedTransferResponse copyWith(void Function(ShieldedTransferResponse) updates) =>
-      super.copyWith((message) => updates(message as ShieldedTransferResponse)) as ShieldedTransferResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ShieldedTransferResponse copyWith(void Function(ShieldedTransferResponse) updates) => super.copyWith((message) => updates(message as ShieldedTransferResponse)) as ShieldedTransferResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3105,17 +2742,13 @@ class ShieldedTransferResponse extends $pb.GeneratedMessage {
   ShieldedTransferResponse createEmptyInstance() => create();
   static $pb.PbList<ShieldedTransferResponse> createRepeated() => $pb.PbList<ShieldedTransferResponse>();
   @$core.pragma('dart2js:noInline')
-  static ShieldedTransferResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShieldedTransferResponse>(create);
+  static ShieldedTransferResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ShieldedTransferResponse>(create);
   static ShieldedTransferResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -3141,29 +2774,26 @@ class TransparentTransferRequest extends $pb.GeneratedMessage {
     return $result;
   }
   TransparentTransferRequest._() : super();
-  factory TransparentTransferRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransparentTransferRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransparentTransferRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransparentTransferRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransparentTransferRequest',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransparentTransferRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'address')
     ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
     ..aInt64(3, _omitFieldNames ? '' : 'feeSats')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransparentTransferRequest clone() => TransparentTransferRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransparentTransferRequest copyWith(void Function(TransparentTransferRequest) updates) =>
-      super.copyWith((message) => updates(message as TransparentTransferRequest)) as TransparentTransferRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransparentTransferRequest copyWith(void Function(TransparentTransferRequest) updates) => super.copyWith((message) => updates(message as TransparentTransferRequest)) as TransparentTransferRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3172,17 +2802,13 @@ class TransparentTransferRequest extends $pb.GeneratedMessage {
   TransparentTransferRequest createEmptyInstance() => create();
   static $pb.PbList<TransparentTransferRequest> createRepeated() => $pb.PbList<TransparentTransferRequest>();
   @$core.pragma('dart2js:noInline')
-  static TransparentTransferRequest getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransparentTransferRequest>(create);
+  static TransparentTransferRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransparentTransferRequest>(create);
   static TransparentTransferRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -3191,10 +2817,7 @@ class TransparentTransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amountSats => $_getI64(1);
   @$pb.TagNumber(2)
-  set amountSats($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmountSats() => $_has(1);
   @$pb.TagNumber(2)
@@ -3203,10 +2826,7 @@ class TransparentTransferRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get feeSats => $_getI64(2);
   @$pb.TagNumber(3)
-  set feeSats($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set feeSats($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFeeSats() => $_has(2);
   @$pb.TagNumber(3)
@@ -3224,27 +2844,24 @@ class TransparentTransferResponse extends $pb.GeneratedMessage {
     return $result;
   }
   TransparentTransferResponse._() : super();
-  factory TransparentTransferResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransparentTransferResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransparentTransferResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransparentTransferResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransparentTransferResponse',
-      package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TransparentTransferResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'zside.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'txid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   TransparentTransferResponse clone() => TransparentTransferResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  TransparentTransferResponse copyWith(void Function(TransparentTransferResponse) updates) =>
-      super.copyWith((message) => updates(message as TransparentTransferResponse)) as TransparentTransferResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TransparentTransferResponse copyWith(void Function(TransparentTransferResponse) updates) => super.copyWith((message) => updates(message as TransparentTransferResponse)) as TransparentTransferResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -3253,17 +2870,13 @@ class TransparentTransferResponse extends $pb.GeneratedMessage {
   TransparentTransferResponse createEmptyInstance() => create();
   static $pb.PbList<TransparentTransferResponse> createRepeated() => $pb.PbList<TransparentTransferResponse>();
   @$core.pragma('dart2js:noInline')
-  static TransparentTransferResponse getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransparentTransferResponse>(create);
+  static TransparentTransferResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransparentTransferResponse>(create);
   static TransparentTransferResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -3275,93 +2888,97 @@ class ZSideServiceApi {
   ZSideServiceApi(this._client);
 
   $async.Future<GetBalanceResponse> getBalance($pb.ClientContext? ctx, GetBalanceRequest request) =>
-      _client.invoke<GetBalanceResponse>(ctx, 'ZSideService', 'GetBalance', request, GetBalanceResponse());
+    _client.invoke<GetBalanceResponse>(ctx, 'ZSideService', 'GetBalance', request, GetBalanceResponse())
+  ;
   $async.Future<GetBlockCountResponse> getBlockCount($pb.ClientContext? ctx, GetBlockCountRequest request) =>
-      _client.invoke<GetBlockCountResponse>(ctx, 'ZSideService', 'GetBlockCount', request, GetBlockCountResponse());
+    _client.invoke<GetBlockCountResponse>(ctx, 'ZSideService', 'GetBlockCount', request, GetBlockCountResponse())
+  ;
   $async.Future<StopResponse> stop($pb.ClientContext? ctx, StopRequest request) =>
-      _client.invoke<StopResponse>(ctx, 'ZSideService', 'Stop', request, StopResponse());
+    _client.invoke<StopResponse>(ctx, 'ZSideService', 'Stop', request, StopResponse())
+  ;
   $async.Future<WithdrawResponse> withdraw($pb.ClientContext? ctx, WithdrawRequest request) =>
-      _client.invoke<WithdrawResponse>(ctx, 'ZSideService', 'Withdraw', request, WithdrawResponse());
+    _client.invoke<WithdrawResponse>(ctx, 'ZSideService', 'Withdraw', request, WithdrawResponse())
+  ;
   $async.Future<TransferResponse> transfer($pb.ClientContext? ctx, TransferRequest request) =>
-      _client.invoke<TransferResponse>(ctx, 'ZSideService', 'Transfer', request, TransferResponse());
-  $async.Future<GetSidechainWealthResponse> getSidechainWealth(
-          $pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
-      _client.invoke<GetSidechainWealthResponse>(
-          ctx, 'ZSideService', 'GetSidechainWealth', request, GetSidechainWealthResponse());
+    _client.invoke<TransferResponse>(ctx, 'ZSideService', 'Transfer', request, TransferResponse())
+  ;
+  $async.Future<GetSidechainWealthResponse> getSidechainWealth($pb.ClientContext? ctx, GetSidechainWealthRequest request) =>
+    _client.invoke<GetSidechainWealthResponse>(ctx, 'ZSideService', 'GetSidechainWealth', request, GetSidechainWealthResponse())
+  ;
   $async.Future<CreateDepositResponse> createDeposit($pb.ClientContext? ctx, CreateDepositRequest request) =>
-      _client.invoke<CreateDepositResponse>(ctx, 'ZSideService', 'CreateDeposit', request, CreateDepositResponse());
-  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-          $pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
-      _client.invoke<GetPendingWithdrawalBundleResponse>(
-          ctx, 'ZSideService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse());
+    _client.invoke<CreateDepositResponse>(ctx, 'ZSideService', 'CreateDeposit', request, CreateDepositResponse())
+  ;
+  $async.Future<GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ClientContext? ctx, GetPendingWithdrawalBundleRequest request) =>
+    _client.invoke<GetPendingWithdrawalBundleResponse>(ctx, 'ZSideService', 'GetPendingWithdrawalBundle', request, GetPendingWithdrawalBundleResponse())
+  ;
   $async.Future<ConnectPeerResponse> connectPeer($pb.ClientContext? ctx, ConnectPeerRequest request) =>
-      _client.invoke<ConnectPeerResponse>(ctx, 'ZSideService', 'ConnectPeer', request, ConnectPeerResponse());
+    _client.invoke<ConnectPeerResponse>(ctx, 'ZSideService', 'ConnectPeer', request, ConnectPeerResponse())
+  ;
   $async.Future<ListPeersResponse> listPeers($pb.ClientContext? ctx, ListPeersRequest request) =>
-      _client.invoke<ListPeersResponse>(ctx, 'ZSideService', 'ListPeers', request, ListPeersResponse());
+    _client.invoke<ListPeersResponse>(ctx, 'ZSideService', 'ListPeers', request, ListPeersResponse())
+  ;
   $async.Future<MineResponse> mine($pb.ClientContext? ctx, MineRequest request) =>
-      _client.invoke<MineResponse>(ctx, 'ZSideService', 'Mine', request, MineResponse());
+    _client.invoke<MineResponse>(ctx, 'ZSideService', 'Mine', request, MineResponse())
+  ;
   $async.Future<GetBlockResponse> getBlock($pb.ClientContext? ctx, GetBlockRequest request) =>
-      _client.invoke<GetBlockResponse>(ctx, 'ZSideService', 'GetBlock', request, GetBlockResponse());
-  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-          $pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
-      _client.invoke<GetBestMainchainBlockHashResponse>(
-          ctx, 'ZSideService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse());
-  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-          $pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
-      _client.invoke<GetBestSidechainBlockHashResponse>(
-          ctx, 'ZSideService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse());
+    _client.invoke<GetBlockResponse>(ctx, 'ZSideService', 'GetBlock', request, GetBlockResponse())
+  ;
+  $async.Future<GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ClientContext? ctx, GetBestMainchainBlockHashRequest request) =>
+    _client.invoke<GetBestMainchainBlockHashResponse>(ctx, 'ZSideService', 'GetBestMainchainBlockHash', request, GetBestMainchainBlockHashResponse())
+  ;
+  $async.Future<GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ClientContext? ctx, GetBestSidechainBlockHashRequest request) =>
+    _client.invoke<GetBestSidechainBlockHashResponse>(ctx, 'ZSideService', 'GetBestSidechainBlockHash', request, GetBestSidechainBlockHashResponse())
+  ;
   $async.Future<GetBmmInclusionsResponse> getBmmInclusions($pb.ClientContext? ctx, GetBmmInclusionsRequest request) =>
-      _client.invoke<GetBmmInclusionsResponse>(
-          ctx, 'ZSideService', 'GetBmmInclusions', request, GetBmmInclusionsResponse());
+    _client.invoke<GetBmmInclusionsResponse>(ctx, 'ZSideService', 'GetBmmInclusions', request, GetBmmInclusionsResponse())
+  ;
   $async.Future<GetWalletUtxosResponse> getWalletUtxos($pb.ClientContext? ctx, GetWalletUtxosRequest request) =>
-      _client.invoke<GetWalletUtxosResponse>(ctx, 'ZSideService', 'GetWalletUtxos', request, GetWalletUtxosResponse());
+    _client.invoke<GetWalletUtxosResponse>(ctx, 'ZSideService', 'GetWalletUtxos', request, GetWalletUtxosResponse())
+  ;
   $async.Future<ListUtxosResponse> listUtxos($pb.ClientContext? ctx, ListUtxosRequest request) =>
-      _client.invoke<ListUtxosResponse>(ctx, 'ZSideService', 'ListUtxos', request, ListUtxosResponse());
-  $async.Future<RemoveFromMempoolResponse> removeFromMempool(
-          $pb.ClientContext? ctx, RemoveFromMempoolRequest request) =>
-      _client.invoke<RemoveFromMempoolResponse>(
-          ctx, 'ZSideService', 'RemoveFromMempool', request, RemoveFromMempoolResponse());
-  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-          $pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
-      _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'ZSideService',
-          'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse());
+    _client.invoke<ListUtxosResponse>(ctx, 'ZSideService', 'ListUtxos', request, ListUtxosResponse())
+  ;
+  $async.Future<RemoveFromMempoolResponse> removeFromMempool($pb.ClientContext? ctx, RemoveFromMempoolRequest request) =>
+    _client.invoke<RemoveFromMempoolResponse>(ctx, 'ZSideService', 'RemoveFromMempool', request, RemoveFromMempoolResponse())
+  ;
+  $async.Future<GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ClientContext? ctx, GetLatestFailedWithdrawalBundleHeightRequest request) =>
+    _client.invoke<GetLatestFailedWithdrawalBundleHeightResponse>(ctx, 'ZSideService', 'GetLatestFailedWithdrawalBundleHeight', request, GetLatestFailedWithdrawalBundleHeightResponse())
+  ;
   $async.Future<GenerateMnemonicResponse> generateMnemonic($pb.ClientContext? ctx, GenerateMnemonicRequest request) =>
-      _client.invoke<GenerateMnemonicResponse>(
-          ctx, 'ZSideService', 'GenerateMnemonic', request, GenerateMnemonicResponse());
-  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-          $pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
-      _client.invoke<SetSeedFromMnemonicResponse>(
-          ctx, 'ZSideService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse());
+    _client.invoke<GenerateMnemonicResponse>(ctx, 'ZSideService', 'GenerateMnemonic', request, GenerateMnemonicResponse())
+  ;
+  $async.Future<SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ClientContext? ctx, SetSeedFromMnemonicRequest request) =>
+    _client.invoke<SetSeedFromMnemonicResponse>(ctx, 'ZSideService', 'SetSeedFromMnemonic', request, SetSeedFromMnemonicResponse())
+  ;
   $async.Future<CallRawResponse> callRaw($pb.ClientContext? ctx, CallRawRequest request) =>
-      _client.invoke<CallRawResponse>(ctx, 'ZSideService', 'CallRaw', request, CallRawResponse());
-  $async.Future<GetNewShieldedAddressResponse> getNewShieldedAddress(
-          $pb.ClientContext? ctx, GetNewShieldedAddressRequest request) =>
-      _client.invoke<GetNewShieldedAddressResponse>(
-          ctx, 'ZSideService', 'GetNewShieldedAddress', request, GetNewShieldedAddressResponse());
-  $async.Future<GetNewTransparentAddressResponse> getNewTransparentAddress(
-          $pb.ClientContext? ctx, GetNewTransparentAddressRequest request) =>
-      _client.invoke<GetNewTransparentAddressResponse>(
-          ctx, 'ZSideService', 'GetNewTransparentAddress', request, GetNewTransparentAddressResponse());
-  $async.Future<GetShieldedWalletAddressesResponse> getShieldedWalletAddresses(
-          $pb.ClientContext? ctx, GetShieldedWalletAddressesRequest request) =>
-      _client.invoke<GetShieldedWalletAddressesResponse>(
-          ctx, 'ZSideService', 'GetShieldedWalletAddresses', request, GetShieldedWalletAddressesResponse());
-  $async.Future<GetTransparentWalletAddressesResponse> getTransparentWalletAddresses(
-          $pb.ClientContext? ctx, GetTransparentWalletAddressesRequest request) =>
-      _client.invoke<GetTransparentWalletAddressesResponse>(
-          ctx, 'ZSideService', 'GetTransparentWalletAddresses', request, GetTransparentWalletAddressesResponse());
+    _client.invoke<CallRawResponse>(ctx, 'ZSideService', 'CallRaw', request, CallRawResponse())
+  ;
+  $async.Future<GetNewShieldedAddressResponse> getNewShieldedAddress($pb.ClientContext? ctx, GetNewShieldedAddressRequest request) =>
+    _client.invoke<GetNewShieldedAddressResponse>(ctx, 'ZSideService', 'GetNewShieldedAddress', request, GetNewShieldedAddressResponse())
+  ;
+  $async.Future<GetNewTransparentAddressResponse> getNewTransparentAddress($pb.ClientContext? ctx, GetNewTransparentAddressRequest request) =>
+    _client.invoke<GetNewTransparentAddressResponse>(ctx, 'ZSideService', 'GetNewTransparentAddress', request, GetNewTransparentAddressResponse())
+  ;
+  $async.Future<GetShieldedWalletAddressesResponse> getShieldedWalletAddresses($pb.ClientContext? ctx, GetShieldedWalletAddressesRequest request) =>
+    _client.invoke<GetShieldedWalletAddressesResponse>(ctx, 'ZSideService', 'GetShieldedWalletAddresses', request, GetShieldedWalletAddressesResponse())
+  ;
+  $async.Future<GetTransparentWalletAddressesResponse> getTransparentWalletAddresses($pb.ClientContext? ctx, GetTransparentWalletAddressesRequest request) =>
+    _client.invoke<GetTransparentWalletAddressesResponse>(ctx, 'ZSideService', 'GetTransparentWalletAddresses', request, GetTransparentWalletAddressesResponse())
+  ;
   $async.Future<ShieldResponse> shield($pb.ClientContext? ctx, ShieldRequest request) =>
-      _client.invoke<ShieldResponse>(ctx, 'ZSideService', 'Shield', request, ShieldResponse());
+    _client.invoke<ShieldResponse>(ctx, 'ZSideService', 'Shield', request, ShieldResponse())
+  ;
   $async.Future<UnshieldResponse> unshield($pb.ClientContext? ctx, UnshieldRequest request) =>
-      _client.invoke<UnshieldResponse>(ctx, 'ZSideService', 'Unshield', request, UnshieldResponse());
+    _client.invoke<UnshieldResponse>(ctx, 'ZSideService', 'Unshield', request, UnshieldResponse())
+  ;
   $async.Future<ShieldedTransferResponse> shieldedTransfer($pb.ClientContext? ctx, ShieldedTransferRequest request) =>
-      _client.invoke<ShieldedTransferResponse>(
-          ctx, 'ZSideService', 'ShieldedTransfer', request, ShieldedTransferResponse());
-  $async.Future<TransparentTransferResponse> transparentTransfer(
-          $pb.ClientContext? ctx, TransparentTransferRequest request) =>
-      _client.invoke<TransparentTransferResponse>(
-          ctx, 'ZSideService', 'TransparentTransfer', request, TransparentTransferResponse());
+    _client.invoke<ShieldedTransferResponse>(ctx, 'ZSideService', 'ShieldedTransfer', request, ShieldedTransferResponse())
+  ;
+  $async.Future<TransparentTransferResponse> transparentTransfer($pb.ClientContext? ctx, TransparentTransferRequest request) =>
+    _client.invoke<TransparentTransferResponse>(ctx, 'ZSideService', 'TransparentTransfer', request, TransparentTransferResponse())
+  ;
 }
+
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/sail_ui/lib/gen/zside/v1/zside.pbenum.dart
+++ b/sail_ui/lib/gen/zside/v1/zside.pbenum.dart
@@ -8,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/sail_ui/lib/gen/zside/v1/zside.pbjson.dart
+++ b/sail_ui/lib/gen/zside/v1/zside.pbjson.dart
@@ -19,7 +19,8 @@ const GetBalanceRequest$json = {
 };
 
 /// Descriptor for `GetBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode('ChFHZXRCYWxhbmNlUmVxdWVzdA==');
+final $typed_data.Uint8List getBalanceRequestDescriptor = $convert.base64Decode(
+    'ChFHZXRCYWxhbmNlUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBalanceResponseDescriptor instead')
 const GetBalanceResponse$json = {
@@ -33,12 +34,12 @@ const GetBalanceResponse$json = {
 };
 
 /// Descriptor for `GetBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBalanceResponseDescriptor =
-    $convert.base64Decode('ChJHZXRCYWxhbmNlUmVzcG9uc2USLgoTdG90YWxfc2hpZWxkZWRfc2F0cxgBIAEoA1IRdG90YW'
-        'xTaGllbGRlZFNhdHMSNAoWdG90YWxfdHJhbnNwYXJlbnRfc2F0cxgCIAEoA1IUdG90YWxUcmFu'
-        'c3BhcmVudFNhdHMSNgoXYXZhaWxhYmxlX3NoaWVsZGVkX3NhdHMYAyABKANSFWF2YWlsYWJsZV'
-        'NoaWVsZGVkU2F0cxI8ChphdmFpbGFibGVfdHJhbnNwYXJlbnRfc2F0cxgEIAEoA1IYYXZhaWxh'
-        'YmxlVHJhbnNwYXJlbnRTYXRz');
+final $typed_data.Uint8List getBalanceResponseDescriptor = $convert.base64Decode(
+    'ChJHZXRCYWxhbmNlUmVzcG9uc2USLgoTdG90YWxfc2hpZWxkZWRfc2F0cxgBIAEoA1IRdG90YW'
+    'xTaGllbGRlZFNhdHMSNAoWdG90YWxfdHJhbnNwYXJlbnRfc2F0cxgCIAEoA1IUdG90YWxUcmFu'
+    'c3BhcmVudFNhdHMSNgoXYXZhaWxhYmxlX3NoaWVsZGVkX3NhdHMYAyABKANSFWF2YWlsYWJsZV'
+    'NoaWVsZGVkU2F0cxI8ChphdmFpbGFibGVfdHJhbnNwYXJlbnRfc2F0cxgEIAEoA1IYYXZhaWxh'
+    'YmxlVHJhbnNwYXJlbnRTYXRz');
 
 @$core.Deprecated('Use getBlockCountRequestDescriptor instead')
 const GetBlockCountRequest$json = {
@@ -46,7 +47,8 @@ const GetBlockCountRequest$json = {
 };
 
 /// Descriptor for `GetBlockCountRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode('ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
+final $typed_data.Uint8List getBlockCountRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRCbG9ja0NvdW50UmVxdWVzdA==');
 
 @$core.Deprecated('Use getBlockCountResponseDescriptor instead')
 const GetBlockCountResponse$json = {
@@ -57,8 +59,8 @@ const GetBlockCountResponse$json = {
 };
 
 /// Descriptor for `GetBlockCountResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockCountResponseDescriptor =
-    $convert.base64Decode('ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
+final $typed_data.Uint8List getBlockCountResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRCbG9ja0NvdW50UmVzcG9uc2USFAoFY291bnQYASABKANSBWNvdW50');
 
 @$core.Deprecated('Use stopRequestDescriptor instead')
 const StopRequest$json = {
@@ -66,7 +68,8 @@ const StopRequest$json = {
 };
 
 /// Descriptor for `StopRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode('CgtTdG9wUmVxdWVzdA==');
+final $typed_data.Uint8List stopRequestDescriptor = $convert.base64Decode(
+    'CgtTdG9wUmVxdWVzdA==');
 
 @$core.Deprecated('Use stopResponseDescriptor instead')
 const StopResponse$json = {
@@ -74,7 +77,8 @@ const StopResponse$json = {
 };
 
 /// Descriptor for `StopResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode('CgxTdG9wUmVzcG9uc2U=');
+final $typed_data.Uint8List stopResponseDescriptor = $convert.base64Decode(
+    'CgxTdG9wUmVzcG9uc2U=');
 
 @$core.Deprecated('Use withdrawRequestDescriptor instead')
 const WithdrawRequest$json = {
@@ -88,10 +92,10 @@ const WithdrawRequest$json = {
 };
 
 /// Descriptor for `WithdrawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawRequestDescriptor =
-    $convert.base64Decode('Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
-        'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
+final $typed_data.Uint8List withdrawRequestDescriptor = $convert.base64Decode(
+    'Cg9XaXRoZHJhd1JlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIiCg1zaWRlX2ZlZV9zYXRzGAMgASgDUgtzaWRlRmVlU2F0'
+    'cxIiCg1tYWluX2ZlZV9zYXRzGAQgASgDUgttYWluRmVlU2F0cw==');
 
 @$core.Deprecated('Use withdrawResponseDescriptor instead')
 const WithdrawResponse$json = {
@@ -102,8 +106,8 @@ const WithdrawResponse$json = {
 };
 
 /// Descriptor for `WithdrawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List withdrawResponseDescriptor =
-    $convert.base64Decode('ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List withdrawResponseDescriptor = $convert.base64Decode(
+    'ChBXaXRoZHJhd1Jlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use transferRequestDescriptor instead')
 const TransferRequest$json = {
@@ -116,9 +120,9 @@ const TransferRequest$json = {
 };
 
 /// Descriptor for `TransferRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferRequestDescriptor =
-    $convert.base64Decode('Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
-        'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List transferRequestDescriptor = $convert.base64Decode(
+    'Cg9UcmFuc2ZlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIfCgthbW91bnRfc2'
+    'F0cxgCIAEoA1IKYW1vdW50U2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use transferResponseDescriptor instead')
 const TransferResponse$json = {
@@ -129,8 +133,8 @@ const TransferResponse$json = {
 };
 
 /// Descriptor for `TransferResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transferResponseDescriptor =
-    $convert.base64Decode('ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List transferResponseDescriptor = $convert.base64Decode(
+    'ChBUcmFuc2ZlclJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use getSidechainWealthRequestDescriptor instead')
 const GetSidechainWealthRequest$json = {
@@ -138,8 +142,8 @@ const GetSidechainWealthRequest$json = {
 };
 
 /// Descriptor for `GetSidechainWealthRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthRequestDescriptor =
-    $convert.base64Decode('ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
+final $typed_data.Uint8List getSidechainWealthRequestDescriptor = $convert.base64Decode(
+    'ChlHZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0');
 
 @$core.Deprecated('Use getSidechainWealthResponseDescriptor instead')
 const GetSidechainWealthResponse$json = {
@@ -150,8 +154,8 @@ const GetSidechainWealthResponse$json = {
 };
 
 /// Descriptor for `GetSidechainWealthResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainWealthResponseDescriptor =
-    $convert.base64Decode('ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
+final $typed_data.Uint8List getSidechainWealthResponseDescriptor = $convert.base64Decode(
+    'ChpHZXRTaWRlY2hhaW5XZWFsdGhSZXNwb25zZRISCgRzYXRzGAEgASgDUgRzYXRz');
 
 @$core.Deprecated('Use createDepositRequestDescriptor instead')
 const CreateDepositRequest$json = {
@@ -164,9 +168,9 @@ const CreateDepositRequest$json = {
 };
 
 /// Descriptor for `CreateDepositRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositRequestDescriptor =
-    $convert.base64Decode('ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
-        'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List createDepositRequestDescriptor = $convert.base64Decode(
+    'ChRDcmVhdGVEZXBvc2l0UmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh0KCnZhbH'
+    'VlX3NhdHMYAiABKANSCXZhbHVlU2F0cxIZCghmZWVfc2F0cxgDIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use createDepositResponseDescriptor instead')
 const CreateDepositResponse$json = {
@@ -177,8 +181,8 @@ const CreateDepositResponse$json = {
 };
 
 /// Descriptor for `CreateDepositResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createDepositResponseDescriptor =
-    $convert.base64Decode('ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List createDepositResponseDescriptor = $convert.base64Decode(
+    'ChVDcmVhdGVEZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleRequestDescriptor instead')
 const GetPendingWithdrawalBundleRequest$json = {
@@ -186,8 +190,8 @@ const GetPendingWithdrawalBundleRequest$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor =
-    $convert.base64Decode('CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
+final $typed_data.Uint8List getPendingWithdrawalBundleRequestDescriptor = $convert.base64Decode(
+    'CiFHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlcXVlc3Q=');
 
 @$core.Deprecated('Use getPendingWithdrawalBundleResponseDescriptor instead')
 const GetPendingWithdrawalBundleResponse$json = {
@@ -198,9 +202,9 @@ const GetPendingWithdrawalBundleResponse$json = {
 };
 
 /// Descriptor for `GetPendingWithdrawalBundleResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor =
-    $convert.base64Decode('CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
-        'gJUgpidW5kbGVKc29u');
+final $typed_data.Uint8List getPendingWithdrawalBundleResponseDescriptor = $convert.base64Decode(
+    'CiJHZXRQZW5kaW5nV2l0aGRyYXdhbEJ1bmRsZVJlc3BvbnNlEh8KC2J1bmRsZV9qc29uGAEgAS'
+    'gJUgpidW5kbGVKc29u');
 
 @$core.Deprecated('Use connectPeerRequestDescriptor instead')
 const ConnectPeerRequest$json = {
@@ -211,8 +215,8 @@ const ConnectPeerRequest$json = {
 };
 
 /// Descriptor for `ConnectPeerRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerRequestDescriptor =
-    $convert.base64Decode('ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+final $typed_data.Uint8List connectPeerRequestDescriptor = $convert.base64Decode(
+    'ChJDb25uZWN0UGVlclJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
 
 @$core.Deprecated('Use connectPeerResponseDescriptor instead')
 const ConnectPeerResponse$json = {
@@ -220,7 +224,8 @@ const ConnectPeerResponse$json = {
 };
 
 /// Descriptor for `ConnectPeerResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode('ChNDb25uZWN0UGVlclJlc3BvbnNl');
+final $typed_data.Uint8List connectPeerResponseDescriptor = $convert.base64Decode(
+    'ChNDb25uZWN0UGVlclJlc3BvbnNl');
 
 @$core.Deprecated('Use listPeersRequestDescriptor instead')
 const ListPeersRequest$json = {
@@ -228,7 +233,8 @@ const ListPeersRequest$json = {
 };
 
 /// Descriptor for `ListPeersRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode('ChBMaXN0UGVlcnNSZXF1ZXN0');
+final $typed_data.Uint8List listPeersRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0UGVlcnNSZXF1ZXN0');
 
 @$core.Deprecated('Use listPeersResponseDescriptor instead')
 const ListPeersResponse$json = {
@@ -239,8 +245,8 @@ const ListPeersResponse$json = {
 };
 
 /// Descriptor for `ListPeersResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPeersResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
+final $typed_data.Uint8List listPeersResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0UGVlcnNSZXNwb25zZRIdCgpwZWVyc19qc29uGAEgASgJUglwZWVyc0pzb24=');
 
 @$core.Deprecated('Use mineRequestDescriptor instead')
 const MineRequest$json = {
@@ -251,8 +257,8 @@ const MineRequest$json = {
 };
 
 /// Descriptor for `MineRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineRequestDescriptor =
-    $convert.base64Decode('CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
+final $typed_data.Uint8List mineRequestDescriptor = $convert.base64Decode(
+    'CgtNaW5lUmVxdWVzdBIZCghmZWVfc2F0cxgBIAEoA1IHZmVlU2F0cw==');
 
 @$core.Deprecated('Use mineResponseDescriptor instead')
 const MineResponse$json = {
@@ -263,8 +269,8 @@ const MineResponse$json = {
 };
 
 /// Descriptor for `MineResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineResponseDescriptor =
-    $convert.base64Decode('CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
+final $typed_data.Uint8List mineResponseDescriptor = $convert.base64Decode(
+    'CgxNaW5lUmVzcG9uc2USJgoPYm1tX3Jlc3VsdF9qc29uGAEgASgJUg1ibW1SZXN1bHRKc29u');
 
 @$core.Deprecated('Use getBlockRequestDescriptor instead')
 const GetBlockRequest$json = {
@@ -275,8 +281,8 @@ const GetBlockRequest$json = {
 };
 
 /// Descriptor for `GetBlockRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockRequestDescriptor =
-    $convert.base64Decode('Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
+final $typed_data.Uint8List getBlockRequestDescriptor = $convert.base64Decode(
+    'Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaA==');
 
 @$core.Deprecated('Use getBlockResponseDescriptor instead')
 const GetBlockResponse$json = {
@@ -287,8 +293,8 @@ const GetBlockResponse$json = {
 };
 
 /// Descriptor for `GetBlockResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBlockResponseDescriptor =
-    $convert.base64Decode('ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
+final $typed_data.Uint8List getBlockResponseDescriptor = $convert.base64Decode(
+    'ChBHZXRCbG9ja1Jlc3BvbnNlEh0KCmJsb2NrX2pzb24YASABKAlSCWJsb2NrSnNvbg==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashRequestDescriptor instead')
 const GetBestMainchainBlockHashRequest$json = {
@@ -296,8 +302,8 @@ const GetBestMainchainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestMainchainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestMainchainBlockHashResponseDescriptor instead')
 const GetBestMainchainBlockHashResponse$json = {
@@ -308,9 +314,9 @@ const GetBestMainchainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestMainchainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestMainchainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0TWFpbmNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashRequestDescriptor instead')
 const GetBestSidechainBlockHashRequest$json = {
@@ -318,8 +324,8 @@ const GetBestSidechainBlockHashRequest$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor =
-    $convert.base64Decode('CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
+final $typed_data.Uint8List getBestSidechainBlockHashRequestDescriptor = $convert.base64Decode(
+    'CiBHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVxdWVzdA==');
 
 @$core.Deprecated('Use getBestSidechainBlockHashResponseDescriptor instead')
 const GetBestSidechainBlockHashResponse$json = {
@@ -330,9 +336,9 @@ const GetBestSidechainBlockHashResponse$json = {
 };
 
 /// Descriptor for `GetBestSidechainBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor =
-    $convert.base64Decode('CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
-        '==');
+final $typed_data.Uint8List getBestSidechainBlockHashResponseDescriptor = $convert.base64Decode(
+    'CiFHZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNoUmVzcG9uc2USEgoEaGFzaBgBIAEoCVIEaGFzaA'
+    '==');
 
 @$core.Deprecated('Use getBmmInclusionsRequestDescriptor instead')
 const GetBmmInclusionsRequest$json = {
@@ -343,9 +349,9 @@ const GetBmmInclusionsRequest$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsRequestDescriptor =
-    $convert.base64Decode('ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
-        'g=');
+final $typed_data.Uint8List getBmmInclusionsRequestDescriptor = $convert.base64Decode(
+    'ChdHZXRCbW1JbmNsdXNpb25zUmVxdWVzdBIdCgpibG9ja19oYXNoGAEgASgJUglibG9ja0hhc2'
+    'g=');
 
 @$core.Deprecated('Use getBmmInclusionsResponseDescriptor instead')
 const GetBmmInclusionsResponse$json = {
@@ -356,9 +362,9 @@ const GetBmmInclusionsResponse$json = {
 };
 
 /// Descriptor for `GetBmmInclusionsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmInclusionsResponseDescriptor =
-    $convert.base64Decode('ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
-        '9ucw==');
+final $typed_data.Uint8List getBmmInclusionsResponseDescriptor = $convert.base64Decode(
+    'ChhHZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USHgoKaW5jbHVzaW9ucxgBIAEoCVIKaW5jbHVzaW'
+    '9ucw==');
 
 @$core.Deprecated('Use getWalletUtxosRequestDescriptor instead')
 const GetWalletUtxosRequest$json = {
@@ -366,7 +372,8 @@ const GetWalletUtxosRequest$json = {
 };
 
 /// Descriptor for `GetWalletUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode('ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
+final $typed_data.Uint8List getWalletUtxosRequestDescriptor = $convert.base64Decode(
+    'ChVHZXRXYWxsZXRVdHhvc1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getWalletUtxosResponseDescriptor instead')
 const GetWalletUtxosResponse$json = {
@@ -377,9 +384,9 @@ const GetWalletUtxosResponse$json = {
 };
 
 /// Descriptor for `GetWalletUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getWalletUtxosResponseDescriptor =
-    $convert.base64Decode('ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
-        '==');
+final $typed_data.Uint8List getWalletUtxosResponseDescriptor = $convert.base64Decode(
+    'ChZHZXRXYWxsZXRVdHhvc1Jlc3BvbnNlEh0KCnV0eG9zX2pzb24YASABKAlSCXV0eG9zSnNvbg'
+    '==');
 
 @$core.Deprecated('Use listUtxosRequestDescriptor instead')
 const ListUtxosRequest$json = {
@@ -387,7 +394,8 @@ const ListUtxosRequest$json = {
 };
 
 /// Descriptor for `ListUtxosRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode('ChBMaXN0VXR4b3NSZXF1ZXN0');
+final $typed_data.Uint8List listUtxosRequestDescriptor = $convert.base64Decode(
+    'ChBMaXN0VXR4b3NSZXF1ZXN0');
 
 @$core.Deprecated('Use listUtxosResponseDescriptor instead')
 const ListUtxosResponse$json = {
@@ -398,8 +406,8 @@ const ListUtxosResponse$json = {
 };
 
 /// Descriptor for `ListUtxosResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listUtxosResponseDescriptor =
-    $convert.base64Decode('ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
+final $typed_data.Uint8List listUtxosResponseDescriptor = $convert.base64Decode(
+    'ChFMaXN0VXR4b3NSZXNwb25zZRIdCgp1dHhvc19qc29uGAEgASgJUgl1dHhvc0pzb24=');
 
 @$core.Deprecated('Use removeFromMempoolRequestDescriptor instead')
 const RemoveFromMempoolRequest$json = {
@@ -410,8 +418,8 @@ const RemoveFromMempoolRequest$json = {
 };
 
 /// Descriptor for `RemoveFromMempoolRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFromMempoolRequestDescriptor =
-    $convert.base64Decode('ChhSZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List removeFromMempoolRequestDescriptor = $convert.base64Decode(
+    'ChhSZW1vdmVGcm9tTWVtcG9vbFJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use removeFromMempoolResponseDescriptor instead')
 const RemoveFromMempoolResponse$json = {
@@ -419,8 +427,8 @@ const RemoveFromMempoolResponse$json = {
 };
 
 /// Descriptor for `RemoveFromMempoolResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFromMempoolResponseDescriptor =
-    $convert.base64Decode('ChlSZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNl');
+final $typed_data.Uint8List removeFromMempoolResponseDescriptor = $convert.base64Decode(
+    'ChlSZW1vdmVGcm9tTWVtcG9vbFJlc3BvbnNl');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightRequestDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightRequest$json = {
@@ -428,8 +436,8 @@ const GetLatestFailedWithdrawalBundleHeightRequest$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor =
-    $convert.base64Decode('CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightRequestDescriptor = $convert.base64Decode(
+    'CixHZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdA==');
 
 @$core.Deprecated('Use getLatestFailedWithdrawalBundleHeightResponseDescriptor instead')
 const GetLatestFailedWithdrawalBundleHeightResponse$json = {
@@ -440,9 +448,9 @@ const GetLatestFailedWithdrawalBundleHeightResponse$json = {
 };
 
 /// Descriptor for `GetLatestFailedWithdrawalBundleHeightResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor =
-    $convert.base64Decode('Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
-        'h0GAEgASgDUgZoZWlnaHQ=');
+final $typed_data.Uint8List getLatestFailedWithdrawalBundleHeightResponseDescriptor = $convert.base64Decode(
+    'Ci1HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVzcG9uc2USFgoGaGVpZ2'
+    'h0GAEgASgDUgZoZWlnaHQ=');
 
 @$core.Deprecated('Use generateMnemonicRequestDescriptor instead')
 const GenerateMnemonicRequest$json = {
@@ -450,8 +458,8 @@ const GenerateMnemonicRequest$json = {
 };
 
 /// Descriptor for `GenerateMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicRequestDescriptor =
-    $convert.base64Decode('ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
+final $typed_data.Uint8List generateMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChdHZW5lcmF0ZU1uZW1vbmljUmVxdWVzdA==');
 
 @$core.Deprecated('Use generateMnemonicResponseDescriptor instead')
 const GenerateMnemonicResponse$json = {
@@ -462,8 +470,8 @@ const GenerateMnemonicResponse$json = {
 };
 
 /// Descriptor for `GenerateMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List generateMnemonicResponseDescriptor =
-    $convert.base64Decode('ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
+final $typed_data.Uint8List generateMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChhHZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USGgoIbW5lbW9uaWMYASABKAlSCG1uZW1vbmlj');
 
 @$core.Deprecated('Use setSeedFromMnemonicRequestDescriptor instead')
 const SetSeedFromMnemonicRequest$json = {
@@ -474,9 +482,9 @@ const SetSeedFromMnemonicRequest$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor =
-    $convert.base64Decode('ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
-        'M=');
+final $typed_data.Uint8List setSeedFromMnemonicRequestDescriptor = $convert.base64Decode(
+    'ChpTZXRTZWVkRnJvbU1uZW1vbmljUmVxdWVzdBIaCghtbmVtb25pYxgBIAEoCVIIbW5lbW9uaW'
+    'M=');
 
 @$core.Deprecated('Use setSeedFromMnemonicResponseDescriptor instead')
 const SetSeedFromMnemonicResponse$json = {
@@ -484,8 +492,8 @@ const SetSeedFromMnemonicResponse$json = {
 };
 
 /// Descriptor for `SetSeedFromMnemonicResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor =
-    $convert.base64Decode('ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
+final $typed_data.Uint8List setSeedFromMnemonicResponseDescriptor = $convert.base64Decode(
+    'ChtTZXRTZWVkRnJvbU1uZW1vbmljUmVzcG9uc2U=');
 
 @$core.Deprecated('Use callRawRequestDescriptor instead')
 const CallRawRequest$json = {
@@ -497,9 +505,9 @@ const CallRawRequest$json = {
 };
 
 /// Descriptor for `CallRawRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawRequestDescriptor =
-    $convert.base64Decode('Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
-        'gCIAEoCVIKcGFyYW1zSnNvbg==');
+final $typed_data.Uint8List callRawRequestDescriptor = $convert.base64Decode(
+    'Cg5DYWxsUmF3UmVxdWVzdBIWCgZtZXRob2QYASABKAlSBm1ldGhvZBIfCgtwYXJhbXNfanNvbh'
+    'gCIAEoCVIKcGFyYW1zSnNvbg==');
 
 @$core.Deprecated('Use callRawResponseDescriptor instead')
 const CallRawResponse$json = {
@@ -510,8 +518,8 @@ const CallRawResponse$json = {
 };
 
 /// Descriptor for `CallRawResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List callRawResponseDescriptor =
-    $convert.base64Decode('Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
+final $typed_data.Uint8List callRawResponseDescriptor = $convert.base64Decode(
+    'Cg9DYWxsUmF3UmVzcG9uc2USHwoLcmVzdWx0X2pzb24YASABKAlSCnJlc3VsdEpzb24=');
 
 @$core.Deprecated('Use getNewShieldedAddressRequestDescriptor instead')
 const GetNewShieldedAddressRequest$json = {
@@ -519,8 +527,8 @@ const GetNewShieldedAddressRequest$json = {
 };
 
 /// Descriptor for `GetNewShieldedAddressRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewShieldedAddressRequestDescriptor =
-    $convert.base64Decode('ChxHZXROZXdTaGllbGRlZEFkZHJlc3NSZXF1ZXN0');
+final $typed_data.Uint8List getNewShieldedAddressRequestDescriptor = $convert.base64Decode(
+    'ChxHZXROZXdTaGllbGRlZEFkZHJlc3NSZXF1ZXN0');
 
 @$core.Deprecated('Use getNewShieldedAddressResponseDescriptor instead')
 const GetNewShieldedAddressResponse$json = {
@@ -531,9 +539,9 @@ const GetNewShieldedAddressResponse$json = {
 };
 
 /// Descriptor for `GetNewShieldedAddressResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewShieldedAddressResponseDescriptor =
-    $convert.base64Decode('Ch1HZXROZXdTaGllbGRlZEFkZHJlc3NSZXNwb25zZRIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZX'
-        'Nz');
+final $typed_data.Uint8List getNewShieldedAddressResponseDescriptor = $convert.base64Decode(
+    'Ch1HZXROZXdTaGllbGRlZEFkZHJlc3NSZXNwb25zZRIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZX'
+    'Nz');
 
 @$core.Deprecated('Use getNewTransparentAddressRequestDescriptor instead')
 const GetNewTransparentAddressRequest$json = {
@@ -541,8 +549,8 @@ const GetNewTransparentAddressRequest$json = {
 };
 
 /// Descriptor for `GetNewTransparentAddressRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewTransparentAddressRequestDescriptor =
-    $convert.base64Decode('Ch9HZXROZXdUcmFuc3BhcmVudEFkZHJlc3NSZXF1ZXN0');
+final $typed_data.Uint8List getNewTransparentAddressRequestDescriptor = $convert.base64Decode(
+    'Ch9HZXROZXdUcmFuc3BhcmVudEFkZHJlc3NSZXF1ZXN0');
 
 @$core.Deprecated('Use getNewTransparentAddressResponseDescriptor instead')
 const GetNewTransparentAddressResponse$json = {
@@ -553,9 +561,9 @@ const GetNewTransparentAddressResponse$json = {
 };
 
 /// Descriptor for `GetNewTransparentAddressResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNewTransparentAddressResponseDescriptor =
-    $convert.base64Decode('CiBHZXROZXdUcmFuc3BhcmVudEFkZHJlc3NSZXNwb25zZRIYCgdhZGRyZXNzGAEgASgJUgdhZG'
-        'RyZXNz');
+final $typed_data.Uint8List getNewTransparentAddressResponseDescriptor = $convert.base64Decode(
+    'CiBHZXROZXdUcmFuc3BhcmVudEFkZHJlc3NSZXNwb25zZRIYCgdhZGRyZXNzGAEgASgJUgdhZG'
+    'RyZXNz');
 
 @$core.Deprecated('Use getShieldedWalletAddressesRequestDescriptor instead')
 const GetShieldedWalletAddressesRequest$json = {
@@ -563,8 +571,8 @@ const GetShieldedWalletAddressesRequest$json = {
 };
 
 /// Descriptor for `GetShieldedWalletAddressesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getShieldedWalletAddressesRequestDescriptor =
-    $convert.base64Decode('CiFHZXRTaGllbGRlZFdhbGxldEFkZHJlc3Nlc1JlcXVlc3Q=');
+final $typed_data.Uint8List getShieldedWalletAddressesRequestDescriptor = $convert.base64Decode(
+    'CiFHZXRTaGllbGRlZFdhbGxldEFkZHJlc3Nlc1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getShieldedWalletAddressesResponseDescriptor instead')
 const GetShieldedWalletAddressesResponse$json = {
@@ -575,9 +583,9 @@ const GetShieldedWalletAddressesResponse$json = {
 };
 
 /// Descriptor for `GetShieldedWalletAddressesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getShieldedWalletAddressesResponseDescriptor =
-    $convert.base64Decode('CiJHZXRTaGllbGRlZFdhbGxldEFkZHJlc3Nlc1Jlc3BvbnNlEhwKCWFkZHJlc3NlcxgBIAMoCV'
-        'IJYWRkcmVzc2Vz');
+final $typed_data.Uint8List getShieldedWalletAddressesResponseDescriptor = $convert.base64Decode(
+    'CiJHZXRTaGllbGRlZFdhbGxldEFkZHJlc3Nlc1Jlc3BvbnNlEhwKCWFkZHJlc3NlcxgBIAMoCV'
+    'IJYWRkcmVzc2Vz');
 
 @$core.Deprecated('Use getTransparentWalletAddressesRequestDescriptor instead')
 const GetTransparentWalletAddressesRequest$json = {
@@ -585,8 +593,8 @@ const GetTransparentWalletAddressesRequest$json = {
 };
 
 /// Descriptor for `GetTransparentWalletAddressesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getTransparentWalletAddressesRequestDescriptor =
-    $convert.base64Decode('CiRHZXRUcmFuc3BhcmVudFdhbGxldEFkZHJlc3Nlc1JlcXVlc3Q=');
+final $typed_data.Uint8List getTransparentWalletAddressesRequestDescriptor = $convert.base64Decode(
+    'CiRHZXRUcmFuc3BhcmVudFdhbGxldEFkZHJlc3Nlc1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getTransparentWalletAddressesResponseDescriptor instead')
 const GetTransparentWalletAddressesResponse$json = {
@@ -597,9 +605,9 @@ const GetTransparentWalletAddressesResponse$json = {
 };
 
 /// Descriptor for `GetTransparentWalletAddressesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getTransparentWalletAddressesResponseDescriptor =
-    $convert.base64Decode('CiVHZXRUcmFuc3BhcmVudFdhbGxldEFkZHJlc3Nlc1Jlc3BvbnNlEhwKCWFkZHJlc3NlcxgBIA'
-        'MoCVIJYWRkcmVzc2Vz');
+final $typed_data.Uint8List getTransparentWalletAddressesResponseDescriptor = $convert.base64Decode(
+    'CiVHZXRUcmFuc3BhcmVudFdhbGxldEFkZHJlc3Nlc1Jlc3BvbnNlEhwKCWFkZHJlc3NlcxgBIA'
+    'MoCVIJYWRkcmVzc2Vz');
 
 @$core.Deprecated('Use shieldRequestDescriptor instead')
 const ShieldRequest$json = {
@@ -611,9 +619,9 @@ const ShieldRequest$json = {
 };
 
 /// Descriptor for `ShieldRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List shieldRequestDescriptor =
-    $convert.base64Decode('Cg1TaGllbGRSZXF1ZXN0Eh8KC2Ftb3VudF9zYXRzGAEgASgDUgphbW91bnRTYXRzEhkKCGZlZV'
-        '9zYXRzGAIgASgDUgdmZWVTYXRz');
+final $typed_data.Uint8List shieldRequestDescriptor = $convert.base64Decode(
+    'Cg1TaGllbGRSZXF1ZXN0Eh8KC2Ftb3VudF9zYXRzGAEgASgDUgphbW91bnRTYXRzEhkKCGZlZV'
+    '9zYXRzGAIgASgDUgdmZWVTYXRz');
 
 @$core.Deprecated('Use shieldResponseDescriptor instead')
 const ShieldResponse$json = {
@@ -624,8 +632,8 @@ const ShieldResponse$json = {
 };
 
 /// Descriptor for `ShieldResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List shieldResponseDescriptor =
-    $convert.base64Decode('Cg5TaGllbGRSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
+final $typed_data.Uint8List shieldResponseDescriptor = $convert.base64Decode(
+    'Cg5TaGllbGRSZXNwb25zZRISCgR0eGlkGAEgASgJUgR0eGlk');
 
 @$core.Deprecated('Use unshieldRequestDescriptor instead')
 const UnshieldRequest$json = {
@@ -637,9 +645,9 @@ const UnshieldRequest$json = {
 };
 
 /// Descriptor for `UnshieldRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List unshieldRequestDescriptor =
-    $convert.base64Decode('Cg9VbnNoaWVsZFJlcXVlc3QSHwoLYW1vdW50X3NhdHMYASABKANSCmFtb3VudFNhdHMSGQoIZm'
-        'VlX3NhdHMYAiABKANSB2ZlZVNhdHM=');
+final $typed_data.Uint8List unshieldRequestDescriptor = $convert.base64Decode(
+    'Cg9VbnNoaWVsZFJlcXVlc3QSHwoLYW1vdW50X3NhdHMYASABKANSCmFtb3VudFNhdHMSGQoIZm'
+    'VlX3NhdHMYAiABKANSB2ZlZVNhdHM=');
 
 @$core.Deprecated('Use unshieldResponseDescriptor instead')
 const UnshieldResponse$json = {
@@ -650,8 +658,8 @@ const UnshieldResponse$json = {
 };
 
 /// Descriptor for `UnshieldResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List unshieldResponseDescriptor =
-    $convert.base64Decode('ChBVbnNoaWVsZFJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List unshieldResponseDescriptor = $convert.base64Decode(
+    'ChBVbnNoaWVsZFJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use shieldedTransferRequestDescriptor instead')
 const ShieldedTransferRequest$json = {
@@ -664,9 +672,9 @@ const ShieldedTransferRequest$json = {
 };
 
 /// Descriptor for `ShieldedTransferRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List shieldedTransferRequestDescriptor =
-    $convert.base64Decode('ChdTaGllbGRlZFRyYW5zZmVyUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh8KC2'
-        'Ftb3VudF9zYXRzGAIgASgDUgphbW91bnRTYXRzEhkKCGZlZV9zYXRzGAMgASgDUgdmZWVTYXRz');
+final $typed_data.Uint8List shieldedTransferRequestDescriptor = $convert.base64Decode(
+    'ChdTaGllbGRlZFRyYW5zZmVyUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh8KC2'
+    'Ftb3VudF9zYXRzGAIgASgDUgphbW91bnRTYXRzEhkKCGZlZV9zYXRzGAMgASgDUgdmZWVTYXRz');
 
 @$core.Deprecated('Use shieldedTransferResponseDescriptor instead')
 const ShieldedTransferResponse$json = {
@@ -677,8 +685,8 @@ const ShieldedTransferResponse$json = {
 };
 
 /// Descriptor for `ShieldedTransferResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List shieldedTransferResponseDescriptor =
-    $convert.base64Decode('ChhTaGllbGRlZFRyYW5zZmVyUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List shieldedTransferResponseDescriptor = $convert.base64Decode(
+    'ChhTaGllbGRlZFRyYW5zZmVyUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 @$core.Deprecated('Use transparentTransferRequestDescriptor instead')
 const TransparentTransferRequest$json = {
@@ -691,10 +699,10 @@ const TransparentTransferRequest$json = {
 };
 
 /// Descriptor for `TransparentTransferRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transparentTransferRequestDescriptor =
-    $convert.base64Decode('ChpUcmFuc3BhcmVudFRyYW5zZmVyUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh'
-        '8KC2Ftb3VudF9zYXRzGAIgASgDUgphbW91bnRTYXRzEhkKCGZlZV9zYXRzGAMgASgDUgdmZWVT'
-        'YXRz');
+final $typed_data.Uint8List transparentTransferRequestDescriptor = $convert.base64Decode(
+    'ChpUcmFuc3BhcmVudFRyYW5zZmVyUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEh'
+    '8KC2Ftb3VudF9zYXRzGAIgASgDUgphbW91bnRTYXRzEhkKCGZlZV9zYXRzGAMgASgDUgdmZWVT'
+    'YXRz');
 
 @$core.Deprecated('Use transparentTransferResponseDescriptor instead')
 const TransparentTransferResponse$json = {
@@ -705,8 +713,8 @@ const TransparentTransferResponse$json = {
 };
 
 /// Descriptor for `TransparentTransferResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transparentTransferResponseDescriptor =
-    $convert.base64Decode('ChtUcmFuc3BhcmVudFRyYW5zZmVyUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+final $typed_data.Uint8List transparentTransferResponseDescriptor = $convert.base64Decode(
+    'ChtUcmFuc3BhcmVudFRyYW5zZmVyUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
 
 const $core.Map<$core.String, $core.dynamic> ZSideServiceBase$json = {
   '1': 'ZSideService',
@@ -716,75 +724,31 @@ const $core.Map<$core.String, $core.dynamic> ZSideServiceBase$json = {
     {'1': 'Stop', '2': '.zside.v1.StopRequest', '3': '.zside.v1.StopResponse'},
     {'1': 'Withdraw', '2': '.zside.v1.WithdrawRequest', '3': '.zside.v1.WithdrawResponse'},
     {'1': 'Transfer', '2': '.zside.v1.TransferRequest', '3': '.zside.v1.TransferResponse'},
-    {
-      '1': 'GetSidechainWealth',
-      '2': '.zside.v1.GetSidechainWealthRequest',
-      '3': '.zside.v1.GetSidechainWealthResponse'
-    },
+    {'1': 'GetSidechainWealth', '2': '.zside.v1.GetSidechainWealthRequest', '3': '.zside.v1.GetSidechainWealthResponse'},
     {'1': 'CreateDeposit', '2': '.zside.v1.CreateDepositRequest', '3': '.zside.v1.CreateDepositResponse'},
-    {
-      '1': 'GetPendingWithdrawalBundle',
-      '2': '.zside.v1.GetPendingWithdrawalBundleRequest',
-      '3': '.zside.v1.GetPendingWithdrawalBundleResponse'
-    },
+    {'1': 'GetPendingWithdrawalBundle', '2': '.zside.v1.GetPendingWithdrawalBundleRequest', '3': '.zside.v1.GetPendingWithdrawalBundleResponse'},
     {'1': 'ConnectPeer', '2': '.zside.v1.ConnectPeerRequest', '3': '.zside.v1.ConnectPeerResponse'},
     {'1': 'ListPeers', '2': '.zside.v1.ListPeersRequest', '3': '.zside.v1.ListPeersResponse'},
     {'1': 'Mine', '2': '.zside.v1.MineRequest', '3': '.zside.v1.MineResponse'},
     {'1': 'GetBlock', '2': '.zside.v1.GetBlockRequest', '3': '.zside.v1.GetBlockResponse'},
-    {
-      '1': 'GetBestMainchainBlockHash',
-      '2': '.zside.v1.GetBestMainchainBlockHashRequest',
-      '3': '.zside.v1.GetBestMainchainBlockHashResponse'
-    },
-    {
-      '1': 'GetBestSidechainBlockHash',
-      '2': '.zside.v1.GetBestSidechainBlockHashRequest',
-      '3': '.zside.v1.GetBestSidechainBlockHashResponse'
-    },
+    {'1': 'GetBestMainchainBlockHash', '2': '.zside.v1.GetBestMainchainBlockHashRequest', '3': '.zside.v1.GetBestMainchainBlockHashResponse'},
+    {'1': 'GetBestSidechainBlockHash', '2': '.zside.v1.GetBestSidechainBlockHashRequest', '3': '.zside.v1.GetBestSidechainBlockHashResponse'},
     {'1': 'GetBmmInclusions', '2': '.zside.v1.GetBmmInclusionsRequest', '3': '.zside.v1.GetBmmInclusionsResponse'},
     {'1': 'GetWalletUtxos', '2': '.zside.v1.GetWalletUtxosRequest', '3': '.zside.v1.GetWalletUtxosResponse'},
     {'1': 'ListUtxos', '2': '.zside.v1.ListUtxosRequest', '3': '.zside.v1.ListUtxosResponse'},
     {'1': 'RemoveFromMempool', '2': '.zside.v1.RemoveFromMempoolRequest', '3': '.zside.v1.RemoveFromMempoolResponse'},
-    {
-      '1': 'GetLatestFailedWithdrawalBundleHeight',
-      '2': '.zside.v1.GetLatestFailedWithdrawalBundleHeightRequest',
-      '3': '.zside.v1.GetLatestFailedWithdrawalBundleHeightResponse'
-    },
+    {'1': 'GetLatestFailedWithdrawalBundleHeight', '2': '.zside.v1.GetLatestFailedWithdrawalBundleHeightRequest', '3': '.zside.v1.GetLatestFailedWithdrawalBundleHeightResponse'},
     {'1': 'GenerateMnemonic', '2': '.zside.v1.GenerateMnemonicRequest', '3': '.zside.v1.GenerateMnemonicResponse'},
-    {
-      '1': 'SetSeedFromMnemonic',
-      '2': '.zside.v1.SetSeedFromMnemonicRequest',
-      '3': '.zside.v1.SetSeedFromMnemonicResponse'
-    },
+    {'1': 'SetSeedFromMnemonic', '2': '.zside.v1.SetSeedFromMnemonicRequest', '3': '.zside.v1.SetSeedFromMnemonicResponse'},
     {'1': 'CallRaw', '2': '.zside.v1.CallRawRequest', '3': '.zside.v1.CallRawResponse'},
-    {
-      '1': 'GetNewShieldedAddress',
-      '2': '.zside.v1.GetNewShieldedAddressRequest',
-      '3': '.zside.v1.GetNewShieldedAddressResponse'
-    },
-    {
-      '1': 'GetNewTransparentAddress',
-      '2': '.zside.v1.GetNewTransparentAddressRequest',
-      '3': '.zside.v1.GetNewTransparentAddressResponse'
-    },
-    {
-      '1': 'GetShieldedWalletAddresses',
-      '2': '.zside.v1.GetShieldedWalletAddressesRequest',
-      '3': '.zside.v1.GetShieldedWalletAddressesResponse'
-    },
-    {
-      '1': 'GetTransparentWalletAddresses',
-      '2': '.zside.v1.GetTransparentWalletAddressesRequest',
-      '3': '.zside.v1.GetTransparentWalletAddressesResponse'
-    },
+    {'1': 'GetNewShieldedAddress', '2': '.zside.v1.GetNewShieldedAddressRequest', '3': '.zside.v1.GetNewShieldedAddressResponse'},
+    {'1': 'GetNewTransparentAddress', '2': '.zside.v1.GetNewTransparentAddressRequest', '3': '.zside.v1.GetNewTransparentAddressResponse'},
+    {'1': 'GetShieldedWalletAddresses', '2': '.zside.v1.GetShieldedWalletAddressesRequest', '3': '.zside.v1.GetShieldedWalletAddressesResponse'},
+    {'1': 'GetTransparentWalletAddresses', '2': '.zside.v1.GetTransparentWalletAddressesRequest', '3': '.zside.v1.GetTransparentWalletAddressesResponse'},
     {'1': 'Shield', '2': '.zside.v1.ShieldRequest', '3': '.zside.v1.ShieldResponse'},
     {'1': 'Unshield', '2': '.zside.v1.UnshieldRequest', '3': '.zside.v1.UnshieldResponse'},
     {'1': 'ShieldedTransfer', '2': '.zside.v1.ShieldedTransferRequest', '3': '.zside.v1.ShieldedTransferResponse'},
-    {
-      '1': 'TransparentTransfer',
-      '2': '.zside.v1.TransparentTransferRequest',
-      '3': '.zside.v1.TransparentTransferResponse'
-    },
+    {'1': 'TransparentTransfer', '2': '.zside.v1.TransparentTransferRequest', '3': '.zside.v1.TransparentTransferResponse'},
   ],
 };
 
@@ -853,53 +817,54 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> ZSideServi
 };
 
 /// Descriptor for `ZSideService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List zSideServiceDescriptor =
-    $convert.base64Decode('CgxaU2lkZVNlcnZpY2USRwoKR2V0QmFsYW5jZRIbLnpzaWRlLnYxLkdldEJhbGFuY2VSZXF1ZX'
-        'N0GhwuenNpZGUudjEuR2V0QmFsYW5jZVJlc3BvbnNlElAKDUdldEJsb2NrQ291bnQSHi56c2lk'
-        'ZS52MS5HZXRCbG9ja0NvdW50UmVxdWVzdBofLnpzaWRlLnYxLkdldEJsb2NrQ291bnRSZXNwb2'
-        '5zZRI1CgRTdG9wEhUuenNpZGUudjEuU3RvcFJlcXVlc3QaFi56c2lkZS52MS5TdG9wUmVzcG9u'
-        'c2USQQoIV2l0aGRyYXcSGS56c2lkZS52MS5XaXRoZHJhd1JlcXVlc3QaGi56c2lkZS52MS5XaX'
-        'RoZHJhd1Jlc3BvbnNlEkEKCFRyYW5zZmVyEhkuenNpZGUudjEuVHJhbnNmZXJSZXF1ZXN0Ghou'
-        'enNpZGUudjEuVHJhbnNmZXJSZXNwb25zZRJfChJHZXRTaWRlY2hhaW5XZWFsdGgSIy56c2lkZS'
-        '52MS5HZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0GiQuenNpZGUudjEuR2V0U2lkZWNoYWluV2Vh'
-        'bHRoUmVzcG9uc2USUAoNQ3JlYXRlRGVwb3NpdBIeLnpzaWRlLnYxLkNyZWF0ZURlcG9zaXRSZX'
-        'F1ZXN0Gh8uenNpZGUudjEuQ3JlYXRlRGVwb3NpdFJlc3BvbnNlEncKGkdldFBlbmRpbmdXaXRo'
-        'ZHJhd2FsQnVuZGxlEisuenNpZGUudjEuR2V0UGVuZGluZ1dpdGhkcmF3YWxCdW5kbGVSZXF1ZX'
-        'N0GiwuenNpZGUudjEuR2V0UGVuZGluZ1dpdGhkcmF3YWxCdW5kbGVSZXNwb25zZRJKCgtDb25u'
-        'ZWN0UGVlchIcLnpzaWRlLnYxLkNvbm5lY3RQZWVyUmVxdWVzdBodLnpzaWRlLnYxLkNvbm5lY3'
-        'RQZWVyUmVzcG9uc2USRAoJTGlzdFBlZXJzEhouenNpZGUudjEuTGlzdFBlZXJzUmVxdWVzdBob'
-        'LnpzaWRlLnYxLkxpc3RQZWVyc1Jlc3BvbnNlEjUKBE1pbmUSFS56c2lkZS52MS5NaW5lUmVxdW'
-        'VzdBoWLnpzaWRlLnYxLk1pbmVSZXNwb25zZRJBCghHZXRCbG9jaxIZLnpzaWRlLnYxLkdldEJs'
-        'b2NrUmVxdWVzdBoaLnpzaWRlLnYxLkdldEJsb2NrUmVzcG9uc2USdAoZR2V0QmVzdE1haW5jaG'
-        'FpbkJsb2NrSGFzaBIqLnpzaWRlLnYxLkdldEJlc3RNYWluY2hhaW5CbG9ja0hhc2hSZXF1ZXN0'
-        'GisuenNpZGUudjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFzaFJlc3BvbnNlEnQKGUdldEJlc3'
-        'RTaWRlY2hhaW5CbG9ja0hhc2gSKi56c2lkZS52MS5HZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNo'
-        'UmVxdWVzdBorLnpzaWRlLnYxLkdldEJlc3RTaWRlY2hhaW5CbG9ja0hhc2hSZXNwb25zZRJZCh'
-        'BHZXRCbW1JbmNsdXNpb25zEiEuenNpZGUudjEuR2V0Qm1tSW5jbHVzaW9uc1JlcXVlc3QaIi56'
-        'c2lkZS52MS5HZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USUwoOR2V0V2FsbGV0VXR4b3MSHy56c2'
-        'lkZS52MS5HZXRXYWxsZXRVdHhvc1JlcXVlc3QaIC56c2lkZS52MS5HZXRXYWxsZXRVdHhvc1Jl'
-        'c3BvbnNlEkQKCUxpc3RVdHhvcxIaLnpzaWRlLnYxLkxpc3RVdHhvc1JlcXVlc3QaGy56c2lkZS'
-        '52MS5MaXN0VXR4b3NSZXNwb25zZRJcChFSZW1vdmVGcm9tTWVtcG9vbBIiLnpzaWRlLnYxLlJl'
-        'bW92ZUZyb21NZW1wb29sUmVxdWVzdBojLnpzaWRlLnYxLlJlbW92ZUZyb21NZW1wb29sUmVzcG'
-        '9uc2USmAEKJUdldExhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHQSNi56c2lkZS52'
-        'MS5HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdBo3LnpzaWRlLn'
-        'YxLkdldExhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHRSZXNwb25zZRJZChBHZW5l'
-        'cmF0ZU1uZW1vbmljEiEuenNpZGUudjEuR2VuZXJhdGVNbmVtb25pY1JlcXVlc3QaIi56c2lkZS'
-        '52MS5HZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USYgoTU2V0U2VlZEZyb21NbmVtb25pYxIkLnpz'
-        'aWRlLnYxLlNldFNlZWRGcm9tTW5lbW9uaWNSZXF1ZXN0GiUuenNpZGUudjEuU2V0U2VlZEZyb2'
-        '1NbmVtb25pY1Jlc3BvbnNlEj4KB0NhbGxSYXcSGC56c2lkZS52MS5DYWxsUmF3UmVxdWVzdBoZ'
-        'LnpzaWRlLnYxLkNhbGxSYXdSZXNwb25zZRJoChVHZXROZXdTaGllbGRlZEFkZHJlc3MSJi56c2'
-        'lkZS52MS5HZXROZXdTaGllbGRlZEFkZHJlc3NSZXF1ZXN0GicuenNpZGUudjEuR2V0TmV3U2hp'
-        'ZWxkZWRBZGRyZXNzUmVzcG9uc2UScQoYR2V0TmV3VHJhbnNwYXJlbnRBZGRyZXNzEikuenNpZG'
-        'UudjEuR2V0TmV3VHJhbnNwYXJlbnRBZGRyZXNzUmVxdWVzdBoqLnpzaWRlLnYxLkdldE5ld1Ry'
-        'YW5zcGFyZW50QWRkcmVzc1Jlc3BvbnNlEncKGkdldFNoaWVsZGVkV2FsbGV0QWRkcmVzc2VzEi'
-        'suenNpZGUudjEuR2V0U2hpZWxkZWRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0GiwuenNpZGUudjEu'
-        'R2V0U2hpZWxkZWRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRKAAQodR2V0VHJhbnNwYXJlbnRXYW'
-        'xsZXRBZGRyZXNzZXMSLi56c2lkZS52MS5HZXRUcmFuc3BhcmVudFdhbGxldEFkZHJlc3Nlc1Jl'
-        'cXVlc3QaLy56c2lkZS52MS5HZXRUcmFuc3BhcmVudFdhbGxldEFkZHJlc3Nlc1Jlc3BvbnNlEj'
-        'sKBlNoaWVsZBIXLnpzaWRlLnYxLlNoaWVsZFJlcXVlc3QaGC56c2lkZS52MS5TaGllbGRSZXNw'
-        'b25zZRJBCghVbnNoaWVsZBIZLnpzaWRlLnYxLlVuc2hpZWxkUmVxdWVzdBoaLnpzaWRlLnYxLl'
-        'Vuc2hpZWxkUmVzcG9uc2USWQoQU2hpZWxkZWRUcmFuc2ZlchIhLnpzaWRlLnYxLlNoaWVsZGVk'
-        'VHJhbnNmZXJSZXF1ZXN0GiIuenNpZGUudjEuU2hpZWxkZWRUcmFuc2ZlclJlc3BvbnNlEmIKE1'
-        'RyYW5zcGFyZW50VHJhbnNmZXISJC56c2lkZS52MS5UcmFuc3BhcmVudFRyYW5zZmVyUmVxdWVz'
-        'dBolLnpzaWRlLnYxLlRyYW5zcGFyZW50VHJhbnNmZXJSZXNwb25zZQ==');
+final $typed_data.Uint8List zSideServiceDescriptor = $convert.base64Decode(
+    'CgxaU2lkZVNlcnZpY2USRwoKR2V0QmFsYW5jZRIbLnpzaWRlLnYxLkdldEJhbGFuY2VSZXF1ZX'
+    'N0GhwuenNpZGUudjEuR2V0QmFsYW5jZVJlc3BvbnNlElAKDUdldEJsb2NrQ291bnQSHi56c2lk'
+    'ZS52MS5HZXRCbG9ja0NvdW50UmVxdWVzdBofLnpzaWRlLnYxLkdldEJsb2NrQ291bnRSZXNwb2'
+    '5zZRI1CgRTdG9wEhUuenNpZGUudjEuU3RvcFJlcXVlc3QaFi56c2lkZS52MS5TdG9wUmVzcG9u'
+    'c2USQQoIV2l0aGRyYXcSGS56c2lkZS52MS5XaXRoZHJhd1JlcXVlc3QaGi56c2lkZS52MS5XaX'
+    'RoZHJhd1Jlc3BvbnNlEkEKCFRyYW5zZmVyEhkuenNpZGUudjEuVHJhbnNmZXJSZXF1ZXN0Ghou'
+    'enNpZGUudjEuVHJhbnNmZXJSZXNwb25zZRJfChJHZXRTaWRlY2hhaW5XZWFsdGgSIy56c2lkZS'
+    '52MS5HZXRTaWRlY2hhaW5XZWFsdGhSZXF1ZXN0GiQuenNpZGUudjEuR2V0U2lkZWNoYWluV2Vh'
+    'bHRoUmVzcG9uc2USUAoNQ3JlYXRlRGVwb3NpdBIeLnpzaWRlLnYxLkNyZWF0ZURlcG9zaXRSZX'
+    'F1ZXN0Gh8uenNpZGUudjEuQ3JlYXRlRGVwb3NpdFJlc3BvbnNlEncKGkdldFBlbmRpbmdXaXRo'
+    'ZHJhd2FsQnVuZGxlEisuenNpZGUudjEuR2V0UGVuZGluZ1dpdGhkcmF3YWxCdW5kbGVSZXF1ZX'
+    'N0GiwuenNpZGUudjEuR2V0UGVuZGluZ1dpdGhkcmF3YWxCdW5kbGVSZXNwb25zZRJKCgtDb25u'
+    'ZWN0UGVlchIcLnpzaWRlLnYxLkNvbm5lY3RQZWVyUmVxdWVzdBodLnpzaWRlLnYxLkNvbm5lY3'
+    'RQZWVyUmVzcG9uc2USRAoJTGlzdFBlZXJzEhouenNpZGUudjEuTGlzdFBlZXJzUmVxdWVzdBob'
+    'LnpzaWRlLnYxLkxpc3RQZWVyc1Jlc3BvbnNlEjUKBE1pbmUSFS56c2lkZS52MS5NaW5lUmVxdW'
+    'VzdBoWLnpzaWRlLnYxLk1pbmVSZXNwb25zZRJBCghHZXRCbG9jaxIZLnpzaWRlLnYxLkdldEJs'
+    'b2NrUmVxdWVzdBoaLnpzaWRlLnYxLkdldEJsb2NrUmVzcG9uc2USdAoZR2V0QmVzdE1haW5jaG'
+    'FpbkJsb2NrSGFzaBIqLnpzaWRlLnYxLkdldEJlc3RNYWluY2hhaW5CbG9ja0hhc2hSZXF1ZXN0'
+    'GisuenNpZGUudjEuR2V0QmVzdE1haW5jaGFpbkJsb2NrSGFzaFJlc3BvbnNlEnQKGUdldEJlc3'
+    'RTaWRlY2hhaW5CbG9ja0hhc2gSKi56c2lkZS52MS5HZXRCZXN0U2lkZWNoYWluQmxvY2tIYXNo'
+    'UmVxdWVzdBorLnpzaWRlLnYxLkdldEJlc3RTaWRlY2hhaW5CbG9ja0hhc2hSZXNwb25zZRJZCh'
+    'BHZXRCbW1JbmNsdXNpb25zEiEuenNpZGUudjEuR2V0Qm1tSW5jbHVzaW9uc1JlcXVlc3QaIi56'
+    'c2lkZS52MS5HZXRCbW1JbmNsdXNpb25zUmVzcG9uc2USUwoOR2V0V2FsbGV0VXR4b3MSHy56c2'
+    'lkZS52MS5HZXRXYWxsZXRVdHhvc1JlcXVlc3QaIC56c2lkZS52MS5HZXRXYWxsZXRVdHhvc1Jl'
+    'c3BvbnNlEkQKCUxpc3RVdHhvcxIaLnpzaWRlLnYxLkxpc3RVdHhvc1JlcXVlc3QaGy56c2lkZS'
+    '52MS5MaXN0VXR4b3NSZXNwb25zZRJcChFSZW1vdmVGcm9tTWVtcG9vbBIiLnpzaWRlLnYxLlJl'
+    'bW92ZUZyb21NZW1wb29sUmVxdWVzdBojLnpzaWRlLnYxLlJlbW92ZUZyb21NZW1wb29sUmVzcG'
+    '9uc2USmAEKJUdldExhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHQSNi56c2lkZS52'
+    'MS5HZXRMYXRlc3RGYWlsZWRXaXRoZHJhd2FsQnVuZGxlSGVpZ2h0UmVxdWVzdBo3LnpzaWRlLn'
+    'YxLkdldExhdGVzdEZhaWxlZFdpdGhkcmF3YWxCdW5kbGVIZWlnaHRSZXNwb25zZRJZChBHZW5l'
+    'cmF0ZU1uZW1vbmljEiEuenNpZGUudjEuR2VuZXJhdGVNbmVtb25pY1JlcXVlc3QaIi56c2lkZS'
+    '52MS5HZW5lcmF0ZU1uZW1vbmljUmVzcG9uc2USYgoTU2V0U2VlZEZyb21NbmVtb25pYxIkLnpz'
+    'aWRlLnYxLlNldFNlZWRGcm9tTW5lbW9uaWNSZXF1ZXN0GiUuenNpZGUudjEuU2V0U2VlZEZyb2'
+    '1NbmVtb25pY1Jlc3BvbnNlEj4KB0NhbGxSYXcSGC56c2lkZS52MS5DYWxsUmF3UmVxdWVzdBoZ'
+    'LnpzaWRlLnYxLkNhbGxSYXdSZXNwb25zZRJoChVHZXROZXdTaGllbGRlZEFkZHJlc3MSJi56c2'
+    'lkZS52MS5HZXROZXdTaGllbGRlZEFkZHJlc3NSZXF1ZXN0GicuenNpZGUudjEuR2V0TmV3U2hp'
+    'ZWxkZWRBZGRyZXNzUmVzcG9uc2UScQoYR2V0TmV3VHJhbnNwYXJlbnRBZGRyZXNzEikuenNpZG'
+    'UudjEuR2V0TmV3VHJhbnNwYXJlbnRBZGRyZXNzUmVxdWVzdBoqLnpzaWRlLnYxLkdldE5ld1Ry'
+    'YW5zcGFyZW50QWRkcmVzc1Jlc3BvbnNlEncKGkdldFNoaWVsZGVkV2FsbGV0QWRkcmVzc2VzEi'
+    'suenNpZGUudjEuR2V0U2hpZWxkZWRXYWxsZXRBZGRyZXNzZXNSZXF1ZXN0GiwuenNpZGUudjEu'
+    'R2V0U2hpZWxkZWRXYWxsZXRBZGRyZXNzZXNSZXNwb25zZRKAAQodR2V0VHJhbnNwYXJlbnRXYW'
+    'xsZXRBZGRyZXNzZXMSLi56c2lkZS52MS5HZXRUcmFuc3BhcmVudFdhbGxldEFkZHJlc3Nlc1Jl'
+    'cXVlc3QaLy56c2lkZS52MS5HZXRUcmFuc3BhcmVudFdhbGxldEFkZHJlc3Nlc1Jlc3BvbnNlEj'
+    'sKBlNoaWVsZBIXLnpzaWRlLnYxLlNoaWVsZFJlcXVlc3QaGC56c2lkZS52MS5TaGllbGRSZXNw'
+    'b25zZRJBCghVbnNoaWVsZBIZLnpzaWRlLnYxLlVuc2hpZWxkUmVxdWVzdBoaLnpzaWRlLnYxLl'
+    'Vuc2hpZWxkUmVzcG9uc2USWQoQU2hpZWxkZWRUcmFuc2ZlchIhLnpzaWRlLnYxLlNoaWVsZGVk'
+    'VHJhbnNmZXJSZXF1ZXN0GiIuenNpZGUudjEuU2hpZWxkZWRUcmFuc2ZlclJlc3BvbnNlEmIKE1'
+    'RyYW5zcGFyZW50VHJhbnNmZXISJC56c2lkZS52MS5UcmFuc3BhcmVudFRyYW5zZmVyUmVxdWVz'
+    'dBolLnpzaWRlLnYxLlRyYW5zcGFyZW50VHJhbnNmZXJSZXNwb25zZQ==');
+

--- a/sail_ui/lib/gen/zside/v1/zside.pbserver.dart
+++ b/sail_ui/lib/gen/zside/v1/zside.pbserver.dart
@@ -26,183 +26,105 @@ abstract class ZSideServiceBase extends $pb.GeneratedService {
   $async.Future<$14.StopResponse> stop($pb.ServerContext ctx, $14.StopRequest request);
   $async.Future<$14.WithdrawResponse> withdraw($pb.ServerContext ctx, $14.WithdrawRequest request);
   $async.Future<$14.TransferResponse> transfer($pb.ServerContext ctx, $14.TransferRequest request);
-  $async.Future<$14.GetSidechainWealthResponse> getSidechainWealth(
-      $pb.ServerContext ctx, $14.GetSidechainWealthRequest request);
+  $async.Future<$14.GetSidechainWealthResponse> getSidechainWealth($pb.ServerContext ctx, $14.GetSidechainWealthRequest request);
   $async.Future<$14.CreateDepositResponse> createDeposit($pb.ServerContext ctx, $14.CreateDepositRequest request);
-  $async.Future<$14.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle(
-      $pb.ServerContext ctx, $14.GetPendingWithdrawalBundleRequest request);
+  $async.Future<$14.GetPendingWithdrawalBundleResponse> getPendingWithdrawalBundle($pb.ServerContext ctx, $14.GetPendingWithdrawalBundleRequest request);
   $async.Future<$14.ConnectPeerResponse> connectPeer($pb.ServerContext ctx, $14.ConnectPeerRequest request);
   $async.Future<$14.ListPeersResponse> listPeers($pb.ServerContext ctx, $14.ListPeersRequest request);
   $async.Future<$14.MineResponse> mine($pb.ServerContext ctx, $14.MineRequest request);
   $async.Future<$14.GetBlockResponse> getBlock($pb.ServerContext ctx, $14.GetBlockRequest request);
-  $async.Future<$14.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash(
-      $pb.ServerContext ctx, $14.GetBestMainchainBlockHashRequest request);
-  $async.Future<$14.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash(
-      $pb.ServerContext ctx, $14.GetBestSidechainBlockHashRequest request);
-  $async.Future<$14.GetBmmInclusionsResponse> getBmmInclusions(
-      $pb.ServerContext ctx, $14.GetBmmInclusionsRequest request);
+  $async.Future<$14.GetBestMainchainBlockHashResponse> getBestMainchainBlockHash($pb.ServerContext ctx, $14.GetBestMainchainBlockHashRequest request);
+  $async.Future<$14.GetBestSidechainBlockHashResponse> getBestSidechainBlockHash($pb.ServerContext ctx, $14.GetBestSidechainBlockHashRequest request);
+  $async.Future<$14.GetBmmInclusionsResponse> getBmmInclusions($pb.ServerContext ctx, $14.GetBmmInclusionsRequest request);
   $async.Future<$14.GetWalletUtxosResponse> getWalletUtxos($pb.ServerContext ctx, $14.GetWalletUtxosRequest request);
   $async.Future<$14.ListUtxosResponse> listUtxos($pb.ServerContext ctx, $14.ListUtxosRequest request);
-  $async.Future<$14.RemoveFromMempoolResponse> removeFromMempool(
-      $pb.ServerContext ctx, $14.RemoveFromMempoolRequest request);
-  $async.Future<$14.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight(
-      $pb.ServerContext ctx, $14.GetLatestFailedWithdrawalBundleHeightRequest request);
-  $async.Future<$14.GenerateMnemonicResponse> generateMnemonic(
-      $pb.ServerContext ctx, $14.GenerateMnemonicRequest request);
-  $async.Future<$14.SetSeedFromMnemonicResponse> setSeedFromMnemonic(
-      $pb.ServerContext ctx, $14.SetSeedFromMnemonicRequest request);
+  $async.Future<$14.RemoveFromMempoolResponse> removeFromMempool($pb.ServerContext ctx, $14.RemoveFromMempoolRequest request);
+  $async.Future<$14.GetLatestFailedWithdrawalBundleHeightResponse> getLatestFailedWithdrawalBundleHeight($pb.ServerContext ctx, $14.GetLatestFailedWithdrawalBundleHeightRequest request);
+  $async.Future<$14.GenerateMnemonicResponse> generateMnemonic($pb.ServerContext ctx, $14.GenerateMnemonicRequest request);
+  $async.Future<$14.SetSeedFromMnemonicResponse> setSeedFromMnemonic($pb.ServerContext ctx, $14.SetSeedFromMnemonicRequest request);
   $async.Future<$14.CallRawResponse> callRaw($pb.ServerContext ctx, $14.CallRawRequest request);
-  $async.Future<$14.GetNewShieldedAddressResponse> getNewShieldedAddress(
-      $pb.ServerContext ctx, $14.GetNewShieldedAddressRequest request);
-  $async.Future<$14.GetNewTransparentAddressResponse> getNewTransparentAddress(
-      $pb.ServerContext ctx, $14.GetNewTransparentAddressRequest request);
-  $async.Future<$14.GetShieldedWalletAddressesResponse> getShieldedWalletAddresses(
-      $pb.ServerContext ctx, $14.GetShieldedWalletAddressesRequest request);
-  $async.Future<$14.GetTransparentWalletAddressesResponse> getTransparentWalletAddresses(
-      $pb.ServerContext ctx, $14.GetTransparentWalletAddressesRequest request);
+  $async.Future<$14.GetNewShieldedAddressResponse> getNewShieldedAddress($pb.ServerContext ctx, $14.GetNewShieldedAddressRequest request);
+  $async.Future<$14.GetNewTransparentAddressResponse> getNewTransparentAddress($pb.ServerContext ctx, $14.GetNewTransparentAddressRequest request);
+  $async.Future<$14.GetShieldedWalletAddressesResponse> getShieldedWalletAddresses($pb.ServerContext ctx, $14.GetShieldedWalletAddressesRequest request);
+  $async.Future<$14.GetTransparentWalletAddressesResponse> getTransparentWalletAddresses($pb.ServerContext ctx, $14.GetTransparentWalletAddressesRequest request);
   $async.Future<$14.ShieldResponse> shield($pb.ServerContext ctx, $14.ShieldRequest request);
   $async.Future<$14.UnshieldResponse> unshield($pb.ServerContext ctx, $14.UnshieldRequest request);
-  $async.Future<$14.ShieldedTransferResponse> shieldedTransfer(
-      $pb.ServerContext ctx, $14.ShieldedTransferRequest request);
-  $async.Future<$14.TransparentTransferResponse> transparentTransfer(
-      $pb.ServerContext ctx, $14.TransparentTransferRequest request);
+  $async.Future<$14.ShieldedTransferResponse> shieldedTransfer($pb.ServerContext ctx, $14.ShieldedTransferRequest request);
+  $async.Future<$14.TransparentTransferResponse> transparentTransfer($pb.ServerContext ctx, $14.TransparentTransferRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
-      case 'GetBalance':
-        return $14.GetBalanceRequest();
-      case 'GetBlockCount':
-        return $14.GetBlockCountRequest();
-      case 'Stop':
-        return $14.StopRequest();
-      case 'Withdraw':
-        return $14.WithdrawRequest();
-      case 'Transfer':
-        return $14.TransferRequest();
-      case 'GetSidechainWealth':
-        return $14.GetSidechainWealthRequest();
-      case 'CreateDeposit':
-        return $14.CreateDepositRequest();
-      case 'GetPendingWithdrawalBundle':
-        return $14.GetPendingWithdrawalBundleRequest();
-      case 'ConnectPeer':
-        return $14.ConnectPeerRequest();
-      case 'ListPeers':
-        return $14.ListPeersRequest();
-      case 'Mine':
-        return $14.MineRequest();
-      case 'GetBlock':
-        return $14.GetBlockRequest();
-      case 'GetBestMainchainBlockHash':
-        return $14.GetBestMainchainBlockHashRequest();
-      case 'GetBestSidechainBlockHash':
-        return $14.GetBestSidechainBlockHashRequest();
-      case 'GetBmmInclusions':
-        return $14.GetBmmInclusionsRequest();
-      case 'GetWalletUtxos':
-        return $14.GetWalletUtxosRequest();
-      case 'ListUtxos':
-        return $14.ListUtxosRequest();
-      case 'RemoveFromMempool':
-        return $14.RemoveFromMempoolRequest();
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return $14.GetLatestFailedWithdrawalBundleHeightRequest();
-      case 'GenerateMnemonic':
-        return $14.GenerateMnemonicRequest();
-      case 'SetSeedFromMnemonic':
-        return $14.SetSeedFromMnemonicRequest();
-      case 'CallRaw':
-        return $14.CallRawRequest();
-      case 'GetNewShieldedAddress':
-        return $14.GetNewShieldedAddressRequest();
-      case 'GetNewTransparentAddress':
-        return $14.GetNewTransparentAddressRequest();
-      case 'GetShieldedWalletAddresses':
-        return $14.GetShieldedWalletAddressesRequest();
-      case 'GetTransparentWalletAddresses':
-        return $14.GetTransparentWalletAddressesRequest();
-      case 'Shield':
-        return $14.ShieldRequest();
-      case 'Unshield':
-        return $14.UnshieldRequest();
-      case 'ShieldedTransfer':
-        return $14.ShieldedTransferRequest();
-      case 'TransparentTransfer':
-        return $14.TransparentTransferRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return $14.GetBalanceRequest();
+      case 'GetBlockCount': return $14.GetBlockCountRequest();
+      case 'Stop': return $14.StopRequest();
+      case 'Withdraw': return $14.WithdrawRequest();
+      case 'Transfer': return $14.TransferRequest();
+      case 'GetSidechainWealth': return $14.GetSidechainWealthRequest();
+      case 'CreateDeposit': return $14.CreateDepositRequest();
+      case 'GetPendingWithdrawalBundle': return $14.GetPendingWithdrawalBundleRequest();
+      case 'ConnectPeer': return $14.ConnectPeerRequest();
+      case 'ListPeers': return $14.ListPeersRequest();
+      case 'Mine': return $14.MineRequest();
+      case 'GetBlock': return $14.GetBlockRequest();
+      case 'GetBestMainchainBlockHash': return $14.GetBestMainchainBlockHashRequest();
+      case 'GetBestSidechainBlockHash': return $14.GetBestSidechainBlockHashRequest();
+      case 'GetBmmInclusions': return $14.GetBmmInclusionsRequest();
+      case 'GetWalletUtxos': return $14.GetWalletUtxosRequest();
+      case 'ListUtxos': return $14.ListUtxosRequest();
+      case 'RemoveFromMempool': return $14.RemoveFromMempoolRequest();
+      case 'GetLatestFailedWithdrawalBundleHeight': return $14.GetLatestFailedWithdrawalBundleHeightRequest();
+      case 'GenerateMnemonic': return $14.GenerateMnemonicRequest();
+      case 'SetSeedFromMnemonic': return $14.SetSeedFromMnemonicRequest();
+      case 'CallRaw': return $14.CallRawRequest();
+      case 'GetNewShieldedAddress': return $14.GetNewShieldedAddressRequest();
+      case 'GetNewTransparentAddress': return $14.GetNewTransparentAddressRequest();
+      case 'GetShieldedWalletAddresses': return $14.GetShieldedWalletAddressesRequest();
+      case 'GetTransparentWalletAddresses': return $14.GetTransparentWalletAddressesRequest();
+      case 'Shield': return $14.ShieldRequest();
+      case 'Unshield': return $14.UnshieldRequest();
+      case 'ShieldedTransfer': return $14.ShieldedTransferRequest();
+      case 'TransparentTransfer': return $14.TransparentTransferRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall(
-      $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
-      case 'GetBalance':
-        return this.getBalance(ctx, request as $14.GetBalanceRequest);
-      case 'GetBlockCount':
-        return this.getBlockCount(ctx, request as $14.GetBlockCountRequest);
-      case 'Stop':
-        return this.stop(ctx, request as $14.StopRequest);
-      case 'Withdraw':
-        return this.withdraw(ctx, request as $14.WithdrawRequest);
-      case 'Transfer':
-        return this.transfer(ctx, request as $14.TransferRequest);
-      case 'GetSidechainWealth':
-        return this.getSidechainWealth(ctx, request as $14.GetSidechainWealthRequest);
-      case 'CreateDeposit':
-        return this.createDeposit(ctx, request as $14.CreateDepositRequest);
-      case 'GetPendingWithdrawalBundle':
-        return this.getPendingWithdrawalBundle(ctx, request as $14.GetPendingWithdrawalBundleRequest);
-      case 'ConnectPeer':
-        return this.connectPeer(ctx, request as $14.ConnectPeerRequest);
-      case 'ListPeers':
-        return this.listPeers(ctx, request as $14.ListPeersRequest);
-      case 'Mine':
-        return this.mine(ctx, request as $14.MineRequest);
-      case 'GetBlock':
-        return this.getBlock(ctx, request as $14.GetBlockRequest);
-      case 'GetBestMainchainBlockHash':
-        return this.getBestMainchainBlockHash(ctx, request as $14.GetBestMainchainBlockHashRequest);
-      case 'GetBestSidechainBlockHash':
-        return this.getBestSidechainBlockHash(ctx, request as $14.GetBestSidechainBlockHashRequest);
-      case 'GetBmmInclusions':
-        return this.getBmmInclusions(ctx, request as $14.GetBmmInclusionsRequest);
-      case 'GetWalletUtxos':
-        return this.getWalletUtxos(ctx, request as $14.GetWalletUtxosRequest);
-      case 'ListUtxos':
-        return this.listUtxos(ctx, request as $14.ListUtxosRequest);
-      case 'RemoveFromMempool':
-        return this.removeFromMempool(ctx, request as $14.RemoveFromMempoolRequest);
-      case 'GetLatestFailedWithdrawalBundleHeight':
-        return this
-            .getLatestFailedWithdrawalBundleHeight(ctx, request as $14.GetLatestFailedWithdrawalBundleHeightRequest);
-      case 'GenerateMnemonic':
-        return this.generateMnemonic(ctx, request as $14.GenerateMnemonicRequest);
-      case 'SetSeedFromMnemonic':
-        return this.setSeedFromMnemonic(ctx, request as $14.SetSeedFromMnemonicRequest);
-      case 'CallRaw':
-        return this.callRaw(ctx, request as $14.CallRawRequest);
-      case 'GetNewShieldedAddress':
-        return this.getNewShieldedAddress(ctx, request as $14.GetNewShieldedAddressRequest);
-      case 'GetNewTransparentAddress':
-        return this.getNewTransparentAddress(ctx, request as $14.GetNewTransparentAddressRequest);
-      case 'GetShieldedWalletAddresses':
-        return this.getShieldedWalletAddresses(ctx, request as $14.GetShieldedWalletAddressesRequest);
-      case 'GetTransparentWalletAddresses':
-        return this.getTransparentWalletAddresses(ctx, request as $14.GetTransparentWalletAddressesRequest);
-      case 'Shield':
-        return this.shield(ctx, request as $14.ShieldRequest);
-      case 'Unshield':
-        return this.unshield(ctx, request as $14.UnshieldRequest);
-      case 'ShieldedTransfer':
-        return this.shieldedTransfer(ctx, request as $14.ShieldedTransferRequest);
-      case 'TransparentTransfer':
-        return this.transparentTransfer(ctx, request as $14.TransparentTransferRequest);
-      default:
-        throw $core.ArgumentError('Unknown method: $methodName');
+      case 'GetBalance': return this.getBalance(ctx, request as $14.GetBalanceRequest);
+      case 'GetBlockCount': return this.getBlockCount(ctx, request as $14.GetBlockCountRequest);
+      case 'Stop': return this.stop(ctx, request as $14.StopRequest);
+      case 'Withdraw': return this.withdraw(ctx, request as $14.WithdrawRequest);
+      case 'Transfer': return this.transfer(ctx, request as $14.TransferRequest);
+      case 'GetSidechainWealth': return this.getSidechainWealth(ctx, request as $14.GetSidechainWealthRequest);
+      case 'CreateDeposit': return this.createDeposit(ctx, request as $14.CreateDepositRequest);
+      case 'GetPendingWithdrawalBundle': return this.getPendingWithdrawalBundle(ctx, request as $14.GetPendingWithdrawalBundleRequest);
+      case 'ConnectPeer': return this.connectPeer(ctx, request as $14.ConnectPeerRequest);
+      case 'ListPeers': return this.listPeers(ctx, request as $14.ListPeersRequest);
+      case 'Mine': return this.mine(ctx, request as $14.MineRequest);
+      case 'GetBlock': return this.getBlock(ctx, request as $14.GetBlockRequest);
+      case 'GetBestMainchainBlockHash': return this.getBestMainchainBlockHash(ctx, request as $14.GetBestMainchainBlockHashRequest);
+      case 'GetBestSidechainBlockHash': return this.getBestSidechainBlockHash(ctx, request as $14.GetBestSidechainBlockHashRequest);
+      case 'GetBmmInclusions': return this.getBmmInclusions(ctx, request as $14.GetBmmInclusionsRequest);
+      case 'GetWalletUtxos': return this.getWalletUtxos(ctx, request as $14.GetWalletUtxosRequest);
+      case 'ListUtxos': return this.listUtxos(ctx, request as $14.ListUtxosRequest);
+      case 'RemoveFromMempool': return this.removeFromMempool(ctx, request as $14.RemoveFromMempoolRequest);
+      case 'GetLatestFailedWithdrawalBundleHeight': return this.getLatestFailedWithdrawalBundleHeight(ctx, request as $14.GetLatestFailedWithdrawalBundleHeightRequest);
+      case 'GenerateMnemonic': return this.generateMnemonic(ctx, request as $14.GenerateMnemonicRequest);
+      case 'SetSeedFromMnemonic': return this.setSeedFromMnemonic(ctx, request as $14.SetSeedFromMnemonicRequest);
+      case 'CallRaw': return this.callRaw(ctx, request as $14.CallRawRequest);
+      case 'GetNewShieldedAddress': return this.getNewShieldedAddress(ctx, request as $14.GetNewShieldedAddressRequest);
+      case 'GetNewTransparentAddress': return this.getNewTransparentAddress(ctx, request as $14.GetNewTransparentAddressRequest);
+      case 'GetShieldedWalletAddresses': return this.getShieldedWalletAddresses(ctx, request as $14.GetShieldedWalletAddressesRequest);
+      case 'GetTransparentWalletAddresses': return this.getTransparentWalletAddresses(ctx, request as $14.GetTransparentWalletAddressesRequest);
+      case 'Shield': return this.shield(ctx, request as $14.ShieldRequest);
+      case 'Unshield': return this.unshield(ctx, request as $14.UnshieldRequest);
+      case 'ShieldedTransfer': return this.shieldedTransfer(ctx, request as $14.ShieldedTransferRequest);
+      case 'TransparentTransfer': return this.transparentTransfer(ctx, request as $14.TransparentTransferRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => ZSideServiceBase$json;
   $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => ZSideServiceBase$messageJson;
 }
+

--- a/sail_ui/lib/mocks/mocks.dart
+++ b/sail_ui/lib/mocks/mocks.dart
@@ -58,7 +58,7 @@ class MockBitcoindConnection extends BitcoindConnection {
 }
 
 class MockEnforcerRPC extends EnforcerRPC {
-  MockEnforcerRPC() : super(binaryType: BinaryType.enforcer);
+  MockEnforcerRPC() : super(binaryType: BinaryType.BINARY_TYPE_ENFORCER);
 
   bool _connected = false;
   bool _initializing = false;
@@ -145,7 +145,7 @@ class MockEnforcerRPC extends EnforcerRPC {
 }
 
 class MockBitwindowRPC extends BitwindowRPC {
-  MockBitwindowRPC() : super(binaryType: BinaryType.bitWindow);
+  MockBitwindowRPC() : super(binaryType: BinaryType.BINARY_TYPE_BITWINDOWD);
 
   bool _connected = false;
   bool _initializing = false;
@@ -233,7 +233,7 @@ class MockBitwindowRPC extends BitwindowRPC {
 }
 
 class MockThunderRPC extends ThunderRPC {
-  MockThunderRPC() : super(binaryType: BinaryType.thunder);
+  MockThunderRPC() : super(binaryType: BinaryType.BINARY_TYPE_THUNDER);
 
   bool _connected = false;
   bool _initializing = false;
@@ -423,7 +423,7 @@ class MockThunderRPC extends ThunderRPC {
 }
 
 class MockTruthcoinRPC extends TruthcoinRPC {
-  MockTruthcoinRPC() : super(binaryType: BinaryType.truthcoin);
+  MockTruthcoinRPC() : super(binaryType: BinaryType.BINARY_TYPE_TRUTHCOIN);
 
   bool _connected = false;
   bool _initializing = false;
@@ -868,7 +868,7 @@ class MockTruthcoinRPC extends TruthcoinRPC {
 }
 
 class MockPhotonRPC extends PhotonRPC {
-  MockPhotonRPC() : super(binaryType: BinaryType.photon);
+  MockPhotonRPC() : super(binaryType: BinaryType.BINARY_TYPE_PHOTON);
 
   bool _connected = false;
   bool _initializing = false;
@@ -1068,7 +1068,7 @@ class MockPhotonRPC extends PhotonRPC {
 }
 
 class MockBitnamesRPC extends BitnamesRPC {
-  MockBitnamesRPC() : super(binaryType: BinaryType.bitnames);
+  MockBitnamesRPC() : super(binaryType: BinaryType.BINARY_TYPE_BITNAMES);
 
   bool _connected = false;
   bool _initializing = false;
@@ -1383,7 +1383,7 @@ class MockBitnamesRPC extends BitnamesRPC {
 }
 
 class MockCoinShiftRPC extends CoinShiftRPC {
-  MockCoinShiftRPC() : super(binaryType: BinaryType.coinShift);
+  MockCoinShiftRPC() : super(binaryType: BinaryType.BINARY_TYPE_COINSHIFT);
 
   bool _connected = false;
   bool _initializing = false;
@@ -1728,7 +1728,7 @@ class MockSyncProvider implements SyncProvider {
 class MockBinary extends Binary {
   final BinaryType _type;
 
-  MockBinary({BinaryType type = BinaryType.bitWindow})
+  MockBinary({BinaryType type = BinaryType.BINARY_TYPE_BITWINDOWD})
     : _type = type,
       super(
         name: _binaryTypeName(type),
@@ -1790,32 +1790,35 @@ class MockBinary extends Binary {
 
 String _binaryTypeName(BinaryType type) {
   switch (type) {
-    case BinaryType.bitcoinCore:
+    case BinaryType.BINARY_TYPE_BITCOIND:
       return 'Bitcoin Core';
-    case BinaryType.enforcer:
+    case BinaryType.BINARY_TYPE_ENFORCER:
       return 'Enforcer';
-    case BinaryType.bitWindow:
+    case BinaryType.BINARY_TYPE_BITWINDOWD:
       return 'BitWindow';
-    case BinaryType.thunder:
+    case BinaryType.BINARY_TYPE_THUNDER:
       return 'Thunder';
-    case BinaryType.bitnames:
+    case BinaryType.BINARY_TYPE_BITNAMES:
       return 'Bitnames';
-    case BinaryType.bitassets:
+    case BinaryType.BINARY_TYPE_BITASSETS:
       return 'BitAssets';
-    case BinaryType.zSide:
+    case BinaryType.BINARY_TYPE_ZSIDE:
       return 'zSide';
-    case BinaryType.grpcurl:
+    case BinaryType.BINARY_TYPE_GRPCURL:
       return 'grpcurl';
-    case BinaryType.photon:
+    case BinaryType.BINARY_TYPE_PHOTON:
       return 'Photon';
-    case BinaryType.truthcoin:
+    case BinaryType.BINARY_TYPE_TRUTHCOIN:
       return 'Truthcoin';
-    case BinaryType.coinShift:
+    case BinaryType.BINARY_TYPE_COINSHIFT:
       return 'CoinShift';
-    case BinaryType.orchestratord:
+    case BinaryType.BINARY_TYPE_ORCHESTRATORD:
       return 'Orchestratord';
-    case BinaryType.zSided:
+    case BinaryType.BINARY_TYPE_ZSIDED:
       return 'ZSided';
+    case BinaryType.BINARY_TYPE_UNSPECIFIED:
+    default:
+      throw StateError('unsupported BinaryType: $type');
   }
 }
 
@@ -1825,14 +1828,14 @@ class MockBinaryProvider extends BinaryProvider {
     : super.test(
         appDir: Directory('/tmp'),
         binaries: [
-          MockBinary(type: BinaryType.bitWindow),
-          MockBinary(type: BinaryType.zSide),
-          MockBinary(type: BinaryType.thunder),
-          MockBinary(type: BinaryType.truthcoin),
-          MockBinary(type: BinaryType.photon),
-          MockBinary(type: BinaryType.bitnames),
-          MockBinary(type: BinaryType.bitassets),
-          MockBinary(type: BinaryType.coinShift),
+          MockBinary(type: BinaryType.BINARY_TYPE_BITWINDOWD),
+          MockBinary(type: BinaryType.BINARY_TYPE_ZSIDE),
+          MockBinary(type: BinaryType.BINARY_TYPE_THUNDER),
+          MockBinary(type: BinaryType.BINARY_TYPE_TRUTHCOIN),
+          MockBinary(type: BinaryType.BINARY_TYPE_PHOTON),
+          MockBinary(type: BinaryType.BINARY_TYPE_BITNAMES),
+          MockBinary(type: BinaryType.BINARY_TYPE_BITASSETS),
+          MockBinary(type: BinaryType.BINARY_TYPE_COINSHIFT),
         ],
       );
 

--- a/sail_ui/lib/models/wallet_data.dart
+++ b/sail_ui/lib/models/wallet_data.dart
@@ -59,9 +59,9 @@ class WalletData {
     final walletType = walletTypeStr != null
         ? BinaryType.values.firstWhere(
             (e) => e.name == walletTypeStr,
-            orElse: () => BinaryType.bitcoinCore,
+            orElse: () => BinaryType.BINARY_TYPE_BITCOIND,
           )
-        : BinaryType.bitcoinCore;
+        : BinaryType.BINARY_TYPE_BITCOIND;
 
     return WalletData(
       version: json['version'] as int? ?? 1,

--- a/sail_ui/lib/providers/backend_state_provider.dart
+++ b/sail_ui/lib/providers/backend_state_provider.dart
@@ -5,7 +5,6 @@ import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:sail_ui/classes/rpc_connection.dart';
-import 'package:sail_ui/config/binaries.dart';
 import 'package:sail_ui/gen/orchestrator/v1/orchestrator.pb.dart';
 import 'package:sail_ui/providers/binaries/binary_provider.dart';
 import 'package:sail_ui/rpcs/bitassets_rpc.dart';
@@ -163,26 +162,26 @@ class BackendStateProvider extends ChangeNotifier {
   BinaryType? _binaryTypeFromName(String name) {
     switch (name) {
       case 'bitcoind':
-        return BinaryType.bitcoinCore;
+        return BinaryType.BINARY_TYPE_BITCOIND;
       case 'enforcer':
-        return BinaryType.enforcer;
+        return BinaryType.BINARY_TYPE_ENFORCER;
       case 'thunder':
-        return BinaryType.thunder;
+        return BinaryType.BINARY_TYPE_THUNDER;
       case 'zside':
-        return BinaryType.zSide;
+        return BinaryType.BINARY_TYPE_ZSIDE;
       case 'bitwindow':
       case 'bitwindowd':
-        return BinaryType.bitWindow;
+        return BinaryType.BINARY_TYPE_BITWINDOWD;
       case 'bitnames':
-        return BinaryType.bitnames;
+        return BinaryType.BINARY_TYPE_BITNAMES;
       case 'bitassets':
-        return BinaryType.bitassets;
+        return BinaryType.BINARY_TYPE_BITASSETS;
       case 'truthcoin':
-        return BinaryType.truthcoin;
+        return BinaryType.BINARY_TYPE_TRUTHCOIN;
       case 'photon':
-        return BinaryType.photon;
+        return BinaryType.BINARY_TYPE_PHOTON;
       case 'coinshift':
-        return BinaryType.coinShift;
+        return BinaryType.BINARY_TYPE_COINSHIFT;
       default:
         return null;
     }

--- a/sail_ui/lib/providers/download_provider.dart
+++ b/sail_ui/lib/providers/download_provider.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/env.dart';
+import 'package:sail_ui/gen/orchestrator/v1/orchestrator.pb.dart' as orch_pb;
+import 'package:sail_ui/sail_ui.dart';
+
+/// Snapshot of one binary's download progress, in the units the orchestrator
+/// stores it in (megabytes). [mbTotal] is `-1` while the server hasn't
+/// reported a Content-Length yet — UIs should render that as "size unknown".
+class DownloadProgress {
+  final BinaryType binary;
+  final int mbDownloaded;
+  final int mbTotal;
+  final String message;
+
+  const DownloadProgress({
+    required this.binary,
+    required this.mbDownloaded,
+    required this.mbTotal,
+    this.message = '',
+  });
+
+  /// Fraction in [0, 1]; falls back to 0 when total is unknown so the UI
+  /// can still show an indeterminate state instead of a NaN bar.
+  double get progressFraction {
+    if (mbTotal <= 0) return 0;
+    final f = mbDownloaded / mbTotal;
+    if (f.isNaN || f.isInfinite) return 0;
+    return f.clamp(0.0, 1.0);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is DownloadProgress &&
+      other.binary == binary &&
+      other.mbDownloaded == mbDownloaded &&
+      other.mbTotal == mbTotal &&
+      other.message == message;
+
+  @override
+  int get hashCode => Object.hash(binary, mbDownloaded, mbTotal, message);
+}
+
+/// Polls the orchestrator's [getDownloadStatus] RPC and surfaces a per-binary
+/// snapshot. Cadence is fast (100 ms) while at least one entry is in flight,
+/// then drops to 2 s once the response is empty — the call is cheap because
+/// the orchestrator just reads its in-memory DownloadManager map. Daemon
+/// cards consult this provider before falling back to [SyncProvider]'s sync
+/// state, so a live download always shows instantly.
+class DownloadProvider extends ChangeNotifier {
+  static const Duration AGGRESSIVE_INTERVAL = Duration(milliseconds: 100);
+  static const Duration PASSIVE_INTERVAL = Duration(seconds: 2);
+
+  Logger get _log => GetIt.I.get<Logger>();
+  OrchestratorRPC get _orchestrator => GetIt.I.get<OrchestratorRPC>();
+
+  Map<BinaryType, DownloadProgress> _downloads = const {};
+  String? _lastError;
+  Timer? _timer;
+  bool _isFetching = false;
+  Duration _currentInterval = AGGRESSIVE_INTERVAL;
+
+  Map<BinaryType, DownloadProgress> get downloads => _downloads;
+  String? get lastError => _lastError;
+
+  /// True when at least one binary is being fetched. Drives the daemon card
+  /// priority: download UI wins over sync UI whenever this returns true for
+  /// the binary in question (see [statusFor]).
+  bool get hasActiveDownloads => _downloads.isNotEmpty;
+
+  /// Looks up the live download for [binary], or null if nothing's in
+  /// flight for that binary.
+  DownloadProgress? statusFor(BinaryType binary) => _downloads[binary];
+
+  DownloadProvider({bool startTimer = true}) {
+    if (startTimer && !Environment.isInTest) {
+      _scheduleNextTick();
+      fetch();
+    }
+  }
+
+  void _scheduleNextTick() {
+    _timer?.cancel();
+    _timer = Timer.periodic(_currentInterval, (_) => _tick());
+  }
+
+  Future<void> _tick() async {
+    if (_isFetching) return;
+    _isFetching = true;
+    try {
+      await fetch();
+      final nextInterval = hasActiveDownloads ? AGGRESSIVE_INTERVAL : PASSIVE_INTERVAL;
+      if (nextInterval != _currentInterval) {
+        _currentInterval = nextInterval;
+        _scheduleNextTick();
+      }
+    } catch (_) {
+      // fetch() already records the error
+    } finally {
+      _isFetching = false;
+    }
+  }
+
+  /// One-shot fetch. Public so callers (e.g. test harnesses, manual refresh
+  /// buttons) can trigger an update without waiting for the timer.
+  Future<void> fetch() async {
+    try {
+      final resp = await _orchestrator.getDownloadStatus();
+      final next = <BinaryType, DownloadProgress>{};
+      for (final s in resp.downloads) {
+        if (s.binary == BinaryType.BINARY_TYPE_UNSPECIFIED) continue;
+        next[s.binary] = DownloadProgress(
+          binary: s.binary,
+          mbDownloaded: s.mbDownloaded.toInt(),
+          mbTotal: s.mbTotal.toInt(),
+          message: s.message,
+        );
+      }
+      _downloads = next;
+      _lastError = null;
+      notifyListeners();
+    } catch (e) {
+      _log.e('DownloadProvider: getDownloadStatus failed: $e');
+      _lastError = e.toString();
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+}
+
+// Keep the orch_pb alias used so the analyzer doesn't strip the import; the
+// proto type surfaces only via the typed RPC return value.
+// ignore: unused_element
+typedef _OrchAlias = orch_pb.GetDownloadStatusResponse;

--- a/sail_ui/lib/providers/sync_provider.dart
+++ b/sail_ui/lib/providers/sync_provider.dart
@@ -9,30 +9,20 @@ import 'package:sail_ui/gen/google/protobuf/timestamp.pb.dart';
 import 'package:sail_ui/gen/orchestrator/v1/orchestrator.pb.dart' as orch_pb;
 import 'package:sail_ui/sail_ui.dart';
 
-/// Detailed sync info for one chain. While downloading, progressCurrent /
-/// progressGoal are MB downloaded / MB total — the same fields used for
-/// blocks/headers when synced. The UI uses [DownloadInfo.isDownloading] to
-/// pick the right label ("MB" vs "blocks").
+/// Detailed sync info for one chain. progressCurrent / progressGoal are
+/// chain heights — download progress lives in [DownloadProvider], not here.
 class SyncInfo {
   final double progressCurrent;
   final double progressGoal;
   final Timestamp? lastBlockAt;
-  final DownloadInfo downloadInfo;
 
-  // progress returns the download progress if it's currently downloading, else
-  // the blockchain sync progress compared to headers
-  double get progress => downloadInfo.progressPercent < 1
-      ? downloadInfo.progressPercent
-      : progressGoal == 0
-      ? 0
-      : progressCurrent / progressGoal;
+  double get progress => progressGoal == 0 ? 0 : progressCurrent / progressGoal;
   bool get isSynced => progressGoal > 0 && progressCurrent == progressGoal;
 
   SyncInfo({
     required this.progressCurrent,
     required this.progressGoal,
     required this.lastBlockAt,
-    required this.downloadInfo,
   });
 
   @override
@@ -41,10 +31,7 @@ class SyncInfo {
     return other is SyncInfo &&
         other.progressCurrent == progressCurrent &&
         other.progressGoal == progressGoal &&
-        other.lastBlockAt == lastBlockAt &&
-        other.progress == progress &&
-        other.isSynced == isSynced &&
-        other.downloadInfo.toString() == downloadInfo.toString();
+        other.lastBlockAt == lastBlockAt;
   }
 
   @override
@@ -61,12 +48,11 @@ class SyncConnection {
 
 /// Polls a single orchestrator RPC (`GetSyncStatus`) for an atomic snapshot
 /// of mainchain + enforcer + every known sidechain (including bitwindowd).
-/// One RPC carries both sync state AND download progress — when a binary is
-/// being downloaded its slot's [SyncInfo.downloadInfo] is populated, with
-/// progressCurrent/progressGoal holding MB downloaded / MB total.
+/// Carries chain-tip state only — download progress is owned by the
+/// [DownloadProvider] which polls its own RPC on a separate cadence.
 ///
-/// Cadence is 100 ms while anything is still syncing or downloading,
-/// then drops to 1 s once everything is fully caught up.
+/// Cadence is 100 ms while any tracked connection is still syncing, then
+/// drops to 1 s once everything is fully caught up.
 class SyncProvider extends ChangeNotifier {
   Logger get log => GetIt.I.get<Logger>();
 
@@ -88,14 +74,13 @@ class SyncProvider extends ChangeNotifier {
 
   /// Per-connection vote on whether the global poll cadence should stay at
   /// the aggressive 100 ms interval. A connection votes yes only if it's
-  /// actively downloading or it's running but not yet synced. Absent or
-  /// errored connections vote no — otherwise an unstarted sidechain pins
-  /// the whole app at 100 ms forever and chews ~37% CPU on the Flutter
-  /// side (issue #1754).
+  /// running but not yet synced. Absent or errored connections vote no —
+  /// otherwise an unstarted sidechain pins the whole app at 100 ms forever
+  /// and chews ~37% CPU on the Flutter side (issue #1754). Download
+  /// progress runs on its own DownloadProvider timer.
   static bool connectionWantsAggressivePoll(SyncInfo? info, String? error) {
     if (info == null) return false;
     if (error != null && error.isNotEmpty) return false;
-    if (info.downloadInfo.isDownloading) return true;
     return !info.isSynced;
   }
 
@@ -262,7 +247,6 @@ class SyncProvider extends ChangeNotifier {
           progressCurrent: info.tipBlockHeight.toDouble(),
           progressGoal: info.headerHeight.toDouble(),
           lastBlockAt: info.tipBlockTime != Int64(0) ? Timestamp(seconds: info.tipBlockTime) : null,
-          downloadInfo: const DownloadInfo(),
         );
         if (_diff(bitwindowdSyncInfo, next) || bitwindowdError != null) {
           bitwindowdSyncInfo = next;
@@ -281,26 +265,14 @@ class SyncProvider extends ChangeNotifier {
     if (changed) notifyListeners();
   }
 
-  /// Builds a SyncInfo from the proto. When `is_downloading=true`,
-  /// blocks/headers carry MB downloaded / MB total — populate
-  /// [DownloadInfo] so the existing UI code that switches on
-  /// `syncInfo.downloadInfo.isDownloading` keeps working.
+  /// Builds a SyncInfo from the proto.
   SyncInfo _toSyncInfo(orch_pb.ChainSync? cs) {
     final blocks = (cs?.blocks ?? 0).toDouble();
     final headers = (cs?.headers ?? 0).toDouble();
-    if (cs?.isDownloading ?? false) {
-      return SyncInfo(
-        progressCurrent: blocks,
-        progressGoal: headers,
-        lastBlockAt: null,
-        downloadInfo: DownloadInfo(progress: blocks, total: headers, isDownloading: true),
-      );
-    }
     return SyncInfo(
       progressCurrent: blocks,
       progressGoal: headers,
       lastBlockAt: (cs?.time ?? Int64(0)) != Int64(0) ? Timestamp(seconds: cs!.time) : null,
-      downloadInfo: const DownloadInfo(),
     );
   }
 

--- a/sail_ui/lib/providers/update_provider.dart
+++ b/sail_ui/lib/providers/update_provider.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import 'package:logger/logger.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:sail_ui/config/binaries.dart';
+import 'package:sail_ui/gen/orchestrator/v1/orchestrator.pbenum.dart';
 
 /// Callback to gracefully shut down all running processes before an update.
 /// Should call BinaryProvider.onShutdown() or equivalent.
@@ -50,13 +51,13 @@ class UpdateProvider extends ChangeNotifier {
 
   /// Get the key used in versions.json for this binary type
   String get _appname => switch (binaryType) {
-    BinaryType.bitWindow => 'bitwindow',
-    BinaryType.thunder => 'thunder',
-    BinaryType.zSide => 'zside',
-    BinaryType.bitnames => 'bitnames',
-    BinaryType.bitassets => 'bitassets',
-    BinaryType.truthcoin => 'truthcoin',
-    BinaryType.photon => 'photon',
+    BinaryType.BINARY_TYPE_BITWINDOWD => 'bitwindow',
+    BinaryType.BINARY_TYPE_THUNDER => 'thunder',
+    BinaryType.BINARY_TYPE_ZSIDE => 'zside',
+    BinaryType.BINARY_TYPE_BITNAMES => 'bitnames',
+    BinaryType.BINARY_TYPE_BITASSETS => 'bitassets',
+    BinaryType.BINARY_TYPE_TRUTHCOIN => 'truthcoin',
+    BinaryType.BINARY_TYPE_PHOTON => 'photon',
     _ => throw UnsupportedError(
       'Update provider not supported for ${binaryType.name}',
     ),

--- a/sail_ui/lib/providers/wallet_reader_provider.dart
+++ b/sail_ui/lib/providers/wallet_reader_provider.dart
@@ -31,7 +31,7 @@ class WalletReaderProvider extends ChangeNotifier {
   bool hasWalletOnDisk = false;
 
   WalletData? get activeWallet => wallets.where((w) => w.id == activeWalletId).firstOrNull;
-  WalletData? get enforcerWallet => wallets.where((w) => w.walletType == BinaryType.enforcer).firstOrNull;
+  WalletData? get enforcerWallet => wallets.where((w) => w.walletType == BinaryType.BINARY_TYPE_ENFORCER).firstOrNull;
 
   List<WalletMetadata> get availableWallets => wallets
       .map(
@@ -136,7 +136,7 @@ class WalletReaderProvider extends ChangeNotifier {
         createdAt: createdAt,
         walletType: BinaryType.values.firstWhere(
           (t) => t.name == protoWallet.walletType,
-          orElse: () => BinaryType.enforcer,
+          orElse: () => BinaryType.BINARY_TYPE_ENFORCER,
         ),
         walletTypeRaw: protoWallet.walletType,
         bip47PaymentCode: protoWallet.bip47PaymentCode,

--- a/sail_ui/lib/rpcs/bitassets_rpc.dart
+++ b/sail_ui/lib/rpcs/bitassets_rpc.dart
@@ -230,7 +230,7 @@ class BitAssetsLive extends BitAssetsRPC {
 
   late BitAssetsServiceClient _client;
 
-  BitAssetsLive() : super(binaryType: BinaryType.bitassets) {
+  BitAssetsLive() : super(binaryType: BinaryType.BINARY_TYPE_BITASSETS) {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),

--- a/sail_ui/lib/rpcs/bitcoind_connection.dart
+++ b/sail_ui/lib/rpcs/bitcoind_connection.dart
@@ -14,7 +14,7 @@ import 'package:sail_ui/sail_ui.dart';
 /// Sync state (blocks/headers/IBD) is fetched by [SyncProvider] from
 /// `OrchestratorRPC.getSyncStatus`, not held here.
 class BitcoindConnection extends RPCConnection {
-  BitcoindConnection() : super(binaryType: BinaryType.bitcoinCore);
+  BitcoindConnection() : super(binaryType: BinaryType.BINARY_TYPE_BITCOIND);
 
   @override
   Future<List<String>> binaryArgs() async {

--- a/sail_ui/lib/rpcs/bitnames_rpc.dart
+++ b/sail_ui/lib/rpcs/bitnames_rpc.dart
@@ -145,7 +145,7 @@ class BitnamesLive extends BitnamesRPC {
 
   late BitnamesServiceClient _client;
 
-  BitnamesLive() : super(binaryType: BinaryType.bitnames) {
+  BitnamesLive() : super(binaryType: BinaryType.BINARY_TYPE_BITNAMES) {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),

--- a/sail_ui/lib/rpcs/bitwindow_api.dart
+++ b/sail_ui/lib/rpcs/bitwindow_api.dart
@@ -60,7 +60,7 @@ class BitwindowRPCLive extends BitwindowRPC {
   @override
   late UtilsAPI utils;
 
-  BitwindowRPCLive({required String host, required int port}) : super(binaryType: BinaryType.bitWindow) {
+  BitwindowRPCLive({required String host, required int port}) : super(binaryType: BinaryType.BINARY_TYPE_BITWINDOWD) {
     _initializeConnection(host: host, port: port);
   }
 

--- a/sail_ui/lib/rpcs/coinshift_rpc.dart
+++ b/sail_ui/lib/rpcs/coinshift_rpc.dart
@@ -106,7 +106,7 @@ class CoinShiftLive extends CoinShiftRPC {
 
   late CoinShiftServiceClient _client;
 
-  CoinShiftLive() : super(binaryType: BinaryType.coinShift) {
+  CoinShiftLive() : super(binaryType: BinaryType.BINARY_TYPE_COINSHIFT) {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),

--- a/sail_ui/lib/rpcs/enforcer_rpc.dart
+++ b/sail_ui/lib/rpcs/enforcer_rpc.dart
@@ -31,7 +31,7 @@ class EnforcerLive extends EnforcerRPC {
   late WalletServiceClient wallet;
   late grpc.Transport _grpcTransport;
 
-  EnforcerLive() : super(binaryType: BinaryType.enforcer) {
+  EnforcerLive() : super(binaryType: BinaryType.BINARY_TYPE_ENFORCER) {
     _initializeConnection();
   }
 

--- a/sail_ui/lib/rpcs/orchestrator_rpc.dart
+++ b/sail_ui/lib/rpcs/orchestrator_rpc.dart
@@ -120,6 +120,13 @@ class OrchestratorRPC {
     return _unaryClient.getSyncStatus(GetSyncStatusRequest());
   }
 
+  /// Snapshot of every binary the orchestrator is currently downloading.
+  /// Empty list is the steady state — drives the [DownloadProvider]'s
+  /// passive-vs-aggressive cadence.
+  Future<GetDownloadStatusResponse> getDownloadStatus() {
+    return _unaryClient.getDownloadStatus(GetDownloadStatusRequest());
+  }
+
   Future<GetMainchainBalanceResponse> getMainchainBalance() {
     return _unaryClient.getMainchainBalance(GetMainchainBalanceRequest());
   }

--- a/sail_ui/lib/rpcs/photon_rpc.dart
+++ b/sail_ui/lib/rpcs/photon_rpc.dart
@@ -65,7 +65,7 @@ class PhotonLive extends PhotonRPC {
 
   late PhotonServiceClient _client;
 
-  PhotonLive() : super(binaryType: BinaryType.photon) {
+  PhotonLive() : super(binaryType: BinaryType.BINARY_TYPE_PHOTON) {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),

--- a/sail_ui/lib/rpcs/rpc_sidechain.dart
+++ b/sail_ui/lib/rpcs/rpc_sidechain.dart
@@ -55,11 +55,11 @@ abstract class SidechainRPC extends RPCConnection {
   Future<int?> fetchExplorerHeaders() async {
     // Map BinaryType to Explorer service keys
     final sidechainKey = switch (binaryType) {
-      BinaryType.thunder => 'thunder',
-      BinaryType.bitassets => 'bitassets',
-      BinaryType.bitnames => 'bitnames',
-      BinaryType.zSide => 'zside',
-      BinaryType.coinShift => 'coinshift',
+      BinaryType.BINARY_TYPE_THUNDER => 'thunder',
+      BinaryType.BINARY_TYPE_BITASSETS => 'bitassets',
+      BinaryType.BINARY_TYPE_BITNAMES => 'bitnames',
+      BinaryType.BINARY_TYPE_ZSIDE => 'zside',
+      BinaryType.BINARY_TYPE_COINSHIFT => 'coinshift',
       _ => null,
     };
 

--- a/sail_ui/lib/rpcs/thunder_rpc.dart
+++ b/sail_ui/lib/rpcs/thunder_rpc.dart
@@ -59,7 +59,7 @@ class ThunderLive extends ThunderRPC {
 
   late ThunderServiceClient _client;
 
-  ThunderLive() : super(binaryType: BinaryType.thunder) {
+  ThunderLive() : super(binaryType: BinaryType.BINARY_TYPE_THUNDER) {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),

--- a/sail_ui/lib/rpcs/truthcoin_rpc.dart
+++ b/sail_ui/lib/rpcs/truthcoin_rpc.dart
@@ -246,7 +246,7 @@ class TruthcoinLive extends TruthcoinRPC {
 
   late TruthcoinServiceClient _client;
 
-  TruthcoinLive() : super(binaryType: BinaryType.truthcoin) {
+  TruthcoinLive() : super(binaryType: BinaryType.BINARY_TYPE_TRUTHCOIN) {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),

--- a/sail_ui/lib/rpcs/zside_rpc.dart
+++ b/sail_ui/lib/rpcs/zside_rpc.dart
@@ -92,7 +92,7 @@ class ZSideLive extends ZSideRPC {
 
   late ZSideServiceClient _client;
 
-  ZSideLive() : super(binaryType: BinaryType.zSide) {
+  ZSideLive() : super(binaryType: BinaryType.BINARY_TYPE_ZSIDE) {
     final transport = connect.Transport(
       baseUrl: 'http://localhost:30400',
       codec: const ProtoCodec(),

--- a/sail_ui/lib/sail_ui.dart
+++ b/sail_ui/lib/sail_ui.dart
@@ -163,6 +163,7 @@ export 'providers/binaries/managers/process_manager.dart';
 export 'providers/sidechain/address_provider.dart';
 export 'providers/sidechain/notification_provider.dart';
 export 'providers/sidechain/sidechain_transactions_provider.dart';
+export 'providers/download_provider.dart';
 export 'providers/sync_provider.dart';
 export 'providers/update_provider.dart';
 export 'providers/homepage_provider.dart';

--- a/sail_ui/lib/widgets/components/daemon_connection_card.dart
+++ b/sail_ui/lib/widgets/components/daemon_connection_card.dart
@@ -33,10 +33,25 @@ class DaemonConnectionCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final downloadProvider = GetIt.I.isRegistered<DownloadProvider>() ? GetIt.I.get<DownloadProvider>() : null;
+    if (downloadProvider == null) {
+      return _buildCard(context, downloadProgress: null);
+    }
+    return ListenableBuilder(
+      listenable: downloadProvider,
+      builder: (context, _) {
+        final progress = downloadProvider.statusFor(connection.binary.type);
+        return _buildCard(context, downloadProgress: progress);
+      },
+    );
+  }
+
+  Widget _buildCard(BuildContext context, {required DownloadProgress? downloadProgress}) {
     final theme = SailTheme.of(context);
     final providerBinary = _binaryProvider.binaries.firstWhereOrNull(
       (b) => b.name == connection.binary.name,
     );
+    final isDownloading = downloadProgress != null;
 
     return SailCard(
       child: SailColumn(
@@ -50,7 +65,7 @@ class DaemonConnectionCard extends StatelessWidget {
               ),
               SailSVG.fromAsset(
                 SailSVGAsset.iconConnectionStatus,
-                color: _getConnectionColor(theme),
+                color: _getConnectionColor(theme, isDownloading: isDownloading),
               ),
               Expanded(child: Container()),
               if (providerBinary != null && providerBinary.updateAvailable)
@@ -130,7 +145,7 @@ class DaemonConnectionCard extends StatelessWidget {
               ),
               _RestartStopButton(
                 binaryName: connection.binary.name,
-                isInitializing: connection.initializingBinary || (syncInfo?.downloadInfo.isDownloading ?? false),
+                isInitializing: connection.initializingBinary || isDownloading,
                 isConnected: connection.connected,
                 isStopping: connection.stoppingBinary,
                 onRestart: restartDaemon,
@@ -145,7 +160,15 @@ class DaemonConnectionCard extends StatelessWidget {
                 ),
             ],
           ),
-          if (syncInfo != null)
+          if (downloadProgress != null)
+            SizedBox(
+              width: 350,
+              child: DownloadStatusRow(
+                name: connection.binary.name,
+                download: downloadProgress,
+              ),
+            )
+          else if (syncInfo != null)
             SizedBox(
               width: 350,
               child: BlockStatus(
@@ -174,15 +197,62 @@ class DaemonConnectionCard extends StatelessWidget {
     );
   }
 
-  Color _getConnectionColor(SailThemeData theme) => resolveDaemonStatusColor(
+  Color _getConnectionColor(SailThemeData theme, {required bool isDownloading}) => resolveDaemonStatusColor(
     theme: theme,
     connectionError: connection.connectionError,
     startupError: connection.startupError,
     initializingBinary: connection.initializingBinary,
     connected: connection.connected,
-    isDownloading: syncInfo?.downloadInfo.isDownloading ?? false,
+    isDownloading: isDownloading,
     hasInfoMessage: infoMessage != null,
   );
+}
+
+/// Renders the in-flight download progress for a daemon. Shown by the
+/// DaemonConnectionCard whenever the DownloadProvider has a live entry for
+/// this binary — sync state is suppressed because the binary isn't running
+/// yet anyway.
+class DownloadStatusRow extends StatelessWidget {
+  final String name;
+  final DownloadProgress download;
+
+  const DownloadStatusRow({
+    super.key,
+    required this.name,
+    required this.download,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final tooltip = download.mbTotal > 0
+        ? 'Downloading $name\nProgress: ${formatDataSizeFromMB(download.mbDownloaded.toDouble())}\nSize: ${formatDataSizeFromMB(download.mbTotal.toDouble())}'
+        : 'Downloading $name\n${formatDataSizeFromMB(download.mbDownloaded.toDouble())} so far (size unknown)';
+
+    return SailRow(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: Tooltip(
+            message: tooltip,
+            child: SailRow(
+              spacing: SailStyleValues.padding08,
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: ProgressBar(
+                    current: download.mbDownloaded.toDouble(),
+                    goal: download.mbTotal > 0 ? download.mbTotal.toDouble() : 0,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
 }
 
 /// Pure function for the daemon-status text precedence. Exposed for testing.
@@ -254,22 +324,8 @@ class BlockStatus extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final currentProgress = formatProgress(
-      syncInfo.progressCurrent,
-      syncInfo.downloadInfo.isDownloading,
-    );
-    final goalProgress = formatProgress(
-      syncInfo.progressGoal,
-      syncInfo.downloadInfo.isDownloading,
-    );
-
-    // Check if download just finished but blockchain sync hasn't started yet
-    // This happens when progressCurrent is very low (download progress was 0-1)
-    // but we're no longer downloading
-    final downloadJustFinished =
-        !syncInfo.downloadInfo.isDownloading &&
-        syncInfo.downloadInfo.progressPercent >= 1 &&
-        syncInfo.progressCurrent <= 1;
+    final currentProgress = formatProgress(syncInfo.progressCurrent, false);
+    final goalProgress = formatProgress(syncInfo.progressGoal, false);
 
     return SailRow(
       mainAxisAlignment: MainAxisAlignment.start,
@@ -277,11 +333,8 @@ class BlockStatus extends StatelessWidget {
       children: [
         Expanded(
           child: Tooltip(
-            message: syncInfo.downloadInfo.isDownloading
-                ? 'Downloading $name\nProgress: ${formatDataSizeFromMB(syncInfo.progressCurrent)}\nSize: ${formatDataSizeFromMB(syncInfo.progressGoal)}'
-                : downloadJustFinished
-                ? 'Starting $name...'
-                : '$name\nCurrent height ${formatWithThousandSpacers(currentProgress)}\nHeader height ${formatWithThousandSpacers(goalProgress)}',
+            message:
+                '$name\nCurrent height ${formatWithThousandSpacers(currentProgress)}\nHeader height ${formatWithThousandSpacers(goalProgress)}',
             child: SailRow(
               spacing: SailStyleValues.padding08,
               mainAxisAlignment: MainAxisAlignment.start,
@@ -294,14 +347,8 @@ class BlockStatus extends StatelessWidget {
                       goal: syncInfo.progressGoal,
                     ),
                   )
-                else if (downloadJustFinished)
-                  SailText.secondary12('Finishing up...')
                 else
-                  SailText.secondary12(
-                    syncInfo.downloadInfo.isDownloading
-                        ? formatDataSizeFromMB(syncInfo.progressCurrent)
-                        : '${formatWithThousandSpacers(currentProgress)} sync height',
-                  ),
+                  SailText.secondary12('${formatWithThousandSpacers(currentProgress)} sync height'),
               ],
             ),
           ),

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -183,9 +183,7 @@ class BottomNav extends StatelessWidget {
                           (b) => b.name == BitcoinCore().name,
                         ),
                       ),
-                      infoMessage: _getDownloadMessage(
-                        model.syncProvider.mainchainSyncInfo,
-                      ),
+                      infoMessage: null,
                       navigateToLogs: model.navigateToLogs,
                       onOpenConfConfigurator: onOpenConfConfigurator,
                     ),
@@ -195,15 +193,11 @@ class BottomNav extends StatelessWidget {
                     DaemonConnectionCard(
                       connection: model.enforcer,
                       syncInfo: model.syncProvider.enforcerSyncInfo,
-                      infoMessage:
-                          _getDownloadMessage(
-                            model.syncProvider.enforcerSyncInfo,
-                          ) ??
-                          (model.mainchain.initializingBinary
-                              ? 'Waiting for mainchain to finish initializing'
-                              : model.syncProvider.inHeaderSync
-                              ? 'Waiting for L1 to sync headers...'
-                              : null),
+                      infoMessage: model.mainchain.initializingBinary
+                          ? 'Waiting for mainchain to finish initializing'
+                          : model.syncProvider.inHeaderSync
+                          ? 'Waiting for L1 to sync headers...'
+                          : null,
                       restartDaemon: () => binaryProvider.restart(
                         binaryProvider.binaries.firstWhere(
                           (b) => b.name == Enforcer().name,
@@ -235,9 +229,7 @@ class BottomNav extends StatelessWidget {
                               !model.mainchain.initializingBinary &&
                               model.mainchain.startupError == null &&
                               !model.syncProvider.inHeaderSync);
-                      final infoMessage =
-                          _getDownloadMessage(model.additionalSyncInfo) ??
-                          (isSidechain && !coreReady ? 'Waiting for Bitcoin Core header sync' : null);
+                      final infoMessage = isSidechain && !coreReady ? 'Waiting for Bitcoin Core header sync' : null;
                       return DaemonConnectionCard(
                         connection: additionalConnection.rpc,
                         syncInfo: coreReady ? model.additionalSyncInfo : null,
@@ -264,26 +256,6 @@ class BottomNav extends StatelessWidget {
         }),
       ),
     );
-  }
-
-  String? _getDownloadMessage(SyncInfo? syncInfo) {
-    if (syncInfo == null) return null;
-
-    if (!syncInfo.downloadInfo.isDownloading) {
-      return null;
-    }
-
-    // Show "downloading X / Y" until progressPercent hits 100%.
-    if (syncInfo.downloadInfo.progressPercent < 1) {
-      final progressPercent = (syncInfo.downloadInfo.progressPercent * 100).toStringAsFixed(0);
-      if (progressPercent == '100') {
-        return null;
-      } else {
-        return syncInfo.downloadInfo.message;
-      }
-    }
-
-    return 'Finishing up...';
   }
 }
 
@@ -343,6 +315,8 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
   EnforcerRPC get enforcer => GetIt.I.get<EnforcerRPC>();
   SyncProvider get syncProvider => GetIt.I.get<SyncProvider>();
   BinaryProvider get binaryProvider => GetIt.I.get<BinaryProvider>();
+  DownloadProvider? get downloadProvider =>
+      GetIt.I.isRegistered<DownloadProvider>() ? GetIt.I.get<DownloadProvider>() : null;
 
   final bool mainchainInfo;
   final Function(String, String, BinaryType) navigateToLogs;
@@ -358,6 +332,7 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
     enforcer.addListener(_onChange);
     additionalConnection.rpc.addListener(_onChange);
     syncProvider.addListener(_onChange);
+    downloadProvider?.addListener(_onChange);
   }
 
   /// Resolves the SyncInfo for the additional daemon card. SyncProvider
@@ -393,11 +368,7 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
   bool get allConnected => mainchain.connected && enforcer.connected && additionalConnection.connected;
   bool get initializingAny =>
       mainchain.initializingBinary || enforcer.initializingBinary || additionalConnection.initializingBinary;
-  bool get downloadingAny =>
-      syncProvider.mainchainSyncInfo?.downloadInfo.isDownloading ??
-      syncProvider.enforcerSyncInfo?.downloadInfo.isDownloading ??
-      additionalSyncInfo?.downloadInfo.isDownloading ??
-      false;
+  bool get downloadingAny => downloadProvider?.hasActiveDownloads ?? false;
 
   Color get connectionColor {
     // Precedence (top wins):
@@ -447,16 +418,17 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
   }
 
   String get _connectionStatusRaw {
-    if (syncProvider.mainchainSyncInfo?.downloadInfo.isDownloading ?? false) {
-      return 'Downloading mainchain...';
-    }
-
-    if (syncProvider.enforcerSyncInfo?.downloadInfo.isDownloading ?? false) {
-      return 'Downloading enforcer...';
-    }
-
-    if (additionalSyncInfo?.downloadInfo.isDownloading ?? false) {
-      return 'Downloading ${additionalConnection.name}...';
+    final dp = downloadProvider;
+    if (dp != null && dp.hasActiveDownloads) {
+      if (dp.statusFor(BinaryType.BINARY_TYPE_BITCOIND) != null) return 'Downloading mainchain...';
+      if (dp.statusFor(BinaryType.BINARY_TYPE_ENFORCER) != null) return 'Downloading enforcer...';
+      final additionalType = additionalConnection.rpc.binary.type;
+      if (dp.statusFor(additionalType) != null) {
+        return 'Downloading ${additionalConnection.name}...';
+      }
+      // Some other binary the user kicked off — just show the first one.
+      final first = dp.downloads.values.first;
+      return 'Downloading ${defaultBinaryFor(first.binary).name}...';
     }
 
     // Precedence per service: connectionError (hard fail) > startupError (warmup message,
@@ -603,27 +575,11 @@ class ChainLoader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final currentProgress = formatProgress(
-      syncInfo.progressCurrent,
-      syncInfo.downloadInfo.isDownloading,
-    );
-    final goalProgress = formatProgress(
-      syncInfo.progressGoal,
-      syncInfo.downloadInfo.isDownloading,
-    );
-
-    // Check if download just finished but blockchain sync hasn't started yet
-    final downloadJustFinished =
-        !syncInfo.downloadInfo.isDownloading &&
-        syncInfo.downloadInfo.progressPercent >= 1 &&
-        syncInfo.progressCurrent <= 1;
+    final currentProgress = formatProgress(syncInfo.progressCurrent, false);
+    final goalProgress = formatProgress(syncInfo.progressGoal, false);
 
     final widget = Tooltip(
-      message: syncInfo.downloadInfo.isDownloading
-          ? 'Downloading $name\n${syncInfo.downloadInfo.message}'
-          : downloadJustFinished
-          ? 'Starting $name...'
-          : '$name\nCurrent height $currentProgress\nHeader height $goalProgress',
+      message: '$name\nCurrent height $currentProgress\nHeader height $goalProgress',
       child: ProgressBar(
         current: syncInfo.progressCurrent,
         goal: syncInfo.progressGoal,

--- a/sail_ui/lib/widgets/nav/persistent_status_bar.dart
+++ b/sail_ui/lib/widgets/nav/persistent_status_bar.dart
@@ -16,7 +16,7 @@ class PersistentStatusBar extends StatelessWidget {
 
   const PersistentStatusBar({
     super.key,
-    this.monitored = const [BinaryType.orchestratord, BinaryType.bitWindow],
+    this.monitored = const [BinaryType.BINARY_TYPE_ORCHESTRATORD, BinaryType.BINARY_TYPE_BITWINDOWD],
   });
 
   @override

--- a/sail_ui/test/download_provider_test.dart
+++ b/sail_ui/test/download_provider_test.dart
@@ -1,0 +1,128 @@
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/gen/orchestrator/v1/orchestrator.pb.dart' as orch_pb;
+import 'package:sail_ui/sail_ui.dart';
+
+class _FakeOrchestratorRPC extends OrchestratorRPC {
+  _FakeOrchestratorRPC() : super(host: '127.0.0.1', port: 1);
+
+  /// What the next [getDownloadStatus] call will return.
+  List<orch_pb.DownloadStatus> nextDownloads = [];
+  Object? nextError;
+  int callCount = 0;
+
+  @override
+  Future<orch_pb.GetDownloadStatusResponse> getDownloadStatus() async {
+    callCount++;
+    if (nextError != null) {
+      throw nextError!;
+    }
+    return orch_pb.GetDownloadStatusResponse(downloads: nextDownloads);
+  }
+}
+
+void main() {
+  setUpAll(() {
+    if (!GetIt.I.isRegistered<Logger>()) {
+      GetIt.I.registerSingleton<Logger>(Logger(level: Level.warning));
+    }
+  });
+
+  setUp(() async {
+    if (GetIt.I.isRegistered<OrchestratorRPC>()) {
+      await GetIt.I.unregister<OrchestratorRPC>();
+    }
+  });
+
+  test('fetch records each download keyed by BinaryType', () async {
+    final fake = _FakeOrchestratorRPC()
+      ..nextDownloads = [
+        orch_pb.DownloadStatus(
+          binary: BinaryType.BINARY_TYPE_BITCOIND,
+          mbDownloaded: Int64(12),
+          mbTotal: Int64(50),
+        ),
+        orch_pb.DownloadStatus(
+          binary: BinaryType.BINARY_TYPE_THUNDER,
+          mbDownloaded: Int64(4),
+          mbTotal: Int64(-1),
+        ),
+      ];
+    GetIt.I.registerSingleton<OrchestratorRPC>(fake);
+
+    final provider = DownloadProvider(startTimer: false);
+    await provider.fetch();
+
+    expect(provider.hasActiveDownloads, isTrue);
+    expect(provider.statusFor(BinaryType.BINARY_TYPE_BITCOIND)?.mbDownloaded, 12);
+    expect(provider.statusFor(BinaryType.BINARY_TYPE_THUNDER)?.mbTotal, -1);
+    expect(provider.statusFor(BinaryType.BINARY_TYPE_BITNAMES), isNull);
+    expect(provider.lastError, isNull);
+  });
+
+  test('UNSPECIFIED entries from the wire are dropped from the map', () async {
+    final fake = _FakeOrchestratorRPC()
+      ..nextDownloads = [
+        orch_pb.DownloadStatus(
+          binary: BinaryType.BINARY_TYPE_UNSPECIFIED,
+          mbDownloaded: Int64(1),
+          mbTotal: Int64(2),
+        ),
+        orch_pb.DownloadStatus(
+          binary: BinaryType.BINARY_TYPE_THUNDER,
+          mbDownloaded: Int64(3),
+          mbTotal: Int64(4),
+        ),
+      ];
+    GetIt.I.registerSingleton<OrchestratorRPC>(fake);
+
+    final provider = DownloadProvider(startTimer: false);
+    await provider.fetch();
+
+    expect(provider.downloads.keys, [BinaryType.BINARY_TYPE_THUNDER]);
+  });
+
+  test('empty response leaves the map empty and clears prior errors', () async {
+    final fake = _FakeOrchestratorRPC();
+    GetIt.I.registerSingleton<OrchestratorRPC>(fake);
+
+    final provider = DownloadProvider(startTimer: false);
+    await provider.fetch();
+
+    expect(provider.hasActiveDownloads, isFalse);
+    expect(provider.downloads, isEmpty);
+  });
+
+  test('rpc failures land in lastError and notify listeners', () async {
+    final fake = _FakeOrchestratorRPC()..nextError = StateError('boom');
+    GetIt.I.registerSingleton<OrchestratorRPC>(fake);
+
+    final provider = DownloadProvider(startTimer: false);
+    var notifyCount = 0;
+    provider.addListener(() => notifyCount++);
+
+    await provider.fetch();
+
+    expect(provider.lastError, contains('boom'));
+    expect(notifyCount, 1);
+  });
+
+  test('progressFraction clamps and survives unknown total', () {
+    expect(
+      const DownloadProgress(binary: BinaryType.BINARY_TYPE_BITCOIND, mbDownloaded: 50, mbTotal: 100).progressFraction,
+      0.5,
+    );
+    // Unknown total → 0 instead of NaN, so the UI can render an indeterminate bar.
+    expect(
+      const DownloadProgress(binary: BinaryType.BINARY_TYPE_BITCOIND, mbDownloaded: 50, mbTotal: -1).progressFraction,
+      0,
+    );
+    // Over 100% (rare, but happens on rounding) is clamped.
+    expect(
+      const DownloadProgress(binary: BinaryType.BINARY_TYPE_BITCOIND, mbDownloaded: 200, mbTotal: 100).progressFraction,
+      1,
+    );
+  });
+}

--- a/sail_ui/test/flutter_frontend_dir_test.dart
+++ b/sail_ui/test/flutter_frontend_dir_test.dart
@@ -7,21 +7,21 @@ void main() {
     const home = '/home/tester';
 
     test('Linux uses bitwindow subdir (no com.layertwolabs prefix)', () {
-      final dir = flutterFrontendDirFor(BinaryType.bitWindow, OS.linux, home);
+      final dir = flutterFrontendDirFor(BinaryType.BINARY_TYPE_BITWINDOWD, OS.linux, home);
       expect(dir, p.join(home, '.local', 'share', 'bitwindow'));
       expect(dir, isNot(contains('com.layertwolabs.bitwindow')));
     });
 
     test('macOS keeps "bitwindow" Application Support folder', () {
       expect(
-        flutterFrontendDirFor(BinaryType.bitWindow, OS.macos, home),
+        flutterFrontendDirFor(BinaryType.BINARY_TYPE_BITWINDOWD, OS.macos, home),
         p.join(home, 'Library', 'Application Support', 'bitwindow'),
       );
     });
 
     test('Windows keeps 10520LayertwoLabs/BitWindow', () {
       expect(
-        flutterFrontendDirFor(BinaryType.bitWindow, OS.windows, home),
+        flutterFrontendDirFor(BinaryType.BINARY_TYPE_BITWINDOWD, OS.windows, home),
         p.join(home, 'AppData', 'Roaming', '10520LayertwoLabs', 'BitWindow'),
       );
     });
@@ -29,11 +29,11 @@ void main() {
 
   test('flutterFrontendDirFor returns null for binaries without a Flutter frontend', () {
     expect(
-      flutterFrontendDirFor(BinaryType.bitcoinCore, OS.linux, '/home/x'),
+      flutterFrontendDirFor(BinaryType.BINARY_TYPE_BITCOIND, OS.linux, '/home/x'),
       isNull,
     );
     expect(
-      flutterFrontendDirFor(BinaryType.enforcer, OS.linux, '/home/x'),
+      flutterFrontendDirFor(BinaryType.BINARY_TYPE_ENFORCER, OS.linux, '/home/x'),
       isNull,
     );
   });

--- a/sail_ui/test/sync_provider_aggressive_poll_test.dart
+++ b/sail_ui/test/sync_provider_aggressive_poll_test.dart
@@ -1,19 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sail_ui/sail_ui.dart';
 
-SyncInfo _info({
-  double current = 0,
-  double goal = 0,
-  bool downloading = false,
-}) => SyncInfo(
+SyncInfo _info({double current = 0, double goal = 0}) => SyncInfo(
   progressCurrent: current,
   progressGoal: goal,
   lastBlockAt: null,
-  downloadInfo: DownloadInfo(
-    progress: current,
-    total: goal,
-    isDownloading: downloading,
-  ),
 );
 
 void main() {
@@ -38,10 +29,10 @@ void main() {
       );
     });
 
-    test('returns true while a binary is being downloaded', () {
-      final info = _info(current: 25, goal: 100, downloading: true);
-      expect(SyncProvider.connectionWantsAggressivePoll(info, null), true);
-      // Empty error string is treated as no error.
+    test('treats an empty error string as no error', () {
+      // Lower-level proto fields default to "" for unset; the helper must
+      // treat that exactly like null.
+      final info = _info(current: 25, goal: 100);
       expect(SyncProvider.connectionWantsAggressivePoll(info, ''), true);
     });
 

--- a/sail_ui/test/wallet_reader_provider_test.dart
+++ b/sail_ui/test/wallet_reader_provider_test.dart
@@ -37,8 +37,8 @@ void main() {
   test('getL1Mnemonic reads from enforcer wallet, not the active one', () {
     final provider = WalletReaderProvider(Directory.systemTemp);
     provider.wallets = [
-      _wallet(id: 'enf', type: BinaryType.enforcer, l1: 'enforcer-l1-mnemonic'),
-      _wallet(id: 'core', type: BinaryType.bitcoinCore, l1: 'core-l1-mnemonic'),
+      _wallet(id: 'enf', type: BinaryType.BINARY_TYPE_ENFORCER, l1: 'enforcer-l1-mnemonic'),
+      _wallet(id: 'core', type: BinaryType.BINARY_TYPE_BITCOIND, l1: 'core-l1-mnemonic'),
     ];
     provider.activeWalletId = 'core';
 
@@ -52,7 +52,7 @@ void main() {
     provider.wallets = [
       _wallet(
         id: 'enf',
-        type: BinaryType.enforcer,
+        type: BinaryType.BINARY_TYPE_ENFORCER,
         sidechains: [
           SidechainWallet(slot: 9, name: 'Thunder', mnemonic: 'thunder-starter'),
           SidechainWallet(slot: 5, name: 'BitNames', mnemonic: 'bitnames-starter'),
@@ -60,7 +60,7 @@ void main() {
       ),
       _wallet(
         id: 'core',
-        type: BinaryType.bitcoinCore,
+        type: BinaryType.BINARY_TYPE_BITCOIND,
         sidechains: [
           SidechainWallet(slot: 9, name: 'Thunder', mnemonic: 'core-thunder'),
         ],
@@ -76,7 +76,7 @@ void main() {
   test('getL1Mnemonic returns null when enforcer wallet absent', () {
     final provider = WalletReaderProvider(Directory.systemTemp);
     provider.wallets = [
-      _wallet(id: 'core', type: BinaryType.bitcoinCore, l1: 'core-l1'),
+      _wallet(id: 'core', type: BinaryType.BINARY_TYPE_BITCOIND, l1: 'core-l1'),
     ];
     provider.activeWalletId = 'core';
 
@@ -91,12 +91,12 @@ void main() {
     // the "not available" message.
     final watchOnly = _wallet(
       id: 'wo',
-      type: BinaryType.enforcer, // junk fallback the proto parser produces
+      type: BinaryType.BINARY_TYPE_ENFORCER, // junk fallback the proto parser produces
       walletTypeRaw: 'watchOnly',
     );
     final hot = _wallet(
       id: 'hot',
-      type: BinaryType.enforcer,
+      type: BinaryType.BINARY_TYPE_ENFORCER,
       walletTypeRaw: 'enforcer',
     );
     expect(watchOnly.isWatchOnly, isTrue);

--- a/sail_ui/test/widgets/daemon_startup_hook_test.dart
+++ b/sail_ui/test/widgets/daemon_startup_hook_test.dart
@@ -75,9 +75,9 @@ void main() {
       binaries: [bitwindow, Orchestratord()],
     );
 
-    provider.addStartupLogForBinary(BinaryType.bitWindow, 'Starting BitWindow...');
+    provider.addStartupLogForBinary(BinaryType.BINARY_TYPE_BITWINDOWD, 'Starting BitWindow...');
 
-    final logs = provider.binaries.firstWhere((b) => b.type == BinaryType.bitWindow).startupLogs;
+    final logs = provider.binaries.firstWhere((b) => b.type == BinaryType.BINARY_TYPE_BITWINDOWD).startupLogs;
     expect(logs, isNotEmpty);
     expect(logs.last.message, 'Starting BitWindow...');
   });
@@ -88,9 +88,9 @@ void main() {
       binaries: [BitWindow(), Orchestratord()],
     );
 
-    provider.addStartupLogForBinary(BinaryType.orchestratord, 'Waiting for orchestratord...');
+    provider.addStartupLogForBinary(BinaryType.BINARY_TYPE_ORCHESTRATORD, 'Waiting for orchestratord...');
 
-    final logs = provider.binaries.firstWhere((b) => b.type == BinaryType.orchestratord).startupLogs;
+    final logs = provider.binaries.firstWhere((b) => b.type == BinaryType.BINARY_TYPE_ORCHESTRATORD).startupLogs;
     expect(logs.last.message, 'Waiting for orchestratord...');
   });
 
@@ -101,7 +101,7 @@ void main() {
       // true before the loop, clear it when the RPC call finally succeeds.
       // This is the exact sequence that keeps DaemonConnectionCard showing
       // "Initializing..." instead of "Not connected" during early boot.
-      final rpc = _StubRpc(binaryType: BinaryType.bitWindow);
+      final rpc = _StubRpc(binaryType: BinaryType.BINARY_TYPE_BITWINDOWD);
       final observedDuringWait = <bool>[];
 
       rpc.initializingBinary = true;

--- a/sail_ui/test/widgets/persistent_status_bar_test.dart
+++ b/sail_ui/test/widgets/persistent_status_bar_test.dart
@@ -115,8 +115,8 @@ void main() {
   }
 
   testWidgets('collapses to shrink when both daemons are healthy', (tester) async {
-    binaryProvider.setState(BinaryType.orchestratord, connected: true);
-    binaryProvider.setState(BinaryType.bitWindow, connected: true);
+    binaryProvider.setState(BinaryType.BINARY_TYPE_ORCHESTRATORD, connected: true);
+    binaryProvider.setState(BinaryType.BINARY_TYPE_BITWINDOWD, connected: true);
 
     await tester.pumpWidget(wrap(const PersistentStatusBar()));
     await tester.pump();
@@ -128,8 +128,8 @@ void main() {
   });
 
   testWidgets('collapses to shrink while a daemon is initializing', (tester) async {
-    binaryProvider.setState(BinaryType.orchestratord, initializing: true, error: 'boot error');
-    binaryProvider.setState(BinaryType.bitWindow, connected: true);
+    binaryProvider.setState(BinaryType.BINARY_TYPE_ORCHESTRATORD, initializing: true, error: 'boot error');
+    binaryProvider.setState(BinaryType.BINARY_TYPE_BITWINDOWD, connected: true);
 
     await tester.pumpWidget(wrap(const PersistentStatusBar()));
     await tester.pump();
@@ -140,8 +140,8 @@ void main() {
   });
 
   testWidgets('shows error banner only when a daemon has a terminal error', (tester) async {
-    binaryProvider.setState(BinaryType.orchestratord, error: 'connection refused');
-    binaryProvider.setState(BinaryType.bitWindow, connected: true);
+    binaryProvider.setState(BinaryType.BINARY_TYPE_ORCHESTRATORD, error: 'connection refused');
+    binaryProvider.setState(BinaryType.BINARY_TYPE_BITWINDOWD, connected: true);
 
     await tester.pumpWidget(wrap(const PersistentStatusBar()));
     await tester.pump();
@@ -153,8 +153,8 @@ void main() {
   });
 
   testWidgets('tapping Restart calls BinaryProvider.restart for every broken daemon', (tester) async {
-    binaryProvider.setState(BinaryType.orchestratord, error: 'down');
-    binaryProvider.setState(BinaryType.bitWindow, error: 'down');
+    binaryProvider.setState(BinaryType.BINARY_TYPE_ORCHESTRATORD, error: 'down');
+    binaryProvider.setState(BinaryType.BINARY_TYPE_BITWINDOWD, error: 'down');
 
     await tester.pumpWidget(wrap(const PersistentStatusBar()));
     await tester.pump();
@@ -164,7 +164,7 @@ void main() {
 
     expect(
       binaryProvider.restartedTypes,
-      containsAll(<BinaryType>[BinaryType.orchestratord, BinaryType.bitWindow]),
+      containsAll(<BinaryType>[BinaryType.BINARY_TYPE_ORCHESTRATORD, BinaryType.BINARY_TYPE_BITWINDOWD]),
     );
   });
 
@@ -176,8 +176,8 @@ void main() {
     //     body: child, bottomNavigationBar: PersistentStatusBar()))
     // The bar must render with no "No Material widget"/"No Overlay widget"/
     // unbounded-constraints errors regardless of daemon state.
-    binaryProvider.setState(BinaryType.orchestratord, error: 'down');
-    binaryProvider.setState(BinaryType.bitWindow, error: 'down');
+    binaryProvider.setState(BinaryType.BINARY_TYPE_ORCHESTRATORD, error: 'down');
+    binaryProvider.setState(BinaryType.BINARY_TYPE_BITWINDOWD, error: 'down');
 
     tester.view.physicalSize = const Size(4000, 1200);
     tester.view.devicePixelRatio = 1.0;

--- a/sidechain-orchestrator/api/get_download_status_test.go
+++ b/sidechain-orchestrator/api/get_download_status_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
+	rpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect"
+)
+
+const (
+	eventuallyTimeout = 10 * time.Second
+	eventuallyPoll    = 50 * time.Millisecond
+)
+
+// TestGetDownloadStatus_EmptyWhenNothingInFlight is the steady-state guard:
+// no downloads running ⇒ the response is the empty list, not a synthetic
+// "all idle" payload. The frontend's DownloadProvider relies on this to
+// drop back to passive cadence.
+func TestGetDownloadStatus_EmptyWhenNothingInFlight(t *testing.T) {
+	orch := newTestOrchHandlerWithBinary(t, orchestrator.BinaryConfig{
+		Name:           "streamtest",
+		BinaryName:     "streamtest",
+		DownloadSource: orchestrator.DownloadSourceDirect,
+		DownloadURLs:   map[string]string{"default": "http://example.invalid/"},
+		Files:          map[string]string{currentOS(): "streamtest.zip"},
+	})
+	client, stop := startTestOrchService(t, orch)
+	defer stop()
+
+	resp, err := client.GetDownloadStatus(context.Background(), connect.NewRequest(&pb.GetDownloadStatusRequest{}))
+	require.NoError(t, err)
+	require.Empty(t, resp.Msg.Downloads)
+}
+
+// TestGetDownloadStatus_ReportsInFlightDownload exercises the live path:
+// kick off a real download against a slow HTTP server, hit the RPC mid-flight,
+// and assert one entry comes back with the expected binary name and a
+// non-zero MB total. We don't pin the exact MB value — the test server runs
+// at whatever speed the host gives us.
+func TestGetDownloadStatus_ReportsInFlightDownload(t *testing.T) {
+	const totalSize = 5 * 1024 * 1024 // 5 MB
+	hold := make(chan struct{})
+	released := false
+	var releaseOnce sync.Once
+	binarySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "5242880")
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		// Send a small chunk, flush, then block until the test releases us.
+		// That gives the in-flight RPC something to read.
+		_, _ = w.Write(make([]byte, 1024))
+		if flusher != nil {
+			flusher.Flush()
+		}
+		<-hold
+		_, _ = w.Write(make([]byte, totalSize-1024))
+	}))
+	defer func() {
+		releaseOnce.Do(func() {
+			released = true
+			close(hold)
+		})
+		binarySrv.Close()
+	}()
+	_ = released
+
+	orch := newTestOrchHandlerWithBinary(t, orchestrator.BinaryConfig{
+		Name:           "streamtest",
+		BinaryName:     "streamtest",
+		DownloadSource: orchestrator.DownloadSourceDirect,
+		DownloadURLs:   map[string]string{"default": binarySrv.URL + "/"},
+		Files:          map[string]string{currentOS(): "streamtest.zip"},
+	})
+	client, stop := startTestOrchService(t, orch)
+	defer stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err := client.DownloadBinary(ctx, connect.NewRequest(&pb.DownloadBinaryRequest{
+		Name:  "streamtest",
+		Force: true,
+	}))
+	require.NoError(t, err)
+
+	// Spin until the manager records something running, then sample the RPC.
+	require.Eventually(t, func() bool {
+		_, running := orch.DownloadStateForTest("streamtest")
+		return running
+	}, eventuallyTimeout, eventuallyPoll, "download never registered as running")
+
+	// streamtest isn't a known BinaryType in the proto enum, so the handler
+	// drops it from the response — exercise the empty-after-drop path.
+	resp, err := client.GetDownloadStatus(ctx, connect.NewRequest(&pb.GetDownloadStatusRequest{}))
+	require.NoError(t, err)
+	require.Empty(
+		t,
+		resp.Msg.Downloads,
+		"unknown binary names must be dropped, not shipped as UNSPECIFIED",
+	)
+
+	releaseOnce.Do(func() { close(hold) })
+}
+
+// TestGetDownloadStatus_KnownBinaryReportsTypedEnum is the typed-name guard:
+// when a binary is in flight whose name maps to a known BinaryType enum, the
+// response carries the enum value (not a string), so frontends can switch on
+// it without parsing magic strings.
+func TestGetDownloadStatus_KnownBinaryReportsTypedEnum(t *testing.T) {
+	const totalSize = 5 * 1024 * 1024
+	hold := make(chan struct{})
+	var releaseOnce sync.Once
+	binarySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "5242880")
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		_, _ = w.Write(make([]byte, 1024))
+		if flusher != nil {
+			flusher.Flush()
+		}
+		<-hold
+		_, _ = w.Write(make([]byte, totalSize-1024))
+	}))
+	defer func() {
+		releaseOnce.Do(func() { close(hold) })
+		binarySrv.Close()
+	}()
+
+	orch := newTestOrchHandlerWithBinary(t, orchestrator.BinaryConfig{
+		Name:           "thunder",
+		BinaryName:     "thunder",
+		DownloadSource: orchestrator.DownloadSourceDirect,
+		DownloadURLs:   map[string]string{"default": binarySrv.URL + "/"},
+		Files:          map[string]string{currentOS(): "thunder.zip"},
+	})
+	client, stop := startTestOrchService(t, orch)
+	defer stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err := client.DownloadBinary(ctx, connect.NewRequest(&pb.DownloadBinaryRequest{
+		Name:  "thunder",
+		Force: true,
+	}))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, running := orch.DownloadStateForTest("thunder")
+		return running
+	}, eventuallyTimeout, eventuallyPoll, "download never registered as running")
+
+	resp, err := client.GetDownloadStatus(ctx, connect.NewRequest(&pb.GetDownloadStatusRequest{}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Downloads, 1)
+	require.Equal(t, pb.BinaryType_BINARY_TYPE_THUNDER, resp.Msg.Downloads[0].Binary)
+}
+
+// startTestOrchService stands up a connect server backed by `orch` and
+// returns a client + a cleanup func. Used by the GetDownloadStatus tests
+// to keep boilerplate out of each case.
+func startTestOrchService(t *testing.T, orch *orchestrator.Orchestrator) (rpc.OrchestratorServiceClient, func()) {
+	t.Helper()
+	mux := http.NewServeMux()
+	path, h := rpc.NewOrchestratorServiceHandler(NewHandler(orch))
+	mux.Handle(path, h)
+	srv := httptest.NewUnstartedServer(h2c.NewHandler(mux, &http2.Server{}))
+	srv.Start()
+	client := rpc.NewOrchestratorServiceClient(srv.Client(), srv.URL, connect.WithGRPC())
+	return client, srv.Close
+}

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -306,11 +306,71 @@ func chainSyncToProto(s *orchestrator.ChainSyncResult) *pb.ChainSync {
 		return nil
 	}
 	return &pb.ChainSync{
-		Blocks:        int32(s.Blocks),
-		Headers:       int32(s.Headers),
-		Time:          s.Time,
-		Error:         s.Error,
-		IsDownloading: s.IsDownloading,
+		Blocks:  int32(s.Blocks),
+		Headers: int32(s.Headers),
+		Time:    s.Time,
+		Error:   s.Error,
+	}
+}
+
+// GetDownloadStatus returns one entry per binary that the orchestrator's
+// DownloadManager is currently fetching. The response is the empty list
+// when nothing is in flight — frontends rely on that as the steady state.
+// Binaries the proto enum doesn't know about (e.g. grpcurl) are dropped so
+// the wire format stays strongly typed.
+func (h *Handler) GetDownloadStatus(ctx context.Context, req *connect.Request[pb.GetDownloadStatusRequest]) (*connect.Response[pb.GetDownloadStatusResponse], error) {
+	states := h.orch.DownloadStates()
+	downloads := make([]*pb.DownloadStatus, 0, len(states))
+	for name, s := range states {
+		t := binaryTypeFromName(name)
+		if t == pb.BinaryType_BINARY_TYPE_UNSPECIFIED {
+			continue
+		}
+		downloads = append(downloads, &pb.DownloadStatus{
+			Binary:       t,
+			MbDownloaded: s.MBDownloaded,
+			MbTotal:      s.MBTotal,
+			Message:      s.Message,
+		})
+	}
+	return connect.NewResponse(&pb.GetDownloadStatusResponse{
+		Downloads: downloads,
+	}), nil
+}
+
+// binaryTypeFromName maps the orchestrator's logical binary name to the
+// proto BinaryType enum. Returns UNSPECIFIED for unknown names — callers
+// should drop those rather than ship the unspecified value.
+func binaryTypeFromName(name string) pb.BinaryType {
+	switch name {
+	case "bitcoind":
+		return pb.BinaryType_BINARY_TYPE_BITCOIND
+	case "enforcer":
+		return pb.BinaryType_BINARY_TYPE_ENFORCER
+	case "bitwindowd":
+		return pb.BinaryType_BINARY_TYPE_BITWINDOWD
+	case "thunder":
+		return pb.BinaryType_BINARY_TYPE_THUNDER
+	case "zside":
+		return pb.BinaryType_BINARY_TYPE_ZSIDE
+	case "bitnames":
+		return pb.BinaryType_BINARY_TYPE_BITNAMES
+	case "bitassets":
+		return pb.BinaryType_BINARY_TYPE_BITASSETS
+	case "truthcoin":
+		return pb.BinaryType_BINARY_TYPE_TRUTHCOIN
+	case "photon":
+		return pb.BinaryType_BINARY_TYPE_PHOTON
+	case "coinshift":
+		return pb.BinaryType_BINARY_TYPE_COINSHIFT
+	case "grpcurl":
+		return pb.BinaryType_BINARY_TYPE_GRPCURL
+	case "orchestratord":
+		return pb.BinaryType_BINARY_TYPE_ORCHESTRATORD
+	case "zsided":
+		return pb.BinaryType_BINARY_TYPE_ZSIDED
+	default:
+		return pb.BinaryType_BINARY_TYPE_UNSPECIFIED
 	}
 }
 

--- a/sidechain-orchestrator/download.go
+++ b/sidechain-orchestrator/download.go
@@ -326,6 +326,27 @@ func (d *DownloadManager) State(binaryName string) (DownloadState, bool) {
 	return state, true
 }
 
+// States returns a snapshot of every download currently in flight, keyed by
+// the binary's logical name. Entries are inserted when a download starts
+// and deleted when its goroutine returns (Done or Error), so the snapshot
+// is naturally restricted to live downloads — no need for a Running check.
+func (d *DownloadManager) States() map[string]DownloadState {
+	out := make(map[string]DownloadState)
+	d.state.Range(func(key, value any) bool {
+		name, ok := key.(string)
+		if !ok {
+			return true
+		}
+		state, ok := value.(DownloadState)
+		if !ok {
+			return true
+		}
+		out[name] = state
+		return true
+	})
+	return out
+}
+
 // resolveGitHubURL queries the GitHub releases API and finds the asset
 // matching the regex pattern.
 func (d *DownloadManager) resolveGitHubURL(ctx context.Context, apiURL, pattern string) (string, error) {

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -89,6 +89,93 @@ func (SidechainType) EnumDescriptor() ([]byte, []int) {
 	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{0}
 }
 
+// BinaryType is the single typed identifier for any binary the system tracks.
+// Used wire-side by the orchestrator and consumed directly by the Flutter
+// frontends — there is no parallel Dart enum. UNSPECIFIED is reserved for
+// forwards-compat: when a frontend sees it, the binary is known to the
+// orchestrator but doesn't have a typed enum value yet.
+type BinaryType int32
+
+const (
+	BinaryType_BINARY_TYPE_UNSPECIFIED   BinaryType = 0
+	BinaryType_BINARY_TYPE_BITCOIND      BinaryType = 1
+	BinaryType_BINARY_TYPE_ENFORCER      BinaryType = 2
+	BinaryType_BINARY_TYPE_BITWINDOWD    BinaryType = 3
+	BinaryType_BINARY_TYPE_THUNDER       BinaryType = 4
+	BinaryType_BINARY_TYPE_ZSIDE         BinaryType = 5
+	BinaryType_BINARY_TYPE_BITNAMES      BinaryType = 6
+	BinaryType_BINARY_TYPE_BITASSETS     BinaryType = 7
+	BinaryType_BINARY_TYPE_TRUTHCOIN     BinaryType = 8
+	BinaryType_BINARY_TYPE_PHOTON        BinaryType = 9
+	BinaryType_BINARY_TYPE_COINSHIFT     BinaryType = 10
+	BinaryType_BINARY_TYPE_GRPCURL       BinaryType = 11
+	BinaryType_BINARY_TYPE_ORCHESTRATORD BinaryType = 12
+	BinaryType_BINARY_TYPE_ZSIDED        BinaryType = 13
+)
+
+// Enum value maps for BinaryType.
+var (
+	BinaryType_name = map[int32]string{
+		0:  "BINARY_TYPE_UNSPECIFIED",
+		1:  "BINARY_TYPE_BITCOIND",
+		2:  "BINARY_TYPE_ENFORCER",
+		3:  "BINARY_TYPE_BITWINDOWD",
+		4:  "BINARY_TYPE_THUNDER",
+		5:  "BINARY_TYPE_ZSIDE",
+		6:  "BINARY_TYPE_BITNAMES",
+		7:  "BINARY_TYPE_BITASSETS",
+		8:  "BINARY_TYPE_TRUTHCOIN",
+		9:  "BINARY_TYPE_PHOTON",
+		10: "BINARY_TYPE_COINSHIFT",
+		11: "BINARY_TYPE_GRPCURL",
+		12: "BINARY_TYPE_ORCHESTRATORD",
+		13: "BINARY_TYPE_ZSIDED",
+	}
+	BinaryType_value = map[string]int32{
+		"BINARY_TYPE_UNSPECIFIED":   0,
+		"BINARY_TYPE_BITCOIND":      1,
+		"BINARY_TYPE_ENFORCER":      2,
+		"BINARY_TYPE_BITWINDOWD":    3,
+		"BINARY_TYPE_THUNDER":       4,
+		"BINARY_TYPE_ZSIDE":         5,
+		"BINARY_TYPE_BITNAMES":      6,
+		"BINARY_TYPE_BITASSETS":     7,
+		"BINARY_TYPE_TRUTHCOIN":     8,
+		"BINARY_TYPE_PHOTON":        9,
+		"BINARY_TYPE_COINSHIFT":     10,
+		"BINARY_TYPE_GRPCURL":       11,
+		"BINARY_TYPE_ORCHESTRATORD": 12,
+		"BINARY_TYPE_ZSIDED":        13,
+	}
+)
+
+func (x BinaryType) Enum() *BinaryType {
+	p := new(BinaryType)
+	*p = x
+	return p
+}
+
+func (x BinaryType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (BinaryType) Descriptor() protoreflect.EnumDescriptor {
+	return file_orchestrator_v1_orchestrator_proto_enumTypes[1].Descriptor()
+}
+
+func (BinaryType) Type() protoreflect.EnumType {
+	return &file_orchestrator_v1_orchestrator_proto_enumTypes[1]
+}
+
+func (x BinaryType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use BinaryType.Descriptor instead.
+func (BinaryType) EnumDescriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{1}
+}
+
 type BinaryStatusMsg struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	Name            string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -1751,20 +1838,16 @@ func (x *SidechainStatus) GetSync() *ChainSync {
 
 type ChainSync struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// While is_downloading=true: blocks = MB downloaded, headers = MB total.
-	// Otherwise: blocks = current tip height, headers = bitcoind's header
-	// count (or this daemon's own headers if mainchain is unavailable).
-	Blocks  int32 `protobuf:"varint,1,opt,name=blocks,proto3" json:"blocks,omitempty"`
+	// Current tip height for the chain.
+	Blocks int32 `protobuf:"varint,1,opt,name=blocks,proto3" json:"blocks,omitempty"`
+	// bitcoind's header count, or this daemon's own headers if mainchain is
+	// unavailable.
 	Headers int32 `protobuf:"varint,2,opt,name=headers,proto3" json:"headers,omitempty"`
 	// Block tip timestamp (unix seconds), 0 if no tip yet.
 	Time int64 `protobuf:"varint,3,opt,name=time,proto3" json:"time,omitempty"`
 	// Empty on success; otherwise a short description of why this daemon's
 	// sync info isn't available (not running, RPC error, etc.).
-	Error string `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`
-	// When true, the orchestrator is currently downloading the binary for
-	// this slot — blocks/headers carry MB downloaded / MB total instead of
-	// chain heights. The UI uses this to format "X MB" vs "N blocks".
-	IsDownloading bool `protobuf:"varint,5,opt,name=is_downloading,json=isDownloading,proto3" json:"is_downloading,omitempty"`
+	Error         string `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1827,11 +1910,157 @@ func (x *ChainSync) GetError() string {
 	return ""
 }
 
-func (x *ChainSync) GetIsDownloading() bool {
+type GetDownloadStatusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetDownloadStatusRequest) Reset() {
+	*x = GetDownloadStatusRequest{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetDownloadStatusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetDownloadStatusRequest) ProtoMessage() {}
+
+func (x *GetDownloadStatusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[30]
 	if x != nil {
-		return x.IsDownloading
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
 	}
-	return false
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetDownloadStatusRequest.ProtoReflect.Descriptor instead.
+func (*GetDownloadStatusRequest) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{30}
+}
+
+type GetDownloadStatusResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Downloads     []*DownloadStatus      `protobuf:"bytes,1,rep,name=downloads,proto3" json:"downloads,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetDownloadStatusResponse) Reset() {
+	*x = GetDownloadStatusResponse{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetDownloadStatusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetDownloadStatusResponse) ProtoMessage() {}
+
+func (x *GetDownloadStatusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetDownloadStatusResponse.ProtoReflect.Descriptor instead.
+func (*GetDownloadStatusResponse) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *GetDownloadStatusResponse) GetDownloads() []*DownloadStatus {
+	if x != nil {
+		return x.Downloads
+	}
+	return nil
+}
+
+type DownloadStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Typed identifier for the binary being downloaded.
+	Binary BinaryType `protobuf:"varint,1,opt,name=binary,proto3,enum=orchestrator.v1.BinaryType" json:"binary,omitempty"`
+	// Megabytes downloaded so far. Source of truth lives in DownloadManager.
+	MbDownloaded int64 `protobuf:"varint,2,opt,name=mb_downloaded,json=mbDownloaded,proto3" json:"mb_downloaded,omitempty"`
+	// Total size in megabytes, or -1 when the server hasn't reported a
+	// Content-Length yet.
+	MbTotal int64 `protobuf:"varint,3,opt,name=mb_total,json=mbTotal,proto3" json:"mb_total,omitempty"`
+	// Optional human-readable progress string ("verifying hash", ...).
+	Message       string `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DownloadStatus) Reset() {
+	*x = DownloadStatus{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DownloadStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DownloadStatus) ProtoMessage() {}
+
+func (x *DownloadStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DownloadStatus.ProtoReflect.Descriptor instead.
+func (*DownloadStatus) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *DownloadStatus) GetBinary() BinaryType {
+	if x != nil {
+		return x.Binary
+	}
+	return BinaryType_BINARY_TYPE_UNSPECIFIED
+}
+
+func (x *DownloadStatus) GetMbDownloaded() int64 {
+	if x != nil {
+		return x.MbDownloaded
+	}
+	return 0
+}
+
+func (x *DownloadStatus) GetMbTotal() int64 {
+	if x != nil {
+		return x.MbTotal
+	}
+	return 0
+}
+
+func (x *DownloadStatus) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
 }
 
 type GetMainchainBalanceRequest struct {
@@ -1842,7 +2071,7 @@ type GetMainchainBalanceRequest struct {
 
 func (x *GetMainchainBalanceRequest) Reset() {
 	*x = GetMainchainBalanceRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[30]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1854,7 +2083,7 @@ func (x *GetMainchainBalanceRequest) String() string {
 func (*GetMainchainBalanceRequest) ProtoMessage() {}
 
 func (x *GetMainchainBalanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[30]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1867,7 +2096,7 @@ func (x *GetMainchainBalanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMainchainBalanceRequest.ProtoReflect.Descriptor instead.
 func (*GetMainchainBalanceRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{30}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{33}
 }
 
 type GetMainchainBalanceResponse struct {
@@ -1880,7 +2109,7 @@ type GetMainchainBalanceResponse struct {
 
 func (x *GetMainchainBalanceResponse) Reset() {
 	*x = GetMainchainBalanceResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[31]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1892,7 +2121,7 @@ func (x *GetMainchainBalanceResponse) String() string {
 func (*GetMainchainBalanceResponse) ProtoMessage() {}
 
 func (x *GetMainchainBalanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[31]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1905,7 +2134,7 @@ func (x *GetMainchainBalanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMainchainBalanceResponse.ProtoReflect.Descriptor instead.
 func (*GetMainchainBalanceResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{31}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GetMainchainBalanceResponse) GetConfirmed() float64 {
@@ -1936,7 +2165,7 @@ type PreviewResetDataRequest struct {
 
 func (x *PreviewResetDataRequest) Reset() {
 	*x = PreviewResetDataRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[32]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1948,7 +2177,7 @@ func (x *PreviewResetDataRequest) String() string {
 func (*PreviewResetDataRequest) ProtoMessage() {}
 
 func (x *PreviewResetDataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[32]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1961,7 +2190,7 @@ func (x *PreviewResetDataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewResetDataRequest.ProtoReflect.Descriptor instead.
 func (*PreviewResetDataRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{32}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *PreviewResetDataRequest) GetDeleteBlockchainData() bool {
@@ -2015,7 +2244,7 @@ type PreviewResetDataResponse struct {
 
 func (x *PreviewResetDataResponse) Reset() {
 	*x = PreviewResetDataResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[33]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2027,7 +2256,7 @@ func (x *PreviewResetDataResponse) String() string {
 func (*PreviewResetDataResponse) ProtoMessage() {}
 
 func (x *PreviewResetDataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[33]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2040,7 +2269,7 @@ func (x *PreviewResetDataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewResetDataResponse.ProtoReflect.Descriptor instead.
 func (*PreviewResetDataResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{33}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *PreviewResetDataResponse) GetFiles() []*ResetFileInfo {
@@ -2062,7 +2291,7 @@ type ResetFileInfo struct {
 
 func (x *ResetFileInfo) Reset() {
 	*x = ResetFileInfo{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[34]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2074,7 +2303,7 @@ func (x *ResetFileInfo) String() string {
 func (*ResetFileInfo) ProtoMessage() {}
 
 func (x *ResetFileInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[34]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2087,7 +2316,7 @@ func (x *ResetFileInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResetFileInfo.ProtoReflect.Descriptor instead.
 func (*ResetFileInfo) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{34}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ResetFileInfo) GetPath() string {
@@ -2132,7 +2361,7 @@ type StreamResetDataRequest struct {
 
 func (x *StreamResetDataRequest) Reset() {
 	*x = StreamResetDataRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[35]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2144,7 +2373,7 @@ func (x *StreamResetDataRequest) String() string {
 func (*StreamResetDataRequest) ProtoMessage() {}
 
 func (x *StreamResetDataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[35]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2157,7 +2386,7 @@ func (x *StreamResetDataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamResetDataRequest.ProtoReflect.Descriptor instead.
 func (*StreamResetDataRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{35}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *StreamResetDataRequest) GetDeleteBlockchainData() bool {
@@ -2217,7 +2446,7 @@ type StreamResetDataResponse struct {
 
 func (x *StreamResetDataResponse) Reset() {
 	*x = StreamResetDataResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[36]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2229,7 +2458,7 @@ func (x *StreamResetDataResponse) String() string {
 func (*StreamResetDataResponse) ProtoMessage() {}
 
 func (x *StreamResetDataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[36]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2242,7 +2471,7 @@ func (x *StreamResetDataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamResetDataResponse.ProtoReflect.Descriptor instead.
 func (*StreamResetDataResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{36}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *StreamResetDataResponse) GetPath() string {
@@ -2302,7 +2531,7 @@ type GetCoreMempoolInfoRequest struct {
 
 func (x *GetCoreMempoolInfoRequest) Reset() {
 	*x = GetCoreMempoolInfoRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[37]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2314,7 +2543,7 @@ func (x *GetCoreMempoolInfoRequest) String() string {
 func (*GetCoreMempoolInfoRequest) ProtoMessage() {}
 
 func (x *GetCoreMempoolInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[37]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2327,7 +2556,7 @@ func (x *GetCoreMempoolInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreMempoolInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetCoreMempoolInfoRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{37}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{40}
 }
 
 // Mirrors bitcoind's getmempoolinfo. Aggregate stats — distinct from
@@ -2360,7 +2589,7 @@ type GetCoreMempoolInfoResponse struct {
 
 func (x *GetCoreMempoolInfoResponse) Reset() {
 	*x = GetCoreMempoolInfoResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[38]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2372,7 +2601,7 @@ func (x *GetCoreMempoolInfoResponse) String() string {
 func (*GetCoreMempoolInfoResponse) ProtoMessage() {}
 
 func (x *GetCoreMempoolInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[38]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2385,7 +2614,7 @@ func (x *GetCoreMempoolInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreMempoolInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetCoreMempoolInfoResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{38}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetCoreMempoolInfoResponse) GetLoaded() bool {
@@ -2483,7 +2712,7 @@ type CoreRawCallRequest struct {
 
 func (x *CoreRawCallRequest) Reset() {
 	*x = CoreRawCallRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[39]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2495,7 +2724,7 @@ func (x *CoreRawCallRequest) String() string {
 func (*CoreRawCallRequest) ProtoMessage() {}
 
 func (x *CoreRawCallRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[39]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2508,7 +2737,7 @@ func (x *CoreRawCallRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoreRawCallRequest.ProtoReflect.Descriptor instead.
 func (*CoreRawCallRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{39}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *CoreRawCallRequest) GetMethod() string {
@@ -2542,7 +2771,7 @@ type CoreRawCallResponse struct {
 
 func (x *CoreRawCallResponse) Reset() {
 	*x = CoreRawCallResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[40]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2554,7 +2783,7 @@ func (x *CoreRawCallResponse) String() string {
 func (*CoreRawCallResponse) ProtoMessage() {}
 
 func (x *CoreRawCallResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[40]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2567,7 +2796,7 @@ func (x *CoreRawCallResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoreRawCallResponse.ProtoReflect.Descriptor instead.
 func (*CoreRawCallResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{40}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *CoreRawCallResponse) GetResultJson() string {
@@ -2709,13 +2938,20 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"sidechains\"u\n" +
 	"\x0fSidechainStatus\x122\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x1e.orchestrator.v1.SidechainTypeR\x04type\x12.\n" +
-	"\x04sync\x18\x02 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\x04sync\"\x8e\x01\n" +
+	"\x04sync\x18\x02 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\x04sync\"g\n" +
 	"\tChainSync\x12\x16\n" +
 	"\x06blocks\x18\x01 \x01(\x05R\x06blocks\x12\x18\n" +
 	"\aheaders\x18\x02 \x01(\x05R\aheaders\x12\x12\n" +
 	"\x04time\x18\x03 \x01(\x03R\x04time\x12\x14\n" +
-	"\x05error\x18\x04 \x01(\tR\x05error\x12%\n" +
-	"\x0eis_downloading\x18\x05 \x01(\bR\risDownloading\"\x1c\n" +
+	"\x05error\x18\x04 \x01(\tR\x05error\"\x1a\n" +
+	"\x18GetDownloadStatusRequest\"Z\n" +
+	"\x19GetDownloadStatusResponse\x12=\n" +
+	"\tdownloads\x18\x01 \x03(\v2\x1f.orchestrator.v1.DownloadStatusR\tdownloads\"\x9f\x01\n" +
+	"\x0eDownloadStatus\x123\n" +
+	"\x06binary\x18\x01 \x01(\x0e2\x1b.orchestrator.v1.BinaryTypeR\x06binary\x12#\n" +
+	"\rmb_downloaded\x18\x02 \x01(\x03R\fmbDownloaded\x12\x19\n" +
+	"\bmb_total\x18\x03 \x01(\x03R\ambTotal\x12\x18\n" +
+	"\amessage\x18\x04 \x01(\tR\amessage\"\x1c\n" +
 	"\x1aGetMainchainBalanceRequest\"]\n" +
 	"\x1bGetMainchainBalanceResponse\x12\x1c\n" +
 	"\tconfirmed\x18\x01 \x01(\x01R\tconfirmed\x12 \n" +
@@ -2783,7 +3019,24 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x18SIDECHAIN_TYPE_BITASSETS\x10\x04\x12\x1c\n" +
 	"\x18SIDECHAIN_TYPE_TRUTHCOIN\x10\x05\x12\x19\n" +
 	"\x15SIDECHAIN_TYPE_PHOTON\x10\x06\x12\x1c\n" +
-	"\x18SIDECHAIN_TYPE_COINSHIFT\x10\a2\xae\x0e\n" +
+	"\x18SIDECHAIN_TYPE_COINSHIFT\x10\a*\xfc\x02\n" +
+	"\n" +
+	"BinaryType\x12\x1b\n" +
+	"\x17BINARY_TYPE_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14BINARY_TYPE_BITCOIND\x10\x01\x12\x18\n" +
+	"\x14BINARY_TYPE_ENFORCER\x10\x02\x12\x1a\n" +
+	"\x16BINARY_TYPE_BITWINDOWD\x10\x03\x12\x17\n" +
+	"\x13BINARY_TYPE_THUNDER\x10\x04\x12\x15\n" +
+	"\x11BINARY_TYPE_ZSIDE\x10\x05\x12\x18\n" +
+	"\x14BINARY_TYPE_BITNAMES\x10\x06\x12\x19\n" +
+	"\x15BINARY_TYPE_BITASSETS\x10\a\x12\x19\n" +
+	"\x15BINARY_TYPE_TRUTHCOIN\x10\b\x12\x16\n" +
+	"\x12BINARY_TYPE_PHOTON\x10\t\x12\x19\n" +
+	"\x15BINARY_TYPE_COINSHIFT\x10\n" +
+	"\x12\x17\n" +
+	"\x13BINARY_TYPE_GRPCURL\x10\v\x12\x1d\n" +
+	"\x19BINARY_TYPE_ORCHESTRATORD\x10\f\x12\x16\n" +
+	"\x12BINARY_TYPE_ZSIDED\x10\r2\x9a\x0f\n" +
 	"\x13OrchestratorService\x12[\n" +
 	"\fListBinaries\x12$.orchestrator.v1.ListBinariesRequest\x1a%.orchestrator.v1.ListBinariesResponse\x12d\n" +
 	"\x0fGetBinaryStatus\x12'.orchestrator.v1.GetBinaryStatusRequest\x1a(.orchestrator.v1.GetBinaryStatusResponse\x12a\n" +
@@ -2799,7 +3052,8 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\vGetBTCPrice\x12#.orchestrator.v1.GetBTCPriceRequest\x1a$.orchestrator.v1.GetBTCPriceResponse\x12\x85\x01\n" +
 	"\x1aGetMainchainBlockchainInfo\x122.orchestrator.v1.GetMainchainBlockchainInfoRequest\x1a3.orchestrator.v1.GetMainchainBlockchainInfoResponse\x12\x82\x01\n" +
 	"\x19GetEnforcerBlockchainInfo\x121.orchestrator.v1.GetEnforcerBlockchainInfoRequest\x1a2.orchestrator.v1.GetEnforcerBlockchainInfoResponse\x12^\n" +
-	"\rGetSyncStatus\x12%.orchestrator.v1.GetSyncStatusRequest\x1a&.orchestrator.v1.GetSyncStatusResponse\x12p\n" +
+	"\rGetSyncStatus\x12%.orchestrator.v1.GetSyncStatusRequest\x1a&.orchestrator.v1.GetSyncStatusResponse\x12j\n" +
+	"\x11GetDownloadStatus\x12).orchestrator.v1.GetDownloadStatusRequest\x1a*.orchestrator.v1.GetDownloadStatusResponse\x12p\n" +
 	"\x13GetMainchainBalance\x12+.orchestrator.v1.GetMainchainBalanceRequest\x1a,.orchestrator.v1.GetMainchainBalanceResponse\x12g\n" +
 	"\x10PreviewResetData\x12(.orchestrator.v1.PreviewResetDataRequest\x1a).orchestrator.v1.PreviewResetDataResponse\x12f\n" +
 	"\x0fStreamResetData\x12'.orchestrator.v1.StreamResetDataRequest\x1a(.orchestrator.v1.StreamResetDataResponse0\x01\x12m\n" +
@@ -2819,107 +3073,115 @@ func file_orchestrator_v1_orchestrator_proto_rawDescGZIP() []byte {
 	return file_orchestrator_v1_orchestrator_proto_rawDescData
 }
 
-var file_orchestrator_v1_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
+var file_orchestrator_v1_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 46)
 var file_orchestrator_v1_orchestrator_proto_goTypes = []any{
 	(SidechainType)(0),                         // 0: orchestrator.v1.SidechainType
-	(*BinaryStatusMsg)(nil),                    // 1: orchestrator.v1.BinaryStatusMsg
-	(*StartupLogEntryMsg)(nil),                 // 2: orchestrator.v1.StartupLogEntryMsg
-	(*ListBinariesRequest)(nil),                // 3: orchestrator.v1.ListBinariesRequest
-	(*ListBinariesResponse)(nil),               // 4: orchestrator.v1.ListBinariesResponse
-	(*GetBinaryStatusRequest)(nil),             // 5: orchestrator.v1.GetBinaryStatusRequest
-	(*GetBinaryStatusResponse)(nil),            // 6: orchestrator.v1.GetBinaryStatusResponse
-	(*DownloadBinaryRequest)(nil),              // 7: orchestrator.v1.DownloadBinaryRequest
-	(*DownloadBinaryResponse)(nil),             // 8: orchestrator.v1.DownloadBinaryResponse
-	(*StartBinaryRequest)(nil),                 // 9: orchestrator.v1.StartBinaryRequest
-	(*StartBinaryResponse)(nil),                // 10: orchestrator.v1.StartBinaryResponse
-	(*StopBinaryRequest)(nil),                  // 11: orchestrator.v1.StopBinaryRequest
-	(*StopBinaryResponse)(nil),                 // 12: orchestrator.v1.StopBinaryResponse
-	(*StreamLogsRequest)(nil),                  // 13: orchestrator.v1.StreamLogsRequest
-	(*StreamLogsResponse)(nil),                 // 14: orchestrator.v1.StreamLogsResponse
-	(*StartWithL1Request)(nil),                 // 15: orchestrator.v1.StartWithL1Request
-	(*StartWithL1Response)(nil),                // 16: orchestrator.v1.StartWithL1Response
-	(*RestartDaemonRequest)(nil),               // 17: orchestrator.v1.RestartDaemonRequest
-	(*RestartDaemonResponse)(nil),              // 18: orchestrator.v1.RestartDaemonResponse
-	(*ShutdownAllRequest)(nil),                 // 19: orchestrator.v1.ShutdownAllRequest
-	(*ShutdownAllResponse)(nil),                // 20: orchestrator.v1.ShutdownAllResponse
-	(*GetBTCPriceRequest)(nil),                 // 21: orchestrator.v1.GetBTCPriceRequest
-	(*GetBTCPriceResponse)(nil),                // 22: orchestrator.v1.GetBTCPriceResponse
-	(*GetMainchainBlockchainInfoRequest)(nil),  // 23: orchestrator.v1.GetMainchainBlockchainInfoRequest
-	(*GetMainchainBlockchainInfoResponse)(nil), // 24: orchestrator.v1.GetMainchainBlockchainInfoResponse
-	(*GetEnforcerBlockchainInfoRequest)(nil),   // 25: orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	(*GetEnforcerBlockchainInfoResponse)(nil),  // 26: orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	(*GetSyncStatusRequest)(nil),               // 27: orchestrator.v1.GetSyncStatusRequest
-	(*GetSyncStatusResponse)(nil),              // 28: orchestrator.v1.GetSyncStatusResponse
-	(*SidechainStatus)(nil),                    // 29: orchestrator.v1.SidechainStatus
-	(*ChainSync)(nil),                          // 30: orchestrator.v1.ChainSync
-	(*GetMainchainBalanceRequest)(nil),         // 31: orchestrator.v1.GetMainchainBalanceRequest
-	(*GetMainchainBalanceResponse)(nil),        // 32: orchestrator.v1.GetMainchainBalanceResponse
-	(*PreviewResetDataRequest)(nil),            // 33: orchestrator.v1.PreviewResetDataRequest
-	(*PreviewResetDataResponse)(nil),           // 34: orchestrator.v1.PreviewResetDataResponse
-	(*ResetFileInfo)(nil),                      // 35: orchestrator.v1.ResetFileInfo
-	(*StreamResetDataRequest)(nil),             // 36: orchestrator.v1.StreamResetDataRequest
-	(*StreamResetDataResponse)(nil),            // 37: orchestrator.v1.StreamResetDataResponse
-	(*GetCoreMempoolInfoRequest)(nil),          // 38: orchestrator.v1.GetCoreMempoolInfoRequest
-	(*GetCoreMempoolInfoResponse)(nil),         // 39: orchestrator.v1.GetCoreMempoolInfoResponse
-	(*CoreRawCallRequest)(nil),                 // 40: orchestrator.v1.CoreRawCallRequest
-	(*CoreRawCallResponse)(nil),                // 41: orchestrator.v1.CoreRawCallResponse
-	nil,                                        // 42: orchestrator.v1.StartBinaryRequest.EnvEntry
-	nil,                                        // 43: orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	(BinaryType)(0),                            // 1: orchestrator.v1.BinaryType
+	(*BinaryStatusMsg)(nil),                    // 2: orchestrator.v1.BinaryStatusMsg
+	(*StartupLogEntryMsg)(nil),                 // 3: orchestrator.v1.StartupLogEntryMsg
+	(*ListBinariesRequest)(nil),                // 4: orchestrator.v1.ListBinariesRequest
+	(*ListBinariesResponse)(nil),               // 5: orchestrator.v1.ListBinariesResponse
+	(*GetBinaryStatusRequest)(nil),             // 6: orchestrator.v1.GetBinaryStatusRequest
+	(*GetBinaryStatusResponse)(nil),            // 7: orchestrator.v1.GetBinaryStatusResponse
+	(*DownloadBinaryRequest)(nil),              // 8: orchestrator.v1.DownloadBinaryRequest
+	(*DownloadBinaryResponse)(nil),             // 9: orchestrator.v1.DownloadBinaryResponse
+	(*StartBinaryRequest)(nil),                 // 10: orchestrator.v1.StartBinaryRequest
+	(*StartBinaryResponse)(nil),                // 11: orchestrator.v1.StartBinaryResponse
+	(*StopBinaryRequest)(nil),                  // 12: orchestrator.v1.StopBinaryRequest
+	(*StopBinaryResponse)(nil),                 // 13: orchestrator.v1.StopBinaryResponse
+	(*StreamLogsRequest)(nil),                  // 14: orchestrator.v1.StreamLogsRequest
+	(*StreamLogsResponse)(nil),                 // 15: orchestrator.v1.StreamLogsResponse
+	(*StartWithL1Request)(nil),                 // 16: orchestrator.v1.StartWithL1Request
+	(*StartWithL1Response)(nil),                // 17: orchestrator.v1.StartWithL1Response
+	(*RestartDaemonRequest)(nil),               // 18: orchestrator.v1.RestartDaemonRequest
+	(*RestartDaemonResponse)(nil),              // 19: orchestrator.v1.RestartDaemonResponse
+	(*ShutdownAllRequest)(nil),                 // 20: orchestrator.v1.ShutdownAllRequest
+	(*ShutdownAllResponse)(nil),                // 21: orchestrator.v1.ShutdownAllResponse
+	(*GetBTCPriceRequest)(nil),                 // 22: orchestrator.v1.GetBTCPriceRequest
+	(*GetBTCPriceResponse)(nil),                // 23: orchestrator.v1.GetBTCPriceResponse
+	(*GetMainchainBlockchainInfoRequest)(nil),  // 24: orchestrator.v1.GetMainchainBlockchainInfoRequest
+	(*GetMainchainBlockchainInfoResponse)(nil), // 25: orchestrator.v1.GetMainchainBlockchainInfoResponse
+	(*GetEnforcerBlockchainInfoRequest)(nil),   // 26: orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	(*GetEnforcerBlockchainInfoResponse)(nil),  // 27: orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	(*GetSyncStatusRequest)(nil),               // 28: orchestrator.v1.GetSyncStatusRequest
+	(*GetSyncStatusResponse)(nil),              // 29: orchestrator.v1.GetSyncStatusResponse
+	(*SidechainStatus)(nil),                    // 30: orchestrator.v1.SidechainStatus
+	(*ChainSync)(nil),                          // 31: orchestrator.v1.ChainSync
+	(*GetDownloadStatusRequest)(nil),           // 32: orchestrator.v1.GetDownloadStatusRequest
+	(*GetDownloadStatusResponse)(nil),          // 33: orchestrator.v1.GetDownloadStatusResponse
+	(*DownloadStatus)(nil),                     // 34: orchestrator.v1.DownloadStatus
+	(*GetMainchainBalanceRequest)(nil),         // 35: orchestrator.v1.GetMainchainBalanceRequest
+	(*GetMainchainBalanceResponse)(nil),        // 36: orchestrator.v1.GetMainchainBalanceResponse
+	(*PreviewResetDataRequest)(nil),            // 37: orchestrator.v1.PreviewResetDataRequest
+	(*PreviewResetDataResponse)(nil),           // 38: orchestrator.v1.PreviewResetDataResponse
+	(*ResetFileInfo)(nil),                      // 39: orchestrator.v1.ResetFileInfo
+	(*StreamResetDataRequest)(nil),             // 40: orchestrator.v1.StreamResetDataRequest
+	(*StreamResetDataResponse)(nil),            // 41: orchestrator.v1.StreamResetDataResponse
+	(*GetCoreMempoolInfoRequest)(nil),          // 42: orchestrator.v1.GetCoreMempoolInfoRequest
+	(*GetCoreMempoolInfoResponse)(nil),         // 43: orchestrator.v1.GetCoreMempoolInfoResponse
+	(*CoreRawCallRequest)(nil),                 // 44: orchestrator.v1.CoreRawCallRequest
+	(*CoreRawCallResponse)(nil),                // 45: orchestrator.v1.CoreRawCallResponse
+	nil,                                        // 46: orchestrator.v1.StartBinaryRequest.EnvEntry
+	nil,                                        // 47: orchestrator.v1.StartWithL1Request.TargetEnvEntry
 }
 var file_orchestrator_v1_orchestrator_proto_depIdxs = []int32{
-	2,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
-	1,  // 1: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
-	1,  // 2: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
-	42, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
-	43, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
-	30, // 5: orchestrator.v1.GetSyncStatusResponse.mainchain:type_name -> orchestrator.v1.ChainSync
-	30, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
-	29, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
+	3,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
+	2,  // 1: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
+	2,  // 2: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
+	46, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
+	47, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	31, // 5: orchestrator.v1.GetSyncStatusResponse.mainchain:type_name -> orchestrator.v1.ChainSync
+	31, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
+	30, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
 	0,  // 8: orchestrator.v1.SidechainStatus.type:type_name -> orchestrator.v1.SidechainType
-	30, // 9: orchestrator.v1.SidechainStatus.sync:type_name -> orchestrator.v1.ChainSync
-	35, // 10: orchestrator.v1.PreviewResetDataResponse.files:type_name -> orchestrator.v1.ResetFileInfo
-	3,  // 11: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
-	5,  // 12: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
-	7,  // 13: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
-	9,  // 14: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
-	11, // 15: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
-	13, // 16: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
-	15, // 17: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
-	17, // 18: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
-	19, // 19: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
-	21, // 20: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
-	23, // 21: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
-	25, // 22: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	27, // 23: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
-	31, // 24: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
-	33, // 25: orchestrator.v1.OrchestratorService.PreviewResetData:input_type -> orchestrator.v1.PreviewResetDataRequest
-	36, // 26: orchestrator.v1.OrchestratorService.StreamResetData:input_type -> orchestrator.v1.StreamResetDataRequest
-	38, // 27: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
-	40, // 28: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
-	4,  // 29: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
-	6,  // 30: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
-	8,  // 31: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
-	10, // 32: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
-	12, // 33: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
-	14, // 34: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
-	16, // 35: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
-	18, // 36: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
-	20, // 37: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
-	22, // 38: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
-	24, // 39: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
-	26, // 40: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	28, // 41: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
-	32, // 42: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
-	34, // 43: orchestrator.v1.OrchestratorService.PreviewResetData:output_type -> orchestrator.v1.PreviewResetDataResponse
-	37, // 44: orchestrator.v1.OrchestratorService.StreamResetData:output_type -> orchestrator.v1.StreamResetDataResponse
-	39, // 45: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
-	41, // 46: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
-	29, // [29:47] is the sub-list for method output_type
-	11, // [11:29] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	31, // 9: orchestrator.v1.SidechainStatus.sync:type_name -> orchestrator.v1.ChainSync
+	34, // 10: orchestrator.v1.GetDownloadStatusResponse.downloads:type_name -> orchestrator.v1.DownloadStatus
+	1,  // 11: orchestrator.v1.DownloadStatus.binary:type_name -> orchestrator.v1.BinaryType
+	39, // 12: orchestrator.v1.PreviewResetDataResponse.files:type_name -> orchestrator.v1.ResetFileInfo
+	4,  // 13: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
+	6,  // 14: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
+	8,  // 15: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
+	10, // 16: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
+	12, // 17: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
+	14, // 18: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
+	16, // 19: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
+	18, // 20: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
+	20, // 21: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
+	22, // 22: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
+	24, // 23: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
+	26, // 24: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	28, // 25: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
+	32, // 26: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
+	35, // 27: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
+	37, // 28: orchestrator.v1.OrchestratorService.PreviewResetData:input_type -> orchestrator.v1.PreviewResetDataRequest
+	40, // 29: orchestrator.v1.OrchestratorService.StreamResetData:input_type -> orchestrator.v1.StreamResetDataRequest
+	42, // 30: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
+	44, // 31: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
+	5,  // 32: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
+	7,  // 33: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
+	9,  // 34: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
+	11, // 35: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
+	13, // 36: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
+	15, // 37: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
+	17, // 38: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
+	19, // 39: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
+	21, // 40: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
+	23, // 41: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
+	25, // 42: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
+	27, // 43: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	29, // 44: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
+	33, // 45: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
+	36, // 46: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
+	38, // 47: orchestrator.v1.OrchestratorService.PreviewResetData:output_type -> orchestrator.v1.PreviewResetDataResponse
+	41, // 48: orchestrator.v1.OrchestratorService.StreamResetData:output_type -> orchestrator.v1.StreamResetDataResponse
+	43, // 49: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
+	45, // 50: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
+	32, // [32:51] is the sub-list for method output_type
+	13, // [13:32] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_orchestrator_v1_orchestrator_proto_init() }
@@ -2932,8 +3194,8 @@ func file_orchestrator_v1_orchestrator_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_orchestrator_v1_orchestrator_proto_rawDesc), len(file_orchestrator_v1_orchestrator_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   43,
+			NumEnums:      2,
+			NumMessages:   46,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect/orchestrator.connect.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect/orchestrator.connect.go
@@ -72,6 +72,9 @@ const (
 	// OrchestratorServiceGetSyncStatusProcedure is the fully-qualified name of the
 	// OrchestratorService's GetSyncStatus RPC.
 	OrchestratorServiceGetSyncStatusProcedure = "/orchestrator.v1.OrchestratorService/GetSyncStatus"
+	// OrchestratorServiceGetDownloadStatusProcedure is the fully-qualified name of the
+	// OrchestratorService's GetDownloadStatus RPC.
+	OrchestratorServiceGetDownloadStatusProcedure = "/orchestrator.v1.OrchestratorService/GetDownloadStatus"
 	// OrchestratorServiceGetMainchainBalanceProcedure is the fully-qualified name of the
 	// OrchestratorService's GetMainchainBalance RPC.
 	OrchestratorServiceGetMainchainBalanceProcedure = "/orchestrator.v1.OrchestratorService/GetMainchainBalance"
@@ -131,6 +134,11 @@ type OrchestratorServiceClient interface {
 	// Backend fans out to all three in parallel so the three numbers are taken
 	// at the same wall-clock instant — no two cards in the UI can ever disagree.
 	GetSyncStatus(context.Context, *connect.Request[v1.GetSyncStatusRequest]) (*connect.Response[v1.GetSyncStatusResponse], error)
+	// Snapshot of every binary the orchestrator is currently downloading.
+	// Reads from the in-memory DownloadManager state — light, polled by the
+	// frontend's DownloadProvider on a fast (100ms) cadence while a download
+	// is in flight, and dropping back to 2s when the response is empty.
+	GetDownloadStatus(context.Context, *connect.Request[v1.GetDownloadStatusRequest]) (*connect.Response[v1.GetDownloadStatusResponse], error)
 	// Get wallet balance from Bitcoin Core (proxied via orchestrator).
 	GetMainchainBalance(context.Context, *connect.Request[v1.GetMainchainBalanceRequest]) (*connect.Response[v1.GetMainchainBalanceResponse], error)
 	// Preview what would be deleted for the given reset categories (no side effects).
@@ -233,6 +241,12 @@ func NewOrchestratorServiceClient(httpClient connect.HTTPClient, baseURL string,
 			connect.WithSchema(orchestratorServiceMethods.ByName("GetSyncStatus")),
 			connect.WithClientOptions(opts...),
 		),
+		getDownloadStatus: connect.NewClient[v1.GetDownloadStatusRequest, v1.GetDownloadStatusResponse](
+			httpClient,
+			baseURL+OrchestratorServiceGetDownloadStatusProcedure,
+			connect.WithSchema(orchestratorServiceMethods.ByName("GetDownloadStatus")),
+			connect.WithClientOptions(opts...),
+		),
 		getMainchainBalance: connect.NewClient[v1.GetMainchainBalanceRequest, v1.GetMainchainBalanceResponse](
 			httpClient,
 			baseURL+OrchestratorServiceGetMainchainBalanceProcedure,
@@ -281,6 +295,7 @@ type orchestratorServiceClient struct {
 	getMainchainBlockchainInfo *connect.Client[v1.GetMainchainBlockchainInfoRequest, v1.GetMainchainBlockchainInfoResponse]
 	getEnforcerBlockchainInfo  *connect.Client[v1.GetEnforcerBlockchainInfoRequest, v1.GetEnforcerBlockchainInfoResponse]
 	getSyncStatus              *connect.Client[v1.GetSyncStatusRequest, v1.GetSyncStatusResponse]
+	getDownloadStatus          *connect.Client[v1.GetDownloadStatusRequest, v1.GetDownloadStatusResponse]
 	getMainchainBalance        *connect.Client[v1.GetMainchainBalanceRequest, v1.GetMainchainBalanceResponse]
 	previewResetData           *connect.Client[v1.PreviewResetDataRequest, v1.PreviewResetDataResponse]
 	streamResetData            *connect.Client[v1.StreamResetDataRequest, v1.StreamResetDataResponse]
@@ -353,6 +368,11 @@ func (c *orchestratorServiceClient) GetSyncStatus(ctx context.Context, req *conn
 	return c.getSyncStatus.CallUnary(ctx, req)
 }
 
+// GetDownloadStatus calls orchestrator.v1.OrchestratorService.GetDownloadStatus.
+func (c *orchestratorServiceClient) GetDownloadStatus(ctx context.Context, req *connect.Request[v1.GetDownloadStatusRequest]) (*connect.Response[v1.GetDownloadStatusResponse], error) {
+	return c.getDownloadStatus.CallUnary(ctx, req)
+}
+
 // GetMainchainBalance calls orchestrator.v1.OrchestratorService.GetMainchainBalance.
 func (c *orchestratorServiceClient) GetMainchainBalance(ctx context.Context, req *connect.Request[v1.GetMainchainBalanceRequest]) (*connect.Response[v1.GetMainchainBalanceResponse], error) {
 	return c.getMainchainBalance.CallUnary(ctx, req)
@@ -421,6 +441,11 @@ type OrchestratorServiceHandler interface {
 	// Backend fans out to all three in parallel so the three numbers are taken
 	// at the same wall-clock instant — no two cards in the UI can ever disagree.
 	GetSyncStatus(context.Context, *connect.Request[v1.GetSyncStatusRequest]) (*connect.Response[v1.GetSyncStatusResponse], error)
+	// Snapshot of every binary the orchestrator is currently downloading.
+	// Reads from the in-memory DownloadManager state — light, polled by the
+	// frontend's DownloadProvider on a fast (100ms) cadence while a download
+	// is in flight, and dropping back to 2s when the response is empty.
+	GetDownloadStatus(context.Context, *connect.Request[v1.GetDownloadStatusRequest]) (*connect.Response[v1.GetDownloadStatusResponse], error)
 	// Get wallet balance from Bitcoin Core (proxied via orchestrator).
 	GetMainchainBalance(context.Context, *connect.Request[v1.GetMainchainBalanceRequest]) (*connect.Response[v1.GetMainchainBalanceResponse], error)
 	// Preview what would be deleted for the given reset categories (no side effects).
@@ -519,6 +544,12 @@ func NewOrchestratorServiceHandler(svc OrchestratorServiceHandler, opts ...conne
 		connect.WithSchema(orchestratorServiceMethods.ByName("GetSyncStatus")),
 		connect.WithHandlerOptions(opts...),
 	)
+	orchestratorServiceGetDownloadStatusHandler := connect.NewUnaryHandler(
+		OrchestratorServiceGetDownloadStatusProcedure,
+		svc.GetDownloadStatus,
+		connect.WithSchema(orchestratorServiceMethods.ByName("GetDownloadStatus")),
+		connect.WithHandlerOptions(opts...),
+	)
 	orchestratorServiceGetMainchainBalanceHandler := connect.NewUnaryHandler(
 		OrchestratorServiceGetMainchainBalanceProcedure,
 		svc.GetMainchainBalance,
@@ -577,6 +608,8 @@ func NewOrchestratorServiceHandler(svc OrchestratorServiceHandler, opts ...conne
 			orchestratorServiceGetEnforcerBlockchainInfoHandler.ServeHTTP(w, r)
 		case OrchestratorServiceGetSyncStatusProcedure:
 			orchestratorServiceGetSyncStatusHandler.ServeHTTP(w, r)
+		case OrchestratorServiceGetDownloadStatusProcedure:
+			orchestratorServiceGetDownloadStatusHandler.ServeHTTP(w, r)
 		case OrchestratorServiceGetMainchainBalanceProcedure:
 			orchestratorServiceGetMainchainBalanceHandler.ServeHTTP(w, r)
 		case OrchestratorServicePreviewResetDataProcedure:
@@ -646,6 +679,10 @@ func (UnimplementedOrchestratorServiceHandler) GetEnforcerBlockchainInfo(context
 
 func (UnimplementedOrchestratorServiceHandler) GetSyncStatus(context.Context, *connect.Request[v1.GetSyncStatusRequest]) (*connect.Response[v1.GetSyncStatusResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("orchestrator.v1.OrchestratorService.GetSyncStatus is not implemented"))
+}
+
+func (UnimplementedOrchestratorServiceHandler) GetDownloadStatus(context.Context, *connect.Request[v1.GetDownloadStatusRequest]) (*connect.Response[v1.GetDownloadStatusResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("orchestrator.v1.OrchestratorService.GetDownloadStatus is not implemented"))
 }
 
 func (UnimplementedOrchestratorServiceHandler) GetMainchainBalance(context.Context, *connect.Request[v1.GetMainchainBalanceRequest]) (*connect.Response[v1.GetMainchainBalanceResponse], error) {

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -195,6 +195,13 @@ func (o *Orchestrator) DownloadStateForTest(name string) (DownloadState, bool) {
 	return o.download.State(name)
 }
 
+// DownloadStates returns the live download snapshot for every binary the
+// manager is currently fetching. Empty map means no in-flight downloads.
+// Source of truth for the GetDownloadStatus RPC.
+func (o *Orchestrator) DownloadStates() map[string]DownloadState {
+	return o.download.States()
+}
+
 // New creates a new Orchestrator.
 func New(dataDir, network, bitwindowDir string, configs []BinaryConfig, log zerolog.Logger) *Orchestrator {
 	pidMgr := NewPidFileManager(dataDir, log)
@@ -1901,16 +1908,12 @@ func (o *Orchestrator) fetchMainchainBlockchainInfo(ctx context.Context) (*Mainc
 }
 
 // ChainSyncResult is one chain's tip snapshot. Error is set on failure; the
-// numeric fields are best-effort zero in that case. While IsDownloading is
-// true, Blocks/Headers carry MB downloaded / MB total instead of chain
-// heights — the polled API reuses the same fields so adding download state
-// didn't require new wire fields.
+// numeric fields are best-effort zero in that case.
 type ChainSyncResult struct {
-	Blocks        int64
-	Headers       int64
-	Time          int64
-	Error         string
-	IsDownloading bool
+	Blocks  int64
+	Headers int64
+	Time    int64
+	Error   string
 }
 
 // SyncStatus is the atomic snapshot returned by GetSyncStatus. Mainchain +
@@ -1977,16 +1980,10 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 		heights = o.fetchExplorerHeights(ctx)
 	}()
 
-	// Mainchain: download check first, then bitcoind getblockchaininfo.
+	// Mainchain: bitcoind getblockchaininfo.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if state, ok := o.download.State("bitcoind"); ok && state.Running {
-			out.Mainchain.Blocks = state.MBDownloaded
-			out.Mainchain.Headers = state.MBTotal
-			out.Mainchain.IsDownloading = true
-			return
-		}
 		info, err := o.GetMainchainBlockchainInfo(ctx)
 		if err != nil {
 			out.Mainchain.Error = err.Error()
@@ -1997,16 +1994,10 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 		out.Mainchain.Time = info.Time
 	}()
 
-	// Enforcer: download check, then ValidatorService.GetChainTip.
+	// Enforcer: ValidatorService.GetChainTip.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if state, ok := o.download.State("enforcer"); ok && state.Running {
-			out.Enforcer.Blocks = state.MBDownloaded
-			out.Enforcer.Headers = state.MBTotal
-			out.Enforcer.IsDownloading = true
-			return
-		}
 		cfg, ok := o.Configs()["enforcer"]
 		if !ok || cfg.Port == 0 {
 			out.Enforcer.Error = "enforcer not configured"
@@ -2038,12 +2029,6 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if state, ok := o.download.State(name); ok && state.Running {
-				slot.Blocks = state.MBDownloaded
-				slot.Headers = state.MBTotal
-				slot.IsDownloading = true
-				return
-			}
 			cfg, ok := o.Configs()[name]
 			if !ok {
 				slot.Error = fmt.Sprintf("unknown sidechain: %s", name)
@@ -2073,10 +2058,10 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 	wg.Wait()
 
 	// Headers fan-out: dependent chains measure progress against bitcoind's
-	// tip. Skip this for downloading slots — their blocks/headers are MB,
-	// not chain heights, and overwriting headers would corrupt the meaning.
-	if !out.Enforcer.IsDownloading && out.Enforcer.Error == "" {
-		if !out.Mainchain.IsDownloading && out.Mainchain.Error == "" {
+	// tip. Errored slots are skipped so we don't overwrite their zero state
+	// with stale mainchain numbers.
+	if out.Enforcer.Error == "" {
+		if out.Mainchain.Error == "" {
 			out.Enforcer.Headers = out.Mainchain.Headers
 		} else {
 			out.Enforcer.Headers = out.Enforcer.Blocks
@@ -2088,7 +2073,7 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 	// effort: when the explorer fetch fails the map is empty and Headers
 	// fall back to slot.Blocks so the UI doesn't divide by zero.
 	for name, slot := range out.Sidechains {
-		if slot.IsDownloading || slot.Error != "" {
+		if slot.Error != "" {
 			continue
 		}
 		if h, ok := heights[name]; ok {

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -56,6 +56,12 @@ service OrchestratorService {
   // at the same wall-clock instant — no two cards in the UI can ever disagree.
   rpc GetSyncStatus(GetSyncStatusRequest) returns (GetSyncStatusResponse);
 
+  // Snapshot of every binary the orchestrator is currently downloading.
+  // Reads from the in-memory DownloadManager state — light, polled by the
+  // frontend's DownloadProvider on a fast (100ms) cadence while a download
+  // is in flight, and dropping back to 2s when the response is empty.
+  rpc GetDownloadStatus(GetDownloadStatusRequest) returns (GetDownloadStatusResponse);
+
   // Get wallet balance from Bitcoin Core (proxied via orchestrator).
   rpc GetMainchainBalance(GetMainchainBalanceRequest) returns (GetMainchainBalanceResponse);
 
@@ -283,26 +289,68 @@ enum SidechainType {
   SIDECHAIN_TYPE_COINSHIFT = 7;
 }
 
+// BinaryType is the single typed identifier for any binary the system tracks.
+// Used wire-side by the orchestrator and consumed directly by the Flutter
+// frontends — there is no parallel Dart enum. UNSPECIFIED is reserved for
+// forwards-compat: when a frontend sees it, the binary is known to the
+// orchestrator but doesn't have a typed enum value yet.
+enum BinaryType {
+  BINARY_TYPE_UNSPECIFIED = 0;
+  BINARY_TYPE_BITCOIND = 1;
+  BINARY_TYPE_ENFORCER = 2;
+  BINARY_TYPE_BITWINDOWD = 3;
+  BINARY_TYPE_THUNDER = 4;
+  BINARY_TYPE_ZSIDE = 5;
+  BINARY_TYPE_BITNAMES = 6;
+  BINARY_TYPE_BITASSETS = 7;
+  BINARY_TYPE_TRUTHCOIN = 8;
+  BINARY_TYPE_PHOTON = 9;
+  BINARY_TYPE_COINSHIFT = 10;
+  BINARY_TYPE_GRPCURL = 11;
+  BINARY_TYPE_ORCHESTRATORD = 12;
+  BINARY_TYPE_ZSIDED = 13;
+}
+
 message SidechainStatus {
   SidechainType type = 1;
   ChainSync sync = 2;
 }
 
 message ChainSync {
-  // While is_downloading=true: blocks = MB downloaded, headers = MB total.
-  // Otherwise: blocks = current tip height, headers = bitcoind's header
-  // count (or this daemon's own headers if mainchain is unavailable).
+  // Current tip height for the chain.
   int32 blocks = 1;
+  // bitcoind's header count, or this daemon's own headers if mainchain is
+  // unavailable.
   int32 headers = 2;
   // Block tip timestamp (unix seconds), 0 if no tip yet.
   int64 time = 3;
   // Empty on success; otherwise a short description of why this daemon's
   // sync info isn't available (not running, RPC error, etc.).
   string error = 4;
-  // When true, the orchestrator is currently downloading the binary for
-  // this slot — blocks/headers carry MB downloaded / MB total instead of
-  // chain heights. The UI uses this to format "X MB" vs "N blocks".
-  bool is_downloading = 5;
+}
+
+// GetDownloadStatus
+//
+// Snapshot of the orchestrator's live download tracking. Returns one entry
+// per binary that is currently being fetched. A daemon that is not in flight
+// is omitted entirely — the empty list is the steady state.
+
+message GetDownloadStatusRequest {}
+
+message GetDownloadStatusResponse {
+  repeated DownloadStatus downloads = 1;
+}
+
+message DownloadStatus {
+  // Typed identifier for the binary being downloaded.
+  BinaryType binary = 1;
+  // Megabytes downloaded so far. Source of truth lives in DownloadManager.
+  int64 mb_downloaded = 2;
+  // Total size in megabytes, or -1 when the server hasn't reported a
+  // Content-Length yet.
+  int64 mb_total = 3;
+  // Optional human-readable progress string ("verifying hash", ...).
+  string message = 4;
 }
 
 // GetMainchainBalance

--- a/thunder/lib/main.dart
+++ b/thunder/lib/main.dart
@@ -78,7 +78,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   late ThunderLive thunderRPC;
 
   await initSidechainDependencies(
-    sidechainType: BinaryType.thunder,
+    sidechainType: BinaryType.BINARY_TYPE_THUNDER,
     createSidechainConnection: (_) {
       thunderRPC = ThunderLive();
       GetIt.I.registerSingleton<ThunderRPC>(thunderRPC);
@@ -95,7 +95,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   unawaited(
     initBackendManagedSidechainRuntime(
       log: log,
-      binary: BinaryType.thunder,
+      binary: BinaryType.BINARY_TYPE_THUNDER,
       appRpc: thunderRPC,
     ),
   );
@@ -158,7 +158,7 @@ void bootBinaries(Logger log) {
   unawaited(
     bootBackendManagedSidechain(
       log: log,
-      binary: BinaryType.orchestratord,
+      binary: BinaryType.BINARY_TYPE_ORCHESTRATORD,
       appRpc: GetIt.I.isRegistered<ThunderRPC>() ? GetIt.I.get<ThunderRPC>() : null,
     ),
   );

--- a/thunder/pubspec.lock
+++ b/thunder/pubspec.lock
@@ -1335,4 +1335,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.225
+version: 1.0.226
 
 environment:
   sdk: 3.11.4

--- a/thunder/test/mocks/mock_binary.dart
+++ b/thunder/test/mocks/mock_binary.dart
@@ -45,7 +45,7 @@ class MockBinary extends Binary {
       );
 
   @override
-  BinaryType get type => BinaryType.thunder;
+  BinaryType get type => BinaryType.BINARY_TYPE_THUNDER;
 
   @override
   Color get color => SailColorScheme.orange;

--- a/thunder/test/mocks/rpc_mock_sidechain.dart
+++ b/thunder/test/mocks/rpc_mock_sidechain.dart
@@ -3,7 +3,7 @@ import 'package:sail_ui/sail_ui.dart';
 class MockSidechainRPC extends SidechainRPC {
   MockSidechainRPC()
     : super(
-        binaryType: BinaryType.zSide,
+        binaryType: BinaryType.BINARY_TYPE_ZSIDE,
       );
 
   @override

--- a/truthcoin/lib/main.dart
+++ b/truthcoin/lib/main.dart
@@ -81,7 +81,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   }
 
   await initSidechainDependencies(
-    sidechainType: BinaryType.truthcoin,
+    sidechainType: BinaryType.BINARY_TYPE_TRUTHCOIN,
     createSidechainConnection: createSidechainConnection,
     applicationDir: applicationDir,
     log: log,
@@ -94,7 +94,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   unawaited(
     initBackendManagedSidechainRuntime(
       log: log,
-      binary: BinaryType.truthcoin,
+      binary: BinaryType.BINARY_TYPE_TRUTHCOIN,
       appRpc: GetIt.I.isRegistered<TruthcoinRPC>() ? GetIt.I.get<TruthcoinRPC>() : null,
     ),
   );
@@ -253,7 +253,7 @@ void bootBinaries(Logger log) {
   unawaited(
     bootBackendManagedSidechain(
       log: log,
-      binary: BinaryType.orchestratord,
+      binary: BinaryType.BINARY_TYPE_ORCHESTRATORD,
       appRpc: GetIt.I.isRegistered<TruthcoinRPC>() ? GetIt.I.get<TruthcoinRPC>() : null,
     ),
   );

--- a/truthcoin/pubspec.lock
+++ b/truthcoin/pubspec.lock
@@ -1335,4 +1335,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.96
+version: 1.0.97
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/test/mocks/mock_binary.dart
+++ b/truthcoin/test/mocks/mock_binary.dart
@@ -45,7 +45,7 @@ class MockBinary extends Binary {
       );
 
   @override
-  BinaryType get type => BinaryType.truthcoin;
+  BinaryType get type => BinaryType.BINARY_TYPE_TRUTHCOIN;
 
   @override
   Color get color => SailColorScheme.orange;

--- a/truthcoin/test/mocks/mock_truthcoin_rpc.dart
+++ b/truthcoin/test/mocks/mock_truthcoin_rpc.dart
@@ -3,7 +3,7 @@ import 'package:sail_ui/sail_ui.dart';
 /// A controllable mock for TruthcoinRPC that allows tests to configure
 /// specific responses for market and voting operations.
 class TestTruthcoinRPC extends TruthcoinRPC {
-  TestTruthcoinRPC() : super(binaryType: BinaryType.truthcoin);
+  TestTruthcoinRPC() : super(binaryType: BinaryType.BINARY_TYPE_TRUTHCOIN);
 
   // Connection state
   bool _connected = true;

--- a/truthcoin/test/mocks/rpc_mock_sidechain.dart
+++ b/truthcoin/test/mocks/rpc_mock_sidechain.dart
@@ -3,7 +3,7 @@ import 'package:sail_ui/sail_ui.dart';
 class MockSidechainRPC extends SidechainRPC {
   MockSidechainRPC()
     : super(
-        binaryType: BinaryType.zSide,
+        binaryType: BinaryType.BINARY_TYPE_ZSIDE,
       );
 
   @override

--- a/zside/lib/main.dart
+++ b/zside/lib/main.dart
@@ -92,7 +92,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   late ZSideLive zsideRPC;
 
   await initSidechainDependencies(
-    sidechainType: BinaryType.zSide,
+    sidechainType: BinaryType.BINARY_TYPE_ZSIDE,
     createSidechainConnection: (_) {
       zsideRPC = ZSideLive();
       GetIt.I.registerSingleton<ZSideRPC>(zsideRPC);
@@ -281,8 +281,8 @@ void bootBinaries(Logger log) async {
       zsideRpc.connectionError = null;
       zsideRpc.markStateChanged();
     }
-    binaryProvider.addStartupLogForBinary(BinaryType.zSide, 'Starting zsided...');
-    binaryProvider.addStartupLogForBinary(BinaryType.zSided, 'Starting zsided...');
+    binaryProvider.addStartupLogForBinary(BinaryType.BINARY_TYPE_ZSIDE, 'Starting zsided...');
+    binaryProvider.addStartupLogForBinary(BinaryType.BINARY_TYPE_ZSIDED, 'Starting zsided...');
 
     // Start zsided via BinaryProvider (it's bundled, not downloaded)
     final zsided = binaryProvider.binaries.firstWhere((b) => b is ZSided);
@@ -290,8 +290,8 @@ void bootBinaries(Logger log) async {
 
     // Wait for zsided to be ready before calling StartWithL1
     log.i('bootBinaries: waiting for zsided readiness');
-    binaryProvider.addStartupLogForBinary(BinaryType.zSide, 'Waiting for zsided...');
-    binaryProvider.addStartupLogForBinary(BinaryType.zSided, 'Waiting for zsided...');
+    binaryProvider.addStartupLogForBinary(BinaryType.BINARY_TYPE_ZSIDE, 'Waiting for zsided...');
+    binaryProvider.addStartupLogForBinary(BinaryType.BINARY_TYPE_ZSIDED, 'Waiting for zsided...');
     final orchestrator = GetIt.I.get<OrchestratorRPC>();
     for (var i = 0; i < 30; i++) {
       try {

--- a/zside/pubspec.lock
+++ b/zside/pubspec.lock
@@ -1335,4 +1335,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.11.4"
-  flutter: ">=3.41.6"
+  flutter: "3.41.6"

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.223
+version: 1.0.224
 
 environment:
   sdk: 3.11.4

--- a/zside/test/mocks/mock_binary.dart
+++ b/zside/test/mocks/mock_binary.dart
@@ -45,7 +45,7 @@ class MockBinary extends Binary {
       );
 
   @override
-  BinaryType get type => BinaryType.zSide;
+  BinaryType get type => BinaryType.BINARY_TYPE_ZSIDE;
 
   @override
   Color get color => SailColorScheme.orange;

--- a/zside/test/mocks/rpc_mock_sidechain.dart
+++ b/zside/test/mocks/rpc_mock_sidechain.dart
@@ -3,7 +3,7 @@ import 'package:sail_ui/sail_ui.dart';
 class MockSidechainRPC extends SidechainRPC {
   MockSidechainRPC()
     : super(
-        binaryType: BinaryType.zSide,
+        binaryType: BinaryType.BINARY_TYPE_ZSIDE,
       );
 
   @override

--- a/zside/test/mocks/rpc_mock_zside.dart
+++ b/zside/test/mocks/rpc_mock_zside.dart
@@ -3,7 +3,7 @@ import 'package:sail_ui/sail_ui.dart';
 class MockZSideRPC extends ZSideRPC {
   MockZSideRPC()
     : super(
-        binaryType: BinaryType.zSide,
+        binaryType: BinaryType.BINARY_TYPE_ZSIDE,
       );
 
   @override


### PR DESCRIPTION
Splits download progress out of the GetSyncStatus overload into a dedicated GetDownloadStatus RPC and DownloadProvider. Daemon status now prefers showing live download state over sync state — a kicked-off download lights up its card instantly.