### PR TITLE
regtest enforcer + sidechain boot fixes

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.229
+version: 1.0.230
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.229
+version: 1.0.230
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.82
+version: 0.2.83
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/server/go.sum
+++ b/bitwindow/server/go.sum
@@ -20,8 +20,8 @@ github.com/btcsuite/btcd/btcec/v2 v2.3.6 h1:IzlsEr9olcSRKB/n7c4351F3xHKxS2lma+1U
 github.com/btcsuite/btcd/btcec/v2 v2.3.6/go.mod h1:m22FrOAiuxl/tht9wIqAoGHcbnCCaPWyauO8y2LGGtQ=
 github.com/btcsuite/btcd/btcutil v1.2.0 h1:p3+S2g3Q+7G5NOh4Ji+2UrBOrg5Z0Q4ykzShWG1Dhgs=
 github.com/btcsuite/btcd/btcutil v1.2.0/go.mod h1:/Taflm113pYjUpbWKKQEfa6XOtI/+WS8awxeMZpY75k=
-github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 h1:59Kx4K6lzOW5w6nFlA0v5+lk/6sjybR934QNHSJZPTQ=
-github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
+github.com/btcsuite/btcd/chaincfg/chainhash v1.2.0 h1:yMIg99+4aBvqfl/HzJRKfxTX9rGfikoI9uvFzterhc8=
+github.com/btcsuite/btcd/chaincfg/chainhash v1.2.0/go.mod h1:Y72Ren9gfhlEvnwnT78BGcSNO2UMphTKLn9AorF+5rg=
 github.com/btcsuite/btclog v1.0.0 h1:sEkpKJMmfGiyZjADwEIgB1NSwMyfdD1FB8v6+w1T0Ns=
 github.com/btcsuite/btclog v1.0.0/go.mod h1:w7xnGOhwT3lmrS4H3b/D1XAXxvh+tbhUm8xeHN2y3TQ=
 github.com/cmars/basen v0.0.0-20150613233007-fe3947df716e h1:0XBUw73chJ1VYSsfvcPvVT7auykAJce9FpRr10L6Qhw=

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.102
+version: 1.0.103
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/config/sidechain_main.dart
+++ b/sail_ui/lib/config/sidechain_main.dart
@@ -114,6 +114,16 @@ Future<void> initSidechainDependencies({
   final sidechainConnection = createSidechainConnection(binary);
   GetIt.I.registerSingleton<SidechainRPC>(sidechainConnection);
 
+  // Register OrchestratorRPC before SyncProvider — the constructor just holds
+  // host/port, the connection dial is lazy. SyncProvider.fetch() runs from its
+  // own constructor and needs this resolvable before initBackendManagedSidechainRuntime
+  // runs. initBackendManagedSidechainRuntime guards against double-registration.
+  if (!GetIt.I.isRegistered<OrchestratorRPC>()) {
+    GetIt.I.registerSingleton<OrchestratorRPC>(
+      OrchestratorRPC(host: 'localhost', port: 30400),
+    );
+  }
+
   // Binary lifecycle is managed by the backend (e.g. orchestratord).
   // State flows through BackendStateProvider.startWatching() → 1s
   // listBinaries poll → RPCConnection.

--- a/sail_ui/lib/models/enforcer_config_options.dart
+++ b/sail_ui/lib/models/enforcer_config_options.dart
@@ -222,7 +222,7 @@ class EnforcerConfigOptions {
       category: 'Wallet',
       description: 'Esplora API URL',
       tooltip:
-          'URL of the Esplora server to use for the wallet. Network defaults: Signet: https://explorer.signet.drivechain.info/api, Mainnet: https://explorer.forknet.drivechain.info/api, Regtest: http://localhost:3003',
+          'URL of the Esplora server to use for the wallet. Network defaults: Signet: https://explorer.signet.drivechain.info/api, Mainnet: https://explorer.forknet.drivechain.info/api. Regtest has no default — the enforcer runs with wallet-sync-source=disabled instead.',
       inputType: EnforcerConfigInputType.url,
       isUseful: true,
     ),

--- a/sidechain-orchestrator/config/enforcer_conf.go
+++ b/sidechain-orchestrator/config/enforcer_conf.go
@@ -298,6 +298,14 @@ func (m *EnforcerConfManager) GetCliArgs() []string {
 		}
 	}
 
+	// Regtest has no esplora to point at and no bundled electrs — without
+	// an explicit sync source the enforcer dies on startup trying to dial
+	// http://localhost:3003. Default to "disabled": BDK still tracks new
+	// blocks via the ZMQ feed, just doesn't backfill from a chain server.
+	if m.bitcoinConf.Network == NetworkRegtest && !seen["wallet-sync-source"] {
+		args = append(args, "--wallet-sync-source=disabled")
+	}
+
 	return args
 }
 

--- a/sidechain-orchestrator/config/enforcer_conf_test.go
+++ b/sidechain-orchestrator/config/enforcer_conf_test.go
@@ -325,7 +325,10 @@ func TestGetCliArgsReflectsCurrentNetwork(t *testing.T) {
 	m.bitcoinConf.Network = NetworkRegtest
 	regtestArgs := m.GetCliArgs()
 	requireArg(t, regtestArgs, fmt.Sprintf("--node-rpc-addr=127.0.0.1:%d", RPCPortForNetwork(NetworkRegtest)))
-	requireArg(t, regtestArgs, fmt.Sprintf("--wallet-esplora-url=%s", EsploraURLForNetwork(NetworkRegtest)))
+	// Regtest has no esplora / electrs in the stack; the enforcer is
+	// switched to wallet-sync-source=disabled and gets no esplora URL.
+	rejectArgPrefix(t, regtestArgs, "--wallet-esplora-url=")
+	requireArg(t, regtestArgs, "--wallet-sync-source=disabled")
 
 	m.bitcoinConf.Network = NetworkMainnet
 	mainnetArgs := m.GetCliArgs()
@@ -363,6 +366,17 @@ func rejectArg(t *testing.T, args []string, bad string) {
 	for _, got := range args {
 		if got == bad {
 			t.Errorf("arg %q must not appear in %v", bad, args)
+		}
+	}
+}
+
+// rejectArgPrefix fails if any arg starts with prefix — use when you want
+// to assert a flag is absent regardless of its value.
+func rejectArgPrefix(t *testing.T, args []string, prefix string) {
+	t.Helper()
+	for _, got := range args {
+		if strings.HasPrefix(got, prefix) {
+			t.Errorf("arg with prefix %q must not appear in %v", prefix, args)
 		}
 	}
 }

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -52,6 +52,9 @@ func RPCPortForNetwork(n Network) int {
 }
 
 // EsploraURLForNetwork returns the esplora API URL for a given network.
+// Regtest returns "" — no public esplora exists for it and we don't ship a
+// local one, so the enforcer falls back to wallet-sync-source=disabled
+// (see GetCliArgs in enforcer_conf.go).
 func EsploraURLForNetwork(n Network) string {
 	switch n {
 	case NetworkSignet:
@@ -60,8 +63,6 @@ func EsploraURLForNetwork(n Network) string {
 		return "https://mempool.space/api"
 	case NetworkForknet:
 		return "https://explorer.forknet.drivechain.info/api"
-	case NetworkRegtest:
-		return "http://localhost:3003"
 	default:
 		return ""
 	}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.231
+version: 1.0.232
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.102
+version: 1.0.103
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.229
+version: 1.0.230
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
## Summary

Two boot-time fixes.

### Sidechain GetIt boot order (Thunder, BitAssets, BitNames, Photon, Truthcoin, CoinShift, ZSide)

`initSidechainDependencies` constructs `SyncProvider`, which immediately calls `fetch()` and resolves `OrchestratorRPC` from GetIt. But `OrchestratorRPC` wasn't registered until `initBackendManagedSidechainRuntime` ran *after* `initSidechainDependencies`, so the first fetch threw `Getit: Object/factory with type OrchestratorRPC is not registered`. BitWindow doesn't hit this because it registers `OrchestratorRPC` before `SyncProvider` in its own `main.dart`.

Fix: register `OrchestratorRPC` in `initSidechainDependencies` right before `SyncProvider` is created. The RPC client constructor only stores host/port — the wire dial is lazy, so registering before orchestratord is up is safe. `initBackendManagedSidechainRuntime` already has an `isRegistered` guard.

### Regtest enforcer crash

For regtest, `EsploraURLForNetwork` returned `http://localhost:3003` even though nothing in the stack starts an esplora/electrs there. The enforcer died on startup with `ConnectionRefused 127.0.0.1:3003` while initializing the esplora client.

Fix in `sidechain-orchestrator/config`:
- `EsploraURLForNetwork(NetworkRegtest)` returns `""` (other networks unchanged).
- `GetCliArgs` adds `--wallet-sync-source=disabled` for regtest when the user hasn't set a sync source explicitly. BDK still tracks new blocks via the bitcoind ZMQ feed; it just doesn't backfill from a chain indexer. For regtest where the user mines their own chain, there's no history to backfill.

Persisted overrides still win — set `wallet-sync-source` or `wallet-esplora-url` in `bitwindow-enforcer.conf` and that takes precedence.

## Test plan

- [x] `go test ./config/... -run TestGetCliArgs` passes (5/5)
- [ ] BitWindow: `chain=regtest` in bitcoin.conf → enforcer comes up cleanly, no esplora connection refused error
- [ ] BitWindow: `chain=signet` still gets `--wallet-esplora-url=https://explorer.signet.drivechain.info/api`
- [ ] Thunder: boots without `Getit: OrchestratorRPC is not registered` exception