### PR TITLE
orchestrator: zero sidechain headers when explorer fetch fails

### DIFF
--- a/sidechain-orchestrator/get_sync_status_test.go
+++ b/sidechain-orchestrator/get_sync_status_test.go
@@ -320,3 +320,119 @@ func TestGetSyncStatus_AddingNewSidechainRequiresThreeRegistrations(t *testing.T
 		)
 	}
 }
+
+// countingSidechainServer returns an httptest.Server that records every
+// hit and replies with {"count": <count>} (or the supplied error status).
+func countingSidechainServer(t *testing.T, count int64) (*httptest.Server, *int32) {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]int64{"count": count})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+func TestGetSidechainBlockCount_CachesWithinTTL(t *testing.T) {
+	o := newTestOrchestrator(t)
+	srv, hits := countingSidechainServer(t, 100)
+	setSidechainPort(t, o, "thunder", srv.URL)
+	adoptSidechain(t, o, "thunder")
+
+	first, err := o.GetSidechainBlockCount(context.Background(), "thunder")
+	require.NoError(t, err)
+	second, err := o.GetSidechainBlockCount(context.Background(), "thunder")
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(100), first)
+	assert.Equal(t, int64(100), second)
+	assert.Equal(t, int32(1), atomic.LoadInt32(hits),
+		"two calls within sidechainCountCacheTTL must share one RPC — the cache is what stops UI flicker")
+}
+
+// Regression for "thunder block count doesn't update during sync": with the
+// old code, every transient RPC error reset slot.Blocks to 0 in the response
+// and the UI saw alternating 0/N values. The fix mirrors bitcoind's last-
+// good cache — failed fetches preserve the previous count.
+func TestGetSidechainBlockCount_PreservesLastGoodOnError(t *testing.T) {
+	o := newTestOrchestrator(t)
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]int64{"count": 1500})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	setSidechainPort(t, o, "thunder", srv.URL)
+	adoptSidechain(t, o, "thunder")
+
+	first, err := o.GetSidechainBlockCount(context.Background(), "thunder")
+	require.NoError(t, err)
+	require.Equal(t, int64(1500), first)
+
+	// Bust the TTL so the next call hits the network (and fails).
+	o.sidechainCountMu.Lock()
+	o.sidechainCountCache["thunder"].fetchedAt = time.Now().Add(-time.Hour)
+	o.sidechainCountMu.Unlock()
+
+	second, err := o.GetSidechainBlockCount(context.Background(), "thunder")
+	require.Error(t, err, "the leader still surfaces the underlying RPC error")
+	assert.Equal(t, int64(1500), second,
+		"last-good blocks must survive a transient failure — bitcoind's pattern at orchestrator.go:1946-1955")
+}
+
+// The full UI flow: GetSyncStatus must report the cached count (and no
+// error) on the second call even when the sidechain RPC has started
+// timing out, otherwise the bottom-nav card flickers 0 → real → 0 → real.
+func TestGetSyncStatus_KeepsLastGoodBlocksAcrossTransientFailures(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.explorerHTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return jsonResponse(map[string]map[string]interface{}{
+				"thunder": {"height": "200"},
+			}), nil
+		}),
+	}
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]int64{"count": 1500})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	setSidechainPort(t, o, "thunder", srv.URL)
+	adoptSidechain(t, o, "thunder")
+
+	// First poll: succeeds, populates cache.
+	out, err := o.GetSyncStatus(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1500), out.Sidechains["thunder"].Blocks)
+	require.Empty(t, out.Sidechains["thunder"].Error)
+
+	// Invalidate the TTL window so the next GetSyncStatus must re-fetch
+	// (and the upstream RPC will fail). Without the last-good cache the
+	// slot would come back Blocks=0, Error="HTTP 500..." — exactly the
+	// flicker the user reported.
+	o.sidechainCountMu.Lock()
+	o.sidechainCountCache["thunder"].fetchedAt = time.Now().Add(-time.Hour)
+	o.sidechainCountMu.Unlock()
+
+	out2, err := o.GetSyncStatus(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1500), out2.Sidechains["thunder"].Blocks,
+		"second poll must show the last-good 1500, not snap to zero")
+	assert.Equal(t, "", out2.Sidechains["thunder"].Error,
+		"transient RPC failure must not leak as a slot.Error — the cache hides it")
+}

--- a/sidechain-orchestrator/get_sync_status_test.go
+++ b/sidechain-orchestrator/get_sync_status_test.go
@@ -335,15 +335,15 @@ func countingSidechainServer(t *testing.T, count int64) (*httptest.Server, *int3
 	return srv, &hits
 }
 
-func TestSidechainProber_CachesWithinTTL(t *testing.T) {
+func TestSidechainConnection_CachesWithinTTL(t *testing.T) {
 	o := newTestOrchestrator(t)
 	srv, hits := countingSidechainServer(t, 100)
 	setSidechainPort(t, o, "thunder", srv.URL)
 	adoptSidechain(t, o, "thunder")
 
-	first, err := o.chainProberFor("thunder").Probe(context.Background())
+	first, err := o.syncConnectionFor("thunder").Fetch(context.Background())
 	require.NoError(t, err)
-	second, err := o.chainProberFor("thunder").Probe(context.Background())
+	second, err := o.syncConnectionFor("thunder").Fetch(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(100), first.Blocks)
@@ -355,9 +355,9 @@ func TestSidechainProber_CachesWithinTTL(t *testing.T) {
 // Regression for "thunder block count doesn't update during sync": with the
 // old code, every transient RPC error reset slot.Blocks to 0 in the response
 // and the UI saw alternating 0/N values. The fix routes every chain through
-// cachedChainProber's last-good machinery — failed fetches preserve the
+// CachedConnection's last-good machinery — failed fetches preserve the
 // previous count.
-func TestSidechainProber_PreservesLastGoodOnError(t *testing.T) {
+func TestSidechainConnection_PreservesLastGoodOnError(t *testing.T) {
 	o := newTestOrchestrator(t)
 
 	var hits int32
@@ -374,18 +374,18 @@ func TestSidechainProber_PreservesLastGoodOnError(t *testing.T) {
 	setSidechainPort(t, o, "thunder", srv.URL)
 	adoptSidechain(t, o, "thunder")
 
-	first, err := o.chainProberFor("thunder").Probe(context.Background())
+	first, err := o.syncConnectionFor("thunder").Fetch(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, int64(1500), first.Blocks)
 
 	// Bust the TTL so the next call hits the network (and fails).
-	o.invalidateChainProberCacheForTest("thunder")
+	o.invalidateSyncConnectionCacheForTest("thunder")
 
-	second, err := o.chainProberFor("thunder").Probe(context.Background())
+	second, err := o.syncConnectionFor("thunder").Fetch(context.Background())
 	require.Error(t, err, "the leader still surfaces the underlying RPC error")
 	require.NotNil(t, second)
 	assert.Equal(t, int64(1500), second.Blocks,
-		"last-good blocks must survive a transient failure — bitcoind's pattern at orchestrator.go:1946-1955")
+		"last-good blocks must survive a transient failure")
 }
 
 // The full UI flow: GetSyncStatus must report the cached count (and no
@@ -425,7 +425,7 @@ func TestGetSyncStatus_KeepsLastGoodBlocksAcrossTransientFailures(t *testing.T) 
 	// (and the upstream RPC will fail). Without the last-good cache the
 	// slot would come back Blocks=0, Error="HTTP 500..." — exactly the
 	// flicker the user reported.
-	o.invalidateChainProberCacheForTest("thunder")
+	o.invalidateSyncConnectionCacheForTest("thunder")
 
 	out2, err := o.GetSyncStatus(context.Background())
 	require.NoError(t, err)

--- a/sidechain-orchestrator/get_sync_status_test.go
+++ b/sidechain-orchestrator/get_sync_status_test.go
@@ -204,11 +204,12 @@ func TestFetchExplorerHeights_ServesStaleOnFailure(t *testing.T) {
 	require.Equal(t, int64(100), first["thunder"])
 
 	// Invalidate the TTL window so the next call hits the network again,
-	// where it will fail. The "keep serving previous values" branch at
-	// orchestrator.go:2196-2202 must still return the cached map.
-	o.explorerMu.Lock()
-	o.explorerFetched = time.Now().Add(-time.Hour)
-	o.explorerMu.Unlock()
+	// where it will fail. CachedConnection's last-good-on-error must still
+	// hand back the previously fetched map.
+	cc := o.explorerHeightsCached()
+	cc.mu.Lock()
+	cc.fetched = time.Now().Add(-time.Hour)
+	cc.mu.Unlock()
 
 	second := o.fetchExplorerHeights(ctx)
 	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "second call must hit the network after TTL expiry")

--- a/sidechain-orchestrator/get_sync_status_test.go
+++ b/sidechain-orchestrator/get_sync_status_test.go
@@ -1,0 +1,322 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// roundTripperFunc lets a test swap an http.Client's transport with a
+// per-request function — used to intercept the hardcoded explorer URL
+// (https://node.<network>.drivechain.info/...) without refactoring prod
+// code to take an injectable base URL.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// jsonResponse builds a 200 OK response carrying the JSON-serialised body.
+func jsonResponse(body interface{}) *http.Response {
+	b, _ := json.Marshal(body)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(string(b))),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+// statusResponse builds a non-200 response with an empty body.
+func statusResponse(code int) *http.Response {
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+	}
+}
+
+// setSidechainPort overwrites the cached BinaryConfig.Port for `name` to
+// point at the httptest server's local port. The orchestrator's GetSyncStatus
+// reads cfg.Port via o.Configs() at probe time so the override is picked up
+// on the next call.
+func setSidechainPort(t *testing.T, o *Orchestrator, name string, serverURL string) {
+	t.Helper()
+	u, err := url.Parse(serverURL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(u.Port())
+	require.NoError(t, err)
+
+	cfg, err := o.getConfig(name)
+	require.NoError(t, err)
+	cfg.Port = port
+	o.UpdateConfigs([]BinaryConfig{cfg})
+}
+
+// adoptSidechain flips o.process.IsRunning(name) to true so GetSyncStatus
+// reaches the RPC probe instead of short-circuiting with "not running".
+func adoptSidechain(t *testing.T, o *Orchestrator, name string) {
+	t.Helper()
+	cfg, err := o.getConfig(name)
+	require.NoError(t, err)
+	o.process.AdoptProcess(cfg, 99999)
+}
+
+// sidechainCountServer spins up an httptest.Server that responds to any
+// POST with {"count": <count>} when status==200, or the supplied non-200
+// status (empty body).
+func sidechainCountServer(t *testing.T, status int, count int64) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]int64{"count": count})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestGetSyncStatus_LeavesHeadersZeroWhenExplorerDown(t *testing.T) {
+	o := newTestOrchestrator(t)
+
+	o.explorerHTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return statusResponse(http.StatusServiceUnavailable), nil
+		}),
+	}
+
+	srv := sidechainCountServer(t, http.StatusOK, 50)
+	setSidechainPort(t, o, "thunder", srv.URL)
+	adoptSidechain(t, o, "thunder")
+
+	out, err := o.GetSyncStatus(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, out.Sidechains["thunder"])
+
+	slot := out.Sidechains["thunder"]
+	assert.Equal(t, int64(50), slot.Blocks)
+	// The public explorer is a UX extra — only signet has one today, so on
+	// mainnet/testnet/regtest/forknet the fetch always fails. Headers must
+	// stay zero so the UI renders an unknown/zero-progress state instead of
+	// the previous Headers=Blocks fallback that made every running sidechain
+	// look fully synced mid-IBD.
+	assert.Equal(t, int64(0), slot.Headers, "headers must stay 0 when the explorer is unreachable, never fall back to Blocks")
+	assert.Equal(t, "", slot.Error)
+}
+
+func TestGetSyncStatus_UsesExplorerHeightsWhenAvailable(t *testing.T) {
+	t.Run("string height (current explorer shape)", func(t *testing.T) {
+		o := newTestOrchestrator(t)
+		o.explorerHTTPClient = &http.Client{
+			Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				return jsonResponse(map[string]map[string]interface{}{
+					"thunder": {"height": "100"},
+				}), nil
+			}),
+		}
+
+		srv := sidechainCountServer(t, http.StatusOK, 50)
+		setSidechainPort(t, o, "thunder", srv.URL)
+		adoptSidechain(t, o, "thunder")
+
+		out, err := o.GetSyncStatus(context.Background())
+		require.NoError(t, err)
+		slot := out.Sidechains["thunder"]
+		require.NotNil(t, slot)
+		assert.Equal(t, int64(50), slot.Blocks)
+		assert.Equal(t, int64(100), slot.Headers)
+		assert.Equal(t, "", slot.Error)
+	})
+
+	t.Run("numeric height (legacy explorer shape)", func(t *testing.T) {
+		o := newTestOrchestrator(t)
+		o.explorerHTTPClient = &http.Client{
+			Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				return jsonResponse(map[string]map[string]interface{}{
+					"thunder": {"height": float64(100)},
+				}), nil
+			}),
+		}
+
+		srv := sidechainCountServer(t, http.StatusOK, 50)
+		setSidechainPort(t, o, "thunder", srv.URL)
+		adoptSidechain(t, o, "thunder")
+
+		out, err := o.GetSyncStatus(context.Background())
+		require.NoError(t, err)
+		slot := out.Sidechains["thunder"]
+		require.NotNil(t, slot)
+		assert.Equal(t, int64(50), slot.Blocks)
+		assert.Equal(t, int64(100), slot.Headers, "code at orchestrator.go:2206-2213 must tolerate float64 heights")
+	})
+}
+
+func TestFetchExplorerHeights_CachesWithinTTL(t *testing.T) {
+	o := newTestOrchestrator(t)
+	var hits int32
+	o.explorerHTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			atomic.AddInt32(&hits, 1)
+			return jsonResponse(map[string]map[string]interface{}{
+				"thunder": {"height": "100"},
+			}), nil
+		}),
+	}
+
+	ctx := context.Background()
+	first := o.fetchExplorerHeights(ctx)
+	second := o.fetchExplorerHeights(ctx)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&hits), "second call within TTL must be served from cache")
+	assert.Equal(t, int64(100), first["thunder"])
+	assert.Equal(t, int64(100), second["thunder"])
+}
+
+func TestFetchExplorerHeights_ServesStaleOnFailure(t *testing.T) {
+	o := newTestOrchestrator(t)
+	var hits int32
+	o.explorerHTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			n := atomic.AddInt32(&hits, 1)
+			if n == 1 {
+				return jsonResponse(map[string]map[string]interface{}{
+					"thunder": {"height": "100"},
+				}), nil
+			}
+			return statusResponse(http.StatusInternalServerError), nil
+		}),
+	}
+
+	ctx := context.Background()
+	first := o.fetchExplorerHeights(ctx)
+	require.Equal(t, int64(100), first["thunder"])
+
+	// Invalidate the TTL window so the next call hits the network again,
+	// where it will fail. The "keep serving previous values" branch at
+	// orchestrator.go:2196-2202 must still return the cached map.
+	o.explorerMu.Lock()
+	o.explorerFetched = time.Now().Add(-time.Hour)
+	o.explorerMu.Unlock()
+
+	second := o.fetchExplorerHeights(ctx)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "second call must hit the network after TTL expiry")
+	require.NotNil(t, second)
+	assert.Equal(t, int64(100), second["thunder"], "stale cache must be served on explorer failure rather than dropping headers")
+}
+
+func TestGetSyncStatus_PerSidechainErrorsAreIsolated(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.explorerHTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return jsonResponse(map[string]map[string]interface{}{
+				"thunder":  {"height": "100"},
+				"bitnames": {"height": "200"},
+			}), nil
+		}),
+	}
+
+	thunderSrv := sidechainCountServer(t, http.StatusOK, 50)
+	bitnamesSrv := sidechainCountServer(t, http.StatusInternalServerError, 0)
+	setSidechainPort(t, o, "thunder", thunderSrv.URL)
+	setSidechainPort(t, o, "bitnames", bitnamesSrv.URL)
+	adoptSidechain(t, o, "thunder")
+	adoptSidechain(t, o, "bitnames")
+
+	out, err := o.GetSyncStatus(context.Background())
+	require.NoError(t, err)
+
+	thunder := out.Sidechains["thunder"]
+	require.NotNil(t, thunder)
+	assert.Equal(t, int64(50), thunder.Blocks)
+	assert.Equal(t, int64(100), thunder.Headers)
+	assert.Equal(t, "", thunder.Error, "thunder must be unaffected by bitnames' 500")
+
+	bitnames := out.Sidechains["bitnames"]
+	require.NotNil(t, bitnames)
+	assert.NotEmpty(t, bitnames.Error, "bitnames slot must surface the upstream HTTP failure")
+	assert.Equal(t, int64(0), bitnames.Blocks)
+
+	// Every other registered sidechain must show "not running" without
+	// leaking into thunder's slot.
+	for name, slot := range out.Sidechains {
+		if name == "thunder" || name == "bitnames" {
+			continue
+		}
+		assert.Equal(t, "not running", slot.Error, "uninstalled sidechain %q should be not running", name)
+		assert.Equal(t, int64(0), slot.Blocks, "uninstalled sidechain %q should report zero blocks", name)
+	}
+}
+
+func TestGetSyncStatus_NotRunningSidechainCarriesError(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.explorerHTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return jsonResponse(map[string]map[string]interface{}{
+				"thunder": {"height": "100"},
+			}), nil
+		}),
+	}
+
+	out, err := o.GetSyncStatus(context.Background())
+	require.NoError(t, err)
+
+	// All L2 sidechain slots must exist (pre-populated at orchestrator.go:2038-2042)
+	// even though none were adopted.
+	var l2 int
+	for _, cfg := range o.Configs() {
+		if cfg.ChainLayer == 2 {
+			l2++
+		}
+	}
+	require.Equal(t, l2, len(out.Sidechains))
+
+	for name, slot := range out.Sidechains {
+		assert.Equal(t, "not running", slot.Error, "sidechain %q should carry not-running error", name)
+		assert.Equal(t, int64(0), slot.Blocks, "sidechain %q blocks must remain zero", name)
+	}
+}
+
+func TestGetSyncStatus_AddingNewSidechainRequiresThreeRegistrations(t *testing.T) {
+	// Invariant: every L2 sidechain registered in chains_config.json has a
+	// corresponding entry in sidechainServicePath (orchestrator.go:2008).
+	// Without it, GetSyncStatus reaches the "unknown sidechain" branch
+	// (orchestrator.go:2117-2120) and the chain never reports a block
+	// height regardless of whether the binary is running. A new sidechain
+	// must be registered in three places: chains_config.json, the
+	// jsonKeyToName map (config_loader.go), and sidechainServicePath here.
+	for _, cfg := range AllDefaults() {
+		if cfg.ChainLayer != 2 {
+			continue
+		}
+		_, ok := sidechainServicePath[cfg.Name]
+		assert.Truef(t, ok,
+			"sidechain %q is registered in chains_config.json but has no entry in sidechainServicePath (orchestrator.go:2008) — it will never report block height",
+			cfg.Name,
+		)
+	}
+
+	// Mirror check against config.AllDirConfigs() — both producers must
+	// agree on the set of L2 names.
+	for key, dc := range config.AllDirConfigs() {
+		if dc.ChainLayer != 2 {
+			continue
+		}
+		_, ok := sidechainServicePath[key]
+		assert.Truef(t, ok,
+			"sidechain JSON key %q (chain_layer=2) has no entry in sidechainServicePath (orchestrator.go:2008)",
+			key,
+		)
+	}
+}

--- a/sidechain-orchestrator/get_sync_status_test.go
+++ b/sidechain-orchestrator/get_sync_status_test.go
@@ -335,28 +335,29 @@ func countingSidechainServer(t *testing.T, count int64) (*httptest.Server, *int3
 	return srv, &hits
 }
 
-func TestGetSidechainBlockCount_CachesWithinTTL(t *testing.T) {
+func TestSidechainProber_CachesWithinTTL(t *testing.T) {
 	o := newTestOrchestrator(t)
 	srv, hits := countingSidechainServer(t, 100)
 	setSidechainPort(t, o, "thunder", srv.URL)
 	adoptSidechain(t, o, "thunder")
 
-	first, err := o.GetSidechainBlockCount(context.Background(), "thunder")
+	first, err := o.chainProberFor("thunder").Probe(context.Background())
 	require.NoError(t, err)
-	second, err := o.GetSidechainBlockCount(context.Background(), "thunder")
+	second, err := o.chainProberFor("thunder").Probe(context.Background())
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(100), first)
-	assert.Equal(t, int64(100), second)
+	assert.Equal(t, int64(100), first.Blocks)
+	assert.Equal(t, int64(100), second.Blocks)
 	assert.Equal(t, int32(1), atomic.LoadInt32(hits),
-		"two calls within sidechainCountCacheTTL must share one RPC — the cache is what stops UI flicker")
+		"two calls within blockchainInfoCacheTTL must share one RPC — the cache is what stops UI flicker")
 }
 
 // Regression for "thunder block count doesn't update during sync": with the
 // old code, every transient RPC error reset slot.Blocks to 0 in the response
-// and the UI saw alternating 0/N values. The fix mirrors bitcoind's last-
-// good cache — failed fetches preserve the previous count.
-func TestGetSidechainBlockCount_PreservesLastGoodOnError(t *testing.T) {
+// and the UI saw alternating 0/N values. The fix routes every chain through
+// cachedChainProber's last-good machinery — failed fetches preserve the
+// previous count.
+func TestSidechainProber_PreservesLastGoodOnError(t *testing.T) {
 	o := newTestOrchestrator(t)
 
 	var hits int32
@@ -373,18 +374,17 @@ func TestGetSidechainBlockCount_PreservesLastGoodOnError(t *testing.T) {
 	setSidechainPort(t, o, "thunder", srv.URL)
 	adoptSidechain(t, o, "thunder")
 
-	first, err := o.GetSidechainBlockCount(context.Background(), "thunder")
+	first, err := o.chainProberFor("thunder").Probe(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, int64(1500), first)
+	require.Equal(t, int64(1500), first.Blocks)
 
 	// Bust the TTL so the next call hits the network (and fails).
-	o.sidechainCountMu.Lock()
-	o.sidechainCountCache["thunder"].fetchedAt = time.Now().Add(-time.Hour)
-	o.sidechainCountMu.Unlock()
+	o.invalidateChainProberCacheForTest("thunder")
 
-	second, err := o.GetSidechainBlockCount(context.Background(), "thunder")
+	second, err := o.chainProberFor("thunder").Probe(context.Background())
 	require.Error(t, err, "the leader still surfaces the underlying RPC error")
-	assert.Equal(t, int64(1500), second,
+	require.NotNil(t, second)
+	assert.Equal(t, int64(1500), second.Blocks,
 		"last-good blocks must survive a transient failure — bitcoind's pattern at orchestrator.go:1946-1955")
 }
 
@@ -425,9 +425,7 @@ func TestGetSyncStatus_KeepsLastGoodBlocksAcrossTransientFailures(t *testing.T) 
 	// (and the upstream RPC will fail). Without the last-good cache the
 	// slot would come back Blocks=0, Error="HTTP 500..." — exactly the
 	// flicker the user reported.
-	o.sidechainCountMu.Lock()
-	o.sidechainCountCache["thunder"].fetchedAt = time.Now().Add(-time.Hour)
-	o.sidechainCountMu.Unlock()
+	o.invalidateChainProberCacheForTest("thunder")
 
 	out2, err := o.GetSyncStatus(context.Background())
 	require.NoError(t, err)

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -168,6 +168,15 @@ type Orchestrator struct {
 	bciErr       error
 	bciFetchedAt time.Time
 
+	// Per-sidechain GetBlockCount cache + single-flight, mirroring the
+	// bitcoind pattern above. Without this every SyncProvider poll
+	// (~10/s during sync) hit the sidechain's RPC raw — when a probe
+	// timed out the slot reset to Blocks=0/Error=timeout and the UI's
+	// block count flickered between 0 and the real value, looking
+	// like "thunder doesn't update during sync" while bitcoind did.
+	sidechainCountMu    sync.Mutex
+	sidechainCountCache map[string]*sidechainCountCacheEntry
+
 	// httpClientsMu guards the lazy HTTP-client singletons used by the
 	// chatty pollers (CoreStatusClient, GetSyncStatus). Each client is built
 	// once and reused across every poll — without this, every probe
@@ -1982,6 +1991,107 @@ func (o *Orchestrator) fetchMainchainBlockchainInfo(ctx context.Context) (*Mainc
 	return &info, nil
 }
 
+// sidechainCountCacheEntry mirrors the bciMu/bciInfo/bciInFlight trio in
+// per-sidechain form. `blocks` holds the last-good count and is preserved
+// across transient RPC errors so the UI doesn't flicker to zero.
+type sidechainCountCacheEntry struct {
+	blocks    int64
+	err       error
+	fetchedAt time.Time
+	inFlight  chan struct{}
+}
+
+// sidechainCountCacheTTL matches blockchainInfoCacheTTL — the sidechain
+// daemons tick once per ~minute so a 1 s cache is plenty fresh for the
+// UI and 10x less load on the daemon under aggressive SyncProvider polling.
+const sidechainCountCacheTTL = time.Second
+
+// GetSidechainBlockCount returns the cached block-count for name, single-
+// flighting concurrent callers and preserving the last-good value across
+// transient RPC errors. Modelled on [GetMainchainBlockchainInfo]: a fresh
+// fetch is only issued once the cached value is older than
+// [sidechainCountCacheTTL] or has never been populated. The returned
+// error mirrors the most recent RPC outcome — callers that want only the
+// last-good number can ignore it (slot.Blocks stays accurate).
+func (o *Orchestrator) GetSidechainBlockCount(ctx context.Context, name string) (int64, error) {
+	o.sidechainCountMu.Lock()
+	if o.sidechainCountCache == nil {
+		o.sidechainCountCache = make(map[string]*sidechainCountCacheEntry)
+	}
+	entry, ok := o.sidechainCountCache[name]
+	if !ok {
+		entry = &sidechainCountCacheEntry{}
+		o.sidechainCountCache[name] = entry
+	}
+
+	// Cache hit on a recent successful fetch — return immediately.
+	if entry.err == nil && !entry.fetchedAt.IsZero() && time.Since(entry.fetchedAt) < sidechainCountCacheTTL {
+		blocks := entry.blocks
+		o.sidechainCountMu.Unlock()
+		return blocks, nil
+	}
+
+	// A fetch is already in flight — wait for it instead of issuing another.
+	if ch := entry.inFlight; ch != nil {
+		o.sidechainCountMu.Unlock()
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+		o.sidechainCountMu.Lock()
+		blocks, err := entry.blocks, entry.err
+		o.sidechainCountMu.Unlock()
+		return blocks, err
+	}
+
+	// We're the leader — install the in-flight signal and run the fetch.
+	ch := make(chan struct{})
+	entry.inFlight = ch
+	o.sidechainCountMu.Unlock()
+
+	blocks, err := o.fetchSidechainBlockCount(ctx, name)
+
+	o.sidechainCountMu.Lock()
+	if err == nil {
+		entry.blocks = blocks
+		entry.err = nil
+		entry.fetchedAt = time.Now()
+	} else {
+		// Don't poison the cached count on transient errors — keep the
+		// last good value but record the error so callers that *do* check
+		// can react. The follower path above will see this same (blocks, err).
+		entry.err = err
+	}
+	entry.inFlight = nil
+	close(ch)
+
+	cachedBlocks := entry.blocks
+	o.sidechainCountMu.Unlock()
+	return cachedBlocks, err
+}
+
+// fetchSidechainBlockCount issues the actual Connect-JSON RPC. Pulled out
+// so GetSidechainBlockCount can wrap it with cache + single-flight.
+func (o *Orchestrator) fetchSidechainBlockCount(ctx context.Context, name string) (int64, error) {
+	cfg, ok := o.Configs()[name]
+	if !ok {
+		return 0, fmt.Errorf("unknown sidechain: %s", name)
+	}
+	path, known := sidechainServicePath[name]
+	if !known {
+		return 0, fmt.Errorf("unknown sidechain: %s", name)
+	}
+	url := fmt.Sprintf("http://localhost:%d%s", cfg.Port, path)
+	var resp struct {
+		Count int64 `json:"count"`
+	}
+	if err := connectJSONPost(ctx, o.sidechainHTTP(), url, &resp); err != nil {
+		return 0, err
+	}
+	return resp.Count, nil
+}
+
 // ChainSyncResult is one chain's tip snapshot. Error is set on failure; the
 // numeric fields are best-effort zero in that case.
 type ChainSyncResult struct {
@@ -2097,15 +2207,16 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 		out.Enforcer.Blocks = int64(resp.Msg.GetBlockHeaderInfo().GetHeight())
 	}()
 
-	// Sidechains: one goroutine per slot. Download check first, then the
-	// chain's block-count RPC.
+	// Sidechains: one goroutine per slot. The actual RPC goes through
+	// GetSidechainBlockCount which caches + single-flights and preserves
+	// last-good blocks across transient errors — the same machinery that
+	// keeps bitcoind's count from flickering during sync.
 	for name, slot := range out.Sidechains {
 		name, slot := name, slot
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			cfg, ok := o.Configs()[name]
-			if !ok {
+			if _, ok := o.Configs()[name]; !ok {
 				slot.Error = fmt.Sprintf("unknown sidechain: %s", name)
 				return
 			}
@@ -2113,20 +2224,19 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 				slot.Error = "not running"
 				return
 			}
-			path, known := sidechainServicePath[name]
-			if !known {
+			if _, known := sidechainServicePath[name]; !known {
 				slot.Error = fmt.Sprintf("unknown sidechain: %s", name)
 				return
 			}
-			url := fmt.Sprintf("http://localhost:%d%s", cfg.Port, path)
-			var resp struct {
-				Count int64 `json:"count"`
-			}
-			if err := connectJSONPost(ctx, o.sidechainHTTP(), url, &resp); err != nil {
+			blocks, err := o.GetSidechainBlockCount(ctx, name)
+			// Only surface the error when there's no cached count to fall
+			// back on — otherwise keep showing the last-good value so the
+			// UI's progress doesn't snap to zero on a transient timeout.
+			if err != nil && blocks == 0 {
 				slot.Error = err.Error()
 				return
 			}
-			slot.Blocks = resp.Count
+			slot.Blocks = blocks
 		}()
 	}
 

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -155,25 +155,18 @@ type Orchestrator struct {
 	explorerHeights map[string]int64
 	explorerFetched time.Time
 
-	// Cache for getblockchaininfo. During IBD this RPC can take seconds
-	// because it blocks on Core's cs_main lock; without a cache, every
-	// caller (orchestrator monitor, frontend SyncProvider, etc.) issues
-	// its own copy and they queue behind cs_main, eventually tripping the
-	// HTTP client timeout and triggering connection-lost cycles. The
-	// cache + single-flight collapses concurrent callers onto one in-flight
-	// RPC and serves recent results from memory.
-	bciMu        sync.Mutex
-	bciInFlight  chan struct{} // non-nil while a fetch is running; closed on completion
-	bciInfo      *MainchainBlockchainInfo
-	bciErr       error
-	bciFetchedAt time.Time
-
-	// chainProbers caches one cachedChainProber per chain (bitcoind, enforcer,
-	// each sidechain). Same cache + single-flight + last-good-on-error machinery
-	// applies to every L1/L2 tip probe so the UI sees identical timing semantics
-	// across the board. Built lazily by chainProberFor.
-	chainProbersMu sync.Mutex
-	chainProbers   map[string]*cachedChainProber
+	// Cached chain-tip connections. Every chain (L1 bitcoind, enforcer, every
+	// L2 sidechain) goes through the same CachedConnection[T] primitive: TTL
+	// cache + single-flight + preserve-last-good-on-error. Only the underlying
+	// Connection differs. bitcoindInfo is the single source of truth for
+	// getblockchaininfo — both the rich external Connect RPC
+	// (GetMainchainBlockchainInfo) and the lean GetSyncStatus dispatch read
+	// through it via a projection, so one HTTP call per TTL covers both.
+	syncConnMu     sync.Mutex
+	bitcoindInfo   *CachedConnection[*MainchainBlockchainInfo]
+	bitcoindSync   Connection[*ChainSyncResult]
+	enforcerSync   *CachedConnection[*ChainSyncResult]
+	sidechainSyncs map[string]*CachedConnection[*ChainSyncResult]
 
 	// httpClientsMu guards the lazy HTTP-client singletons used by the
 	// chatty pollers (CoreStatusClient, GetSyncStatus). Each client is built
@@ -1918,115 +1911,36 @@ type MainchainBalance struct {
 // gives Core room to make actual progress between calls.
 const blockchainInfoCacheTTL = time.Second
 
-// GetMainchainBlockchainInfo proxies getblockchaininfo from bitcoind. The
-// result is cached for [blockchainInfoCacheTTL]; concurrent callers across
-// that window share a single in-flight RPC and the same answer.
-func (o *Orchestrator) GetMainchainBlockchainInfo(ctx context.Context) (*MainchainBlockchainInfo, error) {
-	o.bciMu.Lock()
-	// Cache hit on a recent successful fetch — return immediately.
-	if o.bciInfo != nil && o.bciErr == nil && time.Since(o.bciFetchedAt) < blockchainInfoCacheTTL {
-		info := o.bciInfo
-		o.bciMu.Unlock()
-		return info, nil
-	}
-	// A fetch is already in flight — wait for it instead of issuing another.
-	if ch := o.bciInFlight; ch != nil {
-		o.bciMu.Unlock()
-		select {
-		case <-ch:
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-		o.bciMu.Lock()
-		info, err := o.bciInfo, o.bciErr
-		o.bciMu.Unlock()
-		return info, err
-	}
-	// We're the leader — install the in-flight signal and run the fetch.
-	ch := make(chan struct{})
-	o.bciInFlight = ch
-	o.bciMu.Unlock()
-
-	info, err := o.fetchMainchainBlockchainInfo(ctx)
-
-	o.bciMu.Lock()
-	if err == nil {
-		o.bciInfo = info
-		o.bciErr = nil
-		o.bciFetchedAt = time.Now()
-	} else {
-		// Don't poison the cached info on transient errors — keep the last
-		// good value but record the error for the leader's return. Followers
-		// that joined this fetch see the same error via bciErr below.
-		o.bciErr = err
-	}
-	o.bciInFlight = nil
-	close(ch)
-	o.bciMu.Unlock()
-
-	return info, err
+// Connection is the only thing that differs between chains: a pure RPC call
+// that returns one typed value or an error. No caching, no single-flight,
+// no error preservation. Implementations wrap their wire protocol and
+// nothing else — the surrounding machinery (TTL cache, single-flight,
+// last-good-on-error) lives in CachedConnection and applies uniformly to
+// L1 and L2.
+type Connection[T any] interface {
+	Fetch(ctx context.Context) (T, error)
 }
 
-// fetchMainchainBlockchainInfo runs the actual getblockchaininfo RPC. Pulled
-// out so GetMainchainBlockchainInfo can wrap it with the cache + single-flight
-// machinery above.
-func (o *Orchestrator) fetchMainchainBlockchainInfo(ctx context.Context) (*MainchainBlockchainInfo, error) {
-	client, err := o.CoreStatusClient()
-	if err != nil {
-		return nil, err
-	}
+// CachedConnection wraps any Connection with TTL cache + single-flight +
+// preserve-last-good-on-error. THIS is the only caching primitive in the
+// orchestrator's chain-tip plumbing — every chain ends up here so the UI
+// sees identical timing semantics across the board.
+type CachedConnection[T any] struct {
+	inner Connection[T]
+	ttl   time.Duration
 
-	result, err := client.call(ctx, "getblockchaininfo")
-	if err != nil {
-		return nil, fmt.Errorf("getblockchaininfo: %w", err)
-	}
-
-	var info MainchainBlockchainInfo
-	if err := json.Unmarshal(result, &info); err != nil {
-		return nil, fmt.Errorf("decode getblockchaininfo: %w", err)
-	}
-
-	return &info, nil
+	mu       sync.Mutex
+	last     T
+	hasLast  bool
+	lastErr  error
+	fetched  time.Time
+	inFlight chan struct{}
 }
 
-// ChainSyncResult is one chain's tip snapshot. Error is set on failure; the
-// numeric fields are best-effort zero in that case.
-type ChainSyncResult struct {
-	Blocks  int64
-	Headers int64
-	Time    int64
-	Error   string
-}
-
-// chainProber returns one chain's current tip in its native wire format.
-// Concrete impls: bitcoindProber (JSON-RPC getblockchaininfo), enforcerProber
-// (Connect/gRPC ValidatorService.GetChainTip), sidechainProber (Connect-JSON
-// GetBlockCount). Each returns a partially-filled *ChainSyncResult; the
-// GetSyncStatus caller merges headers afterward (mainchain for enforcer,
-// public explorer for sidechains).
-type chainProber interface {
-	Probe(ctx context.Context) (*ChainSyncResult, error)
-}
-
-// cachedChainProber decorates any chainProber with the bitcoind-style
-// cache + single-flight + preserve-last-good-on-error pattern. Identical
-// machinery to GetMainchainBlockchainInfo, just generic over the underlying
-// probe. Every chain ends up here so the UI sees identical timing semantics
-// across L1 and L2.
-type cachedChainProber struct {
-	inner chainProber
-
-	mu        sync.Mutex
-	last      *ChainSyncResult
-	err       error
-	fetchedAt time.Time
-	inFlight  chan struct{}
-}
-
-func (c *cachedChainProber) Probe(ctx context.Context) (*ChainSyncResult, error) {
+func (c *CachedConnection[T]) Fetch(ctx context.Context) (T, error) {
 	c.mu.Lock()
 	// Cache hit on a recent successful fetch — return immediately.
-	if c.last != nil && c.err == nil && time.Since(c.fetchedAt) < blockchainInfoCacheTTL {
+	if c.hasLast && c.lastErr == nil && time.Since(c.fetched) < c.ttl {
 		out := c.last
 		c.mu.Unlock()
 		return out, nil
@@ -2037,10 +1951,11 @@ func (c *cachedChainProber) Probe(ctx context.Context) (*ChainSyncResult, error)
 		select {
 		case <-ch:
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			var zero T
+			return zero, ctx.Err()
 		}
 		c.mu.Lock()
-		out, err := c.last, c.err
+		out, err := c.last, c.lastErr
 		c.mu.Unlock()
 		return out, err
 	}
@@ -2049,59 +1964,86 @@ func (c *cachedChainProber) Probe(ctx context.Context) (*ChainSyncResult, error)
 	c.inFlight = ch
 	c.mu.Unlock()
 
-	res, err := c.inner.Probe(ctx)
+	res, err := c.inner.Fetch(ctx)
 
 	c.mu.Lock()
 	if err == nil {
 		c.last = res
-		c.err = nil
-		c.fetchedAt = time.Now()
+		c.hasLast = true
+		c.lastErr = nil
+		c.fetched = time.Now()
 	} else {
-		// Don't poison the cached result on transient errors — keep the last
+		// Don't poison the cached value on transient errors — keep the last
 		// good value but record the error for the leader's return. Followers
-		// that joined this fetch see the same error via c.err below.
-		c.err = err
+		// that joined this fetch see the same error via lastErr below.
+		c.lastErr = err
 	}
 	c.inFlight = nil
 	close(ch)
 
 	out := c.last
 	c.mu.Unlock()
-	return out, err
+	if err != nil {
+		return out, err
+	}
+	return out, nil
 }
 
-// bitcoindProber wraps the existing GetMainchainBlockchainInfo (which still
-// has its own bciMu cache because the public Connect RPC at
-// api/orchestrator_handler.go:216 returns the rich *MainchainBlockchainInfo).
-// Projecting it down to *ChainSyncResult lets bitcoind ride the same generic
-// dispatch path as enforcer + sidechains. The double-caching coordinates
-// through bitcoind's underlying single-flight so there's no extra RPC churn.
-type bitcoindProber struct{ o *Orchestrator }
+// projected adapts Connection[A] into Connection[B] via a pure transform.
+// Used to expose one cached source of truth through multiple typed views —
+// e.g. bitcoind's getblockchaininfo powers both the rich Connect RPC and the
+// lean ChainSyncResult dispatch without issuing two HTTP calls per second.
+type projected[A, B any] struct {
+	inner Connection[A]
+	fn    func(A) B
+}
 
-func (p *bitcoindProber) Probe(ctx context.Context) (*ChainSyncResult, error) {
-	info, err := p.o.GetMainchainBlockchainInfo(ctx)
+func (p *projected[A, B]) Fetch(ctx context.Context) (B, error) {
+	a, err := p.inner.Fetch(ctx)
+	var zero B
+	if err != nil {
+		return zero, err
+	}
+	return p.fn(a), nil
+}
+
+// Project decorates a Connection[A] with a transform A→B.
+func Project[A, B any](inner Connection[A], fn func(A) B) Connection[B] {
+	return &projected[A, B]{inner: inner, fn: fn}
+}
+
+// bitcoindInfoConnection is the raw getblockchaininfo RPC. No caching —
+// CachedConnection wraps it for that.
+type bitcoindInfoConnection struct{ o *Orchestrator }
+
+func (c *bitcoindInfoConnection) Fetch(ctx context.Context) (*MainchainBlockchainInfo, error) {
+	client, err := c.o.CoreStatusClient()
 	if err != nil {
 		return nil, err
 	}
-	return &ChainSyncResult{
-		Blocks:  int64(info.Blocks),
-		Headers: int64(info.Headers),
-		Time:    info.Time,
-	}, nil
+	result, err := client.call(ctx, "getblockchaininfo")
+	if err != nil {
+		return nil, fmt.Errorf("getblockchaininfo: %w", err)
+	}
+	var info MainchainBlockchainInfo
+	if err := json.Unmarshal(result, &info); err != nil {
+		return nil, fmt.Errorf("decode getblockchaininfo: %w", err)
+	}
+	return &info, nil
 }
 
-// enforcerProber issues ValidatorService.GetChainTip with a 2s context
-// timeout. Headers stay zero — the GetSyncStatus merge step fills them
-// from the mainchain tip.
-type enforcerProber struct{ o *Orchestrator }
+// enforcerSyncConnection is the raw ValidatorService.GetChainTip RPC.
+// Headers stay zero — the GetSyncStatus merge step fills them from the
+// mainchain tip.
+type enforcerSyncConnection struct{ o *Orchestrator }
 
-func (p *enforcerProber) Probe(ctx context.Context) (*ChainSyncResult, error) {
-	cfg, ok := p.o.Configs()["enforcer"]
+func (c *enforcerSyncConnection) Fetch(ctx context.Context) (*ChainSyncResult, error) {
+	cfg, ok := c.o.Configs()["enforcer"]
 	if !ok || cfg.Port == 0 {
 		return nil, fmt.Errorf("enforcer not configured")
 	}
 	client := enforcerrpc.NewValidatorServiceClient(
-		p.o.enforcerHTTP(),
+		c.o.enforcerHTTP(),
 		fmt.Sprintf("http://127.0.0.1:%d", cfg.Port),
 		connect.WithGRPC(),
 	)
@@ -2116,57 +2058,119 @@ func (p *enforcerProber) Probe(ctx context.Context) (*ChainSyncResult, error) {
 	}, nil
 }
 
-// sidechainProber issues the Connect-JSON GetBlockCount against a single
-// orchestrator-managed L2. Headers stay zero — the GetSyncStatus merge
-// step fills them from the public explorer.
-type sidechainProber struct {
+// sidechainSyncConnection is the raw Connect-JSON GetBlockCount RPC for one
+// L2 sidechain. Headers stay zero — the GetSyncStatus merge step fills them
+// from the public explorer.
+type sidechainSyncConnection struct {
 	o    *Orchestrator
 	name string
 }
 
-func (p *sidechainProber) Probe(ctx context.Context) (*ChainSyncResult, error) {
-	cfg, ok := p.o.Configs()[p.name]
+func (c *sidechainSyncConnection) Fetch(ctx context.Context) (*ChainSyncResult, error) {
+	cfg, ok := c.o.Configs()[c.name]
 	if !ok {
-		return nil, fmt.Errorf("unknown sidechain: %s", p.name)
+		return nil, fmt.Errorf("unknown sidechain: %s", c.name)
 	}
-	path, known := sidechainServicePath[p.name]
+	path, known := sidechainServicePath[c.name]
 	if !known {
-		return nil, fmt.Errorf("unknown sidechain: %s", p.name)
+		return nil, fmt.Errorf("unknown sidechain: %s", c.name)
 	}
 	url := fmt.Sprintf("http://localhost:%d%s", cfg.Port, path)
 	var resp struct {
 		Count int64 `json:"count"`
 	}
-	if err := connectJSONPost(ctx, p.o.sidechainHTTP(), url, &resp); err != nil {
+	if err := connectJSONPost(ctx, c.o.sidechainHTTP(), url, &resp); err != nil {
 		return nil, err
 	}
 	return &ChainSyncResult{Blocks: resp.Count}, nil
 }
 
-// chainProberFor returns the cached chainProber for name, building (and
-// memoising) it on first use. Names match the BinaryConfig keys: "bitcoind",
-// "enforcer", or any L2 sidechain key.
-func (o *Orchestrator) chainProberFor(name string) *cachedChainProber {
-	o.chainProbersMu.Lock()
-	defer o.chainProbersMu.Unlock()
-	if o.chainProbers == nil {
-		o.chainProbers = make(map[string]*cachedChainProber)
+// mainchainInfoToSync projects a *MainchainBlockchainInfo down to the lean
+// *ChainSyncResult view that GetSyncStatus dispatches on.
+func mainchainInfoToSync(info *MainchainBlockchainInfo) *ChainSyncResult {
+	if info == nil {
+		return nil
 	}
-	if p, ok := o.chainProbers[name]; ok {
-		return p
+	return &ChainSyncResult{
+		Blocks:  int64(info.Blocks),
+		Headers: int64(info.Headers),
+		Time:    info.Time,
 	}
-	var inner chainProber
+}
+
+// bitcoindInfoCached returns the single cached Connection backing both
+// GetMainchainBlockchainInfo (rich external Connect RPC) and the lean
+// GetSyncStatus dispatch. Built lazily on first use.
+func (o *Orchestrator) bitcoindInfoCached() *CachedConnection[*MainchainBlockchainInfo] {
+	o.syncConnMu.Lock()
+	defer o.syncConnMu.Unlock()
+	if o.bitcoindInfo == nil {
+		o.bitcoindInfo = &CachedConnection[*MainchainBlockchainInfo]{
+			inner: &bitcoindInfoConnection{o: o},
+			ttl:   blockchainInfoCacheTTL,
+		}
+	}
+	return o.bitcoindInfo
+}
+
+// syncConnectionFor returns the cached *ChainSyncResult connection for name,
+// building (and memoising) it on first use. Names match the BinaryConfig
+// keys: "bitcoind", "enforcer", or any L2 sidechain key. For "bitcoind" the
+// returned value wraps a Project over bitcoindInfoCached so the rich
+// connection and the sync view share one in-flight RPC.
+func (o *Orchestrator) syncConnectionFor(name string) Connection[*ChainSyncResult] {
+	o.syncConnMu.Lock()
+	defer o.syncConnMu.Unlock()
 	switch name {
 	case "bitcoind":
-		inner = &bitcoindProber{o: o}
+		if o.bitcoindInfo == nil {
+			o.bitcoindInfo = &CachedConnection[*MainchainBlockchainInfo]{
+				inner: &bitcoindInfoConnection{o: o},
+				ttl:   blockchainInfoCacheTTL,
+			}
+		}
+		if o.bitcoindSync == nil {
+			o.bitcoindSync = Project[*MainchainBlockchainInfo, *ChainSyncResult](o.bitcoindInfo, mainchainInfoToSync)
+		}
+		return o.bitcoindSync
 	case "enforcer":
-		inner = &enforcerProber{o: o}
+		if o.enforcerSync == nil {
+			o.enforcerSync = &CachedConnection[*ChainSyncResult]{
+				inner: &enforcerSyncConnection{o: o},
+				ttl:   blockchainInfoCacheTTL,
+			}
+		}
+		return o.enforcerSync
 	default:
-		inner = &sidechainProber{o: o, name: name}
+		if o.sidechainSyncs == nil {
+			o.sidechainSyncs = make(map[string]*CachedConnection[*ChainSyncResult])
+		}
+		if c, ok := o.sidechainSyncs[name]; ok {
+			return c
+		}
+		c := &CachedConnection[*ChainSyncResult]{
+			inner: &sidechainSyncConnection{o: o, name: name},
+			ttl:   blockchainInfoCacheTTL,
+		}
+		o.sidechainSyncs[name] = c
+		return c
 	}
-	p := &cachedChainProber{inner: inner}
-	o.chainProbers[name] = p
-	return p
+}
+
+// GetMainchainBlockchainInfo proxies getblockchaininfo from bitcoind through
+// the shared cache. Signature is load-bearing — the public Connect RPC at
+// api/orchestrator_handler.go:216 returns this rich type directly.
+func (o *Orchestrator) GetMainchainBlockchainInfo(ctx context.Context) (*MainchainBlockchainInfo, error) {
+	return o.bitcoindInfoCached().Fetch(ctx)
+}
+
+// ChainSyncResult is one chain's tip snapshot. Error is set on failure; the
+// numeric fields are best-effort zero in that case.
+type ChainSyncResult struct {
+	Blocks  int64
+	Headers int64
+	Time    int64
+	Error   string
 }
 
 // SyncStatus is the atomic snapshot returned by GetSyncStatus. Mainchain +
@@ -2219,18 +2223,19 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 		}
 	}
 
-	// Unified dispatch: build (name, slot, validate) tuples covering L1 +
+	// Unified dispatch: build (slot, conn, validate) tuples covering L1 +
 	// L2. validate returns the short-circuit error string for slots that
-	// shouldn't reach Probe (config missing, process not running, etc).
+	// shouldn't reach Fetch (config missing, process not running, etc). The
+	// dispatch loop body below is RPC-agnostic — only conn differs.
 	type job struct {
-		name     string
 		slot     *ChainSyncResult
+		conn     Connection[*ChainSyncResult]
 		validate func() string
 	}
 	jobs := []job{
 		{
-			name: "bitcoind",
 			slot: out.Mainchain,
+			conn: o.syncConnectionFor("bitcoind"),
 			validate: func() string {
 				if _, ok := o.Configs()["bitcoind"]; !ok {
 					return "bitcoind not configured"
@@ -2239,8 +2244,8 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 			},
 		},
 		{
-			name: "enforcer",
 			slot: out.Enforcer,
+			conn: o.syncConnectionFor("enforcer"),
 			validate: func() string {
 				cfg, ok := o.Configs()["enforcer"]
 				if !ok || cfg.Port == 0 {
@@ -2256,8 +2261,8 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 	for name, slot := range out.Sidechains {
 		name, slot := name, slot
 		jobs = append(jobs, job{
-			name: name,
 			slot: slot,
+			conn: o.syncConnectionFor(name),
 			validate: func() string {
 				if _, ok := o.Configs()[name]; !ok {
 					return fmt.Sprintf("unknown sidechain: %s", name)
@@ -2296,7 +2301,7 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 				j.slot.Error = msg
 				return
 			}
-			res, err := o.chainProberFor(j.name).Probe(ctx)
+			res, err := j.conn.Fetch(ctx)
 			// Only surface the error when there's no cached value to fall
 			// back on — otherwise keep showing the last-good numbers so
 			// the UI's progress doesn't snap to zero on a transient
@@ -2346,15 +2351,32 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 	return out, nil
 }
 
-// invalidateChainProberCacheForTest forces the named chainProber's cache
-// entry to expire so the next Probe call refetches. Test-only helper used
-// by get_sync_status_test.go to drive last-good-on-error coverage without
-// poking at unexported cache fields directly.
-func (o *Orchestrator) invalidateChainProberCacheForTest(name string) {
-	p := o.chainProberFor(name)
-	p.mu.Lock()
-	p.fetchedAt = time.Now().Add(-time.Hour)
-	p.mu.Unlock()
+// invalidateSyncConnectionCacheForTest forces the named CachedConnection's
+// TTL window to expire so the next Fetch call refetches. Test-only helper
+// used by get_sync_status_test.go to drive last-good-on-error coverage
+// without poking at unexported cache fields directly.
+func (o *Orchestrator) invalidateSyncConnectionCacheForTest(name string) {
+	// Building the connection first guarantees the cache field is non-nil.
+	_ = o.syncConnectionFor(name)
+	o.syncConnMu.Lock()
+	defer o.syncConnMu.Unlock()
+	switch name {
+	case "bitcoind":
+		c := o.bitcoindInfo
+		c.mu.Lock()
+		c.fetched = time.Now().Add(-time.Hour)
+		c.mu.Unlock()
+	case "enforcer":
+		c := o.enforcerSync
+		c.mu.Lock()
+		c.fetched = time.Now().Add(-time.Hour)
+		c.mu.Unlock()
+	default:
+		c := o.sidechainSyncs[name]
+		c.mu.Lock()
+		c.fetched = time.Now().Add(-time.Hour)
+		c.mu.Unlock()
+	}
 }
 
 // explorerCacheTTL bounds how often we hit the public explorer. Sidechain

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -151,9 +151,7 @@ type Orchestrator struct {
 	// reasonable; on fetch failure we keep serving the previous values
 	// rather than dropping headers from the response (callers depend on
 	// them being non-zero to compute progress percentages).
-	explorerMu      sync.Mutex
-	explorerHeights map[string]int64
-	explorerFetched time.Time
+	explorerHeightsCache *CachedConnection[map[string]int64]
 
 	// Cached chain-tip connections. Every chain (L1 bitcoind, enforcer, every
 	// L2 sidechain) goes through the same CachedConnection[T] primitive: TTL
@@ -2383,23 +2381,17 @@ func (o *Orchestrator) invalidateSyncConnectionCacheForTest(name string) {
 // tips move on the order of a minute; 30 s is plenty fresh for the UI.
 const explorerCacheTTL = 30 * time.Second
 
-// fetchExplorerHeights returns the canonical per-sidechain network tip
-// heights, keyed by orchestrator binary name (matches the keys in
-// SyncStatus.Sidechains). Cached for [explorerCacheTTL]. On failure we
-// keep serving the previous values rather than dropping headers entirely.
-func (o *Orchestrator) fetchExplorerHeights(ctx context.Context) map[string]int64 {
-	o.explorerMu.Lock()
-	if !o.explorerFetched.IsZero() && time.Since(o.explorerFetched) < explorerCacheTTL {
-		out := o.explorerHeights
-		o.explorerMu.Unlock()
-		return out
-	}
-	o.explorerMu.Unlock()
+// explorerHeightsConnection is the raw GetChainTips RPC against the public
+// drivechain.info explorer. No caching — CachedConnection wraps it for that.
+type explorerHeightsConnection struct{ o *Orchestrator }
 
+func (c *explorerHeightsConnection) Fetch(ctx context.Context) (map[string]int64, error) {
 	// "forknet" runs on mainnet params for the L1 but the explorer host
 	// keys it as "forknet". The other readable names match the URL slug
-	// directly (mainnet/signet/testnet/regtest).
-	url := fmt.Sprintf("https://node.%s.drivechain.info/api/explorer.v1.ExplorerService/GetChainTips", o.Network)
+	// directly (mainnet/signet/testnet/regtest). Today only signet has a
+	// live explorer; calls on any other network fail, the CachedConnection
+	// last-good-on-error logic keeps serving the previous (or empty) map.
+	url := fmt.Sprintf("https://node.%s.drivechain.info/api/explorer.v1.ExplorerService/GetChainTips", c.o.Network)
 
 	rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -2411,12 +2403,8 @@ func (o *Orchestrator) fetchExplorerHeights(ctx context.Context) map[string]int6
 	var resp map[string]struct {
 		Height interface{} `json:"height"`
 	}
-	if err := connectJSONPost(rpcCtx, o.explorerHTTP(), url, &resp); err != nil {
-		o.log.Debug().Err(err).Msg("explorer GetChainTips failed; keeping cached heights")
-		o.explorerMu.Lock()
-		out := o.explorerHeights
-		o.explorerMu.Unlock()
-		return out
+	if err := connectJSONPost(rpcCtx, c.o.explorerHTTP(), url, &resp); err != nil {
+		return nil, err
 	}
 
 	heights := make(map[string]int64, len(resp))
@@ -2430,12 +2418,35 @@ func (o *Orchestrator) fetchExplorerHeights(ctx context.Context) map[string]int6
 			heights[name] = int64(v)
 		}
 	}
+	return heights, nil
+}
 
-	o.explorerMu.Lock()
-	o.explorerHeights = heights
-	o.explorerFetched = time.Now()
-	o.explorerMu.Unlock()
+// explorerHeightsCached returns the single CachedConnection backing every
+// public-explorer fetch. Built lazily on first use under the shared
+// syncConnMu so concurrent first-callers don't race to build two of them.
+func (o *Orchestrator) explorerHeightsCached() *CachedConnection[map[string]int64] {
+	o.syncConnMu.Lock()
+	defer o.syncConnMu.Unlock()
+	if o.explorerHeightsCache == nil {
+		o.explorerHeightsCache = &CachedConnection[map[string]int64]{
+			inner: &explorerHeightsConnection{o: o},
+			ttl:   explorerCacheTTL,
+		}
+	}
+	return o.explorerHeightsCache
+}
 
+// fetchExplorerHeights returns the canonical per-sidechain network-tip
+// heights, keyed by orchestrator binary name. Cached for [explorerCacheTTL]
+// via the same CachedConnection primitive every chain-tip probe uses. On
+// failure we keep serving the previous values rather than dropping headers
+// entirely — the error is logged at debug and swallowed so callers (i.e.
+// GetSyncStatus's header-merge step) don't need to think about it.
+func (o *Orchestrator) fetchExplorerHeights(ctx context.Context) map[string]int64 {
+	heights, err := o.explorerHeightsCached().Fetch(ctx)
+	if err != nil {
+		o.log.Debug().Err(err).Msg("explorer GetChainTips failed; keeping cached heights")
+	}
 	return heights
 }
 

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -168,14 +168,12 @@ type Orchestrator struct {
 	bciErr       error
 	bciFetchedAt time.Time
 
-	// Per-sidechain GetBlockCount cache + single-flight, mirroring the
-	// bitcoind pattern above. Without this every SyncProvider poll
-	// (~10/s during sync) hit the sidechain's RPC raw — when a probe
-	// timed out the slot reset to Blocks=0/Error=timeout and the UI's
-	// block count flickered between 0 and the real value, looking
-	// like "thunder doesn't update during sync" while bitcoind did.
-	sidechainCountMu    sync.Mutex
-	sidechainCountCache map[string]*sidechainCountCacheEntry
+	// chainProbers caches one cachedChainProber per chain (bitcoind, enforcer,
+	// each sidechain). Same cache + single-flight + last-good-on-error machinery
+	// applies to every L1/L2 tip probe so the UI sees identical timing semantics
+	// across the board. Built lazily by chainProberFor.
+	chainProbersMu sync.Mutex
+	chainProbers   map[string]*cachedChainProber
 
 	// httpClientsMu guards the lazy HTTP-client singletons used by the
 	// chatty pollers (CoreStatusClient, GetSyncStatus). Each client is built
@@ -1991,107 +1989,6 @@ func (o *Orchestrator) fetchMainchainBlockchainInfo(ctx context.Context) (*Mainc
 	return &info, nil
 }
 
-// sidechainCountCacheEntry mirrors the bciMu/bciInfo/bciInFlight trio in
-// per-sidechain form. `blocks` holds the last-good count and is preserved
-// across transient RPC errors so the UI doesn't flicker to zero.
-type sidechainCountCacheEntry struct {
-	blocks    int64
-	err       error
-	fetchedAt time.Time
-	inFlight  chan struct{}
-}
-
-// sidechainCountCacheTTL matches blockchainInfoCacheTTL — the sidechain
-// daemons tick once per ~minute so a 1 s cache is plenty fresh for the
-// UI and 10x less load on the daemon under aggressive SyncProvider polling.
-const sidechainCountCacheTTL = time.Second
-
-// GetSidechainBlockCount returns the cached block-count for name, single-
-// flighting concurrent callers and preserving the last-good value across
-// transient RPC errors. Modelled on [GetMainchainBlockchainInfo]: a fresh
-// fetch is only issued once the cached value is older than
-// [sidechainCountCacheTTL] or has never been populated. The returned
-// error mirrors the most recent RPC outcome — callers that want only the
-// last-good number can ignore it (slot.Blocks stays accurate).
-func (o *Orchestrator) GetSidechainBlockCount(ctx context.Context, name string) (int64, error) {
-	o.sidechainCountMu.Lock()
-	if o.sidechainCountCache == nil {
-		o.sidechainCountCache = make(map[string]*sidechainCountCacheEntry)
-	}
-	entry, ok := o.sidechainCountCache[name]
-	if !ok {
-		entry = &sidechainCountCacheEntry{}
-		o.sidechainCountCache[name] = entry
-	}
-
-	// Cache hit on a recent successful fetch — return immediately.
-	if entry.err == nil && !entry.fetchedAt.IsZero() && time.Since(entry.fetchedAt) < sidechainCountCacheTTL {
-		blocks := entry.blocks
-		o.sidechainCountMu.Unlock()
-		return blocks, nil
-	}
-
-	// A fetch is already in flight — wait for it instead of issuing another.
-	if ch := entry.inFlight; ch != nil {
-		o.sidechainCountMu.Unlock()
-		select {
-		case <-ch:
-		case <-ctx.Done():
-			return 0, ctx.Err()
-		}
-		o.sidechainCountMu.Lock()
-		blocks, err := entry.blocks, entry.err
-		o.sidechainCountMu.Unlock()
-		return blocks, err
-	}
-
-	// We're the leader — install the in-flight signal and run the fetch.
-	ch := make(chan struct{})
-	entry.inFlight = ch
-	o.sidechainCountMu.Unlock()
-
-	blocks, err := o.fetchSidechainBlockCount(ctx, name)
-
-	o.sidechainCountMu.Lock()
-	if err == nil {
-		entry.blocks = blocks
-		entry.err = nil
-		entry.fetchedAt = time.Now()
-	} else {
-		// Don't poison the cached count on transient errors — keep the
-		// last good value but record the error so callers that *do* check
-		// can react. The follower path above will see this same (blocks, err).
-		entry.err = err
-	}
-	entry.inFlight = nil
-	close(ch)
-
-	cachedBlocks := entry.blocks
-	o.sidechainCountMu.Unlock()
-	return cachedBlocks, err
-}
-
-// fetchSidechainBlockCount issues the actual Connect-JSON RPC. Pulled out
-// so GetSidechainBlockCount can wrap it with cache + single-flight.
-func (o *Orchestrator) fetchSidechainBlockCount(ctx context.Context, name string) (int64, error) {
-	cfg, ok := o.Configs()[name]
-	if !ok {
-		return 0, fmt.Errorf("unknown sidechain: %s", name)
-	}
-	path, known := sidechainServicePath[name]
-	if !known {
-		return 0, fmt.Errorf("unknown sidechain: %s", name)
-	}
-	url := fmt.Sprintf("http://localhost:%d%s", cfg.Port, path)
-	var resp struct {
-		Count int64 `json:"count"`
-	}
-	if err := connectJSONPost(ctx, o.sidechainHTTP(), url, &resp); err != nil {
-		return 0, err
-	}
-	return resp.Count, nil
-}
-
 // ChainSyncResult is one chain's tip snapshot. Error is set on failure; the
 // numeric fields are best-effort zero in that case.
 type ChainSyncResult struct {
@@ -2099,6 +1996,177 @@ type ChainSyncResult struct {
 	Headers int64
 	Time    int64
 	Error   string
+}
+
+// chainProber returns one chain's current tip in its native wire format.
+// Concrete impls: bitcoindProber (JSON-RPC getblockchaininfo), enforcerProber
+// (Connect/gRPC ValidatorService.GetChainTip), sidechainProber (Connect-JSON
+// GetBlockCount). Each returns a partially-filled *ChainSyncResult; the
+// GetSyncStatus caller merges headers afterward (mainchain for enforcer,
+// public explorer for sidechains).
+type chainProber interface {
+	Probe(ctx context.Context) (*ChainSyncResult, error)
+}
+
+// cachedChainProber decorates any chainProber with the bitcoind-style
+// cache + single-flight + preserve-last-good-on-error pattern. Identical
+// machinery to GetMainchainBlockchainInfo, just generic over the underlying
+// probe. Every chain ends up here so the UI sees identical timing semantics
+// across L1 and L2.
+type cachedChainProber struct {
+	inner chainProber
+
+	mu        sync.Mutex
+	last      *ChainSyncResult
+	err       error
+	fetchedAt time.Time
+	inFlight  chan struct{}
+}
+
+func (c *cachedChainProber) Probe(ctx context.Context) (*ChainSyncResult, error) {
+	c.mu.Lock()
+	// Cache hit on a recent successful fetch — return immediately.
+	if c.last != nil && c.err == nil && time.Since(c.fetchedAt) < blockchainInfoCacheTTL {
+		out := c.last
+		c.mu.Unlock()
+		return out, nil
+	}
+	// A fetch is already in flight — wait for it instead of issuing another.
+	if ch := c.inFlight; ch != nil {
+		c.mu.Unlock()
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		c.mu.Lock()
+		out, err := c.last, c.err
+		c.mu.Unlock()
+		return out, err
+	}
+	// We're the leader — install the in-flight signal and run the fetch.
+	ch := make(chan struct{})
+	c.inFlight = ch
+	c.mu.Unlock()
+
+	res, err := c.inner.Probe(ctx)
+
+	c.mu.Lock()
+	if err == nil {
+		c.last = res
+		c.err = nil
+		c.fetchedAt = time.Now()
+	} else {
+		// Don't poison the cached result on transient errors — keep the last
+		// good value but record the error for the leader's return. Followers
+		// that joined this fetch see the same error via c.err below.
+		c.err = err
+	}
+	c.inFlight = nil
+	close(ch)
+
+	out := c.last
+	c.mu.Unlock()
+	return out, err
+}
+
+// bitcoindProber wraps the existing GetMainchainBlockchainInfo (which still
+// has its own bciMu cache because the public Connect RPC at
+// api/orchestrator_handler.go:216 returns the rich *MainchainBlockchainInfo).
+// Projecting it down to *ChainSyncResult lets bitcoind ride the same generic
+// dispatch path as enforcer + sidechains. The double-caching coordinates
+// through bitcoind's underlying single-flight so there's no extra RPC churn.
+type bitcoindProber struct{ o *Orchestrator }
+
+func (p *bitcoindProber) Probe(ctx context.Context) (*ChainSyncResult, error) {
+	info, err := p.o.GetMainchainBlockchainInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &ChainSyncResult{
+		Blocks:  int64(info.Blocks),
+		Headers: int64(info.Headers),
+		Time:    info.Time,
+	}, nil
+}
+
+// enforcerProber issues ValidatorService.GetChainTip with a 2s context
+// timeout. Headers stay zero — the GetSyncStatus merge step fills them
+// from the mainchain tip.
+type enforcerProber struct{ o *Orchestrator }
+
+func (p *enforcerProber) Probe(ctx context.Context) (*ChainSyncResult, error) {
+	cfg, ok := p.o.Configs()["enforcer"]
+	if !ok || cfg.Port == 0 {
+		return nil, fmt.Errorf("enforcer not configured")
+	}
+	client := enforcerrpc.NewValidatorServiceClient(
+		p.o.enforcerHTTP(),
+		fmt.Sprintf("http://127.0.0.1:%d", cfg.Port),
+		connect.WithGRPC(),
+	)
+	rpcCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	resp, err := client.GetChainTip(rpcCtx, connect.NewRequest(&enforcerpb.GetChainTipRequest{}))
+	if err != nil {
+		return nil, err
+	}
+	return &ChainSyncResult{
+		Blocks: int64(resp.Msg.GetBlockHeaderInfo().GetHeight()),
+	}, nil
+}
+
+// sidechainProber issues the Connect-JSON GetBlockCount against a single
+// orchestrator-managed L2. Headers stay zero — the GetSyncStatus merge
+// step fills them from the public explorer.
+type sidechainProber struct {
+	o    *Orchestrator
+	name string
+}
+
+func (p *sidechainProber) Probe(ctx context.Context) (*ChainSyncResult, error) {
+	cfg, ok := p.o.Configs()[p.name]
+	if !ok {
+		return nil, fmt.Errorf("unknown sidechain: %s", p.name)
+	}
+	path, known := sidechainServicePath[p.name]
+	if !known {
+		return nil, fmt.Errorf("unknown sidechain: %s", p.name)
+	}
+	url := fmt.Sprintf("http://localhost:%d%s", cfg.Port, path)
+	var resp struct {
+		Count int64 `json:"count"`
+	}
+	if err := connectJSONPost(ctx, p.o.sidechainHTTP(), url, &resp); err != nil {
+		return nil, err
+	}
+	return &ChainSyncResult{Blocks: resp.Count}, nil
+}
+
+// chainProberFor returns the cached chainProber for name, building (and
+// memoising) it on first use. Names match the BinaryConfig keys: "bitcoind",
+// "enforcer", or any L2 sidechain key.
+func (o *Orchestrator) chainProberFor(name string) *cachedChainProber {
+	o.chainProbersMu.Lock()
+	defer o.chainProbersMu.Unlock()
+	if o.chainProbers == nil {
+		o.chainProbers = make(map[string]*cachedChainProber)
+	}
+	if p, ok := o.chainProbers[name]; ok {
+		return p
+	}
+	var inner chainProber
+	switch name {
+	case "bitcoind":
+		inner = &bitcoindProber{o: o}
+	case "enforcer":
+		inner = &enforcerProber{o: o}
+	default:
+		inner = &sidechainProber{o: o, name: name}
+	}
+	p := &cachedChainProber{inner: inner}
+	o.chainProbers[name] = p
+	return p
 }
 
 // SyncStatus is the atomic snapshot returned by GetSyncStatus. Mainchain +
@@ -2151,6 +2219,60 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 		}
 	}
 
+	// Unified dispatch: build (name, slot, validate) tuples covering L1 +
+	// L2. validate returns the short-circuit error string for slots that
+	// shouldn't reach Probe (config missing, process not running, etc).
+	type job struct {
+		name     string
+		slot     *ChainSyncResult
+		validate func() string
+	}
+	jobs := []job{
+		{
+			name: "bitcoind",
+			slot: out.Mainchain,
+			validate: func() string {
+				if _, ok := o.Configs()["bitcoind"]; !ok {
+					return "bitcoind not configured"
+				}
+				return ""
+			},
+		},
+		{
+			name: "enforcer",
+			slot: out.Enforcer,
+			validate: func() string {
+				cfg, ok := o.Configs()["enforcer"]
+				if !ok || cfg.Port == 0 {
+					return "enforcer not configured"
+				}
+				if !o.process.IsRunning("enforcer") {
+					return "not running"
+				}
+				return ""
+			},
+		},
+	}
+	for name, slot := range out.Sidechains {
+		name, slot := name, slot
+		jobs = append(jobs, job{
+			name: name,
+			slot: slot,
+			validate: func() string {
+				if _, ok := o.Configs()[name]; !ok {
+					return fmt.Sprintf("unknown sidechain: %s", name)
+				}
+				if _, known := sidechainServicePath[name]; !known {
+					return fmt.Sprintf("unknown sidechain: %s", name)
+				}
+				if !o.process.IsRunning(name) {
+					return "not running"
+				}
+				return ""
+			},
+		})
+	}
+
 	var wg sync.WaitGroup
 
 	// Explorer fan-out runs in parallel with the per-chain probes so its
@@ -2165,78 +2287,29 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 		heights = o.fetchExplorerHeights(ctx)
 	}()
 
-	// Mainchain: bitcoind getblockchaininfo.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		info, err := o.GetMainchainBlockchainInfo(ctx)
-		if err != nil {
-			out.Mainchain.Error = err.Error()
-			return
-		}
-		out.Mainchain.Blocks = int64(info.Blocks)
-		out.Mainchain.Headers = int64(info.Headers)
-		out.Mainchain.Time = info.Time
-	}()
-
-	// Enforcer: ValidatorService.GetChainTip.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		cfg, ok := o.Configs()["enforcer"]
-		if !ok || cfg.Port == 0 {
-			out.Enforcer.Error = "enforcer not configured"
-			return
-		}
-		if !o.process.IsRunning("enforcer") {
-			out.Enforcer.Error = "not running"
-			return
-		}
-		client := enforcerrpc.NewValidatorServiceClient(
-			o.enforcerHTTP(),
-			fmt.Sprintf("http://127.0.0.1:%d", cfg.Port),
-			connect.WithGRPC(),
-		)
-		rpcCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-		defer cancel()
-		resp, err := client.GetChainTip(rpcCtx, connect.NewRequest(&enforcerpb.GetChainTipRequest{}))
-		if err != nil {
-			out.Enforcer.Error = err.Error()
-			return
-		}
-		out.Enforcer.Blocks = int64(resp.Msg.GetBlockHeaderInfo().GetHeight())
-	}()
-
-	// Sidechains: one goroutine per slot. The actual RPC goes through
-	// GetSidechainBlockCount which caches + single-flights and preserves
-	// last-good blocks across transient errors — the same machinery that
-	// keeps bitcoind's count from flickering during sync.
-	for name, slot := range out.Sidechains {
-		name, slot := name, slot
+	for _, j := range jobs {
+		j := j
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if _, ok := o.Configs()[name]; !ok {
-				slot.Error = fmt.Sprintf("unknown sidechain: %s", name)
+			if msg := j.validate(); msg != "" {
+				j.slot.Error = msg
 				return
 			}
-			if !o.process.IsRunning(name) {
-				slot.Error = "not running"
+			res, err := o.chainProberFor(j.name).Probe(ctx)
+			// Only surface the error when there's no cached value to fall
+			// back on — otherwise keep showing the last-good numbers so
+			// the UI's progress doesn't snap to zero on a transient
+			// timeout. Same behaviour for L1 (bitcoind) and L2.
+			if err != nil && (res == nil || res.Blocks == 0) {
+				j.slot.Error = err.Error()
 				return
 			}
-			if _, known := sidechainServicePath[name]; !known {
-				slot.Error = fmt.Sprintf("unknown sidechain: %s", name)
-				return
+			if res != nil {
+				j.slot.Blocks = res.Blocks
+				j.slot.Headers = res.Headers
+				j.slot.Time = res.Time
 			}
-			blocks, err := o.GetSidechainBlockCount(ctx, name)
-			// Only surface the error when there's no cached count to fall
-			// back on — otherwise keep showing the last-good value so the
-			// UI's progress doesn't snap to zero on a transient timeout.
-			if err != nil && blocks == 0 {
-				slot.Error = err.Error()
-				return
-			}
-			slot.Blocks = blocks
 		}()
 	}
 
@@ -2271,6 +2344,17 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 	}
 
 	return out, nil
+}
+
+// invalidateChainProberCacheForTest forces the named chainProber's cache
+// entry to expire so the next Probe call refetches. Test-only helper used
+// by get_sync_status_test.go to drive last-good-on-error coverage without
+// poking at unexported cache fields directly.
+func (o *Orchestrator) invalidateChainProberCacheForTest(name string) {
+	p := o.chainProberFor(name)
+	p.mu.Lock()
+	p.fetchedAt = time.Now().Add(-time.Hour)
+	p.mu.Unlock()
 }
 
 // explorerCacheTTL bounds how often we hit the public explorer. Sidechain

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -2144,17 +2144,19 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 	}
 	// Sidechain headers come from the public explorer (fetched in parallel
 	// above). The local sidechain RPC only reports blocks it has indexed,
-	// which can't act as the goal — that has to be the network tip. Best-
-	// effort: when the explorer fetch fails the map is empty and Headers
-	// fall back to slot.Blocks so the UI doesn't divide by zero.
+	// which can't act as the goal — that has to be the network tip. The
+	// explorer is a best-effort UX extra: only signet has one today, so on
+	// mainnet/testnet/regtest/forknet the fetch always fails. When it does,
+	// leave Headers at zero. The previous behaviour set Headers=Blocks,
+	// which made progress = blocks/blocks = 1.0 and rendered every running
+	// sidechain as fully synced even mid-IBD — a far worse failure mode
+	// than a stuck-at-zero progress bar.
 	for name, slot := range out.Sidechains {
 		if slot.Error != "" {
 			continue
 		}
 		if h, ok := heights[name]; ok {
 			slot.Headers = h
-		} else {
-			slot.Headers = slot.Blocks
 		}
 	}
 


### PR DESCRIPTION
Stops the sidechain progress bar from showing 100% mid-IBD when the public explorer is unreachable.

Previously `slot.Headers = slot.Blocks` was the fallback, which equates "no explorer reachable" with "fully synced". Only signet has an explorer today, so every other network rendered every running sidechain as synced. Now Headers stays 0 and the UI shows zero-progress until the explorer comes back.