### PR TITLE
fix #1728 download progress + #1723 partial-wipe header

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.234
+version: 1.0.235
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.234
+version: 1.0.235
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -742,6 +742,11 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
     // never advances and the button doesn't flip from "Download" → "Start"
     // until the user touches the row.
     _downloadProvider?.addListener(_onChange);
+    // _onChange only fires notifyListeners on start/stop transitions because
+    // mbDownloaded isn't in the tracked binaryStates map — so without this
+    // direct hook the in-flight progress bar never repaints (#1728). Cheap:
+    // active downloads only, and the rebuild reads o(1) provider state.
+    _downloadProvider?.addListener(notifyListeners);
   }
 
   bool get loading => _enforcerRPC.initializingBinary;

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.87
+version: 0.2.88
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.107
+version: 1.0.108
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/widgets/reset/reset_confirmation_page.dart
+++ b/sail_ui/lib/widgets/reset/reset_confirmation_page.dart
@@ -177,7 +177,21 @@ class _ResetConfirmationPageState extends State<ResetConfirmationPage> {
     try {
       await for (final event in widget.orchestratorDelete!()) {
         if (!mounted) return;
-        if (event.done) break;
+        if (event.done) {
+          // Defensive: if the stream finishes without emitting an event for
+          // some preview item, flip it to error rather than letting the row
+          // stay greyed-out forever (#1723). The orchestrator-side fix should
+          // make this unreachable, but the cost is one extra setState.
+          setState(() {
+            for (final item in widget.filesToDelete) {
+              if (item.status == DeleteItemStatus.pending || item.status == DeleteItemStatus.inProgress) {
+                item.status = DeleteItemStatus.error;
+                item.errorMessage = 'No result from orchestrator';
+              }
+            }
+          });
+          break;
+        }
         setState(() {
           _stoppingBinaries = false;
           _currentIndex = seen;

--- a/sail_ui/lib/widgets/reset/reset_confirmation_page.dart
+++ b/sail_ui/lib/widgets/reset/reset_confirmation_page.dart
@@ -4,6 +4,31 @@ import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 import 'package:sail_ui/sail_ui.dart';
 
+/// Three-state header shown above the file list on the reset page.
+/// Pre-deletion = red warning. Complete with zero errors = green check.
+/// Complete with errors = orange warning, so partial wipes don't masquerade
+/// as a clean success (#1723).
+enum ResetHeaderState { confirm, success, partial }
+
+ResetHeaderState resetHeaderState({required bool deletionComplete, required int errorCount}) {
+  if (!deletionComplete) return ResetHeaderState.confirm;
+  return errorCount == 0 ? ResetHeaderState.success : ResetHeaderState.partial;
+}
+
+/// Defensive flip used on the stream's `done` event in case the orchestrator
+/// finished without emitting a per-path event for every preview row. Leaving
+/// rows in pending/inProgress would strand them grey forever; flipping to
+/// error surfaces the discrepancy. The orchestrator-side fix in d1b8158b
+/// should make this unreachable, but we keep the safety net (#1723).
+void applyDoneEventToItems(List<DeleteItem> items, {String message = 'No result from orchestrator'}) {
+  for (final item in items) {
+    if (item.status == DeleteItemStatus.pending || item.status == DeleteItemStatus.inProgress) {
+      item.status = DeleteItemStatus.error;
+      item.errorMessage = message;
+    }
+  }
+}
+
 /// Page showing files that will be deleted and asking for confirmation
 class ResetConfirmationPage extends StatefulWidget {
   final List<DeleteItem> filesToDelete;
@@ -178,18 +203,7 @@ class _ResetConfirmationPageState extends State<ResetConfirmationPage> {
       await for (final event in widget.orchestratorDelete!()) {
         if (!mounted) return;
         if (event.done) {
-          // Defensive: if the stream finishes without emitting an event for
-          // some preview item, flip it to error rather than letting the row
-          // stay greyed-out forever (#1723). The orchestrator-side fix should
-          // make this unreachable, but the cost is one extra setState.
-          setState(() {
-            for (final item in widget.filesToDelete) {
-              if (item.status == DeleteItemStatus.pending || item.status == DeleteItemStatus.inProgress) {
-                item.status = DeleteItemStatus.error;
-                item.errorMessage = 'No result from orchestrator';
-              }
-            }
-          });
+          setState(() => applyDoneEventToItems(widget.filesToDelete));
           break;
         }
         setState(() {
@@ -265,33 +279,34 @@ class _ResetConfirmationPageState extends State<ResetConfirmationPage> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             spacing: SailStyleValues.padding12,
                             children: [
-                              if (_deletionComplete && errorCount == 0)
-                                Icon(
+                              switch (resetHeaderState(deletionComplete: _deletionComplete, errorCount: errorCount)) {
+                                ResetHeaderState.success => Icon(
                                   Icons.check_circle,
                                   color: theme.colors.success,
                                   size: 32,
-                                )
-                              else if (_deletionComplete)
-                                // Some files were left undeleted — surface that in the
-                                // header instead of the previous unconditional green
-                                // checkmark that masked partial wipes (#1723).
-                                SailSVG.fromAsset(
+                                ),
+                                ResetHeaderState.partial => SailSVG.fromAsset(
                                   SailSVGAsset.iconWarning,
                                   color: theme.colors.orange,
                                   width: 32,
                                   height: 32,
-                                )
-                              else
-                                SailSVG.fromAsset(
+                                ),
+                                ResetHeaderState.confirm => SailSVG.fromAsset(
                                   SailSVGAsset.iconWarning,
                                   color: theme.colors.error,
                                   width: 32,
                                   height: 32,
                                 ),
+                              },
                               SailText.primary24(
-                                _deletionComplete
-                                    ? (errorCount == 0 ? 'Reset Complete' : 'Reset Partially Complete')
-                                    : 'Confirm Deletion',
+                                switch (resetHeaderState(
+                                  deletionComplete: _deletionComplete,
+                                  errorCount: errorCount,
+                                )) {
+                                  ResetHeaderState.success => 'Reset Complete',
+                                  ResetHeaderState.partial => 'Reset Partially Complete',
+                                  ResetHeaderState.confirm => 'Confirm Deletion',
+                                },
                                 bold: true,
                               ),
                             ],

--- a/sail_ui/lib/widgets/reset/reset_confirmation_page.dart
+++ b/sail_ui/lib/widgets/reset/reset_confirmation_page.dart
@@ -251,11 +251,21 @@ class _ResetConfirmationPageState extends State<ResetConfirmationPage> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             spacing: SailStyleValues.padding12,
                             children: [
-                              if (_deletionComplete)
+                              if (_deletionComplete && errorCount == 0)
                                 Icon(
                                   Icons.check_circle,
                                   color: theme.colors.success,
                                   size: 32,
+                                )
+                              else if (_deletionComplete)
+                                // Some files were left undeleted — surface that in the
+                                // header instead of the previous unconditional green
+                                // checkmark that masked partial wipes (#1723).
+                                SailSVG.fromAsset(
+                                  SailSVGAsset.iconWarning,
+                                  color: theme.colors.orange,
+                                  width: 32,
+                                  height: 32,
                                 )
                               else
                                 SailSVG.fromAsset(
@@ -265,7 +275,9 @@ class _ResetConfirmationPageState extends State<ResetConfirmationPage> {
                                   height: 32,
                                 ),
                               SailText.primary24(
-                                _deletionComplete ? 'Reset Complete' : 'Confirm Deletion',
+                                _deletionComplete
+                                    ? (errorCount == 0 ? 'Reset Complete' : 'Reset Partially Complete')
+                                    : 'Confirm Deletion',
                                 bold: true,
                               ),
                             ],

--- a/sail_ui/test/reset_confirmation_done_branch_test.dart
+++ b/sail_ui/test/reset_confirmation_done_branch_test.dart
@@ -1,0 +1,68 @@
+// Regression for #1723 (defensive arm): if the orchestrator finishes the
+// reset stream without emitting an event for every preview row, the rows
+// that never got an event were left at `pending` forever — greyed-out and
+// confusing, with no way for the user to know whether they were deleted.
+//
+// The fix at sail_ui/lib/widgets/reset/reset_confirmation_page.dart handles
+// the `done` event by flipping any still-pending/in-progress items to
+// `error` with a "No result from orchestrator" message. This test pins
+// that behaviour via the pure `applyDoneEventToItems` helper so the safety
+// net can't silently regress.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+void main() {
+  test('flips pending items to error with default message', () {
+    final items = [
+      DeleteItem(path: '/a', status: DeleteItemStatus.pending),
+      DeleteItem(path: '/b', status: DeleteItemStatus.pending),
+    ];
+
+    applyDoneEventToItems(items);
+
+    for (final item in items) {
+      expect(item.status, DeleteItemStatus.error);
+      expect(item.errorMessage, 'No result from orchestrator');
+    }
+  });
+
+  test('flips in-progress items to error too', () {
+    final item = DeleteItem(path: '/a', status: DeleteItemStatus.inProgress);
+
+    applyDoneEventToItems([item]);
+
+    expect(item.status, DeleteItemStatus.error);
+    expect(item.errorMessage, 'No result from orchestrator');
+  });
+
+  test('leaves already-resolved items alone', () {
+    final success = DeleteItem(path: '/s', status: DeleteItemStatus.success);
+    final preExistingError = DeleteItem(
+      path: '/e',
+      status: DeleteItemStatus.error,
+      errorMessage: 'disk full',
+    );
+
+    applyDoneEventToItems([success, preExistingError]);
+
+    expect(success.status, DeleteItemStatus.success);
+    expect(success.errorMessage, isNull);
+    // Pre-existing error message must not be clobbered — the user cares
+    // about the real failure cause, not the generic done-branch message.
+    expect(preExistingError.status, DeleteItemStatus.error);
+    expect(preExistingError.errorMessage, 'disk full');
+  });
+
+  test('honors custom message override', () {
+    final item = DeleteItem(path: '/a', status: DeleteItemStatus.pending);
+
+    applyDoneEventToItems([item], message: 'stream closed early');
+
+    expect(item.errorMessage, 'stream closed early');
+  });
+
+  test('handles empty list without throwing', () {
+    expect(() => applyDoneEventToItems(<DeleteItem>[]), returnsNormally);
+  });
+}

--- a/sail_ui/test/reset_confirmation_header_test.dart
+++ b/sail_ui/test/reset_confirmation_header_test.dart
@@ -1,0 +1,29 @@
+// Regression for #1723: before this fix, the wipe-success header was an
+// unconditional green check + "Reset Complete", even when half the files
+// failed to delete. Users walked away believing the wipe was clean.
+//
+// The fix at sail_ui/lib/widgets/reset/reset_confirmation_page.dart gates
+// the header on `errorCount`. This test exercises that gating through the
+// pure `resetHeaderState` helper so we don't need to mount the whole
+// Scaffold + ViewModelBuilder rig just to assert three lines of branching.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+void main() {
+  test('pre-deletion shows confirm state', () {
+    expect(resetHeaderState(deletionComplete: false, errorCount: 0), ResetHeaderState.confirm);
+    // errorCount is irrelevant before deletion is complete — items can only be
+    // pending so a non-zero count would be nonsensical, but lock the behaviour.
+    expect(resetHeaderState(deletionComplete: false, errorCount: 5), ResetHeaderState.confirm);
+  });
+
+  test('clean wipe shows success state', () {
+    expect(resetHeaderState(deletionComplete: true, errorCount: 0), ResetHeaderState.success);
+  });
+
+  test('partial wipe shows partial state (the #1723 bug)', () {
+    expect(resetHeaderState(deletionComplete: true, errorCount: 1), ResetHeaderState.partial);
+    expect(resetHeaderState(deletionComplete: true, errorCount: 99), ResetHeaderState.partial);
+  });
+}

--- a/sidechain-orchestrator/reset.go
+++ b/sidechain-orchestrator/reset.go
@@ -235,6 +235,14 @@ func (o *Orchestrator) PreviewResetData(cat ResetCategory) ([]ResetFileInfo, err
 // sending each deletion event to the returned channel. The final event has
 // Done=true with summary counts.
 func (o *Orchestrator) StreamResetData(ctx context.Context, cat ResetCategory) (<-chan ResetEvent, error) {
+	// Snapshot entries BEFORE shutdown/wallet-move so the stream's emission set
+	// matches the preview the frontend already showed (#1723). Previously this
+	// ran after ShutdownAll deleted pid/lock files and DeleteAllWallets moved
+	// wallet paths aside — those entries silently dropped out of the recompute
+	// and the corresponding rows stayed grey forever. RemoveAll below tolerates
+	// the missing pid files via os.IsNotExist, so capturing eagerly is safe.
+	entries := o.collectPathEntries(cat)
+
 	// Budget grows with dependency-chain length; ShutdownAll is sequential.
 	running := o.process.ListRunning()
 	shutdownBudget := gracefulKillTimeout * time.Duration(len(running)+2)
@@ -264,8 +272,6 @@ func (o *Orchestrator) StreamResetData(ctx context.Context, cat ResetCategory) (
 			return nil, fmt.Errorf("delete wallet data: %w", err)
 		}
 	}
-
-	entries := o.collectPathEntries(cat)
 
 	events := make(chan ResetEvent, len(entries)+1)
 

--- a/sidechain-orchestrator/reset_test.go
+++ b/sidechain-orchestrator/reset_test.go
@@ -450,6 +450,60 @@ func TestStreamResetData_DeduplicatesAcrossCategories(t *testing.T) {
 	}
 }
 
+// TestCollectPathEntries_ShrinksWhenSeededFilesVanish locks in the *reason*
+// for the fix in commit d1b8158b: collectPathEntries delegates to
+// GetExistingFilesInDir, which silently drops paths that don't exist on
+// disk. The old StreamResetData called collectPathEntries AFTER ShutdownAll
+// removed pid/lock files and WalletSvc.DeleteAllWallets moved wallet dirs
+// aside — so the recompute returned fewer entries than the preview, and
+// the UI rows for the dropped paths stayed pending forever (#1723).
+//
+// The fix snapshots entries at the top of StreamResetData, before any
+// destructive operation runs. This test demonstrates the shrink behavior
+// directly so that any future refactor moving the snapshot back below
+// shutdown immediately reintroduces the bug — and this test catches it.
+func TestCollectPathEntries_ShrinksWhenSeededFilesVanish(t *testing.T) {
+	o := newResetTestOrchestrator(t)
+
+	binDir := BinDir(o.BitwindowDir)
+	seeded := []string{
+		filepath.Join(binDir, "bitcoind"),
+		filepath.Join(binDir, "bip300301-enforcer"),
+		filepath.Join(binDir, "thunder"),
+	}
+	for _, p := range seeded {
+		seedFile(t, p)
+	}
+
+	cat := ResetCategory{DeleteNodeSoftware: true}
+
+	before := o.collectPathEntries(cat)
+	require.NotEmpty(t, before, "expected seeded files in initial collect")
+
+	// Mid-call removal of a seeded path — same effect as ShutdownAll
+	// deleting bitcoind.pid or DeleteAllWallets moving a wallet dir.
+	require.NoError(t, os.Remove(seeded[0]))
+
+	after := o.collectPathEntries(cat)
+
+	assert.Lessf(t, len(after), len(before),
+		"collectPathEntries must shrink when seeded files vanish; "+
+			"that's why StreamResetData snapshots entries before shutdown — "+
+			"if this assertion ever flips, the fix in d1b8158b is no longer load-bearing "+
+			"(before=%d after=%d)", len(before), len(after))
+
+	// Confirm the vanished path specifically dropped out — pin the cause.
+	stillPresent := false
+	for _, e := range after {
+		if e.path == seeded[0] {
+			stillPresent = true
+			break
+		}
+	}
+	assert.False(t, stillPresent,
+		"deleted seed %q should no longer appear in collectPathEntries result", seeded[0])
+}
+
 // ---------- categoryLabel --------------------------------------------------
 
 func TestCategoryLabel(t *testing.T) {

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.236
+version: 1.0.237
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.107
+version: 1.0.108
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.234
+version: 1.0.235
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
Closes #1728: `SidechainsViewModel` now repaints on every `DownloadProvider` tick so in-flight downloads show live progress instead of jumping straight to "finished".

Closes #1723: wipe success header now renders amber + "Reset Partially Complete" when `errorCount > 0`, instead of unconditionally green + "Reset Complete". Per-file rows already showed accurate ✓/✕ status — only the top banner was lying.