### PR TITLE
fix #1712 + #1766: enforcer auth, refresh-on-block

### DIFF
--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -232,6 +232,19 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   GetIt.I.registerSingleton<BlockchainProvider>(BlockchainProvider());
   GetIt.I.registerSingleton<NetworkProvider>(NetworkProvider());
   GetIt.I.registerSingleton<TransactionProvider>(TransactionProvider());
+
+  // Refetch live on every new mainchain block so the user sees fresh blocks,
+  // balance, and transactions without waiting for each provider's slower
+  // independent poll (#1766). SyncProvider's onNewBlock fires only on a
+  // strict height increment, so this is a no-op outside of actual new-block
+  // events. Tracked here in main so the wiring is explicit and one-shot.
+  GetIt.I<SyncProvider>().onNewBlock((_) {
+    unawaited(GetIt.I<BalanceProvider>().fetch());
+    unawaited(GetIt.I<BlockchainProvider>().fetch());
+    if (GetIt.I.isRegistered<TransactionProvider>()) {
+      unawaited(GetIt.I<TransactionProvider>().fetch());
+    }
+  });
   GetIt.I.registerSingleton<NewsProvider>(NewsProvider());
   GetIt.I.registerSingleton<SidechainProvider>(SidechainProvider());
   GetIt.I.registerSingleton<M4Provider>(M4Provider());

--- a/sail_ui/lib/config/sidechain_main.dart
+++ b/sail_ui/lib/config/sidechain_main.dart
@@ -202,6 +202,20 @@ Future<void> initSidechainDependencies({
       () => SidechainTransactionsProvider(),
     );
   }
+
+  // Refetch on every new mainchain block — without this the UI relies on
+  // each provider's own (slower) poll cadence and the user sees stale
+  // balance/transactions for up to ~1s after a block lands (#1766). The
+  // SyncProvider's onNewBlock broadcast already dedupes on strict height
+  // increment, so this only fires when there's actually new data to fetch.
+  syncProvider.onNewBlock((_) {
+    if (GetIt.I.isRegistered<BalanceProvider>()) {
+      unawaited(GetIt.I<BalanceProvider>().fetch());
+    }
+    if (GetIt.I.isRegistered<SidechainTransactionsProvider>()) {
+      unawaited(GetIt.I<SidechainTransactionsProvider>().fetch());
+    }
+  });
   if (!GetIt.I.isRegistered<PriceProvider>()) {
     GetIt.I.registerLazySingleton<PriceProvider>(() => PriceProvider());
   }

--- a/sail_ui/lib/mocks/mocks.dart
+++ b/sail_ui/lib/mocks/mocks.dart
@@ -1666,6 +1666,21 @@ class MockSyncProvider implements SyncProvider {
   }
 
   @override
+  void onNewBlock(void Function(int newHeight) cb) {
+    return;
+  }
+
+  @override
+  void offNewBlock(void Function(int newHeight) cb) {
+    return;
+  }
+
+  @override
+  void maybeFireNewBlock(int newBlocks) {
+    return;
+  }
+
+  @override
   bool get hasListeners => false;
 
   @override

--- a/sail_ui/lib/providers/sync_provider.dart
+++ b/sail_ui/lib/providers/sync_provider.dart
@@ -142,6 +142,43 @@ class SyncProvider extends ChangeNotifier {
   bool _isFetching = false;
   Duration _currentInterval = AGGRESSIVE_INTERVAL;
 
+  /// Last seen mainchain block height. Drives the new-block broadcast — every
+  /// _fetch() compares this against the freshly-polled value and, on a strict
+  /// increment, fires [_newBlockListeners] so dependent providers (balance,
+  /// transactions, blocks list) can refetch (#1766).
+  int _lastMainchainBlocks = 0;
+  final Set<void Function(int)> _newBlockListeners = <void Function(int)>{};
+
+  /// Register a callback to fire whenever a new mainchain block arrives.
+  /// The new height is passed to [cb]. Caller is responsible for calling
+  /// [offNewBlock] in dispose. Fire-and-forget — exceptions are swallowed
+  /// so one bad listener can't kill the whole broadcast.
+  void onNewBlock(void Function(int newHeight) cb) {
+    _newBlockListeners.add(cb);
+  }
+
+  void offNewBlock(void Function(int newHeight) cb) {
+    _newBlockListeners.remove(cb);
+  }
+
+  /// Apply the dedupe-and-broadcast logic for a freshly-polled mainchain
+  /// block height. Fires registered listeners only when [newBlocks] is a
+  /// strict increment over the last seen value. Public so tests can drive
+  /// the broadcast without standing up a mocked orchestrator transport;
+  /// production callers should go through [_fetch].
+  @visibleForTesting
+  void maybeFireNewBlock(int newBlocks) {
+    if (newBlocks <= _lastMainchainBlocks) return;
+    _lastMainchainBlocks = newBlocks;
+    for (final cb in _newBlockListeners.toList(growable: false)) {
+      try {
+        cb(newBlocks);
+      } catch (e) {
+        log.w('SyncProvider: new-block listener threw: $e');
+      }
+    }
+  }
+
   /// Wipe cached per-chain sync state. Called on network swap so stale
   /// progress from the previous network doesn't linger in the UI.
   void reset() {
@@ -153,6 +190,11 @@ class SyncProvider extends ChangeNotifier {
     sidechainErrors = const {};
     bitwindowdSyncInfo = null;
     bitwindowdError = null;
+    // Reset the new-block dedupe baseline so the first block on the new
+    // network fires onNewBlock callbacks. Without this a network swap from
+    // mainnet (height 800k) → regtest (height 0) would never fire again
+    // until regtest passed 800k.
+    _lastMainchainBlocks = 0;
     notifyListeners();
   }
 
@@ -219,6 +261,11 @@ class SyncProvider extends ChangeNotifier {
         mainchainError = _errOrNull(resp.mainchain);
         changed = true;
       }
+      // Fire the new-block broadcast on strict block-height increment. The
+      // SyncInfo equality check above includes progressGoal/lastBlockAt
+      // changes too, so we re-check the blocks delta independently to avoid
+      // false positives when only the header height moved.
+      maybeFireNewBlock(newMainchain.progressCurrent.toInt());
 
       final newEnforcer = _toSyncInfo(resp.enforcer);
       if (_diff(enforcerSyncInfo, newEnforcer) || enforcerError != _errOrNull(resp.enforcer)) {

--- a/sail_ui/test/sync_provider_new_block_test.dart
+++ b/sail_ui/test/sync_provider_new_block_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+// SyncProvider's onNewBlock broadcast (#1766). Tests drive the dedupe-and-fire
+// logic via maybeFireNewBlock so they don't need to stand up a fake
+// orchestrator transport — the public path through _fetch composes
+// _toSyncInfo+maybeFireNewBlock+notifyListeners, but the new-block contract
+// lives entirely in maybeFireNewBlock and that's what these tests pin.
+
+void main() {
+  setUpAll(() {
+    if (!GetIt.I.isRegistered<Logger>()) {
+      GetIt.I.registerSingleton<Logger>(Logger(level: Level.warning));
+    }
+  });
+
+  SyncProvider build() => SyncProvider(startTimer: false);
+
+  test('fires once with the new height on a strict increment', () {
+    final p = build();
+    final fired = <int>[];
+    p.onNewBlock(fired.add);
+
+    p.maybeFireNewBlock(100);
+
+    expect(fired, [100]);
+  });
+
+  test('does not fire when the height is unchanged', () {
+    final p = build();
+    final fired = <int>[];
+    p.onNewBlock(fired.add);
+
+    p.maybeFireNewBlock(100);
+    p.maybeFireNewBlock(100);
+
+    expect(fired, [100], reason: 'duplicate same-height polls must not refire');
+  });
+
+  test('does not fire when the height regresses', () {
+    // Edge: a network re-org or the orchestrator returning a stale snapshot
+    // briefly. We don't want to spam refreshes on regress.
+    final p = build();
+    final fired = <int>[];
+    p.onNewBlock(fired.add);
+
+    p.maybeFireNewBlock(100);
+    p.maybeFireNewBlock(99);
+
+    expect(fired, [100]);
+  });
+
+  test('fires once per increment across a sequence', () {
+    final p = build();
+    final fired = <int>[];
+    p.onNewBlock(fired.add);
+
+    p.maybeFireNewBlock(100);
+    p.maybeFireNewBlock(101);
+    p.maybeFireNewBlock(102);
+
+    expect(fired, [100, 101, 102]);
+  });
+
+  test('reset() clears the dedupe baseline so the next block fires again', () {
+    // Network swap goes through reset() — without this clear, a swap from
+    // mainnet (height 800k) to regtest (height 0) would never refire until
+    // regtest passed 800k. See sync_provider.dart's reset().
+    final p = build();
+    final fired = <int>[];
+    p.onNewBlock(fired.add);
+
+    p.maybeFireNewBlock(800000);
+    p.reset();
+    p.maybeFireNewBlock(1);
+
+    expect(fired, [800000, 1]);
+  });
+
+  test('offNewBlock unsubscribes the callback', () {
+    final p = build();
+    final fired = <int>[];
+    void cb(int h) => fired.add(h);
+    p.onNewBlock(cb);
+    p.maybeFireNewBlock(100);
+
+    p.offNewBlock(cb);
+    p.maybeFireNewBlock(101);
+
+    expect(fired, [100]);
+  });
+
+  test('a throwing listener does not block siblings or the dedupe baseline', () {
+    final p = build();
+    final fired = <int>[];
+    p.onNewBlock((_) => throw StateError('bad listener'));
+    p.onNewBlock(fired.add);
+
+    p.maybeFireNewBlock(100);
+    p.maybeFireNewBlock(101);
+
+    expect(fired, [100, 101], reason: 'sibling listener must still fire after a throwing one');
+  });
+}

--- a/sidechain-orchestrator/config/enforcer_conf.go
+++ b/sidechain-orchestrator/config/enforcer_conf.go
@@ -264,20 +264,31 @@ func (m *EnforcerConfManager) WriteConfig(content string) error {
 // Dart: getCliArgs (L275)
 func (m *EnforcerConfManager) GetCliArgs() []string {
 	var args []string
+	// seen[key] is true only when the persisted conf had a NON-EMPTY value
+	// for that key. An empty entry (e.g. `node-rpc-user=` left blank in the
+	// configurator) used to mark seen=true while emitting no arg, then the
+	// overlay below would skip the same key — leaving the enforcer with no
+	// rpc-user flag and the cryptic "precisely one of rpc user and cookie
+	// must be set" error (#1712). Empty-value keys now fall through to the
+	// overlay's default.
 	seen := make(map[string]bool)
 
 	if m.Config != nil {
 		for key, value := range m.Config.Settings {
-			seen[key] = true
 			switch value {
 			case "true":
 				args = append(args, fmt.Sprintf("--%s", key))
+				seen[key] = true
 			case "false":
+				seen[key] = true
 				continue
 			default:
 				if value != "" {
 					args = append(args, fmt.Sprintf("--%s=%s", key, value))
+					seen[key] = true
 				}
+				// empty values intentionally leave seen[key] false so the
+				// overlay below can supply a derived default.
 			}
 		}
 	}

--- a/sidechain-orchestrator/config/enforcer_conf_test.go
+++ b/sidechain-orchestrator/config/enforcer_conf_test.go
@@ -192,6 +192,87 @@ func TestGetCliArgs(t *testing.T) {
 	}
 }
 
+// Regression for #1712 ("Enforcer startup errors due to password and cookie
+// mixups"). The enforcer dies at startup with "precisely one of rpc user and
+// cookie must be set" when --node-rpc-user / --node-rpc-pass don't reach it.
+// These tests pin two invariants of GetCliArgs:
+//  1. A fresh config (no persisted overrides) always emits both flags via
+//     the bitcoin-conf-derived overlay.
+//  2. An EMPTY persisted value (e.g. user cleared the field in the
+//     configurator) must NOT mark the key as seen — the overlay default
+//     must still fire. Previously the seen[key]=true short-circuit ran
+//     first, leaving the enforcer with neither flag.
+func TestGetCliArgs_FreshConfigAlwaysEmitsNodeRpcUserAndPass(t *testing.T) {
+	m, _ := newTestEnforcerManager(t)
+	require.NoError(t, m.LoadConfig())
+
+	args := m.GetCliArgs()
+	hasUser, hasPass := false, false
+	for _, a := range args {
+		if strings.HasPrefix(a, "--node-rpc-user=") {
+			hasUser = true
+		}
+		if strings.HasPrefix(a, "--node-rpc-pass=") {
+			hasPass = true
+		}
+	}
+	if !hasUser {
+		t.Errorf("expected --node-rpc-user=... in args, got %v", args)
+	}
+	if !hasPass {
+		t.Errorf("expected --node-rpc-pass=... in args, got %v", args)
+	}
+}
+
+func TestGetCliArgs_EmptyPersistedValueFallsBackToOverlay(t *testing.T) {
+	m, _ := newTestEnforcerManager(t)
+	require.NoError(t, m.LoadConfig())
+
+	// Simulate the user clearing the value in the configurator. The
+	// persisted settings map carries an entry with an empty value.
+	m.Config.Settings["node-rpc-user"] = ""
+	m.Config.Settings["node-rpc-pass"] = ""
+
+	args := m.GetCliArgs()
+	hasUser, hasPass := false, false
+	for _, a := range args {
+		if strings.HasPrefix(a, "--node-rpc-user=") && a != "--node-rpc-user=" {
+			hasUser = true
+		}
+		if strings.HasPrefix(a, "--node-rpc-pass=") && a != "--node-rpc-pass=" {
+			hasPass = true
+		}
+	}
+	if !hasUser {
+		t.Errorf("empty persisted node-rpc-user must fall back to overlay default; got args=%v", args)
+	}
+	if !hasPass {
+		t.Errorf("empty persisted node-rpc-pass must fall back to overlay default; got args=%v", args)
+	}
+}
+
+func TestGetCliArgs_NonEmptyPersistedValueWinsOverOverlay(t *testing.T) {
+	m, _ := newTestEnforcerManager(t)
+	require.NoError(t, m.LoadConfig())
+
+	m.Config.Settings["node-rpc-user"] = "custom-user"
+	m.Config.Settings["node-rpc-pass"] = "custom-pass"
+
+	args := m.GetCliArgs()
+	hasCustomUser, hasCustomPass := false, false
+	for _, a := range args {
+		if a == "--node-rpc-user=custom-user" {
+			hasCustomUser = true
+		}
+		if a == "--node-rpc-pass=custom-pass" {
+			hasCustomPass = true
+		}
+	}
+	if !hasCustomUser || !hasCustomPass {
+		t.Errorf("expected custom persisted creds to win over overlay; got %v", args)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // File watching tests
 // ---------------------------------------------------------------------------

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -1113,6 +1113,14 @@ func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpt
 		return
 	}
 
+	// Log the literal argv at the actual spawn site (the auto-built-args log
+	// in prepareEnforcerArgs fires before --wallet-seed-file is injected and
+	// before any L1-seed rewrite, so it doesn't reflect the final command
+	// line). Helps diagnose "precisely one of rpc user and cookie must be
+	// set" -class errors (#1712) where the question is whether --node-rpc-user
+	// actually reaches the binary.
+	o.log.Info().Strs("argv", opts.EnforcerArgs).Msg("starting enforcer with final argv")
+
 	if _, err := o.process.Start(ctx, enforcerCfg, opts.EnforcerArgs, enforcerEnv()); err != nil {
 		enforcerMon.SetInitializing(false)
 		o.log.Error().Err(err).Msg("failed to start enforcer")


### PR DESCRIPTION
Closes #1766: `SyncProvider` now broadcasts an onNewBlock signal on every strict mainchain-height increment. Wired bitwindow's BalanceProvider / BlockchainProvider / TransactionProvider plus sail_ui's sidechain transactions provider to refetch on each block. UI shows fresh data within one poll cycle instead of waiting for each provider's independent timer.

Closes #1712: `GetCliArgs`'s seen-key short-circuit used to mark an empty persisted `node-rpc-user` as seen, blocking the overlay default — enforcer launched with no rpc-user flag and hit "precisely one of rpc user and cookie must be set". Empty values now fall through to the overlay. Plus a final-argv log at the actual spawn site so future auth issues are diagnosable from the log alone.