### PR TITLE
thunder shutdown fix

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.237
+version: 1.0.238
 
 environment:
   sdk: 3.11.4

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.237
+version: 1.0.238
 
 environment:
   sdk: 3.11.4

--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -848,6 +848,12 @@ Future<void> bootBitwindowBackend(Logger log) async {
       await orchestrator.listBinaries();
       log.i('STARTUP: orchestratord is ready');
       orchestratorReady = true;
+      // SettingsProvider.create ran before orchestratord was up, so the
+      // test-sidechains flag may still be the cached/default value. Pull
+      // the real one from orchestratord now — BinaryProvider listens to
+      // SettingsProvider and re-fetches binary release timestamps with
+      // the right (test vs prod) URL when this flips.
+      unawaited(GetIt.I.get<SettingsProvider>().reconcileUseTestSidechainsFromOrchestrator());
       if (bitwindowRpc != null) {
         bitwindowRpc.initializingBinary = false;
         bitwindowRpc.markStateChanged();

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.90
+version: 0.2.91
 
 environment:
   sdk: 3.11.4

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.110
+version: 1.0.111
 
 environment:
   sdk: 3.11.4

--- a/sail_ui/lib/config/binaries.dart
+++ b/sail_ui/lib/config/binaries.dart
@@ -924,7 +924,7 @@ abstract class Binary {
           ? GetIt.I.get<SettingsProvider>().useTestSidechains
           : false;
       final hasAlt = metadata.hasAlternativeDownloadConfig;
-      log.i('_checkDirectReleaseDate $name: useTest=$useTest hasAlt=$hasAlt url=$downloadUrl');
+      log.w('_checkDirectReleaseDate $name: useTest=$useTest hasAlt=$hasAlt url=$downloadUrl');
 
       final client = HttpClient();
 

--- a/sail_ui/lib/config/binaries.dart
+++ b/sail_ui/lib/config/binaries.dart
@@ -920,6 +920,11 @@ abstract class Binary {
       }
 
       final downloadUrl = Uri.parse(baseUrl).resolve(fileName).toString();
+      final useTest = GetIt.I.isRegistered<SettingsProvider>()
+          ? GetIt.I.get<SettingsProvider>().useTestSidechains
+          : false;
+      final hasAlt = metadata.hasAlternativeDownloadConfig;
+      log.i('_checkDirectReleaseDate $name: useTest=$useTest hasAlt=$hasAlt url=$downloadUrl');
 
       final client = HttpClient();
 
@@ -2200,6 +2205,8 @@ class MetadataConfig {
   // if test chains enabled, use those, but only if an alternative config exists
   DownloadConfig get downloadConfig =>
       _settingsProvider.useTestSidechains ? _alternativeDownloadConfig ?? _downloadConfig : _downloadConfig;
+
+  bool get hasAlternativeDownloadConfig => _alternativeDownloadConfig != null;
 
   DateTime? remoteTimestamp; // Last-Modified from server
   DateTime? downloadedTimestamp; // Local file timestamp

--- a/sail_ui/lib/providers/binaries/binary_provider.dart
+++ b/sail_ui/lib/providers/binaries/binary_provider.dart
@@ -32,9 +32,12 @@ class BinaryProvider extends ChangeNotifier {
   }) : _processManager = processManager {
     _processManager.addListener(notifyListeners);
     _startMetadataRefreshTimer();
+    _wireSettingsListener();
   }
 
   Timer? _metadataRefreshTimer;
+  VoidCallback? _settingsListener;
+  bool? _lastKnownUseTestSidechains;
 
   /// Refresh remote release timestamps every 5 minutes so newly published
   /// builds light up the daemon-card update indicator and the chain-settings
@@ -42,17 +45,42 @@ class BinaryProvider extends ChangeNotifier {
   /// already runs once during create(); this keeps it ticking after.
   void _startMetadataRefreshTimer() {
     _metadataRefreshTimer?.cancel();
-    _metadataRefreshTimer = Timer.periodic(const Duration(minutes: 5), (_) async {
-      final refreshed = await loadBinaryCreationTimestamp(binaries, appDir);
-      for (final b in refreshed) {
-        updateBinary(b.type, (_) => b);
-      }
+    _metadataRefreshTimer = Timer.periodic(const Duration(minutes: 5), (_) {
+      _refreshMetadata();
     });
+  }
+
+  /// Watch SettingsProvider so a toggle of "use test sidechains" flips the
+  /// cached download URLs immediately. Without this, the modal + sidechains-
+  /// page update indicator would keep showing the *prod* URL's release date
+  /// until the next 5-min refresh tick fired — and on first-boot the toggle
+  /// reconciles AFTER BinaryProvider.create has already cached prod dates.
+  void _wireSettingsListener() {
+    if (!GetIt.I.isRegistered<SettingsProvider>()) return;
+    final settings = GetIt.I.get<SettingsProvider>();
+    _lastKnownUseTestSidechains = settings.useTestSidechains;
+    _settingsListener = () {
+      if (settings.useTestSidechains != _lastKnownUseTestSidechains) {
+        _lastKnownUseTestSidechains = settings.useTestSidechains;
+        _refreshMetadata();
+      }
+    };
+    settings.addListener(_settingsListener!);
+  }
+
+  Future<void> _refreshMetadata() async {
+    final refreshed = await loadBinaryCreationTimestamp(binaries, appDir);
+    for (final b in refreshed) {
+      updateBinary(b.type, (_) => b);
+    }
   }
 
   @override
   void dispose() {
     _metadataRefreshTimer?.cancel();
+    if (_settingsListener != null && GetIt.I.isRegistered<SettingsProvider>()) {
+      GetIt.I.get<SettingsProvider>().removeListener(_settingsListener!);
+    }
     super.dispose();
   }
 

--- a/sail_ui/lib/providers/binaries/binary_provider.dart
+++ b/sail_ui/lib/providers/binaries/binary_provider.dart
@@ -31,6 +31,29 @@ class BinaryProvider extends ChangeNotifier {
     required ProcessManager processManager,
   }) : _processManager = processManager {
     _processManager.addListener(notifyListeners);
+    _startMetadataRefreshTimer();
+  }
+
+  Timer? _metadataRefreshTimer;
+
+  /// Refresh remote release timestamps every 5 minutes so newly published
+  /// builds light up the daemon-card update indicator and the chain-settings
+  /// modal without needing an app restart. `loadBinaryCreationTimestamp`
+  /// already runs once during create(); this keeps it ticking after.
+  void _startMetadataRefreshTimer() {
+    _metadataRefreshTimer?.cancel();
+    _metadataRefreshTimer = Timer.periodic(const Duration(minutes: 5), (_) async {
+      final refreshed = await loadBinaryCreationTimestamp(binaries, appDir);
+      for (final b in refreshed) {
+        updateBinary(b.type, (_) => b);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _metadataRefreshTimer?.cancel();
+    super.dispose();
   }
 
   static Future<BinaryProvider> create({

--- a/sail_ui/lib/providers/settings_provider.dart
+++ b/sail_ui/lib/providers/settings_provider.dart
@@ -80,8 +80,17 @@ class SettingsProvider extends ChangeNotifier {
     useTestSidechains = loadedSetting.value;
     notifyListeners();
 
-    // Reconcile against the orchestrator. If GetIt isn't ready (early bootstrap
-    // path on tests / fresh installs) we keep the cached value.
+    // Reconcile against the orchestrator if it's already registered. On most
+    // boots it isn't — SettingsProvider.create runs before the orchestrator
+    // is registered — and callers must invoke [reconcileUseTestSidechainsFromOrchestrator]
+    // once orchestratord becomes ready.
+    await reconcileUseTestSidechainsFromOrchestrator();
+  }
+
+  /// Re-fetch the test-sidechains flag from orchestratord and update the
+  /// local cache + listeners if it differs. Safe to call multiple times;
+  /// no-op when OrchestratorRPC isn't registered yet.
+  Future<void> reconcileUseTestSidechainsFromOrchestrator() async {
     if (!GetIt.I.isRegistered<OrchestratorRPC>()) {
       return;
     }

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.239
+version: 1.0.240
 
 environment:
   sdk: 3.11.4

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.110
+version: 1.0.111
 
 environment:
   sdk: 3.11.4

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.237
+version: 1.0.238
 
 environment:
   sdk: 3.11.4


### PR DESCRIPTION
- **thunder: drop direct shutdownAll bypass; honour originator gate**
- **sail_ui: resolve test-sidechain binary path for chain settings**
- **sail_ui: force headless backend when starting L2 sidechain daemon**
- **clients: release new version**
- **sail_ui: refresh binary release timestamps every 5 minutes**
- **sail_ui: refresh binary metadata when test sidechains toggle flips**
- **sail_ui: log release-date fetch URL and test sidechains state**
- **sail_ui: temp bump release-date log to warn level**
- **sail_ui: reconcile useTestSidechains with orchestratord after boot**
