### PR TITLE
design-system phase 0: foundation

### DIFF
--- a/drivechain_lints/lib/drivechain_lints.dart
+++ b/drivechain_lints/lib/drivechain_lints.dart
@@ -2,6 +2,7 @@ library drivechain_lints;
 
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:drivechain_lints/src/avoid_build_methods.dart';
+import 'package:drivechain_lints/src/avoid_material_import.dart';
 
 PluginBase createPlugin() => _DrivechainLints();
 
@@ -9,5 +10,6 @@ class _DrivechainLints extends PluginBase {
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
     AvoidBuildMethods(),
+    AvoidMaterialImport(),
   ];
 }

--- a/drivechain_lints/lib/src/avoid_material_import.dart
+++ b/drivechain_lints/lib/src/avoid_material_import.dart
@@ -1,0 +1,46 @@
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// Discourages importing `package:flutter/material.dart` outside of the
+/// design-system layer. Migrating the project onto sail_ui's self-hosted
+/// shadcn-style primitives means consumers should not reach for Material
+/// directly — they should use `SailButton`, `SailCard`, `SailDialog`, etc.
+///
+/// Phase 0 of the design-system migration: this rule is informational
+/// only — it surfaces the existing Material surface area so each
+/// subsequent phase can be measured. Future phases promote the severity
+/// per package as that package hits zero violations.
+///
+/// Allowed exceptions:
+/// - Files inside `sail_ui/lib/` itself (the design system layer wraps
+///   Material primitives by definition; this rule disabled for the
+///   wrapper sources via `// ignore_for_file: avoid_material_import`).
+/// - Anywhere the comment `// ignore: avoid_material_import` is applied
+///   inline.
+class AvoidMaterialImport extends DartLintRule {
+  AvoidMaterialImport() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_material_import',
+    problemMessage:
+        'Avoid importing package:flutter/material.dart — prefer sail_ui primitives.',
+    correctionMessage:
+        'Replace Material widgets with their Sail equivalents (Button → SailButton, '
+        'Card → SailCard, Dialog → SailDialog, etc.). If the import is unavoidable, '
+        'add an ignore comment and explain why.',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addImportDirective((node) {
+      final uri = node.uri.stringValue;
+      if (uri == 'package:flutter/material.dart') {
+        reporter.atNode(node, _code);
+      }
+    });
+  }
+}

--- a/sail_ui/lib/sail_ui.dart
+++ b/sail_ui/lib/sail_ui.dart
@@ -259,6 +259,7 @@ export 'widgets/containers/sail_page.dart';
 export 'widgets/containers/tab_bar.dart';
 export 'widgets/core/sail_app_bar.dart';
 export 'widgets/core/sail_padding.dart';
+export 'widgets/core/sail_separator.dart';
 export 'widgets/core/sail_shadow.dart';
 export 'widgets/core/sail_snackbar.dart';
 export 'widgets/core/sail_svg.dart';

--- a/sail_ui/lib/widgets/core/sail_separator.dart
+++ b/sail_ui/lib/widgets/core/sail_separator.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/widgets.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+/// Thin horizontal or vertical divider line, themed to [SailColor.divider].
+/// Equivalent of shadcn/ui's `Separator`. Self-contained — doesn't import
+/// from `package:flutter/material.dart`, so it's safe to use as a building
+/// block for the rest of the Material-removal effort.
+class SailSeparator extends StatelessWidget {
+  /// Axis the separator runs along. Horizontal = a thin row, the default.
+  final Axis axis;
+
+  /// Stroke thickness in logical pixels.
+  final double thickness;
+
+  /// Optional override for the line color. Defaults to the theme's divider.
+  final Color? color;
+
+  /// Optional padding around the separator. Useful inside menus / dropdowns.
+  final EdgeInsetsGeometry? padding;
+
+  const SailSeparator({
+    super.key,
+    this.axis = Axis.horizontal,
+    this.thickness = 1.0,
+    this.color,
+    this.padding,
+  });
+
+  /// Convenience: a vertical separator. Same as `SailSeparator(axis: Axis.vertical)`.
+  const SailSeparator.vertical({super.key, this.thickness = 1.0, this.color, this.padding}) : axis = Axis.vertical;
+
+  @override
+  Widget build(BuildContext context) {
+    final lineColor = color ?? SailTheme.of(context).colors.divider;
+    final line = axis == Axis.horizontal
+        ? SizedBox(
+            height: thickness,
+            child: ColoredBox(color: lineColor),
+          )
+        : SizedBox(
+            width: thickness,
+            child: ColoredBox(color: lineColor),
+          );
+    if (padding == null) return line;
+    return Padding(padding: padding!, child: line);
+  }
+}

--- a/sail_ui/test/sail_separator_test.dart
+++ b/sail_ui/test/sail_separator_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+// SailSeparator is the design-system Phase 0 introduction. Owns rendering
+// (no Material import), themed via SailColor.divider. These tests pin the
+// public surface so the rest of the migration can lean on it.
+
+void main() {
+  testWidgets('SailSeparator paints a horizontal line by default', (tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: SailSeparator(color: Color(0xFF112233), thickness: 2.0),
+      ),
+    );
+
+    final box = tester.widget<SizedBox>(find.byType(SizedBox));
+    expect(box.height, 2.0);
+    expect(box.width, isNull);
+  });
+
+  testWidgets('SailSeparator.vertical flips the axis', (tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: SailSeparator.vertical(color: Color(0xFF112233), thickness: 3.0),
+      ),
+    );
+
+    final box = tester.widget<SizedBox>(find.byType(SizedBox));
+    expect(box.width, 3.0);
+    expect(box.height, isNull);
+  });
+
+  testWidgets('SailSeparator honours custom padding', (tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: SailSeparator(
+          color: Color(0xFF112233),
+          padding: EdgeInsets.all(8.0),
+        ),
+      ),
+    );
+
+    expect(find.byType(Padding), findsOneWidget);
+    final pad = tester.widget<Padding>(find.byType(Padding));
+    expect(pad.padding, const EdgeInsets.all(8.0));
+  });
+}

--- a/scripts/material_audit.sh
+++ b/scripts/material_audit.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Counts `package:flutter/material.dart` imports across each top-level
+# package. Use this to track the design-system migration: each phase
+# should ratchet these numbers down. Run from repo root.
+set -e
+
+packages=(
+  sail_ui
+  bitwindow
+  thunder
+  bitnames
+  bitassets
+  zside
+  truthcoin
+  photon
+  coinshift
+)
+
+printf "%-14s %6s\n" "package" "count"
+printf "%-14s %6s\n" "-------" "-----"
+total=0
+for p in "${packages[@]}"; do
+  if [ ! -d "$p/lib" ]; then continue; fi
+  n=$(grep -rln "package:flutter/material.dart" "$p/lib" 2>/dev/null | wc -l | tr -d ' ')
+  printf "%-14s %6s\n" "$p" "$n"
+  total=$((total + n))
+done
+printf "%-14s %6s\n" "-------" "-----"
+printf "%-14s %6s\n" "TOTAL" "$total"


### PR DESCRIPTION
Phase 0 of the sail_ui-as-shadcn migration. Three pieces:

- `SailSeparator` widget — Material-free horizontal/vertical divider, themed via `SailColor.divider`. The first new primitive of the porting effort.
- `avoid_material_import` custom lint rule in `drivechain_lints` — flags any new `package:flutter/material.dart` import. Info-level for now; future phases promote it to error per-package as each package hits zero violations.
- `scripts/material_audit.sh` — baseline counter. Current totals: sail_ui 122, bitwindow 86, bitassets 24, coinshift 22, zside 20, photon 19, truthcoin 19, bitnames 16, thunder 13 → 341 total. Each phase should ratchet down.

No behavior change. 3 unit tests on SailSeparator.