### PR TITLE
bitwindow: regression + routing tests for release bugs

### DIFF
--- a/bitwindow/test/denability_viewmodel_dispose_test.dart
+++ b/bitwindow/test/denability_viewmodel_dispose_test.dart
@@ -1,0 +1,41 @@
+import 'package:bitwindow/pages/wallet/denability_page.dart';
+import 'package:bitwindow/providers/transactions_provider.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+
+import 'test_utils.dart';
+
+/// Stand-in for TransactionProvider whose real constructor pulls in half a
+/// dozen providers. We only need its ChangeNotifier behaviour to exercise the
+/// view model's listen/unlisten lifecycle.
+class _FakeTransactionProvider extends ChangeNotifier implements TransactionProvider {
+  void fire() => notifyListeners();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  // Regression for the macOS bug: "opening external deniability throws an error
+  // and the Sidechains tab stops working". DeniabilityViewModel subscribes to
+  // TransactionProvider but used to never unsubscribe, so after the page was
+  // disposed the provider kept invoking the dead view model — which throws
+  // "used after being disposed". dispose() now removes both listeners.
+  testWidgets('DeniabilityViewModel unsubscribes from TransactionProvider on dispose', (tester) async {
+    await registerTestDependencies();
+
+    final fakeProvider = _FakeTransactionProvider();
+    if (GetIt.I.isRegistered<TransactionProvider>()) {
+      await GetIt.I.unregister<TransactionProvider>();
+    }
+    GetIt.I.registerSingleton<TransactionProvider>(fakeProvider);
+
+    final vm = DeniabilityViewModel();
+    vm.dispose();
+
+    // With dispose() correctly removing the listeners, firing the provider does
+    // nothing. Without the fix it would invoke the disposed view model and throw.
+    expect(fakeProvider.fire, returnsNormally);
+  });
+}

--- a/bitwindow/test/network_swap_routing_test.dart
+++ b/bitwindow/test/network_swap_routing_test.dart
@@ -1,0 +1,54 @@
+import 'package:bitwindow/routing/router.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+import 'test_utils.dart';
+
+/// Fake conf provider so the routing test controls the only input the
+/// DataDirGuard cares about: which network is active and whether it already
+/// has a datadir. No real backend / network init.
+class _FakeConf extends ChangeNotifier implements BitcoinConfProvider {
+  @override
+  BitcoinNetwork network = BitcoinNetwork.BITCOIN_NETWORK_MAINNET;
+
+  @override
+  bool networkRequiresDataDir(BitcoinNetwork n) =>
+      n == BitcoinNetwork.BITCOIN_NETWORK_MAINNET || n == BitcoinNetwork.BITCOIN_NETWORK_FORKNET;
+
+  @override
+  bool hasDataDirFor(BitcoinNetwork n) => false;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  // Real router, mocked data layer, assert the destination — the bb pattern.
+  // Regression for "switching to Mainnet doesn't give an option for a datadir":
+  // entering the app on a network that requires a datadir but has none must
+  // route to DataDirSetupPage (DataDirGuard), not silently continue.
+  testWidgets('no datadir for mainnet routes to the datadir setup page', (tester) async {
+    await registerTestDependencies();
+    if (GetIt.I.isRegistered<BitcoinConfProvider>()) {
+      await GetIt.I.unregister<BitcoinConfProvider>();
+    }
+    GetIt.I.registerSingleton<BitcoinConfProvider>(_FakeConf());
+
+    final router = AppRouter();
+    await tester.pumpWidget(
+      SailApp(
+        dense: false,
+        builder: (context) => MaterialApp.router(routerConfig: router.config()),
+        initMethod: (_) async => (),
+        accentColor: SailColorScheme.black,
+        log: GetIt.I.get<Logger>(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DataDirSetupPage), findsOneWidget);
+  });
+}

--- a/sail_ui/test/download_config_variants_test.dart
+++ b/sail_ui/test/download_config_variants_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+/// Regression for "clicking the Settings icon next to Bitcoin Core crashes
+/// BitWindow". Bitcoin Core is variant-aware: its download block carries no
+/// top-level `files`, only per-variant ones. The old ChainSettingsModal did
+/// `downloadConfig.files[network]![os]`, so the null assertion threw the moment
+/// the modal opened for Core. The fix resolves the file from the active variant
+/// instead; this mirrors that resolution so it can't regress.
+String? resolveDownloadFile(DownloadConfig cfg, BitcoinNetwork network, OS os, String activeId) {
+  var file = cfg.files[network]?[os];
+  if (file == null && cfg.variants.isNotEmpty) {
+    file = (cfg.variants[activeId] ?? cfg.variants.values.first)[os];
+  }
+  return file;
+}
+
+void main() {
+  // Mirrors the bitcoincore `download` block in chains_config.json: no `files`,
+  // a `variants` map keyed by variant id, each with its own per-OS files.
+  final coreConfig = DownloadConfigJson.fromJson({
+    'binary': 'bitcoind',
+    'variants': {
+      'core': {
+        'files': {'linux': 'core-linux.tar.gz', 'macos': 'core-mac.tar.gz', 'windows': 'core-win.zip'},
+      },
+      'knots': {
+        'files': {'linux': 'knots-linux.tar.gz', 'macos': 'knots-mac.tar.gz', 'windows': 'knots-win.zip'},
+      },
+    },
+  });
+
+  group('variant-aware DownloadConfig (Bitcoin Core)', () {
+    test('parses with empty top-level files and populated variants', () {
+      // files[network] is null for Core — exactly what the old `!` crashed on.
+      expect(coreConfig.files, isEmpty);
+      expect(coreConfig.variants.keys, containsAll(<String>['core', 'knots']));
+      expect(coreConfig.variants['knots']![OS.macos], 'knots-mac.tar.gz');
+    });
+
+    test('resolution returns the active variant file instead of crashing', () {
+      final file = resolveDownloadFile(
+        coreConfig,
+        BitcoinNetwork.BITCOIN_NETWORK_MAINNET,
+        OS.macos,
+        'knots',
+      );
+      expect(file, 'knots-mac.tar.gz');
+    });
+
+    test('resolution falls back to the first variant for an unknown active id', () {
+      final file = resolveDownloadFile(
+        coreConfig,
+        BitcoinNetwork.BITCOIN_NETWORK_MAINNET,
+        OS.linux,
+        'does-not-exist',
+      );
+      expect(file, 'core-linux.tar.gz');
+    });
+  });
+}

--- a/sidechain-orchestrator/launch_test_sidechain_test.go
+++ b/sidechain-orchestrator/launch_test_sidechain_test.go
@@ -1,0 +1,32 @@
+package orchestrator
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for "Linux: test sidechains stuck on initializing". The launcher
+// used to only handle the macOS .app bundle, so on Linux/Windows nothing was
+// started and the monitor sat at "initializing" forever. launchTestSidechainGUI
+// now resolves a launch target on every OS and must actually attempt a launch —
+// surfacing an error when the build is missing rather than silently no-op'ing
+// (the old non-darwin behaviour).
+func TestLaunchTestSidechainGUI_ErrorsWhenNotDownloaded(t *testing.T) {
+	err := launchTestSidechainGUI(t.TempDir(), "thunder")
+	require.Error(t, err)
+}
+
+// TestSidechainBinaryPath must point at a launch target inside the sidechain's
+// build dir on every OS — never empty, which would leave the launcher with
+// nothing to run (the root of the Linux "initializing" hang).
+func TestSidechainBinaryPath_ResolvesLaunchTarget(t *testing.T) {
+	dir := t.TempDir()
+	p := TestSidechainBinaryPath(dir, "thunder")
+	assert.NotEmpty(t, p)
+	assert.True(t, filepath.IsAbs(p), "path should be absolute, got %q", p)
+	assert.True(t, strings.Contains(p, "thunder"), "path should target the thunder build, got %q", p)
+}

--- a/sidechain-orchestrator/launch_test_sidechain_test.go
+++ b/sidechain-orchestrator/launch_test_sidechain_test.go
@@ -6,18 +6,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-// Regression for "Linux: test sidechains stuck on initializing". The launcher
-// used to only handle the macOS .app bundle, so on Linux/Windows nothing was
-// started and the monitor sat at "initializing" forever. launchTestSidechainGUI
-// now resolves a launch target on every OS and must actually attempt a launch —
-// surfacing an error when the build is missing rather than silently no-op'ing
-// (the old non-darwin behaviour).
-func TestLaunchTestSidechainGUI_ErrorsWhenNotDownloaded(t *testing.T) {
-	err := launchTestSidechainGUI(t.TempDir(), "thunder")
-	require.Error(t, err)
+// Regression for "Linux: test sidechains stuck on initializing". The fix
+// launches the test sidechain's Flutter GUI detached and tracks it under its
+// own "-gui" process name, so it never occupies the rust daemon's process slot
+// (which left the chain stuck at "initializing").
+func TestSidechainGUIProcessName(t *testing.T) {
+	assert.Equal(t, "thunder-gui", sidechainGUIProcessName("thunder"))
 }
 
 // TestSidechainBinaryPath must point at a launch target inside the sidechain's


### PR DESCRIPTION
Adds regression tests for the just-fixed release bugs: Core daemon-settings crash (sail_ui), Linux test-sidechain GUI launch (orchestrator), and macOS deniability listener cleanup (bitwindow).

Plus a real-router routing test: entering on mainnet with no datadir routes to DataDirSetupPage via DataDirGuard (mocks only the data layer, not the router).