### PR TITLE
Add eCash fork mode (countdown + claim sweep)

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.254
+version: 1.0.255
 
 environment:
   sdk: 3.12.0

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.255
+version: 1.0.256
 
 environment:
   sdk: 3.12.0

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.254
+version: 1.0.255
 
 environment:
   sdk: 3.12.0

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.255
+version: 1.0.256
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:bitwindow/providers/bitdrive_provider.dart';
 import 'package:bitwindow/providers/bitwindow_settings_provider.dart';
 import 'package:bitwindow/providers/chat_provider.dart';
 import 'package:bitwindow/providers/fast_withdrawal_provider.dart';
+import 'package:bitwindow/providers/fork_provider.dart';
 import 'package:bitwindow/providers/blockchain_provider.dart';
 import 'package:bitwindow/providers/network_provider.dart';
 import 'package:bitwindow/providers/check_provider.dart';
@@ -269,6 +270,7 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   GetIt.I.registerLazySingleton<BitwindowSettingsProvider>(() => BitwindowSettingsProvider());
   GetIt.I.registerLazySingleton<MempoolProvider>(() => MempoolProvider());
   GetIt.I.registerSingleton<NotificationStreamProvider>(NotificationStreamProvider());
+  GetIt.I.registerSingleton<ForkProvider>(ForkProvider()..init());
   GetIt.I.registerSingleton<ChatProvider>(ChatProvider());
   GetIt.I.registerSingleton<FastWithdrawalProvider>(FastWithdrawalProvider());
   GetIt.I.registerSingleton<UpdateProvider>(

--- a/bitwindow/lib/pages/root_page.dart
+++ b/bitwindow/lib/pages/root_page.dart
@@ -21,6 +21,7 @@ import 'package:bitwindow/pages/merchants/chain_merchants_dialog.dart';
 import 'package:bitwindow/pages/overview_page.dart';
 import 'package:bitwindow/pages/wallet/bitcoin_uri_dialog.dart';
 import 'package:bitwindow/providers/transactions_provider.dart';
+import 'package:bitwindow/widgets/fork_countdown_timer.dart';
 import 'package:bitwindow/widgets/proof_of_funds_modal.dart';
 import 'package:bitwindow/widgets/reset_button.dart';
 import 'package:bitwindow/providers/bitwindow_settings_provider.dart';
@@ -1099,7 +1100,9 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
                       ),
                       body: Column(
                         children: [
-                          Expanded(child: child),
+                          Expanded(
+                            child: ForkCountdownHeader(child: child),
+                          ),
                           const StatusBar(),
                         ],
                       ),

--- a/bitwindow/lib/pages/settings/network_swap_page.dart
+++ b/bitwindow/lib/pages/settings/network_swap_page.dart
@@ -1,5 +1,6 @@
 import 'package:bitwindow/providers/address_book_provider.dart';
 import 'package:bitwindow/providers/blockchain_provider.dart';
+import 'package:bitwindow/providers/fork_provider.dart';
 import 'package:bitwindow/providers/hd_wallet_provider.dart';
 import 'package:bitwindow/providers/sidechain_provider.dart';
 import 'package:bitwindow/providers/transactions_provider.dart';
@@ -79,6 +80,9 @@ class _NetworkSwapPageState extends State<NetworkSwapPage> {
     }
     if (GetIt.I.isRegistered<BalanceProvider>()) {
       GetIt.I.get<BalanceProvider>().clear();
+    }
+    if (GetIt.I.isRegistered<ForkProvider>()) {
+      GetIt.I.get<ForkProvider>().clear();
     }
     if (GetIt.I.isRegistered<SyncProvider>()) {
       GetIt.I.get<SyncProvider>().reset();

--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -57,18 +57,9 @@ class SidechainsPage extends StatelessWidget {
                 : null,
             key: ValueKey('sidechains_page'),
             tabs: [
-              TabItem(
-                label: 'Overview',
-                child: SidechainsTab(),
-              ),
-              TabItem(
-                label: 'Fast Withdrawal',
-                child: FastWithdrawalTab(),
-              ),
-              TabItem(
-                label: 'Starters',
-                child: StartersTab(),
-              ),
+              TabItem(label: 'Overview', child: SidechainsTab()),
+              TabItem(label: 'Fast Withdrawal', child: FastWithdrawalTab()),
+              TabItem(label: 'Starters', child: StartersTab()),
             ],
             initialIndex: 0,
           );
@@ -90,17 +81,9 @@ class SidechainsTab extends ViewModelWidget<SidechainsViewModel> {
     final mainContent = Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Expanded(
-          flex: 6,
-          child: SidechainsList(
-            smallVersion: false,
-          ),
-        ),
+        Expanded(flex: 6, child: SidechainsList(smallVersion: false)),
         const SizedBox(width: SailStyleValues.padding08),
-        Expanded(
-          flex: 4,
-          child: const DepositWithdrawView(),
-        ),
+        Expanded(flex: 4, child: const DepositWithdrawView()),
       ],
     );
 
@@ -181,10 +164,7 @@ class _HashMismatchBanner extends StatelessWidget {
 class SidechainsList extends ViewModelWidget<SidechainsViewModel> {
   final bool smallVersion;
 
-  const SidechainsList({
-    super.key,
-    required this.smallVersion,
-  });
+  const SidechainsList({super.key, required this.smallVersion});
 
   @override
   Widget build(BuildContext context, SidechainsViewModel viewModel) {
@@ -298,30 +278,15 @@ class OnlyFilledTable extends ViewModelWidget<SidechainsViewModel> {
         key: ValueKey('sidechains_table_filled'),
         getRowId: (index) => filledSlots[index].toString(),
         headerBuilder: (context) => [
+          SailTableHeaderCell(name: 'Slot', onSort: () => viewModel.sortSidechains('slot')),
+          SailTableHeaderCell(name: 'Name', onSort: () => viewModel.sortSidechains('name')),
           SailTableHeaderCell(
-            name: 'Slot',
-            onSort: () => viewModel.sortSidechains('slot'),
-          ),
-          SailTableHeaderCell(
-            name: 'Name',
-            onSort: () => viewModel.sortSidechains('name'),
-          ),
-          SailTableHeaderCell(
-            name: 'Balance',
+            name: 'Sidechain Balance',
             onSort: () => viewModel.sortSidechains('balance'),
           ),
-          SailTableHeaderCell(
-            name: 'Action',
-            onSort: () => viewModel.sortSidechains('action'),
-          ),
-          SailTableHeaderCell(
-            name: 'Deposit',
-            onSort: () => viewModel.sortSidechains('deposit'),
-          ),
-          SailTableHeaderCell(
-            name: 'Settings',
-            onSort: () => viewModel.sortSidechains('update'),
-          ),
+          SailTableHeaderCell(name: 'Action', onSort: () => viewModel.sortSidechains('action')),
+          SailTableHeaderCell(name: 'Deposit', onSort: () => viewModel.sortSidechains('deposit')),
+          SailTableHeaderCell(name: 'Settings', onSort: () => viewModel.sortSidechains('update')),
         ],
         rowBuilder: (context, row, selected) {
           final slot = filledSlots[row]; // Get the actual slot number from filtered list
@@ -361,10 +326,7 @@ class OnlyFilledTable extends ViewModelWidget<SidechainsViewModel> {
               SailTableCell(
                 value: '    ',
                 child: Container(
-                  constraints: BoxConstraints(
-                    maxWidth: 40,
-                    maxHeight: 40,
-                  ),
+                  constraints: BoxConstraints(maxWidth: 40, maxHeight: 40),
                   child: Align(
                     alignment: Alignment.center,
                     child: SizedBox(
@@ -415,7 +377,14 @@ class OnlyFilledTable extends ViewModelWidget<SidechainsViewModel> {
         rowCount: filledSlots.length, // Only show filled slots
         emptyPlaceholder: 'No active sidechains',
         sortAscending: viewModel.sortAscending,
-        sortColumnIndex: ['slot', 'name', 'balance', 'action', 'deposit', 'update'].indexOf(viewModel.sortColumn),
+        sortColumnIndex: [
+          'slot',
+          'name',
+          'balance',
+          'action',
+          'deposit',
+          'update',
+        ].indexOf(viewModel.sortColumn),
         onSort: (columnIndex, ascending) => viewModel.sortSidechains(viewModel.sortColumn),
         selectedRowId: viewModel.selectedIndex?.toString(),
         // rowId is the SLOT NUMBER (e.g., "2", "4", "98") from getRowId
@@ -506,30 +475,15 @@ class FullTable extends ViewModelWidget<SidechainsViewModel> {
         key: ValueKey('sidechains_table_full'),
         getRowId: (index) => index.toString(),
         headerBuilder: (context) => [
+          SailTableHeaderCell(name: 'Slot', onSort: () => viewModel.sortSidechains('slot')),
+          SailTableHeaderCell(name: 'Name', onSort: () => viewModel.sortSidechains('name')),
           SailTableHeaderCell(
-            name: 'Slot',
-            onSort: () => viewModel.sortSidechains('slot'),
-          ),
-          SailTableHeaderCell(
-            name: 'Name',
-            onSort: () => viewModel.sortSidechains('name'),
-          ),
-          SailTableHeaderCell(
-            name: 'Balance',
+            name: 'Sidechain Balance',
             onSort: () => viewModel.sortSidechains('balance'),
           ),
-          SailTableHeaderCell(
-            name: 'Action',
-            onSort: () => viewModel.sortSidechains('action'),
-          ),
-          SailTableHeaderCell(
-            name: 'Deposit',
-            onSort: () => viewModel.sortSidechains('deposit'),
-          ),
-          SailTableHeaderCell(
-            name: 'Settings',
-            onSort: () => viewModel.sortSidechains('update'),
-          ),
+          SailTableHeaderCell(name: 'Action', onSort: () => viewModel.sortSidechains('action')),
+          SailTableHeaderCell(name: 'Deposit', onSort: () => viewModel.sortSidechains('deposit')),
+          SailTableHeaderCell(name: 'Settings', onSort: () => viewModel.sortSidechains('update')),
         ],
         rowBuilder: (context, row, selected) {
           final slot = row; // This is now the slot number (0-255)
@@ -580,9 +534,7 @@ class FullTable extends ViewModelWidget<SidechainsViewModel> {
                           : () async {
                               await showThemedDialog(
                                 context: context,
-                                builder: (context) => ChainSettingsModal(
-                                  connection: viewModel.rpcForSlot(slot)!,
-                                ),
+                                builder: (context) => ChainSettingsModal(connection: viewModel.rpcForSlot(slot)!),
                               );
                             },
                     ),
@@ -593,10 +545,7 @@ class FullTable extends ViewModelWidget<SidechainsViewModel> {
                         child: Container(
                           width: 4,
                           height: 4,
-                          decoration: BoxDecoration(
-                            color: Colors.red,
-                            shape: BoxShape.circle,
-                          ),
+                          decoration: BoxDecoration(color: Colors.red, shape: BoxShape.circle),
                         ),
                       ),
                   ],
@@ -608,7 +557,14 @@ class FullTable extends ViewModelWidget<SidechainsViewModel> {
         },
         rowCount: 256, // Show all slots
         sortAscending: viewModel.sortAscending,
-        sortColumnIndex: ['slot', 'name', 'balance', 'action', 'deposit', 'update'].indexOf(viewModel.sortColumn),
+        sortColumnIndex: [
+          'slot',
+          'name',
+          'balance',
+          'action',
+          'deposit',
+          'update',
+        ].indexOf(viewModel.sortColumn),
         onSort: (columnIndex, ascending) => viewModel.sortSidechains(viewModel.sortColumn),
         selectedRowId: viewModel.selectedIndex?.toString(),
         onSelectedRow: (rowId) => viewModel.toggleSelection(int.parse(rowId ?? '0')),
@@ -1023,7 +979,12 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
 
     return SailTooltip(
       message: tooltipMessage,
-      child: SailSVG.fromAsset(SailSVGAsset.iconConnectionStatus, color: color, width: 16, height: 13),
+      child: SailSVG.fromAsset(
+        SailSVGAsset.iconConnectionStatus,
+        color: color,
+        width: 16,
+        height: 13,
+      ),
     );
   }
 
@@ -1399,14 +1360,8 @@ class MakeDepositsView extends ViewModelWidget<SidechainsViewModel> {
                     enabled: !isDisabled,
                   ),
                 ),
-                UnitDropdown(
-                  value: Unit.BTC,
-                  onChanged: (_) => {},
-                  enabled: false,
-                ),
-                Expanded(
-                  child: Container(),
-                ),
+                UnitDropdown(value: Unit.BTC, onChanged: (_) => {}, enabled: false),
+                Expanded(child: Container()),
               ],
             ),
             Padding(
@@ -1471,18 +1426,9 @@ class RecentDepositsTable extends ViewModelWidget<SidechainsViewModel> {
       builder: (context, child) => SailTable(
         getRowId: (index) => viewModel.sortedDeposits[index].txid,
         headerBuilder: (context) => [
-          SailTableHeaderCell(
-            name: 'Txid',
-            onSort: () => viewModel.sortDeposits('txid'),
-          ),
-          SailTableHeaderCell(
-            name: 'Amount',
-            onSort: () => viewModel.sortDeposits('amount'),
-          ),
-          SailTableHeaderCell(
-            name: 'Fee',
-            onSort: () => viewModel.sortDeposits('fee'),
-          ),
+          SailTableHeaderCell(name: 'Txid', onSort: () => viewModel.sortDeposits('txid')),
+          SailTableHeaderCell(name: 'Amount', onSort: () => viewModel.sortDeposits('amount')),
+          SailTableHeaderCell(name: 'Fee', onSort: () => viewModel.sortDeposits('fee')),
           SailTableHeaderCell(
             name: 'Confirmations',
             onSort: () => viewModel.sortDeposits('confirmations'),
@@ -1491,10 +1437,7 @@ class RecentDepositsTable extends ViewModelWidget<SidechainsViewModel> {
         rowBuilder: (context, row, selected) {
           final deposit = viewModel.sortedDeposits[row];
           return [
-            SailTableCell(
-              value: '${deposit.txid.substring(0, 10)}..',
-              copyValue: deposit.txid,
-            ),
+            SailTableCell(value: '${deposit.txid.substring(0, 10)}..', copyValue: deposit.txid),
             SailTableCell(value: formatter.formatSats(deposit.amount.toInt())),
             SailTableCell(value: formatter.formatSats(deposit.fee.toInt())),
             SailTableCell(value: deposit.confirmations.toString()),
@@ -1504,7 +1447,12 @@ class RecentDepositsTable extends ViewModelWidget<SidechainsViewModel> {
         emptyPlaceholder: 'No deposits yet',
         drawGrid: true,
         sortAscending: viewModel.depositSortAscending,
-        sortColumnIndex: ['txid', 'amount', 'fee', 'confirmations'].indexOf(viewModel.depositSortColumn),
+        sortColumnIndex: [
+          'txid',
+          'amount',
+          'fee',
+          'confirmations',
+        ].indexOf(viewModel.depositSortColumn),
         onSort: (columnIndex, ascending) => viewModel.sortDeposits(viewModel.depositSortColumn),
         onDoubleTap: (rowId) => showTransactionDetails(context, rowId),
         contextMenuItems: (rowId) {
@@ -1526,9 +1474,7 @@ class RecentWithdrawalsTable extends ViewModelWidget<SidechainsViewModel> {
   @override
   Widget build(BuildContext context, SidechainsViewModel viewModel) {
     if (viewModel.sortedWithdrawals.isEmpty) {
-      return Center(
-        child: SailText.secondary13('No withdrawal bundles found for this sidechain'),
-      );
+      return Center(child: SailText.secondary13('No withdrawal bundles found for this sidechain'));
     }
 
     return SailTable(
@@ -1548,7 +1494,9 @@ class RecentWithdrawalsTable extends ViewModelWidget<SidechainsViewModel> {
           ),
           SailTableCell(value: withdrawal.status),
           SailTableCell(value: withdrawal.blockHeight.toString()),
-          SailTableCell(value: withdrawal.sequenceNumber.toInt() > 0 ? withdrawal.sequenceNumber.toString() : '-'),
+          SailTableCell(
+            value: withdrawal.sequenceNumber.toInt() > 0 ? withdrawal.sequenceNumber.toString() : '-',
+          ),
         ];
       },
       rowCount: viewModel.sortedWithdrawals.length,
@@ -1572,11 +1520,7 @@ class DepositModal extends StatefulWidget {
   final int slot;
   final String sidechainName;
 
-  const DepositModal({
-    super.key,
-    required this.slot,
-    required this.sidechainName,
-  });
+  const DepositModal({super.key, required this.slot, required this.sidechainName});
 
   @override
   State<DepositModal> createState() => _DepositModalState();
@@ -1782,11 +1726,7 @@ class _DepositModalState extends State<DepositModal> {
                       hintText: '0.00',
                     ),
                   ),
-                  UnitDropdown(
-                    value: Unit.BTC,
-                    onChanged: (_) {},
-                    enabled: false,
-                  ),
+                  UnitDropdown(value: Unit.BTC, onChanged: (_) {}, enabled: false),
                   Expanded(child: Container()),
                 ],
               ),

--- a/bitwindow/lib/pages/wallet/wallet_page.dart
+++ b/bitwindow/lib/pages/wallet/wallet_page.dart
@@ -13,6 +13,7 @@ import 'package:bitwindow/pages/wallet/wallet_receive.dart';
 import 'package:bitwindow/pages/wallet/wallet_send.dart';
 import 'package:bitwindow/pages/wallet/wallet_utxos.dart';
 import 'package:bitwindow/providers/transactions_provider.dart';
+import 'package:bitwindow/widgets/fork_mode_banner.dart';
 import 'package:bitwindow/utils/bitcoin_uri.dart';
 import 'package:bitwindow/utils/explorer_url.dart';
 import 'package:dio/dio.dart';
@@ -169,10 +170,18 @@ class WalletPage extends StatelessWidget {
                 ),
               ];
 
-              return InlineTabBar(
-                key: tabKey,
-                tabs: allTabs,
-                initialIndex: 0,
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const ForkModeBanner(),
+                  Expanded(
+                    child: InlineTabBar(
+                      key: tabKey,
+                      tabs: allTabs,
+                      initialIndex: 0,
+                    ),
+                  ),
+                ],
               );
             },
           );

--- a/bitwindow/lib/providers/fork_provider.dart
+++ b/bitwindow/lib/providers/fork_provider.dart
@@ -1,0 +1,213 @@
+import 'dart:async';
+
+import 'package:bitwindow/providers/transactions_provider.dart';
+import 'package:flutter/foundation.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/gen/wallet/v1/wallet.pb.dart' as bwpb;
+import 'package:sail_ui/sail_ui.dart';
+
+/// One wallet's claimable pre-fork coins, with the exact UTXOs the sweep spends.
+class WalletClaim {
+  final String walletId;
+  final String walletName;
+  final int claimableSats;
+
+  /// False for wallets whose claim can't be replay-protected (the enforcer
+  /// wallet) — shown for awareness, but not swept.
+  final bool replayProtectable;
+  final List<bwpb.UnspentOutput> utxos;
+
+  WalletClaim({
+    required this.walletId,
+    required this.walletName,
+    required this.claimableSats,
+    required this.replayProtectable,
+    required this.utxos,
+  });
+}
+
+/// Thin consumer of the orchestrator's ForkEngine — the single source of truth
+/// for fork state. This holds the last [getForkStatus] snapshot and renders it;
+/// it does NO fork math (heights, claim detection, the claim-before-countdown
+/// gate all live in the engine). The only local concern is smoothing the
+/// countdown's local-clock tick.
+class ForkProvider extends ChangeNotifier {
+  OrchestratorRPC get _orchestrator => GetIt.I<OrchestratorRPC>();
+  OrchestratorWalletRPC get _wallet => _orchestrator.wallet;
+  TransactionProvider get _transactions => GetIt.I<TransactionProvider>();
+  BalanceProvider get _balance => GetIt.I<BalanceProvider>();
+  Logger get _log => GetIt.I<Logger>();
+
+  /// Fee rate used when sweeping; the fee is subtracted from the swept amount.
+  static const _sweepFeeRateSatPerVbyte = 1;
+
+  /// Countdown display assumptions (also used by the engine's height math).
+  static const _minutesPerBlock = 10;
+
+  /// Re-anchor the countdown target only when the header height crosses a new
+  /// bucket of this many blocks, so the time ticks down smoothly instead of
+  /// lurching whenever a block lands.
+  static const _reanchorEveryBlocks = 10;
+
+  bool simulated = false;
+  int forkHeight = 0;
+  int currentHeight = 0;
+  int currentHeaders = 0;
+  int claimBoundary = 0;
+  bool hasFundsToClaim = false;
+  bool showCountdown = false;
+  List<WalletClaim> claims = [];
+
+  /// Estimated wall-clock instant of the next fork. Held stable between
+  /// re-anchors; the timer widget ticks the local clock down to it.
+  DateTime? forkTargetDate;
+  int _anchorBucket = -1;
+  int _anchorForkHeight = -1;
+
+  Timer? _timer;
+  bool _fetching = false;
+
+  /// Claims that can actually be swept (replay-protected). Excludes the
+  /// enforcer wallet, which is detected but not safely claimable.
+  List<WalletClaim> get sweepableClaims => claims.where((c) => c.replayProtectable).toList();
+
+  int get totalClaimableSats => sweepableClaims.fold(0, (sum, c) => sum + c.claimableSats);
+
+  /// Blocks left until the next fork, by header height.
+  int get blocksUntilFork => (forkHeight - currentHeaders).clamp(0, forkHeight == 0 ? 0 : forkHeight);
+
+  void init() {
+    fetch();
+    _timer = Timer.periodic(const Duration(seconds: 10), (_) => fetch());
+  }
+
+  /// Drop cached state on a network swap so the UI never shows the previous
+  /// network's fork data, then repopulate. Mirrors the other providers' clear().
+  void clear() {
+    simulated = false;
+    forkHeight = 0;
+    currentHeight = 0;
+    currentHeaders = 0;
+    claimBoundary = 0;
+    hasFundsToClaim = false;
+    showCountdown = false;
+    claims = [];
+    forkTargetDate = null;
+    _anchorBucket = -1;
+    _anchorForkHeight = -1;
+    notifyListeners();
+    fetch();
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> fetch() async {
+    if (_fetching) return;
+    _fetching = true;
+    try {
+      final s = await _orchestrator.getForkStatus();
+      simulated = s.simulated;
+      forkHeight = s.forkHeight;
+      currentHeight = s.currentHeight;
+      currentHeaders = s.currentHeaders;
+      claimBoundary = s.claimBoundary;
+      hasFundsToClaim = s.hasFundsToClaim;
+      showCountdown = s.showCountdown;
+      claims = s.claims
+          .map(
+            (c) => WalletClaim(
+              walletId: c.walletId,
+              walletName: c.walletName,
+              claimableSats: c.claimableSats.toInt(),
+              replayProtectable: c.replayProtectable,
+              utxos: c.utxos
+                  .map(
+                    (u) => bwpb.UnspentOutput(
+                      output: u.outpoint,
+                      address: u.address,
+                      label: u.label,
+                      valueSats: u.sats,
+                    ),
+                  )
+                  .toList(),
+            ),
+          )
+          .toList();
+
+      _updateForkTarget();
+      notifyListeners();
+    } catch (e) {
+      _log.e('ForkProvider.fetch failed: $e');
+    } finally {
+      _fetching = false;
+    }
+  }
+
+  /// Recompute the countdown target only when the header height enters a new
+  /// 10-block bucket OR the fork height changes (a new cycle/network) — keeps
+  /// the seconds ticking on the local clock between re-anchors, and resets
+  /// cleanly the moment a new fork boundary is set.
+  void _updateForkTarget() {
+    if (!showCountdown || currentHeaders <= 0 || currentHeaders >= forkHeight) {
+      forkTargetDate = null;
+      _anchorBucket = -1;
+      _anchorForkHeight = -1;
+      return;
+    }
+    final bucket = currentHeaders ~/ _reanchorEveryBlocks;
+    if (forkHeight == _anchorForkHeight && bucket == _anchorBucket && forkTargetDate != null) return;
+
+    _anchorForkHeight = forkHeight;
+    _anchorBucket = bucket;
+    final blocksRemaining = forkHeight - currentHeaders;
+    forkTargetDate = DateTime.now().add(Duration(minutes: blocksRemaining * _minutesPerBlock));
+  }
+
+  /// Sweep one wallet's pre-fork coins (from the engine's UTXO list) to a fresh
+  /// address it controls — one sendTransaction, exactly like a send. Returns txid.
+  Future<String> claim(String walletId) async {
+    final claim = claims.firstWhere((c) => c.walletId == walletId);
+    final address = (await _wallet.getNewAddress(walletId)).address;
+
+    _log.i(
+      'Claiming eCash: wallet="${claim.walletName}" id=$walletId '
+      'amount=${claim.claimableSats} sats inputs=${claim.utxos.length} -> $address',
+    );
+
+    final txid = (await _wallet.sendTransaction(
+      walletId: walletId,
+      destinations: {address: claim.claimableSats},
+      requiredInputs: claim.utxos,
+      subtractFeeFromAmount: true,
+      feeRateSatPerVbyte: _sweepFeeRateSatPerVbyte,
+      // Replay protection is off for now — a plain sweep so the claim flow is
+      // testable end-to-end on stock Core (signet/regtest). The replay-protect
+      // path (magic version + byte) stays wired behind this flag for later.
+      replayProtect: false,
+    )).txid;
+
+    _log.i('Claimed eCash: wallet="${claim.walletName}" id=$walletId txid=$txid -> $address');
+
+    // Refresh the wallet views so the swept tx + new balance show immediately,
+    // like the normal send path does — otherwise they stay stale until a poll.
+    await fetch();
+    await _transactions.fetch();
+    await _balance.fetch();
+    return txid;
+  }
+
+  /// Claim every replay-protectable wallet — one call per wallet. Non-protectable
+  /// claims (enforcer) are skipped; sweeping them would have no replay protection.
+  Future<List<String>> claimAll() async {
+    final txids = <String>[];
+    for (final c in sweepableClaims) {
+      txids.add(await claim(c.walletId));
+    }
+    return txids;
+  }
+}

--- a/bitwindow/lib/providers/transactions_provider.dart
+++ b/bitwindow/lib/providers/transactions_provider.dart
@@ -108,7 +108,11 @@ class TransactionProvider extends ChangeNotifier {
                     note: '',
                     confirmationTime: Confirmation(
                       height: tx.confirmations,
-                      timestamp: Timestamp(seconds: tx.blockTime),
+                      // Unconfirmed txs have blockTime 0, which would sink them
+                      // to the bottom of the list (off-screen) until a block
+                      // lands. Fall back to the wallet tx time so pending txs
+                      // sort to the top and show immediately.
+                      timestamp: Timestamp(seconds: tx.blockTime != Int64.ZERO ? tx.blockTime : tx.time),
                     ),
                   ),
                 )

--- a/bitwindow/lib/widgets/fork_countdown_timer.dart
+++ b/bitwindow/lib/widgets/fork_countdown_timer.dart
@@ -1,0 +1,210 @@
+import 'dart:async';
+
+import 'package:bitwindow/providers/fork_provider.dart';
+import 'package:flutter/widgets.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+/// Mounts the [ForkCountdownTimer] above [child] and scrolls it out of the way:
+/// scrolling the page down collapses the timer, returning to the top reveals it
+/// again. Listens to scroll notifications bubbling up from whatever page is
+/// active, so it works on every tab without per-page wiring.
+class ForkCountdownHeader extends StatefulWidget {
+  const ForkCountdownHeader({super.key, required this.child});
+  final Widget child;
+
+  @override
+  State<ForkCountdownHeader> createState() => _ForkCountdownHeaderState();
+}
+
+class _ForkCountdownHeaderState extends State<ForkCountdownHeader> {
+  bool _collapsed = false;
+
+  bool _onScroll(ScrollNotification n) {
+    if (n.metrics.axis != Axis.vertical) return false;
+    final atTop = n.metrics.pixels <= 8;
+    if (atTop && _collapsed) {
+      setState(() => _collapsed = false);
+    } else if (!atTop && !_collapsed && n is ScrollUpdateNotification && (n.scrollDelta ?? 0) > 0) {
+      setState(() => _collapsed = true);
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        AnimatedSize(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeInOut,
+          alignment: Alignment.topCenter,
+          child: _collapsed ? const SizedBox(width: double.infinity) : const ForkCountdownTimer(),
+        ),
+        Expanded(
+          child: NotificationListener<ScrollNotification>(
+            onNotification: _onScroll,
+            child: widget.child,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// "HARDFORK ACTIVATION · T MINUS" countdown, in the style of ecash.com.
+/// Visible on every page while the fork is still ahead. The target instant is
+/// held stable by [ForkProvider] (re-anchored only every 10 blocks); this
+/// widget just ticks the local clock down to it once a second, so DAYS : HOURS
+/// : MIN : SEC counts smoothly rather than jumping a block-interval at a time.
+class ForkCountdownTimer extends StatefulWidget {
+  const ForkCountdownTimer({super.key});
+
+  @override
+  State<ForkCountdownTimer> createState() => _ForkCountdownTimerState();
+}
+
+class _ForkCountdownTimerState extends State<ForkCountdownTimer> {
+  ForkProvider get _fork => GetIt.I<ForkProvider>();
+  Timer? _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: _fork,
+      builder: (context, _) {
+        final target = _fork.forkTargetDate;
+        if (!_fork.showCountdown || target == null) return const SizedBox.shrink();
+
+        final theme = SailTheme.of(context);
+        var remaining = target.difference(DateTime.now());
+        if (remaining.isNegative) remaining = Duration.zero;
+
+        final days = remaining.inDays;
+        final hours = remaining.inHours % 24;
+        final minutes = remaining.inMinutes % 60;
+        final seconds = remaining.inSeconds % 60;
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SailText.secondary12('HARDFORK ACTIVATION · T MINUS', color: theme.colors.textSecondary),
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _unit(theme, days.toString(), 'DAYS'),
+                  _separator(theme),
+                  _unit(theme, hours.toString().padLeft(2, '0'), 'HOURS'),
+                  _separator(theme),
+                  _unit(theme, minutes.toString().padLeft(2, '0'), 'MIN'),
+                  _separator(theme),
+                  _unit(theme, seconds.toString().padLeft(2, '0'), 'SEC'),
+                ],
+              ),
+              const SizedBox(height: 12),
+              _footer(theme, target),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _unit(SailThemeData theme, String value, String label) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          value,
+          style: TextStyle(
+            fontSize: 56,
+            height: 1.0,
+            fontWeight: FontWeight.w700,
+            color: theme.colors.text,
+            fontFeatures: const [FontFeature.tabularFigures()],
+          ),
+        ),
+        const SizedBox(height: 4),
+        SailText.secondary12(label, color: theme.colors.textSecondary),
+      ],
+    );
+  }
+
+  Widget _separator(SailThemeData theme) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Text(
+        ':',
+        style: TextStyle(fontSize: 48, height: 1.0, fontWeight: FontWeight.w700, color: theme.colors.orange),
+      ),
+    );
+  }
+
+  static const _monthNames = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+
+  Widget _footer(SailThemeData theme, DateTime target) {
+    final utc = target.toUtc();
+    final month = _monthNames[utc.month - 1];
+    // Year is omitted unless the fork lands in a different year than now.
+    final date = utc.year == DateTime.now().year ? '$month ${utc.day}' : '$month ${utc.day}, ${utc.year}';
+    final time = '${_two(utc.hour)}:${_two(utc.minute)}';
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        SailText.secondary13(date, color: theme.colors.textSecondary),
+        _divider(theme),
+        SailText.secondary13(time, color: theme.colors.textSecondary),
+        _divider(theme),
+        SailText.secondary13('BLOCK ~${_grouped(_fork.forkHeight)}', color: theme.colors.orange),
+      ],
+    );
+  }
+
+  Widget _divider(SailThemeData theme) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Container(width: 1, height: 14, color: theme.colors.divider),
+    );
+  }
+
+  String _two(int n) => n.toString().padLeft(2, '0');
+
+  String _grouped(int n) {
+    final s = n.toString();
+    final buf = StringBuffer();
+    for (var i = 0; i < s.length; i++) {
+      if (i > 0 && (s.length - i) % 3 == 0) buf.write(',');
+      buf.write(s[i]);
+    }
+    return buf.toString();
+  }
+}

--- a/bitwindow/lib/widgets/fork_mode_banner.dart
+++ b/bitwindow/lib/widgets/fork_mode_banner.dart
@@ -1,0 +1,106 @@
+import 'package:bitwindow/providers/fork_provider.dart';
+import 'package:flutter/widgets.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+/// Drives "fork mode" at the top of the wallet page:
+/// - before the fork: a countdown to the fork height,
+/// - after the fork, with un-swept pre-fork coins: the big "claim your eCash"
+///   hero card,
+/// - otherwise nothing.
+class ForkModeBanner extends StatelessWidget {
+  const ForkModeBanner({super.key});
+
+  ForkProvider get _fork => GetIt.I<ForkProvider>();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: _fork,
+      builder: (context, _) {
+        // Claim card only — the countdown is handled globally by
+        // ForkCountdownTimer, and is hidden by the engine while coins are
+        // unclaimed, so the two never overlap.
+        if (!_fork.hasFundsToClaim) return const SizedBox.shrink();
+        return _ClaimEcashCard(fork: _fork);
+      },
+    );
+  }
+}
+
+class _ClaimEcashCard extends StatelessWidget {
+  const _ClaimEcashCard({required this.fork});
+  final ForkProvider fork;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+    final formatter = GetIt.I<FormatterProvider>();
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: SailCard(
+        color: theme.colors.orange.withValues(alpha: 0.08),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                SailSVG.fromAsset(
+                  SailSVGAsset.iconCoins,
+                  width: 22,
+                  height: 22,
+                  color: theme.colors.orange,
+                ),
+                const SizedBox(width: 8),
+                SailText.primary15('You have eCash to claim', bold: true),
+              ],
+            ),
+            const SizedBox(height: 4),
+            SailText.secondary13(
+              'The eCash fork is live. Sweep your pre-fork coins to a fresh address you '
+              'control — your Bitcoin stays exactly where it is.',
+            ),
+            const SizedBox(height: 16),
+            SailText.primary24(formatter.formatSats(fork.totalClaimableSats)),
+            const SizedBox(height: 12),
+            // Only claimable wallets — the enforcer wallet can't be swept, so
+            // it's left out entirely (it never keeps this card open).
+            ...fork.sweepableClaims.map(
+              (c) => Padding(
+                padding: const EdgeInsets.only(bottom: 2),
+                child: Row(
+                  children: [
+                    SailText.secondary13(c.walletName),
+                    const Spacer(),
+                    SailText.secondary13(formatter.formatSats(c.claimableSats)),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            if (fork.totalClaimableSats > 0)
+              SailButton(
+                label: fork.sweepableClaims.length > 1 ? 'Claim eCash from all wallets' : 'Claim eCash',
+                icon: SailSVGAsset.iconCoins,
+                onPressed: () => _claim(context),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _claim(BuildContext context) async {
+    try {
+      final txids = await fork.claimAll();
+      if (context.mounted) {
+        showSnackBar(context, 'Claimed eCash in ${txids.length} transaction(s).');
+      }
+    } catch (e) {
+      if (context.mounted) {
+        showSnackBar(context, 'Could not claim eCash: $e', duration: 5);
+      }
+    }
+  }
+}

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.109
+version: 0.2.110
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.110
+version: 0.2.111
 
 environment:
   sdk: 3.12.0

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.127
+version: 1.0.128
 
 environment:
   sdk: 3.12.0

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.128
+version: 1.0.129
 
 environment:
   sdk: 3.12.0

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.client.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.client.dart
@@ -456,4 +456,28 @@ extension type OrchestratorServiceClient (connect.Transport _transport) {
       onTrailer: onTrailer,
     );
   }
+
+  /// ─── eCash fork ───────────────────────────────────────────────────────────
+  /// Report where the mainchain tip sits relative to the eCash fork height.
+  /// The orchestrator is the single source of truth for the fork height; the
+  /// frontend renders "fork mode" (the claim card) off fork_active. Per-wallet
+  /// pre-fork coin detection and the sweep itself stay in the frontend via the
+  /// existing WalletManagerService (listUnspent / sendTransaction), one call
+  /// per wallet — this RPC only supplies the height.
+  Future<orchestratorv1orchestrator.GetForkStatusResponse> getForkStatus(
+    orchestratorv1orchestrator.GetForkStatusRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.OrchestratorService.getForkStatus,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
 }

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.spec.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.connect.spec.dart
@@ -228,4 +228,18 @@ abstract final class OrchestratorService {
     orchestratorv1orchestrator.CoreRawCallRequest.new,
     orchestratorv1orchestrator.CoreRawCallResponse.new,
   );
+
+  /// ─── eCash fork ───────────────────────────────────────────────────────────
+  /// Report where the mainchain tip sits relative to the eCash fork height.
+  /// The orchestrator is the single source of truth for the fork height; the
+  /// frontend renders "fork mode" (the claim card) off fork_active. Per-wallet
+  /// pre-fork coin detection and the sweep itself stay in the frontend via the
+  /// existing WalletManagerService (listUnspent / sendTransaction), one call
+  /// per wallet — this RPC only supplies the height.
+  static const getForkStatus = connect.Spec(
+    '/$name/GetForkStatus',
+    connect.StreamType.unary,
+    orchestratorv1orchestrator.GetForkStatusRequest.new,
+    orchestratorv1orchestrator.GetForkStatusResponse.new,
+  );
 }

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -3502,6 +3502,388 @@ class CoreRawCallResponse extends $pb.GeneratedMessage {
   void clearResultJson() => clearField(1);
 }
 
+class GetForkStatusRequest extends $pb.GeneratedMessage {
+  factory GetForkStatusRequest() => create();
+  GetForkStatusRequest._() : super();
+  factory GetForkStatusRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetForkStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetForkStatusRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetForkStatusRequest clone() => GetForkStatusRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetForkStatusRequest copyWith(void Function(GetForkStatusRequest) updates) => super.copyWith((message) => updates(message as GetForkStatusRequest)) as GetForkStatusRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetForkStatusRequest create() => GetForkStatusRequest._();
+  GetForkStatusRequest createEmptyInstance() => create();
+  static $pb.PbList<GetForkStatusRequest> createRepeated() => $pb.PbList<GetForkStatusRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetForkStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetForkStatusRequest>(create);
+  static GetForkStatusRequest? _defaultInstance;
+}
+
+/// Canonical fork snapshot produced by the orchestrator's single ForkEngine.
+/// The frontend renders this verbatim — it does no fork math of its own.
+class GetForkStatusResponse extends $pb.GeneratedMessage {
+  factory GetForkStatusResponse({
+    $core.int? forkHeight,
+    $core.int? currentHeight,
+    $core.int? currentHeaders,
+    $core.int? claimBoundary,
+    $core.bool? simulated,
+    $core.bool? hasFundsToClaim,
+    $core.bool? showCountdown,
+    $core.Iterable<ForkWalletClaim>? claims,
+  }) {
+    final $result = create();
+    if (forkHeight != null) {
+      $result.forkHeight = forkHeight;
+    }
+    if (currentHeight != null) {
+      $result.currentHeight = currentHeight;
+    }
+    if (currentHeaders != null) {
+      $result.currentHeaders = currentHeaders;
+    }
+    if (claimBoundary != null) {
+      $result.claimBoundary = claimBoundary;
+    }
+    if (simulated != null) {
+      $result.simulated = simulated;
+    }
+    if (hasFundsToClaim != null) {
+      $result.hasFundsToClaim = hasFundsToClaim;
+    }
+    if (showCountdown != null) {
+      $result.showCountdown = showCountdown;
+    }
+    if (claims != null) {
+      $result.claims.addAll(claims);
+    }
+    return $result;
+  }
+  GetForkStatusResponse._() : super();
+  factory GetForkStatusResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetForkStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetForkStatusResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'forkHeight', $pb.PbFieldType.O3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'currentHeight', $pb.PbFieldType.O3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'currentHeaders', $pb.PbFieldType.O3)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'claimBoundary', $pb.PbFieldType.O3)
+    ..aOB(6, _omitFieldNames ? '' : 'simulated')
+    ..aOB(7, _omitFieldNames ? '' : 'hasFundsToClaim')
+    ..aOB(8, _omitFieldNames ? '' : 'showCountdown')
+    ..pc<ForkWalletClaim>(9, _omitFieldNames ? '' : 'claims', $pb.PbFieldType.PM, subBuilder: ForkWalletClaim.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetForkStatusResponse clone() => GetForkStatusResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetForkStatusResponse copyWith(void Function(GetForkStatusResponse) updates) => super.copyWith((message) => updates(message as GetForkStatusResponse)) as GetForkStatusResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetForkStatusResponse create() => GetForkStatusResponse._();
+  GetForkStatusResponse createEmptyInstance() => create();
+  static $pb.PbList<GetForkStatusResponse> createRepeated() => $pb.PbList<GetForkStatusResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetForkStatusResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetForkStatusResponse>(create);
+  static GetForkStatusResponse? _defaultInstance;
+
+  /// Next fork height (countdown target). Fixed per network, or the next
+  /// 144-block boundary on signet's simulated daily fork.
+  @$pb.TagNumber(1)
+  $core.int get forkHeight => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set forkHeight($core.int v) { $_setSignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasForkHeight() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearForkHeight() => clearField(1);
+
+  /// Current mainchain tip height.
+  @$pb.TagNumber(2)
+  $core.int get currentHeight => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set currentHeight($core.int v) { $_setSignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCurrentHeight() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCurrentHeight() => clearField(2);
+
+  /// Current mainchain header height. Runs ahead of `current_height` during
+  /// sync; the time-to-fork countdown is driven off this.
+  @$pb.TagNumber(4)
+  $core.int get currentHeaders => $_getIZ(2);
+  @$pb.TagNumber(4)
+  set currentHeaders($core.int v) { $_setSignedInt32(2, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasCurrentHeaders() => $_has(2);
+  @$pb.TagNumber(4)
+  void clearCurrentHeaders() => clearField(4);
+
+  /// Coins confirmed at/before this height are claimable. Equals fork_height on
+  /// fixed-height networks; the last 144-boundary on signet.
+  @$pb.TagNumber(5)
+  $core.int get claimBoundary => $_getIZ(3);
+  @$pb.TagNumber(5)
+  set claimBoundary($core.int v) { $_setSignedInt32(3, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasClaimBoundary() => $_has(3);
+  @$pb.TagNumber(5)
+  void clearClaimBoundary() => clearField(5);
+
+  /// True on signet, where the fork recurs every 144 blocks.
+  @$pb.TagNumber(6)
+  $core.bool get simulated => $_getBF(4);
+  @$pb.TagNumber(6)
+  set simulated($core.bool v) { $_setBool(4, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasSimulated() => $_has(4);
+  @$pb.TagNumber(6)
+  void clearSimulated() => clearField(6);
+
+  /// Any wallet holds un-swept pre-fork coins.
+  @$pb.TagNumber(7)
+  $core.bool get hasFundsToClaim => $_getBF(5);
+  @$pb.TagNumber(7)
+  set hasFundsToClaim($core.bool v) { $_setBool(5, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasHasFundsToClaim() => $_has(5);
+  @$pb.TagNumber(7)
+  void clearHasFundsToClaim() => clearField(7);
+
+  /// Whether to show the next-fork countdown. False while coins are unclaimed
+  /// (claim-before-countdown).
+  @$pb.TagNumber(8)
+  $core.bool get showCountdown => $_getBF(6);
+  @$pb.TagNumber(8)
+  set showCountdown($core.bool v) { $_setBool(6, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasShowCountdown() => $_has(6);
+  @$pb.TagNumber(8)
+  void clearShowCountdown() => clearField(8);
+
+  /// Per-wallet claimable coins, with the exact UTXOs the sweep spends.
+  @$pb.TagNumber(9)
+  $core.List<ForkWalletClaim> get claims => $_getList(7);
+}
+
+class ForkWalletClaim extends $pb.GeneratedMessage {
+  factory ForkWalletClaim({
+    $core.String? walletId,
+    $core.String? walletName,
+    $fixnum.Int64? claimableSats,
+    $core.Iterable<ForkClaimUtxo>? utxos,
+    $core.bool? replayProtectable,
+  }) {
+    final $result = create();
+    if (walletId != null) {
+      $result.walletId = walletId;
+    }
+    if (walletName != null) {
+      $result.walletName = walletName;
+    }
+    if (claimableSats != null) {
+      $result.claimableSats = claimableSats;
+    }
+    if (utxos != null) {
+      $result.utxos.addAll(utxos);
+    }
+    if (replayProtectable != null) {
+      $result.replayProtectable = replayProtectable;
+    }
+    return $result;
+  }
+  ForkWalletClaim._() : super();
+  factory ForkWalletClaim.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ForkWalletClaim.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForkWalletClaim', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'walletId')
+    ..aOS(2, _omitFieldNames ? '' : 'walletName')
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'claimableSats', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..pc<ForkClaimUtxo>(4, _omitFieldNames ? '' : 'utxos', $pb.PbFieldType.PM, subBuilder: ForkClaimUtxo.create)
+    ..aOB(5, _omitFieldNames ? '' : 'replayProtectable')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ForkWalletClaim clone() => ForkWalletClaim()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ForkWalletClaim copyWith(void Function(ForkWalletClaim) updates) => super.copyWith((message) => updates(message as ForkWalletClaim)) as ForkWalletClaim;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ForkWalletClaim create() => ForkWalletClaim._();
+  ForkWalletClaim createEmptyInstance() => create();
+  static $pb.PbList<ForkWalletClaim> createRepeated() => $pb.PbList<ForkWalletClaim>();
+  @$core.pragma('dart2js:noInline')
+  static ForkWalletClaim getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForkWalletClaim>(create);
+  static ForkWalletClaim? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get walletId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set walletId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWalletId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWalletId() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get walletName => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set walletName($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasWalletName() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearWalletName() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get claimableSats => $_getI64(2);
+  @$pb.TagNumber(3)
+  set claimableSats($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasClaimableSats() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearClaimableSats() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<ForkClaimUtxo> get utxos => $_getList(3);
+
+  /// False when this wallet's claim can't be replay-protected (enforcer wallet);
+  /// such coins are shown but not swept.
+  @$pb.TagNumber(5)
+  $core.bool get replayProtectable => $_getBF(4);
+  @$pb.TagNumber(5)
+  set replayProtectable($core.bool v) { $_setBool(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasReplayProtectable() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearReplayProtectable() => clearField(5);
+}
+
+class ForkClaimUtxo extends $pb.GeneratedMessage {
+  factory ForkClaimUtxo({
+    $core.String? outpoint,
+    $core.String? address,
+    $fixnum.Int64? sats,
+    $core.String? label,
+  }) {
+    final $result = create();
+    if (outpoint != null) {
+      $result.outpoint = outpoint;
+    }
+    if (address != null) {
+      $result.address = address;
+    }
+    if (sats != null) {
+      $result.sats = sats;
+    }
+    if (label != null) {
+      $result.label = label;
+    }
+    return $result;
+  }
+  ForkClaimUtxo._() : super();
+  factory ForkClaimUtxo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ForkClaimUtxo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ForkClaimUtxo', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'outpoint')
+    ..aOS(2, _omitFieldNames ? '' : 'address')
+    ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'sats', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOS(4, _omitFieldNames ? '' : 'label')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ForkClaimUtxo clone() => ForkClaimUtxo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ForkClaimUtxo copyWith(void Function(ForkClaimUtxo) updates) => super.copyWith((message) => updates(message as ForkClaimUtxo)) as ForkClaimUtxo;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ForkClaimUtxo create() => ForkClaimUtxo._();
+  ForkClaimUtxo createEmptyInstance() => create();
+  static $pb.PbList<ForkClaimUtxo> createRepeated() => $pb.PbList<ForkClaimUtxo>();
+  @$core.pragma('dart2js:noInline')
+  static ForkClaimUtxo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ForkClaimUtxo>(create);
+  static ForkClaimUtxo? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get outpoint => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set outpoint($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasOutpoint() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearOutpoint() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get address => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set address($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAddress() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAddress() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get sats => $_getI64(2);
+  @$pb.TagNumber(3)
+  set sats($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSats() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSats() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get label => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set label($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasLabel() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearLabel() => clearField(4);
+}
+
 class ShutdownRequest extends $pb.GeneratedMessage {
   factory ShutdownRequest() => create();
   ShutdownRequest._() : super();
@@ -3638,6 +4020,9 @@ class OrchestratorServiceApi {
   ;
   $async.Future<CoreRawCallResponse> coreRawCall($pb.ClientContext? ctx, CoreRawCallRequest request) =>
     _client.invoke<CoreRawCallResponse>(ctx, 'OrchestratorService', 'CoreRawCall', request, CoreRawCallResponse())
+  ;
+  $async.Future<GetForkStatusResponse> getForkStatus($pb.ClientContext? ctx, GetForkStatusRequest request) =>
+    _client.invoke<GetForkStatusResponse>(ctx, 'OrchestratorService', 'GetForkStatus', request, GetForkStatusResponse())
   ;
 }
 

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -838,6 +838,78 @@ const CoreRawCallResponse$json = {
 final $typed_data.Uint8List coreRawCallResponseDescriptor = $convert.base64Decode(
     'ChNDb3JlUmF3Q2FsbFJlc3BvbnNlEh8KC3Jlc3VsdF9qc29uGAEgASgJUgpyZXN1bHRKc29u');
 
+@$core.Deprecated('Use getForkStatusRequestDescriptor instead')
+const GetForkStatusRequest$json = {
+  '1': 'GetForkStatusRequest',
+};
+
+/// Descriptor for `GetForkStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getForkStatusRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRGb3JrU3RhdHVzUmVxdWVzdA==');
+
+@$core.Deprecated('Use getForkStatusResponseDescriptor instead')
+const GetForkStatusResponse$json = {
+  '1': 'GetForkStatusResponse',
+  '2': [
+    {'1': 'fork_height', '3': 1, '4': 1, '5': 5, '10': 'forkHeight'},
+    {'1': 'current_height', '3': 2, '4': 1, '5': 5, '10': 'currentHeight'},
+    {'1': 'current_headers', '3': 4, '4': 1, '5': 5, '10': 'currentHeaders'},
+    {'1': 'claim_boundary', '3': 5, '4': 1, '5': 5, '10': 'claimBoundary'},
+    {'1': 'simulated', '3': 6, '4': 1, '5': 8, '10': 'simulated'},
+    {'1': 'has_funds_to_claim', '3': 7, '4': 1, '5': 8, '10': 'hasFundsToClaim'},
+    {'1': 'show_countdown', '3': 8, '4': 1, '5': 8, '10': 'showCountdown'},
+    {'1': 'claims', '3': 9, '4': 3, '5': 11, '6': '.orchestrator.v1.ForkWalletClaim', '10': 'claims'},
+  ],
+  '9': [
+    {'1': 3, '2': 4},
+  ],
+};
+
+/// Descriptor for `GetForkStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getForkStatusResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRGb3JrU3RhdHVzUmVzcG9uc2USHwoLZm9ya19oZWlnaHQYASABKAVSCmZvcmtIZWlnaH'
+    'QSJQoOY3VycmVudF9oZWlnaHQYAiABKAVSDWN1cnJlbnRIZWlnaHQSJwoPY3VycmVudF9oZWFk'
+    'ZXJzGAQgASgFUg5jdXJyZW50SGVhZGVycxIlCg5jbGFpbV9ib3VuZGFyeRgFIAEoBVINY2xhaW'
+    '1Cb3VuZGFyeRIcCglzaW11bGF0ZWQYBiABKAhSCXNpbXVsYXRlZBIrChJoYXNfZnVuZHNfdG9f'
+    'Y2xhaW0YByABKAhSD2hhc0Z1bmRzVG9DbGFpbRIlCg5zaG93X2NvdW50ZG93bhgIIAEoCFINc2'
+    'hvd0NvdW50ZG93bhI4CgZjbGFpbXMYCSADKAsyIC5vcmNoZXN0cmF0b3IudjEuRm9ya1dhbGxl'
+    'dENsYWltUgZjbGFpbXNKBAgDEAQ=');
+
+@$core.Deprecated('Use forkWalletClaimDescriptor instead')
+const ForkWalletClaim$json = {
+  '1': 'ForkWalletClaim',
+  '2': [
+    {'1': 'wallet_id', '3': 1, '4': 1, '5': 9, '10': 'walletId'},
+    {'1': 'wallet_name', '3': 2, '4': 1, '5': 9, '10': 'walletName'},
+    {'1': 'claimable_sats', '3': 3, '4': 1, '5': 4, '10': 'claimableSats'},
+    {'1': 'utxos', '3': 4, '4': 3, '5': 11, '6': '.orchestrator.v1.ForkClaimUtxo', '10': 'utxos'},
+    {'1': 'replay_protectable', '3': 5, '4': 1, '5': 8, '10': 'replayProtectable'},
+  ],
+};
+
+/// Descriptor for `ForkWalletClaim`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List forkWalletClaimDescriptor = $convert.base64Decode(
+    'Cg9Gb3JrV2FsbGV0Q2xhaW0SGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZXRJZBIfCgt3YWxsZX'
+    'RfbmFtZRgCIAEoCVIKd2FsbGV0TmFtZRIlCg5jbGFpbWFibGVfc2F0cxgDIAEoBFINY2xhaW1h'
+    'YmxlU2F0cxI0CgV1dHhvcxgEIAMoCzIeLm9yY2hlc3RyYXRvci52MS5Gb3JrQ2xhaW1VdHhvUg'
+    'V1dHhvcxItChJyZXBsYXlfcHJvdGVjdGFibGUYBSABKAhSEXJlcGxheVByb3RlY3RhYmxl');
+
+@$core.Deprecated('Use forkClaimUtxoDescriptor instead')
+const ForkClaimUtxo$json = {
+  '1': 'ForkClaimUtxo',
+  '2': [
+    {'1': 'outpoint', '3': 1, '4': 1, '5': 9, '10': 'outpoint'},
+    {'1': 'address', '3': 2, '4': 1, '5': 9, '10': 'address'},
+    {'1': 'sats', '3': 3, '4': 1, '5': 4, '10': 'sats'},
+    {'1': 'label', '3': 4, '4': 1, '5': 9, '10': 'label'},
+  ],
+};
+
+/// Descriptor for `ForkClaimUtxo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List forkClaimUtxoDescriptor = $convert.base64Decode(
+    'Cg1Gb3JrQ2xhaW1VdHhvEhoKCG91dHBvaW50GAEgASgJUghvdXRwb2ludBIYCgdhZGRyZXNzGA'
+    'IgASgJUgdhZGRyZXNzEhIKBHNhdHMYAyABKARSBHNhdHMSFAoFbGFiZWwYBCABKAlSBWxhYmVs');
+
 @$core.Deprecated('Use shutdownRequestDescriptor instead')
 const ShutdownRequest$json = {
   '1': 'ShutdownRequest',
@@ -882,6 +954,7 @@ const $core.Map<$core.String, $core.dynamic> OrchestratorServiceBase$json = {
     {'1': 'DeleteFiles', '2': '.orchestrator.v1.DeleteFilesRequest', '3': '.orchestrator.v1.DeleteFilesResponse', '6': true},
     {'1': 'GetCoreMempoolInfo', '2': '.orchestrator.v1.GetCoreMempoolInfoRequest', '3': '.orchestrator.v1.GetCoreMempoolInfoResponse'},
     {'1': 'CoreRawCall', '2': '.orchestrator.v1.CoreRawCallRequest', '3': '.orchestrator.v1.CoreRawCallResponse'},
+    {'1': 'GetForkStatus', '2': '.orchestrator.v1.GetForkStatusRequest', '3': '.orchestrator.v1.GetForkStatusResponse'},
   ],
 };
 
@@ -942,6 +1015,10 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> Orchestrat
   '.orchestrator.v1.GetCoreMempoolInfoResponse': GetCoreMempoolInfoResponse$json,
   '.orchestrator.v1.CoreRawCallRequest': CoreRawCallRequest$json,
   '.orchestrator.v1.CoreRawCallResponse': CoreRawCallResponse$json,
+  '.orchestrator.v1.GetForkStatusRequest': GetForkStatusRequest$json,
+  '.orchestrator.v1.GetForkStatusResponse': GetForkStatusResponse$json,
+  '.orchestrator.v1.ForkWalletClaim': ForkWalletClaim$json,
+  '.orchestrator.v1.ForkClaimUtxo': ForkClaimUtxo$json,
 };
 
 /// Descriptor for `OrchestratorService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
@@ -987,5 +1064,7 @@ final $typed_data.Uint8List orchestratorServiceDescriptor = $convert.base64Decod
     'dGVGaWxlc1Jlc3BvbnNlMAESbQoSR2V0Q29yZU1lbXBvb2xJbmZvEioub3JjaGVzdHJhdG9yLn'
     'YxLkdldENvcmVNZW1wb29sSW5mb1JlcXVlc3QaKy5vcmNoZXN0cmF0b3IudjEuR2V0Q29yZU1l'
     'bXBvb2xJbmZvUmVzcG9uc2USWAoLQ29yZVJhd0NhbGwSIy5vcmNoZXN0cmF0b3IudjEuQ29yZV'
-    'Jhd0NhbGxSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLkNvcmVSYXdDYWxsUmVzcG9uc2U=');
+    'Jhd0NhbGxSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLkNvcmVSYXdDYWxsUmVzcG9uc2USXgoN'
+    'R2V0Rm9ya1N0YXR1cxIlLm9yY2hlc3RyYXRvci52MS5HZXRGb3JrU3RhdHVzUmVxdWVzdBomLm'
+    '9yY2hlc3RyYXRvci52MS5HZXRGb3JrU3RhdHVzUmVzcG9uc2U=');
 

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbserver.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbserver.dart
@@ -44,6 +44,7 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
   $async.Future<$5.DeleteFilesResponse> deleteFiles($pb.ServerContext ctx, $5.DeleteFilesRequest request);
   $async.Future<$5.GetCoreMempoolInfoResponse> getCoreMempoolInfo($pb.ServerContext ctx, $5.GetCoreMempoolInfoRequest request);
   $async.Future<$5.CoreRawCallResponse> coreRawCall($pb.ServerContext ctx, $5.CoreRawCallRequest request);
+  $async.Future<$5.GetForkStatusResponse> getForkStatus($pb.ServerContext ctx, $5.GetForkStatusRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
@@ -70,6 +71,7 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
       case 'DeleteFiles': return $5.DeleteFilesRequest();
       case 'GetCoreMempoolInfo': return $5.GetCoreMempoolInfoRequest();
       case 'CoreRawCall': return $5.CoreRawCallRequest();
+      case 'GetForkStatus': return $5.GetForkStatusRequest();
       default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
@@ -99,6 +101,7 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
       case 'DeleteFiles': return this.deleteFiles(ctx, request as $5.DeleteFilesRequest);
       case 'GetCoreMempoolInfo': return this.getCoreMempoolInfo(ctx, request as $5.GetCoreMempoolInfoRequest);
       case 'CoreRawCall': return this.coreRawCall(ctx, request as $5.CoreRawCallRequest);
+      case 'GetForkStatus': return this.getForkStatus(ctx, request as $5.GetForkStatusRequest);
       default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -2662,6 +2662,7 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
     $core.String? opReturnHex,
     $fixnum.Int64? fixedFeeSats,
     $core.Iterable<UnspentOutput>? requiredInputs,
+    $core.bool? replayProtect,
   }) {
     final $result = create();
     if (walletId != null) {
@@ -2685,6 +2686,9 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
     if (requiredInputs != null) {
       $result.requiredInputs.addAll(requiredInputs);
     }
+    if (replayProtect != null) {
+      $result.replayProtect = replayProtect;
+    }
     return $result;
   }
   SendTransactionRequest._() : super();
@@ -2699,6 +2703,7 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
     ..aOS(5, _omitFieldNames ? '' : 'opReturnHex')
     ..aInt64(6, _omitFieldNames ? '' : 'fixedFeeSats')
     ..pc<UnspentOutput>(7, _omitFieldNames ? '' : 'requiredInputs', $pb.PbFieldType.PM, subBuilder: UnspentOutput.create)
+    ..aOB(8, _omitFieldNames ? '' : 'replayProtect')
     ..hasRequiredFields = false
   ;
 
@@ -2776,6 +2781,17 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
   /// Explicit wallet inputs to spend.
   @$pb.TagNumber(7)
   $core.List<UnspentOutput> get requiredInputs => $_getList(6);
+
+  /// Build an eCash replay-protected transaction (magic version + extra byte so
+  /// Bitcoin Core can't deserialize it). Core wallets only.
+  @$pb.TagNumber(8)
+  $core.bool get replayProtect => $_getBF(7);
+  @$pb.TagNumber(8)
+  set replayProtect($core.bool v) { $_setBool(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasReplayProtect() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearReplayProtect() => clearField(8);
 }
 
 class SendTransactionResponse extends $pb.GeneratedMessage {

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -643,6 +643,7 @@ const SendTransactionRequest$json = {
     {'1': 'op_return_hex', '3': 5, '4': 1, '5': 9, '10': 'opReturnHex'},
     {'1': 'fixed_fee_sats', '3': 6, '4': 1, '5': 3, '10': 'fixedFeeSats'},
     {'1': 'required_inputs', '3': 7, '4': 3, '5': 11, '6': '.walletmanager.v1.UnspentOutput', '10': 'requiredInputs'},
+    {'1': 'replay_protect', '3': 8, '4': 1, '5': 8, '10': 'replayProtect'},
   ],
   '3': [SendTransactionRequest_DestinationsEntry$json],
 };
@@ -666,8 +667,9 @@ final $typed_data.Uint8List sendTransactionRequestDescriptor = $convert.base64De
     'X2Ftb3VudBgEIAEoCFIVc3VidHJhY3RGZWVGcm9tQW1vdW50EiIKDW9wX3JldHVybl9oZXgYBS'
     'ABKAlSC29wUmV0dXJuSGV4EiQKDmZpeGVkX2ZlZV9zYXRzGAYgASgDUgxmaXhlZEZlZVNhdHMS'
     'SAoPcmVxdWlyZWRfaW5wdXRzGAcgAygLMh8ud2FsbGV0bWFuYWdlci52MS5VbnNwZW50T3V0cH'
-    'V0Ug5yZXF1aXJlZElucHV0cxo/ChFEZXN0aW5hdGlvbnNFbnRyeRIQCgNrZXkYASABKAlSA2tl'
-    'eRIUCgV2YWx1ZRgCIAEoA1IFdmFsdWU6AjgB');
+    'V0Ug5yZXF1aXJlZElucHV0cxIlCg5yZXBsYXlfcHJvdGVjdBgIIAEoCFINcmVwbGF5UHJvdGVj'
+    'dBo/ChFEZXN0aW5hdGlvbnNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoA1'
+    'IFdmFsdWU6AjgB');
 
 @$core.Deprecated('Use sendTransactionResponseDescriptor instead')
 const SendTransactionResponse$json = {

--- a/sail_ui/lib/rpcs/orchestrator_rpc.dart
+++ b/sail_ui/lib/rpcs/orchestrator_rpc.dart
@@ -125,6 +125,14 @@ class OrchestratorRPC {
     return _unaryClient.getMainchainBlockchainInfo(GetMainchainBlockchainInfoRequest());
   }
 
+  /// Canonical eCash fork state from the orchestrator's ForkEngine — the single
+  /// source of truth. Carries the heights, the claim-before-countdown gate, and
+  /// the per-wallet claimable UTXOs. The frontend renders this verbatim and does
+  /// no fork math of its own; the sweep spends the UTXOs listed here.
+  Future<GetForkStatusResponse> getForkStatus() {
+    return _unaryClient.getForkStatus(GetForkStatusRequest());
+  }
+
   /// Atomic snapshot of mainchain + enforcer + every known sidechain.
   /// Each ChainSync also reports download progress: when `is_downloading`
   /// is true, blocks/headers carry MB downloaded / MB total.

--- a/sail_ui/lib/rpcs/orchestrator_wallet_rpc.dart
+++ b/sail_ui/lib/rpcs/orchestrator_wallet_rpc.dart
@@ -167,6 +167,7 @@ class OrchestratorWalletRPC {
     String? opReturnMessage,
     String? opReturnHex,
     List<bwpb.UnspentOutput>? requiredInputs,
+    bool replayProtect = false,
   }) {
     final resolvedOpReturnHex =
         opReturnHex ?? (opReturnMessage == null ? null : _bytesToHex(utf8.encode(opReturnMessage)));
@@ -180,6 +181,7 @@ class OrchestratorWalletRPC {
         opReturnHex: resolvedOpReturnHex ?? '',
         fixedFeeSats: Int64(fixedFeeSats ?? 0),
         requiredInputs: requiredInputs?.map(_mapRequiredInput).toList() ?? [],
+        replayProtect: replayProtect,
       ),
     );
   }

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -280,6 +280,42 @@ func (h *Handler) GetMainchainBlockchainInfo(ctx context.Context, req *connect.R
 	}), nil
 }
 
+func (h *Handler) GetForkStatus(ctx context.Context, req *connect.Request[pb.GetForkStatusRequest]) (*connect.Response[pb.GetForkStatusResponse], error) {
+	s, err := h.orch.ForkState(ctx)
+	if err != nil {
+		return nil, err
+	}
+	claims := make([]*pb.ForkWalletClaim, len(s.Claims))
+	for i, c := range s.Claims {
+		utxos := make([]*pb.ForkClaimUtxo, len(c.UTXOs))
+		for j, u := range c.UTXOs {
+			utxos[j] = &pb.ForkClaimUtxo{
+				Outpoint: u.Outpoint,
+				Address:  u.Address,
+				Sats:     u.Sats,
+				Label:    u.Label,
+			}
+		}
+		claims[i] = &pb.ForkWalletClaim{
+			WalletId:          c.WalletID,
+			WalletName:        c.WalletName,
+			ClaimableSats:     c.ClaimableSats,
+			ReplayProtectable: c.ReplayProtectable,
+			Utxos:             utxos,
+		}
+	}
+	return connect.NewResponse(&pb.GetForkStatusResponse{
+		ForkHeight:      int32(s.ForkHeight),
+		CurrentHeight:   int32(s.CurrentHeight),
+		CurrentHeaders:  int32(s.CurrentHeaders),
+		ClaimBoundary:   int32(s.ClaimBoundary),
+		Simulated:       s.Simulated,
+		HasFundsToClaim: s.HasFundsToClaim,
+		ShowCountdown:   s.ShowCountdown,
+		Claims:          claims,
+	}), nil
+}
+
 // GetEnforcerBlockchainInfo is a thin compatibility shim over the new
 // GetSyncStatus path. Frontends should migrate to GetSyncStatus directly.
 func (h *Handler) GetEnforcerBlockchainInfo(ctx context.Context, req *connect.Request[pb.GetEnforcerBlockchainInfoRequest]) (*connect.Response[pb.GetEnforcerBlockchainInfoResponse], error) {

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -22,6 +22,7 @@ import (
 	orchestratorpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	rpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/replay"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47state"
 )
@@ -509,6 +510,13 @@ func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Reques
 		_ = notifTxID
 	}
 
+	if req.Msg.ReplayProtect && wType == walletTypeEnforcer {
+		return nil, connect.NewError(
+			connect.CodeInvalidArgument,
+			errors.New("replay protection is only supported for Bitcoin Core wallets"),
+		)
+	}
+
 	if wType == walletTypeEnforcer {
 		if err := h.requireEnforcerWallet(); err != nil {
 			return nil, connect.NewError(connect.CodeFailedPrecondition, err)
@@ -576,7 +584,8 @@ func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Reques
 	needsAdvancedSend := req.Msg.OpReturnHex != "" ||
 		req.Msg.FeeRateSatPerVbyte > 0 ||
 		req.Msg.FixedFeeSats > 0 ||
-		len(req.Msg.RequiredInputs) > 0
+		len(req.Msg.RequiredInputs) > 0 ||
+		req.Msg.ReplayProtect // custom serialization needs the raw-tx path
 
 	if needsAdvancedSend {
 		txid, err := h.sendAdvancedTransaction(ctx, coreName, req.Msg)
@@ -666,7 +675,7 @@ func (h *WalletHandler) sendAdvancedTransaction(
 			return "", fmt.Errorf("create raw transaction: %w", err)
 		}
 
-		return h.signAndBroadcastRawTransaction(ctx, coreName, rawHex)
+		return h.signAndBroadcastRawTransaction(ctx, coreName, rawHex, req.ReplayProtect)
 	}
 
 	rawHex, err := h.engine.CoreRPC().CreateRawTransaction(ctx, inputs, outputs)
@@ -694,7 +703,7 @@ func (h *WalletHandler) sendAdvancedTransaction(
 		return "", fmt.Errorf("fund raw transaction: %w", err)
 	}
 
-	return h.signAndBroadcastRawTransaction(ctx, coreName, funded.Hex)
+	return h.signAndBroadcastRawTransaction(ctx, coreName, funded.Hex, req.ReplayProtect)
 }
 
 func (h *WalletHandler) selectInputsForFixedFee(
@@ -751,7 +760,18 @@ func buildRawOutputs(req *pb.SendTransactionRequest) ([]map[string]interface{}, 
 func (h *WalletHandler) signAndBroadcastRawTransaction(
 	ctx context.Context,
 	coreName, rawHex string,
+	replayProtect bool,
 ) (string, error) {
+	// Set the magic version BEFORE signing so the signature commits to it
+	// (the fork's sighash is computed over this version).
+	if replayProtect {
+		var err error
+		rawHex, err = replay.SetVersion(rawHex)
+		if err != nil {
+			return "", fmt.Errorf("set replay version: %w", err)
+		}
+	}
+
 	signed, err := h.engine.CoreRPC().SignRawTransactionWithWallet(ctx, coreName, rawHex)
 	if err != nil {
 		return "", fmt.Errorf("sign raw transaction: %w", err)
@@ -760,7 +780,17 @@ func (h *WalletHandler) signAndBroadcastRawTransaction(
 		return "", errors.New("transaction signing incomplete")
 	}
 
-	txid, err := h.engine.CoreRPC().SendRawTransaction(ctx, signed.Hex)
+	hexToSend := signed.Hex
+	// Inject the extra byte AFTER signing — it's a serialization marker, not
+	// part of the sighash, and it makes the tx un-deserializable by Bitcoin.
+	if replayProtect {
+		hexToSend, err = replay.InjectReplayByte(hexToSend)
+		if err != nil {
+			return "", fmt.Errorf("inject replay byte: %w", err)
+		}
+	}
+
+	txid, err := h.engine.CoreRPC().SendRawTransaction(ctx, hexToSend)
 	if err != nil {
 		return "", fmt.Errorf("broadcast raw transaction: %w", err)
 	}

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -286,6 +286,10 @@ func run(cctx *cli.Context) error {
 		walletEngine := wallet.NewWalletEngine(walletSvc, coreRPC, netParams, log)
 		walletHandler.SetEngine(walletEngine)
 
+		// Fork engine: single source of truth for eCash fork state, needs the
+		// same Core RPC + wallet access for its claimable scan.
+		orch.InitForkEngine(walletEngine)
+
 		log.Info().Int("rpc_port", port).Msg("wallet engine initialized with Core RPC")
 
 		// BIP47 receive engine: watches each Core wallet's notification address
@@ -315,6 +319,7 @@ func run(cctx *cli.Context) error {
 		}
 		enforcerClient := enforcerrpc.NewWalletServiceClient(httpClient, enforcerURL, connect.WithGRPC())
 		walletHandler.SetEnforcerWallet(enforcerClient)
+		orch.SetForkEnforcerWallet(enforcerClient)
 		log.Info().Int("enforcer_port", enforcerCfg.Port).Msg("enforcer wallet client registered")
 	}
 

--- a/sidechain-orchestrator/fork.go
+++ b/sidechain-orchestrator/fork.go
@@ -1,0 +1,150 @@
+package orchestrator
+
+import (
+	"context"
+	"time"
+
+	"connectrpc.com/connect"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/fork"
+	enforcerpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
+	enforcerrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+)
+
+// InitForkEngine wires the fork engine once the wallet engine (Core RPC) is
+// available — called from main after NewWalletEngine. The fork.Engine is the
+// single source of truth for fork state; ForkState is a thin pass-through.
+func (o *Orchestrator) InitForkEngine(we *wallet.WalletEngine) {
+	o.forkEngine = fork.NewEngine(o, &forkWalletScanner{o: o, engine: we}, time.Second)
+}
+
+// SetForkEnforcerWallet attaches the enforcer wallet client to the fork scan so
+// the enforcer wallet's pre-fork coins are claimable too. Called from main once
+// the enforcer client exists (which is after InitForkEngine), so it's read
+// dynamically by the scanner rather than captured at construction.
+func (o *Orchestrator) SetForkEnforcerWallet(client enforcerrpc.WalletServiceClient) {
+	o.forkEnforcerWallet = client
+}
+
+// ForkState returns the canonical fork snapshot, or a zero state if the fork
+// engine isn't wired yet (no Core RPC).
+func (o *Orchestrator) ForkState(ctx context.Context) (*fork.ForkState, error) {
+	if o.forkEngine == nil {
+		return &fork.ForkState{}, nil
+	}
+	return o.forkEngine.State(ctx)
+}
+
+// ForkTip implements fork.TipSource off the cached getblockchaininfo.
+func (o *Orchestrator) ForkTip(ctx context.Context) (fork.Tip, error) {
+	info, err := o.GetMainchainBlockchainInfo(ctx)
+	if err != nil {
+		return fork.Tip{}, err
+	}
+	return fork.Tip{Chain: info.Chain, Blocks: info.Blocks, Headers: info.Headers}, nil
+}
+
+// forkWalletScanner adapts wallet.Service + wallet.WalletEngine + the enforcer
+// wallet to fork.WalletScanner, normalizing each backend's UTXOs to an absolute
+// confirmation height.
+type forkWalletScanner struct {
+	o      *Orchestrator
+	engine *wallet.WalletEngine
+}
+
+func (s *forkWalletScanner) Wallets() []fork.WalletMeta {
+	if s.o.WalletSvc == nil {
+		return nil
+	}
+	var out []fork.WalletMeta
+	for _, w := range s.o.WalletSvc.GetAllWallets() {
+		// Watch-only has no key, so it can't be swept. Core and enforcer
+		// wallets both hold spendable L1 BTC, but only Core claims can be
+		// replay-protected (the custom-serialized tx path is Core-only).
+		if w.WalletType == "watchOnly" {
+			continue
+		}
+		out = append(out, fork.WalletMeta{
+			ID:                w.ID,
+			Name:              w.Name,
+			ReplayProtectable: w.WalletType != "enforcer",
+		})
+	}
+	return out
+}
+
+func (s *forkWalletScanner) Unspent(ctx context.Context, walletID string, tipHeight int) ([]fork.Utxo, error) {
+	if s.walletType(walletID) == "enforcer" {
+		return s.enforcerUnspent(ctx)
+	}
+	return s.coreUnspent(ctx, walletID, tipHeight)
+}
+
+func (s *forkWalletScanner) walletType(walletID string) string {
+	for _, w := range s.o.WalletSvc.GetAllWallets() {
+		if w.ID == walletID {
+			return w.WalletType
+		}
+	}
+	return ""
+}
+
+// coreUnspent reads a Core wallet's UTXOs; Core only reports confirmations, so
+// height is derived tip - confirmations + 1.
+func (s *forkWalletScanner) coreUnspent(ctx context.Context, walletID string, tipHeight int) ([]fork.Utxo, error) {
+	if s.engine == nil {
+		return nil, nil
+	}
+	name, err := s.engine.GetCoreWalletName(ctx, walletID)
+	if err != nil {
+		return nil, err
+	}
+	coreUTXOs, err := s.engine.CoreRPC().ListUnspent(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]fork.Utxo, 0, len(coreUTXOs))
+	for _, u := range coreUTXOs {
+		height := 0
+		if u.Confirmations > 0 {
+			height = tipHeight - u.Confirmations + 1
+		}
+		out = append(out, fork.Utxo{
+			Outpoint:  fork.Outpoint(u.TxID, u.Vout),
+			Address:   u.Address,
+			Label:     u.Label,
+			Sats:      fork.BTCToSats(u.Amount),
+			Height:    height,
+			Spendable: u.Spendable,
+		})
+	}
+	return out, nil
+}
+
+// enforcerUnspent reads the enforcer wallet's UTXOs; the enforcer exposes the
+// confirming block height directly (ConfirmedAtBlock).
+func (s *forkWalletScanner) enforcerUnspent(ctx context.Context) ([]fork.Utxo, error) {
+	if s.o.forkEnforcerWallet == nil {
+		return nil, nil
+	}
+	resp, err := s.o.forkEnforcerWallet.ListUnspentOutputs(ctx, connect.NewRequest(&enforcerpb.ListUnspentOutputsRequest{}))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]fork.Utxo, 0, len(resp.Msg.Outputs))
+	for _, u := range resp.Msg.Outputs {
+		height := 0
+		if u.IsConfirmed {
+			height = int(u.ConfirmedAtBlock)
+		}
+		out = append(out, fork.Utxo{
+			Outpoint:  fork.Outpoint(u.Txid.GetHex().GetValue(), int(u.Vout)),
+			Address:   u.Address.GetValue(),
+			Sats:      u.ValueSats,
+			Height:    height,
+			Spendable: true,
+		})
+	}
+	return out, nil
+}

--- a/sidechain-orchestrator/fork/engine.go
+++ b/sidechain-orchestrator/fork/engine.go
@@ -1,0 +1,252 @@
+// Package fork is the single source of truth for eCash fork state. One engine
+// computes everything fork-related — the fork/claim heights (fixed per network,
+// or a recurring 144-block "daily fork" simulation on signet), the pre-fork
+// claimable scan across wallets, and the claim-before-countdown gate. Every
+// consumer (the GetForkStatus RPC, the countdown, the claim card, the sweep's
+// input list) reads the one ForkState this produces; nothing re-derives it.
+package fork
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+)
+
+// signetForkInterval makes signet "fork" every 144 blocks (~1 day at 10
+// min/block) so the whole fork UI + sweep can be exercised daily on a loop.
+const signetForkInterval = 144
+
+// ForkHeightFor is the fixed fork height for non-simulated networks — the single
+// source of truth for per-network fork heights.
+func ForkHeightFor(chain string) int {
+	switch chain {
+	case "regtest":
+		return 400
+	default: // main, signet (non-sim path is unused for signet), testnet, ...
+		return 100_000
+	}
+}
+
+// Tip is the minimal mainchain view the engine needs. Kept local to this
+// package so the engine imports nothing app-specific (no import cycle, easy to
+// fake in tests).
+type Tip struct {
+	Chain   string
+	Blocks  int
+	Headers int
+}
+
+// TipSource yields the current mainchain tip. The orchestrator satisfies this.
+type TipSource interface {
+	ForkTip(ctx context.Context) (Tip, error)
+}
+
+// WalletMeta identifies a spendable L1 wallet to scan for claimable coins.
+// ReplayProtectable is false for wallets whose claim can't be replay-protected
+// (the enforcer wallet) — those coins are detected but not safely sweepable.
+type WalletMeta struct {
+	ID                string
+	Name              string
+	ReplayProtectable bool
+}
+
+// Utxo is one unspent output at an absolute confirmation height (0 if
+// unconfirmed). The scanner adapter normalizes each wallet backend to this —
+// Core derives height from confirmations, the enforcer reads it directly — so
+// the engine only ever compares heights.
+type Utxo struct {
+	Outpoint  string // "txid:vout"
+	Address   string
+	Label     string
+	Sats      uint64
+	Height    int
+	Spendable bool
+}
+
+// WalletScanner enumerates spendable wallets and their UTXOs, server-side. The
+// orchestrator adapts wallet.Service + wallet.WalletEngine + the enforcer wallet
+// to this. tipHeight is supplied so adapters that only know confirmations can
+// derive an absolute height.
+type WalletScanner interface {
+	Wallets() []WalletMeta
+	Unspent(ctx context.Context, walletID string, tipHeight int) ([]Utxo, error)
+}
+
+// ClaimUTXO carries everything the frontend sweep needs as a requiredInput.
+type ClaimUTXO struct {
+	Outpoint string
+	Address  string
+	Label    string
+	Sats     uint64
+}
+
+// WalletClaim is one wallet's claimable pre-fork coins.
+type WalletClaim struct {
+	WalletID          string
+	WalletName        string
+	ClaimableSats     uint64
+	ReplayProtectable bool
+	UTXOs             []ClaimUTXO
+}
+
+// ForkState is the canonical fork snapshot every consumer reads.
+type ForkState struct {
+	Simulated       bool
+	ForkHeight      int // next fork / countdown target
+	ClaimBoundary   int // coins confirmed at/before this height are claimable
+	CurrentHeight   int
+	CurrentHeaders  int
+	HasFundsToClaim bool
+	ShowCountdown   bool
+	Claims          []WalletClaim
+}
+
+// Engine computes ForkState. Construct with NewEngine; call State.
+type Engine struct {
+	tip     TipSource
+	wallets WalletScanner // may be nil before Core RPC is up — claims skipped
+	ttl     time.Duration
+
+	mu       sync.Mutex
+	cached   *ForkState
+	cachedAt time.Time
+}
+
+// NewEngine wires the tip + wallet sources. ttl caches the (per-wallet UTXO
+// scan) result so a fast poll cadence doesn't re-scan every tick; ttl<=0
+// disables caching (used by tests).
+func NewEngine(tip TipSource, wallets WalletScanner, ttl time.Duration) *Engine {
+	return &Engine{tip: tip, wallets: wallets, ttl: ttl}
+}
+
+// State returns the current canonical fork state.
+func (e *Engine) State(ctx context.Context) (*ForkState, error) {
+	e.mu.Lock()
+	if e.ttl > 0 && e.cached != nil && time.Since(e.cachedAt) < e.ttl {
+		st := e.cached
+		e.mu.Unlock()
+		return st, nil
+	}
+	e.mu.Unlock()
+
+	st, err := e.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	e.mu.Lock()
+	e.cached, e.cachedAt = st, time.Now()
+	e.mu.Unlock()
+	return st, nil
+}
+
+func (e *Engine) compute(ctx context.Context) (*ForkState, error) {
+	tip, err := e.tip.ForkTip(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	simulated, forkHeight, claimBoundary := heightsFor(tip)
+
+	st := &ForkState{
+		Simulated:      simulated,
+		ForkHeight:     forkHeight,
+		ClaimBoundary:  claimBoundary,
+		CurrentHeight:  tip.Blocks,
+		CurrentHeaders: tip.Headers,
+	}
+
+	// The fork has "happened" for these coins only once the tip reaches the
+	// claim boundary — guards against a fixed-height network showing claims
+	// before the fork.
+	if tip.Blocks >= claimBoundary {
+		st.Claims = e.scan(ctx, claimBoundary, tip.Blocks)
+	}
+	// Only replay-protectable claims count as "funds to claim" — the enforcer
+	// wallet is detected but can't be swept, so it must not keep the claim card
+	// open (or the countdown suppressed) once everything claimable is gone.
+	for _, c := range st.Claims {
+		if c.ReplayProtectable && c.ClaimableSats > 0 {
+			st.HasFundsToClaim = true
+			break
+		}
+	}
+
+	// Claim-before-countdown: never show the next-fork timer while coins are
+	// still unclaimed. This gate lives here and only here.
+	st.ShowCountdown = !st.HasFundsToClaim && (simulated || tip.Headers < forkHeight)
+	return st, nil
+}
+
+// heightsFor returns (simulated, forkHeight, claimBoundary). Signet simulates a
+// recurring fork every 144 blocks: claimBoundary = last boundary (by confirmed
+// tip), forkHeight = next boundary (by header tip).
+func heightsFor(tip Tip) (bool, int, int) {
+	if tip.Chain == "signet" {
+		claimBoundary := (tip.Blocks / signetForkInterval) * signetForkInterval
+		forkHeight := (tip.Headers/signetForkInterval)*signetForkInterval + signetForkInterval
+		return true, forkHeight, claimBoundary
+	}
+	h := ForkHeightFor(tip.Chain)
+	return false, h, h
+}
+
+// scan collects each wallet's claimable pre-fork UTXOs. A wallet whose Core
+// wallet isn't loaded/unlocked errors and is skipped — never fatal.
+func (e *Engine) scan(ctx context.Context, claimBoundary, tipHeight int) []WalletClaim {
+	if e.wallets == nil {
+		return nil
+	}
+	var claims []WalletClaim
+	for _, w := range e.wallets.Wallets() {
+		utxos, err := e.wallets.Unspent(ctx, w.ID, tipHeight)
+		if err != nil {
+			continue
+		}
+		var (
+			sum   uint64
+			picks []ClaimUTXO
+		)
+		for _, u := range utxos {
+			if !u.Spendable || u.Height <= 0 {
+				continue
+			}
+			if u.Height > claimBoundary {
+				continue // confirmed after the fork — not claimable
+			}
+			sum += u.Sats
+			picks = append(picks, ClaimUTXO{
+				Outpoint: u.Outpoint,
+				Address:  u.Address,
+				Label:    u.Label,
+				Sats:     u.Sats,
+			})
+		}
+		if len(picks) > 0 {
+			claims = append(claims, WalletClaim{
+				WalletID:          w.ID,
+				WalletName:        w.Name,
+				ClaimableSats:     sum,
+				ReplayProtectable: w.ReplayProtectable,
+				UTXOs:             picks,
+			})
+		}
+	}
+	return claims
+}
+
+// BTCToSats converts a bitcoind BTC amount to satoshis. Exported so the
+// orchestrator's scanner adapter shares the one rounding rule.
+func BTCToSats(btc float64) uint64 {
+	if btc <= 0 {
+		return 0
+	}
+	return uint64(math.Round(btc * 1e8))
+}
+
+// Outpoint formats a txid:vout the way the frontend sweep expects.
+func Outpoint(txid string, vout int) string {
+	return fmt.Sprintf("%s:%d", txid, vout)
+}

--- a/sidechain-orchestrator/fork/engine_test.go
+++ b/sidechain-orchestrator/fork/engine_test.go
@@ -1,0 +1,97 @@
+package fork
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeTip struct{ tip Tip }
+
+func (f fakeTip) ForkTip(context.Context) (Tip, error) { return f.tip, nil }
+
+type fakeWallets struct {
+	meta  []WalletMeta
+	utxos map[string][]Utxo
+}
+
+func (f fakeWallets) Wallets() []WalletMeta { return f.meta }
+func (f fakeWallets) Unspent(_ context.Context, id string, _ int) ([]Utxo, error) {
+	return f.utxos[id], nil
+}
+
+// one wallet "w" holding a single spendable UTXO confirmed at the given height.
+func walletsAt(height int) fakeWallets {
+	return fakeWallets{
+		meta: []WalletMeta{{ID: "w", Name: "Main", ReplayProtectable: true}},
+		utxos: map[string][]Utxo{
+			"w": {{Outpoint: "tx:0", Address: "addr", Sats: 1000, Height: height, Spendable: true}},
+		},
+	}
+}
+
+func state(t *testing.T, tip Tip, w WalletScanner) *ForkState {
+	t.Helper()
+	st, err := NewEngine(fakeTip{tip}, w, 0).State(context.Background())
+	if err != nil {
+		t.Fatalf("State: %v", err)
+	}
+	return st
+}
+
+func TestSignetSimulatesRecurringFork(t *testing.T) {
+	// tip just past the 288 boundary; a coin confirmed at 286 <= 288 is claimable.
+	st := state(t, Tip{Chain: "signet", Blocks: 290, Headers: 290}, walletsAt(286))
+	if !st.Simulated {
+		t.Fatal("signet must be simulated")
+	}
+	if st.ClaimBoundary != 288 || st.ForkHeight != 432 {
+		t.Fatalf("boundaries: claim=%d fork=%d, want 288/432", st.ClaimBoundary, st.ForkHeight)
+	}
+	if !st.HasFundsToClaim {
+		t.Fatal("pre-boundary coin should be claimable")
+	}
+	// Claim-before-countdown: unclaimed coins hide the countdown.
+	if st.ShowCountdown {
+		t.Fatal("countdown must be hidden while coins are unclaimed")
+	}
+}
+
+func TestSignetCountdownShowsOnceClaimed(t *testing.T) {
+	// Same tip, but the only coin is post-boundary (height 290 > 288), so
+	// nothing is claimable and the countdown to the next fork shows.
+	st := state(t, Tip{Chain: "signet", Blocks: 290, Headers: 290}, walletsAt(290))
+	if st.HasFundsToClaim {
+		t.Fatal("post-boundary coin must not be claimable")
+	}
+	if !st.ShowCountdown {
+		t.Fatal("countdown should show once nothing is claimable")
+	}
+}
+
+func TestFixedHeightNoClaimsBeforeFork(t *testing.T) {
+	// regtest forks at 400; at height 100 the fork hasn't happened, so no claims.
+	st := state(t, Tip{Chain: "regtest", Blocks: 100, Headers: 100}, walletsAt(51))
+	if st.Simulated || st.ForkHeight != 400 || st.ClaimBoundary != 400 {
+		t.Fatalf("regtest fixed: sim=%v fork=%d claim=%d", st.Simulated, st.ForkHeight, st.ClaimBoundary)
+	}
+	if st.HasFundsToClaim {
+		t.Fatal("no claims before the fork height is reached")
+	}
+	if !st.ShowCountdown {
+		t.Fatal("countdown should show before the fork")
+	}
+}
+
+func TestFixedHeightClaimsAfterFork(t *testing.T) {
+	// past height 400, a coin confirmed at 391 <= 400 is claimable, countdown gone.
+	st := state(t, Tip{Chain: "regtest", Blocks: 410, Headers: 410}, walletsAt(391))
+	if !st.HasFundsToClaim {
+		t.Fatal("coin confirmed at height 391 <= 400 should be claimable")
+	}
+	if st.ShowCountdown {
+		t.Fatal("no countdown after a fixed-height fork")
+	}
+	if len(st.Claims) != 1 || st.Claims[0].ClaimableSats != 1000 {
+		t.Fatalf("claims: %+v", st.Claims)
+	}
+}

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -3112,6 +3112,302 @@ func (x *CoreRawCallResponse) GetResultJson() string {
 	return ""
 }
 
+type GetForkStatusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetForkStatusRequest) Reset() {
+	*x = GetForkStatusRequest{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetForkStatusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetForkStatusRequest) ProtoMessage() {}
+
+func (x *GetForkStatusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetForkStatusRequest.ProtoReflect.Descriptor instead.
+func (*GetForkStatusRequest) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{51}
+}
+
+// Canonical fork snapshot produced by the orchestrator's single ForkEngine.
+// The frontend renders this verbatim — it does no fork math of its own.
+type GetForkStatusResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Next fork height (countdown target). Fixed per network, or the next
+	// 144-block boundary on signet's simulated daily fork.
+	ForkHeight int32 `protobuf:"varint,1,opt,name=fork_height,json=forkHeight,proto3" json:"fork_height,omitempty"`
+	// Current mainchain tip height.
+	CurrentHeight int32 `protobuf:"varint,2,opt,name=current_height,json=currentHeight,proto3" json:"current_height,omitempty"`
+	// Current mainchain header height. Runs ahead of `current_height` during
+	// sync; the time-to-fork countdown is driven off this.
+	CurrentHeaders int32 `protobuf:"varint,4,opt,name=current_headers,json=currentHeaders,proto3" json:"current_headers,omitempty"`
+	// Coins confirmed at/before this height are claimable. Equals fork_height on
+	// fixed-height networks; the last 144-boundary on signet.
+	ClaimBoundary int32 `protobuf:"varint,5,opt,name=claim_boundary,json=claimBoundary,proto3" json:"claim_boundary,omitempty"`
+	// True on signet, where the fork recurs every 144 blocks.
+	Simulated bool `protobuf:"varint,6,opt,name=simulated,proto3" json:"simulated,omitempty"`
+	// Any wallet holds un-swept pre-fork coins.
+	HasFundsToClaim bool `protobuf:"varint,7,opt,name=has_funds_to_claim,json=hasFundsToClaim,proto3" json:"has_funds_to_claim,omitempty"`
+	// Whether to show the next-fork countdown. False while coins are unclaimed
+	// (claim-before-countdown).
+	ShowCountdown bool `protobuf:"varint,8,opt,name=show_countdown,json=showCountdown,proto3" json:"show_countdown,omitempty"`
+	// Per-wallet claimable coins, with the exact UTXOs the sweep spends.
+	Claims        []*ForkWalletClaim `protobuf:"bytes,9,rep,name=claims,proto3" json:"claims,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetForkStatusResponse) Reset() {
+	*x = GetForkStatusResponse{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetForkStatusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetForkStatusResponse) ProtoMessage() {}
+
+func (x *GetForkStatusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetForkStatusResponse.ProtoReflect.Descriptor instead.
+func (*GetForkStatusResponse) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *GetForkStatusResponse) GetForkHeight() int32 {
+	if x != nil {
+		return x.ForkHeight
+	}
+	return 0
+}
+
+func (x *GetForkStatusResponse) GetCurrentHeight() int32 {
+	if x != nil {
+		return x.CurrentHeight
+	}
+	return 0
+}
+
+func (x *GetForkStatusResponse) GetCurrentHeaders() int32 {
+	if x != nil {
+		return x.CurrentHeaders
+	}
+	return 0
+}
+
+func (x *GetForkStatusResponse) GetClaimBoundary() int32 {
+	if x != nil {
+		return x.ClaimBoundary
+	}
+	return 0
+}
+
+func (x *GetForkStatusResponse) GetSimulated() bool {
+	if x != nil {
+		return x.Simulated
+	}
+	return false
+}
+
+func (x *GetForkStatusResponse) GetHasFundsToClaim() bool {
+	if x != nil {
+		return x.HasFundsToClaim
+	}
+	return false
+}
+
+func (x *GetForkStatusResponse) GetShowCountdown() bool {
+	if x != nil {
+		return x.ShowCountdown
+	}
+	return false
+}
+
+func (x *GetForkStatusResponse) GetClaims() []*ForkWalletClaim {
+	if x != nil {
+		return x.Claims
+	}
+	return nil
+}
+
+type ForkWalletClaim struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	WalletId      string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	WalletName    string                 `protobuf:"bytes,2,opt,name=wallet_name,json=walletName,proto3" json:"wallet_name,omitempty"`
+	ClaimableSats uint64                 `protobuf:"varint,3,opt,name=claimable_sats,json=claimableSats,proto3" json:"claimable_sats,omitempty"`
+	Utxos         []*ForkClaimUtxo       `protobuf:"bytes,4,rep,name=utxos,proto3" json:"utxos,omitempty"`
+	// False when this wallet's claim can't be replay-protected (enforcer wallet);
+	// such coins are shown but not swept.
+	ReplayProtectable bool `protobuf:"varint,5,opt,name=replay_protectable,json=replayProtectable,proto3" json:"replay_protectable,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ForkWalletClaim) Reset() {
+	*x = ForkWalletClaim{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ForkWalletClaim) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ForkWalletClaim) ProtoMessage() {}
+
+func (x *ForkWalletClaim) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ForkWalletClaim.ProtoReflect.Descriptor instead.
+func (*ForkWalletClaim) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *ForkWalletClaim) GetWalletId() string {
+	if x != nil {
+		return x.WalletId
+	}
+	return ""
+}
+
+func (x *ForkWalletClaim) GetWalletName() string {
+	if x != nil {
+		return x.WalletName
+	}
+	return ""
+}
+
+func (x *ForkWalletClaim) GetClaimableSats() uint64 {
+	if x != nil {
+		return x.ClaimableSats
+	}
+	return 0
+}
+
+func (x *ForkWalletClaim) GetUtxos() []*ForkClaimUtxo {
+	if x != nil {
+		return x.Utxos
+	}
+	return nil
+}
+
+func (x *ForkWalletClaim) GetReplayProtectable() bool {
+	if x != nil {
+		return x.ReplayProtectable
+	}
+	return false
+}
+
+type ForkClaimUtxo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Outpoint      string                 `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"` // "txid:vout"
+	Address       string                 `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
+	Sats          uint64                 `protobuf:"varint,3,opt,name=sats,proto3" json:"sats,omitempty"`
+	Label         string                 `protobuf:"bytes,4,opt,name=label,proto3" json:"label,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ForkClaimUtxo) Reset() {
+	*x = ForkClaimUtxo{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ForkClaimUtxo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ForkClaimUtxo) ProtoMessage() {}
+
+func (x *ForkClaimUtxo) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ForkClaimUtxo.ProtoReflect.Descriptor instead.
+func (*ForkClaimUtxo) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *ForkClaimUtxo) GetOutpoint() string {
+	if x != nil {
+		return x.Outpoint
+	}
+	return ""
+}
+
+func (x *ForkClaimUtxo) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *ForkClaimUtxo) GetSats() uint64 {
+	if x != nil {
+		return x.Sats
+	}
+	return 0
+}
+
+func (x *ForkClaimUtxo) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
 type ShutdownRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -3120,7 +3416,7 @@ type ShutdownRequest struct {
 
 func (x *ShutdownRequest) Reset() {
 	*x = ShutdownRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[51]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3132,7 +3428,7 @@ func (x *ShutdownRequest) String() string {
 func (*ShutdownRequest) ProtoMessage() {}
 
 func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[51]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3145,7 +3441,7 @@ func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownRequest.ProtoReflect.Descriptor instead.
 func (*ShutdownRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{51}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{55}
 }
 
 type ShutdownResponse struct {
@@ -3156,7 +3452,7 @@ type ShutdownResponse struct {
 
 func (x *ShutdownResponse) Reset() {
 	*x = ShutdownResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[52]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3168,7 +3464,7 @@ func (x *ShutdownResponse) String() string {
 func (*ShutdownResponse) ProtoMessage() {}
 
 func (x *ShutdownResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[52]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3181,7 +3477,7 @@ func (x *ShutdownResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownResponse.ProtoReflect.Descriptor instead.
 func (*ShutdownResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{52}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{56}
 }
 
 var File_orchestrator_v1_orchestrator_proto protoreflect.FileDescriptor
@@ -3392,7 +3688,30 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x06wallet\x18\x03 \x01(\tR\x06wallet\"6\n" +
 	"\x13CoreRawCallResponse\x12\x1f\n" +
 	"\vresult_json\x18\x01 \x01(\tR\n" +
-	"resultJson\"\x11\n" +
+	"resultJson\"\x16\n" +
+	"\x14GetForkStatusRequest\"\xe1\x02\n" +
+	"\x15GetForkStatusResponse\x12\x1f\n" +
+	"\vfork_height\x18\x01 \x01(\x05R\n" +
+	"forkHeight\x12%\n" +
+	"\x0ecurrent_height\x18\x02 \x01(\x05R\rcurrentHeight\x12'\n" +
+	"\x0fcurrent_headers\x18\x04 \x01(\x05R\x0ecurrentHeaders\x12%\n" +
+	"\x0eclaim_boundary\x18\x05 \x01(\x05R\rclaimBoundary\x12\x1c\n" +
+	"\tsimulated\x18\x06 \x01(\bR\tsimulated\x12+\n" +
+	"\x12has_funds_to_claim\x18\a \x01(\bR\x0fhasFundsToClaim\x12%\n" +
+	"\x0eshow_countdown\x18\b \x01(\bR\rshowCountdown\x128\n" +
+	"\x06claims\x18\t \x03(\v2 .orchestrator.v1.ForkWalletClaimR\x06claimsJ\x04\b\x03\x10\x04\"\xdb\x01\n" +
+	"\x0fForkWalletClaim\x12\x1b\n" +
+	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x1f\n" +
+	"\vwallet_name\x18\x02 \x01(\tR\n" +
+	"walletName\x12%\n" +
+	"\x0eclaimable_sats\x18\x03 \x01(\x04R\rclaimableSats\x124\n" +
+	"\x05utxos\x18\x04 \x03(\v2\x1e.orchestrator.v1.ForkClaimUtxoR\x05utxos\x12-\n" +
+	"\x12replay_protectable\x18\x05 \x01(\bR\x11replayProtectable\"o\n" +
+	"\rForkClaimUtxo\x12\x1a\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x18\n" +
+	"\aaddress\x18\x02 \x01(\tR\aaddress\x12\x12\n" +
+	"\x04sats\x18\x03 \x01(\x04R\x04sats\x12\x14\n" +
+	"\x05label\x18\x04 \x01(\tR\x05label\"\x11\n" +
 	"\x0fShutdownRequest\"\x12\n" +
 	"\x10ShutdownResponse*\xf7\x01\n" +
 	"\rSidechainType\x12\x1e\n" +
@@ -3427,7 +3746,7 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x14DELETION_TYPE_WALLET\x10\x02\x12\x1a\n" +
 	"\x16DELETION_TYPE_SETTINGS\x10\x03\x12\x16\n" +
 	"\x12DELETION_TYPE_LOGS\x10\x04\x12\x1a\n" +
-	"\x16DELETION_TYPE_SOFTWARE\x10\x052\x97\x12\n" +
+	"\x16DELETION_TYPE_SOFTWARE\x10\x052\xf7\x12\n" +
 	"\x13OrchestratorService\x12[\n" +
 	"\fListBinaries\x12$.orchestrator.v1.ListBinariesRequest\x1a%.orchestrator.v1.ListBinariesResponse\x12d\n" +
 	"\x0fGetBinaryStatus\x12'.orchestrator.v1.GetBinaryStatusRequest\x1a(.orchestrator.v1.GetBinaryStatusResponse\x12g\n" +
@@ -3453,7 +3772,8 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x13GatherFilesToDelete\x12+.orchestrator.v1.GatherFilesToDeleteRequest\x1a,.orchestrator.v1.GatherFilesToDeleteResponse\x12Z\n" +
 	"\vDeleteFiles\x12#.orchestrator.v1.DeleteFilesRequest\x1a$.orchestrator.v1.DeleteFilesResponse0\x01\x12m\n" +
 	"\x12GetCoreMempoolInfo\x12*.orchestrator.v1.GetCoreMempoolInfoRequest\x1a+.orchestrator.v1.GetCoreMempoolInfoResponse\x12X\n" +
-	"\vCoreRawCall\x12#.orchestrator.v1.CoreRawCallRequest\x1a$.orchestrator.v1.CoreRawCallResponseB\xe2\x01\n" +
+	"\vCoreRawCall\x12#.orchestrator.v1.CoreRawCallRequest\x1a$.orchestrator.v1.CoreRawCallResponse\x12^\n" +
+	"\rGetForkStatus\x12%.orchestrator.v1.GetForkStatusRequest\x1a&.orchestrator.v1.GetForkStatusResponseB\xe2\x01\n" +
 	"\x13com.orchestrator.v1B\x11OrchestratorProtoP\x01Z[github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1;orchestratorv1\xa2\x02\x03OXX\xaa\x02\x0fOrchestrator.V1\xca\x02\x0fOrchestrator\\V1\xe2\x02\x1bOrchestrator\\V1\\GPBMetadata\xea\x02\x10Orchestrator::V1b\x06proto3"
 
 var (
@@ -3469,7 +3789,7 @@ func file_orchestrator_v1_orchestrator_proto_rawDescGZIP() []byte {
 }
 
 var file_orchestrator_v1_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 55)
+var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 59)
 var file_orchestrator_v1_orchestrator_proto_goTypes = []any{
 	(SidechainType)(0),                         // 0: orchestrator.v1.SidechainType
 	(BinaryType)(0),                            // 1: orchestrator.v1.BinaryType
@@ -3525,17 +3845,21 @@ var file_orchestrator_v1_orchestrator_proto_goTypes = []any{
 	(*GetCoreMempoolInfoResponse)(nil),         // 51: orchestrator.v1.GetCoreMempoolInfoResponse
 	(*CoreRawCallRequest)(nil),                 // 52: orchestrator.v1.CoreRawCallRequest
 	(*CoreRawCallResponse)(nil),                // 53: orchestrator.v1.CoreRawCallResponse
-	(*ShutdownRequest)(nil),                    // 54: orchestrator.v1.ShutdownRequest
-	(*ShutdownResponse)(nil),                   // 55: orchestrator.v1.ShutdownResponse
-	nil,                                        // 56: orchestrator.v1.StartBinaryRequest.EnvEntry
-	nil,                                        // 57: orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	(*GetForkStatusRequest)(nil),               // 54: orchestrator.v1.GetForkStatusRequest
+	(*GetForkStatusResponse)(nil),              // 55: orchestrator.v1.GetForkStatusResponse
+	(*ForkWalletClaim)(nil),                    // 56: orchestrator.v1.ForkWalletClaim
+	(*ForkClaimUtxo)(nil),                      // 57: orchestrator.v1.ForkClaimUtxo
+	(*ShutdownRequest)(nil),                    // 58: orchestrator.v1.ShutdownRequest
+	(*ShutdownResponse)(nil),                   // 59: orchestrator.v1.ShutdownResponse
+	nil,                                        // 60: orchestrator.v1.StartBinaryRequest.EnvEntry
+	nil,                                        // 61: orchestrator.v1.StartWithL1Request.TargetEnvEntry
 }
 var file_orchestrator_v1_orchestrator_proto_depIdxs = []int32{
 	4,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
 	3,  // 1: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
 	3,  // 2: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
-	56, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
-	57, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	60, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
+	61, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
 	36, // 5: orchestrator.v1.GetSyncStatusResponse.mainchain:type_name -> orchestrator.v1.ChainSync
 	36, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
 	35, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
@@ -3551,57 +3875,61 @@ var file_orchestrator_v1_orchestrator_proto_depIdxs = []int32{
 	2,  // 17: orchestrator.v1.ResetFileInfo.deletion_type:type_name -> orchestrator.v1.DeletionType
 	1,  // 18: orchestrator.v1.ResetFileInfo.binary:type_name -> orchestrator.v1.BinaryType
 	44, // 19: orchestrator.v1.DeleteFilesRequest.items:type_name -> orchestrator.v1.SingleDeletion
-	5,  // 20: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
-	7,  // 21: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
-	9,  // 22: orchestrator.v1.OrchestratorService.GetBinaryVersion:input_type -> orchestrator.v1.GetBinaryVersionRequest
-	11, // 23: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
-	13, // 24: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
-	15, // 25: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
-	17, // 26: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
-	19, // 27: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
-	21, // 28: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
-	23, // 29: orchestrator.v1.OrchestratorService.RestartL1:input_type -> orchestrator.v1.RestartL1Request
-	25, // 30: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
-	54, // 31: orchestrator.v1.OrchestratorService.Shutdown:input_type -> orchestrator.v1.ShutdownRequest
-	27, // 32: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
-	29, // 33: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
-	31, // 34: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	33, // 35: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
-	37, // 36: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
-	40, // 37: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
-	42, // 38: orchestrator.v1.OrchestratorService.GetSidechainBalance:input_type -> orchestrator.v1.GetSidechainBalanceRequest
-	45, // 39: orchestrator.v1.OrchestratorService.GatherFilesToDelete:input_type -> orchestrator.v1.GatherFilesToDeleteRequest
-	48, // 40: orchestrator.v1.OrchestratorService.DeleteFiles:input_type -> orchestrator.v1.DeleteFilesRequest
-	50, // 41: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
-	52, // 42: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
-	6,  // 43: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
-	8,  // 44: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
-	10, // 45: orchestrator.v1.OrchestratorService.GetBinaryVersion:output_type -> orchestrator.v1.GetBinaryVersionResponse
-	12, // 46: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
-	14, // 47: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
-	16, // 48: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
-	18, // 49: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
-	20, // 50: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
-	22, // 51: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
-	24, // 52: orchestrator.v1.OrchestratorService.RestartL1:output_type -> orchestrator.v1.RestartL1Response
-	26, // 53: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
-	55, // 54: orchestrator.v1.OrchestratorService.Shutdown:output_type -> orchestrator.v1.ShutdownResponse
-	28, // 55: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
-	30, // 56: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
-	32, // 57: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	34, // 58: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
-	38, // 59: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
-	41, // 60: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
-	43, // 61: orchestrator.v1.OrchestratorService.GetSidechainBalance:output_type -> orchestrator.v1.GetSidechainBalanceResponse
-	46, // 62: orchestrator.v1.OrchestratorService.GatherFilesToDelete:output_type -> orchestrator.v1.GatherFilesToDeleteResponse
-	49, // 63: orchestrator.v1.OrchestratorService.DeleteFiles:output_type -> orchestrator.v1.DeleteFilesResponse
-	51, // 64: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
-	53, // 65: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
-	43, // [43:66] is the sub-list for method output_type
-	20, // [20:43] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	56, // 20: orchestrator.v1.GetForkStatusResponse.claims:type_name -> orchestrator.v1.ForkWalletClaim
+	57, // 21: orchestrator.v1.ForkWalletClaim.utxos:type_name -> orchestrator.v1.ForkClaimUtxo
+	5,  // 22: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
+	7,  // 23: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
+	9,  // 24: orchestrator.v1.OrchestratorService.GetBinaryVersion:input_type -> orchestrator.v1.GetBinaryVersionRequest
+	11, // 25: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
+	13, // 26: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
+	15, // 27: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
+	17, // 28: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
+	19, // 29: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
+	21, // 30: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
+	23, // 31: orchestrator.v1.OrchestratorService.RestartL1:input_type -> orchestrator.v1.RestartL1Request
+	25, // 32: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
+	58, // 33: orchestrator.v1.OrchestratorService.Shutdown:input_type -> orchestrator.v1.ShutdownRequest
+	27, // 34: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
+	29, // 35: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
+	31, // 36: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	33, // 37: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
+	37, // 38: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
+	40, // 39: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
+	42, // 40: orchestrator.v1.OrchestratorService.GetSidechainBalance:input_type -> orchestrator.v1.GetSidechainBalanceRequest
+	45, // 41: orchestrator.v1.OrchestratorService.GatherFilesToDelete:input_type -> orchestrator.v1.GatherFilesToDeleteRequest
+	48, // 42: orchestrator.v1.OrchestratorService.DeleteFiles:input_type -> orchestrator.v1.DeleteFilesRequest
+	50, // 43: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
+	52, // 44: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
+	54, // 45: orchestrator.v1.OrchestratorService.GetForkStatus:input_type -> orchestrator.v1.GetForkStatusRequest
+	6,  // 46: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
+	8,  // 47: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
+	10, // 48: orchestrator.v1.OrchestratorService.GetBinaryVersion:output_type -> orchestrator.v1.GetBinaryVersionResponse
+	12, // 49: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
+	14, // 50: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
+	16, // 51: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
+	18, // 52: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
+	20, // 53: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
+	22, // 54: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
+	24, // 55: orchestrator.v1.OrchestratorService.RestartL1:output_type -> orchestrator.v1.RestartL1Response
+	26, // 56: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
+	59, // 57: orchestrator.v1.OrchestratorService.Shutdown:output_type -> orchestrator.v1.ShutdownResponse
+	28, // 58: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
+	30, // 59: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
+	32, // 60: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	34, // 61: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
+	38, // 62: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
+	41, // 63: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
+	43, // 64: orchestrator.v1.OrchestratorService.GetSidechainBalance:output_type -> orchestrator.v1.GetSidechainBalanceResponse
+	46, // 65: orchestrator.v1.OrchestratorService.GatherFilesToDelete:output_type -> orchestrator.v1.GatherFilesToDeleteResponse
+	49, // 66: orchestrator.v1.OrchestratorService.DeleteFiles:output_type -> orchestrator.v1.DeleteFilesResponse
+	51, // 67: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
+	53, // 68: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
+	55, // 69: orchestrator.v1.OrchestratorService.GetForkStatus:output_type -> orchestrator.v1.GetForkStatusResponse
+	46, // [46:70] is the sub-list for method output_type
+	22, // [22:46] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_orchestrator_v1_orchestrator_proto_init() }
@@ -3615,7 +3943,7 @@ func file_orchestrator_v1_orchestrator_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_orchestrator_v1_orchestrator_proto_rawDesc), len(file_orchestrator_v1_orchestrator_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   55,
+			NumMessages:   59,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect/orchestrator.connect.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect/orchestrator.connect.go
@@ -102,6 +102,9 @@ const (
 	// OrchestratorServiceCoreRawCallProcedure is the fully-qualified name of the OrchestratorService's
 	// CoreRawCall RPC.
 	OrchestratorServiceCoreRawCallProcedure = "/orchestrator.v1.OrchestratorService/CoreRawCall"
+	// OrchestratorServiceGetForkStatusProcedure is the fully-qualified name of the
+	// OrchestratorService's GetForkStatus RPC.
+	OrchestratorServiceGetForkStatusProcedure = "/orchestrator.v1.OrchestratorService/GetForkStatus"
 )
 
 // OrchestratorServiceClient is a client for the orchestrator.v1.OrchestratorService service.
@@ -187,6 +190,14 @@ type OrchestratorServiceClient interface {
 	// Generic raw bitcoind RPC. Optional `wallet` field routes the call to
 	// /wallet/{name} on bitcoind for wallet-scoped RPCs.
 	CoreRawCall(context.Context, *connect.Request[v1.CoreRawCallRequest]) (*connect.Response[v1.CoreRawCallResponse], error)
+	// ─── eCash fork ───────────────────────────────────────────────────────────
+	// Report where the mainchain tip sits relative to the eCash fork height.
+	// The orchestrator is the single source of truth for the fork height; the
+	// frontend renders "fork mode" (the claim card) off fork_active. Per-wallet
+	// pre-fork coin detection and the sweep itself stay in the frontend via the
+	// existing WalletManagerService (listUnspent / sendTransaction), one call
+	// per wallet — this RPC only supplies the height.
+	GetForkStatus(context.Context, *connect.Request[v1.GetForkStatusRequest]) (*connect.Response[v1.GetForkStatusResponse], error)
 }
 
 // NewOrchestratorServiceClient constructs a client for the orchestrator.v1.OrchestratorService
@@ -338,6 +349,12 @@ func NewOrchestratorServiceClient(httpClient connect.HTTPClient, baseURL string,
 			connect.WithSchema(orchestratorServiceMethods.ByName("CoreRawCall")),
 			connect.WithClientOptions(opts...),
 		),
+		getForkStatus: connect.NewClient[v1.GetForkStatusRequest, v1.GetForkStatusResponse](
+			httpClient,
+			baseURL+OrchestratorServiceGetForkStatusProcedure,
+			connect.WithSchema(orchestratorServiceMethods.ByName("GetForkStatus")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -366,6 +383,7 @@ type orchestratorServiceClient struct {
 	deleteFiles                *connect.Client[v1.DeleteFilesRequest, v1.DeleteFilesResponse]
 	getCoreMempoolInfo         *connect.Client[v1.GetCoreMempoolInfoRequest, v1.GetCoreMempoolInfoResponse]
 	coreRawCall                *connect.Client[v1.CoreRawCallRequest, v1.CoreRawCallResponse]
+	getForkStatus              *connect.Client[v1.GetForkStatusRequest, v1.GetForkStatusResponse]
 }
 
 // ListBinaries calls orchestrator.v1.OrchestratorService.ListBinaries.
@@ -483,6 +501,11 @@ func (c *orchestratorServiceClient) CoreRawCall(ctx context.Context, req *connec
 	return c.coreRawCall.CallUnary(ctx, req)
 }
 
+// GetForkStatus calls orchestrator.v1.OrchestratorService.GetForkStatus.
+func (c *orchestratorServiceClient) GetForkStatus(ctx context.Context, req *connect.Request[v1.GetForkStatusRequest]) (*connect.Response[v1.GetForkStatusResponse], error) {
+	return c.getForkStatus.CallUnary(ctx, req)
+}
+
 // OrchestratorServiceHandler is an implementation of the orchestrator.v1.OrchestratorService
 // service.
 type OrchestratorServiceHandler interface {
@@ -567,6 +590,14 @@ type OrchestratorServiceHandler interface {
 	// Generic raw bitcoind RPC. Optional `wallet` field routes the call to
 	// /wallet/{name} on bitcoind for wallet-scoped RPCs.
 	CoreRawCall(context.Context, *connect.Request[v1.CoreRawCallRequest]) (*connect.Response[v1.CoreRawCallResponse], error)
+	// ─── eCash fork ───────────────────────────────────────────────────────────
+	// Report where the mainchain tip sits relative to the eCash fork height.
+	// The orchestrator is the single source of truth for the fork height; the
+	// frontend renders "fork mode" (the claim card) off fork_active. Per-wallet
+	// pre-fork coin detection and the sweep itself stay in the frontend via the
+	// existing WalletManagerService (listUnspent / sendTransaction), one call
+	// per wallet — this RPC only supplies the height.
+	GetForkStatus(context.Context, *connect.Request[v1.GetForkStatusRequest]) (*connect.Response[v1.GetForkStatusResponse], error)
 }
 
 // NewOrchestratorServiceHandler builds an HTTP handler from the service implementation. It returns
@@ -714,6 +745,12 @@ func NewOrchestratorServiceHandler(svc OrchestratorServiceHandler, opts ...conne
 		connect.WithSchema(orchestratorServiceMethods.ByName("CoreRawCall")),
 		connect.WithHandlerOptions(opts...),
 	)
+	orchestratorServiceGetForkStatusHandler := connect.NewUnaryHandler(
+		OrchestratorServiceGetForkStatusProcedure,
+		svc.GetForkStatus,
+		connect.WithSchema(orchestratorServiceMethods.ByName("GetForkStatus")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/orchestrator.v1.OrchestratorService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case OrchestratorServiceListBinariesProcedure:
@@ -762,6 +799,8 @@ func NewOrchestratorServiceHandler(svc OrchestratorServiceHandler, opts ...conne
 			orchestratorServiceGetCoreMempoolInfoHandler.ServeHTTP(w, r)
 		case OrchestratorServiceCoreRawCallProcedure:
 			orchestratorServiceCoreRawCallHandler.ServeHTTP(w, r)
+		case OrchestratorServiceGetForkStatusProcedure:
+			orchestratorServiceGetForkStatusHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -861,4 +900,8 @@ func (UnimplementedOrchestratorServiceHandler) GetCoreMempoolInfo(context.Contex
 
 func (UnimplementedOrchestratorServiceHandler) CoreRawCall(context.Context, *connect.Request[v1.CoreRawCallRequest]) (*connect.Response[v1.CoreRawCallResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("orchestrator.v1.OrchestratorService.CoreRawCall is not implemented"))
+}
+
+func (UnimplementedOrchestratorServiceHandler) GetForkStatus(context.Context, *connect.Request[v1.GetForkStatusRequest]) (*connect.Response[v1.GetForkStatusResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("orchestrator.v1.OrchestratorService.GetForkStatus is not implemented"))
 }

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -2357,8 +2357,11 @@ type SendTransactionRequest struct {
 	FixedFeeSats int64 `protobuf:"varint,6,opt,name=fixed_fee_sats,json=fixedFeeSats,proto3" json:"fixed_fee_sats,omitempty"`
 	// Explicit wallet inputs to spend.
 	RequiredInputs []*UnspentOutput `protobuf:"bytes,7,rep,name=required_inputs,json=requiredInputs,proto3" json:"required_inputs,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Build an eCash replay-protected transaction (magic version + extra byte so
+	// Bitcoin Core can't deserialize it). Core wallets only.
+	ReplayProtect bool `protobuf:"varint,8,opt,name=replay_protect,json=replayProtect,proto3" json:"replay_protect,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SendTransactionRequest) Reset() {
@@ -2438,6 +2441,13 @@ func (x *SendTransactionRequest) GetRequiredInputs() []*UnspentOutput {
 		return x.RequiredInputs
 	}
 	return nil
+}
+
+func (x *SendTransactionRequest) GetReplayProtect() bool {
+	if x != nil {
+		return x.ReplayProtect
+	}
+	return false
 }
 
 type SendTransactionResponse struct {
@@ -4542,7 +4552,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\"G\n" +
 	"\x15GetNewAddressResponse\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x14\n" +
-	"\x05index\x18\x02 \x01(\x05R\x05index\"\xd7\x03\n" +
+	"\x05index\x18\x02 \x01(\x05R\x05index\"\xfe\x03\n" +
 	"\x16SendTransactionRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12^\n" +
 	"\fdestinations\x18\x02 \x03(\v2:.walletmanager.v1.SendTransactionRequest.DestinationsEntryR\fdestinations\x122\n" +
@@ -4550,7 +4560,8 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x18subtract_fee_from_amount\x18\x04 \x01(\bR\x15subtractFeeFromAmount\x12\"\n" +
 	"\rop_return_hex\x18\x05 \x01(\tR\vopReturnHex\x12$\n" +
 	"\x0efixed_fee_sats\x18\x06 \x01(\x03R\ffixedFeeSats\x12H\n" +
-	"\x0frequired_inputs\x18\a \x03(\v2\x1f.walletmanager.v1.UnspentOutputR\x0erequiredInputs\x1a?\n" +
+	"\x0frequired_inputs\x18\a \x03(\v2\x1f.walletmanager.v1.UnspentOutputR\x0erequiredInputs\x12%\n" +
+	"\x0ereplay_protect\x18\b \x01(\bR\rreplayProtect\x1a?\n" +
 	"\x11DestinationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"-\n" +

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/net/http2"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/fork"
 	enforcerpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
 	enforcerrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
@@ -115,6 +116,12 @@ type Orchestrator struct {
 	WalletSvc      *wallet.Service // for seed injection into sidechain/enforcer args
 	WalletEngine   *WalletEngine   // manages wallet→Core mapping, sync, backend routing
 	Settings       *SettingsStore
+
+	// forkEngine is the single source of truth for eCash fork state; wired by
+	// InitForkEngine once Core RPC is up. forkEnforcerWallet lets its scan reach
+	// the enforcer wallet's UTXOs (set later, once the enforcer client exists).
+	forkEngine         *fork.Engine
+	forkEnforcerWallet enforcerrpc.WalletServiceClient
 
 	configs    map[string]BinaryConfig
 	download   *DownloadManager

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -112,6 +112,15 @@ service OrchestratorService {
   // Generic raw bitcoind RPC. Optional `wallet` field routes the call to
   // /wallet/{name} on bitcoind for wallet-scoped RPCs.
   rpc CoreRawCall(CoreRawCallRequest) returns (CoreRawCallResponse);
+
+  // ─── eCash fork ───────────────────────────────────────────────────────────
+  // Report where the mainchain tip sits relative to the eCash fork height.
+  // The orchestrator is the single source of truth for the fork height; the
+  // frontend renders "fork mode" (the claim card) off fork_active. Per-wallet
+  // pre-fork coin detection and the sweep itself stay in the frontend via the
+  // existing WalletManagerService (listUnspent / sendTransaction), one call
+  // per wallet — this RPC only supplies the height.
+  rpc GetForkStatus(GetForkStatusRequest) returns (GetForkStatusResponse);
 }
 
 message BinaryStatusMsg {
@@ -523,6 +532,53 @@ message CoreRawCallRequest {
 message CoreRawCallResponse {
   // JSON-encoded result. Caller decodes to its expected shape.
   string result_json = 1;
+}
+
+// ─── eCash fork ─────────────────────────────────────────────────────────────
+
+message GetForkStatusRequest {}
+
+// Canonical fork snapshot produced by the orchestrator's single ForkEngine.
+// The frontend renders this verbatim — it does no fork math of its own.
+message GetForkStatusResponse {
+  // Next fork height (countdown target). Fixed per network, or the next
+  // 144-block boundary on signet's simulated daily fork.
+  int32 fork_height = 1;
+  // Current mainchain tip height.
+  int32 current_height = 2;
+  reserved 3; // was fork_active
+  // Current mainchain header height. Runs ahead of `current_height` during
+  // sync; the time-to-fork countdown is driven off this.
+  int32 current_headers = 4;
+  // Coins confirmed at/before this height are claimable. Equals fork_height on
+  // fixed-height networks; the last 144-boundary on signet.
+  int32 claim_boundary = 5;
+  // True on signet, where the fork recurs every 144 blocks.
+  bool simulated = 6;
+  // Any wallet holds un-swept pre-fork coins.
+  bool has_funds_to_claim = 7;
+  // Whether to show the next-fork countdown. False while coins are unclaimed
+  // (claim-before-countdown).
+  bool show_countdown = 8;
+  // Per-wallet claimable coins, with the exact UTXOs the sweep spends.
+  repeated ForkWalletClaim claims = 9;
+}
+
+message ForkWalletClaim {
+  string wallet_id = 1;
+  string wallet_name = 2;
+  uint64 claimable_sats = 3;
+  repeated ForkClaimUtxo utxos = 4;
+  // False when this wallet's claim can't be replay-protected (enforcer wallet);
+  // such coins are shown but not swept.
+  bool replay_protectable = 5;
+}
+
+message ForkClaimUtxo {
+  string outpoint = 1; // "txid:vout"
+  string address = 2;
+  uint64 sats = 3;
+  string label = 4;
 }
 
 // ─── Detached-daemon lifecycle ──────────────────────────────────────────────

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -312,6 +312,9 @@ message SendTransactionRequest {
   int64 fixed_fee_sats = 6;
   // Explicit wallet inputs to spend.
   repeated UnspentOutput required_inputs = 7;
+  // Build an eCash replay-protected transaction (magic version + extra byte so
+  // Bitcoin Core can't deserialize it). Core wallets only.
+  bool replay_protect = 8;
 }
 
 message SendTransactionResponse {

--- a/sidechain-orchestrator/replay/replay.go
+++ b/sidechain-orchestrator/replay/replay.go
@@ -1,0 +1,58 @@
+// Package replay encodes eCash replay-protected transactions. A claim tx is made
+// un-deserializable by Bitcoin Core (so it can't replay onto Bitcoin) by giving
+// it a magic version and writing one extra byte right after the version field —
+// CryptAxe's deprecated-mainchain scheme. Bitcoin Core chokes on that byte; the
+// eCash fork node knows to read past it.
+//
+// This package is pure hex surgery on a serialized transaction — no node, no
+// keys — so it's trivially testable. The version must be set BEFORE the tx is
+// signed (the signature commits to it); the byte is injected AFTER signing.
+package replay
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+// TxReplayVersion is the magic transaction version that triggers the eCash
+// serialization. 12566463 == 0x00BFBFBF; little-endian on the wire it is the 4
+// bytes bf bf bf 00.
+const TxReplayVersion int32 = 12566463
+
+// versionHexLE is TxReplayVersion as the first 4 little-endian bytes of a tx.
+const versionHexLE = "bfbfbf00"
+
+// TxReplayByte is the extra byte written after the version when it equals
+// TxReplayVersion. Its value only matters in that it breaks Bitcoin Core's
+// deserializer.
+const TxReplayByte byte = 0x3f
+
+// SetVersion overwrites the transaction's 4-byte version field with the magic
+// replay version, leaving the rest of the serialization untouched. Call this on
+// the unsigned tx so the signature commits to the magic version.
+func SetVersion(rawHex string) (string, error) {
+	if err := validate(rawHex); err != nil {
+		return "", err
+	}
+	return versionHexLE + rawHex[8:], nil
+}
+
+// InjectReplayByte inserts TxReplayByte immediately after the 4-byte version
+// field, producing the eCash wire format that Bitcoin Core cannot deserialize.
+// Call this on the fully signed tx, just before broadcast.
+func InjectReplayByte(rawHex string) (string, error) {
+	if err := validate(rawHex); err != nil {
+		return "", err
+	}
+	return rawHex[:8] + fmt.Sprintf("%02x", TxReplayByte) + rawHex[8:], nil
+}
+
+func validate(rawHex string) error {
+	if len(rawHex) < 8 {
+		return fmt.Errorf("raw tx hex too short: %d chars", len(rawHex))
+	}
+	if _, err := hex.DecodeString(rawHex); err != nil {
+		return fmt.Errorf("raw tx is not valid hex: %w", err)
+	}
+	return nil
+}

--- a/sidechain-orchestrator/replay/replay_test.go
+++ b/sidechain-orchestrator/replay/replay_test.go
@@ -1,0 +1,78 @@
+package replay
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// sampleTxHex builds a minimal, valid version-2 transaction and returns its hex.
+func sampleTxHex(t *testing.T) string {
+	t.Helper()
+	tx := wire.NewMsgTx(2)
+	var prev chainhash.Hash
+	tx.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&prev, 0), nil, nil))
+	tx.AddTxOut(wire.NewTxOut(1000, []byte{0x51})) // OP_TRUE
+	var buf bytes.Buffer
+	if err := tx.Serialize(&buf); err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	return hex.EncodeToString(buf.Bytes())
+}
+
+func deserialize(t *testing.T, rawHex string) (*wire.MsgTx, error) {
+	t.Helper()
+	raw, err := hex.DecodeString(rawHex)
+	if err != nil {
+		t.Fatalf("decode hex: %v", err)
+	}
+	tx := wire.NewMsgTx(1)
+	return tx, tx.Deserialize(bytes.NewReader(raw))
+}
+
+func TestSetVersionGivesMagicVersion(t *testing.T) {
+	versioned, err := SetVersion(sampleTxHex(t))
+	if err != nil {
+		t.Fatalf("SetVersion: %v", err)
+	}
+	if !strings.HasPrefix(versioned, "bfbfbf00") {
+		t.Fatalf("version bytes not set: %s", versioned[:8])
+	}
+	// Still a valid Bitcoin tx — only the version changed.
+	tx, err := deserialize(t, versioned)
+	if err != nil {
+		t.Fatalf("versioned tx should still deserialize: %v", err)
+	}
+	if tx.Version != TxReplayVersion {
+		t.Fatalf("version = %d, want %d", tx.Version, TxReplayVersion)
+	}
+}
+
+func TestInjectReplayByteBreaksBitcoinDeserialization(t *testing.T) {
+	versioned, err := SetVersion(sampleTxHex(t))
+	if err != nil {
+		t.Fatalf("SetVersion: %v", err)
+	}
+	injected, err := InjectReplayByte(versioned)
+	if err != nil {
+		t.Fatalf("InjectReplayByte: %v", err)
+	}
+	// The whole point: Bitcoin's deserializer cannot read the eCash format, so
+	// the tx can't replay onto Bitcoin.
+	if _, err := deserialize(t, injected); err == nil {
+		t.Fatal("expected Bitcoin deserialization to FAIL on the replay-encoded tx")
+	}
+}
+
+func TestRejectsBadInput(t *testing.T) {
+	if _, err := SetVersion("ab"); err == nil {
+		t.Fatal("SetVersion should reject too-short hex")
+	}
+	if _, err := InjectReplayByte("nothex!!"); err == nil {
+		t.Fatal("InjectReplayByte should reject non-hex")
+	}
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.257
+version: 1.0.258
 
 environment:
   sdk: 3.12.0

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.256
+version: 1.0.257
 
 environment:
   sdk: 3.12.0

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.127
+version: 1.0.128
 
 environment:
   sdk: 3.12.0

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.128
+version: 1.0.129
 
 environment:
   sdk: 3.12.0

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.255
+version: 1.0.256
 
 environment:
   sdk: 3.12.0

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.254
+version: 1.0.255
 
 environment:
   sdk: 3.12.0


### PR DESCRIPTION
Adds "fork mode" to bitwindow for the eCash fork.

- **Fork engine** (orchestrator `fork/`): single source of truth — per-network fork height (signet simulates a fork every 144 blocks for testing; regtest fixed at 400), per-wallet pre-fork coin detection, and claim-before-countdown gating. Served over `GetForkStatus`.
- **Countdown** (`fork_countdown_timer.dart`): ecash.com-style "T-MINUS" timer, scroll-away, shown on every tab while the fork is still ahead.
- **Claim card** (`fork_mode_banner.dart`): sweeps a wallet's pre-fork coins to a fresh address, one tx per wallet. The enforcer wallet is detected but not claimable.
- **Replay protection**: the `replay` package + `replay_protect` plumbing are wired but currently OFF — the claim broadcasts a plain (replayable) tx so the flow is testable on stock Core. Real opt-in/one-way protection is a follow-up.
- Also fixes unconfirmed txs not showing for Core wallets.

Generated `gen/` is regenerated proto. The standalone `ecash-broadcaster` server is a separate PR (#1817).