### PR TITLE
sailui: choose wallet provider on first screen; skip L1 for electrum

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.263
+version: 1.0.264
 
 environment:
   sdk: 3.12.0

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.263
+version: 1.0.264
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.118
+version: 0.2.119
 
 environment:
   sdk: 3.12.0

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.136
+version: 1.0.137
 
 environment:
   sdk: 3.12.0

--- a/sail_ui/lib/pages/create_wallet_page.dart
+++ b/sail_ui/lib/pages/create_wallet_page.dart
@@ -40,8 +40,22 @@ class SailCreateWalletPage extends StatefulWidget {
 
 enum WelcomeScreen { initial, restore, advanced, success }
 
+/// Which backend serves the first wallet. The seed comes from the same master
+/// flow regardless; the provider only picks the wallet type and which backend
+/// serves chain data. Electrum needs no local Bitcoin Core or enforcer.
+enum InitialWalletProvider {
+  enforcer('Enforcer', 'Full drivechain node — runs Bitcoin Core and the enforcer locally'),
+  bitcoinCore('Bitcoin Core', 'Served by your local Bitcoin Core node'),
+  electrum('Electrum', 'Lightweight — chain data from a remote server, no local node');
+
+  const InitialWalletProvider(this.label, this.description);
+  final String label;
+  final String description;
+}
+
 class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
   late WelcomeScreen _currentScreen;
+  InitialWalletProvider _selectedProvider = InitialWalletProvider.enforcer;
   final TextEditingController _mnemonicController = TextEditingController();
   final TextEditingController _passphraseController = TextEditingController();
   final TextEditingController _walletNameController = TextEditingController();
@@ -255,10 +269,15 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
         return;
       }
 
+      // Derive the master seed from the entropy without committing it, then
+      // import the same mnemonic into the chosen provider's wallet.
       final wallet = await _walletProvider.generateWalletFromEntropy(
         entropy,
-        name: walletName.isEmpty ? 'Enforcer Wallet' : walletName,
-        passphrase: null,
+        doNotSave: true,
+      );
+      await _createForProvider(
+        name: walletName.isEmpty ? _defaultWalletName : walletName,
+        customMnemonic: wallet['mnemonic'] as String?,
       );
       _currentWalletData = Map<String, dynamic>.from(wallet);
       _isValidInput = true;
@@ -749,6 +768,33 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
                   ),
                 ),
               ],
+              const SizedBox(height: 32),
+              SizedBox(
+                width: 400,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SailText.primary13('Provider', bold: true),
+                    const SailSpacing(SailStyleValues.padding08),
+                    SailDropdownButton<InitialWalletProvider>(
+                      value: _selectedProvider,
+                      items: InitialWalletProvider.values
+                          .map(
+                            (p) => SailDropdownItem<InitialWalletProvider>(
+                              value: p,
+                              label: p.label,
+                            ),
+                          )
+                          .toList(),
+                      onChanged: (p) {
+                        if (p != null) setState(() => _selectedProvider = p);
+                      },
+                    ),
+                    const SailSpacing(4),
+                    SailText.secondary12(_selectedProvider.description),
+                  ],
+                ),
+              ),
               Spacer(),
               SizedBox(
                 width: 400,
@@ -945,6 +991,39 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
     );
   }
 
+  String get _defaultWalletName => '${_selectedProvider.label} Wallet';
+
+  /// Creates the first wallet of the chosen [InitialWalletProvider]. The seed
+  /// always comes from the master flow — the backend generates it, or imports
+  /// [customMnemonic] — so the user's backup is identical across providers.
+  /// The provider only selects the wallet type and chain-data backend.
+  Future<void> _createForProvider({
+    required String name,
+    String? customMnemonic,
+    String? passphrase,
+  }) async {
+    switch (_selectedProvider) {
+      case InitialWalletProvider.enforcer:
+        await _walletProvider.generateWallet(
+          name: name,
+          customMnemonic: customMnemonic,
+          passphrase: passphrase,
+        );
+      case InitialWalletProvider.bitcoinCore:
+        await _walletProvider.createBitcoinCoreWallet(
+          name: name,
+          gradient: WalletGradient.fromWalletId(name),
+          customMnemonic: customMnemonic,
+        );
+      case InitialWalletProvider.electrum:
+        await _walletProvider.createElectrumWallet(
+          name: name,
+          gradient: WalletGradient.fromWalletId(name),
+          customMnemonic: customMnemonic,
+        );
+    }
+  }
+
   Future<void> _handleFastMode() async {
     if (mounted) setState(() => _error = null);
     try {
@@ -966,9 +1045,9 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
         return;
       }
 
-      final finalWalletName = walletName.isEmpty ? 'Enforcer Wallet' : walletName;
+      final finalWalletName = walletName.isEmpty ? _defaultWalletName : walletName;
 
-      await _walletProvider.generateWallet(name: finalWalletName);
+      await _createForProvider(name: finalWalletName);
       if (mounted) {
         _setScreen(WelcomeScreen.success);
       }
@@ -1006,9 +1085,9 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
     }
 
     try {
-      final finalWalletName = walletName.isEmpty ? 'Enforcer Wallet' : walletName;
+      final finalWalletName = walletName.isEmpty ? _defaultWalletName : walletName;
 
-      await _walletProvider.generateWallet(
+      await _createForProvider(
         name: finalWalletName,
         customMnemonic: _mnemonicController.text,
         passphrase: _passphraseController.text.isNotEmpty ? _passphraseController.text : null,

--- a/sail_ui/test/pages/create_wallet_page_test.dart
+++ b/sail_ui/test/pages/create_wallet_page_test.dart
@@ -28,4 +28,16 @@ void main() {
     );
     ready.dispose();
   });
+
+  test('InitialWalletProvider offers all three backends with enforcer first', () {
+    expect(InitialWalletProvider.values, [
+      InitialWalletProvider.enforcer,
+      InitialWalletProvider.bitcoinCore,
+      InitialWalletProvider.electrum,
+    ]);
+    for (final p in InitialWalletProvider.values) {
+      expect(p.label, isNotEmpty);
+      expect(p.description, isNotEmpty);
+    }
+  });
 }

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -691,6 +691,16 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 	go func() {
 		defer close(ch)
 
+		// Electrum (and any future remote-backed) wallets serve chain data with
+		// no local Bitcoin Core or enforcer. When such a wallet is active, every
+		// L1 boot path is a no-op. The gate lives here so no frontend can force
+		// the local stack up for a remote wallet — the backend owns the decision.
+		if o.WalletSvc != nil && !o.WalletSvc.ActiveWalletNeedsBitcoinBackends() {
+			o.log.Info().Str("target", target).Msg("active wallet is electrum; skipping local Bitcoin backends")
+			ch <- StartupProgress{Stage: "skipped-l1", Message: "electrum wallet active — no local Bitcoin backends needed", Done: true}
+			return
+		}
+
 		// If a previous bitwindowd's drain is still in flight, adopt it:
 		// flip the will-exit bit off and block until the drained stops
 		// finish. UI surfacing happens via per-binary startup logs inside

--- a/sidechain-orchestrator/start_with_l1_electrum_test.go
+++ b/sidechain-orchestrator/start_with_l1_electrum_test.go
@@ -1,0 +1,51 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestWalletService(t *testing.T) *wallet.Service {
+	t.Helper()
+	return wallet.NewService(t.TempDir(), testLogger(t))
+}
+
+// An electrum wallet serves chain data remotely, so StartWithL1 must boot
+// neither Bitcoin Core nor the enforcer — it short-circuits to a skipped-l1
+// completion and starts no processes.
+func TestStartWithL1SkipsBackendsForElectrum(t *testing.T) {
+	o := newTestOrchestrator(t)
+	svc := newTestWalletService(t)
+	_, err := svc.CreateElectrumWallet("Electrum", nil, nil, "", "", "")
+	require.NoError(t, err)
+	require.False(t, svc.ActiveWalletNeedsBitcoinBackends())
+	o.WalletSvc = svc
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch, err := o.StartWithL1(ctx, "bitcoind", StartOpts{})
+	require.NoError(t, err)
+
+	var stages []string
+	for p := range ch {
+		require.NoError(t, p.Error)
+		stages = append(stages, p.Stage)
+	}
+
+	require.Equal(t, []string{"skipped-l1"}, stages)
+	require.False(t, o.process.IsRunning("bitcoind"))
+	require.False(t, o.process.IsRunning("enforcer"))
+}
+
+// A non-electrum wallet needs the local stack, so the gate must not skip it.
+func TestStartWithL1NeedsBackendsForCoreWallet(t *testing.T) {
+	svc := newTestWalletService(t)
+	_, err := svc.GenerateWallet("Core", "", "", nil)
+	require.NoError(t, err)
+	require.True(t, svc.ActiveWalletNeedsBitcoinBackends())
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.265
+version: 1.0.266
 
 environment:
   sdk: 3.12.0

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.136
+version: 1.0.137
 
 environment:
   sdk: 3.12.0

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.263
+version: 1.0.264
 
 environment:
   sdk: 3.12.0


### PR DESCRIPTION
Adds a provider dropdown (Enforcer/Core/Electrum) to the first-run wallet screen, all routed through the master-seed flow.

Backend gates `StartWithL1`: when the active wallet is electrum, Bitcoin Core + enforcer never boot — at cold start or restart. Decision lives in the orchestrator.