### PR TITLE
orchestrator: electrum mode reads from a hosted remote instance

### DIFF
--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.118
+version: 0.2.119
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -49,10 +49,12 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/utils/v1/utilsv1connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1/walletv1connect"
 
+	orchconfig "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/datasource"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/enforcerproxy"
 	cryptorpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/crypto/v1/cryptov1connect"
 	validatorrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/localauth"
 	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
@@ -219,11 +221,15 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 	stdOpts := []connect.HandlerOption{connect.WithInterceptors(logInterceptor(), localauth.Interceptor(s.svcs.BitwindowDir))}
 
 	// Read-only data source: every handler reads chain/drivechain data through
-	// this interface instead of the raw clients. Backed by the local Core +
-	// enforcer clients. The getters are the seam: a future change can return a
-	// remote-dialed client (e.g. when the active wallet is electrum) without
-	// touching any handler. No remote implementation exists yet.
-	dataSource := datasource.NewLocal(s.Bitcoind.Get, s.Enforcer.Get, s.Wallet.Get)
+	// this interface instead of the raw clients. Local-backed for Core/enforcer
+	// wallets; for an electrum wallet (no local Core or enforcer) it dials a
+	// hosted, read-only orchestrator instead, so every read handler works
+	// unchanged. Rebuilt on Recycle, so a wallet-type switch re-selects.
+	var dataSource datasource.DataSource = datasource.NewLocal(s.Bitcoind.Get, s.Enforcer.Get, s.Wallet.Get)
+	if remote := remoteDataSourceForElectrum(ctx, s.svcs, conf.BitcoinCoreNetwork); remote != nil {
+		dataSource = remote
+		log.Info().Msg("electrum wallet active: routing bitwindow reads through remote orchestrator")
+	}
 
 	// bitwindowd — UpdateNetwork captured here calls back into Server.Recycle,
 	// which builds a fresh Runtime. Method value is bound to s, late-binds
@@ -418,6 +424,36 @@ func (rt *Runtime) runZMQ(ctx context.Context, log *zerolog.Logger) {
 	if err := zmqEngine.Run(ctx); err != nil && ctx.Err() == nil {
 		log.Error().Err(err).Msg("ZMQ engine exited with error")
 	}
+}
+
+// remoteDataSourceForElectrum returns a DataSource dialing the hosted,
+// read-only orchestrator for network when the active wallet is electrum (which
+// runs no local Core or enforcer), or nil to keep the local source. A missing
+// hosted instance or any lookup error falls back to local.
+func remoteDataSourceForElectrum(ctx context.Context, svcs Services, network config.Network) datasource.DataSource {
+	remoteURL := orchconfig.RemoteOrchestratorURLForNetwork(orchconfig.NetworkFromString(string(network)))
+	if remoteURL == "" || svcs.OrchestratorAddr == "" {
+		return nil
+	}
+	c := orchrpc.NewWalletManagerServiceClient(
+		http.DefaultClient,
+		svcs.OrchestratorAddr,
+		connect.WithInterceptors(localauth.Interceptor(svcs.BitwindowDir)),
+	)
+	resp, err := c.ListWallets(ctx, connect.NewRequest(&orchpb.ListWalletsRequest{}))
+	if err != nil {
+		return nil
+	}
+	for _, w := range resp.Msg.Wallets {
+		if w.Id != resp.Msg.ActiveWalletId {
+			continue
+		}
+		if w.WalletType == orchpb.WalletType_WALLET_TYPE_ELECTRUM {
+			return datasource.NewRemote(remoteURL)
+		}
+		return nil
+	}
+	return nil
 }
 
 func dialZmqEngine(ctx context.Context, conf config.Config) (*engines.ZMQ, error) {

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -328,11 +328,12 @@ func run(cctx *cli.Context) error {
 	}
 
 	// Electrum wallet provider — derives BIP84 keys locally and reads/broadcasts
-	// chain state over the Esplora REST API. No local Core/enforcer needed.
+	// chain state from a hosted, read-only orchestrator (orchestrator.<network>.
+	// drivechain.info). No local Core/enforcer needed.
 	var electrumBackend wallet.Backend
-	if esploraURL := config.EsploraURLForNetwork(config.NetworkFromString(network)); esploraURL != "" && netParams != nil {
-		electrumBackend = wallet.NewElectrumBackend(walletSvc, wallet.NewEsploraClient(esploraURL), netParams, log)
-		log.Info().Str("esplora_url", esploraURL).Msg("electrum wallet provider initialized")
+	if chainURL := config.ElectrumChainURLForNetwork(config.NetworkFromString(network)); chainURL != "" && netParams != nil {
+		electrumBackend = wallet.NewElectrumBackend(walletSvc, wallet.NewEsploraClient(chainURL), netParams, log)
+		log.Info().Str("chain_url", chainURL).Msg("electrum wallet provider initialized")
 	}
 
 	router := wallet.NewBackendRouter(walletSvc, enforcerBackend, chainBackend, electrumBackend)

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -68,6 +68,48 @@ func EsploraURLForNetwork(n Network) string {
 	}
 }
 
+// RemoteOrchestratorURLForNetwork returns the URL of a hosted, read-only
+// orchestrator for a given network. Electrum wallets run no local Core or
+// enforcer, so they read chain/BIP300 state from this remote instance while
+// signing and broadcasting locally. Mirrors node.<network>.drivechain.info.
+// Networks without a hosted instance return "".
+func RemoteOrchestratorURLForNetwork(n Network) string {
+	switch n {
+	case NetworkSignet:
+		return "https://orchestrator.signet.drivechain.info"
+	case NetworkForknet:
+		return "https://orchestrator.forknet.drivechain.info"
+	default:
+		return ""
+	}
+}
+
+// RemoteBitwindowURLForNetwork returns the URL of a hosted, read-only
+// bitwindowd for a given network. Companion to
+// RemoteOrchestratorURLForNetwork for the bitwindow-side read RPCs (news,
+// explorer, address book, stats). Networks without a hosted instance return "".
+func RemoteBitwindowURLForNetwork(n Network) string {
+	switch n {
+	case NetworkSignet:
+		return "https://bitwindow.signet.drivechain.info"
+	case NetworkForknet:
+		return "https://bitwindow.forknet.drivechain.info"
+	default:
+		return ""
+	}
+}
+
+// ElectrumChainURLForNetwork returns the chain-data API endpoint an electrum
+// wallet reads from. When a hosted read-only orchestrator exists for the
+// network the wallet routes through it; otherwise it falls back to the public
+// Esplora API. Returns "" when neither is available.
+func ElectrumChainURLForNetwork(n Network) string {
+	if remote := RemoteOrchestratorURLForNetwork(n); remote != "" {
+		return strings.TrimRight(remote, "/") + "/api"
+	}
+	return EsploraURLForNetwork(n)
+}
+
 // CoreSection returns the Bitcoin Core config section name for this network.
 func (n Network) CoreSection() string {
 	return CoreSectionForNetwork(n)

--- a/sidechain-orchestrator/config/remote_url_test.go
+++ b/sidechain-orchestrator/config/remote_url_test.go
@@ -1,0 +1,34 @@
+package config
+
+import "testing"
+
+func TestElectrumChainURLPrefersHostedOrchestrator(t *testing.T) {
+	// Signet has a hosted orchestrator → route through it, not public esplora.
+	got := ElectrumChainURLForNetwork(NetworkSignet)
+	want := "https://orchestrator.signet.drivechain.info/api"
+	if got != want {
+		t.Fatalf("signet electrum chain URL = %q, want %q", got, want)
+	}
+}
+
+func TestElectrumChainURLFallsBackToEsplora(t *testing.T) {
+	// Mainnet has no hosted orchestrator yet → fall back to the esplora URL.
+	if RemoteOrchestratorURLForNetwork(NetworkMainnet) != "" {
+		t.Skip("mainnet now has a hosted orchestrator; update this test")
+	}
+	got := ElectrumChainURLForNetwork(NetworkMainnet)
+	if got != EsploraURLForNetwork(NetworkMainnet) {
+		t.Fatalf("mainnet electrum chain URL = %q, want esplora fallback %q", got, EsploraURLForNetwork(NetworkMainnet))
+	}
+}
+
+func TestRemoteURLsEmptyForUnhostedNetworks(t *testing.T) {
+	for _, n := range []Network{NetworkRegtest, NetworkTestnet} {
+		if got := RemoteOrchestratorURLForNetwork(n); got != "" {
+			t.Errorf("RemoteOrchestratorURLForNetwork(%s) = %q, want empty", n, got)
+		}
+		if got := RemoteBitwindowURLForNetwork(n); got != "" {
+			t.Errorf("RemoteBitwindowURLForNetwork(%s) = %q, want empty", n, got)
+		}
+	}
+}

--- a/sidechain-orchestrator/datasource/remote.go
+++ b/sidechain-orchestrator/datasource/remote.go
@@ -1,0 +1,31 @@
+package datasource
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
+)
+
+// NewRemote builds a DataSource backed by a hosted, read-only orchestrator at
+// baseURL (e.g. https://orchestrator.signet.drivechain.info). Electrum wallets
+// run no local Core or enforcer, so their chain/drivechain reads come from this
+// remote instance, which bridges the Core proxy and the enforcer Validator and
+// Wallet services behind one host. Cookie-free: the remote is public read-only,
+// not local-auth gated, and speaks the Connect protocol over HTTPS.
+func NewRemote(baseURL string) *Local {
+	hc := &http.Client{Timeout: 30 * time.Second}
+	bitcoind := func(context.Context) (bitcoindv1alphaconnect.BitcoinServiceClient, error) {
+		return bitcoindv1alphaconnect.NewBitcoinServiceClient(hc, baseURL), nil
+	}
+	validator := func(context.Context) (mainchainv1connect.ValidatorServiceClient, error) {
+		return mainchainv1connect.NewValidatorServiceClient(hc, baseURL), nil
+	}
+	wallet := func(context.Context) (mainchainv1connect.WalletServiceClient, error) {
+		return mainchainv1connect.NewWalletServiceClient(hc, baseURL), nil
+	}
+	return NewLocal(bitcoind, validator, wallet)
+}


### PR DESCRIPTION
Electrum wallets run no local Core or enforcer, so their reads now come from a hosted, read-only orchestrator (`orchestrator.<network>.drivechain.info`) instead of public esplora.

- `config`: network-templated remote URLs, mirroring node.<network>.drivechain.info
- `datasource.NewRemote`: the remote implementation the seam was built for
- `bitwindow`: runtime selects the remote datasource when the active wallet is electrum

Keys/signing/broadcast stay local. Follow-up: route the DB-indexed feeds (news, graffiti, recent-tx) to the remote bitwindowd.