### PR TITLE
orchestrator: wipe stale chain data off the startup path

### DIFF
--- a/sidechain-orchestrator/config/binaries.go
+++ b/sidechain-orchestrator/config/binaries.go
@@ -352,14 +352,65 @@ func (b BinaryDirConfig) GetBlockchainDataPaths(networkDir string, network Netwo
 	}
 }
 
+// wipingSuffix marks a chain-data path that has been renamed aside and is being
+// deleted in the background.
+const wipingSuffix = ".wiping"
+
 // WipeChainData deletes on-disk chain state for network across all known
 // binaries. Wallet files are preserved. bitcoinDatadirOverride is the user's
 // datadir= setting for bitcoind, empty for the platform default.
+//
+// The whole operation runs in the background and returns immediately. It must
+// never block the caller: the chain datadir can be large, slow, or on an
+// unresponsive volume (e.g. an external disk that's asleep or unplugged), and
+// even a readdir or rename against a stalled mount hangs indefinitely. This
+// runs inside orchestrator startup, before the RPC listener binds, so a stall
+// here surfaced to the frontend as "backend not ready". Doomed paths are
+// renamed aside first — atomic and O(1) on the same filesystem — so a freshly
+// started bitcoind never sees half-deleted data, then deleted; leftover
+// ".wiping" siblings from an interrupted prior wipe are swept into the delete.
 func WipeChainData(network Network, bitcoinDatadirOverride string, log zerolog.Logger) {
-	for _, dc := range AllDirConfigs() {
-		networkDir := dc.DatadirNetwork(network, bitcoinDatadirOverride)
-		DeleteFilesWithRetry(dc.GetBlockchainDataPaths(networkDir, network, log), log)
+	go func() {
+		var doomed []string
+		for _, dc := range AllDirConfigs() {
+			networkDir := dc.DatadirNetwork(network, bitcoinDatadirOverride)
+			for _, p := range dc.GetBlockchainDataPaths(networkDir, network, log) {
+				orphans, _ := filepath.Glob(p + wipingSuffix + "*")
+				doomed = append(doomed, orphans...)
+				if aside := renameAside(p, log); aside != "" {
+					doomed = append(doomed, aside)
+				}
+			}
+		}
+		DeleteFilesWithRetry(doomed, log)
+	}()
+}
+
+// renameAside moves a doomed chain path to a unique sibling so the delete can
+// run off the startup critical path. Returns the new path, "" if p was already
+// gone, or p itself when a rename can't cross filesystems (still deleted in the
+// background). A collision means an orphaned wipe still owns that name, so the
+// next free suffix is used rather than blocking on a synchronous delete.
+func renameAside(p string, log zerolog.Logger) string {
+	for i := 0; i < 1000; i++ {
+		aside := p + wipingSuffix
+		if i > 0 {
+			aside = fmt.Sprintf("%s%d", aside, i)
+		}
+		if _, err := os.Lstat(aside); err == nil {
+			continue
+		}
+		if err := os.Rename(p, aside); err != nil {
+			if os.IsNotExist(err) {
+				return ""
+			}
+			log.Warn().Err(err).Str("path", p).Msg("rename-aside failed; deleting in place")
+			return p
+		}
+		return aside
 	}
+	log.Warn().Str("path", p).Msg("too many orphaned wipes; deleting in place")
+	return p
 }
 
 // GetWalletPaths returns wallet file paths for a binary.

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -120,14 +120,42 @@ func TestWipeChainDataPreservesWallets(t *testing.T) {
 
 	WipeChainData(NetworkSignet, "", zerolog.Nop())
 
-	for _, gone := range []string{"blocks", "chainstate", "indexes", "mempool.dat", "fee_estimates.dat", "peers.dat"} {
-		if _, err := os.Stat(filepath.Join(bcNet, gone)); !os.IsNotExist(err) {
-			t.Errorf("%s should be deleted", gone)
+	require.Eventually(t, func() bool {
+		for _, gone := range []string{"blocks", "chainstate", "indexes", "mempool.dat", "fee_estimates.dat", "peers.dat"} {
+			if _, err := os.Stat(filepath.Join(bcNet, gone)); !os.IsNotExist(err) {
+				return false
+			}
 		}
-	}
+		return true
+	}, 5*time.Second, 20*time.Millisecond)
+
 	if _, err := os.Stat(filepath.Join(bcNet, "wallets", "wallet.dat")); err != nil {
 		t.Error("wallets must survive a chain data wipe")
 	}
+}
+
+// The wipe runs entirely in the background and returns immediately so a large,
+// slow, or unresponsive datadir can't block orchestrator startup — that stall
+// is what kept the RPC listener down past the frontend's readiness timeout. The
+// data (and any renamed-aside .wiping copy) is gone once the background work
+// completes.
+func TestWipeChainDataDeletesInBackground(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	bcNet := BitcoinCoreDirs.DatadirNetwork(NetworkSignet, "")
+	blocks := filepath.Join(bcNet, "blocks", "blk00000.dat")
+	require.NoError(t, os.MkdirAll(filepath.Dir(blocks), 0o755))
+	require.NoError(t, os.WriteFile(blocks, []byte("stub"), 0o644))
+
+	WipeChainData(NetworkSignet, "", zerolog.Nop())
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(filepath.Join(bcNet, "blocks"))
+		_, wErr := os.Stat(filepath.Join(bcNet, "blocks"+wipingSuffix))
+		return os.IsNotExist(err) && os.IsNotExist(wErr)
+	}, 5*time.Second, 20*time.Millisecond)
 }
 
 // A user-set datadir= must be honoured so the wipe hits the real chain data.
@@ -143,9 +171,10 @@ func TestWipeChainDataHonoursDatadirOverride(t *testing.T) {
 
 	WipeChainData(NetworkSignet, custom, zerolog.Nop())
 
-	if _, err := os.Stat(filepath.Join(custom, "signet", "blocks")); !os.IsNotExist(err) {
-		t.Error("blocks under the overridden datadir should be deleted")
-	}
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(filepath.Join(custom, "signet", "blocks"))
+		return os.IsNotExist(err)
+	}, 5*time.Second, 20*time.Millisecond)
 }
 
 // A config that already carries the new challenge gets the version bump but


### PR DESCRIPTION
The signet-challenge migration wiped stale chain data synchronously inside orchestrator.New(), before the RPC listener binds. On a large, slow, or unresponsive datadir (e.g. an external volume that's asleep/unplugged) the os.RemoveAll — and even a readdir or rename — blocks indefinitely, so the listener never comes up and the frontend reports "backend not ready".

Run the whole wipe in the background: nothing on the startup path touches the chain datadir. Doomed paths are renamed aside (atomic, O(1)) so a fresh bitcoind never sees half-deleted data, then deleted; orphaned .wiping siblings are swept in.