### PR TITLE
Cap backup zip entry size to prevent zip bomb on restore

### DIFF
--- a/bitwindow/server/engines/backup_engine.go
+++ b/bitwindow/server/engines/backup_engine.go
@@ -223,6 +223,26 @@ func addToZip(zw *zip.Writer, name string, data []byte) error {
 	return err
 }
 
+// caps decompressed size of a backup zip entry to stop zip bombs (var for tests)
+var maxBackupEntrySize int64 = 50 << 20 // 50 MiB
+
+// readZipEntry reads a zip entry, rejecting ones larger than maxBackupEntrySize
+func readZipEntry(f *zip.File) ([]byte, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(io.LimitReader(rc, maxBackupEntrySize+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBackupEntrySize {
+		return nil, fmt.Errorf("backup entry %q exceeds %d byte limit", f.Name, maxBackupEntrySize)
+	}
+	return data, nil
+}
+
 func (e *BackupEngine) exportMultisigJSON(ctx context.Context) ([]byte, error) {
 	groups, err := e.multisigStore.ListGroups(ctx)
 	if err != nil {
@@ -437,12 +457,7 @@ func (e *BackupEngine) validateZIP(data []byte) (*BackupContents, error) {
 	for _, f := range r.File {
 		switch f.Name {
 		case "wallet.json":
-			rc, err := f.Open()
-			if err != nil {
-				return nil, fmt.Errorf("open wallet.json in zip: %w", err)
-			}
-			walletData, err := io.ReadAll(rc)
-			rc.Close()
+			walletData, err := readZipEntry(f)
 			if err != nil {
 				return nil, fmt.Errorf("read wallet.json in zip: %w", err)
 			}
@@ -451,12 +466,7 @@ func (e *BackupEngine) validateZIP(data []byte) (*BackupContents, error) {
 			}
 			contents.HasWallet = true
 		case "multisig/multisig.json", "multisig\\multisig.json":
-			rc, err := f.Open()
-			if err != nil {
-				continue
-			}
-			msData, err := io.ReadAll(rc)
-			rc.Close()
+			msData, err := readZipEntry(f)
 			if err != nil {
 				continue
 			}
@@ -465,12 +475,7 @@ func (e *BackupEngine) validateZIP(data []byte) (*BackupContents, error) {
 				contents.HasMultisig = true
 			}
 		case "transactions.json":
-			rc, err := f.Open()
-			if err != nil {
-				continue
-			}
-			txData, err := io.ReadAll(rc)
-			rc.Close()
+			txData, err := readZipEntry(f)
 			if err != nil {
 				continue
 			}
@@ -495,26 +500,24 @@ func extractZIP(data []byte) (walletJSON, metadataJSON, multisigJSON, txJSON []b
 	}
 
 	for _, f := range r.File {
-		rc, err := f.Open()
-		if err != nil {
-			continue
-		}
-		content, err := io.ReadAll(rc)
-		rc.Close()
-		if err != nil {
-			continue
-		}
-
+		var dst *[]byte
 		switch f.Name {
 		case "wallet.json":
-			walletJSON = content
+			dst = &walletJSON
 		case "metadata.json":
-			metadataJSON = content
+			dst = &metadataJSON
 		case "multisig/multisig.json", "multisig\\multisig.json":
-			multisigJSON = content
+			dst = &multisigJSON
 		case "transactions.json":
-			txJSON = content
+			dst = &txJSON
+		default:
+			continue
 		}
+		content, rerr := readZipEntry(f)
+		if rerr != nil {
+			return nil, nil, nil, nil, fmt.Errorf("read %s in zip: %w", f.Name, rerr)
+		}
+		*dst = content
 	}
 
 	return

--- a/bitwindow/server/engines/backup_engine_zipbomb_test.go
+++ b/bitwindow/server/engines/backup_engine_zipbomb_test.go
@@ -1,0 +1,49 @@
+package engines
+
+import (
+	"archive/zip"
+	"bytes"
+	"testing"
+)
+
+func zipWith(t *testing.T, name string, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	if err := addToZip(zw, name, data); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// an over-cap zip entry must be rejected, not read into memory
+func TestBackupZipEntryCapped(t *testing.T) {
+	orig := maxBackupEntrySize
+	maxBackupEntrySize = 1 << 10
+	defer func() { maxBackupEntrySize = orig }()
+
+	bomb := zipWith(t, "wallet.json", bytes.Repeat([]byte("a"), 8<<10))
+	if _, _, _, _, err := extractZIP(bomb); err == nil {
+		t.Fatal("extractZIP accepted an over-cap entry")
+	}
+	e := &BackupEngine{}
+	if _, err := e.validateZIP(bomb); err == nil {
+		t.Fatal("validateZIP accepted an over-cap entry")
+	}
+
+	// a valid within-cap backup still works
+	ok := zipWith(t, "wallet.json", []byte(`{"master":"x","l1":"y"}`))
+	wallet, _, _, _, err := extractZIP(ok)
+	if err != nil {
+		t.Fatalf("extractZIP rejected a valid backup: %v", err)
+	}
+	if len(wallet) == 0 {
+		t.Fatal("extractZIP did not return wallet.json")
+	}
+	if _, err := e.validateZIP(ok); err != nil {
+		t.Fatalf("validateZIP rejected a valid backup: %v", err)
+	}
+}


### PR DESCRIPTION
`validateZIP` and `extractZIP` read each backup zip entry with `io.ReadAll` and no decompressed-size limit. A malicious backup can inflate a tiny compressed entry into gigabytes, so importing it exhausts memory during `ValidateBackup` /
`RestoreBackup`. `extractZIP` also read every entry (including unknown names) before checking the name, so a bomb hidden in an ignored entry was still read.

Add `readZipEntry`, which reads through `io.LimitReader `and rejects entries larger than `maxBackupEntrySize` (50 MiB, well above any real backup). `extractZIP` now matches the entry name first and only reads the four known files. Trigger is a user importing a malicious backup file (local).

Add a regression test that a zip entry over the cap is rejected by both `extractZIP` and `validateZIP` while a valid backup still restores.