### PR TITLE
more fixes for electrum wallet

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.268
+version: 1.0.269
 
 environment:
   sdk: 3.12.0

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.268
+version: 1.0.269
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/lib/providers/hd_wallet_provider.dart
+++ b/bitwindow/lib/providers/hd_wallet_provider.dart
@@ -97,7 +97,12 @@ class HDWalletProvider extends ChangeNotifier {
       log.i('HDWalletProvider: getL1Starter returned len=${l1Mnemonic?.length ?? -1}');
 
       if (l1Mnemonic == null || l1Mnemonic.isEmpty) {
-        throw Exception('Could not load L1 wallet mnemonic');
+        // Electrum wallets have no L1 (enforcer) seed, so the HD Explorer has
+        // nothing to derive — leave it uninitialized without surfacing an error.
+        _seedHex = _masterKey = _mnemonic = null;
+        _initialized = false;
+        _error = null;
+        return;
       }
 
       _mnemonic = l1Mnemonic.trim();

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.125
+version: 0.2.126
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -98,6 +98,11 @@ type Runtime struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
+	// inflight counts in-flight request handlers so Close drains them before
+	// closing the DB — otherwise a network swap closes db out from under a
+	// running handler ("sql: database is closed").
+	inflight sync.WaitGroup
+
 	db       *sql.DB
 	mux      *http.ServeMux
 	services []string // service paths registered on mux, for grpcreflect
@@ -563,13 +568,36 @@ func (rt *Runtime) autoUnlockWallet(ctx context.Context) {
 	log.Info().Msg("wallet engine auto-unlocked successfully")
 }
 
-// Close cancels engines, waits for goroutines, and closes the DB.
-// Safe to call once. Subsequent calls are no-ops.
+// Handler wraps the runtime mux so in-flight requests are tracked in
+// rt.inflight; Close drains them before closing the DB.
+func (rt *Runtime) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rt.inflight.Add(1)
+		defer rt.inflight.Done()
+		rt.mux.ServeHTTP(w, r)
+	})
+}
+
+// Close cancels engines, waits for goroutines, drains in-flight request
+// handlers, then closes the DB. Safe to call once. Subsequent calls are no-ops.
 func (rt *Runtime) Close() {
 	if rt.cancel != nil {
 		rt.cancel()
 	}
 	rt.wg.Wait()
+
+	// Wait for in-flight handlers so none queries the DB after it closes.
+	// Bounded so a hung handler can't block teardown forever.
+	drained := make(chan struct{})
+	go func() {
+		rt.inflight.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+	case <-time.After(10 * time.Second):
+	}
+
 	if rt.db != nil {
 		_ = rt.db.Close()
 	}

--- a/bitwindow/server/api/server.go
+++ b/bitwindow/server/api/server.go
@@ -167,7 +167,7 @@ func New(
 	if err != nil {
 		return nil, fmt.Errorf("build initial runtime: %w", err)
 	}
-	srv.topSwap.swap(rt.mux)
+	srv.topSwap.swap(rt.Handler())
 	srv.current.Store(rt)
 	rt.Start(ctx)
 
@@ -205,7 +205,7 @@ func (s *Server) Recycle(ctx context.Context, network config.Network) error {
 	}
 
 	s.conf = newConf
-	s.topSwap.swap(rt.mux)
+	s.topSwap.swap(rt.Handler())
 	s.current.Store(rt)
 	rt.Start(s.rootCtx)
 

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.141
+version: 1.0.142
 
 environment:
   sdk: 3.12.0

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -370,8 +370,17 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
     notifyIfChanged(); // Use change tracking for normal updates
   }
 
+  // Electrum wallets run no local Core/enforcer, so the L1 daemons must not
+  // gate the bottom-nav connection status — otherwise it sticks on "Waiting
+  // for Bitcoin Core" forever. True for enforcer/core wallets and when no
+  // wallet is loaded yet.
+  bool get _needsBackends =>
+      !GetIt.I.isRegistered<WalletReaderProvider>() ||
+      GetIt.I.get<WalletReaderProvider>().activeWalletNeedsBitcoinBackends;
+
   // Connection status
-  bool get allConnected => mainchain.connected && enforcer.connected && additionalConnection.connected;
+  bool get allConnected =>
+      (!_needsBackends || (mainchain.connected && enforcer.connected)) && additionalConnection.connected;
   bool get initializingAny =>
       mainchain.initializingBinary || enforcer.initializingBinary || additionalConnection.initializingBinary;
   bool get downloadingAny => downloadProvider?.hasActiveDownloads ?? false;
@@ -386,8 +395,7 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
     //
     // `connected` is the authoritative "healthy" signal — stale startupError /
     // initializingBinary on an already-connected daemon are ignored.
-    if (mainchain.connectionError != null ||
-        enforcer.connectionError != null ||
+    if ((_needsBackends && (mainchain.connectionError != null || enforcer.connectionError != null)) ||
         additionalConnection.connectionError != null) {
       return SailColorScheme.red;
     }
@@ -400,11 +408,11 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
       return SailColorScheme.orange;
     }
 
-    if (!(syncProvider.mainchainSyncInfo?.isSynced ?? false)) {
+    if (_needsBackends && !(syncProvider.mainchainSyncInfo?.isSynced ?? false)) {
       return SailColorScheme.orange;
     }
 
-    if (!(syncProvider.enforcerSyncInfo?.isSynced ?? false)) {
+    if (_needsBackends && !(syncProvider.enforcerSyncInfo?.isSynced ?? false)) {
       return SailColorScheme.orange;
     }
 
@@ -445,17 +453,19 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
     // Precedence per service: connectionError (hard fail) > startupError (warmup message,
     // primary signal during boot per orchestrator design) > initializingBinary > !connected.
     // Bitcoin Core first because nothing else can make progress without it.
-    final mainchainLine = _statusLineFor(
-      rpc: mainchain,
-      binaryLabel: 'Bitcoin Core',
-    );
-    if (mainchainLine != null) return mainchainLine;
+    if (_needsBackends) {
+      final mainchainLine = _statusLineFor(
+        rpc: mainchain,
+        binaryLabel: 'Bitcoin Core',
+      );
+      if (mainchainLine != null) return mainchainLine;
 
-    final enforcerLine = _statusLineFor(
-      rpc: enforcer,
-      binaryLabel: 'Enforcer',
-    );
-    if (enforcerLine != null) return enforcerLine;
+      final enforcerLine = _statusLineFor(
+        rpc: enforcer,
+        binaryLabel: 'Enforcer',
+      );
+      if (enforcerLine != null) return enforcerLine;
+    }
 
     final additionalLine = _statusLineFor(
       rpc: additionalConnection.rpc,
@@ -463,11 +473,11 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
     );
     if (additionalLine != null) return additionalLine;
 
-    if (!(syncProvider.mainchainSyncInfo?.isSynced ?? false)) {
+    if (_needsBackends && !(syncProvider.mainchainSyncInfo?.isSynced ?? false)) {
       return 'Syncing mainchain blocks';
     }
 
-    if (!(syncProvider.enforcerSyncInfo?.isSynced ?? false)) {
+    if (_needsBackends && !(syncProvider.enforcerSyncInfo?.isSynced ?? false)) {
       return 'Syncing enforcer blocks';
     }
 

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -374,13 +374,13 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
   // gate the bottom-nav connection status — otherwise it sticks on "Waiting
   // for Bitcoin Core" forever. True for enforcer/core wallets and when no
   // wallet is loaded yet.
-  bool get _needsBackends =>
+  bool get needsBackends =>
       !GetIt.I.isRegistered<WalletReaderProvider>() ||
       GetIt.I.get<WalletReaderProvider>().activeWalletNeedsBitcoinBackends;
 
   // Connection status
   bool get allConnected =>
-      (!_needsBackends || (mainchain.connected && enforcer.connected)) && additionalConnection.connected;
+      (!needsBackends || (mainchain.connected && enforcer.connected)) && additionalConnection.connected;
   bool get initializingAny =>
       mainchain.initializingBinary || enforcer.initializingBinary || additionalConnection.initializingBinary;
   bool get downloadingAny => downloadProvider?.hasActiveDownloads ?? false;
@@ -395,7 +395,7 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
     //
     // `connected` is the authoritative "healthy" signal — stale startupError /
     // initializingBinary on an already-connected daemon are ignored.
-    if ((_needsBackends && (mainchain.connectionError != null || enforcer.connectionError != null)) ||
+    if ((needsBackends && (mainchain.connectionError != null || enforcer.connectionError != null)) ||
         additionalConnection.connectionError != null) {
       return SailColorScheme.red;
     }
@@ -408,15 +408,15 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
       return SailColorScheme.orange;
     }
 
-    if (_needsBackends && !(syncProvider.mainchainSyncInfo?.isSynced ?? false)) {
+    if (needsBackends && !(syncProvider.mainchainSyncInfo?.isSynced ?? false)) {
       return SailColorScheme.orange;
     }
 
-    if (_needsBackends && !(syncProvider.enforcerSyncInfo?.isSynced ?? false)) {
+    if (needsBackends && !(syncProvider.enforcerSyncInfo?.isSynced ?? false)) {
       return SailColorScheme.orange;
     }
 
-    if (!(additionalSyncInfo?.isSynced ?? false)) {
+    if (needsBackends && !(additionalSyncInfo?.isSynced ?? false)) {
       return SailColorScheme.orange;
     }
 
@@ -453,7 +453,7 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
     // Precedence per service: connectionError (hard fail) > startupError (warmup message,
     // primary signal during boot per orchestrator design) > initializingBinary > !connected.
     // Bitcoin Core first because nothing else can make progress without it.
-    if (_needsBackends) {
+    if (needsBackends) {
       final mainchainLine = _statusLineFor(
         rpc: mainchain,
         binaryLabel: 'Bitcoin Core',
@@ -473,15 +473,15 @@ class BottomNavViewModel extends BaseViewModel with ChangeTrackingMixin {
     );
     if (additionalLine != null) return additionalLine;
 
-    if (_needsBackends && !(syncProvider.mainchainSyncInfo?.isSynced ?? false)) {
+    if (needsBackends && !(syncProvider.mainchainSyncInfo?.isSynced ?? false)) {
       return 'Syncing mainchain blocks';
     }
 
-    if (_needsBackends && !(syncProvider.enforcerSyncInfo?.isSynced ?? false)) {
+    if (needsBackends && !(syncProvider.enforcerSyncInfo?.isSynced ?? false)) {
       return 'Syncing enforcer blocks';
     }
 
-    if (!(additionalSyncInfo?.isSynced ?? false)) {
+    if (needsBackends && !(additionalSyncInfo?.isSynced ?? false)) {
       return 'Syncing ${additionalConnection.name} blocks';
     }
 
@@ -524,6 +524,9 @@ class ChainLoaders extends ViewModelWidget<BottomNavViewModel> {
 
   @override
   Widget build(BuildContext context, BottomNavViewModel viewModel) {
+    // Electrum wallets run no L1 daemons, so there are no block-sync bars to
+    // show — the electrum scan status is rendered separately.
+    if (!viewModel.needsBackends) return const SizedBox.shrink();
     final mainchainConnected = viewModel.syncProvider.mainchainSyncInfo != null;
     final enforcerConnected = viewModel.syncProvider.enforcerSyncInfo != null;
     final additionalConnected = viewModel.additionalSyncInfo != null;

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -272,9 +272,17 @@ func run(cctx *cli.Context) error {
 	walletHandler.SetOrchestrator(orch)
 	walletHandler.SetBip47StateStore(bip47state.NewStore(bitwindowDir))
 
-	netParams, perr := bip47send.NetworkParams(network)
+	// Wallet derivation must follow the resolved/persisted network: bitwindow-
+	// bitcoin.conf wins over the --network flag (orchestratord is usually
+	// launched without --network). Using the raw flag derives signet/testnet
+	// addresses while the user is on mainnet.
+	resolvedNetwork := network
+	if orch.Network != "" {
+		resolvedNetwork = orch.Network
+	}
+	netParams, perr := bip47send.NetworkParams(resolvedNetwork)
 	if perr != nil {
-		log.Warn().Err(perr).Str("network", network).Msg("unrecognised network; BIP47 features will be disabled")
+		log.Warn().Err(perr).Str("network", resolvedNetwork).Msg("unrecognised network; BIP47 features will be disabled")
 	}
 
 	// Chain wallet provider — CoreBackend today; electrum/btcd providers
@@ -332,7 +340,7 @@ func run(cctx *cli.Context) error {
 	// so it needs an Esplora endpoint; bitwindow's higher-level reads route
 	// through the hosted orchestrator separately (see Server.buildDataSource).
 	var electrumBackend wallet.Backend
-	if net := config.NetworkFromString(network); config.ElectrumWalletSupportedForNetwork(net) && netParams != nil {
+	if net := config.NetworkFromString(resolvedNetwork); config.ElectrumWalletSupportedForNetwork(net) && netParams != nil {
 		esploraURL := config.EsploraURLForNetwork(net)
 		electrumBackend = wallet.NewElectrumBackend(walletSvc, wallet.NewEsploraClient(esploraURL), netParams, log)
 		log.Info().Str("esplora_url", esploraURL).Msg("electrum wallet provider initialized")

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -342,7 +342,7 @@ func run(cctx *cli.Context) error {
 	var electrumBackend wallet.Backend
 	if net := config.NetworkFromString(resolvedNetwork); config.ElectrumWalletSupportedForNetwork(net) && netParams != nil {
 		esploraURL := config.EsploraURLForNetwork(net)
-		electrumBackend = wallet.NewElectrumBackend(walletSvc, wallet.NewEsploraClient(esploraURL), netParams, log)
+		electrumBackend = wallet.NewElectrumBackend(walletSvc, wallet.NewEsploraClient(esploraURL, log), netParams, log)
 		log.Info().Str("esplora_url", esploraURL).Msg("electrum wallet provider initialized")
 	}
 

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -60,7 +60,10 @@ func EsploraURLForNetwork(n Network) string {
 	case NetworkSignet:
 		return "https://explorer.signet.drivechain.info/api"
 	case NetworkMainnet:
-		return "https://mempool.space/api"
+		// blockstream.info is the reference Esplora REST API, built for
+		// programmatic access. mempool.space's /api drops non-browser clients
+		// (requests hang until timeout), which stalls the gap-limit scan.
+		return "https://blockstream.info/api"
 	case NetworkForknet:
 		return "https://explorer.forknet.drivechain.info/api"
 	default:

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -48,6 +48,12 @@ type ElectrumBackend struct {
 	warmScan  map[string]*electrumScan // walletID -> cached scan, served between blocks
 	tipAt     map[string]int           // walletID -> chain tip the cached scan reflects
 	lastScan  map[string][]byte        // walletID -> last persisted scan bytes (skip rewrites)
+
+	// scanLocks serialises live scans per wallet so concurrent readers
+	// (balance, txs, utxos, stats all poll at once) collapse into a single
+	// gap-walk instead of each firing its own burst of Esplora requests.
+	scanMu    sync.Mutex
+	scanLocks map[string]*sync.Mutex
 }
 
 var _ Backend = (*ElectrumBackend)(nil)
@@ -64,6 +70,7 @@ func NewElectrumBackend(svc *Service, client Esplora, network *chaincfg.Params, 
 		warmScan:  make(map[string]*electrumScan),
 		tipAt:     make(map[string]int),
 		lastScan:  make(map[string][]byte),
+		scanLocks: make(map[string]*sync.Mutex),
 	}
 }
 
@@ -935,6 +942,18 @@ func (p *ElectrumBackend) scan(ctx context.Context, walletID string, allowCache 
 		if scan := p.cachedScan(ctx, walletID); scan != nil {
 			return scan, nil
 		}
+	}
+
+	// Serialise scans per wallet: when several readers miss the cache at once
+	// (cold boot, or just after a new block), only one walks the chain; the
+	// rest wait and then get the cache it just populated.
+	unlock := p.lockScan(walletID)
+	defer unlock()
+
+	if allowCache {
+		if scan := p.cachedScan(ctx, walletID); scan != nil {
+			return scan, nil
+		}
 		// Cold-boot fast path: rebuild the previous scan from disk with no network.
 		if scan, ok := p.loadColdScan(walletID, w); ok {
 			p.cacheScan(ctx, walletID, scan)
@@ -992,6 +1011,20 @@ func (p *ElectrumBackend) scan(ctx context.Context, walletID string, allowCache 
 	p.mu.Unlock()
 	p.cacheScan(ctx, walletID, scan)
 	return scan, nil
+}
+
+// lockScan returns the per-wallet scan mutex (creating it on first use), locked.
+// Call the returned func to unlock.
+func (p *ElectrumBackend) lockScan(walletID string) func() {
+	p.scanMu.Lock()
+	m := p.scanLocks[walletID]
+	if m == nil {
+		m = &sync.Mutex{}
+		p.scanLocks[walletID] = m
+	}
+	p.scanMu.Unlock()
+	m.Lock()
+	return m.Unlock
 }
 
 // cachedScan returns the in-memory scan when it still reflects the current chain

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -932,13 +932,19 @@ func (p *ElectrumBackend) scan(ctx context.Context, walletID string, allowCache 
 	}
 	scan.watchOnly = watchOnly
 	chainNames := []string{"external", "change"}
+	// Only stream per-address progress on a wallet's first scan this process
+	// (the initial sync). Warm wallets re-scan on routine balance polls, and
+	// streaming those would spin the bottom-nav "Scanning…" status forever.
+	p.mu.Lock()
+	initial := !p.warm[walletID]
+	p.mu.Unlock()
 	defer p.svc.syncReporter.publish(walletID, SyncProgress{Phase: SyncIdle, Message: "Idle"})
 	for i, d := range derivers {
 		chain := "external"
 		if i < len(chainNames) {
 			chain = chainNames[i]
 		}
-		addrs, err := p.scanChain(ctx, walletID, chain, d)
+		addrs, err := p.scanChain(ctx, walletID, chain, d, initial)
 		if err != nil {
 			return nil, err
 		}
@@ -1069,12 +1075,14 @@ func (p *ElectrumBackend) chainDerivers(w *WalletData) ([]chainDeriver, bool, er
 	return out, w.IsWatchOnly(), nil
 }
 
-func (p *ElectrumBackend) scanChain(ctx context.Context, walletID, chain string, derive chainDeriver) ([]scannedAddr, error) {
+func (p *ElectrumBackend) scanChain(ctx context.Context, walletID, chain string, derive chainDeriver, initial bool) ([]scannedAddr, error) {
 	var out []scannedAddr
 	consecutiveUnused := 0
 	found := 0
 	for i := uint32(0); consecutiveUnused < electrumGapLimit && i < electrumMaxScan; i++ {
-		p.svc.syncReporter.publish(walletID, scanProgress(chain, len(out), found))
+		if initial {
+			p.svc.syncReporter.publish(walletID, scanProgress(chain, len(out), found))
+		}
 		a, err := derive(i)
 		if err != nil {
 			return nil, err

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -43,9 +43,11 @@ type ElectrumBackend struct {
 	log     zerolog.Logger
 
 	mu        sync.Mutex
-	watchKeys map[string][]WatchKey // walletID -> extra keys to track
-	warm      map[string]bool       // walletID -> a live scan has run this process
-	lastScan  map[string][]byte     // walletID -> last persisted scan bytes (skip rewrites)
+	watchKeys map[string][]WatchKey    // walletID -> extra keys to track
+	warm      map[string]bool          // walletID -> a live scan has run this process
+	warmScan  map[string]*electrumScan // walletID -> cached scan, served between blocks
+	tipAt     map[string]int           // walletID -> chain tip the cached scan reflects
+	lastScan  map[string][]byte        // walletID -> last persisted scan bytes (skip rewrites)
 }
 
 var _ Backend = (*ElectrumBackend)(nil)
@@ -59,6 +61,8 @@ func NewElectrumBackend(svc *Service, client Esplora, network *chaincfg.Params, 
 		log:       log.With().Str("component", "electrum-backend").Logger(),
 		watchKeys: make(map[string][]WatchKey),
 		warm:      make(map[string]bool),
+		warmScan:  make(map[string]*electrumScan),
+		tipAt:     make(map[string]int),
 		lastScan:  make(map[string][]byte),
 	}
 }
@@ -403,13 +407,22 @@ func (p *ElectrumBackend) WatchKeys(ctx context.Context, walletID string, keys [
 	for _, k := range existing {
 		seen[k.WIF] = true
 	}
+	added := false
 	for _, k := range keys {
 		if !seen[k.WIF] {
 			existing = append(existing, k)
 			seen[k.WIF] = true
+			added = true
 		}
 	}
 	p.watchKeys[walletID] = existing
+	if added {
+		// The cache is keyed on a fixed address set + chain tip. BIP47 grows the
+		// address set mid-session without a new block, so tip-gating alone would
+		// keep serving the stale scan and never see payments to the new
+		// addresses. Drop the cache to force a re-walk on the next read.
+		delete(p.warmScan, walletID)
+	}
 	return nil
 }
 
@@ -914,9 +927,17 @@ func (p *ElectrumBackend) scan(ctx context.Context, walletID string, allowCache 
 		return nil, fmt.Errorf("wallet %s not found", walletID)
 	}
 
-	// Cold-boot fast path: rebuild the previous scan from disk with no network.
 	if allowCache {
+		// Sparrow-style: scan a wallet once, then serve from an in-memory cache
+		// between blocks. A wallet's balance/history can't change without a new
+		// block, so reads do a single cheap tip check instead of re-deriving the
+		// whole chain over Esplora on every poll.
+		if scan := p.cachedScan(ctx, walletID); scan != nil {
+			return scan, nil
+		}
+		// Cold-boot fast path: rebuild the previous scan from disk with no network.
 		if scan, ok := p.loadColdScan(walletID, w); ok {
+			p.cacheScan(ctx, walletID, scan)
 			return scan, nil
 		}
 	}
@@ -969,7 +990,45 @@ func (p *ElectrumBackend) scan(ctx context.Context, walletID string, allowCache 
 	p.mu.Lock()
 	p.warm[walletID] = true
 	p.mu.Unlock()
+	p.cacheScan(ctx, walletID, scan)
 	return scan, nil
+}
+
+// cachedScan returns the in-memory scan when it still reflects the current chain
+// tip. Between blocks a wallet's funds can't change, so a read is served from
+// cache after one cheap TipHeight call instead of a full re-walk. Returns nil
+// when there is no cache or a new block has arrived (the caller re-walks once
+// and refreshes the cache).
+func (p *ElectrumBackend) cachedScan(ctx context.Context, walletID string) *electrumScan {
+	p.mu.Lock()
+	scan := p.warmScan[walletID]
+	at, hasTip := p.tipAt[walletID]
+	p.mu.Unlock()
+	if scan == nil {
+		return nil
+	}
+	tip, err := p.client.TipHeight(ctx)
+	if err != nil {
+		return scan // network blip: serve cache rather than re-walk or fail the read
+	}
+	if hasTip && tip == at {
+		return scan // no new block → nothing changed
+	}
+	return nil // new block (or unknown tip): re-walk once to refresh
+}
+
+// cacheScan stores a completed scan as the in-memory cache, tagged with the
+// chain tip it reflects so cachedScan can detect staleness on the next block.
+func (p *ElectrumBackend) cacheScan(ctx context.Context, walletID string, scan *electrumScan) {
+	tip, err := p.client.TipHeight(ctx)
+	p.mu.Lock()
+	p.warmScan[walletID] = scan
+	if err == nil {
+		p.tipAt[walletID] = tip
+	} else {
+		delete(p.tipAt, walletID) // unknown tip → force a refresh on the next read
+	}
+	p.mu.Unlock()
 }
 
 // loadColdScan rebuilds a wallet's scan from its persisted cache without any

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -784,12 +784,13 @@ func TestElectrumScanPersistsAcrossRestart(t *testing.T) {
 	assert.InDelta(t, 0.0025, confirmed2, 1e-9, "cold boot returns the cached balance")
 	assert.Zero(t, atomic.LoadInt32(&counting.statsCalls), "cold boot must not query Esplora")
 
-	// The next call this session is live again: the empty backend now re-scans
-	// and sees no funds.
+	// The next call this session is served from the in-memory cache: no new
+	// block has arrived, so it does not re-query Esplora and returns the same
+	// balance (Sparrow-style scan-once-refresh-on-block).
 	confirmed3, _, err := p2.Balance(ctx, w.ID)
 	require.NoError(t, err)
-	assert.Zero(t, confirmed3, "second call re-scans live")
-	assert.Positive(t, atomic.LoadInt32(&counting.statsCalls), "second call queries Esplora")
+	assert.InDelta(t, 0.0025, confirmed3, 1e-9, "served from warm cache while tip unchanged")
+	assert.Zero(t, atomic.LoadInt32(&counting.statsCalls), "no re-query without a new block")
 }
 
 // recordingEsplora captures the wallet's sync snapshot at each AddressStats

--- a/sidechain-orchestrator/wallet/esplora.go
+++ b/sidechain-orchestrator/wallet/esplora.go
@@ -169,6 +169,8 @@ func (c *EsploraClient) do(ctx context.Context, method, path string, reqBody io.
 		if err != nil {
 			return nil, fmt.Errorf("build request %s: %w", path, err)
 		}
+		// Public Esplora hosts commonly drop requests without a User-Agent.
+		req.Header.Set("User-Agent", "bitwindow-orchestratord")
 
 		resp, err := c.client.Do(req)
 		if err != nil {

--- a/sidechain-orchestrator/wallet/esplora.go
+++ b/sidechain-orchestrator/wallet/esplora.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/rs/zerolog"
 )
 
 // Esplora is the chain-data surface an electrum wallet needs. ElectrumBackend
@@ -33,6 +35,7 @@ type Esplora interface {
 type EsploraClient struct {
 	baseURL string
 	client  *http.Client
+	log     zerolog.Logger
 
 	// Pacing keeps a gap-limit scan under public rate limits (mempool.space
 	// 429s a fast sequential burst). nextReq is the earliest the next request
@@ -40,6 +43,13 @@ type EsploraClient struct {
 	mu          sync.Mutex
 	nextReq     time.Time
 	minInterval time.Duration
+
+	// TipHeight is read on every wallet poll (balance, utxos, txs, stats), so
+	// cache it briefly — otherwise each read makes its own /blocks/tip/height
+	// call and the combined rate alone trips public Esplora 429 limits.
+	tipMu      sync.Mutex
+	tipVal     int
+	tipFetched time.Time
 }
 
 var _ Esplora = (*EsploraClient)(nil)
@@ -49,14 +59,16 @@ const (
 	esploraBackoffBase = 500 * time.Millisecond
 	esploraBackoffMax  = 8 * time.Second
 	esploraMinInterval = 120 * time.Millisecond
+	esploraTipTTL      = 30 * time.Second
 )
 
 // NewEsploraClient creates an Esplora REST client. baseURL is the API root
 // (e.g. https://explorer.signet.drivechain.info/api), trailing slash optional.
-func NewEsploraClient(baseURL string) *EsploraClient {
+func NewEsploraClient(baseURL string, log zerolog.Logger) *EsploraClient {
 	return &EsploraClient{
 		baseURL:     strings.TrimRight(baseURL, "/"),
 		client:      &http.Client{Timeout: 30 * time.Second},
+		log:         log.With().Str("component", "esplora").Logger(),
 		minInterval: esploraMinInterval,
 	}
 }
@@ -171,6 +183,7 @@ func (c *EsploraClient) do(ctx context.Context, method, path string, reqBody io.
 		}
 		// Public Esplora hosts commonly drop requests without a User-Agent.
 		req.Header.Set("User-Agent", "bitwindow-orchestratord")
+		c.log.Info().Str("method", method).Str("path", path).Int("attempt", attempt).Msg("esplora request")
 
 		resp, err := c.client.Do(req)
 		if err != nil {
@@ -338,6 +351,14 @@ func (c *EsploraClient) Broadcast(ctx context.Context, rawHex string) (string, e
 
 // TipHeight returns the height of the chain tip.
 func (c *EsploraClient) TipHeight(ctx context.Context) (int, error) {
+	c.tipMu.Lock()
+	if !c.tipFetched.IsZero() && time.Since(c.tipFetched) < esploraTipTTL {
+		v := c.tipVal
+		c.tipMu.Unlock()
+		return v, nil
+	}
+	c.tipMu.Unlock()
+
 	body, err := c.do(ctx, http.MethodGet, "/blocks/tip/height", nil)
 	if err != nil {
 		return 0, err
@@ -346,6 +367,10 @@ func (c *EsploraClient) TipHeight(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("parse tip height %q: %w", body, err)
 	}
+	c.tipMu.Lock()
+	c.tipVal = h
+	c.tipFetched = time.Now()
+	c.tipMu.Unlock()
 	return h, nil
 }
 

--- a/sidechain-orchestrator/wallet/esplora_retry_test.go
+++ b/sidechain-orchestrator/wallet/esplora_retry_test.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +25,7 @@ func TestEsploraRetriesOn429(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewEsploraClient(srv.URL + "/api")
+	c := NewEsploraClient(srv.URL+"/api", zerolog.Nop())
 	c.minInterval = 0
 
 	stats, err := c.AddressStats(context.Background(), "abc")
@@ -42,7 +43,7 @@ func TestEsploraDoesNotRetryClientError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewEsploraClient(srv.URL + "/api")
+	c := NewEsploraClient(srv.URL+"/api", zerolog.Nop())
 	c.minInterval = 0
 
 	_, err := c.AddressStats(context.Background(), "abc")

--- a/sidechain-orchestrator/wallet/esplora_test.go
+++ b/sidechain-orchestrator/wallet/esplora_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,7 +42,7 @@ func TestEsploraAddressTxsPaginationUsesConfirmedCursor(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewEsploraClient(srv.URL + "/api")
+	client := NewEsploraClient(srv.URL+"/api", zerolog.Nop())
 	txs, err := client.AddressTxs(context.Background(), "A")
 	require.NoError(t, err)
 	require.Len(t, txs, 27, "all pages must be fetched via the confirmed cursor")

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.270
+version: 1.0.271
 
 environment:
   sdk: 3.12.0

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.141
+version: 1.0.142
 
 environment:
   sdk: 3.12.0

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.268
+version: 1.0.269
 
 environment:
   sdk: 3.12.0


### PR DESCRIPTION
- **bitwindow: drain in-flight requests before closing runtime DB**
- **bitwindow: don't error HD explorer when wallet is electrum (no L1 seed)**
- **orchestrator: only stream electrum scan progress on initial sync**
- **sail_ui: don't gate bottom-nav status on L1 for electrum wallets**
- **orchestrator: derive wallet network from resolved net, not flag**
- **orchestrator: cache electrum scan, refresh on new block (Sparrow-style)**
- **orchestrator: use blockstream.info Esplora on mainnet + set User-Agent**
