### PR TITLE
Electrum wallet: SQLite-backed state, instant reads, BIP47, explorer fix

### DIFF
--- a/bitwindow/lib/utils/explorer_url.dart
+++ b/bitwindow/lib/utils/explorer_url.dart
@@ -1,19 +1,4 @@
-import 'package:sail_ui/sail_ui.dart';
-
-/// Resolve the explorer host for the active network. Mainnet sits at the
-/// bare `explorer.drivechain.info`; every other network gets its own
-/// subdomain. Regtest has no public explorer, so fall through to signet's.
-String _explorerHost(BitcoinNetwork network) => switch (network) {
-  BitcoinNetwork.BITCOIN_NETWORK_MAINNET => 'explorer.drivechain.info',
-  BitcoinNetwork.BITCOIN_NETWORK_FORKNET => 'explorer.forknet.drivechain.info',
-  BitcoinNetwork.BITCOIN_NETWORK_TESTNET => 'explorer.testnet.drivechain.info',
-  _ => 'explorer.signet.drivechain.info',
-};
-
-String mempoolAddressUrl(String address, BitcoinNetwork network) {
-  return 'https://${_explorerHost(network)}/address/$address';
-}
-
-String mempoolTxUrl(String txid, BitcoinNetwork network) {
-  return 'https://${_explorerHost(network)}/tx/$txid';
-}
+// The explorer-URL helpers live in sail_ui so shared widgets (e.g. the tx
+// context menu) resolve the same per-network host. Re-exported here so existing
+// bitwindow imports keep working.
+export 'package:sail_ui/utils/explorer_url.dart';

--- a/bitwindow/server/database/migrate.go
+++ b/bitwindow/server/database/migrate.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"embed"
-	"errors"
-	"fmt"
-	"sort"
 
+	"github.com/LayerTwo-Labs/sidesail/sqlitemigrate"
 	"github.com/rs/zerolog"
 )
 
@@ -15,68 +13,19 @@ import (
 var migrations embed.FS
 
 func runMigrations(ctx context.Context, db *sql.DB) error {
-	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS migrations (
-		id INTEGER PRIMARY KEY CHECK (id = 1), -- hard-coded id to force conflict when we later REPLACE INTO
-		latest_version TEXT NOT NULL
-	)`); err != nil {
-		return fmt.Errorf("could not create migrations table: %v", err)
-	}
-
-	// Fetch the latest applied migration
-	var latestVersion string
-	err := db.QueryRowContext(ctx, `SELECT latest_version FROM migrations`).Scan(&latestVersion)
-	if errors.Is(err, sql.ErrNoRows) {
-		// no migrations have been applied yet
-	} else if err != nil {
-		return fmt.Errorf("could not get latest migration: %v", err)
-	}
-
-	files, err := migrations.ReadDir("migrations")
+	applied, err := sqlitemigrate.Run(ctx, db, migrations, "migrations")
 	if err != nil {
-		return fmt.Errorf("could not read migrations directory: %v", err)
+		return err
 	}
-	sort.Slice(files, func(i, j int) bool {
-		return files[i].Name() < files[j].Name()
-	})
 
-	if len(files) > 0 && latestVersion == files[len(files)-1].Name() {
-		zerolog.Ctx(ctx).Info().Msg("database schema is up to date")
+	log := zerolog.Ctx(ctx)
+	if len(applied) == 0 {
+		log.Info().Msg("database schema is up to date")
 		return nil
 	}
-
-	zerolog.Ctx(ctx).Debug().
-		Str("latest_version", latestVersion).
-		Msg("applying migrations")
-
-	// apply each migration in order
-	for _, file := range files {
-		filename := file.Name()
-		if filename <= latestVersion {
-			continue
-		}
-		zerolog.Ctx(ctx).Debug().
-			Str("filename", filename).
-			Str("latest_version", latestVersion).
-			Msg("applying migration")
-
-		content, err := migrations.ReadFile("migrations/" + filename)
-		if err != nil {
-			return fmt.Errorf("could not read migration %s: %v", filename, err)
-		}
-
-		if _, err := db.Exec(string(content)); err != nil {
-			return fmt.Errorf("could not execute migration %s: %v", filename, err)
-		}
-
-		// Hard-coded id to force conflict, and replace the row
-		if _, err := db.Exec(`REPLACE INTO migrations (id, latest_version) VALUES (1, ?)`, filename); err != nil {
-			return fmt.Errorf("could not update latest migration: %v", err)
-		}
-
-		zerolog.Ctx(ctx).Info().Msgf("applied migration %s", filename)
+	for _, filename := range applied {
+		log.Info().Msgf("applied migration %s", filename)
 	}
-
-	zerolog.Ctx(ctx).Info().Msg("successfully applied all migrations")
-
+	log.Info().Msg("successfully applied all migrations")
 	return nil
 }

--- a/bitwindow/server/go.mod
+++ b/bitwindow/server/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e // indirect
 	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect
 	github.com/LayerTwo-Labs/sidesail/coinnews/codec v0.0.0
+	github.com/LayerTwo-Labs/sidesail/sqlitemigrate v0.0.0
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 )
@@ -70,3 +71,5 @@ require (
 replace github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator => ../../sidechain-orchestrator
 
 replace github.com/LayerTwo-Labs/sidesail/coinnews/codec => ../../coinnews/codec
+
+replace github.com/LayerTwo-Labs/sidesail/sqlitemigrate => ../../sqlitemigrate

--- a/sail_ui/lib/utils/explorer_url.dart
+++ b/sail_ui/lib/utils/explorer_url.dart
@@ -1,0 +1,19 @@
+import 'package:sail_ui/sail_ui.dart';
+
+/// Resolve the explorer host for the active network. Mainnet is real Bitcoin,
+/// so it points at mempool.space; the drivechain test networks each get their
+/// own explorer. Regtest has no public explorer, so fall through to signet's.
+String _explorerHost(BitcoinNetwork network) => switch (network) {
+  BitcoinNetwork.BITCOIN_NETWORK_MAINNET => 'mempool.space',
+  BitcoinNetwork.BITCOIN_NETWORK_FORKNET => 'explorer.forknet.drivechain.info',
+  BitcoinNetwork.BITCOIN_NETWORK_TESTNET => 'explorer.testnet.drivechain.info',
+  _ => 'explorer.signet.drivechain.info',
+};
+
+String mempoolAddressUrl(String address, BitcoinNetwork network) {
+  return 'https://${_explorerHost(network)}/address/$address';
+}
+
+String mempoolTxUrl(String txid, BitcoinNetwork network) {
+  return 'https://${_explorerHost(network)}/tx/$txid';
+}

--- a/sail_ui/lib/widgets/inputs/menu_items.dart
+++ b/sail_ui/lib/widgets/inputs/menu_items.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:sail_ui/sail_ui.dart';
+import 'package:sail_ui/utils/explorer_url.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 const _menuItemHeight = 33.0;
@@ -199,12 +201,12 @@ class MempoolMenuItem extends StatelessWidget implements SailMenuEntity {
 
   @override
   Widget build(BuildContext context) {
-    final url = 'https://explorer.drivechain.info/tx/$txid';
+    final network = GetIt.I.get<BitcoinConfProvider>().network;
     return SailMenuItem(
       onSelected: () async {
-        await launchUrl(Uri.parse(url));
+        await launchUrl(Uri.parse(mempoolTxUrl(txid, network)));
       },
-      child: SailText.primary12('View on explorer.drivechain.info'),
+      child: SailText.primary12('View transaction'),
     );
   }
 }

--- a/sidechain-orchestrator/api/bip47_send.go
+++ b/sidechain-orchestrator/api/bip47_send.go
@@ -53,17 +53,15 @@ func (h *WalletHandler) expandBip47Destinations(
 		return &bip47Expansion{destinations: destinations}, nil
 	}
 
-	var walletType wallet.WalletType
-	if w := h.svc.GetWalletByID(walletID); w != nil {
-		walletType = w.WalletType
-	}
-	if walletType != wallet.WalletTypeBitcoinCore {
-		return nil, connect.NewError(connect.CodeFailedPrecondition,
-			fmt.Errorf("BIP47 send for %s wallets is not yet supported: orchestrator can only blind ECDH for bitcoinCore wallets, where the master seed is locally derivable", walletType))
-	}
-
 	if h.engine == nil {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("bitcoin Core RPC not configured"))
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet backend not configured"))
+	}
+	// BIP47 send works for any backend that can sign the notification tx and
+	// hold the seed for ECDH blinding — Core and electrum both qualify. The
+	// enforcer (no spendable wallet) does not implement Bip47Backend.
+	if _, ok := h.engine.Bip47BackendFor(walletID); !ok {
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("BIP47 send is not supported for wallet %s: its backend cannot build the notification transaction", walletID))
 	}
 	if h.bip47State == nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("bip47 state store not configured"))

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -172,12 +172,10 @@ func (h *WalletHandler) ListWallets(ctx context.Context, req *connect.Request[pb
 			gradientJSON = string(w.Gradient)
 		}
 		// Watch-only wallets hold no seed, so BIP47 derivation is both pointless
-		// and noisy (it errors on the empty seed); skip it.
+		// and noisy (it errors on the empty seed); skip it. Advertise only for
+		// BIP47-capable backends (Core + electrum), the wallets the engine watches.
 		var bip47Code string
-		// Electrum wallets advertise no BIP47 code: inbound BIP47 (BIP47Engine)
-		// only watches bitcoinCore wallets, so a published code would receive
-		// payments the wallet never discovers.
-		if !w.IsWatchOnly() && w.WalletType != wallet.WalletTypeElectrum {
+		if !w.IsWatchOnly() && h.bip47Capable(w.ID) {
 			code, err := wallet.Bip47PaymentCodeFromSeed(w.Master.SeedHex, h.bip47NetParams())
 			if err != nil {
 				h.svc.Log().Error().Err(err).Str("wallet_id", w.ID).Msg("ListWallets: bip47 derivation failed")
@@ -950,6 +948,7 @@ func (h *WalletHandler) sendWalletData(stream *connect.ServerStream[pb.WatchWall
 		h.svc.IsEncrypted(),
 		h.svc.IsUnlocked(),
 		h.bip47NetParams(),
+		h.bip47Capable,
 		bip47Logger(h.svc),
 	)
 	*seq++
@@ -967,19 +966,30 @@ func bip47Logger(svc *wallet.Service) func(walletID string, err error) {
 	}
 }
 
-func buildWatchWalletDataResponse(wallets []wallet.WalletData, activeID string, hasWallet, encrypted, unlocked bool, netParams *chaincfg.Params, onBip47Err func(walletID string, err error)) *pb.WatchWalletDataResponse {
+// bip47Capable reports whether a wallet's backend can participate in BIP47, so a
+// payment code is advertised only for wallets the inbound engine actually
+// watches. Same capability source the engine and send path use (Core + electrum,
+// not the enforcer or an unconfigured backend).
+func (h *WalletHandler) bip47Capable(walletID string) bool {
+	if h.engine == nil {
+		return false
+	}
+	_, ok := h.engine.Bip47BackendFor(walletID)
+	return ok
+}
+
+func buildWatchWalletDataResponse(wallets []wallet.WalletData, activeID string, hasWallet, encrypted, unlocked bool, netParams *chaincfg.Params, bip47Capable func(walletID string) bool, onBip47Err func(walletID string, err error)) *pb.WatchWalletDataResponse {
 	pbWallets := make([]*pb.WalletMetadata, len(wallets))
 	for i, w := range wallets {
 		var gradientJSON string
 		if w.Gradient != nil {
 			gradientJSON = string(w.Gradient)
 		}
-		// Watch-only wallets hold no seed; skip BIP47 derivation on them.
+		// Watch-only wallets hold no seed; skip BIP47 derivation on them. The
+		// code is advertised only for BIP47-capable backends (Core + electrum),
+		// the same wallets the inbound engine watches.
 		var bip47Code string
-		// Electrum wallets advertise no BIP47 code: inbound BIP47 (BIP47Engine)
-		// only watches bitcoinCore wallets, so a published code would receive
-		// payments the wallet never discovers.
-		if !w.IsWatchOnly() && w.WalletType != wallet.WalletTypeElectrum {
+		if !w.IsWatchOnly() && bip47Capable(w.ID) {
 			code, err := wallet.Bip47PaymentCodeFromSeed(w.Master.SeedHex, netParams)
 			if err != nil && onBip47Err != nil {
 				onBip47Err(w.ID, err)

--- a/sidechain-orchestrator/api/wallet_handler_test.go
+++ b/sidechain-orchestrator/api/wallet_handler_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 )
 
+// bip47CapableAll marks every wallet BIP47-capable, exercising the response
+// builder's payment-code branch independently of backend wiring.
+func bip47CapableAll(string) bool { return true }
+
 func TestBuildWatchWalletDataResponseStartersAttachToEnforcer(t *testing.T) {
 	now := time.Now().UTC()
 	enforcer := wallet.WalletData{
@@ -37,7 +41,7 @@ func TestBuildWatchWalletDataResponseStartersAttachToEnforcer(t *testing.T) {
 	resp := buildWatchWalletDataResponse(
 		[]wallet.WalletData{enforcer, core},
 		core.ID, // active wallet is the Core wallet, NOT the enforcer
-		true, false, true, nil, nil,
+		true, false, true, nil, bip47CapableAll, nil,
 	)
 
 	if got := resp.GetActiveWalletId(); got != core.ID {
@@ -104,7 +108,7 @@ func TestBuildWatchWalletDataResponseEnforcerSidechainsRoundTrip(t *testing.T) {
 	}
 
 	resp := buildWatchWalletDataResponse(
-		[]wallet.WalletData{enforcer}, enforcer.ID, true, false, true, nil, nil,
+		[]wallet.WalletData{enforcer}, enforcer.ID, true, false, true, nil, bip47CapableAll, nil,
 	)
 
 	w := resp.GetWallets()[0]
@@ -146,7 +150,7 @@ func TestBuildWatchWalletDataResponseBip47Populated(t *testing.T) {
 
 	resp := buildWatchWalletDataResponse(
 		[]wallet.WalletData{hot, watchOnly},
-		hot.ID, true, false, true, nil, nil,
+		hot.ID, true, false, true, nil, bip47CapableAll, nil,
 	)
 
 	var hotMd, watchMd string
@@ -184,7 +188,7 @@ func TestBuildWatchWalletDataResponseBip47ErrorSurfaces(t *testing.T) {
 	cb := func(id string, err error) { seenID = id; seenErr = err }
 
 	resp := buildWatchWalletDataResponse(
-		[]wallet.WalletData{bad}, bad.ID, true, false, true, nil, cb,
+		[]wallet.WalletData{bad}, bad.ID, true, false, true, nil, bip47CapableAll, cb,
 	)
 
 	if resp.GetWallets()[0].GetBip47PaymentCode() != "" {
@@ -214,7 +218,7 @@ func TestBuildWatchWalletDataResponseLegacyWalletTypeStarters(t *testing.T) {
 		Sidechains: []wallet.SidechainWallet{{Slot: 9, Name: "Thunder", Mnemonic: "legacy-side"}},
 	}
 	resp := buildWatchWalletDataResponse(
-		[]wallet.WalletData{legacy}, legacy.ID, true, false, true, nil, nil,
+		[]wallet.WalletData{legacy}, legacy.ID, true, false, true, nil, bip47CapableAll, nil,
 	)
 	w := resp.GetWallets()[0]
 	if w.GetMasterMnemonic() != "legacy master" {

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -354,11 +354,14 @@ func run(cctx *cli.Context) error {
 		// Fork engine: single source of truth for eCash fork state, needs
 		// Core-backed wallet access for its claimable scan.
 		orch.InitForkEngine(walletEngine)
+	}
 
-		// BIP47 receive engine: watches each Core wallet's notification address
-		// for incoming notification txs, decodes their OP_RETURN payload to
-		// recover the sender's payment code, and imports per-payment receive
-		// descriptors so subsequent payments are spendable.
+	// BIP47 receive engine: watches each BIP47-capable wallet's (Core + electrum)
+	// notification address for incoming notification txs, decodes their OP_RETURN
+	// payload to recover the sender's payment code, and imports per-payment
+	// receive keys so subsequent payments are spendable. Starts whenever any
+	// BIP47-capable backend is configured — an electrum-only wallet needs it too.
+	if chainBackend != nil || electrumBackend != nil {
 		bip47InboundStore := bip47state.NewInboundStore(bitwindowDir)
 		bip47Engine := engines.NewBIP47Engine(log, walletSvc, walletEngine, bip47InboundStore)
 		go func() {

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -341,9 +341,9 @@ func run(cctx *cli.Context) error {
 	// through the hosted orchestrator separately (see Server.buildDataSource).
 	var electrumBackend wallet.Backend
 	if net := config.NetworkFromString(resolvedNetwork); config.ElectrumWalletSupportedForNetwork(net) && netParams != nil {
-		esploraURL := config.EsploraURLForNetwork(net)
-		electrumBackend = wallet.NewElectrumBackend(walletSvc, wallet.NewEsploraClient(esploraURL, log), netParams, log)
-		log.Info().Str("esplora_url", esploraURL).Msg("electrum wallet provider initialized")
+		esploraURLs := config.EsploraURLsForNetwork(net)
+		electrumBackend = wallet.NewElectrumBackend(walletSvc, wallet.NewEsploraClient(esploraURLs, log), netParams, log)
+		log.Info().Strs("esplora_urls", esploraURLs).Msg("electrum wallet provider initialized")
 	}
 
 	router := wallet.NewBackendRouter(walletSvc, enforcerBackend, chainBackend, electrumBackend)

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -61,10 +61,10 @@ func EsploraURLsForNetwork(n Network) []string {
 	case NetworkSignet:
 		return []string{"https://explorer.signet.drivechain.info/api"}
 	case NetworkMainnet:
-		// mempool.space first, blockstream.info as fallback. Both are reference
-		// Esplora REST APIs; the wallet sends a browser User-Agent so mempool
-		// (which drops non-browser clients) serves it.
-		return []string{"https://mempool.space/api", "https://blockstream.info/api"}
+		// blockstream.info first (reliable for programmatic clients), mempool.space
+		// as fallback. mempool throttles/stalls non-browser traffic, so it is the
+		// backup rather than the primary.
+		return []string{"https://blockstream.info/api", "https://mempool.space/api"}
 	case NetworkForknet:
 		return []string{"https://explorer.forknet.drivechain.info/api"}
 	default:

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -51,24 +51,36 @@ func RPCPortForNetwork(n Network) int {
 	}
 }
 
-// EsploraURLForNetwork returns the esplora API URL for a given network.
-// Regtest returns "" — no public esplora exists for it and we don't ship a
-// local one, so the enforcer falls back to wallet-sync-source=disabled
-// (see GetCliArgs in enforcer_conf.go).
-func EsploraURLForNetwork(n Network) string {
+// EsploraURLsForNetwork returns the esplora API URLs for a network, primary
+// first. The wallet rotates to the next on a rate-limit/outage, so a network
+// can list multiple providers for resilience. Regtest returns nil — no public
+// esplora exists for it and we don't ship a local one, so the enforcer falls
+// back to wallet-sync-source=disabled (see GetCliArgs in enforcer_conf.go).
+func EsploraURLsForNetwork(n Network) []string {
 	switch n {
 	case NetworkSignet:
-		return "https://explorer.signet.drivechain.info/api"
+		return []string{"https://explorer.signet.drivechain.info/api"}
 	case NetworkMainnet:
-		// blockstream.info is the reference Esplora REST API, built for
-		// programmatic access. mempool.space's /api drops non-browser clients
-		// (requests hang until timeout), which stalls the gap-limit scan.
-		return "https://blockstream.info/api"
+		// mempool.space first, blockstream.info as fallback. Both are reference
+		// Esplora REST APIs; the wallet sends a browser User-Agent so mempool
+		// (which drops non-browser clients) serves it.
+		return []string{"https://mempool.space/api", "https://blockstream.info/api"}
 	case NetworkForknet:
-		return "https://explorer.forknet.drivechain.info/api"
+		return []string{"https://explorer.forknet.drivechain.info/api"}
 	default:
+		return nil
+	}
+}
+
+// EsploraURLForNetwork returns a network's primary esplora API URL (or "" when
+// none exists), for callers that take a single endpoint such as the enforcer's
+// wallet-sync-source.
+func EsploraURLForNetwork(n Network) string {
+	urls := EsploraURLsForNetwork(n)
+	if len(urls) == 0 {
 		return ""
 	}
+	return urls[0]
 }
 
 // RemoteOrchestratorURLForNetwork returns the URL of a hosted, read-only

--- a/sidechain-orchestrator/engines/bip47_engine.go
+++ b/sidechain-orchestrator/engines/bip47_engine.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -49,14 +50,20 @@ type BIP47Engine struct {
 	svc     *wallet.Service
 	engine  *wallet.WalletEngine
 	inbound *bip47state.InboundStore
+
+	mu sync.Mutex
+	// notifWatched records wallets whose own notification key has been
+	// registered with the backend this process, so we only do it once.
+	notifWatched map[string]bool
 }
 
 func NewBIP47Engine(log zerolog.Logger, svc *wallet.Service, walletEngine *wallet.WalletEngine, inbound *bip47state.InboundStore) *BIP47Engine {
 	return &BIP47Engine{
-		log:     log.With().Str("component", "bip47").Logger(),
-		svc:     svc,
-		engine:  walletEngine,
-		inbound: inbound,
+		log:          log.With().Str("component", "bip47").Logger(),
+		svc:          svc,
+		engine:       walletEngine,
+		inbound:      inbound,
+		notifWatched: make(map[string]bool),
 	}
 }
 
@@ -85,16 +92,22 @@ func (e *BIP47Engine) tick(ctx context.Context) {
 	wallets := e.svc.GetAllWallets()
 	for i := range wallets {
 		w := &wallets[i]
-		if w.WalletType == wallet.WalletTypeEnforcer {
+		backend, ok := e.engine.Bip47BackendFor(w.ID)
+		if !ok {
+			// Not BIP47-capable (the enforcer wallet, or its backend isn't
+			// configured) — nothing to watch.
 			continue
 		}
 		seedHex := w.Master.SeedHex
 		if seedHex == "" {
 			continue
 		}
-		if _, err := e.engine.Backend().Ensure(ctx, w.ID); err != nil {
+		if _, err := backend.Ensure(ctx, w.ID); err != nil {
 			// Wallet may still be warming up on the backend; retry next tick.
 			continue
+		}
+		if err := e.ensureNotificationWatched(ctx, backend, w.ID, seedHex, net); err != nil {
+			e.log.Warn().Err(err).Str("wallet", w.ID).Msg("ensure notification watched failed")
 		}
 		if err := e.scanWallet(ctx, w.ID, seedHex, net); err != nil {
 			e.log.Warn().Err(err).Str("wallet", w.ID).Msg("scan failed")
@@ -103,6 +116,36 @@ func (e *BIP47Engine) tick(ctx context.Context) {
 			e.log.Warn().Err(err).Str("wallet", w.ID).Msg("extend imports failed")
 		}
 	}
+}
+
+// ensureNotificationWatched registers a wallet's own notification key with its
+// backend once per process, so the backend scans the notification address and
+// inbound notification txs surface in ListTransactionsRange. RescanFrom 0 forces
+// a full history rescan so notifications received before first observation are
+// still found. For Core this is a no-op after the creation-time descriptor
+// import; for electrum it adds the address to the scan.
+func (e *BIP47Engine) ensureNotificationWatched(ctx context.Context, backend wallet.Bip47Backend, walletID, seedHex string, net *chaincfg.Params) error {
+	e.mu.Lock()
+	already := e.notifWatched[walletID]
+	e.mu.Unlock()
+	if already {
+		return nil
+	}
+	notifPriv, _, err := bip47.DeriveOwnNotificationKey(seedHex, net)
+	if err != nil {
+		return fmt.Errorf("derive own notification key: %w", err)
+	}
+	wif, err := btcutil.NewWIF(notifPriv, net, true)
+	if err != nil {
+		return fmt.Errorf("encode notification wif: %w", err)
+	}
+	if err := backend.EnsureNotificationWatched(ctx, walletID, wallet.WatchKey{WIF: wif.String(), RescanFrom: 0}); err != nil {
+		return err
+	}
+	e.mu.Lock()
+	e.notifWatched[walletID] = true
+	e.mu.Unlock()
+	return nil
 }
 
 // scanWallet walks listtransactions forward from the persisted cursor looking

--- a/sidechain-orchestrator/go.mod
+++ b/sidechain-orchestrator/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/btcsuite/btcd/btcutil/psbt v1.2.0
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/mattn/go-sqlite3 v1.14.45
 	github.com/rs/zerolog v1.34.0
 	github.com/samber/lo v1.52.0
 	github.com/stretchr/testify v1.11.1
@@ -27,6 +28,7 @@ require (
 	connectrpc.com/grpcreflect v1.3.0 // indirect
 	github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e // indirect
 	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect
+	github.com/LayerTwo-Labs/sidesail/sqlitemigrate v0.0.0
 	github.com/btcsuite/btclog v1.0.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -44,3 +46,5 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/LayerTwo-Labs/sidesail/sqlitemigrate => ../sqlitemigrate

--- a/sidechain-orchestrator/go.sum
+++ b/sidechain-orchestrator/go.sum
@@ -92,6 +92,8 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-sqlite3 v1.14.45 h1:6KA/spDguL3KV8rnybG7ezSaE4SeMR3KC9VbUoAQaIk=
+github.com/mattn/go-sqlite3 v1.14.45/go.mod h1:pjEuOr8IwzLJP2MfGeTb0A35jauH+C2kbHKBr7yXKVQ=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=

--- a/sidechain-orchestrator/wallet/backend.go
+++ b/sidechain-orchestrator/wallet/backend.go
@@ -52,6 +52,21 @@ type Backend interface {
 	Chain() ChainSource
 }
 
+// Bip47Backend is a Backend that can participate in BIP47. Everything the send
+// path and inbound engine need is already on Backend (WatchKeys, the chain
+// reads, signing); the one backend-specific operation is watching the wallet's
+// own notification address. Core (descriptor import) and electrum (watch key)
+// implement it; the enforcer does not, so it is simply not BIP47-capable. A new
+// provider becomes BIP47-capable by implementing this one method.
+type Bip47Backend interface {
+	Backend
+	// EnsureNotificationWatched makes the wallet track its own BIP47
+	// notification address (the P2PKH for notifKey), rescanning history per
+	// notifKey.RescanFrom so past notifications surface in ListTransactionsRange.
+	// Idempotent.
+	EnsureNotificationWatched(ctx context.Context, walletID string, notifKey WatchKey) error
+}
+
 // ChainSource is wallet-agnostic chain access shared by all backends.
 type ChainSource interface {
 	GetRawTransaction(ctx context.Context, txid string) (*RawTransaction, error)

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -50,7 +50,10 @@ type CoreBackend struct {
 	loadingErr   error
 }
 
-var _ Backend = (*CoreBackend)(nil)
+var (
+	_ Backend      = (*CoreBackend)(nil)
+	_ Bip47Backend = (*CoreBackend)(nil)
+)
 
 // NewCoreBackend creates the Bitcoin Core wallet backend.
 func NewCoreBackend(svc *Service, rpc *CoreRPCClient, network *chaincfg.Params, log zerolog.Logger) *CoreBackend {
@@ -311,6 +314,13 @@ func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []Wat
 		p.log.Warn().Int("descriptor_index", i).Str("error", msg).Msg("watch key import failed")
 	}
 	return nil
+}
+
+// EnsureNotificationWatched imports the wallet's own BIP47 notification key as a
+// pkh() descriptor so Core's listtransactions surfaces inbound notification
+// txs. Idempotent — Core ignores already-known descriptors.
+func (p *CoreBackend) EnsureNotificationWatched(ctx context.Context, walletID string, notifKey WatchKey) error {
+	return p.WatchKeys(ctx, walletID, []WatchKey{notifKey})
 }
 
 // Send routes simple sends through Core's own coin selection

--- a/sidechain-orchestrator/wallet/db.go
+++ b/sidechain-orchestrator/wallet/db.go
@@ -1,0 +1,31 @@
+package wallet
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"fmt"
+
+	"github.com/LayerTwo-Labs/sidesail/sqlitemigrate"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+//go:embed migrations/*.sql
+var electrumMigrations embed.FS
+
+// OpenElectrumDB opens (creating if needed) the orchestrator-owned database of
+// electrum wallet chain state at path and applies any pending migrations. The
+// orchestrator is its sole reader and writer, so a single connection sidesteps
+// SQLite lock contention (mirroring bitwindowd's MaxOpenConns(1)).
+func OpenElectrumDB(ctx context.Context, path string) (*sql.DB, error) {
+	db, err := sql.Open("sqlite3", path+"?_busy_timeout=5000")
+	if err != nil {
+		return nil, fmt.Errorf("open electrum db: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := sqlitemigrate.Run(ctx, db, electrumMigrations, "migrations"); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("migrate electrum db: %w", err)
+	}
+	return db, nil
+}

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -92,6 +92,11 @@ type scannedAddr struct {
 	hdPath        string
 	derivations   []keyDerivation // PSBT key-derivation records (signer key matching)
 	stats         EsploraAddressStats
+	// utxos and txs are the address's chain data, fetched alongside stats and
+	// cached on the scan so balance/utxo/history reads never re-hit Esplora.
+	// Both are empty for an unused address.
+	utxos []EsploraUTXO
+	txs   []EsploraTx
 }
 
 type electrumScan struct {
@@ -158,17 +163,9 @@ func (p *ElectrumBackend) ListUnspent(ctx context.Context, walletID string) ([]U
 	if err != nil {
 		return nil, err
 	}
-	var out []UTXO
-	for _, a := range scan.addrs {
-		if !a.stats.Used() {
-			continue
-		}
-		utxos, err := p.client.AddressUTXOs(ctx, a.address)
-		if err != nil {
-			return nil, err
-		}
-		for _, u := range utxos {
-			out = append(out, UTXO{
+	out := lo.FlatMap(scan.addrs, func(a scannedAddr, _ int) []UTXO {
+		return lo.Map(a.utxos, func(u EsploraUTXO, _ int) UTXO {
+			return UTXO{
 				TxID:          u.TxID,
 				Vout:          u.Vout,
 				Address:       a.address,
@@ -179,9 +176,9 @@ func (p *ElectrumBackend) ListUnspent(ctx context.Context, walletID string) ([]U
 				Spendable:  !scan.watchOnly,
 				Solvable:   true,
 				ReceivedAt: u.Status.BlockTime,
-			})
-		}
-	}
+			}
+		})
+	})
 	return out, nil
 }
 
@@ -199,24 +196,12 @@ func (p *ElectrumBackend) ListTransactionsRange(ctx context.Context, walletID st
 		return nil, err
 	}
 
-	txByID := map[string]EsploraTx{}
-	for _, a := range scan.addrs {
-		if !a.stats.Used() {
-			continue
-		}
-		txs, err := p.client.AddressTxs(ctx, a.address)
-		if err != nil {
-			return nil, err
-		}
-		for _, tx := range txs {
-			txByID[tx.TxID] = tx
-		}
-	}
+	allTxs := lo.FlatMap(scan.addrs, func(a scannedAddr, _ int) []EsploraTx { return a.txs })
+	txByID := lo.KeyBy(allTxs, func(tx EsploraTx) string { return tx.TxID })
 
-	var rows []WalletTransaction
-	for _, tx := range txByID {
-		rows = append(rows, walletRowsForTx(tx, scan, tip)...)
-	}
+	rows := lo.FlatMap(lo.Values(txByID), func(tx EsploraTx, _ int) []WalletTransaction {
+		return walletRowsForTx(tx, scan, tip)
+	})
 
 	// Newest first, matching Core's listtransactions default ordering after
 	// the frontend reverses it; sort by time descending here.
@@ -252,32 +237,26 @@ func (p *ElectrumBackend) ListReceivedByAddress(ctx context.Context, walletID st
 			continue
 		}
 		entry := ReceivedByAddress{Address: a.address}
-		if a.stats.Used() {
-			txs, err := p.client.AddressTxs(ctx, a.address)
-			if err != nil {
-				return nil, err
-			}
-			var receivedSats int64
-			maxConfs := 0
-			for _, tx := range txs {
-				var paid int64
-				for _, vout := range tx.Vout {
-					if vout.ScriptPubKeyAddress == a.address {
-						paid += vout.Value
-					}
-				}
-				if paid == 0 {
-					continue
-				}
-				receivedSats += paid
-				entry.TxIDs = append(entry.TxIDs, tx.TxID)
-				if c := confsFor(tx.Status, tip); c > maxConfs {
-					maxConfs = c
+		var receivedSats int64
+		maxConfs := 0
+		for _, tx := range a.txs {
+			var paid int64
+			for _, vout := range tx.Vout {
+				if vout.ScriptPubKeyAddress == a.address {
+					paid += vout.Value
 				}
 			}
-			entry.Amount = float64(receivedSats) / 1e8
-			entry.Confirmations = maxConfs
+			if paid == 0 {
+				continue
+			}
+			receivedSats += paid
+			entry.TxIDs = append(entry.TxIDs, tx.TxID)
+			if c := confsFor(tx.Status, tip); c > maxConfs {
+				maxConfs = c
+			}
 		}
+		entry.Amount = float64(receivedSats) / 1e8
+		entry.Confirmations = maxConfs
 		out = append(out, entry)
 	}
 	return out, nil
@@ -342,8 +321,12 @@ func (p *ElectrumBackend) NextChangeAddress(ctx context.Context, walletID string
 	return p.nextUnused(ctx, walletID, true)
 }
 
+// nextUnused picks the next unused address from the cached scan, deriving past
+// the cache locally when every scanned address is used. It serves the warm or
+// on-disk scan with no network, so address allocation is instant once a wallet
+// has synced; only a never-synced wallet falls through to a one-time live scan.
 func (p *ElectrumBackend) nextUnused(ctx context.Context, walletID string, change bool) (string, error) {
-	scan, err := p.scanWalletLive(ctx, walletID)
+	scan, err := p.scanWallet(ctx, walletID)
 	if err != nil {
 		return "", err
 	}
@@ -481,10 +464,7 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 	}
 	outputs, totalOutSats := buildSendOutputs(req)
 
-	pool, err := p.spendableUTXOs(ctx, scan)
-	if err != nil {
-		return nil, nil, err
-	}
+	pool := p.spendableUTXOs(scan)
 
 	// Pin required inputs, then fill from the remaining pool largest-first.
 	required := make(map[string]bool)
@@ -971,14 +951,24 @@ func (p *ElectrumBackend) scan(ctx context.Context, walletID string, allowCache 
 	// streaming those would spin the bottom-nav "Scanning…" status forever.
 	p.mu.Lock()
 	initial := !p.warm[walletID]
+	prior := p.warmScan[walletID]
 	p.mu.Unlock()
+	// prior holds the wallet's last known chain data (warm cache, else the
+	// on-disk scan). Addresses whose stats are unchanged copy their UTXOs and
+	// transactions from it instead of re-fetching, so only what moved hits
+	// the network.
+	if prior == nil {
+		if cold, _, ok := p.rebuildScanFromDisk(walletID, w); ok {
+			prior = cold
+		}
+	}
 	defer p.svc.syncReporter.publish(walletID, SyncProgress{Phase: SyncIdle, Message: "Idle"})
 	for i, d := range derivers {
 		chain := "external"
 		if i < len(chainNames) {
 			chain = chainNames[i]
 		}
-		addrs, err := p.scanChain(ctx, walletID, chain, d, initial)
+		addrs, err := p.scanChain(ctx, walletID, chain, d, prior, initial)
 		if err != nil {
 			return nil, err
 		}
@@ -990,7 +980,7 @@ func (p *ElectrumBackend) scan(ctx context.Context, walletID string, allowCache 
 	watch := append([]WatchKey(nil), p.watchKeys[walletID]...)
 	p.mu.Unlock()
 	for _, k := range watch {
-		a, err := p.watchKeyAddr(ctx, k)
+		a, err := p.watchKeyAddr(ctx, k, prior)
 		if err != nil {
 			p.log.Warn().Err(err).Msg("electrum watch key derivation failed")
 			continue
@@ -1059,9 +1049,9 @@ func (p *ElectrumBackend) cacheScan(ctx context.Context, walletID string, scan *
 }
 
 // loadColdScan rebuilds a wallet's scan from its persisted cache without any
-// network calls, used once per process before the first live scan. Keys and
-// scripts are re-derived from the descriptor; only the Esplora stats come from
-// disk. ok is false when warm, when no cache exists, or on any derive error.
+// network calls, used once per process before the first live scan. ok is false
+// when warm, when no cache exists, or on any derive error. On success it marks
+// the wallet warm so the next read serves the cache instead of re-walking.
 func (p *ElectrumBackend) loadColdScan(walletID string, w *WalletData) (*electrumScan, bool) {
 	p.mu.Lock()
 	warm := p.warm[walletID]
@@ -1069,13 +1059,31 @@ func (p *ElectrumBackend) loadColdScan(walletID string, w *WalletData) (*electru
 	if warm {
 		return nil, false
 	}
-	ps, ok := p.svc.loadElectrumScan(walletID)
+	scan, ps, ok := p.rebuildScanFromDisk(walletID, w)
 	if !ok {
 		return nil, false
 	}
+	p.mu.Lock()
+	p.warm[walletID] = true
+	p.lastScan[walletID], _ = json.Marshal(ps)
+	p.mu.Unlock()
+	p.log.Debug().Str("wallet", walletID).Int("addrs", len(scan.addrs)).Msg("electrum scan loaded from cache")
+	return scan, true
+}
+
+// rebuildScanFromDisk reconstructs a wallet's scan purely from its persisted
+// cache: keys and scripts are re-derived from the descriptor, stats come from
+// disk, and no network call is made. It mutates no backend state, so reads that
+// only need the known chain (e.g. address allocation) can use it freely. ok is
+// false when no cache exists or the persisted addresses drift from derivation.
+func (p *ElectrumBackend) rebuildScanFromDisk(walletID string, w *WalletData) (*electrumScan, *persistedScan, bool) {
+	ps, ok := p.svc.loadElectrumScan(walletID)
+	if !ok {
+		return nil, nil, false
+	}
 	d, err := p.walletDescriptor(w)
 	if err != nil {
-		return nil, false
+		return nil, nil, false
 	}
 	scan := &electrumScan{
 		byAddr:    make(map[string]scannedAddr),
@@ -1085,18 +1093,15 @@ func (p *ElectrumBackend) loadColdScan(walletID string, w *WalletData) (*electru
 	for _, pa := range ps.Addrs {
 		a, err := p.deriveAddr(d, pa.Change, pa.Index)
 		if err != nil || a.address != pa.Address {
-			return nil, false // cache drift — fall back to a live scan
+			return nil, nil, false // cache drift — fall back to a live scan
 		}
 		a.stats = pa.Stats
+		a.utxos = pa.UTXOs
+		a.txs = pa.Txs
 		scan.addrs = append(scan.addrs, a)
 	}
 	finalizeScan(scan)
-	p.mu.Lock()
-	p.warm[walletID] = true
-	p.lastScan[walletID], _ = json.Marshal(ps)
-	p.mu.Unlock()
-	p.log.Debug().Str("wallet", walletID).Int("addrs", len(scan.addrs)).Msg("electrum scan loaded from cache")
-	return scan, true
+	return scan, ps, true
 }
 
 // finalizeScan builds the by-address and key lookups from a scan's addresses.
@@ -1113,13 +1118,14 @@ func finalizeScan(scan *electrumScan) {
 // nothing changed since the last persist. BIP47 watch keys (no hdPath) are not
 // part of the derivation chain and are excluded.
 func (p *ElectrumBackend) persistScan(walletID string, scan *electrumScan) {
-	ps := persistedScan{Version: persistedScanVersion, WalletID: walletID}
+	ps := persistedScan{WalletID: walletID}
 	ps.Addrs = lo.FilterMap(scan.addrs, func(a scannedAddr, _ int) (persistedAddr, bool) {
 		if a.hdPath == "" {
 			return persistedAddr{}, false
 		}
 		return persistedAddr{
-			Change: a.change, Index: a.index, Address: a.address, Stats: a.stats,
+			Change: a.change, Index: a.index, Address: a.address,
+			Stats: a.stats, UTXOs: a.utxos, Txs: a.txs,
 		}, true
 	})
 	data, err := json.Marshal(ps)
@@ -1132,7 +1138,7 @@ func (p *ElectrumBackend) persistScan(walletID string, scan *electrumScan) {
 	if unchanged {
 		return
 	}
-	if err := p.svc.saveElectrumScan(walletID, data); err != nil {
+	if err := p.svc.saveElectrumScan(walletID, &ps); err != nil {
 		p.log.Warn().Err(err).Str("wallet", walletID).Msg("persist electrum scan failed")
 		return // don't record the write as done — retry on the next scan
 	}
@@ -1161,7 +1167,7 @@ func (p *ElectrumBackend) chainDerivers(w *WalletData) ([]chainDeriver, bool, er
 	return out, w.IsWatchOnly(), nil
 }
 
-func (p *ElectrumBackend) scanChain(ctx context.Context, walletID, chain string, derive chainDeriver, initial bool) ([]scannedAddr, error) {
+func (p *ElectrumBackend) scanChain(ctx context.Context, walletID, chain string, derive chainDeriver, prior *electrumScan, initial bool) ([]scannedAddr, error) {
 	var out []scannedAddr
 	consecutiveUnused := 0
 	found := 0
@@ -1173,13 +1179,11 @@ func (p *ElectrumBackend) scanChain(ctx context.Context, walletID, chain string,
 		if err != nil {
 			return nil, err
 		}
-		stats, err := p.client.AddressStats(ctx, a.address)
-		if err != nil {
-			return nil, fmt.Errorf("address stats %s: %w", a.address, err)
+		if err := p.hydrate(ctx, &a, prior); err != nil {
+			return nil, err
 		}
-		a.stats = stats
 		out = append(out, a)
-		if stats.Used() {
+		if a.stats.Used() {
 			consecutiveUnused = 0
 			found++
 		} else {
@@ -1187,6 +1191,39 @@ func (p *ElectrumBackend) scanChain(ctx context.Context, walletID, chain string,
 		}
 	}
 	return out, nil
+}
+
+// hydrate fills an address's stats and, when it has history, its UTXOs and
+// transactions. When prior holds the same address with identical stats the
+// chain data is unchanged since the last scan, so it is copied instead of
+// re-fetched — Esplora is only queried for what actually moved.
+func (p *ElectrumBackend) hydrate(ctx context.Context, a *scannedAddr, prior *electrumScan) error {
+	stats, err := p.client.AddressStats(ctx, a.address)
+	if err != nil {
+		return fmt.Errorf("address stats %s: %w", a.address, err)
+	}
+	a.stats = stats
+	if !stats.Used() {
+		return nil
+	}
+	if prior != nil {
+		if prev, ok := prior.byAddr[a.address]; ok && prev.stats == stats {
+			a.utxos = prev.utxos
+			a.txs = prev.txs
+			return nil
+		}
+	}
+	utxos, err := p.client.AddressUTXOs(ctx, a.address)
+	if err != nil {
+		return fmt.Errorf("address utxos %s: %w", a.address, err)
+	}
+	txs, err := p.client.AddressTxs(ctx, a.address)
+	if err != nil {
+		return fmt.Errorf("address txs %s: %w", a.address, err)
+	}
+	a.utxos = utxos
+	a.txs = txs
+	return nil
 }
 
 // watchOnlyDescriptorString returns the descriptor (or bare xpub) stored in a
@@ -1210,7 +1247,7 @@ func watchOnlyDescriptorString(w *WalletData) (string, error) {
 	return "", errors.New("watch-only electrum wallet has no descriptor or xpub")
 }
 
-func (p *ElectrumBackend) watchKeyAddr(ctx context.Context, k WatchKey) (scannedAddr, error) {
+func (p *ElectrumBackend) watchKeyAddr(ctx context.Context, k WatchKey, prior *electrumScan) (scannedAddr, error) {
 	wif, err := btcutil.DecodeWIF(k.WIF)
 	if err != nil {
 		return scannedAddr{}, fmt.Errorf("decode watch WIF: %w", err)
@@ -1220,12 +1257,11 @@ func (p *ElectrumBackend) watchKeyAddr(ctx context.Context, k WatchKey) (scanned
 	if err != nil {
 		return scannedAddr{}, fmt.Errorf("watch key address: %w", err)
 	}
-	encoded := addr.EncodeAddress()
-	stats, err := p.client.AddressStats(ctx, encoded)
-	if err != nil {
-		return scannedAddr{}, fmt.Errorf("watch key stats: %w", err)
+	a := scannedAddr{address: addr.EncodeAddress(), priv: wif.PrivKey}
+	if err := p.hydrate(ctx, &a, prior); err != nil {
+		return scannedAddr{}, err
 	}
-	return scannedAddr{address: encoded, priv: wif.PrivKey, stats: stats}, nil
+	return a, nil
 }
 
 // ============================================================================
@@ -1240,27 +1276,18 @@ type electrumUTXO struct {
 	confirmed  bool
 }
 
-func (p *ElectrumBackend) spendableUTXOs(ctx context.Context, scan *electrumScan) ([]electrumUTXO, error) {
-	var out []electrumUTXO
-	for _, a := range scan.addrs {
-		if !a.stats.Used() {
-			continue
-		}
-		utxos, err := p.client.AddressUTXOs(ctx, a.address)
-		if err != nil {
-			return nil, err
-		}
-		for _, u := range utxos {
-			out = append(out, electrumUTXO{
+func (p *ElectrumBackend) spendableUTXOs(scan *electrumScan) []electrumUTXO {
+	return lo.FlatMap(scan.addrs, func(a scannedAddr, _ int) []electrumUTXO {
+		return lo.Map(a.utxos, func(u EsploraUTXO, _ int) electrumUTXO {
+			return electrumUTXO{
 				txid:       u.TxID,
 				vout:       u.Vout,
 				address:    a.address,
 				amountSats: u.Value,
 				confirmed:  u.Status.Confirmed,
-			})
-		}
-	}
-	return out, nil
+			}
+		})
+	})
 }
 
 func findUTXO(pool []electrumUTXO, txid string, vout int) (electrumUTXO, bool) {

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -57,7 +57,10 @@ type ElectrumBackend struct {
 	scanLocks map[string]*sync.Mutex
 }
 
-var _ Backend = (*ElectrumBackend)(nil)
+var (
+	_ Backend      = (*ElectrumBackend)(nil)
+	_ Bip47Backend = (*ElectrumBackend)(nil)
+)
 
 // NewElectrumBackend creates an Esplora-backed wallet backend.
 func NewElectrumBackend(svc *Service, client Esplora, network *chaincfg.Params, log zerolog.Logger) *ElectrumBackend {
@@ -220,14 +223,10 @@ func (p *ElectrumBackend) ListTransactionsRange(ctx context.Context, walletID st
 }
 
 func (p *ElectrumBackend) ListReceivedByAddress(ctx context.Context, walletID string) ([]ReceivedByAddress, error) {
-	scan, err := p.scanWallet(ctx, walletID)
-	if err != nil {
-		return nil, err
-	}
-	tip, err := p.client.TipHeight(ctx)
-	if err != nil {
-		return nil, err
-	}
+	// Served from the local cache so the receive screen never blocks on a scan;
+	// confirmations come from the cached tip, best-effort.
+	scan := p.localScan(walletID)
+	tip, _ := p.client.TipHeight(ctx)
 
 	out := make([]ReceivedByAddress, 0, len(scan.addrs))
 	for _, a := range scan.addrs {
@@ -314,37 +313,57 @@ func (p *ElectrumBackend) AddressHDPath(ctx context.Context, walletID, address s
 }
 
 func (p *ElectrumBackend) NextReceiveAddress(ctx context.Context, walletID string) (string, error) {
-	return p.nextUnused(ctx, walletID, false)
+	return p.nextUnused(walletID, false)
 }
 
 func (p *ElectrumBackend) NextChangeAddress(ctx context.Context, walletID string) (string, error) {
-	return p.nextUnused(ctx, walletID, true)
+	return p.nextUnused(walletID, true)
 }
 
-// nextUnused picks the next unused address from the cached scan, deriving past
-// the cache locally when every scanned address is used. It serves the warm or
-// on-disk scan with no network, so address allocation is instant once a wallet
-// has synced; only a never-synced wallet falls through to a one-time live scan.
-func (p *ElectrumBackend) nextUnused(ctx context.Context, walletID string, change bool) (string, error) {
-	scan, err := p.scanWallet(ctx, walletID)
+// nextUnused picks the next unused address with no network call: a plain SELECT
+// for the lowest-index address on the chain with no history, and when none is on
+// record (fresh wallet, or every stored address is used) it derives the next
+// index locally. Either way it is instant — address allocation never blocks on a
+// scan. The background scan keeps electrum_addresses' usage current.
+func (p *ElectrumBackend) nextUnused(walletID string, change bool) (string, error) {
+	if addr, ok := p.svc.firstUnusedAddress(walletID, change); ok {
+		return addr, nil
+	}
+	w := p.svc.GetWalletByID(walletID)
+	if w == nil {
+		return "", fmt.Errorf("wallet %s not found", walletID)
+	}
+	derivers, _, err := p.chainDerivers(w)
 	if err != nil {
 		return "", err
 	}
-	return p.nextUnusedFromScan(walletID, scan, change)
-}
-
-// nextUnusedFromScan picks the next unused address on a chain from an existing
-// scan, avoiding a second full wallet scan on the send path.
-func (p *ElectrumBackend) nextUnusedFromScan(walletID string, scan *electrumScan, change bool) (string, error) {
-	a, err := p.nextUnusedAddrFromScan(walletID, scan, change)
+	a, err := derivers[chainIndex(change)](uint32(p.svc.maxAddressIndex(walletID, change) + 1))
 	if err != nil {
 		return "", err
 	}
 	return a.address, nil
 }
 
-// nextUnusedAddrFromScan is nextUnusedFromScan but returns the full scannedAddr
-// (with derivation records), for callers that build a change output.
+// localScan returns the wallet's known chain state with no network calls: the
+// warm in-memory scan, else the on-disk scan, else an empty scan.
+func (p *ElectrumBackend) localScan(walletID string) *electrumScan {
+	p.mu.Lock()
+	scan := p.warmScan[walletID]
+	p.mu.Unlock()
+	if scan != nil {
+		return scan
+	}
+	if w := p.svc.GetWalletByID(walletID); w != nil {
+		if cold, _, ok := p.rebuildScanFromDisk(walletID, w); ok {
+			return cold
+		}
+	}
+	return &electrumScan{byAddr: make(map[string]scannedAddr), keys: make(mapKeySource)}
+}
+
+// nextUnusedAddrFromScan returns the next unused address on a chain from an
+// existing scan (with derivation records), for the send path that builds a
+// change output without a second wallet scan.
 func (p *ElectrumBackend) nextUnusedAddrFromScan(walletID string, scan *electrumScan, change bool) (scannedAddr, error) {
 	highest := -1
 	for _, a := range scan.addrs {
@@ -413,6 +432,13 @@ func (p *ElectrumBackend) WatchKeys(ctx context.Context, walletID string, keys [
 	return nil
 }
 
+// EnsureNotificationWatched registers the wallet's own BIP47 notification key so
+// the scan tracks its notification address and inbound notification txs surface
+// in ListTransactionsRange.
+func (p *ElectrumBackend) EnsureNotificationWatched(ctx context.Context, walletID string, notifKey WatchKey) error {
+	return p.WatchKeys(ctx, walletID, []WatchKey{notifKey})
+}
+
 func (p *ElectrumBackend) Send(ctx context.Context, walletID string, req SendRequest) (string, error) {
 	scan, err := p.scanWalletLive(ctx, walletID)
 	if err != nil {
@@ -421,7 +447,7 @@ func (p *ElectrumBackend) Send(ctx context.Context, walletID string, req SendReq
 	if scan.watchOnly {
 		return "", errors.New("watch-only electrum wallet cannot sign or send")
 	}
-	packet, psbtInputs, err := p.buildSendPSBT(ctx, walletID, scan, req)
+	packet, psbtInputs, effect, err := p.buildSendPSBT(ctx, walletID, scan, req)
 	if err != nil {
 		return "", err
 	}
@@ -447,20 +473,130 @@ func (p *ElectrumBackend) Send(ctx context.Context, walletID string, req SendReq
 			return "", fmt.Errorf("inject replay byte: %w", err)
 		}
 	}
-	return p.client.Broadcast(ctx, hexToSend)
+	txid, err := p.client.Broadcast(ctx, hexToSend)
+	if err != nil {
+		return "", err
+	}
+	// We already know exactly what the spend changed — the inputs it consumed and
+	// the change it created — so apply that to the cached scan directly instead of
+	// re-walking the whole wallet over Esplora. Balance/utxo reads reflect the
+	// send immediately; the next block's scan reconciles against the chain.
+	p.applySpend(walletID, txid, effect, packet)
+	return txid, nil
+}
+
+// spendEffect captures what a send consumed and produced so the cached scan can
+// be updated in place after broadcast instead of re-walking the wallet: the
+// inputs it spent and the change it created (change is nil when none).
+type spendEffect struct {
+	spent      []electrumUTXO
+	change     *scannedAddr
+	changeSats int64
+}
+
+// applySpend folds a just-broadcast send into the cached scan with no network
+// call: it drops the spent UTXOs (marking their addresses mempool-spent) and
+// adds the change UTXO (marking the change address mempool-funded), so balance
+// and UTXO reads reflect the send at once. The next block's scan reconciles this
+// optimistic view against the chain.
+func (p *ElectrumBackend) applySpend(walletID, txid string, effect *spendEffect, packet *psbt.Packet) {
+	if effect == nil {
+		return
+	}
+	p.mu.Lock()
+	cached := p.warmScan[walletID]
+	p.mu.Unlock()
+	if cached == nil {
+		return // nothing cached; the next read scans fresh anyway
+	}
+	scan := copyScan(cached)
+
+	spentOutpoints := make(map[string]bool, len(effect.spent))
+	spentByAddr := make(map[string]int64)
+	for _, u := range effect.spent {
+		spentOutpoints[fmt.Sprintf("%s:%d", u.txid, u.vout)] = true
+		spentByAddr[u.address] += u.amountSats
+	}
+	for i := range scan.addrs {
+		a := &scan.addrs[i]
+		sats, ok := spentByAddr[a.address]
+		if !ok {
+			continue
+		}
+		a.utxos = lo.Filter(a.utxos, func(u EsploraUTXO, _ int) bool {
+			return !spentOutpoints[fmt.Sprintf("%s:%d", u.TxID, u.Vout)]
+		})
+		a.stats.MempoolStats.SpentTxoSum += sats
+		a.stats.MempoolStats.SpentTxoCount++
+		a.stats.MempoolStats.TxCount++
+	}
+
+	if effect.change != nil {
+		vout := -1
+		for i, out := range packet.UnsignedTx.TxOut {
+			if bytes.Equal(out.PkScript, effect.change.scriptPubKey) {
+				vout = i
+				break
+			}
+		}
+		if vout >= 0 {
+			utxo := EsploraUTXO{TxID: txid, Vout: vout, Value: effect.changeSats}
+			if i := indexOfAddr(scan.addrs, effect.change.address); i >= 0 {
+				a := &scan.addrs[i]
+				a.utxos = append(append([]EsploraUTXO(nil), a.utxos...), utxo)
+				a.stats.MempoolStats.FundedTxoSum += effect.changeSats
+				a.stats.MempoolStats.FundedTxoCount++
+				a.stats.MempoolStats.TxCount++
+			} else {
+				ca := *effect.change
+				ca.utxos = []EsploraUTXO{utxo}
+				ca.stats.Address = ca.address
+				ca.stats.MempoolStats.FundedTxoSum += effect.changeSats
+				ca.stats.MempoolStats.FundedTxoCount++
+				ca.stats.MempoolStats.TxCount++
+				scan.addrs = append(scan.addrs, ca)
+			}
+		}
+	}
+
+	finalizeScan(scan)
+	p.mu.Lock()
+	p.warmScan[walletID] = scan
+	p.mu.Unlock()
+	p.persistScan(walletID, scan)
+}
+
+// copyScan returns a copy of a scan with fresh addrs/byAddr/keys containers, so
+// applySpend can mutate it without racing readers of the original.
+func copyScan(s *electrumScan) *electrumScan {
+	return &electrumScan{
+		addrs:     append([]scannedAddr(nil), s.addrs...),
+		byAddr:    make(map[string]scannedAddr, len(s.byAddr)),
+		keys:      make(mapKeySource, len(s.keys)),
+		watchOnly: s.watchOnly,
+	}
+}
+
+func indexOfAddr(addrs []scannedAddr, address string) int {
+	for i := range addrs {
+		if addrs[i].address == address {
+			return i
+		}
+	}
+	return -1
 }
 
 // buildSendPSBT performs coin selection and builds an unsigned PSBT for a send.
 // It does not require signing keys, so it serves both Send and CreatePSBT
 // (including watch-only wallets, which produce a PSBT for an external signer).
-func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, scan *electrumScan, req SendRequest) (*psbt.Packet, []psbtInput, error) {
+func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, scan *electrumScan, req SendRequest) (*psbt.Packet, []psbtInput, *spendEffect, error) {
 	if req.FeeRateSatPerVB > 0 && req.FixedFeeSats > 0 {
-		return nil, nil, errors.New("fee rate and fixed fee are mutually exclusive")
+		return nil, nil, nil, errors.New("fee rate and fixed fee are mutually exclusive")
 	}
 	// Destinations come from a map, so the first output is not stable; only a
 	// single-recipient subtract-fee send has a well-defined output to reduce.
 	if req.SubtractFeeFromAmount && len(req.DestinationsSats) > 1 {
-		return nil, nil, errors.New("subtractFeeFromAmount requires a single destination")
+		return nil, nil, nil, errors.New("subtractFeeFromAmount requires a single destination")
 	}
 	outputs, totalOutSats := buildSendOutputs(req)
 
@@ -475,7 +611,7 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 		required[key] = true
 		u, ok := findUTXO(pool, ri.TxID, ri.Vout)
 		if !ok {
-			return nil, nil, fmt.Errorf("required input %s not found among wallet UTXOs", key)
+			return nil, nil, nil, fmt.Errorf("required input %s not found among wallet UTXOs", key)
 		}
 		selected = append(selected, u)
 		selectedSats += u.amountSats
@@ -498,11 +634,11 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 	// output (the wallet's own type) unless a send leaves none.
 	w := p.svc.GetWalletByID(walletID)
 	if w == nil {
-		return nil, nil, fmt.Errorf("wallet %s not found", walletID)
+		return nil, nil, nil, fmt.Errorf("wallet %s not found", walletID)
 	}
 	d, err := p.walletDescriptor(w)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	inVsize := walletInputVsize(d)
 	changeDust := dustThreshold(d.Kind)
@@ -534,7 +670,7 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 			break
 		}
 		if i >= len(remaining) {
-			return nil, nil, fmt.Errorf("insufficient funds: need %d sats, have %d sats", target, selectedSats)
+			return nil, nil, nil, fmt.Errorf("insufficient funds: need %d sats, have %d sats", target, selectedSats)
 		}
 		selected = append(selected, remaining[i])
 		selectedSats += remaining[i].amountSats
@@ -550,13 +686,13 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 	var changeSats int64
 	if req.SubtractFeeFromAmount {
 		if len(outputs) == 0 || outputs[0].OpReturnHex != "" {
-			return nil, nil, errors.New("subtractFeeFromAmount requires a payable first output")
+			return nil, nil, nil, errors.New("subtractFeeFromAmount requires a payable first output")
 		}
 		// Take the fee out of the first output; the rest of the selected value
 		// returns as change, matching Bitcoin Core's subtract-fee semantics.
 		reduced := int64(math.Round(outputs[0].AmountBTC*1e8)) - fee
 		if reduced < dustForOutput(outputs[0], p.network) {
-			return nil, nil, fmt.Errorf("fee %d sats exceeds first output", fee)
+			return nil, nil, nil, fmt.Errorf("fee %d sats exceeds first output", fee)
 		}
 		outputs[0].AmountBTC = float64(reduced) / 1e8
 		changeSats = selectedSats - totalOutSats
@@ -564,13 +700,16 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 		changeSats = selectedSats - totalOutSats - fee
 	}
 	if changeSats < 0 {
-		return nil, nil, fmt.Errorf("insufficient funds: short %d sats", -changeSats)
+		return nil, nil, nil, fmt.Errorf("insufficient funds: short %d sats", -changeSats)
 	}
+	effect := &spendEffect{spent: selected}
 	if changeSats >= changeDust {
 		changeAddr, err := p.nextUnusedAddrFromScan(walletID, scan, true)
 		if err != nil {
-			return nil, nil, fmt.Errorf("derive change address: %w", err)
+			return nil, nil, nil, fmt.Errorf("derive change address: %w", err)
 		}
+		effect.change = &changeAddr
+		effect.changeSats = changeSats
 		outputs = append(outputs, TxOutSpec{
 			Address:     changeAddr.address,
 			AmountBTC:   float64(changeSats) / 1e8,
@@ -583,11 +722,11 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 	for idx, u := range selected {
 		sa, ok := scan.byAddr[u.address]
 		if !ok {
-			return nil, nil, fmt.Errorf("no derivation info for input address %s", u.address)
+			return nil, nil, nil, fmt.Errorf("no derivation info for input address %s", u.address)
 		}
 		h, err := chainhash.NewHashFromStr(u.txid)
 		if err != nil {
-			return nil, nil, fmt.Errorf("parse input txid %q: %w", u.txid, err)
+			return nil, nil, nil, fmt.Errorf("parse input txid %q: %w", u.txid, err)
 		}
 		psbtInputs[idx] = psbtInput{
 			outpoint: wire.OutPoint{Hash: *h, Index: uint32(u.vout)},
@@ -598,9 +737,9 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 
 	packet, err := buildPSBT(psbtInputs, outputs, p.network, p.prevTxFetcher(ctx))
 	if err != nil {
-		return nil, nil, fmt.Errorf("build psbt: %w", err)
+		return nil, nil, nil, fmt.Errorf("build psbt: %w", err)
 	}
-	return packet, psbtInputs, nil
+	return packet, psbtInputs, effect, nil
 }
 
 func (p *ElectrumBackend) requireElectrum(walletID string) error {
@@ -623,7 +762,7 @@ func (p *ElectrumBackend) CreatePSBT(ctx context.Context, walletID string, req S
 	if err != nil {
 		return "", err
 	}
-	packet, _, err := p.buildSendPSBT(ctx, walletID, scan, req)
+	packet, _, _, err := p.buildSendPSBT(ctx, walletID, scan, req)
 	if err != nil {
 		return "", err
 	}

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -511,6 +512,11 @@ func (p *ElectrumBackend) applySpend(walletID, txid string, effect *spendEffect,
 	}
 	scan := copyScan(cached)
 
+	// The synthesized mempool tx, stamped now so it sorts to the top of history
+	// as the newest entry. The next block's scan replaces it with the confirmed
+	// version from Esplora.
+	sentTx := buildSentTx(txid, effect, packet, p.network, time.Now().Unix())
+
 	spentOutpoints := make(map[string]bool, len(effect.spent))
 	spentByAddr := make(map[string]int64)
 	for _, u := range effect.spent {
@@ -529,6 +535,7 @@ func (p *ElectrumBackend) applySpend(walletID, txid string, effect *spendEffect,
 		a.stats.MempoolStats.SpentTxoSum += sats
 		a.stats.MempoolStats.SpentTxoCount++
 		a.stats.MempoolStats.TxCount++
+		a.txs = append(append([]EsploraTx(nil), a.txs...), sentTx)
 	}
 
 	if effect.change != nil {
@@ -547,9 +554,11 @@ func (p *ElectrumBackend) applySpend(walletID, txid string, effect *spendEffect,
 				a.stats.MempoolStats.FundedTxoSum += effect.changeSats
 				a.stats.MempoolStats.FundedTxoCount++
 				a.stats.MempoolStats.TxCount++
+				a.txs = append(append([]EsploraTx(nil), a.txs...), sentTx)
 			} else {
 				ca := *effect.change
 				ca.utxos = []EsploraUTXO{utxo}
+				ca.txs = []EsploraTx{sentTx}
 				ca.stats.Address = ca.address
 				ca.stats.MempoolStats.FundedTxoSum += effect.changeSats
 				ca.stats.MempoolStats.FundedTxoCount++
@@ -564,6 +573,38 @@ func (p *ElectrumBackend) applySpend(walletID, txid string, effect *spendEffect,
 	p.warmScan[walletID] = scan
 	p.mu.Unlock()
 	p.persistScan(walletID, scan)
+}
+
+// buildSentTx reconstructs the Esplora view of a just-broadcast send from the
+// data we already hold: the prevouts it spent (address + value) and the outputs
+// it created (decoded from the packet). Marked unconfirmed and stamped at now so
+// history and walletRowsForTx render it exactly like the real tx will.
+func buildSentTx(txid string, effect *spendEffect, packet *psbt.Packet, net *chaincfg.Params, now int64) EsploraTx {
+	var inSum int64
+	vin := lo.Map(effect.spent, func(u electrumUTXO, _ int) EsploraVin {
+		inSum += u.amountSats
+		return EsploraVin{
+			TxID:    u.txid,
+			Vout:    u.vout,
+			Prevout: &EsploraVout{ScriptPubKeyAddress: u.address, Value: u.amountSats},
+		}
+	})
+	var outSum int64
+	vout := lo.Map(packet.UnsignedTx.TxOut, func(out *wire.TxOut, _ int) EsploraVout {
+		outSum += out.Value
+		addr := ""
+		if _, addrs, _, err := txscript.ExtractPkScriptAddrs(out.PkScript, net); err == nil && len(addrs) > 0 {
+			addr = addrs[0].EncodeAddress()
+		}
+		return EsploraVout{ScriptPubKeyAddress: addr, Value: out.Value}
+	})
+	return EsploraTx{
+		TxID:   txid,
+		Vin:    vin,
+		Vout:   vout,
+		Fee:    inSum - outSum,
+		Status: EsploraStatus{Confirmed: false, BlockTime: now},
+	}
 }
 
 // copyScan returns a copy of a scan with fresh addrs/byAddr/keys containers, so

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -793,6 +793,53 @@ func TestElectrumScanPersistsAcrossRestart(t *testing.T) {
 	assert.Zero(t, atomic.LoadInt32(&counting.statsCalls), "no re-query without a new block")
 }
 
+// TestElectrumScanPersistsUTXOsAndTxs proves a wallet's UTXOs and transactions
+// survive a restart by reconstructing from electrum.db, not by re-querying
+// Esplora: a cold-boot backend returns the same utxos/history with zero network
+// calls.
+func TestElectrumScanPersistsUTXOsAndTxs(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	ctx := context.Background()
+
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 250_000, TxCount: 1},
+	}
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID:   "aa",
+		Vout:   0,
+		Value:  250_000,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100, BlockHash: "hash", BlockTime: 1_700_000_000},
+	}}
+	fake.txs[addr] = []EsploraTx{{
+		TxID:   "aa",
+		Vout:   []EsploraVout{{ScriptPubKeyAddress: addr, Value: 250_000}},
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100, BlockTime: 1_700_000_000},
+	}}
+
+	utxos, err := p.ListUnspent(ctx, w.ID) // live scan → persists to electrum.db
+	require.NoError(t, err)
+	require.Len(t, utxos, 1)
+
+	// Cold boot: a fresh backend whose Esplora holds no data and counts stats
+	// calls. UTXOs and history must come entirely from the database.
+	counting := &countingEsplora{Esplora: newFakeEsplora()}
+	p2 := NewElectrumBackend(p.svc, counting, &chaincfg.SigNetParams, zerolog.New(zerolog.NewTestWriter(t)))
+
+	utxos2, err := p2.ListUnspent(ctx, w.ID)
+	require.NoError(t, err)
+	require.Len(t, utxos2, 1, "utxos reconstructed from electrum.db")
+	assert.Equal(t, "aa", utxos2[0].TxID)
+	assert.InDelta(t, 0.0025, utxos2[0].Amount, 1e-9)
+
+	txs2, err := p2.ListTransactions(ctx, w.ID, 0)
+	require.NoError(t, err)
+	require.Len(t, txs2, 1, "transactions reconstructed from electrum.db")
+	assert.Equal(t, "aa", txs2[0].TxID)
+
+	assert.Zero(t, atomic.LoadInt32(&counting.statsCalls), "cold boot must not query Esplora")
+}
+
 // recordingEsplora captures the wallet's sync snapshot at each AddressStats
 // call, so a test can prove the polled status reflects scan progress.
 type recordingEsplora struct {

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -222,6 +222,58 @@ func TestElectrumSendBuildsSignsBroadcasts(t *testing.T) {
 	assert.Equal(t, int64(50_000), tx.TxOut[0].Value)
 }
 
+// TestElectrumSendUpdatesCacheInstantly proves a send reflects in balance, UTXOs
+// and history immediately with no re-scan: the fake Esplora still reports the
+// pre-send state, so anything showing the spend came from the local applySpend.
+func TestElectrumSendUpdatesCacheInstantly(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	ctx := context.Background()
+
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 200_000, TxCount: 1},
+	}
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID: "1111111111111111111111111111111111111111111111111111111111111111",
+		Vout: 0, Value: 200_000,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}
+
+	// Warm the cache: confirmed reflects the single 200k UTXO, nothing pending.
+	confirmed, pending, err := p.Balance(ctx, w.ID)
+	require.NoError(t, err)
+	require.InDelta(t, 0.002, confirmed, 1e-9)
+	require.Zero(t, pending)
+
+	dest := "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+	txid, err := p.Send(ctx, w.ID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FeeRateSatPerVB:  2,
+	})
+	require.NoError(t, err)
+
+	confirmed, pending, err = p.Balance(ctx, w.ID)
+	require.NoError(t, err)
+	assert.Zero(t, confirmed, "spent input no longer counts as confirmed")
+	assert.Greater(t, pending, 0.0, "change returns as pending")
+	assert.InDelta(t, 0.0015, confirmed+pending, 5e-5, "total = 200k - 50k - fee")
+
+	utxos, err := p.ListUnspent(ctx, w.ID)
+	require.NoError(t, err)
+	require.Len(t, utxos, 1, "old UTXO spent, change UTXO added")
+	assert.Equal(t, txid, utxos[0].TxID, "remaining UTXO is the change output")
+
+	txs, err := p.ListTransactions(ctx, w.ID, 0)
+	require.NoError(t, err)
+	found := false
+	for _, tx := range txs {
+		if tx.TxID == txid {
+			found = true
+		}
+	}
+	assert.True(t, found, "sent tx appears in history immediately")
+}
+
 func TestElectrumSendMaxSubtractsFee(t *testing.T) {
 	p, fake, w, addr := newElectrumFixture(t)
 	ctx := context.Background()

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -175,6 +175,9 @@ func TestElectrumNextReceiveSkipsUsed(t *testing.T) {
 	p, fake, w, addr := newElectrumFixture(t)
 	fake.stats[addr] = EsploraAddressStats{Address: addr, ChainStats: EsploraTxoStats{TxCount: 1}}
 
+	_, _, err := p.Balance(context.Background(), w.ID) // warm the scan so usage is known
+	require.NoError(t, err)
+
 	next, err := p.NextReceiveAddress(context.Background(), w.ID)
 	require.NoError(t, err)
 	assert.NotEqual(t, addr, next, "used address must not be offered for receive")
@@ -409,6 +412,9 @@ func TestElectrumWatchOnlyNextReceiveAdvances(t *testing.T) {
 	fake := newFakeEsplora()
 	p := NewElectrumBackend(svc, fake, &chaincfg.SigNetParams, zerolog.New(zerolog.NewTestWriter(t)))
 	fake.stats[used] = EsploraAddressStats{Address: used, ChainStats: EsploraTxoStats{TxCount: 1}}
+
+	_, _, err = p.Balance(ctx, wo.ID) // warm the scan so usage is known
+	require.NoError(t, err)
 
 	got, err := p.NextReceiveAddress(ctx, wo.ID)
 	require.NoError(t, err)
@@ -671,6 +677,9 @@ func TestElectrumListReceivedExcludesChange(t *testing.T) {
 
 	fake.stats[addr] = EsploraAddressStats{Address: addr, ChainStats: EsploraTxoStats{TxCount: 1}}
 	fake.stats[chgAddr] = EsploraAddressStats{Address: chgAddr, ChainStats: EsploraTxoStats{TxCount: 1}}
+
+	_, _, err = p.Balance(context.Background(), w.ID) // warm the scan so addresses are known
+	require.NoError(t, err)
 
 	recv, err := p.ListReceivedByAddress(context.Background(), w.ID)
 	require.NoError(t, err)

--- a/sidechain-orchestrator/wallet/engine.go
+++ b/sidechain-orchestrator/wallet/engine.go
@@ -43,6 +43,17 @@ func (e *WalletEngine) ElectrumConfigured() bool {
 	return ok && r.ElectrumConfigured()
 }
 
+// Bip47BackendFor returns the wallet's backend as a Bip47Backend when it is
+// BIP47-capable. ok is false for non-capable wallets (the enforcer), so the
+// BIP47 engine and send path skip them without a wallet-type switch.
+func (e *WalletEngine) Bip47BackendFor(walletID string) (Bip47Backend, bool) {
+	if r, ok := e.backend.(*BackendRouter); ok {
+		return r.Bip47BackendFor(walletID)
+	}
+	b, ok := e.backend.(Bip47Backend)
+	return b, ok
+}
+
 // ChainForWallet returns the chain source for a wallet's backend, dispatching
 // by wallet type so electrum wallets read/broadcast over Esplora.
 func (e *WalletEngine) ChainForWallet(walletID string) ChainSource {

--- a/sidechain-orchestrator/wallet/esplora.go
+++ b/sidechain-orchestrator/wallet/esplora.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/samber/lo"
 )
 
 // Esplora is the chain-data surface an electrum wallet needs. ElectrumBackend
@@ -33,9 +34,13 @@ type Esplora interface {
 // Bitcoin chain data an electrum wallet needs — address history, UTXOs, raw
 // transactions, fee estimates, broadcast — without a local Core or enforcer.
 type EsploraClient struct {
-	baseURL string
-	client  *http.Client
-	log     zerolog.Logger
+	// baseURLs is an ordered provider list, primary first. A request rotates to
+	// the next provider on each retry, so a rate-limited or unreachable primary
+	// (e.g. mempool.space 429s) fails over to the fallback (e.g. blockstream.info)
+	// on the very next attempt instead of stalling on one host.
+	baseURLs []string
+	client   *http.Client
+	log      zerolog.Logger
 
 	// Pacing keeps a gap-limit scan under public rate limits (mempool.space
 	// 429s a fast sequential burst). nextReq is the earliest the next request
@@ -60,13 +65,19 @@ const (
 	esploraBackoffMax  = 8 * time.Second
 	esploraMinInterval = 120 * time.Millisecond
 	esploraTipTTL      = 30 * time.Second
+	// esploraUserAgent presents a browser identity so providers that reject
+	// non-browser clients (mempool.space) still serve us.
+	esploraUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
 )
 
-// NewEsploraClient creates an Esplora REST client. baseURL is the API root
-// (e.g. https://explorer.signet.drivechain.info/api), trailing slash optional.
-func NewEsploraClient(baseURL string, log zerolog.Logger) *EsploraClient {
+// NewEsploraClient creates an Esplora REST client over an ordered list of API
+// roots (e.g. https://mempool.space/api, https://blockstream.info/api), primary
+// first; trailing slashes optional. Requests rotate to the next root on retry,
+// so a single rate-limited host fails over instead of stalling the wallet.
+func NewEsploraClient(baseURLs []string, log zerolog.Logger) *EsploraClient {
+	roots := lo.Map(baseURLs, func(u string, _ int) string { return strings.TrimRight(u, "/") })
 	return &EsploraClient{
-		baseURL:     strings.TrimRight(baseURL, "/"),
+		baseURLs:    roots,
 		client:      &http.Client{Timeout: 30 * time.Second},
 		log:         log.With().Str("component", "esplora").Logger(),
 		minInterval: esploraMinInterval,
@@ -177,13 +188,18 @@ func (c *EsploraClient) do(ctx context.Context, method, path string, reqBody io.
 		if bodyBytes != nil {
 			rdr = bytes.NewReader(bodyBytes)
 		}
-		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, rdr)
+		// Rotate providers across retries: attempt 0 hits the primary, and each
+		// retry advances to the next root so a 429/outage on one host fails over
+		// to the next instead of backing off against the same dead provider.
+		base := c.baseURLs[attempt%len(c.baseURLs)]
+		req, err := http.NewRequestWithContext(ctx, method, base+path, rdr)
 		if err != nil {
 			return nil, fmt.Errorf("build request %s: %w", path, err)
 		}
-		// Public Esplora hosts commonly drop requests without a User-Agent.
-		req.Header.Set("User-Agent", "bitwindow-orchestratord")
-		c.log.Info().Str("method", method).Str("path", path).Int("attempt", attempt).Msg("esplora request")
+		// mempool.space drops requests from non-browser clients, so present a
+		// browser User-Agent; other public Esplora hosts accept it too.
+		req.Header.Set("User-Agent", esploraUserAgent)
+		c.log.Info().Str("method", method).Str("path", path).Str("base", base).Int("attempt", attempt).Msg("esplora request")
 
 		resp, err := c.client.Do(req)
 		if err != nil {

--- a/sidechain-orchestrator/wallet/esplora_retry_test.go
+++ b/sidechain-orchestrator/wallet/esplora_retry_test.go
@@ -25,7 +25,7 @@ func TestEsploraRetriesOn429(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewEsploraClient(srv.URL+"/api", zerolog.Nop())
+	c := NewEsploraClient([]string{srv.URL + "/api"}, zerolog.Nop())
 	c.minInterval = 0
 
 	stats, err := c.AddressStats(context.Background(), "abc")
@@ -43,7 +43,7 @@ func TestEsploraDoesNotRetryClientError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewEsploraClient(srv.URL+"/api", zerolog.Nop())
+	c := NewEsploraClient([]string{srv.URL + "/api"}, zerolog.Nop())
 	c.minInterval = 0
 
 	_, err := c.AddressStats(context.Background(), "abc")

--- a/sidechain-orchestrator/wallet/esplora_test.go
+++ b/sidechain-orchestrator/wallet/esplora_test.go
@@ -42,7 +42,7 @@ func TestEsploraAddressTxsPaginationUsesConfirmedCursor(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewEsploraClient(srv.URL+"/api", zerolog.Nop())
+	client := NewEsploraClient([]string{srv.URL + "/api"}, zerolog.Nop())
 	txs, err := client.AddressTxs(context.Background(), "A")
 	require.NoError(t, err)
 	require.Len(t, txs, 27, "all pages must be fetched via the confirmed cursor")

--- a/sidechain-orchestrator/wallet/migrations/001_init.sql
+++ b/sidechain-orchestrator/wallet/migrations/001_init.sql
@@ -1,0 +1,38 @@
+CREATE TABLE electrum_addresses (
+    wallet_id            TEXT    NOT NULL,
+    change               INTEGER NOT NULL,
+    idx                  INTEGER NOT NULL,
+    address              TEXT    NOT NULL,
+    chain_funded_count   INTEGER NOT NULL,
+    chain_funded_sum     INTEGER NOT NULL,
+    chain_spent_count    INTEGER NOT NULL,
+    chain_spent_sum      INTEGER NOT NULL,
+    chain_tx_count       INTEGER NOT NULL,
+    mempool_funded_count INTEGER NOT NULL,
+    mempool_funded_sum   INTEGER NOT NULL,
+    mempool_spent_count  INTEGER NOT NULL,
+    mempool_spent_sum    INTEGER NOT NULL,
+    mempool_tx_count     INTEGER NOT NULL,
+    PRIMARY KEY (wallet_id, change, idx)
+);
+
+CREATE TABLE electrum_utxos (
+    wallet_id    TEXT    NOT NULL,
+    address      TEXT    NOT NULL,
+    txid         TEXT    NOT NULL,
+    vout         INTEGER NOT NULL,
+    value        INTEGER NOT NULL,
+    confirmed    INTEGER NOT NULL,
+    block_height INTEGER NOT NULL,
+    block_hash   TEXT    NOT NULL,
+    block_time   INTEGER NOT NULL,
+    PRIMARY KEY (wallet_id, txid, vout)
+);
+
+CREATE TABLE electrum_txs (
+    wallet_id TEXT NOT NULL,
+    address   TEXT NOT NULL,
+    txid      TEXT NOT NULL,
+    raw       TEXT NOT NULL,
+    PRIMARY KEY (wallet_id, address, txid)
+);

--- a/sidechain-orchestrator/wallet/router.go
+++ b/sidechain-orchestrator/wallet/router.go
@@ -39,6 +39,18 @@ func (r *BackendRouter) ElectrumBackend() (*ElectrumBackend, bool) {
 	return eb, ok
 }
 
+// Bip47BackendFor returns the wallet's backend as a Bip47Backend when it is
+// BIP47-capable (Core and electrum are; the enforcer is not). ok is false for a
+// non-capable or unconfigured backend, so the caller skips BIP47 for it.
+func (r *BackendRouter) Bip47BackendFor(walletID string) (Bip47Backend, bool) {
+	p, err := r.pick(walletID)
+	if err != nil {
+		return nil, false
+	}
+	b, ok := p.(Bip47Backend)
+	return b, ok
+}
+
 func (r *BackendRouter) pick(walletID string) (Backend, error) {
 	w := r.svc.GetWalletByID(walletID)
 	if w == nil {

--- a/sidechain-orchestrator/wallet/scancache.go
+++ b/sidechain-orchestrator/wallet/scancache.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 )
 
@@ -139,6 +140,40 @@ func (s *Service) loadElectrumTxs(ctx context.Context, walletID string, byAddr m
 		}
 	}
 	return rows.Err() == nil
+}
+
+// firstUnusedAddress returns the lowest-index address on a chain with no
+// on-chain or mempool history — the next address to hand out for receiving.
+// ok is false when the wallet has no stored addresses for that chain yet, or
+// every one is used; the caller then derives the next index locally.
+func (s *Service) firstUnusedAddress(walletID string, change bool) (string, bool) {
+	if s.electrumDB == nil {
+		return "", false
+	}
+	var addr string
+	err := s.electrumDB.QueryRowContext(context.Background(),
+		`SELECT address FROM electrum_addresses
+		 WHERE wallet_id = ? AND change = ? AND chain_tx_count = 0 AND mempool_tx_count = 0
+		 ORDER BY idx LIMIT 1`, walletID, change).Scan(&addr)
+	if err != nil {
+		return "", false
+	}
+	return addr, true
+}
+
+// maxAddressIndex returns the highest stored address index on a chain, or -1
+// when none are stored. Used to derive the next address past what is known.
+func (s *Service) maxAddressIndex(walletID string, change bool) int {
+	if s.electrumDB == nil {
+		return -1
+	}
+	var max sql.NullInt64
+	if err := s.electrumDB.QueryRowContext(context.Background(),
+		`SELECT MAX(idx) FROM electrum_addresses WHERE wallet_id = ? AND change = ?`,
+		walletID, change).Scan(&max); err != nil || !max.Valid {
+		return -1
+	}
+	return int(max.Int64)
 }
 
 // saveElectrumScan replaces a wallet's stored scan with ps in a single

--- a/sidechain-orchestrator/wallet/scancache.go
+++ b/sidechain-orchestrator/wallet/scancache.go
@@ -1,69 +1,228 @@
 package wallet
 
 import (
+	"context"
 	"encoding/json"
-	"os"
-	"path/filepath"
 )
 
-// persistedScanVersion guards the on-disk format; a mismatch is treated as no
-// cache (the wallet re-scans live).
-const persistedScanVersion = 1
+// electrumScanTables are the per-wallet chain-state tables, cleared together
+// when a wallet's scan is rewritten or removed.
+var electrumScanTables = []string{"electrum_addresses", "electrum_utxos", "electrum_txs"}
 
 // persistedAddr is one scanned chain address and the Esplora data fetched for
-// it — the same EsploraAddressStats the live scan stored. Keys and scripts are
-// re-derived from the seed on load, so only fetched data is persisted.
+// it: stats plus the UTXOs and transactions that back balance/history reads.
+// Keys and scripts are re-derived from the seed on load, so only fetched data
+// is persisted.
 type persistedAddr struct {
-	Change  bool                `json:"change"`
-	Index   uint32              `json:"index"`
-	Address string              `json:"address"`
-	Stats   EsploraAddressStats `json:"stats"`
+	Change  bool
+	Index   uint32
+	Address string
+	Stats   EsploraAddressStats
+	UTXOs   []EsploraUTXO
+	Txs     []EsploraTx
 }
 
-// persistedScan is a wallet's scan as written to disk, so a cold boot rebuilds
-// it without re-querying Esplora.
+// persistedScan is a wallet's scan as stored in electrum.db, so a cold boot
+// rebuilds it without re-querying Esplora.
 type persistedScan struct {
-	Version  int             `json:"version"`
-	WalletID string          `json:"wallet_id"`
-	Addrs    []persistedAddr `json:"addrs"`
+	WalletID string
+	Addrs    []persistedAddr
 }
 
-func (s *Service) electrumCacheDir() string {
-	return filepath.Join(s.bitwindowDir, "electrum-cache")
-}
-
-func (s *Service) electrumScanPath(walletID string) string {
-	return filepath.Join(s.electrumCacheDir(), walletID+".json")
-}
-
-// loadElectrumScan reads a wallet's persisted scan; ok is false if absent or
-// written by a different format version.
+// loadElectrumScan reads a wallet's persisted scan from electrum.db; ok is false
+// when the wallet has no stored addresses (or the db is unavailable). Reads run
+// sequentially — the db is MaxOpenConns(1), so a query must not be issued while
+// another's rows are still open.
 func (s *Service) loadElectrumScan(walletID string) (*persistedScan, bool) {
-	data, err := os.ReadFile(s.electrumScanPath(walletID))
+	if s.electrumDB == nil {
+		return nil, false
+	}
+	ctx := context.Background()
+
+	byAddr, order, ok := s.loadElectrumAddrs(ctx, walletID)
+	if !ok || len(order) == 0 {
+		return nil, false
+	}
+	if !s.loadElectrumUTXOs(ctx, walletID, byAddr) {
+		return nil, false
+	}
+	if !s.loadElectrumTxs(ctx, walletID, byAddr) {
+		return nil, false
+	}
+
+	ps := &persistedScan{WalletID: walletID}
+	for _, addr := range order {
+		ps.Addrs = append(ps.Addrs, *byAddr[addr])
+	}
+	return ps, true
+}
+
+func (s *Service) loadElectrumAddrs(ctx context.Context, walletID string) (map[string]*persistedAddr, []string, bool) {
+	rows, err := s.electrumDB.QueryContext(ctx, `
+		SELECT address, change, idx,
+		       chain_funded_count, chain_funded_sum, chain_spent_count, chain_spent_sum, chain_tx_count,
+		       mempool_funded_count, mempool_funded_sum, mempool_spent_count, mempool_spent_sum, mempool_tx_count
+		FROM electrum_addresses WHERE wallet_id = ? ORDER BY change, idx`, walletID)
 	if err != nil {
-		return nil, false
+		s.log.Warn().Err(err).Msg("load electrum addresses failed")
+		return nil, nil, false
 	}
-	var ps persistedScan
-	if err := json.Unmarshal(data, &ps); err != nil || ps.Version != persistedScanVersion {
-		return nil, false
+	defer rows.Close() //nolint:errcheck
+
+	byAddr := map[string]*persistedAddr{}
+	var order []string
+	for rows.Next() {
+		var a persistedAddr
+		cs, ms := &a.Stats.ChainStats, &a.Stats.MempoolStats
+		if err := rows.Scan(&a.Address, &a.Change, &a.Index,
+			&cs.FundedTxoCount, &cs.FundedTxoSum, &cs.SpentTxoCount, &cs.SpentTxoSum, &cs.TxCount,
+			&ms.FundedTxoCount, &ms.FundedTxoSum, &ms.SpentTxoCount, &ms.SpentTxoSum, &ms.TxCount); err != nil {
+			s.log.Warn().Err(err).Msg("scan electrum address failed")
+			return nil, nil, false
+		}
+		a.Stats.Address = a.Address
+		byAddr[a.Address] = &a
+		order = append(order, a.Address)
 	}
-	return &ps, true
+	return byAddr, order, rows.Err() == nil
 }
 
-// saveElectrumScan writes a wallet's scan atomically (temp file + rename).
-func (s *Service) saveElectrumScan(walletID string, data []byte) error {
-	if err := os.MkdirAll(s.electrumCacheDir(), 0o700); err != nil {
-		return err
+func (s *Service) loadElectrumUTXOs(ctx context.Context, walletID string, byAddr map[string]*persistedAddr) bool {
+	rows, err := s.electrumDB.QueryContext(ctx, `
+		SELECT address, txid, vout, value, confirmed, block_height, block_hash, block_time
+		FROM electrum_utxos WHERE wallet_id = ?`, walletID)
+	if err != nil {
+		s.log.Warn().Err(err).Msg("load electrum utxos failed")
+		return false
 	}
-	path := s.electrumScanPath(walletID)
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return err
+	defer rows.Close() //nolint:errcheck
+
+	for rows.Next() {
+		var addr string
+		var u EsploraUTXO
+		var confirmed int
+		if err := rows.Scan(&addr, &u.TxID, &u.Vout, &u.Value,
+			&confirmed, &u.Status.BlockHeight, &u.Status.BlockHash, &u.Status.BlockTime); err != nil {
+			s.log.Warn().Err(err).Msg("scan electrum utxo failed")
+			return false
+		}
+		u.Status.Confirmed = confirmed != 0
+		if a, ok := byAddr[addr]; ok {
+			a.UTXOs = append(a.UTXOs, u)
+		}
 	}
-	return os.Rename(tmp, path)
+	return rows.Err() == nil
 }
 
-// deleteElectrumScan removes a wallet's persisted scan.
+func (s *Service) loadElectrumTxs(ctx context.Context, walletID string, byAddr map[string]*persistedAddr) bool {
+	rows, err := s.electrumDB.QueryContext(ctx, `
+		SELECT address, raw FROM electrum_txs WHERE wallet_id = ?`, walletID)
+	if err != nil {
+		s.log.Warn().Err(err).Msg("load electrum txs failed")
+		return false
+	}
+	defer rows.Close() //nolint:errcheck
+
+	for rows.Next() {
+		var addr, raw string
+		if err := rows.Scan(&addr, &raw); err != nil {
+			s.log.Warn().Err(err).Msg("scan electrum tx failed")
+			return false
+		}
+		var tx EsploraTx
+		if err := json.Unmarshal([]byte(raw), &tx); err != nil {
+			s.log.Warn().Err(err).Msg("decode electrum tx failed")
+			return false
+		}
+		if a, ok := byAddr[addr]; ok {
+			a.Txs = append(a.Txs, tx)
+		}
+	}
+	return rows.Err() == nil
+}
+
+// saveElectrumScan replaces a wallet's stored scan with ps in a single
+// transaction.
+func (s *Service) saveElectrumScan(walletID string, ps *persistedScan) error {
+	if s.electrumDB == nil {
+		return nil
+	}
+	ctx := context.Background()
+	tx, err := s.electrumDB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rolled back unless Commit succeeds
+
+	for _, table := range electrumScanTables {
+		if _, err := tx.ExecContext(ctx, "DELETE FROM "+table+" WHERE wallet_id = ?", walletID); err != nil {
+			return err
+		}
+	}
+	for _, a := range ps.Addrs {
+		cs, ms := a.Stats.ChainStats, a.Stats.MempoolStats
+		if _, err := tx.ExecContext(ctx, `INSERT INTO electrum_addresses
+			(wallet_id, change, idx, address,
+			 chain_funded_count, chain_funded_sum, chain_spent_count, chain_spent_sum, chain_tx_count,
+			 mempool_funded_count, mempool_funded_sum, mempool_spent_count, mempool_spent_sum, mempool_tx_count)
+			VALUES (?,?,?,?, ?,?,?,?,?, ?,?,?,?,?)`,
+			walletID, a.Change, a.Index, a.Address,
+			cs.FundedTxoCount, cs.FundedTxoSum, cs.SpentTxoCount, cs.SpentTxoSum, cs.TxCount,
+			ms.FundedTxoCount, ms.FundedTxoSum, ms.SpentTxoCount, ms.SpentTxoSum, ms.TxCount); err != nil {
+			return err
+		}
+		for _, u := range a.UTXOs {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO electrum_utxos
+				(wallet_id, address, txid, vout, value, confirmed, block_height, block_hash, block_time)
+				VALUES (?,?,?,?,?,?,?,?,?)`,
+				walletID, a.Address, u.TxID, u.Vout, u.Value, boolToInt(u.Status.Confirmed),
+				u.Status.BlockHeight, u.Status.BlockHash, u.Status.BlockTime); err != nil {
+				return err
+			}
+		}
+		for _, t := range a.Txs {
+			raw, err := json.Marshal(t)
+			if err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, `INSERT INTO electrum_txs (wallet_id, address, txid, raw) VALUES (?,?,?,?)`,
+				walletID, a.Address, t.TxID, string(raw)); err != nil {
+				return err
+			}
+		}
+	}
+	return tx.Commit()
+}
+
+// deleteElectrumScan removes a single wallet's stored scan.
 func (s *Service) deleteElectrumScan(walletID string) {
-	_ = os.Remove(s.electrumScanPath(walletID))
+	if s.electrumDB == nil {
+		return
+	}
+	ctx := context.Background()
+	for _, table := range electrumScanTables {
+		if _, err := s.electrumDB.ExecContext(ctx, "DELETE FROM "+table+" WHERE wallet_id = ?", walletID); err != nil {
+			s.log.Warn().Err(err).Str("table", table).Msg("delete electrum scan failed")
+		}
+	}
+}
+
+// wipeElectrumScans clears every wallet's stored scan, used on a full reset.
+func (s *Service) wipeElectrumScans() {
+	if s.electrumDB == nil {
+		return
+	}
+	ctx := context.Background()
+	for _, table := range electrumScanTables {
+		if _, err := s.electrumDB.ExecContext(ctx, "DELETE FROM "+table); err != nil {
+			s.log.Warn().Err(err).Str("table", table).Msg("wipe electrum scans failed")
+		}
+	}
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -29,6 +30,11 @@ type Service struct {
 
 	bitwindowDir string
 	log          zerolog.Logger
+
+	// electrumDB stores electrum wallet chain state (addresses, UTXOs, txs) so
+	// reads serve from disk and only deltas hit Esplora. Owned solely by the
+	// orchestrator; nil when it could not be opened.
+	electrumDB *sql.DB
 
 	// In-memory state
 	wallets        []WalletData
@@ -269,8 +275,14 @@ func (s *Service) Init() error {
 		return fmt.Errorf("create bitwindow dir: %w", err)
 	}
 
+	db, err := OpenElectrumDB(context.Background(), filepath.Join(s.bitwindowDir, "electrum.db"))
+	if err != nil {
+		return fmt.Errorf("open electrum db: %w", err)
+	}
+	s.electrumDB = db
+
 	s.mu.Lock()
-	err := s.loadWalletFile()
+	err = s.loadWalletFile()
 	s.mu.Unlock()
 	if err != nil {
 		s.log.Warn().Err(err).Msg("initial wallet load failed (may not exist yet)")
@@ -293,6 +305,9 @@ func (s *Service) Close() {
 		close(s.done)
 		if s.watcher != nil {
 			_ = s.watcher.Close()
+		}
+		if s.electrumDB != nil {
+			_ = s.electrumDB.Close()
 		}
 		s.CleanupStarterFiles()
 	})
@@ -1303,7 +1318,7 @@ func (s *Service) DeleteAllWallets(onStatusUpdate func(string), beforeBoot func(
 	s.encryptionKey = nil
 	s.unlockedPass = ""
 	s.mu.Unlock()
-	_ = os.RemoveAll(s.electrumCacheDir())
+	s.wipeElectrumScans()
 
 	// Dart L642-648: beforeBoot callback
 	if beforeBoot != nil {

--- a/sqlitemigrate/go.mod
+++ b/sqlitemigrate/go.mod
@@ -1,0 +1,3 @@
+module github.com/LayerTwo-Labs/sidesail/sqlitemigrate
+
+go 1.25.0

--- a/sqlitemigrate/sqlitemigrate.go
+++ b/sqlitemigrate/sqlitemigrate.go
@@ -1,0 +1,74 @@
+// Package sqlitemigrate applies embedded .sql migration files to a SQLite
+// database, in filename order, recording the highest-applied filename in a
+// single-row `migrations` table. It is stdlib-only so any module can depend on
+// it without pulling in a driver or logger.
+//
+// The bookkeeping table layout matches what bitwindowd has shipped, so it reads
+// existing databases correctly:
+//
+//	CREATE TABLE migrations (
+//	    id             INTEGER PRIMARY KEY CHECK (id = 1),
+//	    latest_version TEXT NOT NULL
+//	)
+package sqlitemigrate
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+)
+
+// Run applies every *.sql file in dir of fsys whose name sorts after the last
+// applied migration, in ascending filename order, and records progress in the
+// `migrations` table. Already-applied files are skipped, so it is safe to call
+// on every startup. It returns the filenames applied this call (empty when the
+// schema was already up to date) so the caller can log as it sees fit.
+func Run(ctx context.Context, db *sql.DB, fsys fs.FS, dir string) ([]string, error) {
+	if _, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS migrations (
+		id INTEGER PRIMARY KEY CHECK (id = 1), -- hard-coded id so REPLACE INTO updates the single row
+		latest_version TEXT NOT NULL
+	)`); err != nil {
+		return nil, fmt.Errorf("create migrations table: %w", err)
+	}
+
+	var latest string
+	if err := db.QueryRowContext(ctx, `SELECT latest_version FROM migrations`).Scan(&latest); err != nil &&
+		!errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("read latest migration: %w", err)
+	}
+
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return nil, fmt.Errorf("read migrations dir %q: %w", dir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".sql") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+
+	var applied []string
+	for _, name := range names {
+		if name <= latest {
+			continue
+		}
+		body, err := fs.ReadFile(fsys, dir+"/"+name)
+		if err != nil {
+			return applied, fmt.Errorf("read migration %s: %w", name, err)
+		}
+		if _, err := db.ExecContext(ctx, string(body)); err != nil {
+			return applied, fmt.Errorf("apply migration %s: %w", name, err)
+		}
+		if _, err := db.ExecContext(ctx, `REPLACE INTO migrations (id, latest_version) VALUES (1, ?)`, name); err != nil {
+			return applied, fmt.Errorf("record migration %s: %w", name, err)
+		}
+		applied = append(applied, name)
+	}
+	return applied, nil
+}


### PR DESCRIPTION
Moves electrum wallet chain state into a dedicated SQLite database (electrum.db) owned by the orchestrator, so the wallet boots instantly from disk and only queries Esplora for what changed since the last scan. The migration runner is shared with bitwindowd through a new zero-dependency sqlitemigrate module rather than duplicated.

Address allocation and the receive screen are now local and instant. NextReceiveAddress is a plain SELECT for the first unused address with a local-derivation fallback, so it never blocks on a scan. After a send, the spent inputs and change output are applied directly to the cached scan, so balance, UTXOs and history all update immediately with no re-scan; the next block reconciles the optimistic view against the chain.

Esplora gains an ordered provider list with failover (blockstream first, mempool as fallback). BIP47 now works for electrum wallets through a Bip47Backend interface that both Core and electrum implement, replacing the previous wallet-type checks in the engine, send path and code advertising.

Also fixes the mainnet explorer links in the notifications list and the transaction context menu, which pointed at drivechain's signet explorer; mainnet now resolves to mempool.space.
