### PR TITLE
faucet: fetch initial claims in an effect

### DIFF
--- a/faucet/app/page.tsx
+++ b/faucet/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { createClient } from "@connectrpc/connect";
 import { format } from "date-fns";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -72,9 +72,10 @@ export default function Home() {
   };
 
   // Initial fetch
-  useState(() => {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fetch once on mount
+  useEffect(() => {
     fetchClaims();
-  });
+  }, []);
 
   const MAX_AMOUNT = 5;
 


### PR DESCRIPTION
the initial claims fetch was written as `useState(() => fetchClaims())`, which runs the fetch as a side effect during render. in react 19 the initializer is double-invoked in strict mode (dev), so it fires twice on mount, and fetching inside useState is the wrong tool regardless.

moved it to a `useEffect(..., [])` so it runs once after mount. biome-ignore on the dep array since the effect intentionally only runs on mount.

verified: tsc, biome and prettier clean, and the page loads and lists claims against the signet backend.