### PR TITLE
bitwindow: forknet-default build variant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
           add_client_configs() {
             local client=$1
             local build_flag=$2
+            local variant=${3:-standard}
 
             if [[ "${{ needs.check-changes.outputs.build_all }}" == "true" || "$build_flag" == "true" ]]; then
                     # use windows-2022 because we need Inno Setup. -2022-image is heavier than latest
@@ -128,7 +129,7 @@ jobs:
                 fi
 
                 # No chains - just add the basic config
-                configurations+=("{\"os\":\"$os\",\"client\":\"$client\"}")
+                configurations+=("{\"os\":\"$os\",\"client\":\"$client\",\"variant\":\"$variant\"}")
               done
             fi
           }
@@ -142,6 +143,9 @@ jobs:
           add_client_configs "zside" "${{ needs.check-changes.outputs.zside }}"
           add_client_configs "coinshift" "${{ needs.check-changes.outputs.coinshift }}"
           add_client_configs "bitwindow" "${{ needs.check-changes.outputs.bitwindow }}"
+          # Second BitWindow build: identical app that defaults to ForkNet, shipped as
+          # the bitwindow-forknet variant (eCash brand). Same source, build-time flag only.
+          add_client_configs "bitwindow" "${{ needs.check-changes.outputs.bitwindow }}" "forknet"
 
           # Join configurations with commas
           matrix=$(IFS=,; echo "{\"include\":[${configurations[*]}]}")
@@ -197,8 +201,11 @@ jobs:
 
       - name: Setup build directory
         run: |
-          # Create build directory name, isolated per OS AND client to avoid race conditions
-          BUILD_DIR="b-${{ matrix.os }}-${{ matrix.client }}"
+          # Create build directory name, isolated per OS AND client (AND variant, so
+          # the two bitwindow rows on the same OS don't collide) to avoid races.
+          VARIANT_SUFFIX=""
+          [ -n "${{ matrix.variant }}" ] && [ "${{ matrix.variant }}" != "standard" ] && VARIANT_SUFFIX="-${{ matrix.variant }}"
+          BUILD_DIR="b-${{ matrix.os }}-${{ matrix.client }}${VARIANT_SUFFIX}"
           rm -rf "$BUILD_DIR"
           mkdir -p "$BUILD_DIR"
           # Copy source files to build directory
@@ -361,6 +368,9 @@ jobs:
             fi
           fi
 
+          # Variant flavor consumed by set-app-name.sh (standard | forknet).
+          export BITWINDOW_VARIANT="${{ matrix.variant }}"
+
           # Everything after the third line is only relevant for macOS
           ./scripts/build-app.sh ${{ runner.os }} ${{ matrix.client }} \
             "$NOTARIZATION_KEY_PATH" "$NOTARIZATION_KEY_PASSWORD" \
@@ -413,6 +423,12 @@ jobs:
           fi
 
       - name: Generate appcast fragment for this build
+        # Only the standard build feeds the BitWindow appcast. The forknet variant
+        # would otherwise emit a "bitwindow" fragment whose EdDSA signature is over
+        # the forknet zip, poisoning the standard auto-update feed. Forknet
+        # auto-update is a follow-up (needs its own release-name mapping in the
+        # appcast scripts + appcast-bitwindow-forknet.xml).
+        if: matrix.variant == '' || matrix.variant == 'standard'
         continue-on-error: true
         run: |
           # Find built files with platform-specific patterns
@@ -807,8 +823,9 @@ jobs:
       - uses: actions/upload-artifact@v5
         with:
           name:
-            ${{ matrix.client }}-binaries-${{ runner.os }}${{ matrix.chain != ''
-            && format('-{0}', matrix.chain) || '' }}
+            ${{ matrix.client }}-binaries-${{ runner.os }}${{ (matrix.variant != ''
+            && matrix.variant != 'standard') && format('-{0}', matrix.variant) || ''
+            }}${{ matrix.chain != '' && format('-{0}', matrix.chain) || '' }}
           if-no-files-found: error
           path: ${{ env.BUILD_DIR }}/${{ matrix.client }}/release/*
 
@@ -968,6 +985,18 @@ jobs:
             mv bitwindow-binaries-Windows/bitwindow.exe BitWindow-latest-x86_64-windows.exe || true
           else
             echo "Skipping BitWindow artifacts (version not increased)"
+          fi
+
+          # BitWindow forknet variant - same source/version, defaults to ForkNet.
+          # Rides BitWindow's version gate (same pubspec). The BitWindow-* scp and
+          # hashes globs below already pick up these BitWindow-forknet-* files.
+          if [ "$UPLOAD_BITWINDOW" = "true" ]; then
+            echo "Preparing BitWindow (forknet) artifacts for upload..."
+            mv bitwindow-binaries-macOS-forknet/bitwindow-osx64.zip BitWindow-forknet-latest-x86_64-apple-darwin.zip || true
+            mv bitwindow-binaries-macOS-forknet/bitwindow-osx64.dmg BitWindow-forknet-latest-x86_64-apple-darwin.dmg || true
+            mv bitwindow-binaries-Linux-forknet/bitwindow-x86_64-linux-gnu.zip BitWindow-forknet-latest-x86_64-unknown-linux-gnu.zip || true
+            mv bitwindow-binaries-Linux-forknet/BitWindow-x86_64.AppImage BitWindow-forknet-latest-x86_64-unknown-linux-gnu.AppImage || true
+            mv bitwindow-binaries-Windows-forknet/bitwindow.exe BitWindow-forknet-latest-x86_64-windows.exe || true
           fi
 
       - name: Install jq for merging version files

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.270
+version: 1.0.271
 
 environment:
   sdk: 3.12.0

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.270
+version: 1.0.271
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -999,7 +999,11 @@ Future<void> initAutoUpdater(Logger log) async {
   }
 
   try {
-    const feedURL = 'https://releases.drivechain.info/appcast-bitwindow.xml';
+    // Variant builds self-update from their own feed (the forknet build sets
+    // BITWINDOW_APPCAST=appcast-bitwindow-forknet.xml) so they don't cross-update
+    // to the standard BitWindow release.
+    const appcast = String.fromEnvironment('BITWINDOW_APPCAST', defaultValue: 'appcast-bitwindow.xml');
+    final feedURL = 'https://releases.drivechain.info/$appcast';
     log.i('Initializing auto updater with feed URL: $feedURL');
 
     await autoUpdater.setFeedURL(feedURL);

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.128
+version: 0.2.129
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/scripts/download-binaries.sh
+++ b/bitwindow/scripts/download-binaries.sh
@@ -56,7 +56,14 @@ build_orch_tool() {
         # CGO must stay on when cross-compiling amd64 on an arm host (Go defaults
         # it off for cross builds); macOS clang handles -arch from GOARCH.
         export CGO_ENABLED=1
-        go build -o "$out" "./cmd/$cmd"
+        # Variant builds embed a different default network into orchestratord
+        # (the forknet build defaults to forknet). Only orchestratord has the
+        # defaultNetwork symbol; orchestratorctl is built plain.
+        if [[ "$cmd" == "orchestratord" && -n "${BITWINDOW_DEFAULT_NETWORK:-}" ]]; then
+            go build -ldflags "-X main.defaultNetwork=${BITWINDOW_DEFAULT_NETWORK}" -o "$out" "./cmd/$cmd"
+        else
+            go build -o "$out" "./cmd/$cmd"
+        fi
     )
 }
 

--- a/bitwindow/scripts/set-app-name.sh
+++ b/bitwindow/scripts/set-app-name.sh
@@ -2,9 +2,28 @@
 
 set -e
 
+# Same name/icon for every variant (default-network-only variants, no rebrand).
 app_name=BitWindow
 
-echo "" > build-vars.env
+# BITWINDOW_VARIANT selects the build flavor: "standard" (default) or "forknet".
+# The forknet variant ships an identical app that simply defaults to ForkNet and
+# self-updates from its own appcast feed. Everything below is the only build-time
+# difference between the two.
+: "${BITWINDOW_VARIANT:=standard}"
 
-# Export the app_name variable so it's available to the parent script
-export app_name
+if [ "$BITWINDOW_VARIANT" = "forknet" ]; then
+    # Flutter compile-time defines (consumed via --dart-define-from-file).
+    {
+        echo "BITWINDOW_NETWORK=forknet"
+        echo "BITWINDOW_APPCAST=appcast-bitwindow-forknet.xml"
+    } > build-vars.env
+    # Picked up by download-binaries.sh to embed the default network into
+    # orchestratord (-ldflags -X main.defaultNetwork). This is the authoritative
+    # lever — orchestratord owns the first-run network; Flutter follows it.
+    export BITWINDOW_DEFAULT_NETWORK=forknet
+else
+    echo "" > build-vars.env
+fi
+
+# Export so the parent build script (and the binary build it spawns) see them.
+export app_name BITWINDOW_VARIANT

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.143
+version: 1.0.144
 
 environment:
   sdk: 3.12.0

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -53,6 +53,12 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47state"
 )
 
+// defaultNetwork is the network the orchestrator boots on when there's no saved
+// config and no --network/ORCHESTRATOR_NETWORK override. "signet" for the standard
+// build; variant builds override it at build time (the forknet build sets "forknet")
+// via: go build -ldflags "-X main.defaultNetwork=forknet" ./cmd/orchestratord
+var defaultNetwork = "signet"
+
 func main() {
 	app := &cli.App{
 		Name:  "orchestratord",
@@ -66,8 +72,8 @@ func main() {
 			},
 			&cli.StringFlag{
 				Name:    "network",
-				Usage:   "bitcoin network (mainnet, testnet, signet, regtest)",
-				Value:   "signet",
+				Usage:   "bitcoin network (mainnet, testnet, signet, regtest, forknet)",
+				Value:   defaultNetwork,
 				EnvVars: []string{"ORCHESTRATOR_NETWORK"},
 			},
 			&cli.StringFlag{

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.272
+version: 1.0.273
 
 environment:
   sdk: 3.12.0

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.143
+version: 1.0.144
 
 environment:
   sdk: 3.12.0

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.270
+version: 1.0.271
 
 environment:
   sdk: 3.12.0


### PR DESCRIPTION
Builds a second BitWindow variant from the same repo via a build flag, so a download can default to opening on ForkNet without maintaining a fork.

The authoritative lever is orchestratord's default network, set at build time with ldflags (-X main.defaultNetwork=forknet) — the orchestrator owns the first-run network and bitwindowd/Flutter follow it. The forknet build also gets a matching Flutter define and self-updates from its own appcast feed (appcast-bitwindow-forknet.xml) so it never cross-updates to the standard release. The standard build is byte-for-byte unchanged.

CI gains a variant matrix axis (bitwindow only) that builds and uploads both BitWindow-* and BitWindow-forknet-* artifacts. Forknet auto-update generation (its appcast feed) is intentionally deferred so it can't poison the standard feed; that wiring is a small follow-up. The CI workflow change should get a branch dry-run before relying on it.