### PR TITLE
electrum: drivechain/coinnews txs + send fixes

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.269
+version: 1.0.270
 
 environment:
   sdk: 3.12.0

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.269
+version: 1.0.270
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/lib/pages/root_page.dart
+++ b/bitwindow/lib/pages/root_page.dart
@@ -1221,26 +1221,30 @@ class _StatusBarState extends State<StatusBar> {
         GetCoinsButton(),
       ],
       endWidgets: [
-        SailSkeletonizer(
-          description: 'Waiting for bitcoind to connect..',
-          enabled: !blockchainProvider.mainchain.connected,
-          child: SailTooltip(
-            message: blockchainProvider.blocks.firstOrNull?.toPretty() ?? '',
-            child: SailText.secondary12('Last block: ${_getTimeSinceLastBlock()}'),
-          ),
-        ),
-        const DividerDot(),
-        SailSkeletonizer(
-          description: 'Waiting for bitcoind to connect..',
-          enabled: !blockchainProvider.mainchain.connected,
-          child: SailTooltip(
-            message: blockchainProvider.peers.map((e) => 'Peer id=${e.id} addr=${e.addr}').join('\n'),
-            child: SailText.secondary12(
-              formatTimeDifference(blockchainProvider.peers.length, 'peer'),
+        // Electrum wallets run no local bitcoind, so block height and peer
+        // counts don't apply — only show them when a Bitcoin Core backend runs.
+        if (GetIt.I.get<WalletReaderProvider>().activeWalletNeedsBitcoinBackends) ...[
+          SailSkeletonizer(
+            description: 'Waiting for bitcoind to connect..',
+            enabled: !blockchainProvider.mainchain.connected,
+            child: SailTooltip(
+              message: blockchainProvider.blocks.firstOrNull?.toPretty() ?? '',
+              child: SailText.secondary12('Last block: ${_getTimeSinceLastBlock()}'),
             ),
           ),
-        ),
-        const DividerDot(),
+          const DividerDot(),
+          SailSkeletonizer(
+            description: 'Waiting for bitcoind to connect..',
+            enabled: !blockchainProvider.mainchain.connected,
+            child: SailTooltip(
+              message: blockchainProvider.peers.map((e) => 'Peer id=${e.id} addr=${e.addr}').join('\n'),
+              child: SailText.secondary12(
+                formatTimeDifference(blockchainProvider.peers.length, 'peer'),
+              ),
+            ),
+          ),
+          const DividerDot(),
+        ],
         ResetButton(
           onTap: () async {
             final confProvider = GetIt.I.get<BitcoinConfProvider>();

--- a/bitwindow/lib/pages/wallet/wallet_send.dart
+++ b/bitwindow/lib/pages/wallet/wallet_send.dart
@@ -464,6 +464,9 @@ class SendPageViewModel extends BaseViewModel {
   }
 
   Future<void> init() async {
+    // Refresh on open — the provider's startup fetch can race bitwindowd's
+    // connection, leaving the dropdown empty until some later refetch.
+    await addressBookProvider.fetch();
     applicationDir = await Environment.datadir();
     logFile = await getLogFile();
   }

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.127
+version: 0.2.128
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/server/api/bitdrive/bitdrive.go
+++ b/bitwindow/server/api/bitdrive/bitdrive.go
@@ -3,13 +3,9 @@ package api_bitdrive
 import (
 	"context"
 	"database/sql"
-	"encoding/hex"
 	"fmt"
 
 	"connectrpc.com/connect"
-	commonv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/common/v1"
-	validatorpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
-	validatorrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
 	bitdrivev1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/bitdrive/v1"
@@ -22,7 +18,6 @@ import (
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 var _ rpc.BitDriveServiceHandler = new(Server)
@@ -30,23 +25,23 @@ var _ rpc.BitDriveServiceHandler = new(Server)
 // New creates a new BitDrive API server
 func New(
 	database *sql.DB,
-	wallet *service.Service[validatorrpc.WalletServiceClient],
 	bitcoind *service.Service[corerpc.BitcoinServiceClient],
 	bitdriveEngine *engines.BitDriveEngine,
+	walletEngine *engines.WalletEngine,
 ) *Server {
 	return &Server{
 		database:       database,
-		wallet:         wallet,
 		bitcoind:       bitcoind,
 		bitdriveEngine: bitdriveEngine,
+		walletEngine:   walletEngine,
 	}
 }
 
 type Server struct {
 	database       *sql.DB
-	wallet         *service.Service[validatorrpc.WalletServiceClient]
 	bitcoind       *service.Service[corerpc.BitcoinServiceClient]
 	bitdriveEngine *engines.BitDriveEngine
+	walletEngine   *engines.WalletEngine
 }
 
 // StoreFile implements bitdrivev1connect.BitDriveServiceHandler.
@@ -70,34 +65,12 @@ func (s *Server) StoreFile(ctx context.Context, req *connect.Request[bitdrivev1.
 
 	opReturnData := engines.FormatOPReturnData(metadataB64, contentStr)
 
-	// Send transaction
-	wallet, err := s.wallet.Get(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get wallet: %w", err)
-	}
-
-	sendReq := &validatorpb.SendTransactionRequest{
-		OpReturnMessage: &commonv1.Hex{
-			Hex: &wrapperspb.StringValue{
-				Value: hex.EncodeToString([]byte(opReturnData)),
-			},
-		},
-	}
-
-	if req.Msg.FeeSatPerVbyte > 0 {
-		sendReq.FeeRate = &validatorpb.SendTransactionRequest_FeeRate{
-			Fee: &validatorpb.SendTransactionRequest_FeeRate_SatPerVbyte{
-				SatPerVbyte: req.Msg.FeeSatPerVbyte,
-			},
-		}
-	}
-
-	resp, err := wallet.SendTransaction(ctx, connect.NewRequest(sendReq))
+	// Broadcast the OP_RETURN through the active wallet's backend (electrum or
+	// enforcer) so BitDrive works regardless of whether a local enforcer runs.
+	txid, err := s.walletEngine.BroadcastOpReturn(ctx, []byte(opReturnData), req.Msg.FeeSatPerVbyte, 0)
 	if err != nil {
 		return nil, fmt.Errorf("send transaction: %w", err)
 	}
-
-	txid := resp.Msg.Txid.Hex.Value
 
 	log.Info().
 		Str("txid", txid).
@@ -376,34 +349,12 @@ func (s *Server) StoreMultisigData(ctx context.Context, req *connect.Request[bit
 		return nil, fmt.Errorf("encode multisig data: %w", err)
 	}
 
-	// Send transaction
-	wallet, err := s.wallet.Get(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get wallet: %w", err)
-	}
-
-	sendReq := &validatorpb.SendTransactionRequest{
-		OpReturnMessage: &commonv1.Hex{
-			Hex: &wrapperspb.StringValue{
-				Value: hex.EncodeToString([]byte(opReturnData)),
-			},
-		},
-	}
-
-	if req.Msg.FeeSatPerVbyte > 0 {
-		sendReq.FeeRate = &validatorpb.SendTransactionRequest_FeeRate{
-			Fee: &validatorpb.SendTransactionRequest_FeeRate_SatPerVbyte{
-				SatPerVbyte: req.Msg.FeeSatPerVbyte,
-			},
-		}
-	}
-
-	resp, err := wallet.SendTransaction(ctx, connect.NewRequest(sendReq))
+	// Broadcast the OP_RETURN through the active wallet's backend (electrum or
+	// enforcer) so BitDrive works regardless of whether a local enforcer runs.
+	txid, err := s.walletEngine.BroadcastOpReturn(ctx, []byte(opReturnData), req.Msg.FeeSatPerVbyte, 0)
 	if err != nil {
 		return nil, fmt.Errorf("send transaction: %w", err)
 	}
-
-	txid := resp.Msg.Txid.Hex.Value
 
 	log.Info().
 		Str("txid", txid).

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -389,6 +389,23 @@ func (s *Server) CreateAddressBookEntry(ctx context.Context, req *connect.Reques
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
+	// A label must map to a single address — reject collisions with a
+	// different address (re-saving the same address still upserts below).
+	label := strings.TrimSpace(req.Msg.Label)
+	if label != "" {
+		existing, err := addressbook.List(ctx, s.db)
+		if err != nil {
+			zerolog.Ctx(ctx).Error().Err(err).Msg("could not list address book entries")
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		for _, entry := range existing {
+			if strings.EqualFold(strings.TrimSpace(entry.Label), label) && entry.Address != addr {
+				err := fmt.Errorf("an address book entry with label %q already exists", label)
+				return nil, connect.NewError(connect.CodeAlreadyExists, err)
+			}
+		}
+	}
+
 	// User-added addresses don't belong to a specific wallet (nil walletId)
 	if err := addressbook.Create(ctx, s.db, nil, req.Msg.Label, addr, direction); err != nil {
 		// Check if this is a unique constraint error for address+direction
@@ -470,6 +487,21 @@ func (s *Server) ListAddressBook(ctx context.Context, req *connect.Request[empty
 }
 
 func (s *Server) UpdateAddressBookEntry(ctx context.Context, req *connect.Request[pb.UpdateAddressBookEntryRequest]) (*connect.Response[emptypb.Empty], error) {
+	label := strings.TrimSpace(req.Msg.Label)
+	if label != "" {
+		existing, err := addressbook.List(ctx, s.db)
+		if err != nil {
+			zerolog.Ctx(ctx).Error().Err(err).Msg("could not list address book entries")
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		for _, entry := range existing {
+			if entry.ID != req.Msg.Id && strings.EqualFold(strings.TrimSpace(entry.Label), label) {
+				err := fmt.Errorf("an address book entry with label %q already exists", label)
+				return nil, connect.NewError(connect.CodeAlreadyExists, err)
+			}
+		}
+	}
+
 	if err := addressbook.UpdateLabel(ctx, s.db, req.Msg.Id, req.Msg.Label); err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not update address book entry")
 		return nil, connect.NewError(connect.CodeInternal, err)

--- a/bitwindow/server/api/drivechain/drivechain.go
+++ b/bitwindow/server/api/drivechain/drivechain.go
@@ -9,6 +9,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/config"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
 	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/drivechain/v1"
 	rpc "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/drivechain/v1/drivechainv1connect"
 	service "github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
@@ -50,22 +51,25 @@ func New(
 	wallet *service.Service[validatorrpc.WalletServiceClient],
 	db *sql.DB,
 	conf config.Config,
+	walletEngine *engines.WalletEngine,
 ) *Server {
 	s := &Server{
 		data:             data,
 		wallet:           wallet,
 		db:               db,
 		conf:             conf,
+		walletEngine:     walletEngine,
 		withdrawalCaches: make(map[uint32]*withdrawalCache),
 	}
 	return s
 }
 
 type Server struct {
-	data   datasource.DrivechainReader
-	wallet *service.Service[validatorrpc.WalletServiceClient]
-	db     *sql.DB
-	conf   config.Config
+	data         datasource.DrivechainReader
+	wallet       *service.Service[validatorrpc.WalletServiceClient]
+	db           *sql.DB
+	conf         config.Config
+	walletEngine *engines.WalletEngine
 
 	// Cache for withdrawal bundles per sidechain ID
 	withdrawalCacheMu sync.RWMutex
@@ -257,6 +261,10 @@ func (s *Server) ProposeSidechain(
 	if c.Msg.Hashid2 != "" && len(c.Msg.Hashid2) != 40 {
 		return nil, connect.NewError(connect.CodeInvalidArgument,
 			fmt.Errorf("hashid2 must be 40 hex chars (160 bits)"))
+	}
+
+	if err := s.walletEngine.RequireFullNode(ctx, "proposing a sidechain"); err != nil {
+		return nil, err
 	}
 
 	wallet, err := s.wallet.Get(ctx)

--- a/bitwindow/server/api/enforcer/enforcer.go
+++ b/bitwindow/server/api/enforcer/enforcer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
 	service "github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/datasource"
 	cryptov1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/crypto/v1"
@@ -23,22 +24,25 @@ func New(
 	validator *service.Service[validatorrpc.ValidatorServiceClient],
 	wallet *service.Service[validatorrpc.WalletServiceClient],
 	crypto *service.Service[cryptorpc.CryptoServiceClient],
+	walletEngine *engines.WalletEngine,
 ) *Server {
 	s := &Server{
-		data:      data,
-		validator: validator,
-		wallet:    wallet,
-		crypto:    crypto,
+		data:         data,
+		validator:    validator,
+		wallet:       wallet,
+		crypto:       crypto,
+		walletEngine: walletEngine,
 	}
 
 	return s
 }
 
 type Server struct {
-	data      datasource.DataSource
-	validator *service.Service[validatorrpc.ValidatorServiceClient]
-	wallet    *service.Service[validatorrpc.WalletServiceClient]
-	crypto    *service.Service[cryptorpc.CryptoServiceClient]
+	data         datasource.DataSource
+	validator    *service.Service[validatorrpc.ValidatorServiceClient]
+	wallet       *service.Service[validatorrpc.WalletServiceClient]
+	crypto       *service.Service[cryptorpc.CryptoServiceClient]
+	walletEngine *engines.WalletEngine
 }
 
 // Stop implements mainchainv1connect.ValidatorServiceHandler.
@@ -73,6 +77,9 @@ func (s *Server) SubscribeHeaderSyncProgress(ctx context.Context, c *connect.Req
 
 // BroadcastWithdrawalBundle implements mainchainv1connect.WalletServiceHandler.
 func (s *Server) BroadcastWithdrawalBundle(ctx context.Context, c *connect.Request[mainchainv1.BroadcastWithdrawalBundleRequest]) (*connect.Response[mainchainv1.BroadcastWithdrawalBundleResponse], error) {
+	if err := s.walletEngine.RequireFullNode(ctx, "broadcasting a withdrawal bundle"); err != nil {
+		return nil, err
+	}
 	wallet, err := s.wallet.Get(ctx)
 	if err != nil {
 		return nil, err
@@ -111,6 +118,9 @@ func (s *Server) CreateNewAddress(ctx context.Context, c *connect.Request[mainch
 // CreateSidechainProposal implements mainchainv1connect.WalletServiceHandler.
 // nolint:dupl
 func (s *Server) CreateSidechainProposal(ctx context.Context, c *connect.Request[mainchainv1.CreateSidechainProposalRequest], stream *connect.ServerStream[mainchainv1.CreateSidechainProposalResponse]) error {
+	if err := s.walletEngine.RequireFullNode(ctx, "creating a sidechain proposal"); err != nil {
+		return err
+	}
 	wallet, err := s.wallet.Get(ctx)
 	if err != nil {
 		return err
@@ -131,6 +141,9 @@ func (s *Server) CreateSidechainProposal(ctx context.Context, c *connect.Request
 
 // SubmitSidechainProposal implements mainchainv1connect.WalletServiceHandler.
 func (s *Server) SubmitSidechainProposal(ctx context.Context, c *connect.Request[mainchainv1.SubmitSidechainProposalRequest]) (*connect.Response[mainchainv1.SubmitSidechainProposalResponse], error) {
+	if err := s.walletEngine.RequireFullNode(ctx, "submitting a sidechain proposal"); err != nil {
+		return nil, err
+	}
 	wallet, err := s.wallet.Get(ctx)
 	if err != nil {
 		return nil, err

--- a/bitwindow/server/api/misc/misc.go
+++ b/bitwindow/server/api/misc/misc.go
@@ -17,9 +17,6 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/timestamps"
 	service "github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
 	codec "github.com/LayerTwo-Labs/sidesail/coinnews/codec"
-	commonv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/common/v1"
-	validatorpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
-	validatorrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
 	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
@@ -27,7 +24,6 @@ import (
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 var _ rpc.MiscServiceHandler = new(Server)
@@ -36,23 +32,23 @@ var _ rpc.MiscServiceHandler = new(Server)
 // anything else just yet.
 func New(
 	database *sql.DB,
-	wallet *service.Service[validatorrpc.WalletServiceClient],
 	timestampEngine *engines.TimestampEngine,
 	bitcoind *service.Service[corerpc.BitcoinServiceClient],
+	walletEngine *engines.WalletEngine,
 ) *Server {
 	return &Server{
 		database:        database,
-		wallet:          wallet,
 		timestampEngine: timestampEngine,
 		bitcoind:        bitcoind,
+		walletEngine:    walletEngine,
 	}
 }
 
 type Server struct {
 	database        *sql.DB
-	wallet          *service.Service[validatorrpc.WalletServiceClient]
 	timestampEngine *engines.TimestampEngine
 	bitcoind        *service.Service[corerpc.BitcoinServiceClient]
+	walletEngine    *engines.WalletEngine
 }
 
 // listOPReturnLimit is the cap for the gRPC ListOPReturn handler. The
@@ -116,11 +112,6 @@ func (s *Server) BroadcastNews(ctx context.Context, req *connect.Request[miscv1.
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	wallet, err := s.wallet.Get(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	storyBytes, err := opreturns.EncodeNewsMessageWithOptions(topicID, req.Msg.Headline, req.Msg.Content, opreturns.StoryOptions{
 		URL:     req.Msg.Url,
 		Lang:    req.Msg.Lang,
@@ -130,30 +121,8 @@ func (s *Server) BroadcastNews(ctx context.Context, req *connect.Request[miscv1.
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
-	sendReq := &validatorpb.SendTransactionRequest{
-		OpReturnMessage: &commonv1.Hex{
-			Hex: &wrapperspb.StringValue{
-				Value: hex.EncodeToString(storyBytes),
-			},
-		},
-	}
 
-	// Set fee rate if specified
-	if req.Msg.FeeSatPerVbyte > 0 {
-		sendReq.FeeRate = &validatorpb.SendTransactionRequest_FeeRate{
-			Fee: &validatorpb.SendTransactionRequest_FeeRate_SatPerVbyte{
-				SatPerVbyte: req.Msg.FeeSatPerVbyte,
-			},
-		}
-	} else if req.Msg.FeeSats > 0 {
-		sendReq.FeeRate = &validatorpb.SendTransactionRequest_FeeRate{
-			Fee: &validatorpb.SendTransactionRequest_FeeRate_Sats{
-				Sats: req.Msg.FeeSats,
-			},
-		}
-	}
-
-	resp, err := wallet.SendTransaction(ctx, connect.NewRequest(sendReq))
+	txid, err := s.walletEngine.BroadcastOpReturn(ctx, storyBytes, req.Msg.FeeSatPerVbyte, req.Msg.FeeSats)
 	if err != nil {
 		return nil, fmt.Errorf("broadcast news: %w", err)
 	}
@@ -162,11 +131,11 @@ func (s *Server) BroadcastNews(ctx context.Context, req *connect.Request[miscv1.
 	log.Info().
 		Hex("topic", topicID[:]).
 		Str("headline", req.Msg.Headline).
-		Str("txid", resp.Msg.Txid.String()).
+		Str("txid", txid).
 		Msg("broadcast news transaction")
 
 	return connect.NewResponse(&miscv1.BroadcastNewsResponse{
-		Txid: resp.Msg.Txid.Hex.Value,
+		Txid: txid,
 	}), nil
 }
 
@@ -212,33 +181,7 @@ func (s *Server) broadcastVote(ctx context.Context, req *miscv1.UpvoteNewsReques
 		return nil, fmt.Errorf("vote news: encode vote: %w", err)
 	}
 
-	wallet, err := s.wallet.Get(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	sendReq := &validatorpb.SendTransactionRequest{
-		OpReturnMessage: &commonv1.Hex{
-			Hex: &wrapperspb.StringValue{
-				Value: hex.EncodeToString(voteBytes),
-			},
-		},
-	}
-	if req.FeeSatPerVbyte > 0 {
-		sendReq.FeeRate = &validatorpb.SendTransactionRequest_FeeRate{
-			Fee: &validatorpb.SendTransactionRequest_FeeRate_SatPerVbyte{
-				SatPerVbyte: req.FeeSatPerVbyte,
-			},
-		}
-	} else if req.FeeSats > 0 {
-		sendReq.FeeRate = &validatorpb.SendTransactionRequest_FeeRate{
-			Fee: &validatorpb.SendTransactionRequest_FeeRate_Sats{
-				Sats: req.FeeSats,
-			},
-		}
-	}
-
-	resp, err := wallet.SendTransaction(ctx, connect.NewRequest(sendReq))
+	txid, err := s.walletEngine.BroadcastOpReturn(ctx, voteBytes, req.FeeSatPerVbyte, req.FeeSats)
 	if err != nil {
 		return nil, fmt.Errorf("vote news: %w", err)
 	}
@@ -246,11 +189,11 @@ func (s *Server) broadcastVote(ctx context.Context, req *miscv1.UpvoteNewsReques
 	zerolog.Ctx(ctx).Info().
 		Str("item_id", req.ItemId).
 		Uint8("kind", uint8(kind)).
-		Str("txid", resp.Msg.Txid.String()).
+		Str("txid", txid).
 		Msg("broadcast vote transaction")
 
 	return connect.NewResponse(&miscv1.UpvoteNewsResponse{
-		Txid: resp.Msg.Txid.Hex.Value,
+		Txid: txid,
 	}), nil
 }
 
@@ -285,27 +228,14 @@ func (s *Server) CreateTopic(ctx context.Context, req *connect.Request[miscv1.Cr
 		retentionDays = 7 // Default to 7 days
 	}
 
-	// Send the transaction
-	wallet, err := s.wallet.Get(ctx)
-	if err != nil {
-		return nil, err
-	}
 	topicCreationBytes, err := opreturns.EncodeTopicCreationMessageNewFormat(topicID, req.Msg.Name, retentionDays)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
-	resp, err := wallet.SendTransaction(ctx,
-		connect.NewRequest(&validatorpb.SendTransactionRequest{
-			OpReturnMessage: &commonv1.Hex{
-				Hex: &wrapperspb.StringValue{
-					Value: hex.EncodeToString(topicCreationBytes),
-				},
-			},
-		}))
+	txid, err := s.walletEngine.BroadcastOpReturn(ctx, topicCreationBytes, 0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("broadcast topic creation: %w", err)
 	}
-	txid := resp.Msg.Txid.Hex.Value
 
 	log := zerolog.Ctx(ctx)
 	log.Info().
@@ -439,38 +369,18 @@ func (s *Server) CommentNews(ctx context.Context, req *connect.Request[miscv1.Co
 		return nil, fmt.Errorf("comment news: encode comment: %w", err)
 	}
 
-	wallet, err := s.wallet.Get(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	sendReq := &validatorpb.SendTransactionRequest{
-		OpReturnMessage: &commonv1.Hex{
-			Hex: &wrapperspb.StringValue{Value: hex.EncodeToString(commentBytes)},
-		},
-	}
-	if req.Msg.FeeSatPerVbyte > 0 {
-		sendReq.FeeRate = &validatorpb.SendTransactionRequest_FeeRate{
-			Fee: &validatorpb.SendTransactionRequest_FeeRate_SatPerVbyte{SatPerVbyte: req.Msg.FeeSatPerVbyte},
-		}
-	} else if req.Msg.FeeSats > 0 {
-		sendReq.FeeRate = &validatorpb.SendTransactionRequest_FeeRate{
-			Fee: &validatorpb.SendTransactionRequest_FeeRate_Sats{Sats: req.Msg.FeeSats},
-		}
-	}
-
-	resp, err := wallet.SendTransaction(ctx, connect.NewRequest(sendReq))
+	txid, err := s.walletEngine.BroadcastOpReturn(ctx, commentBytes, req.Msg.FeeSatPerVbyte, req.Msg.FeeSats)
 	if err != nil {
 		return nil, fmt.Errorf("comment news: %w", err)
 	}
 
 	zerolog.Ctx(ctx).Info().
 		Str("parent_id", req.Msg.ParentId).
-		Str("txid", resp.Msg.Txid.String()).
+		Str("txid", txid).
 		Msg("broadcast comment transaction")
 
 	return connect.NewResponse(&miscv1.CommentNewsResponse{
-		Txid: resp.Msg.Txid.Hex.Value,
+		Txid: txid,
 	}), nil
 }
 

--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -184,7 +184,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 	}
 
 	rt.chequeEngine = engines.NewChequeEngine(rt.walletEngine, rt.chainParams, s.Bitcoind)
-	walletAdapter := engines.NewWalletAdapter(s.Wallet)
+	walletAdapter := engines.NewWalletAdapter(rt.walletEngine)
 	timestampLogger := log.With().Str("component", "timestamp").Logger()
 	rt.timestampEngine = engines.NewTimestampEngine(rt.db, timestampLogger, walletAdapter, s.Bitcoind)
 	rt.m4Engine = engines.NewM4Engine(rt.db)
@@ -243,7 +243,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 		register(path, h)
 	}
 	{
-		drivechainSvc := api_drivechain.New(dataSource, s.Wallet, rt.db, conf)
+		drivechainSvc := api_drivechain.New(dataSource, s.Wallet, rt.db, conf, rt.walletEngine)
 		path, h := drivechainv1connect.NewDrivechainServiceHandler(drivechainSvc, stdOpts...)
 		register(path, h)
 	}
@@ -268,7 +268,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 		register(path, h)
 	}
 	{
-		miscSvc := api_misc.New(rt.db, s.Wallet, rt.timestampEngine, s.Bitcoind)
+		miscSvc := api_misc.New(rt.db, rt.timestampEngine, s.Bitcoind, rt.walletEngine)
 		path, h := miscv1connect.NewMiscServiceHandler(miscSvc, stdOpts...)
 		register(path, h)
 	}
@@ -288,7 +288,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 		register(path, h)
 	}
 	{
-		bitdriveSvc := api_bitdrive.New(rt.db, s.Wallet, s.Bitcoind, rt.bitdriveEngine)
+		bitdriveSvc := api_bitdrive.New(rt.db, s.Bitcoind, rt.bitdriveEngine, rt.walletEngine)
 		path, h := bitdrivev1connect.NewBitDriveServiceHandler(bitdriveSvc, stdOpts...)
 		register(path, h)
 	}
@@ -313,7 +313,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 		register(path, h)
 	}
 	// Enforcer bridge — single impl serves three separate services
-	enforcerSvc := api_enforcer.New(dataSource, s.Enforcer, s.Wallet, s.Crypto)
+	enforcerSvc := api_enforcer.New(dataSource, s.Enforcer, s.Wallet, s.Crypto, rt.walletEngine)
 	{
 		path, h := validatorrpc.NewValidatorServiceHandler(enforcerSvc, stdOpts...)
 		register(path, h)

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -34,6 +34,7 @@ import (
 	cryptorpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/crypto/v1/cryptov1connect"
 	validatorpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
 	validatorrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
 	"github.com/btcsuite/btcd/btcutil"
@@ -1215,15 +1216,6 @@ func (s *Server) CreateSidechainDeposit(ctx context.Context, c *connect.Request[
 		return nil, fmt.Errorf("get wallet type: %w", err)
 	}
 
-	// Sidechain deposits only work with enforcer wallet
-	if walletType != engines.WalletTypeEnforcer {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("sidechain operations only supported with enforcer wallet"))
-	}
-
-	if s.wallet == nil {
-		return nil, errors.New("wallet not connected")
-	}
-
 	slot, depositAddress, _, err := drivechain.DecodeDepositAddress(c.Msg.Destination)
 	if err != nil {
 		return nil, fmt.Errorf("invalid deposit address: %w", err)
@@ -1232,6 +1224,9 @@ func (s *Server) CreateSidechainDeposit(ctx context.Context, c *connect.Request[
 		return nil, fmt.Errorf("address is not a sidechain deposit address, expected slot or format: s<slot>_<address> or s9_<address>_<checksum>")
 	} else if slot == nil {
 		slot = &c.Msg.Slot
+	}
+	if *slot > 255 {
+		return nil, fmt.Errorf("invalid sidechain slot %d: must be 0-255", *slot)
 	}
 
 	amount, err := btcutil.NewAmount(c.Msg.Amount)
@@ -1242,6 +1237,20 @@ func (s *Server) CreateSidechainDeposit(ctx context.Context, c *connect.Request[
 	fee, err := btcutil.NewAmount(c.Msg.Fee)
 	if err != nil || fee < 0 {
 		return nil, fmt.Errorf("invalid fee, must be a BTC-amount greater than zero")
+	}
+
+	// Electrum wallets build the M5 deposit themselves (no local enforcer) and
+	// broadcast it through the orchestrator wallet manager.
+	if walletType == engines.WalletTypeElectrum {
+		return s.createElectrumSidechainDeposit(ctx, walletId, uint32(*slot), depositAddress, amount, fee)
+	}
+
+	// Enforcer wallets delegate construction to the enforcer.
+	if walletType != engines.WalletTypeEnforcer {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("sidechain deposits require an enforcer or electrum wallet"))
+	}
+	if s.wallet == nil {
+		return nil, errors.New("wallet not connected")
 	}
 
 	wallet, err := s.wallet.Get(ctx)
@@ -1263,6 +1272,62 @@ func (s *Server) CreateSidechainDeposit(ctx context.Context, c *connect.Request[
 	return connect.NewResponse(&pb.CreateSidechainDepositResponse{
 		Txid: created.Msg.Txid.Hex.Value,
 	}), nil
+}
+
+// createElectrumSidechainDeposit builds and broadcasts a BIP300 M5 deposit from
+// an electrum wallet. The M5 must spend the sidechain's current CTIP (treasury)
+// and produce, in order: out[0] the new OP_DRIVECHAIN treasury (old CTIP value +
+// deposit), out[1] an OP_RETURN of the sidechain address. The orchestrator funds
+// the deposit amount + fee from the wallet and adds change.
+func (s *Server) createElectrumSidechainDeposit(
+	ctx context.Context,
+	walletId string,
+	slot uint32,
+	depositAddress string,
+	amount, fee btcutil.Amount,
+) (*connect.Response[pb.CreateSidechainDepositResponse], error) {
+	// Current treasury UTXO. Nil means this is the first deposit to the slot, so
+	// there is no prior CTIP to spend and the treasury starts at the deposit.
+	ctipResp, err := s.data.Ctip(ctx, &validatorpb.GetCtipRequest{
+		SidechainNumber: wrapperspb.UInt32(slot),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get sidechain ctip: %w", err)
+	}
+
+	var ctipValue uint64
+	var externalInputs []*orchpb.ExternalInput
+	if ctip := ctipResp.Ctip; ctip != nil {
+		ctipValue = ctip.Value
+		externalInputs = []*orchpb.ExternalInput{{
+			Txid:      ctip.Txid.Hex.Value,
+			Vout:      int32(ctip.Vout),
+			ValueSats: int64(ctip.Value),
+		}}
+	}
+
+	// Treasury scriptPubKey: OP_DRIVECHAIN OP_PUSHBYTES_1 <slot> OP_TRUE. Built as
+	// raw bytes — minimal-push encoding would collapse a 1-16 slot to OP_N.
+	treasuryScript := []byte{0xB4, 0x01, byte(slot), 0x51}
+
+	req := &orchpb.SendTransactionRequest{
+		WalletId:     walletId,
+		FixedFeeSats: int64(fee),
+		RawOutputs: []*orchpb.RawOutput{
+			{ValueSats: int64(ctipValue) + int64(amount), ScriptHex: hex.EncodeToString(treasuryScript)},
+		},
+		OpReturnHex:    hex.EncodeToString([]byte(depositAddress)),
+		ExternalInputs: externalInputs,
+	}
+
+	txid, err := s.walletEngine.SendTransaction(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("broadcast sidechain deposit: %w", err)
+	}
+
+	zerolog.Ctx(ctx).Info().Str("txid", txid).Uint32("slot", slot).Msg("create electrum deposit tx: broadcast")
+
+	return connect.NewResponse(&pb.CreateSidechainDepositResponse{Txid: txid}), nil
 }
 
 // SignMessage implements walletv1connect.WalletServiceHandler.

--- a/bitwindow/server/engines/deniability_engine.go
+++ b/bitwindow/server/engines/deniability_engine.go
@@ -14,6 +14,7 @@ import (
 	commonv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/common/v1"
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
 	validatorrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
 	"github.com/rs/zerolog"
@@ -293,7 +294,7 @@ func (e *DeniabilityEngine) ProcessUTXO(ctx context.Context, utxo *pb.ListUnspen
 		}
 		txid, err = e.sendBitcoinCoreTransaction(ctx, walletId, destinations)
 	case WalletTypeElectrum:
-		return fmt.Errorf("deniability is not supported for electrum wallets")
+		txid, err = e.sendElectrumTransaction(ctx, walletId, utxo, destinations, fee)
 	default:
 		return fmt.Errorf("unknown wallet type: %s", walletType)
 	}
@@ -403,6 +404,28 @@ func (e *DeniabilityEngine) sendBitcoinCoreTransaction(
 	}
 
 	return resp.Msg.Txid, nil
+}
+
+// sendElectrumTransaction sends a transaction via the orchestrator wallet
+// manager, spending the chosen UTXO into the denial destinations.
+func (e *DeniabilityEngine) sendElectrumTransaction(
+	ctx context.Context,
+	walletId string,
+	utxo *pb.ListUnspentOutputsResponse_Output,
+	destinations map[string]uint64,
+	fee uint64,
+) (string, error) {
+	dests := lo.MapValues(destinations, func(sats uint64, _ string) int64 {
+		return int64(sats)
+	})
+	return e.walletEngine.SendTransaction(ctx, &orchpb.SendTransactionRequest{
+		WalletId:     walletId,
+		Destinations: dests,
+		FixedFeeSats: int64(fee),
+		RequiredInputs: []*orchpb.UnspentOutput{
+			{Txid: utxo.Txid.Hex.Value, Vout: int32(utxo.Vout)},
+		},
+	})
 }
 
 // the enforcer wallet takes a few seconds/minutes to add the sent transaction
@@ -537,24 +560,7 @@ func (e *DeniabilityEngine) simpleSplit(
 	walletType WalletType,
 	walletId string,
 ) (map[string]uint64, error) {
-	// Get a new address based on wallet type
-	var address string
-	var err error
-
-	switch walletType {
-	case WalletTypeEnforcer:
-		address, err = e.getEnforcerNewAddress(ctx)
-	case WalletTypeBitcoinCore:
-		if werr := e.rejectWatchOnly(ctx, walletId); werr != nil {
-			return nil, werr
-		}
-		address, err = e.getBitcoinCoreNewAddress(ctx, walletId)
-	case WalletTypeElectrum:
-		return nil, fmt.Errorf("deniability not supported for electrum wallets")
-	default:
-		return nil, fmt.Errorf("unsupported wallet type for deniability: %s", walletType)
-	}
-
+	address, err := e.getNewAddress(ctx, walletType, walletId)
 	if err != nil {
 		return nil, fmt.Errorf("get new address: %w", err)
 	}
@@ -588,24 +594,7 @@ func (e *DeniabilityEngine) targetAmountSplit(
 	walletId string,
 	targetSize int64,
 ) (map[string]uint64, error) {
-	// Get a new address based on wallet type
-	var address string
-	var err error
-
-	switch walletType {
-	case WalletTypeEnforcer:
-		address, err = e.getEnforcerNewAddress(ctx)
-	case WalletTypeBitcoinCore:
-		if werr := e.rejectWatchOnly(ctx, walletId); werr != nil {
-			return nil, werr
-		}
-		address, err = e.getBitcoinCoreNewAddress(ctx, walletId)
-	case WalletTypeElectrum:
-		return nil, fmt.Errorf("deniability not supported for electrum wallets")
-	default:
-		return nil, fmt.Errorf("unsupported wallet type for deniability: %s", walletType)
-	}
-
+	address, err := e.getNewAddress(ctx, walletType, walletId)
 	if err != nil {
 		return nil, fmt.Errorf("get new address: %w", err)
 	}
@@ -628,6 +617,24 @@ func (e *DeniabilityEngine) targetAmountSplit(
 	return map[string]uint64{
 		address: targetAmount,
 	}, nil
+}
+
+// getNewAddress returns a fresh destination address for the active wallet's
+// backend. Watch-only Bitcoin Core wallets are rejected (they can't sign).
+func (e *DeniabilityEngine) getNewAddress(ctx context.Context, walletType WalletType, walletId string) (string, error) {
+	switch walletType {
+	case WalletTypeEnforcer:
+		return e.getEnforcerNewAddress(ctx)
+	case WalletTypeBitcoinCore:
+		if werr := e.rejectWatchOnly(ctx, walletId); werr != nil {
+			return "", werr
+		}
+		return e.getBitcoinCoreNewAddress(ctx, walletId)
+	case WalletTypeElectrum:
+		return e.walletEngine.GetElectrumReceiveAddress(ctx, walletId)
+	default:
+		return "", fmt.Errorf("unsupported wallet type for deniability: %s", walletType)
+	}
 }
 
 // getEnforcerNewAddress creates a new address from the enforcer wallet
@@ -710,11 +717,29 @@ func (e *DeniabilityEngine) listUTXOsForWallet(ctx context.Context, walletId str
 		return e.listBitcoinCoreUTXOs(ctx, walletId)
 
 	case WalletTypeElectrum:
-		return nil, fmt.Errorf("deniability not supported for electrum wallets")
+		return e.listElectrumUTXOs(ctx, walletId)
 
 	default:
 		return nil, fmt.Errorf("unknown wallet type: %s", walletType)
 	}
+}
+
+// listElectrumUTXOs lists an electrum wallet's UTXOs (served via the
+// orchestrator/Esplora) and converts them to the enforcer output shape the
+// rest of the engine works with.
+func (e *DeniabilityEngine) listElectrumUTXOs(ctx context.Context, walletId string) ([]*pb.ListUnspentOutputsResponse_Output, error) {
+	utxos, err := e.walletEngine.GetElectrumUnspent(ctx, walletId)
+	if err != nil {
+		return nil, fmt.Errorf("electrum: list unspent: %w", err)
+	}
+	return lo.Map(utxos, func(u *orchpb.UnspentOutput, _ int) *pb.ListUnspentOutputsResponse_Output {
+		return &pb.ListUnspentOutputsResponse_Output{
+			Txid:      &commonv1.ReverseHex{Hex: &wrapperspb.StringValue{Value: u.Txid}},
+			Vout:      uint32(u.Vout),
+			ValueSats: uint64(u.AmountSats),
+			Address:   &wrapperspb.StringValue{Value: u.Address},
+		}
+	}), nil
 }
 
 // listEnforcerUTXOs lists UTXOs from the enforcer wallet

--- a/bitwindow/server/engines/wallet_adapter.go
+++ b/bitwindow/server/engines/wallet_adapter.go
@@ -2,42 +2,18 @@ package engines
 
 import (
 	"context"
-	"encoding/hex"
-	"fmt"
-
-	"connectrpc.com/connect"
-	service "github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
-	commonv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/common/v1"
-	validatorpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
-	validatorrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-// WalletAdapter adapts the wallet service for timestamp engine
+// WalletAdapter adapts the wallet engine for the timestamp engine, routing
+// OP_RETURN broadcasts through the active wallet's backend (electrum or enforcer).
 type WalletAdapter struct {
-	wallet *service.Service[validatorrpc.WalletServiceClient]
+	engine *WalletEngine
 }
 
-func NewWalletAdapter(wallet *service.Service[validatorrpc.WalletServiceClient]) *WalletAdapter {
-	return &WalletAdapter{wallet: wallet}
+func NewWalletAdapter(engine *WalletEngine) *WalletAdapter {
+	return &WalletAdapter{engine: engine}
 }
 
 func (w *WalletAdapter) SendTransaction(ctx context.Context, opReturnData []byte) (string, error) {
-	client, err := w.wallet.Get(ctx)
-	if err != nil {
-		return "", fmt.Errorf("get wallet client: %w", err)
-	}
-
-	resp, err := client.SendTransaction(ctx, connect.NewRequest(&validatorpb.SendTransactionRequest{
-		OpReturnMessage: &commonv1.Hex{
-			Hex: &wrapperspb.StringValue{
-				Value: hex.EncodeToString(opReturnData),
-			},
-		},
-	}))
-	if err != nil {
-		return "", fmt.Errorf("send transaction: %w", err)
-	}
-
-	return resp.Msg.Txid.Hex.Value, nil
+	return w.engine.BroadcastOpReturn(ctx, opReturnData, 0, 0)
 }

--- a/bitwindow/server/engines/wallet_engine.go
+++ b/bitwindow/server/engines/wallet_engine.go
@@ -15,6 +15,8 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/wallet"
+	commonv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/common/v1"
+	validatorpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
 	validatorrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
@@ -28,6 +30,7 @@ import (
 	"github.com/samber/lo"
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // WalletType is a wallet's provider backend. Watch-only is an orthogonal
@@ -798,6 +801,89 @@ func (e *WalletEngine) FinalizePsbt(ctx context.Context, psbtBase64 string) (str
 		return "", fmt.Errorf("electrum: finalize psbt: %w", err)
 	}
 	return resp.Msg.RawTxHex, nil
+}
+
+// RequireFullNode returns a clear error when the active wallet is electrum, for
+// L1 operations (sidechain proposals, withdrawal bundles) that can only be
+// produced by a full node with the BIP300/301 enforcer — they live in the block
+// coinbase / are built by the enforcer, so no standalone wallet can broadcast
+// them. Returns nil when the wallet type can't be determined, so the caller's
+// own error path still runs.
+func (e *WalletEngine) RequireFullNode(ctx context.Context, op string) error {
+	w, err := e.GetActiveWallet(ctx)
+	if err != nil {
+		return nil
+	}
+	if w.WalletType == WalletTypeElectrum {
+		return connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("%s requires a full node with the BIP300/301 enforcer; not available for electrum wallets", op))
+	}
+	return nil
+}
+
+// BroadcastOpReturn publishes raw OP_RETURN data through the active wallet's
+// backend and returns the txid. Electrum wallets run no local enforcer, so they
+// broadcast through the orchestrator wallet manager — the same path the normal
+// "Send" flow uses; enforcer and Bitcoin Core wallets use the enforcer wallet.
+// This is the single broadcast seam every server-side OP_RETURN sender shares.
+func (e *WalletEngine) BroadcastOpReturn(ctx context.Context, data []byte, feeSatPerVByte, feeSats uint64) (string, error) {
+	activeWallet, err := e.GetActiveWallet(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get active wallet: %w", err)
+	}
+
+	if activeWallet.WalletType == WalletTypeElectrum {
+		req := &orchpb.SendTransactionRequest{
+			WalletId:    activeWallet.ID,
+			OpReturnHex: hex.EncodeToString(data),
+		}
+		switch {
+		case feeSatPerVByte > 0:
+			req.FeeRateSatPerVbyte = int64(feeSatPerVByte)
+		case feeSats > 0:
+			req.FixedFeeSats = int64(feeSats)
+		}
+		return e.SendTransaction(ctx, req)
+	}
+
+	wallet, err := e.enforcerConnector(ctx)
+	if err != nil {
+		return "", err
+	}
+	req := &validatorpb.SendTransactionRequest{
+		OpReturnMessage: &commonv1.Hex{
+			Hex: &wrapperspb.StringValue{Value: hex.EncodeToString(data)},
+		},
+	}
+	switch {
+	case feeSatPerVByte > 0:
+		req.FeeRate = &validatorpb.SendTransactionRequest_FeeRate{
+			Fee: &validatorpb.SendTransactionRequest_FeeRate_SatPerVbyte{SatPerVbyte: feeSatPerVByte},
+		}
+	case feeSats > 0:
+		req.FeeRate = &validatorpb.SendTransactionRequest_FeeRate{
+			Fee: &validatorpb.SendTransactionRequest_FeeRate_Sats{Sats: feeSats},
+		}
+	}
+	resp, err := wallet.SendTransaction(ctx, connect.NewRequest(req))
+	if err != nil {
+		return "", err
+	}
+	return resp.Msg.Txid.Hex.Value, nil
+}
+
+// SendTransaction builds, signs, and broadcasts a transaction through the
+// orchestrator wallet manager, which routes to the active wallet's backend
+// (electrum or Bitcoin Core). Used by server-side senders like news OP_RETURNs.
+func (e *WalletEngine) SendTransaction(ctx context.Context, req *orchpb.SendTransactionRequest) (string, error) {
+	if e.orchClient == nil {
+		return "", fmt.Errorf("orchestrator wallet client not connected")
+	}
+	resp, err := e.orchClient.SendTransaction(ctx, connect.NewRequest(req))
+	if err != nil {
+		return "", fmt.Errorf("send transaction: %w", err)
+	}
+	return resp.Msg.Txid, nil
 }
 
 // GetElectrumUnspent returns an electrum wallet's UTXOs from the orchestrator,

--- a/bitwindow/server/main.go
+++ b/bitwindow/server/main.go
@@ -415,14 +415,27 @@ func startOrchestratord(ctx context.Context, conf config.Config) (*exec.Cmd, err
 	}
 	defer orchLogFile.Close() //nolint:errcheck — child has its own fd post-spawn
 
-	args = append(args, "--logfile", orchLogPath)
+	// Dev ergonomics: with ORCHESTRATORD_STDOUT=1, skip --logfile so orchestratord
+	// logs to its stdout (zerolog's default), and tee that into bitwindowd's own
+	// stdout — which the Flutter ProcessManager already streams to the `just run`
+	// terminal. The file copy is kept too. Prod leaves this unset so the detached
+	// orchestratord keeps logging after bitwindowd's stdout is orphaned.
+	orchToStdout := os.Getenv("ORCHESTRATORD_STDOUT") == "1" || os.Getenv("ORCHESTRATORD_STDOUT") == "true"
+	if !orchToStdout {
+		args = append(args, "--logfile", orchLogPath)
+	}
 
-	log.Info().Str("path", orchPath).Strs("args", args).Str("logfile", orchLogPath).Msg("starting orchestratord (detached)")
+	log.Info().Str("path", orchPath).Strs("args", args).Str("logfile", orchLogPath).Bool("stdout", orchToStdout).Msg("starting orchestratord (detached)")
 
 	cmd := exec.Command(orchPath, args...)
 	configureOrchestratordSpawn(cmd)
-	cmd.Stdout = orchLogFile
-	cmd.Stderr = orchLogFile
+	if orchToStdout {
+		cmd.Stdout = io.MultiWriter(os.Stdout, orchLogFile)
+		cmd.Stderr = io.MultiWriter(os.Stderr, orchLogFile)
+	} else {
+		cmd.Stdout = orchLogFile
+		cmd.Stderr = orchLogFile
+	}
 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("start orchestratord: %w", err)

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.142
+version: 1.0.143
 
 environment:
   sdk: 3.12.0

--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "binaries": {
     "bitcoincore": {
       "type": "core",
@@ -70,7 +70,16 @@
               "macos-arm64": "L1-bitcoin-patched-v30.2-aarch64-apple-darwin.zip",
               "windows-x86_64": "L1-bitcoin-patched-latest-x86_64-w64-msvc.zip"
             },
-            "available_networks": ["mainnet", "signet", "testnet", "regtest", "forknet"]
+            "available_networks": ["mainnet", "signet", "testnet", "regtest"]
+          },
+          "forknet": {
+            "subfolder": "forknet",
+            "base_url": "https://releases.drivechain.info/",
+            "files": {
+              "linux-x86_64": "L1-drivechain-forknet-x86_64-unknown-linux-gnu.zip",
+              "windows-x86_64": "L1-drivechain-forknet-x86_64-w64-msvc.zip"
+            },
+            "available_networks": ["forknet"]
           },
           "knots": {
             "subfolder": "knots",

--- a/sail_ui/assets/migrations/005_chains_config.json
+++ b/sail_ui/assets/migrations/005_chains_config.json
@@ -1,0 +1,24 @@
+{
+  "version": 5,
+  "migration": "patch",
+  "binaries": {
+    "bitcoincore": {
+      "download": {
+        "variants": {
+          "patched": {
+            "available_networks": ["mainnet", "signet", "testnet", "regtest"]
+          },
+          "forknet": {
+            "subfolder": "forknet",
+            "base_url": "https://releases.drivechain.info/",
+            "files": {
+              "linux-x86_64": "L1-drivechain-forknet-x86_64-unknown-linux-gnu.zip",
+              "windows-x86_64": "L1-drivechain-forknet-x86_64-w64-msvc.zip"
+            },
+            "available_networks": ["forknet"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/sail_ui/lib/config/binaries.dart
+++ b/sail_ui/lib/config/binaries.dart
@@ -498,9 +498,9 @@ class BitcoinCore extends Binary {
                      OS.windows: 'bitcoin-30.2-win64.zip',
                    }),
                    BitcoinNetwork.BITCOIN_NETWORK_FORKNET: {
-                     OS.linux: 'L1-bitcoin-patched-forknet-x86_64-unknown-linux-gnu.zip',
-                     OS.macos: 'L1-bitcoin-patched-forknet-x86_64-apple-darwin.zip',
-                     OS.windows: 'L1-bitcoin-patched-forknet-x86_64-w64-msvc.zip',
+                     OS.linux: 'L1-drivechain-forknet-x86_64-unknown-linux-gnu.zip',
+                     OS.macos: 'L1-drivechain-forknet-x86_64-apple-darwin.zip',
+                     OS.windows: 'L1-drivechain-forknet-x86_64-w64-msvc.zip',
                    },
                  },
                  extractSubfolder: {

--- a/sail_ui/lib/rpcs/bitwindow_api.dart
+++ b/sail_ui/lib/rpcs/bitwindow_api.dart
@@ -422,7 +422,7 @@ class _BitwindowAPILive implements BitwindowAPI {
       return response;
     } catch (e) {
       final error = 'could not start mining: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -527,7 +527,7 @@ class _BitwindowAPILive implements BitwindowAPI {
       return response.transactions;
     } catch (e) {
       final error = 'could not list unconfirmed transactions: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -545,7 +545,7 @@ class _BitwindowAPILive implements BitwindowAPI {
       return (response.recentBlocks, response.hasMore);
     } catch (e) {
       final error = 'could not list blocks: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -556,7 +556,7 @@ class _BitwindowAPILive implements BitwindowAPI {
       return response;
     } catch (e) {
       final error = 'could not get network stats: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -565,7 +565,7 @@ class _BitwindowAPILive implements BitwindowAPI {
     try {
       await _client.updateNetwork(UpdateNetworkRequest(network: network));
     } catch (e) {
-      throw BitcoindException('could not update network: ${extractConnectException(e)}');
+      throw BitwindowException('could not update network: ${extractConnectException(e)}');
     }
   }
 }
@@ -1338,7 +1338,7 @@ class _MiscAPILive implements MiscAPI {
       return response.opReturns;
     } catch (e) {
       final error = 'could not list op returns: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1374,7 +1374,7 @@ class _MiscAPILive implements MiscAPI {
       return response;
     } catch (e) {
       final error = 'could not broadcast news: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1397,7 +1397,7 @@ class _MiscAPILive implements MiscAPI {
       return response;
     } catch (e) {
       final error = 'could not upvote news: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1420,7 +1420,7 @@ class _MiscAPILive implements MiscAPI {
       return response;
     } catch (e) {
       final error = 'could not downvote news: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1452,7 +1452,7 @@ class _MiscAPILive implements MiscAPI {
       return response;
     } catch (e) {
       final error = 'could not comment on news: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1463,7 +1463,7 @@ class _MiscAPILive implements MiscAPI {
       return response.comments;
     } catch (e) {
       final error = 'could not list comments: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1483,7 +1483,7 @@ class _MiscAPILive implements MiscAPI {
       return response;
     } catch (e) {
       final error = 'could not create topic: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1494,7 +1494,7 @@ class _MiscAPILive implements MiscAPI {
       return response.coinNews;
     } catch (e) {
       final error = 'could not list coin news: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1505,7 +1505,7 @@ class _MiscAPILive implements MiscAPI {
       return response.topics;
     } catch (e) {
       final error = 'could not list topics: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1523,7 +1523,7 @@ class _MiscAPILive implements MiscAPI {
       return response;
     } catch (e) {
       final error = 'could not timestamp file: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1534,7 +1534,7 @@ class _MiscAPILive implements MiscAPI {
       return response.timestamps;
     } catch (e) {
       final error = 'could not list timestamps: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1552,7 +1552,7 @@ class _MiscAPILive implements MiscAPI {
       return response;
     } catch (e) {
       final error = 'could not verify timestamp: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 }
@@ -1583,7 +1583,7 @@ class _M4APILive implements M4API {
       return response.history;
     } catch (e) {
       final error = 'could not get M4 history: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1596,7 +1596,7 @@ class _M4APILive implements M4API {
       return response.preferences;
     } catch (e) {
       final error = 'could not get vote preferences: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1618,7 +1618,7 @@ class _M4APILive implements M4API {
       await _client.setVotePreference(request);
     } catch (e) {
       final error = 'could not set vote preference: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 
@@ -1631,7 +1631,7 @@ class _M4APILive implements M4API {
       return response;
     } catch (e) {
       final error = 'could not generate M4 bytes: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 }
@@ -1653,7 +1653,7 @@ class _NotificationAPILive implements NotificationAPI {
       return response;
     } catch (e) {
       final error = 'could not watch notifications: ${extractConnectException(e)}';
-      throw BitcoindException(error);
+      throw BitwindowException(error);
     }
   }
 }
@@ -2123,11 +2123,11 @@ class WalletException implements Exception {
   String toString() => 'WalletException: $message';
 }
 
-class BitcoindException implements Exception {
+class BitwindowException implements Exception {
   final String message;
-  BitcoindException(this.message);
+  BitwindowException(this.message);
   @override
-  String toString() => 'BitcoindException: $message';
+  String toString() => 'BitwindowException: $message';
 }
 
 class DrivechainException implements Exception {

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -476,8 +476,11 @@ func mapExternalInputs(exts []*pb.ExternalInput) []wallet.ExternalInput {
 }
 
 func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Request[pb.SendTransactionRequest]) (*connect.Response[pb.SendTransactionResponse], error) {
-	if len(req.Msg.Destinations) == 0 {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("must provide at least one destination"))
+	// A transaction needs at least one output, but it doesn't have to be a
+	// payment: an OP_RETURN-only broadcast (e.g. coinnews) or a raw-script
+	// output (e.g. a sidechain deposit treasury) is a valid send on its own.
+	if len(req.Msg.Destinations) == 0 && req.Msg.OpReturnHex == "" && len(req.Msg.RawOutputs) == 0 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("must provide at least one output"))
 	}
 
 	if req.Msg.FeeRateSatPerVbyte > 0 && req.Msg.FixedFeeSats > 0 {
@@ -903,6 +906,17 @@ func (h *WalletHandler) GetWalletSeed(ctx context.Context, req *connect.Request[
 func (h *WalletHandler) WatchWalletData(ctx context.Context, req *connect.Request[emptypb.Empty], stream *connect.ServerStream[pb.WatchWalletDataResponse]) error {
 	var seq int64
 
+	// Per-stream subscription. The wallet service fans out notifyChanged to
+	// every subscriber, so concurrent Watch streams don't steal each other's
+	// events. ctx scopes the subscription to this stream's lifetime.
+	//
+	// Subscribe BEFORE the initial send: the channel is buffered (cap 1), so a
+	// wallet-load notification that fires during or right after the first frame
+	// is retained and replayed by the loop below. Subscribing after the initial
+	// send loses that wakeup, leaving the stream stuck on an empty first frame
+	// (empty wallet dropdown, null activeWalletId, endless status recovery).
+	stateChanged := h.svc.Subscribe(ctx)
+
 	if err := h.sendWalletData(stream, &seq); err != nil {
 		return err
 	}
@@ -918,11 +932,6 @@ func (h *WalletHandler) WatchWalletData(ctx context.Context, req *connect.Reques
 	// frame goes out so we don't double up.
 	heartbeat := time.NewTicker(WatchHeartbeatInterval)
 	defer heartbeat.Stop()
-
-	// Per-stream subscription. The wallet service fans out notifyChanged to
-	// every subscriber, so concurrent Watch streams don't steal each other's
-	// events. ctx scopes the subscription to this stream's lifetime.
-	stateChanged := h.svc.Subscribe(ctx)
 
 	send := func() error {
 		if err := h.sendWalletData(stream, &seq); err != nil {

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -456,6 +456,25 @@ func (h *WalletHandler) GetNewAddress(ctx context.Context, req *connect.Request[
 	}), nil
 }
 
+// mapRawOutputs converts proto raw outputs to the wallet's TxOutSpec shape.
+func mapRawOutputs(raws []*pb.RawOutput) []wallet.TxOutSpec {
+	return lo.Map(raws, func(r *pb.RawOutput, _ int) wallet.TxOutSpec {
+		return wallet.TxOutSpec{RawScriptHex: r.ScriptHex, AmountSats: r.ValueSats}
+	})
+}
+
+// mapExternalInputs converts proto external inputs to the wallet's shape.
+func mapExternalInputs(exts []*pb.ExternalInput) []wallet.ExternalInput {
+	return lo.Map(exts, func(e *pb.ExternalInput, _ int) wallet.ExternalInput {
+		return wallet.ExternalInput{
+			TxID:            e.Txid,
+			Vout:            int(e.Vout),
+			AmountSats:      e.ValueSats,
+			ScriptPubKeyHex: e.ScriptPubkeyHex,
+		}
+	})
+}
+
 func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Request[pb.SendTransactionRequest]) (*connect.Response[pb.SendTransactionResponse], error) {
 	if len(req.Msg.Destinations) == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("must provide at least one destination"))
@@ -517,6 +536,8 @@ func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Reques
 			AmountSats: u.AmountSats,
 		}
 	})
+	sendReq.RawOutputs = mapRawOutputs(req.Msg.RawOutputs)
+	sendReq.ExternalInputs = mapExternalInputs(req.Msg.ExternalInputs)
 
 	txid, err := h.engine.Backend().Send(ctx, walletID, sendReq)
 	if err != nil {
@@ -1211,6 +1232,8 @@ func (h *WalletHandler) CreatePsbt(ctx context.Context, req *connect.Request[pb.
 			TxID: u.Txid, Vout: int(u.Vout), AmountSats: u.AmountSats,
 		}
 	})
+	sendReq.RawOutputs = mapRawOutputs(req.Msg.RawOutputs)
+	sendReq.ExternalInputs = mapExternalInputs(req.Msg.ExternalInputs)
 	b64, err := h.engine.CreatePSBT(ctx, walletID, sendReq)
 	if err != nil {
 		return nil, rpcError(err)

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "binaries": {
     "bitcoincore": {
       "type": "core",
@@ -70,7 +70,16 @@
               "macos-arm64": "L1-bitcoin-patched-v30.2-aarch64-apple-darwin.zip",
               "windows-x86_64": "L1-bitcoin-patched-latest-x86_64-w64-msvc.zip"
             },
-            "available_networks": ["mainnet", "signet", "testnet", "regtest", "forknet"]
+            "available_networks": ["mainnet", "signet", "testnet", "regtest"]
+          },
+          "forknet": {
+            "subfolder": "forknet",
+            "base_url": "https://releases.drivechain.info/",
+            "files": {
+              "linux-x86_64": "L1-drivechain-forknet-x86_64-unknown-linux-gnu.zip",
+              "windows-x86_64": "L1-drivechain-forknet-x86_64-w64-msvc.zip"
+            },
+            "available_networks": ["forknet"]
           },
           "knots": {
             "subfolder": "knots",

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "binaries": {
     "bitcoincore": {
       "type": "core",
@@ -70,7 +70,16 @@
               "macos-arm64": "L1-bitcoin-patched-v30.2-aarch64-apple-darwin.zip",
               "windows-x86_64": "L1-bitcoin-patched-latest-x86_64-w64-msvc.zip"
             },
-            "available_networks": ["mainnet", "signet", "testnet", "regtest", "forknet"]
+            "available_networks": ["mainnet", "signet", "testnet", "regtest"]
+          },
+          "forknet": {
+            "subfolder": "forknet",
+            "base_url": "https://releases.drivechain.info/",
+            "files": {
+              "linux-x86_64": "L1-drivechain-forknet-x86_64-unknown-linux-gnu.zip",
+              "windows-x86_64": "L1-drivechain-forknet-x86_64-w64-msvc.zip"
+            },
+            "available_networks": ["forknet"]
           },
           "knots": {
             "subfolder": "knots",

--- a/sidechain-orchestrator/core_variants_test.go
+++ b/sidechain-orchestrator/core_variants_test.go
@@ -98,7 +98,7 @@ func TestParseConfigJSON_BitcoincoreVariants(t *testing.T) {
 	}
 	require.NotEmpty(t, core.Variants, "embedded config must declare core variants")
 
-	for _, id := range []string{"core", "patched", "knots"} {
+	for _, id := range []string{"core", "patched", "knots", "forknet"} {
 		v, ok := core.Variants[id]
 		require.True(t, ok, "missing variant %s", id)
 		assert.NotEmpty(t, v.Subfolder)
@@ -107,7 +107,8 @@ func TestParseConfigJSON_BitcoincoreVariants(t *testing.T) {
 		assert.NotEmpty(t, v.AvailableNetworks)
 	}
 
-	assert.True(t, core.Variants["patched"].AvailableOn("forknet"))
+	assert.True(t, core.Variants["forknet"].AvailableOn("forknet"))
+	assert.False(t, core.Variants["patched"].AvailableOn("forknet"))
 	assert.True(t, core.Variants["patched"].AvailableOn("mainnet"))
 	assert.True(t, core.Variants["core"].AvailableOn("mainnet"))
 	assert.True(t, core.Variants["knots"].AvailableOn("mainnet"))
@@ -202,13 +203,13 @@ func TestOrchestrator_ListCoreVariants(t *testing.T) {
 		network string
 		want    []string
 	}{
-		// "patched" (drivechain.info L1-bitcoin-patched-latest) is available on
-		// every chain. core + knots are available everywhere except forknet.
+		// core/patched/knots are available on every chain except forknet, which
+		// has its own dedicated build (L1-drivechain-forknet) as the sole option.
 		{"mainnet", []string{"core", "knots", "patched"}},
 		{"signet", []string{"core", "knots", "patched"}},
 		{"testnet", []string{"core", "knots", "patched"}},
 		{"regtest", []string{"core", "knots", "patched"}},
-		{"forknet", []string{"patched"}},
+		{"forknet", []string{"forknet"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.network, func(t *testing.T) {

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -2560,8 +2560,16 @@ type SendTransactionRequest struct {
 	// Build an eCash replay-protected transaction (magic version + extra byte so
 	// Bitcoin Core can't deserialize it). Core wallets only.
 	ReplayProtect bool `protobuf:"varint,8,opt,name=replay_protect,json=replayProtect,proto3" json:"replay_protect,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Outputs with an explicit raw scriptPubKey, kept in order before any
+	// address/op_return outputs. Used for non-standard scripts (e.g. a sidechain
+	// OP_DRIVECHAIN treasury output).
+	RawOutputs []*RawOutput `protobuf:"bytes,9,rep,name=raw_outputs,json=rawOutputs,proto3" json:"raw_outputs,omitempty"`
+	// Inputs not owned by the wallet that must be spent as-is, in order, before
+	// wallet-funded inputs. Used for anyone-can-spend scripts (e.g. a sidechain
+	// CTIP). They are added with an empty scriptSig and not signed.
+	ExternalInputs []*ExternalInput `protobuf:"bytes,10,rep,name=external_inputs,json=externalInputs,proto3" json:"external_inputs,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *SendTransactionRequest) Reset() {
@@ -2650,6 +2658,20 @@ func (x *SendTransactionRequest) GetReplayProtect() bool {
 	return false
 }
 
+func (x *SendTransactionRequest) GetRawOutputs() []*RawOutput {
+	if x != nil {
+		return x.RawOutputs
+	}
+	return nil
+}
+
+func (x *SendTransactionRequest) GetExternalInputs() []*ExternalInput {
+	if x != nil {
+		return x.ExternalInputs
+	}
+	return nil
+}
+
 type SendTransactionResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Txid          string                 `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
@@ -2694,6 +2716,129 @@ func (x *SendTransactionResponse) GetTxid() string {
 	return ""
 }
 
+// RawOutput is a transaction output with a caller-supplied scriptPubKey.
+type RawOutput struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ValueSats     int64                  `protobuf:"varint,1,opt,name=value_sats,json=valueSats,proto3" json:"value_sats,omitempty"`
+	ScriptHex     string                 `protobuf:"bytes,2,opt,name=script_hex,json=scriptHex,proto3" json:"script_hex,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RawOutput) Reset() {
+	*x = RawOutput{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RawOutput) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RawOutput) ProtoMessage() {}
+
+func (x *RawOutput) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RawOutput.ProtoReflect.Descriptor instead.
+func (*RawOutput) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *RawOutput) GetValueSats() int64 {
+	if x != nil {
+		return x.ValueSats
+	}
+	return 0
+}
+
+func (x *RawOutput) GetScriptHex() string {
+	if x != nil {
+		return x.ScriptHex
+	}
+	return ""
+}
+
+// ExternalInput is a UTXO spent by the transaction that the wallet does not own
+// and does not sign — its script must be satisfiable with an empty scriptSig.
+type ExternalInput struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Txid            string                 `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
+	Vout            int32                  `protobuf:"varint,2,opt,name=vout,proto3" json:"vout,omitempty"`
+	ValueSats       int64                  `protobuf:"varint,3,opt,name=value_sats,json=valueSats,proto3" json:"value_sats,omitempty"`
+	ScriptPubkeyHex string                 `protobuf:"bytes,4,opt,name=script_pubkey_hex,json=scriptPubkeyHex,proto3" json:"script_pubkey_hex,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ExternalInput) Reset() {
+	*x = ExternalInput{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExternalInput) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExternalInput) ProtoMessage() {}
+
+func (x *ExternalInput) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExternalInput.ProtoReflect.Descriptor instead.
+func (*ExternalInput) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{51}
+}
+
+func (x *ExternalInput) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+func (x *ExternalInput) GetVout() int32 {
+	if x != nil {
+		return x.Vout
+	}
+	return 0
+}
+
+func (x *ExternalInput) GetValueSats() int64 {
+	if x != nil {
+		return x.ValueSats
+	}
+	return 0
+}
+
+func (x *ExternalInput) GetScriptPubkeyHex() string {
+	if x != nil {
+		return x.ScriptPubkeyHex
+	}
+	return ""
+}
+
 type CreatePsbtRequest struct {
 	state                 protoimpl.MessageState `protogen:"open.v1"`
 	WalletId              string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`                                                                    // empty = active wallet
@@ -2703,13 +2848,15 @@ type CreatePsbtRequest struct {
 	OpReturnHex           string                 `protobuf:"bytes,5,opt,name=op_return_hex,json=opReturnHex,proto3" json:"op_return_hex,omitempty"`
 	FixedFeeSats          int64                  `protobuf:"varint,6,opt,name=fixed_fee_sats,json=fixedFeeSats,proto3" json:"fixed_fee_sats,omitempty"`
 	RequiredInputs        []*UnspentOutput       `protobuf:"bytes,7,rep,name=required_inputs,json=requiredInputs,proto3" json:"required_inputs,omitempty"`
+	RawOutputs            []*RawOutput           `protobuf:"bytes,8,rep,name=raw_outputs,json=rawOutputs,proto3" json:"raw_outputs,omitempty"`
+	ExternalInputs        []*ExternalInput       `protobuf:"bytes,9,rep,name=external_inputs,json=externalInputs,proto3" json:"external_inputs,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
 
 func (x *CreatePsbtRequest) Reset() {
 	*x = CreatePsbtRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[50]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2721,7 +2868,7 @@ func (x *CreatePsbtRequest) String() string {
 func (*CreatePsbtRequest) ProtoMessage() {}
 
 func (x *CreatePsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[50]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2734,7 +2881,7 @@ func (x *CreatePsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreatePsbtRequest.ProtoReflect.Descriptor instead.
 func (*CreatePsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{50}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *CreatePsbtRequest) GetWalletId() string {
@@ -2786,6 +2933,20 @@ func (x *CreatePsbtRequest) GetRequiredInputs() []*UnspentOutput {
 	return nil
 }
 
+func (x *CreatePsbtRequest) GetRawOutputs() []*RawOutput {
+	if x != nil {
+		return x.RawOutputs
+	}
+	return nil
+}
+
+func (x *CreatePsbtRequest) GetExternalInputs() []*ExternalInput {
+	if x != nil {
+		return x.ExternalInputs
+	}
+	return nil
+}
+
 type CreatePsbtResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	PsbtBase64    string                 `protobuf:"bytes,1,opt,name=psbt_base64,json=psbtBase64,proto3" json:"psbt_base64,omitempty"`
@@ -2795,7 +2956,7 @@ type CreatePsbtResponse struct {
 
 func (x *CreatePsbtResponse) Reset() {
 	*x = CreatePsbtResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[51]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2807,7 +2968,7 @@ func (x *CreatePsbtResponse) String() string {
 func (*CreatePsbtResponse) ProtoMessage() {}
 
 func (x *CreatePsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[51]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2820,7 +2981,7 @@ func (x *CreatePsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreatePsbtResponse.ProtoReflect.Descriptor instead.
 func (*CreatePsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{51}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *CreatePsbtResponse) GetPsbtBase64() string {
@@ -2840,7 +3001,7 @@ type SignPsbtRequest struct {
 
 func (x *SignPsbtRequest) Reset() {
 	*x = SignPsbtRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[52]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2852,7 +3013,7 @@ func (x *SignPsbtRequest) String() string {
 func (*SignPsbtRequest) ProtoMessage() {}
 
 func (x *SignPsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[52]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2865,7 +3026,7 @@ func (x *SignPsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignPsbtRequest.ProtoReflect.Descriptor instead.
 func (*SignPsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{52}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *SignPsbtRequest) GetWalletId() string {
@@ -2891,7 +3052,7 @@ type SignPsbtResponse struct {
 
 func (x *SignPsbtResponse) Reset() {
 	*x = SignPsbtResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[53]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2903,7 +3064,7 @@ func (x *SignPsbtResponse) String() string {
 func (*SignPsbtResponse) ProtoMessage() {}
 
 func (x *SignPsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[53]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2916,7 +3077,7 @@ func (x *SignPsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignPsbtResponse.ProtoReflect.Descriptor instead.
 func (*SignPsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{53}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *SignPsbtResponse) GetPsbtBase64() string {
@@ -2935,7 +3096,7 @@ type CombinePsbtRequest struct {
 
 func (x *CombinePsbtRequest) Reset() {
 	*x = CombinePsbtRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[54]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2947,7 +3108,7 @@ func (x *CombinePsbtRequest) String() string {
 func (*CombinePsbtRequest) ProtoMessage() {}
 
 func (x *CombinePsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[54]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2960,7 +3121,7 @@ func (x *CombinePsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CombinePsbtRequest.ProtoReflect.Descriptor instead.
 func (*CombinePsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{54}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *CombinePsbtRequest) GetPsbtBase64() []string {
@@ -2979,7 +3140,7 @@ type CombinePsbtResponse struct {
 
 func (x *CombinePsbtResponse) Reset() {
 	*x = CombinePsbtResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[55]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2991,7 +3152,7 @@ func (x *CombinePsbtResponse) String() string {
 func (*CombinePsbtResponse) ProtoMessage() {}
 
 func (x *CombinePsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[55]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3004,7 +3165,7 @@ func (x *CombinePsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CombinePsbtResponse.ProtoReflect.Descriptor instead.
 func (*CombinePsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{55}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *CombinePsbtResponse) GetPsbtBase64() string {
@@ -3023,7 +3184,7 @@ type FinalizePsbtRequest struct {
 
 func (x *FinalizePsbtRequest) Reset() {
 	*x = FinalizePsbtRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[56]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3035,7 +3196,7 @@ func (x *FinalizePsbtRequest) String() string {
 func (*FinalizePsbtRequest) ProtoMessage() {}
 
 func (x *FinalizePsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[56]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3048,7 +3209,7 @@ func (x *FinalizePsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinalizePsbtRequest.ProtoReflect.Descriptor instead.
 func (*FinalizePsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{56}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *FinalizePsbtRequest) GetPsbtBase64() string {
@@ -3067,7 +3228,7 @@ type FinalizePsbtResponse struct {
 
 func (x *FinalizePsbtResponse) Reset() {
 	*x = FinalizePsbtResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[57]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3079,7 +3240,7 @@ func (x *FinalizePsbtResponse) String() string {
 func (*FinalizePsbtResponse) ProtoMessage() {}
 
 func (x *FinalizePsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[57]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3092,7 +3253,7 @@ func (x *FinalizePsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinalizePsbtResponse.ProtoReflect.Descriptor instead.
 func (*FinalizePsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{57}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *FinalizePsbtResponse) GetRawTxHex() string {
@@ -3112,7 +3273,7 @@ type ListTransactionsRequest struct {
 
 func (x *ListTransactionsRequest) Reset() {
 	*x = ListTransactionsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[58]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3124,7 +3285,7 @@ func (x *ListTransactionsRequest) String() string {
 func (*ListTransactionsRequest) ProtoMessage() {}
 
 func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[58]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3137,7 +3298,7 @@ func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsRequest.ProtoReflect.Descriptor instead.
 func (*ListTransactionsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{58}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *ListTransactionsRequest) GetWalletId() string {
@@ -3175,7 +3336,7 @@ type TransactionEntry struct {
 
 func (x *TransactionEntry) Reset() {
 	*x = TransactionEntry{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[59]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3187,7 +3348,7 @@ func (x *TransactionEntry) String() string {
 func (*TransactionEntry) ProtoMessage() {}
 
 func (x *TransactionEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[59]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3200,7 +3361,7 @@ func (x *TransactionEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionEntry.ProtoReflect.Descriptor instead.
 func (*TransactionEntry) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{59}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *TransactionEntry) GetTxid() string {
@@ -3303,7 +3464,7 @@ type ListTransactionsResponse struct {
 
 func (x *ListTransactionsResponse) Reset() {
 	*x = ListTransactionsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[60]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3315,7 +3476,7 @@ func (x *ListTransactionsResponse) String() string {
 func (*ListTransactionsResponse) ProtoMessage() {}
 
 func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[60]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3328,7 +3489,7 @@ func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsResponse.ProtoReflect.Descriptor instead.
 func (*ListTransactionsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{60}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *ListTransactionsResponse) GetTransactions() []*TransactionEntry {
@@ -3347,7 +3508,7 @@ type ListUnspentRequest struct {
 
 func (x *ListUnspentRequest) Reset() {
 	*x = ListUnspentRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[61]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3359,7 +3520,7 @@ func (x *ListUnspentRequest) String() string {
 func (*ListUnspentRequest) ProtoMessage() {}
 
 func (x *ListUnspentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[61]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3372,7 +3533,7 @@ func (x *ListUnspentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUnspentRequest.ProtoReflect.Descriptor instead.
 func (*ListUnspentRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{61}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ListUnspentRequest) GetWalletId() string {
@@ -3403,7 +3564,7 @@ type UnspentOutput struct {
 
 func (x *UnspentOutput) Reset() {
 	*x = UnspentOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[62]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3415,7 +3576,7 @@ func (x *UnspentOutput) String() string {
 func (*UnspentOutput) ProtoMessage() {}
 
 func (x *UnspentOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[62]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3428,7 +3589,7 @@ func (x *UnspentOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnspentOutput.ProtoReflect.Descriptor instead.
 func (*UnspentOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{62}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *UnspentOutput) GetTxid() string {
@@ -3517,7 +3678,7 @@ type ListUnspentResponse struct {
 
 func (x *ListUnspentResponse) Reset() {
 	*x = ListUnspentResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[63]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3529,7 +3690,7 @@ func (x *ListUnspentResponse) String() string {
 func (*ListUnspentResponse) ProtoMessage() {}
 
 func (x *ListUnspentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[63]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3542,7 +3703,7 @@ func (x *ListUnspentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUnspentResponse.ProtoReflect.Descriptor instead.
 func (*ListUnspentResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{63}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ListUnspentResponse) GetUtxos() []*UnspentOutput {
@@ -3561,7 +3722,7 @@ type ListReceiveAddressesRequest struct {
 
 func (x *ListReceiveAddressesRequest) Reset() {
 	*x = ListReceiveAddressesRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[64]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3573,7 +3734,7 @@ func (x *ListReceiveAddressesRequest) String() string {
 func (*ListReceiveAddressesRequest) ProtoMessage() {}
 
 func (x *ListReceiveAddressesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[64]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3586,7 +3747,7 @@ func (x *ListReceiveAddressesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListReceiveAddressesRequest.ProtoReflect.Descriptor instead.
 func (*ListReceiveAddressesRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{64}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *ListReceiveAddressesRequest) GetWalletId() string {
@@ -3609,7 +3770,7 @@ type ReceiveAddress struct {
 
 func (x *ReceiveAddress) Reset() {
 	*x = ReceiveAddress{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[65]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3621,7 +3782,7 @@ func (x *ReceiveAddress) String() string {
 func (*ReceiveAddress) ProtoMessage() {}
 
 func (x *ReceiveAddress) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[65]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3634,7 +3795,7 @@ func (x *ReceiveAddress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAddress.ProtoReflect.Descriptor instead.
 func (*ReceiveAddress) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{65}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *ReceiveAddress) GetAddress() string {
@@ -3681,7 +3842,7 @@ type ListReceiveAddressesResponse struct {
 
 func (x *ListReceiveAddressesResponse) Reset() {
 	*x = ListReceiveAddressesResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[66]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3693,7 +3854,7 @@ func (x *ListReceiveAddressesResponse) String() string {
 func (*ListReceiveAddressesResponse) ProtoMessage() {}
 
 func (x *ListReceiveAddressesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[66]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3706,7 +3867,7 @@ func (x *ListReceiveAddressesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListReceiveAddressesResponse.ProtoReflect.Descriptor instead.
 func (*ListReceiveAddressesResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{66}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *ListReceiveAddressesResponse) GetAddresses() []*ReceiveAddress {
@@ -3726,7 +3887,7 @@ type GetTransactionDetailsRequest struct {
 
 func (x *GetTransactionDetailsRequest) Reset() {
 	*x = GetTransactionDetailsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[67]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3738,7 +3899,7 @@ func (x *GetTransactionDetailsRequest) String() string {
 func (*GetTransactionDetailsRequest) ProtoMessage() {}
 
 func (x *GetTransactionDetailsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[67]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3751,7 +3912,7 @@ func (x *GetTransactionDetailsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionDetailsRequest.ProtoReflect.Descriptor instead.
 func (*GetTransactionDetailsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{67}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *GetTransactionDetailsRequest) GetWalletId() string {
@@ -3792,7 +3953,7 @@ type GetTransactionDetailsResponse struct {
 
 func (x *GetTransactionDetailsResponse) Reset() {
 	*x = GetTransactionDetailsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[68]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3804,7 +3965,7 @@ func (x *GetTransactionDetailsResponse) String() string {
 func (*GetTransactionDetailsResponse) ProtoMessage() {}
 
 func (x *GetTransactionDetailsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[68]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3817,7 +3978,7 @@ func (x *GetTransactionDetailsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionDetailsResponse.ProtoReflect.Descriptor instead.
 func (*GetTransactionDetailsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{68}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *GetTransactionDetailsResponse) GetTransaction() *TransactionEntry {
@@ -3950,7 +4111,7 @@ type TransactionInput struct {
 
 func (x *TransactionInput) Reset() {
 	*x = TransactionInput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[69]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3962,7 +4123,7 @@ func (x *TransactionInput) String() string {
 func (*TransactionInput) ProtoMessage() {}
 
 func (x *TransactionInput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[69]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3975,7 +4136,7 @@ func (x *TransactionInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionInput.ProtoReflect.Descriptor instead.
 func (*TransactionInput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{69}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *TransactionInput) GetIndex() int32 {
@@ -4062,7 +4223,7 @@ type TransactionOutput struct {
 
 func (x *TransactionOutput) Reset() {
 	*x = TransactionOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[70]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4074,7 +4235,7 @@ func (x *TransactionOutput) String() string {
 func (*TransactionOutput) ProtoMessage() {}
 
 func (x *TransactionOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[70]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4087,7 +4248,7 @@ func (x *TransactionOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionOutput.ProtoReflect.Descriptor instead.
 func (*TransactionOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{70}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *TransactionOutput) GetIndex() int32 {
@@ -4143,7 +4304,7 @@ type BumpFeeRequest struct {
 
 func (x *BumpFeeRequest) Reset() {
 	*x = BumpFeeRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[71]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4155,7 +4316,7 @@ func (x *BumpFeeRequest) String() string {
 func (*BumpFeeRequest) ProtoMessage() {}
 
 func (x *BumpFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[71]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4168,7 +4329,7 @@ func (x *BumpFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeRequest.ProtoReflect.Descriptor instead.
 func (*BumpFeeRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{71}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *BumpFeeRequest) GetWalletId() string {
@@ -4201,7 +4362,7 @@ type BumpFeeResponse struct {
 
 func (x *BumpFeeResponse) Reset() {
 	*x = BumpFeeResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[72]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4213,7 +4374,7 @@ func (x *BumpFeeResponse) String() string {
 func (*BumpFeeResponse) ProtoMessage() {}
 
 func (x *BumpFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[72]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4226,7 +4387,7 @@ func (x *BumpFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeResponse.ProtoReflect.Descriptor instead.
 func (*BumpFeeResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{72}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *BumpFeeResponse) GetNewTxid() string {
@@ -4247,7 +4408,7 @@ type DeriveAddressesRequest struct {
 
 func (x *DeriveAddressesRequest) Reset() {
 	*x = DeriveAddressesRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[73]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4259,7 +4420,7 @@ func (x *DeriveAddressesRequest) String() string {
 func (*DeriveAddressesRequest) ProtoMessage() {}
 
 func (x *DeriveAddressesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[73]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4272,7 +4433,7 @@ func (x *DeriveAddressesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeriveAddressesRequest.ProtoReflect.Descriptor instead.
 func (*DeriveAddressesRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{73}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *DeriveAddressesRequest) GetWalletId() string {
@@ -4305,7 +4466,7 @@ type DeriveAddressesResponse struct {
 
 func (x *DeriveAddressesResponse) Reset() {
 	*x = DeriveAddressesResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[74]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4317,7 +4478,7 @@ func (x *DeriveAddressesResponse) String() string {
 func (*DeriveAddressesResponse) ProtoMessage() {}
 
 func (x *DeriveAddressesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[74]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4330,7 +4491,7 @@ func (x *DeriveAddressesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeriveAddressesResponse.ProtoReflect.Descriptor instead.
 func (*DeriveAddressesResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{74}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *DeriveAddressesResponse) GetAddresses() []string {
@@ -4349,7 +4510,7 @@ type GetWalletSeedRequest struct {
 
 func (x *GetWalletSeedRequest) Reset() {
 	*x = GetWalletSeedRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[75]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4361,7 +4522,7 @@ func (x *GetWalletSeedRequest) String() string {
 func (*GetWalletSeedRequest) ProtoMessage() {}
 
 func (x *GetWalletSeedRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[75]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4374,7 +4535,7 @@ func (x *GetWalletSeedRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletSeedRequest.ProtoReflect.Descriptor instead.
 func (*GetWalletSeedRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{75}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *GetWalletSeedRequest) GetWalletId() string {
@@ -4395,7 +4556,7 @@ type GetWalletSeedResponse struct {
 
 func (x *GetWalletSeedResponse) Reset() {
 	*x = GetWalletSeedResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[76]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4407,7 +4568,7 @@ func (x *GetWalletSeedResponse) String() string {
 func (*GetWalletSeedResponse) ProtoMessage() {}
 
 func (x *GetWalletSeedResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[76]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4420,7 +4581,7 @@ func (x *GetWalletSeedResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletSeedResponse.ProtoReflect.Descriptor instead.
 func (*GetWalletSeedResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{76}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *GetWalletSeedResponse) GetSeedHex() string {
@@ -4445,7 +4606,7 @@ type ListCoreVariantsRequest struct {
 
 func (x *ListCoreVariantsRequest) Reset() {
 	*x = ListCoreVariantsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[77]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4457,7 +4618,7 @@ func (x *ListCoreVariantsRequest) String() string {
 func (*ListCoreVariantsRequest) ProtoMessage() {}
 
 func (x *ListCoreVariantsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[77]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4470,7 +4631,7 @@ func (x *ListCoreVariantsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCoreVariantsRequest.ProtoReflect.Descriptor instead.
 func (*ListCoreVariantsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{77}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{79}
 }
 
 type CoreVariant struct {
@@ -4484,7 +4645,7 @@ type CoreVariant struct {
 
 func (x *CoreVariant) Reset() {
 	*x = CoreVariant{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[78]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4496,7 +4657,7 @@ func (x *CoreVariant) String() string {
 func (*CoreVariant) ProtoMessage() {}
 
 func (x *CoreVariant) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[78]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4509,7 +4670,7 @@ func (x *CoreVariant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoreVariant.ProtoReflect.Descriptor instead.
 func (*CoreVariant) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{78}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *CoreVariant) GetId() string {
@@ -4543,7 +4704,7 @@ type ListCoreVariantsResponse struct {
 
 func (x *ListCoreVariantsResponse) Reset() {
 	*x = ListCoreVariantsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[79]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4555,7 +4716,7 @@ func (x *ListCoreVariantsResponse) String() string {
 func (*ListCoreVariantsResponse) ProtoMessage() {}
 
 func (x *ListCoreVariantsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[79]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4568,7 +4729,7 @@ func (x *ListCoreVariantsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCoreVariantsResponse.ProtoReflect.Descriptor instead.
 func (*ListCoreVariantsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{79}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *ListCoreVariantsResponse) GetVariants() []*CoreVariant {
@@ -4593,7 +4754,7 @@ type GetCoreVariantRequest struct {
 
 func (x *GetCoreVariantRequest) Reset() {
 	*x = GetCoreVariantRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[80]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4605,7 +4766,7 @@ func (x *GetCoreVariantRequest) String() string {
 func (*GetCoreVariantRequest) ProtoMessage() {}
 
 func (x *GetCoreVariantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[80]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4618,7 +4779,7 @@ func (x *GetCoreVariantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreVariantRequest.ProtoReflect.Descriptor instead.
 func (*GetCoreVariantRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{80}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{82}
 }
 
 type GetCoreVariantResponse struct {
@@ -4630,7 +4791,7 @@ type GetCoreVariantResponse struct {
 
 func (x *GetCoreVariantResponse) Reset() {
 	*x = GetCoreVariantResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[81]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4642,7 +4803,7 @@ func (x *GetCoreVariantResponse) String() string {
 func (*GetCoreVariantResponse) ProtoMessage() {}
 
 func (x *GetCoreVariantResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[81]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4655,7 +4816,7 @@ func (x *GetCoreVariantResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreVariantResponse.ProtoReflect.Descriptor instead.
 func (*GetCoreVariantResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{81}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *GetCoreVariantResponse) GetId() string {
@@ -4674,7 +4835,7 @@ type SetCoreVariantRequest struct {
 
 func (x *SetCoreVariantRequest) Reset() {
 	*x = SetCoreVariantRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[82]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4686,7 +4847,7 @@ func (x *SetCoreVariantRequest) String() string {
 func (*SetCoreVariantRequest) ProtoMessage() {}
 
 func (x *SetCoreVariantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[82]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4699,7 +4860,7 @@ func (x *SetCoreVariantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCoreVariantRequest.ProtoReflect.Descriptor instead.
 func (*SetCoreVariantRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{82}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *SetCoreVariantRequest) GetId() string {
@@ -4717,7 +4878,7 @@ type SetCoreVariantResponse struct {
 
 func (x *SetCoreVariantResponse) Reset() {
 	*x = SetCoreVariantResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[83]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4729,7 +4890,7 @@ func (x *SetCoreVariantResponse) String() string {
 func (*SetCoreVariantResponse) ProtoMessage() {}
 
 func (x *SetCoreVariantResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[83]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4742,7 +4903,7 @@ func (x *SetCoreVariantResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCoreVariantResponse.ProtoReflect.Descriptor instead.
 func (*SetCoreVariantResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{83}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{85}
 }
 
 type GetTestSidechainsRequest struct {
@@ -4753,7 +4914,7 @@ type GetTestSidechainsRequest struct {
 
 func (x *GetTestSidechainsRequest) Reset() {
 	*x = GetTestSidechainsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[84]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4765,7 +4926,7 @@ func (x *GetTestSidechainsRequest) String() string {
 func (*GetTestSidechainsRequest) ProtoMessage() {}
 
 func (x *GetTestSidechainsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[84]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4778,7 +4939,7 @@ func (x *GetTestSidechainsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTestSidechainsRequest.ProtoReflect.Descriptor instead.
 func (*GetTestSidechainsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{84}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{86}
 }
 
 type GetTestSidechainsResponse struct {
@@ -4790,7 +4951,7 @@ type GetTestSidechainsResponse struct {
 
 func (x *GetTestSidechainsResponse) Reset() {
 	*x = GetTestSidechainsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[85]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4802,7 +4963,7 @@ func (x *GetTestSidechainsResponse) String() string {
 func (*GetTestSidechainsResponse) ProtoMessage() {}
 
 func (x *GetTestSidechainsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[85]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4815,7 +4976,7 @@ func (x *GetTestSidechainsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTestSidechainsResponse.ProtoReflect.Descriptor instead.
 func (*GetTestSidechainsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{85}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *GetTestSidechainsResponse) GetEnabled() bool {
@@ -4834,7 +4995,7 @@ type SetTestSidechainsRequest struct {
 
 func (x *SetTestSidechainsRequest) Reset() {
 	*x = SetTestSidechainsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[86]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4846,7 +5007,7 @@ func (x *SetTestSidechainsRequest) String() string {
 func (*SetTestSidechainsRequest) ProtoMessage() {}
 
 func (x *SetTestSidechainsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[86]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4859,7 +5020,7 @@ func (x *SetTestSidechainsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTestSidechainsRequest.ProtoReflect.Descriptor instead.
 func (*SetTestSidechainsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{86}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *SetTestSidechainsRequest) GetEnabled() bool {
@@ -4877,7 +5038,7 @@ type SetTestSidechainsResponse struct {
 
 func (x *SetTestSidechainsResponse) Reset() {
 	*x = SetTestSidechainsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[87]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4889,7 +5050,7 @@ func (x *SetTestSidechainsResponse) String() string {
 func (*SetTestSidechainsResponse) ProtoMessage() {}
 
 func (x *SetTestSidechainsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[87]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4902,7 +5063,7 @@ func (x *SetTestSidechainsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTestSidechainsResponse.ProtoReflect.Descriptor instead.
 func (*SetTestSidechainsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{87}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{89}
 }
 
 type WatchWalletDataResponse struct {
@@ -4930,7 +5091,7 @@ type WatchWalletDataResponse struct {
 
 func (x *WatchWalletDataResponse) Reset() {
 	*x = WatchWalletDataResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[88]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4942,7 +5103,7 @@ func (x *WatchWalletDataResponse) String() string {
 func (*WatchWalletDataResponse) ProtoMessage() {}
 
 func (x *WatchWalletDataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[88]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4955,7 +5116,7 @@ func (x *WatchWalletDataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchWalletDataResponse.ProtoReflect.Descriptor instead.
 func (*WatchWalletDataResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{88}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *WatchWalletDataResponse) GetHasWallet() bool {
@@ -5173,7 +5334,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\"G\n" +
 	"\x15GetNewAddressResponse\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x14\n" +
-	"\x05index\x18\x02 \x01(\x05R\x05index\"\xfe\x03\n" +
+	"\x05index\x18\x02 \x01(\x05R\x05index\"\x86\x05\n" +
 	"\x16SendTransactionRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12^\n" +
 	"\fdestinations\x18\x02 \x03(\v2:.walletmanager.v1.SendTransactionRequest.DestinationsEntryR\fdestinations\x122\n" +
@@ -5182,12 +5343,27 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\rop_return_hex\x18\x05 \x01(\tR\vopReturnHex\x12$\n" +
 	"\x0efixed_fee_sats\x18\x06 \x01(\x03R\ffixedFeeSats\x12H\n" +
 	"\x0frequired_inputs\x18\a \x03(\v2\x1f.walletmanager.v1.UnspentOutputR\x0erequiredInputs\x12%\n" +
-	"\x0ereplay_protect\x18\b \x01(\bR\rreplayProtect\x1a?\n" +
+	"\x0ereplay_protect\x18\b \x01(\bR\rreplayProtect\x12<\n" +
+	"\vraw_outputs\x18\t \x03(\v2\x1b.walletmanager.v1.RawOutputR\n" +
+	"rawOutputs\x12H\n" +
+	"\x0fexternal_inputs\x18\n" +
+	" \x03(\v2\x1f.walletmanager.v1.ExternalInputR\x0eexternalInputs\x1a?\n" +
 	"\x11DestinationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"-\n" +
 	"\x17SendTransactionResponse\x12\x12\n" +
-	"\x04txid\x18\x01 \x01(\tR\x04txid\"\xcd\x03\n" +
+	"\x04txid\x18\x01 \x01(\tR\x04txid\"I\n" +
+	"\tRawOutput\x12\x1d\n" +
+	"\n" +
+	"value_sats\x18\x01 \x01(\x03R\tvalueSats\x12\x1d\n" +
+	"\n" +
+	"script_hex\x18\x02 \x01(\tR\tscriptHex\"\x82\x01\n" +
+	"\rExternalInput\x12\x12\n" +
+	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x12\n" +
+	"\x04vout\x18\x02 \x01(\x05R\x04vout\x12\x1d\n" +
+	"\n" +
+	"value_sats\x18\x03 \x01(\x03R\tvalueSats\x12*\n" +
+	"\x11script_pubkey_hex\x18\x04 \x01(\tR\x0fscriptPubkeyHex\"\xd5\x04\n" +
 	"\x11CreatePsbtRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12Y\n" +
 	"\fdestinations\x18\x02 \x03(\v25.walletmanager.v1.CreatePsbtRequest.DestinationsEntryR\fdestinations\x122\n" +
@@ -5195,7 +5371,10 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x18subtract_fee_from_amount\x18\x04 \x01(\bR\x15subtractFeeFromAmount\x12\"\n" +
 	"\rop_return_hex\x18\x05 \x01(\tR\vopReturnHex\x12$\n" +
 	"\x0efixed_fee_sats\x18\x06 \x01(\x03R\ffixedFeeSats\x12H\n" +
-	"\x0frequired_inputs\x18\a \x03(\v2\x1f.walletmanager.v1.UnspentOutputR\x0erequiredInputs\x1a?\n" +
+	"\x0frequired_inputs\x18\a \x03(\v2\x1f.walletmanager.v1.UnspentOutputR\x0erequiredInputs\x12<\n" +
+	"\vraw_outputs\x18\b \x03(\v2\x1b.walletmanager.v1.RawOutputR\n" +
+	"rawOutputs\x12H\n" +
+	"\x0fexternal_inputs\x18\t \x03(\v2\x1f.walletmanager.v1.ExternalInputR\x0eexternalInputs\x1a?\n" +
 	"\x11DestinationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"5\n" +
@@ -5438,7 +5617,7 @@ func file_walletmanager_v1_walletmanager_proto_rawDescGZIP() []byte {
 }
 
 var file_walletmanager_v1_walletmanager_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_walletmanager_v1_walletmanager_proto_msgTypes = make([]protoimpl.MessageInfo, 91)
+var file_walletmanager_v1_walletmanager_proto_msgTypes = make([]protoimpl.MessageInfo, 93)
 var file_walletmanager_v1_walletmanager_proto_goTypes = []any{
 	(WalletType)(0),                             // 0: walletmanager.v1.WalletType
 	(RestoreWalletBackupStepState)(0),           // 1: walletmanager.v1.RestoreWalletBackupStepState
@@ -5492,160 +5671,166 @@ var file_walletmanager_v1_walletmanager_proto_goTypes = []any{
 	(*GetNewAddressResponse)(nil),               // 49: walletmanager.v1.GetNewAddressResponse
 	(*SendTransactionRequest)(nil),              // 50: walletmanager.v1.SendTransactionRequest
 	(*SendTransactionResponse)(nil),             // 51: walletmanager.v1.SendTransactionResponse
-	(*CreatePsbtRequest)(nil),                   // 52: walletmanager.v1.CreatePsbtRequest
-	(*CreatePsbtResponse)(nil),                  // 53: walletmanager.v1.CreatePsbtResponse
-	(*SignPsbtRequest)(nil),                     // 54: walletmanager.v1.SignPsbtRequest
-	(*SignPsbtResponse)(nil),                    // 55: walletmanager.v1.SignPsbtResponse
-	(*CombinePsbtRequest)(nil),                  // 56: walletmanager.v1.CombinePsbtRequest
-	(*CombinePsbtResponse)(nil),                 // 57: walletmanager.v1.CombinePsbtResponse
-	(*FinalizePsbtRequest)(nil),                 // 58: walletmanager.v1.FinalizePsbtRequest
-	(*FinalizePsbtResponse)(nil),                // 59: walletmanager.v1.FinalizePsbtResponse
-	(*ListTransactionsRequest)(nil),             // 60: walletmanager.v1.ListTransactionsRequest
-	(*TransactionEntry)(nil),                    // 61: walletmanager.v1.TransactionEntry
-	(*ListTransactionsResponse)(nil),            // 62: walletmanager.v1.ListTransactionsResponse
-	(*ListUnspentRequest)(nil),                  // 63: walletmanager.v1.ListUnspentRequest
-	(*UnspentOutput)(nil),                       // 64: walletmanager.v1.UnspentOutput
-	(*ListUnspentResponse)(nil),                 // 65: walletmanager.v1.ListUnspentResponse
-	(*ListReceiveAddressesRequest)(nil),         // 66: walletmanager.v1.ListReceiveAddressesRequest
-	(*ReceiveAddress)(nil),                      // 67: walletmanager.v1.ReceiveAddress
-	(*ListReceiveAddressesResponse)(nil),        // 68: walletmanager.v1.ListReceiveAddressesResponse
-	(*GetTransactionDetailsRequest)(nil),        // 69: walletmanager.v1.GetTransactionDetailsRequest
-	(*GetTransactionDetailsResponse)(nil),       // 70: walletmanager.v1.GetTransactionDetailsResponse
-	(*TransactionInput)(nil),                    // 71: walletmanager.v1.TransactionInput
-	(*TransactionOutput)(nil),                   // 72: walletmanager.v1.TransactionOutput
-	(*BumpFeeRequest)(nil),                      // 73: walletmanager.v1.BumpFeeRequest
-	(*BumpFeeResponse)(nil),                     // 74: walletmanager.v1.BumpFeeResponse
-	(*DeriveAddressesRequest)(nil),              // 75: walletmanager.v1.DeriveAddressesRequest
-	(*DeriveAddressesResponse)(nil),             // 76: walletmanager.v1.DeriveAddressesResponse
-	(*GetWalletSeedRequest)(nil),                // 77: walletmanager.v1.GetWalletSeedRequest
-	(*GetWalletSeedResponse)(nil),               // 78: walletmanager.v1.GetWalletSeedResponse
-	(*ListCoreVariantsRequest)(nil),             // 79: walletmanager.v1.ListCoreVariantsRequest
-	(*CoreVariant)(nil),                         // 80: walletmanager.v1.CoreVariant
-	(*ListCoreVariantsResponse)(nil),            // 81: walletmanager.v1.ListCoreVariantsResponse
-	(*GetCoreVariantRequest)(nil),               // 82: walletmanager.v1.GetCoreVariantRequest
-	(*GetCoreVariantResponse)(nil),              // 83: walletmanager.v1.GetCoreVariantResponse
-	(*SetCoreVariantRequest)(nil),               // 84: walletmanager.v1.SetCoreVariantRequest
-	(*SetCoreVariantResponse)(nil),              // 85: walletmanager.v1.SetCoreVariantResponse
-	(*GetTestSidechainsRequest)(nil),            // 86: walletmanager.v1.GetTestSidechainsRequest
-	(*GetTestSidechainsResponse)(nil),           // 87: walletmanager.v1.GetTestSidechainsResponse
-	(*SetTestSidechainsRequest)(nil),            // 88: walletmanager.v1.SetTestSidechainsRequest
-	(*SetTestSidechainsResponse)(nil),           // 89: walletmanager.v1.SetTestSidechainsResponse
-	(*WatchWalletDataResponse)(nil),             // 90: walletmanager.v1.WatchWalletDataResponse
-	nil,                                         // 91: walletmanager.v1.SendTransactionRequest.DestinationsEntry
-	nil,                                         // 92: walletmanager.v1.CreatePsbtRequest.DestinationsEntry
-	(v1.BinaryType)(0),                          // 93: orchestrator.v1.BinaryType
-	(*timestamppb.Timestamp)(nil),               // 94: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                       // 95: google.protobuf.Empty
+	(*RawOutput)(nil),                           // 52: walletmanager.v1.RawOutput
+	(*ExternalInput)(nil),                       // 53: walletmanager.v1.ExternalInput
+	(*CreatePsbtRequest)(nil),                   // 54: walletmanager.v1.CreatePsbtRequest
+	(*CreatePsbtResponse)(nil),                  // 55: walletmanager.v1.CreatePsbtResponse
+	(*SignPsbtRequest)(nil),                     // 56: walletmanager.v1.SignPsbtRequest
+	(*SignPsbtResponse)(nil),                    // 57: walletmanager.v1.SignPsbtResponse
+	(*CombinePsbtRequest)(nil),                  // 58: walletmanager.v1.CombinePsbtRequest
+	(*CombinePsbtResponse)(nil),                 // 59: walletmanager.v1.CombinePsbtResponse
+	(*FinalizePsbtRequest)(nil),                 // 60: walletmanager.v1.FinalizePsbtRequest
+	(*FinalizePsbtResponse)(nil),                // 61: walletmanager.v1.FinalizePsbtResponse
+	(*ListTransactionsRequest)(nil),             // 62: walletmanager.v1.ListTransactionsRequest
+	(*TransactionEntry)(nil),                    // 63: walletmanager.v1.TransactionEntry
+	(*ListTransactionsResponse)(nil),            // 64: walletmanager.v1.ListTransactionsResponse
+	(*ListUnspentRequest)(nil),                  // 65: walletmanager.v1.ListUnspentRequest
+	(*UnspentOutput)(nil),                       // 66: walletmanager.v1.UnspentOutput
+	(*ListUnspentResponse)(nil),                 // 67: walletmanager.v1.ListUnspentResponse
+	(*ListReceiveAddressesRequest)(nil),         // 68: walletmanager.v1.ListReceiveAddressesRequest
+	(*ReceiveAddress)(nil),                      // 69: walletmanager.v1.ReceiveAddress
+	(*ListReceiveAddressesResponse)(nil),        // 70: walletmanager.v1.ListReceiveAddressesResponse
+	(*GetTransactionDetailsRequest)(nil),        // 71: walletmanager.v1.GetTransactionDetailsRequest
+	(*GetTransactionDetailsResponse)(nil),       // 72: walletmanager.v1.GetTransactionDetailsResponse
+	(*TransactionInput)(nil),                    // 73: walletmanager.v1.TransactionInput
+	(*TransactionOutput)(nil),                   // 74: walletmanager.v1.TransactionOutput
+	(*BumpFeeRequest)(nil),                      // 75: walletmanager.v1.BumpFeeRequest
+	(*BumpFeeResponse)(nil),                     // 76: walletmanager.v1.BumpFeeResponse
+	(*DeriveAddressesRequest)(nil),              // 77: walletmanager.v1.DeriveAddressesRequest
+	(*DeriveAddressesResponse)(nil),             // 78: walletmanager.v1.DeriveAddressesResponse
+	(*GetWalletSeedRequest)(nil),                // 79: walletmanager.v1.GetWalletSeedRequest
+	(*GetWalletSeedResponse)(nil),               // 80: walletmanager.v1.GetWalletSeedResponse
+	(*ListCoreVariantsRequest)(nil),             // 81: walletmanager.v1.ListCoreVariantsRequest
+	(*CoreVariant)(nil),                         // 82: walletmanager.v1.CoreVariant
+	(*ListCoreVariantsResponse)(nil),            // 83: walletmanager.v1.ListCoreVariantsResponse
+	(*GetCoreVariantRequest)(nil),               // 84: walletmanager.v1.GetCoreVariantRequest
+	(*GetCoreVariantResponse)(nil),              // 85: walletmanager.v1.GetCoreVariantResponse
+	(*SetCoreVariantRequest)(nil),               // 86: walletmanager.v1.SetCoreVariantRequest
+	(*SetCoreVariantResponse)(nil),              // 87: walletmanager.v1.SetCoreVariantResponse
+	(*GetTestSidechainsRequest)(nil),            // 88: walletmanager.v1.GetTestSidechainsRequest
+	(*GetTestSidechainsResponse)(nil),           // 89: walletmanager.v1.GetTestSidechainsResponse
+	(*SetTestSidechainsRequest)(nil),            // 90: walletmanager.v1.SetTestSidechainsRequest
+	(*SetTestSidechainsResponse)(nil),           // 91: walletmanager.v1.SetTestSidechainsResponse
+	(*WatchWalletDataResponse)(nil),             // 92: walletmanager.v1.WatchWalletDataResponse
+	nil,                                         // 93: walletmanager.v1.SendTransactionRequest.DestinationsEntry
+	nil,                                         // 94: walletmanager.v1.CreatePsbtRequest.DestinationsEntry
+	(v1.BinaryType)(0),                          // 95: orchestrator.v1.BinaryType
+	(*timestamppb.Timestamp)(nil),               // 96: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                       // 97: google.protobuf.Empty
 }
 var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	0,  // 0: walletmanager.v1.WalletMetadata.wallet_type:type_name -> walletmanager.v1.WalletType
 	17, // 1: walletmanager.v1.WalletMetadata.sidechains:type_name -> walletmanager.v1.SidechainStarter
 	16, // 2: walletmanager.v1.ListWalletsResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
-	93, // 3: walletmanager.v1.BalanceSnapshot.binary:type_name -> orchestrator.v1.BinaryType
-	94, // 4: walletmanager.v1.BalanceSnapshot.updated_at:type_name -> google.protobuf.Timestamp
-	94, // 5: walletmanager.v1.WalletBackup.created_at:type_name -> google.protobuf.Timestamp
+	95, // 3: walletmanager.v1.BalanceSnapshot.binary:type_name -> orchestrator.v1.BinaryType
+	96, // 4: walletmanager.v1.BalanceSnapshot.updated_at:type_name -> google.protobuf.Timestamp
+	96, // 5: walletmanager.v1.WalletBackup.created_at:type_name -> google.protobuf.Timestamp
 	29, // 6: walletmanager.v1.WalletBackup.wallets:type_name -> walletmanager.v1.BackupWalletSummary
 	28, // 7: walletmanager.v1.WalletBackup.latest_known_balance:type_name -> walletmanager.v1.BalanceSnapshot
 	30, // 8: walletmanager.v1.ListWalletBackupsResponse.backups:type_name -> walletmanager.v1.WalletBackup
 	1,  // 9: walletmanager.v1.RestoreWalletBackupProgressStatus.state:type_name -> walletmanager.v1.RestoreWalletBackupStepState
 	35, // 10: walletmanager.v1.RestoreWalletBackupProgressResponse.steps:type_name -> walletmanager.v1.RestoreWalletBackupStep
 	36, // 11: walletmanager.v1.RestoreWalletBackupProgressResponse.status:type_name -> walletmanager.v1.RestoreWalletBackupProgressStatus
-	91, // 12: walletmanager.v1.SendTransactionRequest.destinations:type_name -> walletmanager.v1.SendTransactionRequest.DestinationsEntry
-	64, // 13: walletmanager.v1.SendTransactionRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
-	92, // 14: walletmanager.v1.CreatePsbtRequest.destinations:type_name -> walletmanager.v1.CreatePsbtRequest.DestinationsEntry
-	64, // 15: walletmanager.v1.CreatePsbtRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
-	61, // 16: walletmanager.v1.ListTransactionsResponse.transactions:type_name -> walletmanager.v1.TransactionEntry
-	94, // 17: walletmanager.v1.UnspentOutput.received_at:type_name -> google.protobuf.Timestamp
-	64, // 18: walletmanager.v1.ListUnspentResponse.utxos:type_name -> walletmanager.v1.UnspentOutput
-	67, // 19: walletmanager.v1.ListReceiveAddressesResponse.addresses:type_name -> walletmanager.v1.ReceiveAddress
-	61, // 20: walletmanager.v1.GetTransactionDetailsResponse.transaction:type_name -> walletmanager.v1.TransactionEntry
-	71, // 21: walletmanager.v1.GetTransactionDetailsResponse.inputs:type_name -> walletmanager.v1.TransactionInput
-	72, // 22: walletmanager.v1.GetTransactionDetailsResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
-	80, // 23: walletmanager.v1.ListCoreVariantsResponse.variants:type_name -> walletmanager.v1.CoreVariant
-	16, // 24: walletmanager.v1.WatchWalletDataResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
-	2,  // 25: walletmanager.v1.WalletManagerService.GetWalletStatus:input_type -> walletmanager.v1.GetWalletStatusRequest
-	4,  // 26: walletmanager.v1.WalletManagerService.GenerateWallet:input_type -> walletmanager.v1.GenerateWalletRequest
-	6,  // 27: walletmanager.v1.WalletManagerService.UnlockWallet:input_type -> walletmanager.v1.UnlockWalletRequest
-	8,  // 28: walletmanager.v1.WalletManagerService.LockWallet:input_type -> walletmanager.v1.LockWalletRequest
-	10, // 29: walletmanager.v1.WalletManagerService.EncryptWallet:input_type -> walletmanager.v1.EncryptWalletRequest
-	12, // 30: walletmanager.v1.WalletManagerService.ChangePassword:input_type -> walletmanager.v1.ChangePasswordRequest
-	14, // 31: walletmanager.v1.WalletManagerService.RemoveEncryption:input_type -> walletmanager.v1.RemoveEncryptionRequest
-	18, // 32: walletmanager.v1.WalletManagerService.ListWallets:input_type -> walletmanager.v1.ListWalletsRequest
-	20, // 33: walletmanager.v1.WalletManagerService.SwitchWallet:input_type -> walletmanager.v1.SwitchWalletRequest
-	22, // 34: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:input_type -> walletmanager.v1.UpdateWalletMetadataRequest
-	24, // 35: walletmanager.v1.WalletManagerService.DeleteWallet:input_type -> walletmanager.v1.DeleteWalletRequest
-	26, // 36: walletmanager.v1.WalletManagerService.DeleteAllWallets:input_type -> walletmanager.v1.DeleteAllWalletsRequest
-	31, // 37: walletmanager.v1.WalletManagerService.ListWalletBackups:input_type -> walletmanager.v1.ListWalletBackupsRequest
-	33, // 38: walletmanager.v1.WalletManagerService.RestoreWalletBackup:input_type -> walletmanager.v1.RestoreWalletBackupRequest
-	33, // 39: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:input_type -> walletmanager.v1.RestoreWalletBackupRequest
-	38, // 40: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:input_type -> walletmanager.v1.CreateWatchOnlyWalletRequest
-	40, // 41: walletmanager.v1.WalletManagerService.CreateElectrumWallet:input_type -> walletmanager.v1.CreateElectrumWalletRequest
-	42, // 42: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:input_type -> walletmanager.v1.CreateBitcoinCoreWalletRequest
-	44, // 43: walletmanager.v1.WalletManagerService.EnsureCoreWallets:input_type -> walletmanager.v1.EnsureCoreWalletsRequest
-	46, // 44: walletmanager.v1.WalletManagerService.GetBalance:input_type -> walletmanager.v1.GetBalanceRequest
-	48, // 45: walletmanager.v1.WalletManagerService.GetNewAddress:input_type -> walletmanager.v1.GetNewAddressRequest
-	50, // 46: walletmanager.v1.WalletManagerService.SendTransaction:input_type -> walletmanager.v1.SendTransactionRequest
-	60, // 47: walletmanager.v1.WalletManagerService.ListTransactions:input_type -> walletmanager.v1.ListTransactionsRequest
-	63, // 48: walletmanager.v1.WalletManagerService.ListUnspent:input_type -> walletmanager.v1.ListUnspentRequest
-	66, // 49: walletmanager.v1.WalletManagerService.ListReceiveAddresses:input_type -> walletmanager.v1.ListReceiveAddressesRequest
-	69, // 50: walletmanager.v1.WalletManagerService.GetTransactionDetails:input_type -> walletmanager.v1.GetTransactionDetailsRequest
-	73, // 51: walletmanager.v1.WalletManagerService.BumpFee:input_type -> walletmanager.v1.BumpFeeRequest
-	75, // 52: walletmanager.v1.WalletManagerService.DeriveAddresses:input_type -> walletmanager.v1.DeriveAddressesRequest
-	52, // 53: walletmanager.v1.WalletManagerService.CreatePsbt:input_type -> walletmanager.v1.CreatePsbtRequest
-	54, // 54: walletmanager.v1.WalletManagerService.SignPsbt:input_type -> walletmanager.v1.SignPsbtRequest
-	56, // 55: walletmanager.v1.WalletManagerService.CombinePsbt:input_type -> walletmanager.v1.CombinePsbtRequest
-	58, // 56: walletmanager.v1.WalletManagerService.FinalizePsbt:input_type -> walletmanager.v1.FinalizePsbtRequest
-	77, // 57: walletmanager.v1.WalletManagerService.GetWalletSeed:input_type -> walletmanager.v1.GetWalletSeedRequest
-	79, // 58: walletmanager.v1.WalletManagerService.ListCoreVariants:input_type -> walletmanager.v1.ListCoreVariantsRequest
-	82, // 59: walletmanager.v1.WalletManagerService.GetCoreVariant:input_type -> walletmanager.v1.GetCoreVariantRequest
-	84, // 60: walletmanager.v1.WalletManagerService.SetCoreVariant:input_type -> walletmanager.v1.SetCoreVariantRequest
-	86, // 61: walletmanager.v1.WalletManagerService.GetTestSidechains:input_type -> walletmanager.v1.GetTestSidechainsRequest
-	88, // 62: walletmanager.v1.WalletManagerService.SetTestSidechains:input_type -> walletmanager.v1.SetTestSidechainsRequest
-	95, // 63: walletmanager.v1.WalletManagerService.WatchWalletData:input_type -> google.protobuf.Empty
-	3,  // 64: walletmanager.v1.WalletManagerService.GetWalletStatus:output_type -> walletmanager.v1.GetWalletStatusResponse
-	5,  // 65: walletmanager.v1.WalletManagerService.GenerateWallet:output_type -> walletmanager.v1.GenerateWalletResponse
-	7,  // 66: walletmanager.v1.WalletManagerService.UnlockWallet:output_type -> walletmanager.v1.UnlockWalletResponse
-	9,  // 67: walletmanager.v1.WalletManagerService.LockWallet:output_type -> walletmanager.v1.LockWalletResponse
-	11, // 68: walletmanager.v1.WalletManagerService.EncryptWallet:output_type -> walletmanager.v1.EncryptWalletResponse
-	13, // 69: walletmanager.v1.WalletManagerService.ChangePassword:output_type -> walletmanager.v1.ChangePasswordResponse
-	15, // 70: walletmanager.v1.WalletManagerService.RemoveEncryption:output_type -> walletmanager.v1.RemoveEncryptionResponse
-	19, // 71: walletmanager.v1.WalletManagerService.ListWallets:output_type -> walletmanager.v1.ListWalletsResponse
-	21, // 72: walletmanager.v1.WalletManagerService.SwitchWallet:output_type -> walletmanager.v1.SwitchWalletResponse
-	23, // 73: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:output_type -> walletmanager.v1.UpdateWalletMetadataResponse
-	25, // 74: walletmanager.v1.WalletManagerService.DeleteWallet:output_type -> walletmanager.v1.DeleteWalletResponse
-	27, // 75: walletmanager.v1.WalletManagerService.DeleteAllWallets:output_type -> walletmanager.v1.DeleteAllWalletsResponse
-	32, // 76: walletmanager.v1.WalletManagerService.ListWalletBackups:output_type -> walletmanager.v1.ListWalletBackupsResponse
-	34, // 77: walletmanager.v1.WalletManagerService.RestoreWalletBackup:output_type -> walletmanager.v1.RestoreWalletBackupResponse
-	37, // 78: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:output_type -> walletmanager.v1.RestoreWalletBackupProgressResponse
-	39, // 79: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:output_type -> walletmanager.v1.CreateWatchOnlyWalletResponse
-	41, // 80: walletmanager.v1.WalletManagerService.CreateElectrumWallet:output_type -> walletmanager.v1.CreateElectrumWalletResponse
-	43, // 81: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:output_type -> walletmanager.v1.CreateBitcoinCoreWalletResponse
-	45, // 82: walletmanager.v1.WalletManagerService.EnsureCoreWallets:output_type -> walletmanager.v1.EnsureCoreWalletsResponse
-	47, // 83: walletmanager.v1.WalletManagerService.GetBalance:output_type -> walletmanager.v1.GetBalanceResponse
-	49, // 84: walletmanager.v1.WalletManagerService.GetNewAddress:output_type -> walletmanager.v1.GetNewAddressResponse
-	51, // 85: walletmanager.v1.WalletManagerService.SendTransaction:output_type -> walletmanager.v1.SendTransactionResponse
-	62, // 86: walletmanager.v1.WalletManagerService.ListTransactions:output_type -> walletmanager.v1.ListTransactionsResponse
-	65, // 87: walletmanager.v1.WalletManagerService.ListUnspent:output_type -> walletmanager.v1.ListUnspentResponse
-	68, // 88: walletmanager.v1.WalletManagerService.ListReceiveAddresses:output_type -> walletmanager.v1.ListReceiveAddressesResponse
-	70, // 89: walletmanager.v1.WalletManagerService.GetTransactionDetails:output_type -> walletmanager.v1.GetTransactionDetailsResponse
-	74, // 90: walletmanager.v1.WalletManagerService.BumpFee:output_type -> walletmanager.v1.BumpFeeResponse
-	76, // 91: walletmanager.v1.WalletManagerService.DeriveAddresses:output_type -> walletmanager.v1.DeriveAddressesResponse
-	53, // 92: walletmanager.v1.WalletManagerService.CreatePsbt:output_type -> walletmanager.v1.CreatePsbtResponse
-	55, // 93: walletmanager.v1.WalletManagerService.SignPsbt:output_type -> walletmanager.v1.SignPsbtResponse
-	57, // 94: walletmanager.v1.WalletManagerService.CombinePsbt:output_type -> walletmanager.v1.CombinePsbtResponse
-	59, // 95: walletmanager.v1.WalletManagerService.FinalizePsbt:output_type -> walletmanager.v1.FinalizePsbtResponse
-	78, // 96: walletmanager.v1.WalletManagerService.GetWalletSeed:output_type -> walletmanager.v1.GetWalletSeedResponse
-	81, // 97: walletmanager.v1.WalletManagerService.ListCoreVariants:output_type -> walletmanager.v1.ListCoreVariantsResponse
-	83, // 98: walletmanager.v1.WalletManagerService.GetCoreVariant:output_type -> walletmanager.v1.GetCoreVariantResponse
-	85, // 99: walletmanager.v1.WalletManagerService.SetCoreVariant:output_type -> walletmanager.v1.SetCoreVariantResponse
-	87, // 100: walletmanager.v1.WalletManagerService.GetTestSidechains:output_type -> walletmanager.v1.GetTestSidechainsResponse
-	89, // 101: walletmanager.v1.WalletManagerService.SetTestSidechains:output_type -> walletmanager.v1.SetTestSidechainsResponse
-	90, // 102: walletmanager.v1.WalletManagerService.WatchWalletData:output_type -> walletmanager.v1.WatchWalletDataResponse
-	64, // [64:103] is the sub-list for method output_type
-	25, // [25:64] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	93, // 12: walletmanager.v1.SendTransactionRequest.destinations:type_name -> walletmanager.v1.SendTransactionRequest.DestinationsEntry
+	66, // 13: walletmanager.v1.SendTransactionRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
+	52, // 14: walletmanager.v1.SendTransactionRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
+	53, // 15: walletmanager.v1.SendTransactionRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
+	94, // 16: walletmanager.v1.CreatePsbtRequest.destinations:type_name -> walletmanager.v1.CreatePsbtRequest.DestinationsEntry
+	66, // 17: walletmanager.v1.CreatePsbtRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
+	52, // 18: walletmanager.v1.CreatePsbtRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
+	53, // 19: walletmanager.v1.CreatePsbtRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
+	63, // 20: walletmanager.v1.ListTransactionsResponse.transactions:type_name -> walletmanager.v1.TransactionEntry
+	96, // 21: walletmanager.v1.UnspentOutput.received_at:type_name -> google.protobuf.Timestamp
+	66, // 22: walletmanager.v1.ListUnspentResponse.utxos:type_name -> walletmanager.v1.UnspentOutput
+	69, // 23: walletmanager.v1.ListReceiveAddressesResponse.addresses:type_name -> walletmanager.v1.ReceiveAddress
+	63, // 24: walletmanager.v1.GetTransactionDetailsResponse.transaction:type_name -> walletmanager.v1.TransactionEntry
+	73, // 25: walletmanager.v1.GetTransactionDetailsResponse.inputs:type_name -> walletmanager.v1.TransactionInput
+	74, // 26: walletmanager.v1.GetTransactionDetailsResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
+	82, // 27: walletmanager.v1.ListCoreVariantsResponse.variants:type_name -> walletmanager.v1.CoreVariant
+	16, // 28: walletmanager.v1.WatchWalletDataResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
+	2,  // 29: walletmanager.v1.WalletManagerService.GetWalletStatus:input_type -> walletmanager.v1.GetWalletStatusRequest
+	4,  // 30: walletmanager.v1.WalletManagerService.GenerateWallet:input_type -> walletmanager.v1.GenerateWalletRequest
+	6,  // 31: walletmanager.v1.WalletManagerService.UnlockWallet:input_type -> walletmanager.v1.UnlockWalletRequest
+	8,  // 32: walletmanager.v1.WalletManagerService.LockWallet:input_type -> walletmanager.v1.LockWalletRequest
+	10, // 33: walletmanager.v1.WalletManagerService.EncryptWallet:input_type -> walletmanager.v1.EncryptWalletRequest
+	12, // 34: walletmanager.v1.WalletManagerService.ChangePassword:input_type -> walletmanager.v1.ChangePasswordRequest
+	14, // 35: walletmanager.v1.WalletManagerService.RemoveEncryption:input_type -> walletmanager.v1.RemoveEncryptionRequest
+	18, // 36: walletmanager.v1.WalletManagerService.ListWallets:input_type -> walletmanager.v1.ListWalletsRequest
+	20, // 37: walletmanager.v1.WalletManagerService.SwitchWallet:input_type -> walletmanager.v1.SwitchWalletRequest
+	22, // 38: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:input_type -> walletmanager.v1.UpdateWalletMetadataRequest
+	24, // 39: walletmanager.v1.WalletManagerService.DeleteWallet:input_type -> walletmanager.v1.DeleteWalletRequest
+	26, // 40: walletmanager.v1.WalletManagerService.DeleteAllWallets:input_type -> walletmanager.v1.DeleteAllWalletsRequest
+	31, // 41: walletmanager.v1.WalletManagerService.ListWalletBackups:input_type -> walletmanager.v1.ListWalletBackupsRequest
+	33, // 42: walletmanager.v1.WalletManagerService.RestoreWalletBackup:input_type -> walletmanager.v1.RestoreWalletBackupRequest
+	33, // 43: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:input_type -> walletmanager.v1.RestoreWalletBackupRequest
+	38, // 44: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:input_type -> walletmanager.v1.CreateWatchOnlyWalletRequest
+	40, // 45: walletmanager.v1.WalletManagerService.CreateElectrumWallet:input_type -> walletmanager.v1.CreateElectrumWalletRequest
+	42, // 46: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:input_type -> walletmanager.v1.CreateBitcoinCoreWalletRequest
+	44, // 47: walletmanager.v1.WalletManagerService.EnsureCoreWallets:input_type -> walletmanager.v1.EnsureCoreWalletsRequest
+	46, // 48: walletmanager.v1.WalletManagerService.GetBalance:input_type -> walletmanager.v1.GetBalanceRequest
+	48, // 49: walletmanager.v1.WalletManagerService.GetNewAddress:input_type -> walletmanager.v1.GetNewAddressRequest
+	50, // 50: walletmanager.v1.WalletManagerService.SendTransaction:input_type -> walletmanager.v1.SendTransactionRequest
+	62, // 51: walletmanager.v1.WalletManagerService.ListTransactions:input_type -> walletmanager.v1.ListTransactionsRequest
+	65, // 52: walletmanager.v1.WalletManagerService.ListUnspent:input_type -> walletmanager.v1.ListUnspentRequest
+	68, // 53: walletmanager.v1.WalletManagerService.ListReceiveAddresses:input_type -> walletmanager.v1.ListReceiveAddressesRequest
+	71, // 54: walletmanager.v1.WalletManagerService.GetTransactionDetails:input_type -> walletmanager.v1.GetTransactionDetailsRequest
+	75, // 55: walletmanager.v1.WalletManagerService.BumpFee:input_type -> walletmanager.v1.BumpFeeRequest
+	77, // 56: walletmanager.v1.WalletManagerService.DeriveAddresses:input_type -> walletmanager.v1.DeriveAddressesRequest
+	54, // 57: walletmanager.v1.WalletManagerService.CreatePsbt:input_type -> walletmanager.v1.CreatePsbtRequest
+	56, // 58: walletmanager.v1.WalletManagerService.SignPsbt:input_type -> walletmanager.v1.SignPsbtRequest
+	58, // 59: walletmanager.v1.WalletManagerService.CombinePsbt:input_type -> walletmanager.v1.CombinePsbtRequest
+	60, // 60: walletmanager.v1.WalletManagerService.FinalizePsbt:input_type -> walletmanager.v1.FinalizePsbtRequest
+	79, // 61: walletmanager.v1.WalletManagerService.GetWalletSeed:input_type -> walletmanager.v1.GetWalletSeedRequest
+	81, // 62: walletmanager.v1.WalletManagerService.ListCoreVariants:input_type -> walletmanager.v1.ListCoreVariantsRequest
+	84, // 63: walletmanager.v1.WalletManagerService.GetCoreVariant:input_type -> walletmanager.v1.GetCoreVariantRequest
+	86, // 64: walletmanager.v1.WalletManagerService.SetCoreVariant:input_type -> walletmanager.v1.SetCoreVariantRequest
+	88, // 65: walletmanager.v1.WalletManagerService.GetTestSidechains:input_type -> walletmanager.v1.GetTestSidechainsRequest
+	90, // 66: walletmanager.v1.WalletManagerService.SetTestSidechains:input_type -> walletmanager.v1.SetTestSidechainsRequest
+	97, // 67: walletmanager.v1.WalletManagerService.WatchWalletData:input_type -> google.protobuf.Empty
+	3,  // 68: walletmanager.v1.WalletManagerService.GetWalletStatus:output_type -> walletmanager.v1.GetWalletStatusResponse
+	5,  // 69: walletmanager.v1.WalletManagerService.GenerateWallet:output_type -> walletmanager.v1.GenerateWalletResponse
+	7,  // 70: walletmanager.v1.WalletManagerService.UnlockWallet:output_type -> walletmanager.v1.UnlockWalletResponse
+	9,  // 71: walletmanager.v1.WalletManagerService.LockWallet:output_type -> walletmanager.v1.LockWalletResponse
+	11, // 72: walletmanager.v1.WalletManagerService.EncryptWallet:output_type -> walletmanager.v1.EncryptWalletResponse
+	13, // 73: walletmanager.v1.WalletManagerService.ChangePassword:output_type -> walletmanager.v1.ChangePasswordResponse
+	15, // 74: walletmanager.v1.WalletManagerService.RemoveEncryption:output_type -> walletmanager.v1.RemoveEncryptionResponse
+	19, // 75: walletmanager.v1.WalletManagerService.ListWallets:output_type -> walletmanager.v1.ListWalletsResponse
+	21, // 76: walletmanager.v1.WalletManagerService.SwitchWallet:output_type -> walletmanager.v1.SwitchWalletResponse
+	23, // 77: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:output_type -> walletmanager.v1.UpdateWalletMetadataResponse
+	25, // 78: walletmanager.v1.WalletManagerService.DeleteWallet:output_type -> walletmanager.v1.DeleteWalletResponse
+	27, // 79: walletmanager.v1.WalletManagerService.DeleteAllWallets:output_type -> walletmanager.v1.DeleteAllWalletsResponse
+	32, // 80: walletmanager.v1.WalletManagerService.ListWalletBackups:output_type -> walletmanager.v1.ListWalletBackupsResponse
+	34, // 81: walletmanager.v1.WalletManagerService.RestoreWalletBackup:output_type -> walletmanager.v1.RestoreWalletBackupResponse
+	37, // 82: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:output_type -> walletmanager.v1.RestoreWalletBackupProgressResponse
+	39, // 83: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:output_type -> walletmanager.v1.CreateWatchOnlyWalletResponse
+	41, // 84: walletmanager.v1.WalletManagerService.CreateElectrumWallet:output_type -> walletmanager.v1.CreateElectrumWalletResponse
+	43, // 85: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:output_type -> walletmanager.v1.CreateBitcoinCoreWalletResponse
+	45, // 86: walletmanager.v1.WalletManagerService.EnsureCoreWallets:output_type -> walletmanager.v1.EnsureCoreWalletsResponse
+	47, // 87: walletmanager.v1.WalletManagerService.GetBalance:output_type -> walletmanager.v1.GetBalanceResponse
+	49, // 88: walletmanager.v1.WalletManagerService.GetNewAddress:output_type -> walletmanager.v1.GetNewAddressResponse
+	51, // 89: walletmanager.v1.WalletManagerService.SendTransaction:output_type -> walletmanager.v1.SendTransactionResponse
+	64, // 90: walletmanager.v1.WalletManagerService.ListTransactions:output_type -> walletmanager.v1.ListTransactionsResponse
+	67, // 91: walletmanager.v1.WalletManagerService.ListUnspent:output_type -> walletmanager.v1.ListUnspentResponse
+	70, // 92: walletmanager.v1.WalletManagerService.ListReceiveAddresses:output_type -> walletmanager.v1.ListReceiveAddressesResponse
+	72, // 93: walletmanager.v1.WalletManagerService.GetTransactionDetails:output_type -> walletmanager.v1.GetTransactionDetailsResponse
+	76, // 94: walletmanager.v1.WalletManagerService.BumpFee:output_type -> walletmanager.v1.BumpFeeResponse
+	78, // 95: walletmanager.v1.WalletManagerService.DeriveAddresses:output_type -> walletmanager.v1.DeriveAddressesResponse
+	55, // 96: walletmanager.v1.WalletManagerService.CreatePsbt:output_type -> walletmanager.v1.CreatePsbtResponse
+	57, // 97: walletmanager.v1.WalletManagerService.SignPsbt:output_type -> walletmanager.v1.SignPsbtResponse
+	59, // 98: walletmanager.v1.WalletManagerService.CombinePsbt:output_type -> walletmanager.v1.CombinePsbtResponse
+	61, // 99: walletmanager.v1.WalletManagerService.FinalizePsbt:output_type -> walletmanager.v1.FinalizePsbtResponse
+	80, // 100: walletmanager.v1.WalletManagerService.GetWalletSeed:output_type -> walletmanager.v1.GetWalletSeedResponse
+	83, // 101: walletmanager.v1.WalletManagerService.ListCoreVariants:output_type -> walletmanager.v1.ListCoreVariantsResponse
+	85, // 102: walletmanager.v1.WalletManagerService.GetCoreVariant:output_type -> walletmanager.v1.GetCoreVariantResponse
+	87, // 103: walletmanager.v1.WalletManagerService.SetCoreVariant:output_type -> walletmanager.v1.SetCoreVariantResponse
+	89, // 104: walletmanager.v1.WalletManagerService.GetTestSidechains:output_type -> walletmanager.v1.GetTestSidechainsResponse
+	91, // 105: walletmanager.v1.WalletManagerService.SetTestSidechains:output_type -> walletmanager.v1.SetTestSidechainsResponse
+	92, // 106: walletmanager.v1.WalletManagerService.WatchWalletData:output_type -> walletmanager.v1.WatchWalletDataResponse
+	68, // [68:107] is the sub-list for method output_type
+	29, // [29:68] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_walletmanager_v1_walletmanager_proto_init() }
@@ -5659,7 +5844,7 @@ func file_walletmanager_v1_walletmanager_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_walletmanager_v1_walletmanager_proto_rawDesc), len(file_walletmanager_v1_walletmanager_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   91,
+			NumMessages:   93,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -365,10 +365,33 @@ message SendTransactionRequest {
   // Build an eCash replay-protected transaction (magic version + extra byte so
   // Bitcoin Core can't deserialize it). Core wallets only.
   bool replay_protect = 8;
+  // Outputs with an explicit raw scriptPubKey, kept in order before any
+  // address/op_return outputs. Used for non-standard scripts (e.g. a sidechain
+  // OP_DRIVECHAIN treasury output).
+  repeated RawOutput raw_outputs = 9;
+  // Inputs not owned by the wallet that must be spent as-is, in order, before
+  // wallet-funded inputs. Used for anyone-can-spend scripts (e.g. a sidechain
+  // CTIP). They are added with an empty scriptSig and not signed.
+  repeated ExternalInput external_inputs = 10;
 }
 
 message SendTransactionResponse {
   string txid = 1;
+}
+
+// RawOutput is a transaction output with a caller-supplied scriptPubKey.
+message RawOutput {
+  int64 value_sats = 1;
+  string script_hex = 2;
+}
+
+// ExternalInput is a UTXO spent by the transaction that the wallet does not own
+// and does not sign — its script must be satisfiable with an empty scriptSig.
+message ExternalInput {
+  string txid = 1;
+  int32 vout = 2;
+  int64 value_sats = 3;
+  string script_pubkey_hex = 4;
 }
 
 message CreatePsbtRequest {
@@ -379,6 +402,8 @@ message CreatePsbtRequest {
   string op_return_hex = 5;
   int64 fixed_fee_sats = 6;
   repeated UnspentOutput required_inputs = 7;
+  repeated RawOutput raw_outputs = 8;
+  repeated ExternalInput external_inputs = 9;
 }
 
 message CreatePsbtResponse {

--- a/sidechain-orchestrator/wallet/backend_types.go
+++ b/sidechain-orchestrator/wallet/backend_types.go
@@ -146,6 +146,12 @@ type SendRequest struct {
 	RequiredInputs        []RequiredInput
 	SubtractFeeFromAmount bool
 	ReplayProtect         bool
+	// RawOutputs carry caller-supplied scriptPubKeys, placed in order before any
+	// address/op_return outputs (e.g. a sidechain OP_DRIVECHAIN treasury output).
+	RawOutputs []TxOutSpec
+	// ExternalInputs are non-wallet UTXOs spent with an empty scriptSig and not
+	// signed — for anyone-can-spend scripts like a sidechain CTIP.
+	ExternalInputs []ExternalInput
 }
 
 // RequiredInput pins one outpoint that the transaction must spend.
@@ -153,6 +159,15 @@ type RequiredInput struct {
 	TxID       string
 	Vout       int
 	AmountSats int64
+}
+
+// ExternalInput is a UTXO the wallet does not own and does not sign; its script
+// must be satisfiable with an empty scriptSig (e.g. a sidechain CTIP).
+type ExternalInput struct {
+	TxID            string
+	Vout            int
+	AmountSats      int64
+	ScriptPubKeyHex string
 }
 
 // WatchKey is one private key whose address the backend must track.

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -429,8 +429,14 @@ func rpcOutputs(outputs []TxOutSpec) []map[string]interface{} {
 // buildSendOutputs maps the request's destinations (plus optional OP_RETURN)
 // to ordered outputs and returns the destination total in sats.
 func buildSendOutputs(req SendRequest) ([]TxOutSpec, int64) {
-	outputs := make([]TxOutSpec, 0, len(req.DestinationsSats)+1)
+	outputs := make([]TxOutSpec, 0, len(req.RawOutputs)+len(req.DestinationsSats)+1)
 	totalDestinationSats := int64(0)
+	// Raw outputs come first so consensus-ordered scripts (e.g. an OP_DRIVECHAIN
+	// treasury immediately before its OP_RETURN address) keep their positions.
+	for _, raw := range req.RawOutputs {
+		outputs = append(outputs, raw)
+		totalDestinationSats += raw.AmountSats
+	}
 	for address, sats := range req.DestinationsSats {
 		outputs = append(outputs, TxOutSpec{Address: address, AmountBTC: float64(sats) / 1e8})
 		totalDestinationSats += sats

--- a/sidechain-orchestrator/wallet/deposit_primitives_test.go
+++ b/sidechain-orchestrator/wallet/deposit_primitives_test.go
@@ -1,0 +1,119 @@
+package wallet
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildSendOutputsRawOutputsFirst verifies raw outputs keep their order at
+// the front (so consensus-ordered scripts like an OP_DRIVECHAIN treasury and its
+// OP_RETURN address stay adjacent and first) and that their value is funded.
+func TestBuildSendOutputsRawOutputsFirst(t *testing.T) {
+	treasuryHex := hex.EncodeToString([]byte{0xB4, 0x01, 0x01, 0x51})
+	req := SendRequest{
+		RawOutputs:       []TxOutSpec{{RawScriptHex: treasuryHex, AmountSats: 600_000}},
+		DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000},
+		OpReturnHex:      "deadbeef",
+	}
+
+	outs, total := buildSendOutputs(req)
+
+	require.Len(t, outs, 3)
+	assert.Equal(t, treasuryHex, outs[0].RawScriptHex, "raw output comes first")
+	assert.Equal(t, int64(600_000), outs[0].AmountSats)
+	assert.Equal(t, int64(50_000), int64(outs[1].AmountBTC*1e8), "destination follows raw outputs")
+	assert.Equal(t, "deadbeef", outs[2].OpReturnHex, "op_return is last")
+	assert.Equal(t, int64(650_000), total, "raw output value counts toward funding")
+}
+
+// TestOutputToTxOutRawScript verifies a raw-script output is emitted verbatim,
+// with no minimal-push rewriting that would corrupt an OP_DRIVECHAIN script.
+func TestOutputToTxOutRawScript(t *testing.T) {
+	// OP_DRIVECHAIN OP_PUSHBYTES_1 <slot=1> OP_TRUE — slot 1 must NOT collapse to OP_1.
+	script := []byte{0xB4, 0x01, 0x01, 0x51}
+	out, err := outputToTxOut(
+		TxOutSpec{RawScriptHex: hex.EncodeToString(script), AmountSats: 600_000},
+		&chaincfg.SigNetParams,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, script, out.PkScript)
+	assert.Equal(t, int64(600_000), out.Value)
+}
+
+// TestM5TreasuryScriptAllSlots verifies the OP_DRIVECHAIN treasury script is
+// emitted byte-for-byte for every slot 0-255, with OP_PUSHBYTES_1 (0x01) intact —
+// i.e. low slots (1-16) are NOT collapsed to OP_1..OP_16 by minimal-push encoding,
+// which would make the script unparseable as a CTIP.
+func TestM5TreasuryScriptAllSlots(t *testing.T) {
+	for slot := 0; slot <= 255; slot++ {
+		want := []byte{0xB4, 0x01, byte(slot), 0x51}
+		out, err := outputToTxOut(
+			TxOutSpec{RawScriptHex: hex.EncodeToString(want), AmountSats: 12_345},
+			&chaincfg.SigNetParams,
+		)
+		require.NoErrorf(t, err, "slot %d", slot)
+		require.Equalf(t, want, out.PkScript, "slot %d script mismatch", slot)
+		assert.Equalf(t, int64(12_345), out.Value, "slot %d value", slot)
+	}
+}
+
+// TestM5OpReturnAddressRoundtrip verifies the sidechain address survives the
+// OP_RETURN encoding intact — mirrors the enforcer's try_parse_op_return_address.
+func TestM5OpReturnAddressRoundtrip(t *testing.T) {
+	for _, addr := range []string{
+		"s1_examplesidechainaddress",
+		"thunder1qxyz",
+		"a",
+	} {
+		out, err := outputToTxOut(
+			TxOutSpec{OpReturnHex: hex.EncodeToString([]byte(addr))},
+			&chaincfg.SigNetParams,
+		)
+		require.NoError(t, err)
+		require.Equal(t, byte(txscript.OP_RETURN), out.PkScript[0])
+		assert.Zero(t, out.Value)
+
+		pushed, err := txscript.PushedData(out.PkScript)
+		require.NoErrorf(t, err, "addr %q", addr)
+		require.Lenf(t, pushed, 1, "addr %q", addr)
+		assert.Equalf(t, []byte(addr), pushed[0], "addr %q roundtrip", addr)
+	}
+}
+
+// TestBuildPSBTExternalInputPrefinalized verifies an external (anyone-can-spend)
+// input is added from its previous transaction, pre-finalized with an empty
+// scriptSig, and skipped by the signer.
+func TestBuildPSBTExternalInputPrefinalized(t *testing.T) {
+	net := &chaincfg.SigNetParams
+
+	drivechainScript := []byte{0xB4, 0x01, 0x01, 0x51}
+	treasuryPrev := wire.NewMsgTx(2)
+	treasuryPrev.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	treasuryPrev.AddTxOut(wire.NewTxOut(500_000, drivechainScript))
+
+	inputs := []psbtInput{{
+		outpoint: wire.OutPoint{Hash: treasuryPrev.TxHash(), Index: 0},
+		amount:   500_000,
+		external: true,
+	}}
+	outputs := []TxOutSpec{{RawScriptHex: hex.EncodeToString(drivechainScript), AmountSats: 500_000}}
+
+	packet, err := buildPSBT(inputs, outputs, net, func(string) (*wire.MsgTx, error) {
+		return treasuryPrev, nil
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, packet.Inputs[0].FinalScriptSig, "external input is pre-finalized")
+	assert.Len(t, packet.Inputs[0].FinalScriptSig, 0, "with an empty scriptSig")
+	require.NotNil(t, packet.Inputs[0].NonWitnessUtxo, "external input carries its prev tx")
+
+	signed, err := signPSBT(packet, inputs, net)
+	require.NoError(t, err)
+	assert.Equal(t, 0, signed, "external input is never signed")
+}

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -441,7 +441,7 @@ func (p *ElectrumBackend) EnsureNotificationWatched(ctx context.Context, walletI
 }
 
 func (p *ElectrumBackend) Send(ctx context.Context, walletID string, req SendRequest) (string, error) {
-	scan, err := p.scanWalletLive(ctx, walletID)
+	scan, err := p.scanForSend(ctx, walletID, req)
 	if err != nil {
 		return "", err
 	}
@@ -828,7 +828,7 @@ func (p *ElectrumBackend) CreatePSBT(ctx context.Context, walletID string, req S
 	if err := p.requireElectrum(walletID); err != nil {
 		return "", err
 	}
-	scan, err := p.scanWalletLive(ctx, walletID)
+	scan, err := p.scanForSend(ctx, walletID, req)
 	if err != nil {
 		return "", err
 	}
@@ -1109,6 +1109,23 @@ func (p *ElectrumBackend) scanWallet(ctx context.Context, walletID string) (*ele
 // for address allocation and spends, where stale data risks reuse or misspend.
 func (p *ElectrumBackend) scanWalletLive(ctx context.Context, walletID string) (*electrumScan, error) {
 	return p.scan(ctx, walletID, false)
+}
+
+// scanForSend picks the scan strategy for building a send/PSBT. An OP_RETURN-only
+// broadcast (e.g. coinnews) needs only a fee UTXO, so the cached, tip-gated scan
+// is enough and avoids a full live re-walk that hammers rate-limited esplora
+// providers. Anything that pays an address, spends a specific/external input, or
+// adds a raw output forces a live scan for fresh UTXO data.
+func (p *ElectrumBackend) scanForSend(ctx context.Context, walletID string, req SendRequest) (*electrumScan, error) {
+	opReturnOnly := req.OpReturnHex != "" &&
+		len(req.DestinationsSats) == 0 &&
+		len(req.RawOutputs) == 0 &&
+		len(req.ExternalInputs) == 0 &&
+		len(req.RequiredInputs) == 0
+	if opReturnOnly {
+		return p.scanWallet(ctx, walletID)
+	}
+	return p.scanWalletLive(ctx, walletID)
 }
 
 func (p *ElectrumBackend) scan(ctx context.Context, walletID string, allowCache bool) (*electrumScan, error) {

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -461,7 +461,15 @@ func (p *ElectrumBackend) Send(ctx context.Context, walletID string, req SendReq
 	if err != nil {
 		return "", fmt.Errorf("sign psbt: %w", err)
 	}
-	if signedCount < len(psbtInputs) {
+	// External inputs (e.g. a CTIP) are pre-finalized and need no signature; only
+	// the wallet's own inputs must be signed.
+	walletInputs := 0
+	for i := range psbtInputs {
+		if !psbtInputs[i].external {
+			walletInputs++
+		}
+	}
+	if signedCount < walletInputs {
 		return "", errors.New("transaction signing incomplete")
 	}
 	hexToSend, err := finalizeAndExtract(packet)
@@ -643,10 +651,19 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 
 	pool := p.spendableUTXOs(scan)
 
+	// External (non-wallet) inputs — e.g. an anyone-can-spend sidechain CTIP —
+	// contribute their value toward the outputs but are not signed by us. Their
+	// vsize is not added to fee estimation, so callers that supply them use a
+	// fixed fee (FixedFeeSats).
+	externalSats := int64(0)
+	for _, ei := range req.ExternalInputs {
+		externalSats += ei.AmountSats
+	}
+
 	// Pin required inputs, then fill from the remaining pool largest-first.
 	required := make(map[string]bool)
 	var selected []electrumUTXO
-	var selectedSats int64
+	selectedSats := externalSats
 	for _, ri := range req.RequiredInputs {
 		key := fmt.Sprintf("%s:%d", ri.TxID, ri.Vout)
 		required[key] = true
@@ -759,8 +776,20 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 		})
 	}
 
-	psbtInputs := make([]psbtInput, len(selected))
-	for idx, u := range selected {
+	// External inputs come first (e.g. the CTIP at input 0), then wallet inputs.
+	psbtInputs := make([]psbtInput, 0, len(req.ExternalInputs)+len(selected))
+	for _, ei := range req.ExternalInputs {
+		h, err := chainhash.NewHashFromStr(ei.TxID)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("parse external input txid %q: %w", ei.TxID, err)
+		}
+		psbtInputs = append(psbtInputs, psbtInput{
+			outpoint: wire.OutPoint{Hash: *h, Index: uint32(ei.Vout)},
+			amount:   ei.AmountSats,
+			external: true,
+		})
+	}
+	for _, u := range selected {
 		sa, ok := scan.byAddr[u.address]
 		if !ok {
 			return nil, nil, nil, fmt.Errorf("no derivation info for input address %s", u.address)
@@ -769,11 +798,11 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("parse input txid %q: %w", u.txid, err)
 		}
-		psbtInputs[idx] = psbtInput{
+		psbtInputs = append(psbtInputs, psbtInput{
 			outpoint: wire.OutPoint{Hash: *h, Index: uint32(u.vout)},
 			amount:   u.amountSats,
 			addr:     sa,
-		}
+		})
 	}
 
 	packet, err := buildPSBT(psbtInputs, outputs, p.network, p.prevTxFetcher(ctx))

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
@@ -220,6 +221,191 @@ func TestElectrumSendBuildsSignsBroadcasts(t *testing.T) {
 	// One destination output + a change output back to the wallet.
 	require.Len(t, tx.TxOut, 2)
 	assert.Equal(t, int64(50_000), tx.TxOut[0].Value)
+}
+
+// TestElectrumSendSidechainDeposit drives the full BIP300 M5 deposit through the
+// real Send path across a range of slots and the first-deposit (no CTIP) case,
+// and validates EVERY input through txscript.Engine — proving the constructed
+// transaction is consensus-spendable: the CTIP is an anyone-can-spend
+// OP_DRIVECHAIN output spent with an empty scriptSig, and the wallet input
+// carries a valid signature. Outputs are asserted byte-for-byte and in order.
+func TestElectrumSendSidechainDeposit(t *testing.T) {
+	net := &chaincfg.SigNetParams
+	const (
+		walletAmount  = int64(2_000_000)
+		depositAmount = int64(400_000)
+		fee           = int64(1_000)
+	)
+
+	cases := []struct {
+		name        string
+		slot        byte
+		withCtip    bool
+		oldCtip     int64
+		depositAddr string
+	}{
+		{"slot_0_with_ctip", 0, true, 250_000, "s0_examplesidechainaddress"},
+		{"slot_1_with_ctip", 1, true, 500_000, "s1_anotheraddress"},
+		// Slots 1-16 must NOT collapse to OP_1..OP_16 (minimal push) — the script
+		// is emitted as raw bytes, so OP_PUSHBYTES_1 (0x01) stays put.
+		{"slot_16_with_ctip", 16, true, 1, "s16_x"},
+		{"slot_255_with_ctip", 255, true, 999_999, "s255_maxslot"},
+		{"slot_7_first_deposit", 7, false, 0, "s7_firstdeposit"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, fake, w, addr := newElectrumFixture(t)
+			ctx := context.Background()
+
+			fake.stats[addr] = EsploraAddressStats{
+				Address:    addr,
+				ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: walletAmount, TxCount: 1},
+			}
+			fake.utxos[addr] = []EsploraUTXO{{
+				TxID: "3333333333333333333333333333333333333333333333333333333333333333",
+				Vout: 0, Value: walletAmount,
+				Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+			}}
+
+			drivechainScript := []byte{txscript.OP_NOP5, txscript.OP_DATA_1, tc.slot, txscript.OP_TRUE}
+
+			var externalInputs []ExternalInput
+			var ctipTxid string
+			if tc.withCtip {
+				treasuryPrev := wire.NewMsgTx(2)
+				treasuryPrev.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+				treasuryPrev.AddTxOut(wire.NewTxOut(tc.oldCtip, drivechainScript))
+				var buf bytes.Buffer
+				require.NoError(t, treasuryPrev.Serialize(&buf))
+				ctipTxid = treasuryPrev.TxHash().String()
+				fake.hexByID[ctipTxid] = hex.EncodeToString(buf.Bytes())
+				externalInputs = []ExternalInput{{TxID: ctipTxid, Vout: 0, AmountSats: tc.oldCtip}}
+			}
+
+			treasuryValue := tc.oldCtip + depositAmount
+			txid, err := p.Send(ctx, w.ID, SendRequest{
+				FixedFeeSats: fee,
+				RawOutputs: []TxOutSpec{
+					{RawScriptHex: hex.EncodeToString(drivechainScript), AmountSats: treasuryValue},
+				},
+				OpReturnHex:    hex.EncodeToString([]byte(tc.depositAddr)),
+				ExternalInputs: externalInputs,
+			})
+			require.NoError(t, err)
+			require.Equal(t, "broadcasttxid", txid)
+			require.Len(t, fake.broadcast, 1)
+
+			var tx wire.MsgTx
+			raw, err := hex.DecodeString(fake.broadcast[0])
+			require.NoError(t, err)
+			require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+
+			// Outputs: treasury, OP_RETURN address, change — exact bytes and order.
+			require.Len(t, tx.TxOut, 3)
+			assert.Equal(t, []byte{0xB4, 0x01, tc.slot, 0x51}, tx.TxOut[0].PkScript,
+				"out[0] treasury = OP_DRIVECHAIN OP_PUSHBYTES_1 <slot> OP_TRUE, raw (no minimal-push)")
+			assert.Equal(t, treasuryValue, tx.TxOut[0].Value, "treasury value = old CTIP + deposit")
+
+			require.Equal(t, byte(txscript.OP_RETURN), tx.TxOut[1].PkScript[0], "out[1] must be OP_RETURN")
+			pushed, err := txscript.PushedData(tx.TxOut[1].PkScript)
+			require.NoError(t, err)
+			require.Len(t, pushed, 1)
+			assert.Equal(t, []byte(tc.depositAddr), pushed[0], "OP_RETURN carries the address bytes verbatim")
+			assert.Zero(t, tx.TxOut[1].Value)
+			assert.Equal(t, walletAmount-depositAmount-fee, tx.TxOut[2].Value, "change = wallet - deposit - fee")
+
+			// Map every input to its prevout and locate the CTIP vs wallet inputs.
+			walletAddr, err := btcutil.DecodeAddress(addr, net)
+			require.NoError(t, err)
+			walletScript, err := txscript.PayToAddrScript(walletAddr)
+			require.NoError(t, err)
+
+			prevByOutpoint := map[wire.OutPoint]*wire.TxOut{}
+			ctipIdx, walletIdx := -1, -1
+			for i := range tx.TxIn {
+				op := tx.TxIn[i].PreviousOutPoint
+				if tc.withCtip && op.Hash.String() == ctipTxid {
+					prevByOutpoint[op] = wire.NewTxOut(tc.oldCtip, drivechainScript)
+					ctipIdx = i
+				} else {
+					prevByOutpoint[op] = wire.NewTxOut(walletAmount, walletScript)
+					walletIdx = i
+				}
+			}
+			require.NotEqual(t, -1, walletIdx, "wallet input present")
+
+			prevOuts := txscript.NewMultiPrevOutFetcher(prevByOutpoint)
+			sigHashes := txscript.NewTxSigHashes(&tx, prevOuts)
+
+			if tc.withCtip {
+				require.Len(t, tx.TxIn, 2)
+				require.NotEqual(t, -1, ctipIdx, "CTIP input present")
+				assert.Empty(t, tx.TxIn[ctipIdx].SignatureScript, "CTIP spent with empty scriptSig")
+				assert.Empty(t, tx.TxIn[ctipIdx].Witness, "CTIP input is not signed")
+				// OP_DRIVECHAIN is a NOP under base rules → anyone-can-spend; verify
+				// without upgradable-NOP/cleanstack policy (BIP300 is enforced separately).
+				vm, err := txscript.NewEngine(drivechainScript, &tx, ctipIdx, txscript.ScriptBip16, nil, sigHashes, tc.oldCtip, prevOuts)
+				require.NoError(t, err)
+				require.NoError(t, vm.Execute(), "CTIP anyone-can-spend input must validate with empty scriptSig")
+			} else {
+				require.Len(t, tx.TxIn, 1, "first deposit has only the wallet input")
+			}
+
+			require.NotEmpty(t, tx.TxIn[walletIdx].Witness, "wallet input must be signed")
+			vmWallet, err := txscript.NewEngine(walletScript, &tx, walletIdx,
+				txscript.StandardVerifyFlags|txscript.ScriptVerifyTaproot, nil, sigHashes, walletAmount, prevOuts)
+			require.NoError(t, err)
+			require.NoError(t, vmWallet.Execute(), "wallet input signature must validate")
+		})
+	}
+}
+
+// TestElectrumSendSidechainDepositInsufficientFunds proves the deposit fails
+// cleanly when the wallet can't cover the deposit amount plus fee (the CTIP value
+// funds only the treasury output, not the user's contribution).
+func TestElectrumSendSidechainDepositInsufficientFunds(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	ctx := context.Background()
+
+	const (
+		walletAmount  = int64(100_000)
+		oldCtip       = int64(500_000)
+		depositAmount = int64(400_000) // exceeds wallet funds
+		fee           = int64(1_000)
+		slot          = byte(1)
+	)
+
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: walletAmount, TxCount: 1},
+	}
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID: "4444444444444444444444444444444444444444444444444444444444444444",
+		Vout: 0, Value: walletAmount,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}
+
+	drivechainScript := []byte{txscript.OP_NOP5, txscript.OP_DATA_1, slot, txscript.OP_TRUE}
+	treasuryPrev := wire.NewMsgTx(2)
+	treasuryPrev.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	treasuryPrev.AddTxOut(wire.NewTxOut(oldCtip, drivechainScript))
+	var buf bytes.Buffer
+	require.NoError(t, treasuryPrev.Serialize(&buf))
+	ctipTxid := treasuryPrev.TxHash().String()
+	fake.hexByID[ctipTxid] = hex.EncodeToString(buf.Bytes())
+
+	_, err := p.Send(ctx, w.ID, SendRequest{
+		FixedFeeSats: fee,
+		RawOutputs: []TxOutSpec{
+			{RawScriptHex: hex.EncodeToString(drivechainScript), AmountSats: oldCtip + depositAmount},
+		},
+		OpReturnHex:    hex.EncodeToString([]byte("s1_addr")),
+		ExternalInputs: []ExternalInput{{TxID: ctipTxid, Vout: 0, AmountSats: oldCtip}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient funds")
+	assert.Empty(t, fake.broadcast, "nothing is broadcast when funding fails")
 }
 
 // TestElectrumSendUpdatesCacheInstantly proves a send reflects in balance, UTXOs

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -361,6 +361,51 @@ func TestElectrumSendSidechainDeposit(t *testing.T) {
 	}
 }
 
+// TestElectrumSendOpReturnOnly proves an OP_RETURN-only broadcast (e.g. coinnews)
+// works with no destinations: the backend still selects a wallet input to cover
+// the fee, signs it, emits the OP_RETURN output and returns change.
+func TestElectrumSendOpReturnOnly(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	ctx := context.Background()
+
+	const walletAmount = int64(200_000)
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: walletAmount, TxCount: 1},
+	}
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID: "5555555555555555555555555555555555555555555555555555555555555555",
+		Vout: 0, Value: walletAmount,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}
+
+	payload := []byte("coinnews: hello world")
+	txid, err := p.Send(ctx, w.ID, SendRequest{
+		FixedFeeSats: 1_000,
+		OpReturnHex:  hex.EncodeToString(payload),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "broadcasttxid", txid)
+	require.Len(t, fake.broadcast, 1)
+
+	var tx wire.MsgTx
+	raw, err := hex.DecodeString(fake.broadcast[0])
+	require.NoError(t, err)
+	require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+
+	require.Len(t, tx.TxIn, 1, "a fee-paying input must be selected")
+	assert.NotEmpty(t, tx.TxIn[0].Witness, "the input must be signed")
+
+	require.Len(t, tx.TxOut, 2, "OP_RETURN output + change")
+	require.Equal(t, byte(txscript.OP_RETURN), tx.TxOut[0].PkScript[0])
+	pushed, err := txscript.PushedData(tx.TxOut[0].PkScript)
+	require.NoError(t, err)
+	require.Len(t, pushed, 1)
+	assert.Equal(t, payload, pushed[0])
+	assert.Zero(t, tx.TxOut[0].Value)
+	assert.Equal(t, walletAmount-1_000, tx.TxOut[1].Value, "change = funds - fee")
+}
+
 // TestElectrumSendSidechainDepositInsufficientFunds proves the deposit fails
 // cleanly when the wallet can't cover the deposit amount plus fee (the CTIP value
 // funds only the treasury output, not the user's contribution).

--- a/sidechain-orchestrator/wallet/psbt.go
+++ b/sidechain-orchestrator/wallet/psbt.go
@@ -22,6 +22,9 @@ type psbtInput struct {
 	outpoint wire.OutPoint
 	amount   int64
 	addr     scannedAddr
+	// external marks a non-wallet input spent with an empty scriptSig (no
+	// signing); it is added via its previous transaction and pre-finalized.
+	external bool
 }
 
 // keyDerivation is a PSBT BIP32/taproot derivation record: a pubkey, the master
@@ -97,6 +100,23 @@ func buildPSBT(inputs []psbtInput, outputs []TxOutSpec, net *chaincfg.Params, pr
 	}
 
 	for i, in := range inputs {
+		// External inputs (e.g. an anyone-can-spend sidechain CTIP) are added
+		// via their previous transaction and pre-finalized with an empty
+		// scriptSig — they carry no keys and are never signed.
+		if in.external {
+			if prevTx == nil {
+				return nil, fmt.Errorf("external input %d needs the previous transaction", i)
+			}
+			pt, err := prevTx(in.outpoint.Hash.String())
+			if err != nil {
+				return nil, fmt.Errorf("fetch prev tx for external input %d: %w", i, err)
+			}
+			if err := updater.AddInNonWitnessUtxo(pt, i); err != nil {
+				return nil, err
+			}
+			packet.Inputs[i].FinalScriptSig = []byte{}
+			continue
+		}
 		if in.addr.kind.isNonWitness() {
 			if prevTx == nil {
 				return nil, fmt.Errorf("legacy input %d needs the previous transaction", i)
@@ -160,6 +180,9 @@ func signPSBT(packet *psbt.Packet, inputs []psbtInput, net *chaincfg.Params) (in
 
 	signed := 0
 	for i := range inputs {
+		if inputs[i].external {
+			continue // pre-finalized, anyone-can-spend; nothing to sign
+		}
 		n, err := signPSBTInput(packet, updater, i, inputs[i], tx, sigHashes, net)
 		if err != nil {
 			return signed, fmt.Errorf("sign input %d: %w", i, err)
@@ -355,6 +378,13 @@ func combinePSBT(base *psbt.Packet, others ...*psbt.Packet) error {
 }
 
 func outputToTxOut(out TxOutSpec, net *chaincfg.Params) (*wire.TxOut, error) {
+	if out.RawScriptHex != "" {
+		script, err := hex.DecodeString(out.RawScriptHex)
+		if err != nil {
+			return nil, fmt.Errorf("decode raw output script: %w", err)
+		}
+		return wire.NewTxOut(out.AmountSats, script), nil
+	}
 	if out.OpReturnHex != "" {
 		data, err := hex.DecodeString(out.OpReturnHex)
 		if err != nil {

--- a/sidechain-orchestrator/wallet/tx.go
+++ b/sidechain-orchestrator/wallet/tx.go
@@ -23,6 +23,10 @@ type TxOutSpec struct {
 	Address     string
 	AmountBTC   float64
 	OpReturnHex string
+	// RawScriptHex sets an explicit scriptPubKey (with AmountSats as its value),
+	// for non-standard outputs that have no address (e.g. OP_DRIVECHAIN).
+	RawScriptHex string
+	AmountSats   int64
 	// Set for an owned change output so the PSBT carries its derivation records.
 	Kind        ScriptKind
 	Derivations []keyDerivation

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.271
+version: 1.0.272
 
 environment:
   sdk: 3.12.0

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.142
+version: 1.0.143
 
 environment:
   sdk: 3.12.0

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.269
+version: 1.0.270
 
 environment:
   sdk: 3.12.0


### PR DESCRIPTION
Makes bitwindow's server-side transactions work for electrum wallets (no local bitcoind/enforcer).

OP_RETURN broadcasts (coinnews, votes, comments, topics, bitdrive, timestamps) and the deniability shuffle now route through the orchestrator wallet manager. Sidechain deposits (M5) are built client-side and broadcast via the orchestrator; proposals (M1) and withdrawal bundles (M6) stay enforcer-only (coinbase-produced) behind a clear message.

Also: fixes a wallet-stream lost-wakeup that left the wallet dropdown empty, sends OP_RETURN-only txs via the cached scan to dodge esplora rate limits, and renames BitcoindException to BitwindowException.