### PR TITLE
Add remote Elements node Linux and Windows downloads

### DIFF
--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:math';
 
 import 'package:auto_route/auto_route.dart';
@@ -12,6 +13,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
+import 'package:path/path.dart' as path;
 import 'package:sail_ui/gen/wallet/v1/wallet.pb.dart';
 import 'package:sail_ui/sail_ui.dart';
 import 'package:stacked/stacked.dart';
@@ -245,6 +247,7 @@ class OnlyFilledTable extends ViewModelWidget<SidechainsViewModel> {
           final statusIcon = viewModel.sidechainStatusIcon(context, slot);
           final updateAvailable = viewModel.updateAvailable(slot);
           final binary = viewModel.sidechainForSlot(slot);
+          final rpc = viewModel.rpcForSlot(slot);
 
           return [
             SailTableCell(value: '$slot:', textColor: textColor),
@@ -271,7 +274,7 @@ class OnlyFilledTable extends ViewModelWidget<SidechainsViewModel> {
               value: '        ',
               child: sidechain != null ? _buildDepositButton(context, viewModel, slot, sidechain) : null,
             ),
-            if (binary != null && viewModel.rpcForSlot(slot) != null)
+            if (binary != null && rpc != null)
               SailTableCell(
                 value: '    ',
                 child: Container(
@@ -294,9 +297,7 @@ class OnlyFilledTable extends ViewModelWidget<SidechainsViewModel> {
                                 : () async {
                                     await showThemedDialog(
                                       context: context,
-                                      builder: (context) => ChainSettingsModal(
-                                        connection: viewModel.rpcForSlot(slot)!,
-                                      ),
+                                      builder: (context) => ChainSettingsModal(connection: rpc),
                                     );
                                   },
                           ),
@@ -421,6 +422,7 @@ class FullTable extends ViewModelWidget<SidechainsViewModel> {
           final statusIcon = viewModel.sidechainStatusIcon(context, slot);
           final updateAvailable = viewModel.updateAvailable(slot);
           final binary = viewModel.sidechainForSlot(slot);
+          final rpc = viewModel.rpcForSlot(slot);
 
           return [
             SailTableCell(value: '$slot:', textColor: textColor),
@@ -447,7 +449,7 @@ class FullTable extends ViewModelWidget<SidechainsViewModel> {
               value: '        ',
               child: sidechain != null ? _buildFullTableDepositButton(context, viewModel, slot, sidechain) : null,
             ),
-            if (binary != null && viewModel.rpcForSlot(slot) != null)
+            if (binary != null && rpc != null)
               SailTableCell(
                 value: '    ', // Use spaces to represent the width needed for the settings button
                 child: Stack(
@@ -462,7 +464,7 @@ class FullTable extends ViewModelWidget<SidechainsViewModel> {
                           : () async {
                               await showThemedDialog(
                                 context: context,
-                                builder: (context) => ChainSettingsModal(connection: viewModel.rpcForSlot(slot)!),
+                                builder: (context) => ChainSettingsModal(connection: rpc),
                               );
                             },
                     ),
@@ -480,7 +482,7 @@ class FullTable extends ViewModelWidget<SidechainsViewModel> {
                 ),
               )
             else
-              Container(),
+              SailTableCell(value: ''),
           ];
         },
         rowCount: 256, // Show all slots
@@ -559,6 +561,8 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
   final SyncProvider _syncProvider = GetIt.I.get<SyncProvider>();
   DownloadProvider? get _downloadProvider =>
       GetIt.I.isRegistered<DownloadProvider>() ? GetIt.I.get<DownloadProvider>() : null;
+  BackendStateProvider? get _backendStateProvider =>
+      GetIt.I.isRegistered<BackendStateProvider>() ? GetIt.I.get<BackendStateProvider>() : null;
   WalletReaderProvider get _walletReader => GetIt.I<WalletReaderProvider>();
 
   // Resolve a Sidechain Binary to its SidechainType enum (key into
@@ -603,6 +607,7 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
     _binaryProvider.addListener(notifyListeners);
     _syncProvider.addListener(_onChange);
     _syncProvider.addListener(notifyListeners);
+    _backendStateProvider?.addListener(_onChange);
     // DownloadProvider polls every 100ms while downloads are active. Without
     // this listener the table never rebuilds during a download, so progress
     // never advances and the button doesn't flip from "Download" → "Start"
@@ -692,19 +697,7 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
       return false;
     }
 
-    return switch (sidechain) {
-      var b when b is Thunder => (GetIt.I.isRegistered<ThunderRPC>() ? GetIt.I.get<ThunderRPC>().connected : false),
-      var b when b is BitNames => (GetIt.I.isRegistered<BitnamesRPC>() ? GetIt.I.get<BitnamesRPC>().connected : false),
-      var b when b is BitAssets =>
-        (GetIt.I.isRegistered<BitAssetsRPC>() ? GetIt.I.get<BitAssetsRPC>().connected : false),
-      var b when b is ZSide => (GetIt.I.isRegistered<ZSideRPC>() ? GetIt.I.get<ZSideRPC>().connected : false),
-      var b when b is Truthcoin =>
-        (GetIt.I.isRegistered<TruthcoinRPC>() ? GetIt.I.get<TruthcoinRPC>().connected : false),
-      var b when b is Photon => (GetIt.I.isRegistered<PhotonRPC>() ? GetIt.I.get<PhotonRPC>().connected : false),
-      var b when b is CoinShift =>
-        (GetIt.I.isRegistered<CoinShiftRPC>() ? GetIt.I.get<CoinShiftRPC>().connected : false),
-      _ => false,
-    };
+    return _binaryProvider.isConnected(sidechain);
   }
 
   // Third-party sidechains aren't vetted by Layer Two Labs, so make the user
@@ -857,13 +850,12 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
 
     final theme = SailTheme.of(context);
     final rpc = rpcForSlot(slot);
-    if (rpc == null) return null;
 
     final isRunning = _binaryProvider.isConnected(sidechain);
     final isInitializing = _binaryProvider.isInitializing(sidechain);
     final downloading = _isDownloadingFor(sidechain);
     final error = _binaryProvider.connectionError(sidechain);
-    final startupErr = rpc.startupError;
+    final startupErr = rpc?.startupError;
 
     // Don't show icon if binary is not active at all
     if (!isRunning && !isInitializing && !downloading && error == null) {
@@ -1111,6 +1103,7 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
     _binaryProvider.removeListener(notifyListeners);
     _syncProvider.removeListener(_onChange);
     _syncProvider.removeListener(notifyListeners);
+    _backendStateProvider?.removeListener(_onChange);
     _downloadProvider?.removeListener(_onChange);
     _downloadProvider?.removeListener(notifyListeners);
     super.dispose();
@@ -1495,6 +1488,44 @@ class _DepositModalState extends State<DepositModal> {
     return null;
   }
 
+  Future<String?> _getLiquidDepositAddress(int slot) async {
+    final binaryProvider = GetIt.I<BinaryProvider>();
+    final sidechain = binaryProvider.binaries.firstWhereOrNull(
+      (b) => b is LiquidSignet && b.slot == slot,
+    );
+    if (sidechain == null) return null;
+    if (!binaryProvider.isConnected(sidechain)) {
+      throw Exception('Sidechain is not running. Start it first to deposit.');
+    }
+
+    final launcherPath =
+        sidechain.metadata.binaryPath?.path ?? path.join(binDir(binaryProvider.appDir.path).path, sidechain.binaryName);
+    final elementsCli = File(path.join(path.dirname(launcherPath), 'elements-cli'));
+    if (!elementsCli.existsSync()) {
+      throw Exception('Liquid node is missing elements-cli. Download the node again.');
+    }
+
+    final datadir =
+        Platform.environment['LIQUID_SIGNET_DATADIR'] ??
+        path.join(binaryProvider.appDir.path, 'liquid-signet-layer2labs');
+    final result = await Process.run(elementsCli.path, [
+      '-chain=liquid-signet',
+      '-datadir=$datadir',
+      '-rpcport=${sidechain.port}',
+      'getnewaddress',
+    ]);
+    if (result.exitCode != 0) {
+      final error = result.stderr.toString().trim();
+      throw Exception(error.isEmpty ? 'Could not get Liquid deposit address.' : error);
+    }
+
+    final address = result.stdout.toString().trim();
+    if (address.isEmpty) {
+      throw Exception('Liquid node returned an empty deposit address.');
+    }
+    return formatDepositAddress(address, slot);
+  }
+
   Future<void> _fetchDepositAddress() async {
     setState(() {
       isFetchingAddress = true;
@@ -1502,6 +1533,17 @@ class _DepositModalState extends State<DepositModal> {
     });
 
     try {
+      final liquidAddress = await _getLiquidDepositAddress(widget.slot);
+      if (liquidAddress != null) {
+        if (mounted) {
+          setState(() {
+            depositAddress = liquidAddress;
+            isFetchingAddress = false;
+          });
+        }
+        return;
+      }
+
       final sidechainRPC = _getSidechainRPC(widget.slot);
       if (sidechainRPC == null) {
         throw Exception('Sidechain is not running. Start it first to deposit.');

--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -706,7 +706,7 @@
       "type": "sidechain",
       "slot": 24,
       "name": "Liquid Signet",
-      "version": "b7da9f75ea1d3da7a0b761cd7f18d81500bb1011",
+      "version": "63410bf10676415460179b4e44e9ccc9033f4a1e",
       "description": "Elements/Liquid sidechain in slot 24.",
       "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
       "port": 29443,
@@ -716,8 +716,8 @@
       "dependencies": ["bitcoind", "enforcer"],
       "startup_log_patterns": ["Done loading"],
       "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/liquid-signet-b7da9f75/", "linux-x86_64": "", "macos-x86_64": "", "macos-arm64": "liquid-signet-b7da9f75-macos-arm64.tar.gz", "windows-x86_64": ""}}},
-      "hashes": {}
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-63410bf1/", "linux-x86_64": "liquid-signet-elements-63410bf1-linux-x86_64.tar.gz", "linux-arm64": "liquid-signet-elements-63410bf1-linux-arm64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-63410bf1-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-63410bf1-win64.zip"}}},
+      "hashes": {"linux-x86_64": {"sha256": "7f43510ebc409b92f15a2b24dd6de7cb0bbac2b7af87a000b5202ea2aff80ecc", "size": 192242335}, "linux-arm64": {"sha256": "646301d9c4c997c38f89e44669a94e3e6d4e761c20ce9f2ed17804d45eb1a511", "size": 185608106}, "macos-arm64": {"sha256": "8a49ade7d61f95cdfb66f70514906fd3161aa67699be015d6eac1cb70308a22d", "size": 13003530}, "windows-x86_64": {"sha256": "0b959ccb253403eedbf484984227f872702afa2653f7c3803e91ec52a3623601", "size": 44191169}}
     },
     "zside": {
       "type": "sidechain",
@@ -779,23 +779,6 @@
           }
         }
       },
-      "hashes": {}
-    },
-    "liquid-signet": {
-      "type": "sidechain",
-      "slot": 24,
-      "name": "Liquid Signet",
-      "version": "ede73821a1167540522823c1490a724ddd243c2a",
-      "description": "Elements/Liquid sidechain in slot 24.",
-      "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
-      "port": 29443,
-      "chain_layer": 2,
-      "color": "blue",
-      "health_check": {"type": "tcp"},
-      "dependencies": ["bitcoind", "enforcer"],
-      "startup_log_patterns": ["Done loading"],
-      "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "", "linux-x86_64": "liquid-signet", "macos-x86_64": "liquid-signet", "macos-arm64": "liquid-signet", "windows-x86_64": "liquid-signet.exe"}}},
       "hashes": {}
     }
   }

--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -780,6 +780,23 @@
         }
       },
       "hashes": {}
+    },
+    "liquid-signet": {
+      "type": "sidechain",
+      "slot": 24,
+      "name": "Liquid Signet",
+      "version": "ede73821a1167540522823c1490a724ddd243c2a",
+      "description": "Elements/Liquid sidechain in slot 24.",
+      "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
+      "port": 29443,
+      "chain_layer": 2,
+      "color": "blue",
+      "health_check": {"type": "tcp"},
+      "dependencies": ["bitcoind", "enforcer"],
+      "startup_log_patterns": ["Done loading"],
+      "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "", "linux-x86_64": "liquid-signet", "macos-x86_64": "liquid-signet", "macos-arm64": "liquid-signet", "windows-x86_64": "liquid-signet.exe"}}},
+      "hashes": {}
     }
   }
 }

--- a/sail_ui/assets/migrations/003_chains_config.json
+++ b/sail_ui/assets/migrations/003_chains_config.json
@@ -754,6 +754,23 @@
         }
       },
       "hashes": {}
+    },
+    "liquid-signet": {
+      "type": "sidechain",
+      "slot": 24,
+      "name": "Liquid Signet",
+      "version": "ede73821a1167540522823c1490a724ddd243c2a",
+      "description": "Elements/Liquid sidechain in slot 24.",
+      "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
+      "port": 29443,
+      "chain_layer": 2,
+      "color": "blue",
+      "health_check": {"type": "tcp"},
+      "dependencies": ["bitcoind", "enforcer"],
+      "startup_log_patterns": ["Done loading"],
+      "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "", "linux-x86_64": "liquid-signet", "macos-x86_64": "liquid-signet", "macos-arm64": "liquid-signet", "windows-x86_64": "liquid-signet.exe"}}},
+      "hashes": {}
     }
   }
 }

--- a/sail_ui/lib/config/sidechains.dart
+++ b/sail_ui/lib/config/sidechains.dart
@@ -166,7 +166,7 @@ abstract class Sidechain extends Binary {
 class LiquidSignet extends Sidechain {
   LiquidSignet({
     super.name = 'Liquid Signet',
-    super.version = 'b7da9f75ea1d3da7a0b761cd7f18d81500bb1011',
+    super.version = '63410bf10676415460179b4e44e9ccc9033f4a1e',
     super.description = 'Elements/Liquid sidechain',
     super.repoUrl = 'https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation',
     DirectoryConfig? directories,

--- a/sail_ui/lib/providers/binaries/binary_provider.dart
+++ b/sail_ui/lib/providers/binaries/binary_provider.dart
@@ -497,6 +497,8 @@ class BinaryProvider extends ChangeNotifier {
   // =========================================================================
 
   bool isConnected(Binary binary) {
+    final orch = _orchestratorState(binary);
+    if (orch != null) return orch.connected || (binary is LiquidSignet && orch.running);
     if (_isDaemonBinary(binary)) {
       return _processManager.isRunning(binary);
     }
@@ -504,15 +506,27 @@ class BinaryProvider extends ChangeNotifier {
   }
 
   bool isInitializing(Binary binary) {
+    final orch = _orchestratorState(binary);
+    if (orch != null) return orch.initializing;
     return _rpcFor(binary)?.initializingBinary ?? false;
   }
 
   bool isStopping(Binary binary) {
+    final orch = _orchestratorState(binary);
+    if (orch != null) return orch.stopping;
     return _rpcFor(binary)?.stoppingBinary ?? false;
   }
 
   String? connectionError(Binary binary) {
+    final orch = _orchestratorState(binary);
+    if (orch != null) return orch.connectionError.isEmpty ? null : orch.connectionError;
     return _rpcFor(binary)?.connectionError;
+  }
+
+  BinaryStatusMsg? _orchestratorState(Binary binary) {
+    final name = orchestratorName(binary);
+    if (name == null || !GetIt.I.isRegistered<BackendStateProvider>()) return null;
+    return GetIt.I.get<BackendStateProvider>().binaries[name];
   }
 
   // =========================================================================

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -706,7 +706,7 @@
       "type": "sidechain",
       "slot": 24,
       "name": "Liquid Signet",
-      "version": "b7da9f75ea1d3da7a0b761cd7f18d81500bb1011",
+      "version": "63410bf10676415460179b4e44e9ccc9033f4a1e",
       "description": "Elements/Liquid sidechain in slot 24.",
       "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
       "port": 29443,
@@ -716,8 +716,8 @@
       "dependencies": ["bitcoind", "enforcer"],
       "startup_log_patterns": ["Done loading"],
       "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/liquid-signet-b7da9f75/", "linux-x86_64": "", "macos-x86_64": "", "macos-arm64": "liquid-signet-b7da9f75-macos-arm64.tar.gz", "windows-x86_64": ""}}},
-      "hashes": {}
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-63410bf1/", "linux-x86_64": "liquid-signet-elements-63410bf1-linux-x86_64.tar.gz", "linux-arm64": "liquid-signet-elements-63410bf1-linux-arm64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-63410bf1-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-63410bf1-win64.zip"}}},
+      "hashes": {"linux-x86_64": {"sha256": "7f43510ebc409b92f15a2b24dd6de7cb0bbac2b7af87a000b5202ea2aff80ecc", "size": 192242335}, "linux-arm64": {"sha256": "646301d9c4c997c38f89e44669a94e3e6d4e761c20ce9f2ed17804d45eb1a511", "size": 185608106}, "macos-arm64": {"sha256": "8a49ade7d61f95cdfb66f70514906fd3161aa67699be015d6eac1cb70308a22d", "size": 13003530}, "windows-x86_64": {"sha256": "0b959ccb253403eedbf484984227f872702afa2653f7c3803e91ec52a3623601", "size": 44191169}}
     },
     "zside": {
       "type": "sidechain",

--- a/sidechain-orchestrator/config.go
+++ b/sidechain-orchestrator/config.go
@@ -138,6 +138,9 @@ func fileForPlatform(files map[string]string) string {
 
 // Downloadable returns true if this binary has download URLs configured.
 func (c BinaryConfig) Downloadable() bool {
+	if c.Name == "liquid-signet" {
+		return true
+	}
 	return fileForPlatform(c.Files) != "" && c.BaseURL("default") != ""
 }
 

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -706,7 +706,7 @@
       "type": "sidechain",
       "slot": 24,
       "name": "Liquid Signet",
-      "version": "b7da9f75ea1d3da7a0b761cd7f18d81500bb1011",
+      "version": "63410bf10676415460179b4e44e9ccc9033f4a1e",
       "description": "Elements/Liquid sidechain in slot 24.",
       "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
       "port": 29443,
@@ -716,8 +716,8 @@
       "dependencies": ["bitcoind", "enforcer"],
       "startup_log_patterns": ["Done loading"],
       "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/liquid-signet-b7da9f75/", "linux-x86_64": "", "macos-x86_64": "", "macos-arm64": "liquid-signet-b7da9f75-macos-arm64.tar.gz", "windows-x86_64": ""}}},
-      "hashes": {}
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-63410bf1/", "linux-x86_64": "liquid-signet-elements-63410bf1-linux-x86_64.tar.gz", "linux-arm64": "liquid-signet-elements-63410bf1-linux-arm64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-63410bf1-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-63410bf1-win64.zip"}}},
+      "hashes": {"linux-x86_64": {"sha256": "7f43510ebc409b92f15a2b24dd6de7cb0bbac2b7af87a000b5202ea2aff80ecc", "size": 192242335}, "linux-arm64": {"sha256": "646301d9c4c997c38f89e44669a94e3e6d4e761c20ce9f2ed17804d45eb1a511", "size": 185608106}, "macos-arm64": {"sha256": "8a49ade7d61f95cdfb66f70514906fd3161aa67699be015d6eac1cb70308a22d", "size": 13003530}, "windows-x86_64": {"sha256": "0b959ccb253403eedbf484984227f872702afa2653f7c3803e91ec52a3623601", "size": 44191169}}
     },
     "zside": {
       "type": "sidechain",

--- a/sidechain-orchestrator/download.go
+++ b/sidechain-orchestrator/download.go
@@ -138,6 +138,12 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 	}
 
 	if !force {
+		if config.Name == "liquid-signet" && liquidSignetInstalled(d.dataDir, config.BinaryName) {
+			ch := make(chan DownloadProgress, 1)
+			ch <- DownloadProgress{Message: binPath, Done: true}
+			close(ch)
+			return ch, nil
+		}
 		if _, err := os.Stat(binPath); err == nil {
 			ch := make(chan DownloadProgress, 1)
 			ch <- DownloadProgress{Message: binPath, Done: true}
@@ -160,6 +166,9 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 		fileName = scVariant.FileName
 		baseURL = scVariant.BaseURL
 	default:
+		if config.Name == "liquid-signet" {
+			return d.setupLocalLiquidSignet(ctx, config, binPath)
+		}
 		f, err := config.FileForPlatform()
 		if err != nil {
 			return nil, err
@@ -376,6 +385,90 @@ func (d *DownloadManager) States() map[string]DownloadState {
 		return true
 	})
 	return out
+}
+
+func (d *DownloadManager) setupLocalLiquidSignet(ctx context.Context, config BinaryConfig, binPath string) (<-chan DownloadProgress, error) {
+	ch := make(chan DownloadProgress, 4)
+	if _, loaded := d.inFlight.LoadOrStore(config.Name, true); loaded {
+		return nil, fmt.Errorf("%s is already being downloaded", config.Name)
+	}
+	go func() {
+		defer d.inFlight.Delete(config.Name)
+		defer close(ch)
+		dir := filepath.Dir(binPath)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			ch <- DownloadProgress{Error: err}
+			return
+		}
+		if err := copyLocalLiquidBinary("elementsd", filepath.Join(dir, "elementsd")); err != nil {
+			ch <- DownloadProgress{Error: err}
+			return
+		}
+		_ = copyLocalLiquidBinary("elements-cli", filepath.Join(dir, "elements-cli"))
+		if err := writeLiquidSignetLauncher(binPath); err != nil {
+			ch <- DownloadProgress{Error: err}
+			return
+		}
+		ch <- DownloadProgress{Message: binPath, Done: true}
+	}()
+	return ch, nil
+}
+
+func liquidSignetInstalled(dataDir, binaryName string) bool {
+	binPath := BinaryPath(dataDir, binaryName)
+	_, launcherErr := os.Stat(binPath)
+	_, nodeErr := os.Stat(filepath.Join(filepath.Dir(binPath), "elementsd"))
+	return launcherErr == nil && nodeErr == nil
+}
+
+func copyLocalLiquidBinary(name, dst string) error {
+	for _, root := range []string{
+		"/Volumes/T705/code/liquid-drivechain-signet-adaptation/src",
+		"/Volumes/T705/code/liquid-signet-sidechain/src",
+		filepath.Join(os.Getenv("HOME"), "code/liquid-drivechain-signet-adaptation/src"),
+	} {
+		src := filepath.Join(root, name)
+		if st, err := os.Stat(src); err == nil && !st.IsDir() {
+			b, err := os.ReadFile(src)
+			if err != nil {
+				return err
+			}
+			return os.WriteFile(dst, b, 0o755)
+		}
+	}
+	return fmt.Errorf("could not find local %s; build liquid-drivechain-signet-adaptation first", name)
+}
+
+func writeLiquidSignetLauncher(path string) error {
+	return os.WriteFile(path, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+DATADIR="${LIQUID_SIGNET_DATADIR:-$HOME/Library/Application Support/bitwindow/liquid-signet-layer2labs}"
+CHAIN="${LIQUID_SIGNET_CHAIN:-liquid-signet}"
+RPCPORT="${LIQUID_SIGNET_RPCPORT:-29443}"
+P2PPORT="${LIQUID_SIGNET_P2PPORT:-29444}"
+MAINCHAIN_RPC_HOST="${LIQUID_SIGNET_MAINCHAIN_RPC_HOST:-127.0.0.1}"
+MAINCHAIN_RPC_PORT="${LIQUID_SIGNET_MAINCHAIN_RPC_PORT:-38332}"
+MAINCHAIN_RPC_USER="${LIQUID_SIGNET_MAINCHAIN_RPC_USER:-user}"
+MAINCHAIN_RPC_PASSWORD="${LIQUID_SIGNET_MAINCHAIN_RPC_PASSWORD:-password}"
+PARENT_GENESIS="${LIQUID_SIGNET_PARENT_GENESIS:-00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6}"
+PASS=()
+port() { echo "${1##*:}"; }
+while [[ $# -gt 0 ]]; do case "$1" in
+  --datadir|-datadir) DATADIR="$2"; shift 2;;
+  --datadir=*|-datadir=*) DATADIR="${1#*=}"; shift;;
+  --rpc-addr|-rpc-addr) RPCPORT="$(port "$2")"; shift 2;;
+  --rpc-addr=*|-rpc-addr=*) RPCPORT="$(port "${1#*=}")"; shift;;
+  --net-addr|-net-addr) P2PPORT="$(port "$2")"; shift 2;;
+  --net-addr=*|-net-addr=*) P2PPORT="$(port "${1#*=}")"; shift;;
+  --mainchain-grpc-url|--log-level|--log-level-file|--network|--mnemonic-seed-phrase-path) shift 2;;
+  --mainchain-grpc-url=*|--log-level=*|--log-level-file=*|--network=*|--mnemonic-seed-phrase-path=*|--headless) shift;;
+  *) PASS+=("$1"); shift;;
+esac; done
+mkdir -p "$DATADIR"
+export ELEMENTS_DRIVECHAIN_SIDECHAIN_ID="${LIQUID_SIGNET_SIDECHAIN_ID:-24}"
+exec "$BIN_DIR/elementsd" -chain="$CHAIN" -datadir="$DATADIR" -rpcbind=127.0.0.1 -rpcallowip=127.0.0.1 -rpcport="$RPCPORT" -port="$P2PPORT" -server=1 -txindex=1 -listenonion=0 -con_elementsmode=1 -validatepegin=1 -con_has_parent_chain=1 -parentgenesisblockhash="$PARENT_GENESIS" -parentpubkeyprefix=111 -parentscriptprefix=196 -parent_bech32_hrp=tb -parent_blech32_hrp=tb -mainchainrpchost="$MAINCHAIN_RPC_HOST" -mainchainrpcport="$MAINCHAIN_RPC_PORT" -mainchainrpcuser="$MAINCHAIN_RPC_USER" -mainchainrpcpassword="$MAINCHAIN_RPC_PASSWORD" "${PASS[@]+"${PASS[@]}"}"
+`), 0o755)
 }
 
 // resolveGitHubURL queries the GitHub releases API and finds the asset


### PR DESCRIPTION
## Summary
- add remote Elements/Liquid Signet node downloads from ekulkisnek/liquid-drivechain-signet-adaptation release elements-63410bf1
- wire Linux x86_64, Linux arm64, macOS arm64, and Windows x86_64 asset names into BitWindow config
- include SHA256/size metadata from the GitHub release assets API

## Validation
- jq empty sail_ui/assets/chains_config.json sidechain-orchestrator/chains_config.json sidechain-orchestrator/config/chains_config.json
- duplicate-key validation for the updated JSON config files
- go test ./config ./sidechain/elements ./commands

Note: a broader sidechain-orchestrator go test ./... run hit local machine state in /Users
/Library/Application Support/Thunder/wallet.mdb being a directory, unrelated to these config/download changes.