### PR TITLE
sailui: eCash theme + forknet default

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.271
+version: 1.0.272
 
 environment:
   sdk: 3.12.0

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.271
+version: 1.0.272
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.129
+version: 0.2.130
 
 environment:
   sdk: 3.12.0

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.144
+version: 1.0.145
 
 environment:
   sdk: 3.12.0

--- a/sail_ui/lib/sail_ui.dart
+++ b/sail_ui/lib/sail_ui.dart
@@ -226,6 +226,7 @@ export 'style/shadows.dart';
 export 'style/style.dart';
 export 'style/style_values.dart';
 export 'theme/sail_chrome.dart';
+export 'theme/ecash_theme.dart';
 export 'theme/theme.dart';
 export 'theme/theme_data.dart';
 export 'theme/theme_registry.dart';

--- a/sail_ui/lib/settings/bitwindow_settings.dart
+++ b/sail_ui/lib/settings/bitwindow_settings.dart
@@ -4,6 +4,11 @@ import 'dart:io';
 import 'package:logger/logger.dart';
 import 'package:sail_ui/sail_ui.dart';
 
+// First-run theme: the forknet/eCash build (BITWINDOW_NETWORK=forknet) defaults to
+// the eCash theme; every other build defaults to Sail. A user's choice persists and
+// overrides this.
+const String defaultThemeStyleId = String.fromEnvironment('BITWINDOW_NETWORK') == 'forknet' ? 'ecash' : 'sail';
+
 // BitwindowSettings is a special kind of setting. It is *global* bitwindow
 // settings that can be accessed by bitwindow (duh), but also all sidechains!
 // magic
@@ -11,7 +16,7 @@ class BitwindowSettings {
   final bool paranoidMode;
   final String themeStyle;
 
-  BitwindowSettings({this.paranoidMode = false, this.themeStyle = 'sail'});
+  BitwindowSettings({this.paranoidMode = false, this.themeStyle = defaultThemeStyleId});
 
   Map<String, dynamic> toMap() {
     return {'paranoidMode': paranoidMode, 'themeStyle': themeStyle};
@@ -20,7 +25,7 @@ class BitwindowSettings {
   factory BitwindowSettings.fromMap(Map<String, dynamic> map) {
     return BitwindowSettings(
       paranoidMode: map['paranoidMode'] ?? false,
-      themeStyle: map['themeStyle'] ?? 'sail',
+      themeStyle: map['themeStyle'] ?? defaultThemeStyleId,
     );
   }
 

--- a/sail_ui/lib/theme/ecash_theme.dart
+++ b/sail_ui/lib/theme/ecash_theme.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+// Exact tokens from ecash.com/assets/index-CXBK_JTU.css. See tasks/ecash-design-tokens.md.
+const Color ecashAmber = Color(0xffE8A84A);
+const Color ecashError = Color(0xffF77070);
+
+// Light ([data-theme=light])
+const Color _lBg0 = Color(0xffF7F7F4);
+const Color _lBg1 = Color(0xffEEEEEB);
+const Color _lBorder0 = Color(0xffDADAD6);
+const Color _lBorder2 = Color(0xffD0D0CC);
+const Color _lText0 = Color(0xff09090B);
+const Color _lText1 = Color(0xff3F3F46);
+const Color _lText2 = Color(0xff52525B);
+
+// Dark (:root)
+const Color _dBg0 = Color(0xff0A0A0C);
+const Color _dBg1 = Color(0xff0D0D0F);
+const Color _dBorder0 = Color(0xff1F1F23);
+const Color _dBorder2 = Color(0xff27272A);
+const Color _dText0 = Color(0xffFAFAFA);
+const Color _dText1 = Color(0xffA1A1AA);
+const Color _dText2 = Color(0xff71717A);
+
+const List<Color> _ecashChartPalette = [
+  ecashAmber,
+  Color(0xff0D9488),
+  Color(0xff4F46E5),
+  Color(0xff5400AA),
+  Color(0xff2AB517),
+  Color(0xffF7931E),
+  ecashError,
+];
+
+/// Terminal-card panel: surface fill, hairline border, tight radius.
+BoxDecoration ecashPanel(SailColor colors) => BoxDecoration(
+  color: colors.backgroundSecondary,
+  borderRadius: SailStyleValues.borderRadiusLarge,
+  border: Border.all(color: colors.border, width: 1.0),
+);
+
+/// Header strip with the amber underline used for active nav on ecash.com.
+BoxDecoration ecashTitleBar(SailColor colors) => BoxDecoration(
+  color: colors.background,
+  border: const Border(bottom: BorderSide(color: ecashAmber, width: 1.5)),
+);
+
+/// Tooltips read as terminal popups — dark ink regardless of brightness.
+const Color ecashTooltipBackground = _dBg1;
+
+/// eCash light theme — warm cream surfaces, amber accent, near-black ink.
+SailColor ecashLightTheme(Color accent) => SailColor(
+  background: _lBg0,
+  backgroundSecondary: _lBg1,
+  backgroundActionModal: _lBg1,
+  popoverBackground: _lBg1,
+  formField: _lBg0,
+  border: _lBorder0,
+  divider: _lBorder0,
+  shadow: SailColorScheme.black.withValues(alpha: 0.06),
+  text: _lText0,
+  textSecondary: _lText1,
+  textTertiary: _lText2,
+  textHint: _lText2,
+  iconHighlighted: ecashAmber,
+  icon: _lText1,
+  primary: ecashAmber,
+  error: ecashError,
+  success: SailColorScheme.green,
+  info: ecashAmber,
+  warning: SailColorScheme.orange,
+  warningLight: SailColorScheme.orangeLight,
+  chartPalette: _ecashChartPalette,
+  orange: SailColorScheme.orange,
+  orangeLight: SailColorScheme.orangeLight,
+  actionHeader: _lBg1,
+  chip: _lBorder0.withValues(alpha: 0.6),
+  disabledBackground: _lBorder0.withValues(alpha: 0.4),
+  primaryButtonBackground: ecashAmber,
+  primaryButtonText: _lBg0,
+  primaryButtonHover: ecashAmber.withValues(alpha: 0.9),
+  secondaryButtonBackground: _lBg1,
+  secondaryButtonText: _lText0,
+  secondaryButtonHover: _lBg1.withValues(alpha: 0.9),
+  destructiveButtonBackground: ecashError,
+  destructiveButtonText: _lBg0,
+  destructiveButtonHover: ecashError.withValues(alpha: 0.9),
+  outlineButtonText: _lText1,
+  outlineButtonBorder: _lBorder2,
+  outlineButtonHover: _lBg1,
+  ghostButtonText: _lText1,
+  ghostButtonHover: _lBg1,
+  linkButtonText: ecashAmber,
+  activeNavText: ecashAmber,
+  inactiveNavText: _lText2,
+  inactiveSubNavText: _lText2,
+  avatarBackground: _lBg1,
+);
+
+/// eCash dark theme — near-black terminal surfaces, amber accent.
+SailColor ecashDarkTheme(Color accent) => SailColor(
+  background: _dBg0,
+  backgroundSecondary: _dBg1,
+  backgroundActionModal: _dBg1,
+  popoverBackground: _dBg1,
+  formField: _dBg0,
+  border: _dBorder0,
+  divider: _dBorder0,
+  shadow: SailColorScheme.black.withValues(alpha: 0.5),
+  text: _dText0,
+  textSecondary: _dText1,
+  textTertiary: _dText2,
+  textHint: _dText2,
+  iconHighlighted: ecashAmber,
+  icon: _dText1,
+  primary: ecashAmber,
+  error: ecashError,
+  success: SailColorScheme.green,
+  info: ecashAmber,
+  warning: SailColorScheme.orange,
+  warningLight: SailColorScheme.orangeLight,
+  chartPalette: _ecashChartPalette,
+  orange: SailColorScheme.orange,
+  orangeLight: SailColorScheme.orangeLight,
+  actionHeader: _dBg1,
+  chip: _dBorder0,
+  disabledBackground: _dBorder0.withValues(alpha: 0.4),
+  primaryButtonBackground: ecashAmber,
+  primaryButtonText: _dBg0,
+  primaryButtonHover: ecashAmber.withValues(alpha: 0.9),
+  secondaryButtonBackground: _dBg1,
+  secondaryButtonText: _dText0,
+  secondaryButtonHover: _dBg1.withValues(alpha: 0.9),
+  destructiveButtonBackground: ecashError,
+  destructiveButtonText: _dBg0,
+  destructiveButtonHover: ecashError.withValues(alpha: 0.9),
+  outlineButtonText: _dText1,
+  outlineButtonBorder: _dBorder2,
+  outlineButtonHover: _dBg1,
+  ghostButtonText: _dText1,
+  ghostButtonHover: _dBg1,
+  linkButtonText: ecashAmber,
+  activeNavText: ecashAmber,
+  inactiveNavText: _dText2,
+  inactiveSubNavText: _dText2,
+  avatarBackground: _dBg1,
+);

--- a/sail_ui/lib/theme/sail_chrome.dart
+++ b/sail_ui/lib/theme/sail_chrome.dart
@@ -46,6 +46,10 @@ class SailChrome {
   final bool buttonsRaised;
   final bool fieldsSunken;
 
+  /// Flat terminal aesthetic (eCash): outline-first controls, uppercase
+  /// letter-spaced labels, amber accents. Mutually exclusive with [bevel].
+  final bool terminalStyle;
+
   /// Surface decoration for cards/panels.
   final BoxDecoration Function(SailColor colors) panel;
 
@@ -66,6 +70,7 @@ class SailChrome {
     required this.panel,
     required this.titleBar,
     this.tooltipBackground,
+    this.terminalStyle = false,
   });
 
   bool get beveled => bevel != null;

--- a/sail_ui/lib/theme/theme_registry.dart
+++ b/sail_ui/lib/theme/theme_registry.dart
@@ -3,7 +3,7 @@ import 'package:sail_ui/sail_ui.dart';
 
 /// Identifies a theme bundle. The enum name is the persisted string id.
 /// Adding a theme = one new value + one new [SailThemeBundle] entry below.
-enum SailThemeStyle { sail, win95 }
+enum SailThemeStyle { sail, win95, ecash }
 
 extension SailThemeStyleStringer on SailThemeStyle {
   String get id => name;
@@ -76,10 +76,33 @@ final SailThemeBundle _win95Bundle = SailThemeBundle(
   chrome: win95Chrome,
 );
 
+/// eCash — Sail's rounded/flat chrome, but fully monospace to match ecash.com.
+final SailThemeBundle _ecashBundle = SailThemeBundle(
+  style: SailThemeStyle.ecash,
+  displayName: 'eCash',
+  light: ecashLightTheme,
+  dark: ecashDarkTheme,
+  supportsDarkMode: true,
+  chrome: SailChrome(
+    radius: const BorderRadius.all(Radius.circular(4)),
+    radiusSmall: const BorderRadius.all(Radius.circular(3)),
+    radiusLarge: const BorderRadius.all(Radius.circular(8)),
+    bevel: null,
+    fontFamily: 'IBMPlexMono',
+    buttonsRaised: false,
+    fieldsSunken: false,
+    panel: ecashPanel,
+    titleBar: ecashTitleBar,
+    tooltipBackground: ecashTooltipBackground,
+    terminalStyle: true,
+  ),
+);
+
 /// All registered theme bundles, keyed by style.
 final Map<SailThemeStyle, SailThemeBundle> sailThemeBundles = {
   SailThemeStyle.sail: _sailBundle,
   SailThemeStyle.win95: _win95Bundle,
+  SailThemeStyle.ecash: _ecashBundle,
 };
 
 SailThemeBundle sailBundleFor(SailThemeStyle style) => sailThemeBundles[style] ?? _sailBundle;

--- a/sail_ui/lib/widgets/buttons/button.dart
+++ b/sail_ui/lib/widgets/buttons/button.dart
@@ -89,8 +89,9 @@ class _SailButtonState extends State<SailButton> {
   Widget build(BuildContext context) {
     final theme = SailTheme.of(context);
     final colors = theme.colors;
+    final terminalStyle = theme.chrome.terminalStyle;
 
-    final style = _getVariantStyle(widget.variant, colors, widget.textColor);
+    final style = _getVariantStyle(widget.variant, colors, widget.textColor, terminalStyle);
     final content = _ButtonContent(
       foregroundColor: style.foregroundColor,
       variant: widget.variant,
@@ -104,6 +105,7 @@ class _SailButtonState extends State<SailButton> {
       label: widget.label,
       small: widget.small,
       insideTable: widget.insideTable,
+      terminalStyle: terminalStyle,
     );
 
     return _SailScaleButton(
@@ -148,6 +150,7 @@ class _ButtonContent extends StatelessWidget {
   final String? label;
   final bool small;
   final bool insideTable;
+  final bool terminalStyle;
 
   const _ButtonContent({
     required this.foregroundColor,
@@ -162,7 +165,25 @@ class _ButtonContent extends StatelessWidget {
     this.label,
     required this.small,
     required this.insideTable,
+    required this.terminalStyle,
   });
+
+  Widget _terminalLabel(BuildContext context) {
+    final theme = SailTheme.of(context);
+    final text = isLoading ? loadingLabel ?? 'Please wait' : label!;
+    final base = small || insideTable ? SailStyleValues.ten : SailStyleValues.twelve;
+    return Text(
+      text.toUpperCase(),
+      overflow: TextOverflow.ellipsis,
+      style: base.copyWith(
+        color: foregroundColor,
+        fontWeight: SailStyleValues.boldWeight,
+        fontFamily: theme.chrome.fontFamily,
+        letterSpacing: 1.2,
+        decoration: variant == ButtonVariant.link ? TextDecoration.underline : null,
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -197,7 +218,9 @@ class _ButtonContent extends StatelessWidget {
           if (endIcon != null && label != null) const SizedBox(width: 8),
         ],
         if (label != null)
-          small || insideTable
+          terminalStyle
+              ? _terminalLabel(context)
+              : small || insideTable
               ? SailText.primary10(
                   isLoading ? loadingLabel ?? 'Please wait' : label!,
                   color: foregroundColor,
@@ -241,7 +264,11 @@ _ButtonVariantStyle _getVariantStyle(
   ButtonVariant variant,
   SailColor colors,
   Color? textColor,
+  bool terminalStyle,
 ) {
+  if (terminalStyle) {
+    return _getTerminalVariantStyle(variant, colors, textColor);
+  }
   switch (variant) {
     case ButtonVariant.primary:
       return _ButtonVariantStyle(
@@ -285,6 +312,50 @@ _ButtonVariantStyle _getVariantStyle(
         backgroundColor: Colors.transparent,
         foregroundColor: textColor ?? colors.ghostButtonText,
         hoverColor: colors.ghostButtonHover,
+      );
+  }
+}
+
+_ButtonVariantStyle _getTerminalVariantStyle(
+  ButtonVariant variant,
+  SailColor colors,
+  Color? textColor,
+) {
+  switch (variant) {
+    case ButtonVariant.primary:
+      return _ButtonVariantStyle(
+        backgroundColor: Colors.transparent,
+        foregroundColor: textColor ?? colors.primary,
+        borderColor: colors.primary,
+        hoverColor: colors.primary.withValues(alpha: 0.08),
+      );
+    case ButtonVariant.destructive:
+      return _ButtonVariantStyle(
+        backgroundColor: Colors.transparent,
+        foregroundColor: textColor ?? colors.error,
+        borderColor: colors.error,
+        hoverColor: colors.error.withValues(alpha: 0.08),
+      );
+    case ButtonVariant.link:
+      return _ButtonVariantStyle(
+        backgroundColor: Colors.transparent,
+        foregroundColor: textColor ?? colors.linkButtonText,
+        hoverColor: colors.linkButtonText,
+      );
+    case ButtonVariant.icon:
+      return _ButtonVariantStyle(
+        backgroundColor: Colors.transparent,
+        foregroundColor: textColor ?? colors.outlineButtonText,
+        hoverColor: colors.outlineButtonHover,
+      );
+    case ButtonVariant.secondary:
+    case ButtonVariant.outline:
+    case ButtonVariant.ghost:
+      return _ButtonVariantStyle(
+        backgroundColor: Colors.transparent,
+        foregroundColor: textColor ?? colors.outlineButtonText,
+        borderColor: colors.outlineButtonBorder,
+        hoverColor: colors.outlineButtonHover,
       );
   }
 }
@@ -498,6 +569,17 @@ class __SailScaleButtonState extends State<_SailScaleButton> with SingleTickerPr
                           decoration: BoxDecoration(
                             color: currentColor,
                             border: _isPressed ? theme.chrome.bevel!.sunken : theme.chrome.bevel!.raised,
+                          ),
+                          child: widget.child,
+                        )
+                      : theme.chrome.terminalStyle && widget.variant != ButtonVariant.link
+                      ? DecoratedBox(
+                          decoration: BoxDecoration(
+                            color: currentColor,
+                            borderRadius: theme.chrome.radiusSmall,
+                            border: widget.borderColor != null
+                                ? Border.all(color: widget.borderColor!, width: 1)
+                                : null,
                           ),
                           child: widget.child,
                         )

--- a/sail_ui/lib/widgets/containers/notification.dart
+++ b/sail_ui/lib/widgets/containers/notification.dart
@@ -37,19 +37,21 @@ class SailNotification extends StatelessWidget {
           child: Container(
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
-              color: SailTheme.of(context).colors.backgroundSecondary,
+              color: theme.colors.backgroundSecondary,
               border: Border.all(
-                color: SailTheme.of(context).colors.divider,
+                color: theme.chrome.terminalStyle ? theme.colors.border : theme.colors.divider,
                 width: 1,
               ),
-              borderRadius: SailStyleValues.borderRadius,
-              boxShadow: [
-                BoxShadow(
-                  color: SailTheme.of(context).colors.shadow,
-                  blurRadius: 8,
-                  offset: const Offset(0, 2),
-                ),
-              ],
+              borderRadius: theme.chrome.terminalStyle ? theme.chrome.radiusSmall : SailStyleValues.borderRadius,
+              boxShadow: theme.chrome.terminalStyle
+                  ? null
+                  : [
+                      BoxShadow(
+                        color: theme.colors.shadow,
+                        blurRadius: 8,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
             ),
             child: Row(
               mainAxisSize: MainAxisSize.min,

--- a/sail_ui/lib/widgets/containers/sail_card.dart
+++ b/sail_ui/lib/widgets/containers/sail_card.dart
@@ -35,6 +35,9 @@ class SailCard extends StatelessWidget {
   final bool inSeparateWindow;
   final SailWindow? newWindow;
 
+  /// eCash terminal theme only: draws the amber left-accent (`.sc-card` active).
+  final bool selected;
+
   const SailCard({
     super.key,
     this.title,
@@ -54,12 +57,13 @@ class SailCard extends StatelessWidget {
     this.withCloseButton = false,
     this.inSeparateWindow = false,
     this.newWindow,
+    this.selected = false,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = SailTheme.of(context);
-    final radius = borderRadius ?? theme.chrome.radiusLarge;
+    final radius = borderRadius ?? (theme.chrome.terminalStyle ? theme.chrome.radius : theme.chrome.radiusLarge);
 
     return LayoutBuilder(
       builder: (context, constraints) => _build(context, theme, radius, constraints.hasBoundedHeight),
@@ -73,8 +77,22 @@ class SailCard extends StatelessWidget {
         child: ClipRRect(
           borderRadius: radius,
           child: DecoratedBox(
-            decoration: theme.chrome.bevel != null
+            decoration: theme.chrome.beveled
                 ? theme.chrome.panel(theme.colors)
+                : theme.chrome.terminalStyle
+                ? BoxDecoration(
+                    border: Border(
+                      top: BorderSide(color: theme.colors.border, width: 1.0),
+                      right: BorderSide(color: theme.colors.border, width: 1.0),
+                      bottom: BorderSide(color: theme.colors.border, width: 1.0),
+                      left: BorderSide(
+                        color: selected ? theme.colors.primary : theme.colors.border,
+                        width: selected ? 2.0 : 1.0,
+                      ),
+                    ),
+                    borderRadius: radius,
+                    color: color ?? theme.colors.backgroundSecondary,
+                  )
                 : BoxDecoration(
                     border: Border.all(color: theme.colors.border, width: 1.0),
                     borderRadius: radius,

--- a/sail_ui/lib/widgets/containers/sail_popover.dart
+++ b/sail_ui/lib/widgets/containers/sail_popover.dart
@@ -230,7 +230,11 @@ class _SailPopoverState extends State<SailPopover> {
                   child: DecoratedBox(
                     decoration: BoxDecoration(
                       color: theme.colors.popoverBackground,
-                      borderRadius: theme.chrome.beveled ? BorderRadius.zero : BorderRadius.circular(6),
+                      borderRadius: theme.chrome.beveled
+                          ? BorderRadius.zero
+                          : theme.chrome.terminalStyle
+                          ? theme.chrome.radius
+                          : BorderRadius.circular(6),
                       border: theme.chrome.beveled
                           ? theme.chrome.bevel!.raised
                           : Border.all(color: theme.colors.border),

--- a/sail_ui/lib/widgets/containers/sail_sheet.dart
+++ b/sail_ui/lib/widgets/containers/sail_sheet.dart
@@ -100,6 +100,7 @@ class SailSheet extends StatelessWidget {
         decoration: BoxDecoration(
           color: theme.colors.background,
           border: theme.chrome.beveled ? theme.chrome.bevel!.raised : Border.all(color: theme.colors.border),
+          borderRadius: theme.chrome.terminalStyle ? theme.chrome.radiusLarge : null,
           boxShadow: [
             BoxShadow(
               color: theme.colors.shadow,

--- a/sail_ui/lib/widgets/containers/tab_bar.dart
+++ b/sail_ui/lib/widgets/containers/tab_bar.dart
@@ -227,12 +227,23 @@ class _TabItem extends StatelessWidget {
           vertical: SailStyleValues.padding04,
           horizontal: SailStyleValues.padding12,
         ),
-        decoration: BoxDecoration(
-          color: isSelected
-              ? (secondary ? context.sailTheme.colors.background : context.sailTheme.colors.backgroundSecondary)
-              : Colors.transparent,
-          borderRadius: theme.chrome.radius,
-        ),
+        decoration: theme.chrome.terminalStyle
+            ? BoxDecoration(
+                color: Colors.transparent,
+                borderRadius: theme.chrome.radiusSmall,
+                border: Border(
+                  bottom: BorderSide(
+                    color: isSelected ? context.sailTheme.colors.activeNavText : Colors.transparent,
+                    width: 2.0,
+                  ),
+                ),
+              )
+            : BoxDecoration(
+                color: isSelected
+                    ? (secondary ? context.sailTheme.colors.background : context.sailTheme.colors.backgroundSecondary)
+                    : Colors.transparent,
+                borderRadius: theme.chrome.radius,
+              ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/sail_ui/lib/widgets/core/sail_separator.dart
+++ b/sail_ui/lib/widgets/core/sail_separator.dart
@@ -35,7 +35,7 @@ class SailSeparator extends StatelessWidget {
     final lineColor = color ?? theme.colors.divider;
     final bevel = theme.chrome.bevel;
     final Widget line;
-    if (bevel != null) {
+    if (bevel != null && !theme.chrome.terminalStyle) {
       // win95 groove: dark band with a light band beneath/beside it
       line = axis == Axis.horizontal
           ? Column(

--- a/sail_ui/lib/widgets/core/sail_text.dart
+++ b/sail_ui/lib/widgets/core/sail_text.dart
@@ -264,18 +264,21 @@ class SailText {
     bool monospace = false,
     TextOverflow? overflow,
     int? maxLines,
+    bool eyebrow = false,
   }) {
     return Builder(
       builder: (context) {
         final theme = SailTheme.of(context);
+        final eyebrowOn = eyebrow && theme.chrome.terminalStyle;
         return _Text(
-          label: label,
+          label: eyebrowOn ? label.toUpperCase() : label,
           style: SailStyleValues.twelve.copyWith(
             color: color ?? theme.colors.textSecondary,
             fontWeight: bold ? SailStyleValues.boldWeight : null,
             fontStyle: italic ? FontStyle.italic : FontStyle.normal,
             fontFamily: theme.chrome.fontFamily ?? (monospace ? 'IBMPlexMono' : 'Inter'),
             overflow: overflow,
+            letterSpacing: eyebrowOn ? 2.0 : null,
           ),
           maxLines: maxLines,
           textAlign: textAlign,

--- a/sail_ui/lib/widgets/feedback/sail_alert.dart
+++ b/sail_ui/lib/widgets/feedback/sail_alert.dart
@@ -22,7 +22,32 @@ class SailAlert extends StatelessWidget {
          'SailAlert requires title or description',
        );
 
+  Color _semanticColor(SailThemeData theme) {
+    switch (variant) {
+      case SailAlertVariant.defaultVariant:
+        return theme.colors.border;
+      case SailAlertVariant.destructive:
+        return theme.colors.error;
+      case SailAlertVariant.warning:
+        return theme.colors.orange;
+      case SailAlertVariant.info:
+        return theme.colors.info;
+      case SailAlertVariant.success:
+        return theme.colors.success;
+    }
+  }
+
   _AlertColors _resolveColors(SailThemeData theme) {
+    if (theme.chrome.terminalStyle) {
+      final semantic = _semanticColor(theme);
+      return _AlertColors(
+        background: theme.colors.backgroundSecondary,
+        border: theme.colors.border,
+        foreground: theme.colors.text,
+        iconColor: semantic,
+        leftAccent: semantic,
+      );
+    }
     switch (variant) {
       case SailAlertVariant.defaultVariant:
         return _AlertColors(
@@ -99,8 +124,15 @@ class SailAlert extends StatelessWidget {
       padding: padding,
       decoration: BoxDecoration(
         color: c.background,
-        borderRadius: BorderRadius.circular(6),
-        border: Border.all(color: c.border),
+        borderRadius: theme.chrome.terminalStyle ? theme.chrome.radiusSmall : BorderRadius.circular(6),
+        border: theme.chrome.terminalStyle && c.leftAccent != null
+            ? Border(
+                top: BorderSide(color: c.border),
+                right: BorderSide(color: c.border),
+                bottom: BorderSide(color: c.border),
+                left: BorderSide(color: c.leftAccent!, width: 2),
+              )
+            : Border.all(color: c.border),
       ),
       child: icon == null
           ? content
@@ -124,10 +156,12 @@ class _AlertColors {
   final Color border;
   final Color foreground;
   final Color iconColor;
+  final Color? leftAccent;
   _AlertColors({
     required this.background,
     required this.border,
     required this.foreground,
     required this.iconColor,
+    this.leftAccent,
   });
 }

--- a/sail_ui/lib/widgets/feedback/sail_tooltip.dart
+++ b/sail_ui/lib/widgets/feedback/sail_tooltip.dart
@@ -101,19 +101,25 @@ class _SailTooltipState extends State<SailTooltip> {
                 padding: widget.padding,
                 decoration: BoxDecoration(
                   color: theme.chrome.tooltipBackground ?? theme.colors.popoverBackground,
-                  borderRadius: theme.chrome.beveled ? BorderRadius.zero : BorderRadius.circular(4),
+                  borderRadius: theme.chrome.beveled
+                      ? BorderRadius.zero
+                      : theme.chrome.terminalStyle
+                      ? theme.chrome.radiusSmall
+                      : BorderRadius.circular(4),
                   border: theme.chrome.beveled
                       ? Border.all(color: theme.colors.text, width: 1)
                       : Border.all(color: theme.colors.border),
-                  boxShadow: [
-                    BoxShadow(
-                      color: theme.colors.shadow,
-                      blurRadius: 6,
-                      offset: const Offset(0, 2),
-                    ),
-                  ],
+                  boxShadow: theme.chrome.terminalStyle
+                      ? null
+                      : [
+                          BoxShadow(
+                            color: theme.colors.shadow,
+                            blurRadius: 6,
+                            offset: const Offset(0, 2),
+                          ),
+                        ],
                 ),
-                child: SailText.primary12(widget.message),
+                child: SailText.primary12(widget.message, monospace: theme.chrome.terminalStyle),
               ),
             ),
           ),

--- a/sail_ui/lib/widgets/inputs/checkbox.dart
+++ b/sail_ui/lib/widgets/inputs/checkbox.dart
@@ -50,6 +50,15 @@ class _SailCheckboxState extends State<SailCheckbox> {
                 color: context.sailTheme.colors.formField,
                 border: chrome.bevel!.sunken,
               )
+            : chrome.terminalStyle
+            ? BoxDecoration(
+                borderRadius: BorderRadius.circular(2),
+                color: enabled ? context.sailTheme.colors.primary : context.sailTheme.colors.disabledBackground,
+                border: Border.all(
+                  color: context.sailTheme.colors.outlineButtonBorder,
+                  width: 1,
+                ),
+              )
             : BoxDecoration(
                 borderRadius: BorderRadius.all(Radius.circular(widget.cornerRadius)),
                 color: color,
@@ -73,6 +82,15 @@ class _SailCheckboxState extends State<SailCheckbox> {
             ? BoxDecoration(
                 color: context.sailTheme.colors.formField,
                 border: chrome.bevel!.sunken,
+              )
+            : chrome.terminalStyle
+            ? BoxDecoration(
+                borderRadius: BorderRadius.circular(2),
+                color: Colors.transparent,
+                border: Border.all(
+                  color: context.sailTheme.colors.outlineButtonBorder,
+                  width: 1,
+                ),
               )
             : BoxDecoration(
                 borderRadius: BorderRadius.all(Radius.circular(widget.cornerRadius)),

--- a/sail_ui/lib/widgets/inputs/dropdown_menu.dart
+++ b/sail_ui/lib/widgets/inputs/dropdown_menu.dart
@@ -59,6 +59,7 @@ class _SailDropdownButtonState<T> extends State<SailDropdownButton<T>> {
   @override
   Widget build(BuildContext context) {
     final theme = SailTheme.of(context);
+    final terminal = theme.chrome.terminalStyle;
 
     var items = widget.items
         .where(
@@ -83,10 +84,14 @@ class _SailDropdownButtonState<T> extends State<SailDropdownButton<T>> {
       if (currentIndex >= 0) {
         currentDisplay = widget.items[currentIndex];
       } else {
-        currentDisplay = widget.hint != null ? SailText.primary12(widget.hint!, color: Colors.white) : const SizedBox();
+        currentDisplay = widget.hint != null
+            ? SailText.primary12(widget.hint!, color: terminal ? theme.colors.textHint : Colors.white)
+            : const SizedBox();
       }
     } else {
-      currentDisplay = widget.hint != null ? SailText.primary12(widget.hint!, color: Colors.white) : const SizedBox();
+      currentDisplay = widget.hint != null
+          ? SailText.primary12(widget.hint!, color: terminal ? theme.colors.textHint : Colors.white)
+          : const SizedBox();
     }
 
     void toggleMenu() {
@@ -115,11 +120,13 @@ class _SailDropdownButtonState<T> extends State<SailDropdownButton<T>> {
           child: DecoratedBox(
             decoration: BoxDecoration(
               border: Border.all(
-                color: context.sailTheme.colors.border,
+                color: terminal ? theme.colors.outlineButtonBorder : context.sailTheme.colors.border,
                 width: 1,
               ),
-              borderRadius: theme.chrome.radius,
-              color: widget.value == null ? theme.colors.primary : Colors.transparent,
+              borderRadius: terminal ? theme.chrome.radiusSmall : theme.chrome.radius,
+              color: terminal
+                  ? theme.colors.background
+                  : (widget.value == null ? theme.colors.primary : Colors.transparent),
             ),
             child: Padding(
               padding: EdgeInsets.symmetric(vertical: 6, horizontal: 12),
@@ -131,7 +138,9 @@ class _SailDropdownButtonState<T> extends State<SailDropdownButton<T>> {
                   currentDisplay,
                   SailSVG.fromAsset(
                     _open ? SailSVGAsset.chevronUp : SailSVGAsset.chevronDown,
-                    color: widget.value == null ? Colors.white : theme.colors.text,
+                    color: terminal
+                        ? (_open ? theme.colors.primary : theme.colors.text)
+                        : (widget.value == null ? Colors.white : theme.colors.text),
                     width: 13,
                   ),
                 ],

--- a/sail_ui/lib/widgets/inputs/radio_button.dart
+++ b/sail_ui/lib/widgets/inputs/radio_button.dart
@@ -30,6 +30,8 @@ class _SailRadioButtonState<T> extends State<SailRadioButton<T>> {
   Widget build(BuildContext context) {
     var enabled = widget.onChanged != null && widget.enabled;
 
+    final chrome = SailTheme.of(context).chrome;
+
     Widget visual;
     if (widget.value == widget.groupValue) {
       Color color;
@@ -41,38 +43,77 @@ class _SailRadioButtonState<T> extends State<SailRadioButton<T>> {
         color = Theme.of(context).disabledColor;
       }
 
-      visual = Container(
-        width: widget.size,
-        height: widget.size,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          // borderRadius: BorderRadius.all(Radius.circular(widget.cornerRadius)),
-          color: color,
-          boxShadow: enabled ? sailBoxShadow(context) : null,
-        ),
-        child: Icon(
-          Icons.circle,
-          size: widget.size / 2,
-          color: SailTheme.of(context).colors.background,
-        ),
-      );
+      if (chrome.terminalStyle) {
+        visual = Container(
+          width: widget.size,
+          height: widget.size,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: Colors.transparent,
+            border: Border.all(
+              color: SailTheme.of(context).colors.outlineButtonBorder,
+              width: 1.0,
+            ),
+          ),
+          child: Center(
+            child: Container(
+              width: widget.size / 2,
+              height: widget.size / 2,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: enabled ? SailTheme.of(context).colors.primary : color,
+              ),
+            ),
+          ),
+        );
+      } else {
+        visual = Container(
+          width: widget.size,
+          height: widget.size,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: color,
+            boxShadow: enabled ? sailBoxShadow(context) : null,
+          ),
+          child: Icon(
+            Icons.circle,
+            size: widget.size / 2,
+            color: SailTheme.of(context).colors.background,
+          ),
+        );
+      }
     } else {
       var color = SailTheme.of(context).colors.background;
       if (_pressed) color = Color.lerp(color, Colors.black, 0.2)!;
 
-      visual = Container(
-        width: widget.size,
-        height: widget.size,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          color: color,
-          border: Border.all(
-            color: SailTheme.of(context).colors.border,
-            width: 1.0,
+      if (chrome.terminalStyle) {
+        visual = Container(
+          width: widget.size,
+          height: widget.size,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: Colors.transparent,
+            border: Border.all(
+              color: SailTheme.of(context).colors.outlineButtonBorder,
+              width: 1.0,
+            ),
           ),
-          boxShadow: sailBoxShadow(context),
-        ),
-      );
+        );
+      } else {
+        visual = Container(
+          width: widget.size,
+          height: widget.size,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: color,
+            border: Border.all(
+              color: SailTheme.of(context).colors.border,
+              width: 1.0,
+            ),
+            boxShadow: sailBoxShadow(context),
+          ),
+        );
+      }
     }
 
     if (widget.label != null) {

--- a/sail_ui/lib/widgets/inputs/sail_slider.dart
+++ b/sail_ui/lib/widgets/inputs/sail_slider.dart
@@ -43,10 +43,11 @@ class _SailSliderState extends State<SailSlider> {
   @override
   Widget build(BuildContext context) {
     final theme = SailTheme.of(context);
+    final terminal = theme.chrome.terminalStyle;
     final enabled = widget._isEnabled;
     final clampedValue = widget.value.clamp(widget.min, widget.max);
     final t = (clampedValue - widget.min) / (widget.max - widget.min);
-    const thumbRadius = 8.0;
+    final thumbRadius = terminal ? 6.0 : 8.0;
     const trackHeight = 4.0;
 
     return LayoutBuilder(
@@ -77,7 +78,7 @@ class _SailSliderState extends State<SailSlider> {
                         height: trackHeight,
                         decoration: BoxDecoration(
                           color: theme.colors.backgroundSecondary,
-                          borderRadius: BorderRadius.circular(trackHeight),
+                          borderRadius: terminal ? BorderRadius.circular(2) : BorderRadius.circular(trackHeight),
                         ),
                       ),
                     ),
@@ -89,29 +90,39 @@ class _SailSliderState extends State<SailSlider> {
                         height: trackHeight,
                         decoration: BoxDecoration(
                           color: theme.colors.primary,
-                          borderRadius: BorderRadius.circular(trackHeight),
+                          borderRadius: terminal ? BorderRadius.circular(2) : BorderRadius.circular(trackHeight),
                         ),
                       ),
                     ),
                     // thumb
                     Positioned(
                       left: thumbX - thumbRadius,
-                      child: Container(
-                        width: thumbRadius * 2,
-                        height: thumbRadius * 2,
-                        decoration: BoxDecoration(
-                          color: theme.colors.background,
-                          shape: BoxShape.circle,
-                          border: Border.all(color: theme.colors.primary, width: 2),
-                          boxShadow: [
-                            BoxShadow(
-                              color: theme.colors.shadow,
-                              blurRadius: 2,
-                              offset: const Offset(0, 1),
+                      child: terminal
+                          ? Container(
+                              width: thumbRadius * 2,
+                              height: thumbRadius * 2,
+                              decoration: BoxDecoration(
+                                color: theme.colors.primary,
+                                borderRadius: BorderRadius.circular(2),
+                                border: Border.all(color: theme.colors.outlineButtonBorder, width: 1),
+                              ),
+                            )
+                          : Container(
+                              width: thumbRadius * 2,
+                              height: thumbRadius * 2,
+                              decoration: BoxDecoration(
+                                color: theme.colors.background,
+                                shape: BoxShape.circle,
+                                border: Border.all(color: theme.colors.primary, width: 2),
+                                boxShadow: [
+                                  BoxShadow(
+                                    color: theme.colors.shadow,
+                                    blurRadius: 2,
+                                    offset: const Offset(0, 1),
+                                  ),
+                                ],
+                              ),
                             ),
-                          ],
-                        ),
-                      ),
                     ),
                   ],
                 ),

--- a/sail_ui/lib/widgets/inputs/sail_switch.dart
+++ b/sail_ui/lib/widgets/inputs/sail_switch.dart
@@ -85,13 +85,14 @@ class _SailSwitchState extends State<SailSwitch> with SingleTickerProviderStateM
             animation: _animation,
             builder: (context, _) {
               final t = _animation.value;
+              final terminal = theme.chrome.terminalStyle;
               final trackColor = Color.lerp(inactiveColor, activeColor, t)!;
               return Container(
                 width: widget.width,
                 height: widget.height,
                 decoration: BoxDecoration(
                   color: trackColor,
-                  borderRadius: BorderRadius.circular(widget.height),
+                  borderRadius: BorderRadius.circular(terminal ? 3 : widget.height),
                   border: Border.all(color: borderColor, width: 1),
                 ),
                 child: Padding(
@@ -101,17 +102,22 @@ class _SailSwitchState extends State<SailSwitch> with SingleTickerProviderStateM
                     child: Container(
                       width: thumbSize,
                       height: thumbSize,
-                      decoration: BoxDecoration(
-                        color: thumbColor,
-                        shape: BoxShape.circle,
-                        boxShadow: [
-                          BoxShadow(
-                            color: theme.colors.shadow,
-                            blurRadius: 2,
-                            offset: const Offset(0, 1),
-                          ),
-                        ],
-                      ),
+                      decoration: terminal
+                          ? BoxDecoration(
+                              color: thumbColor,
+                              borderRadius: BorderRadius.circular(2),
+                            )
+                          : BoxDecoration(
+                              color: thumbColor,
+                              shape: BoxShape.circle,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: theme.colors.shadow,
+                                  blurRadius: 2,
+                                  offset: const Offset(0, 1),
+                                ),
+                              ],
+                            ),
                     ),
                   ),
                 ),

--- a/sail_ui/lib/widgets/inputs/text_field.dart
+++ b/sail_ui/lib/widgets/inputs/text_field.dart
@@ -72,6 +72,12 @@ class SailTextField extends StatelessWidget {
     final padding = EdgeInsets.symmetric(vertical: 11.5, horizontal: 12);
     final textSize = size == TextFieldSize.regular ? 13.0 : 10.0;
 
+    final terminal = theme.chrome.terminalStyle;
+    final borderRadius = terminal ? theme.chrome.radiusSmall : theme.chrome.radius;
+    final restingBorderColor = terminal ? theme.colors.outlineButtonBorder : theme.colors.border;
+    final focusedBorderColor = terminal ? theme.colors.primary : theme.colors.text;
+    final hintColor = terminal ? theme.colors.textHint : theme.colors.inactiveNavText;
+
     final field = Theme(
       data: Theme.of(context).copyWith(
         textSelectionTheme: TextSelectionThemeData(
@@ -107,12 +113,12 @@ class SailTextField extends StatelessWidget {
           errorBorder: InputBorder.none,
           disabledBorder: InputBorder.none,
           enabledBorder: OutlineInputBorder(
-            borderRadius: theme.chrome.radius,
-            borderSide: BorderSide(color: theme.colors.border),
+            borderRadius: borderRadius,
+            borderSide: BorderSide(color: restingBorderColor),
           ),
           focusedBorder: OutlineInputBorder(
-            borderRadius: theme.chrome.radius,
-            borderSide: BorderSide(color: theme.colors.text),
+            borderRadius: borderRadius,
+            borderSide: BorderSide(color: focusedBorderColor),
           ),
           suffixStyle: TextStyle(
             color: SailTheme.of(context).colors.inactiveNavText,
@@ -120,8 +126,8 @@ class SailTextField extends StatelessWidget {
           ),
           suffixText: suffix,
           border: OutlineInputBorder(
-            borderRadius: theme.chrome.radius,
-            borderSide: BorderSide(color: theme.colors.border),
+            borderRadius: borderRadius,
+            borderSide: BorderSide(color: restingBorderColor),
           ),
           suffixIcon: loading != null && loading!.enabled
               ? Tooltip(
@@ -164,7 +170,7 @@ class SailTextField extends StatelessWidget {
             fontSize: textSize,
           ),
           hintStyle: SailStyleValues.thirteen.copyWith(
-            color: SailTheme.of(context).colors.inactiveNavText,
+            color: hintColor,
             fontSize: textSize,
           ),
         ),

--- a/sail_ui/lib/widgets/loaders/progress.dart
+++ b/sail_ui/lib/widgets/loaders/progress.dart
@@ -44,24 +44,40 @@ class ProgressBar extends StatelessWidget {
                 // Background container
                 Container(
                   decoration: BoxDecoration(
-                    color: theme.colors.backgroundSecondary.withValues(
-                      alpha: 0.5,
-                    ),
-                    borderRadius: theme.chrome.beveled ? BorderRadius.zero : BorderRadius.circular(999),
+                    color: theme.chrome.terminalStyle
+                        ? theme.colors.backgroundSecondary
+                        : theme.colors.backgroundSecondary.withValues(
+                            alpha: 0.5,
+                          ),
+                    borderRadius: theme.chrome.beveled
+                        ? BorderRadius.zero
+                        : theme.chrome.terminalStyle
+                        ? theme.chrome.radiusSmall
+                        : BorderRadius.circular(999),
                     border: theme.chrome.beveled ? theme.chrome.bevel!.sunken : null,
                   ),
                 ),
                 // Progress indicator
                 ClipRRect(
-                  borderRadius: theme.chrome.beveled ? BorderRadius.zero : BorderRadius.circular(999),
+                  borderRadius: theme.chrome.beveled
+                      ? BorderRadius.zero
+                      : theme.chrome.terminalStyle
+                      ? theme.chrome.radiusSmall
+                      : BorderRadius.circular(999),
                   child: FractionallySizedBox(
                     alignment: Alignment.centerLeft,
                     widthFactor: progress,
                     child: Container(
                       decoration: BoxDecoration(
-                        color: color ?? (theme.chrome.beveled ? theme.colors.primary : theme.colors.text),
+                        color:
+                            color ??
+                            (theme.chrome.beveled || theme.chrome.terminalStyle
+                                ? theme.colors.primary
+                                : theme.colors.text),
                         borderRadius: theme.chrome.beveled
                             ? BorderRadius.zero
+                            : theme.chrome.terminalStyle
+                            ? theme.chrome.radiusSmall
                             : BorderRadius.horizontal(
                                 left: const Radius.circular(999),
                                 right: Radius.circular(

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.273
+version: 1.0.274
 
 environment:
   sdk: 3.12.0

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.144
+version: 1.0.145
 
 environment:
   sdk: 3.12.0

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.271
+version: 1.0.272
 
 environment:
   sdk: 3.12.0


### PR DESCRIPTION
Adds a third selectable theme (eCash) alongside Sail and Windows 95: exact ecash.com tokens (light+dark), full sail_ui component port gated on a new terminalStyle chrome flag. The forknet build defaults to it; Sail/win95 render unchanged.