### PR TITLE
Update Elements node downloads for Linux, Windows, and macOS

### DIFF
--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 6,
   "binaries": {
     "bitcoincore": {
       "type": "core",
@@ -706,7 +706,7 @@
       "type": "sidechain",
       "slot": 24,
       "name": "Liquid Signet",
-      "version": "b7da9f75ea1d3da7a0b761cd7f18d81500bb1011",
+      "version": "bf81d90968d080a20e97b76c2a2431baa9a8f9a1",
       "description": "Elements/Liquid sidechain in slot 24.",
       "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
       "port": 29443,
@@ -716,7 +716,7 @@
       "dependencies": ["bitcoind", "enforcer"],
       "startup_log_patterns": ["Done loading"],
       "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/liquid-signet-b7da9f75/", "linux-x86_64": "", "macos-x86_64": "", "macos-arm64": "liquid-signet-b7da9f75-macos-arm64.tar.gz", "windows-x86_64": ""}}},
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-bf81d909/", "linux-x86_64": "liquid-signet-elements-bf81d909-linux-x86_64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-bf81d909-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-bf81d909-win64.zip"}}},
       "hashes": {}
     },
     "zside": {

--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -706,7 +706,7 @@
       "type": "sidechain",
       "slot": 24,
       "name": "Liquid Signet",
-      "version": "bf81d90968d080a20e97b76c2a2431baa9a8f9a1",
+      "version": "3d19db429089e3dd52c8b0607a7bc2c636997008",
       "description": "Elements/Liquid sidechain in slot 24.",
       "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
       "port": 29443,
@@ -716,8 +716,12 @@
       "dependencies": ["bitcoind", "enforcer"],
       "startup_log_patterns": ["Done loading"],
       "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-bf81d909/", "linux-x86_64": "liquid-signet-elements-bf81d909-linux-x86_64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-bf81d909-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-bf81d909-win64.zip"}}},
-      "hashes": {}
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-3d19db42/", "linux-x86_64": "liquid-signet-elements-3d19db42-linux-x86_64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-3d19db42-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-3d19db42-win64.zip"}}},
+      "hashes": {
+        "linux-x86_64": {"sha256": "901547336876ba713992c858c4de363f174183e581f6636486fd543ed0f7504b", "size": 193470451},
+        "macos-arm64": {"sha256": "777be45360ccba962e6063b50171d2d3cacf04f04891805575ed9f2ab2550857", "size": 13011574},
+        "windows-x86_64": {"sha256": "15e14b43a9c11239b85f1e5203a4d7bfdaad4671908572df0eead8da2a7d4a12", "size": 22355070}
+      }
     },
     "zside": {
       "type": "sidechain",

--- a/sail_ui/assets/migrations/006_chains_config.json
+++ b/sail_ui/assets/migrations/006_chains_config.json
@@ -1,0 +1,21 @@
+{
+  "version": 6,
+  "migration": "patch",
+  "binaries": {
+    "liquid-signet": {
+      "version": "bf81d90968d080a20e97b76c2a2431baa9a8f9a1",
+      "download": {
+        "binary": "liquid-signet",
+        "files": {
+          "default": {
+            "base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-bf81d909/",
+            "linux-x86_64": "liquid-signet-elements-bf81d909-linux-x86_64.tar.gz",
+            "macos-x86_64": "",
+            "macos-arm64": "liquid-signet-elements-bf81d909-macos-arm64.tar.gz",
+            "windows-x86_64": "liquid-signet-elements-bf81d909-win64.zip"
+          }
+        }
+      }
+    }
+  }
+}

--- a/sail_ui/assets/migrations/006_chains_config.json
+++ b/sail_ui/assets/migrations/006_chains_config.json
@@ -3,18 +3,23 @@
   "migration": "patch",
   "binaries": {
     "liquid-signet": {
-      "version": "bf81d90968d080a20e97b76c2a2431baa9a8f9a1",
+      "version": "3d19db429089e3dd52c8b0607a7bc2c636997008",
       "download": {
         "binary": "liquid-signet",
         "files": {
           "default": {
-            "base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-bf81d909/",
-            "linux-x86_64": "liquid-signet-elements-bf81d909-linux-x86_64.tar.gz",
+            "base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-3d19db42/",
+            "linux-x86_64": "liquid-signet-elements-3d19db42-linux-x86_64.tar.gz",
             "macos-x86_64": "",
-            "macos-arm64": "liquid-signet-elements-bf81d909-macos-arm64.tar.gz",
-            "windows-x86_64": "liquid-signet-elements-bf81d909-win64.zip"
+            "macos-arm64": "liquid-signet-elements-3d19db42-macos-arm64.tar.gz",
+            "windows-x86_64": "liquid-signet-elements-3d19db42-win64.zip"
           }
         }
+      },
+      "hashes": {
+        "linux-x86_64": {"sha256": "901547336876ba713992c858c4de363f174183e581f6636486fd543ed0f7504b", "size": 193470451},
+        "macos-arm64": {"sha256": "777be45360ccba962e6063b50171d2d3cacf04f04891805575ed9f2ab2550857", "size": 13011574},
+        "windows-x86_64": {"sha256": "15e14b43a9c11239b85f1e5203a4d7bfdaad4671908572df0eead8da2a7d4a12", "size": 22355070}
       }
     }
   }

--- a/sail_ui/lib/config/sidechains.dart
+++ b/sail_ui/lib/config/sidechains.dart
@@ -166,7 +166,7 @@ abstract class Sidechain extends Binary {
 class LiquidSignet extends Sidechain {
   LiquidSignet({
     super.name = 'Liquid Signet',
-    super.version = 'b7da9f75ea1d3da7a0b761cd7f18d81500bb1011',
+    super.version = 'bf81d90968d080a20e97b76c2a2431baa9a8f9a1',
     super.description = 'Elements/Liquid sidechain',
     super.repoUrl = 'https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation',
     DirectoryConfig? directories,

--- a/sail_ui/lib/config/sidechains.dart
+++ b/sail_ui/lib/config/sidechains.dart
@@ -166,7 +166,7 @@ abstract class Sidechain extends Binary {
 class LiquidSignet extends Sidechain {
   LiquidSignet({
     super.name = 'Liquid Signet',
-    super.version = 'bf81d90968d080a20e97b76c2a2431baa9a8f9a1',
+    super.version = '3d19db429089e3dd52c8b0607a7bc2c636997008',
     super.description = 'Elements/Liquid sidechain',
     super.repoUrl = 'https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation',
     DirectoryConfig? directories,

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 6,
   "binaries": {
     "bitcoincore": {
       "type": "core",
@@ -706,7 +706,7 @@
       "type": "sidechain",
       "slot": 24,
       "name": "Liquid Signet",
-      "version": "b7da9f75ea1d3da7a0b761cd7f18d81500bb1011",
+      "version": "bf81d90968d080a20e97b76c2a2431baa9a8f9a1",
       "description": "Elements/Liquid sidechain in slot 24.",
       "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
       "port": 29443,
@@ -716,7 +716,7 @@
       "dependencies": ["bitcoind", "enforcer"],
       "startup_log_patterns": ["Done loading"],
       "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/liquid-signet-b7da9f75/", "linux-x86_64": "", "macos-x86_64": "", "macos-arm64": "liquid-signet-b7da9f75-macos-arm64.tar.gz", "windows-x86_64": ""}}},
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-bf81d909/", "linux-x86_64": "liquid-signet-elements-bf81d909-linux-x86_64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-bf81d909-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-bf81d909-win64.zip"}}},
       "hashes": {}
     },
     "zside": {

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -706,7 +706,7 @@
       "type": "sidechain",
       "slot": 24,
       "name": "Liquid Signet",
-      "version": "bf81d90968d080a20e97b76c2a2431baa9a8f9a1",
+      "version": "3d19db429089e3dd52c8b0607a7bc2c636997008",
       "description": "Elements/Liquid sidechain in slot 24.",
       "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
       "port": 29443,
@@ -716,8 +716,12 @@
       "dependencies": ["bitcoind", "enforcer"],
       "startup_log_patterns": ["Done loading"],
       "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-bf81d909/", "linux-x86_64": "liquid-signet-elements-bf81d909-linux-x86_64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-bf81d909-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-bf81d909-win64.zip"}}},
-      "hashes": {}
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-3d19db42/", "linux-x86_64": "liquid-signet-elements-3d19db42-linux-x86_64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-3d19db42-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-3d19db42-win64.zip"}}},
+      "hashes": {
+        "linux-x86_64": {"sha256": "901547336876ba713992c858c4de363f174183e581f6636486fd543ed0f7504b", "size": 193470451},
+        "macos-arm64": {"sha256": "777be45360ccba962e6063b50171d2d3cacf04f04891805575ed9f2ab2550857", "size": 13011574},
+        "windows-x86_64": {"sha256": "15e14b43a9c11239b85f1e5203a4d7bfdaad4671908572df0eead8da2a7d4a12", "size": 22355070}
+      }
     },
     "zside": {
       "type": "sidechain",

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 6,
   "binaries": {
     "bitcoincore": {
       "type": "core",
@@ -706,7 +706,7 @@
       "type": "sidechain",
       "slot": 24,
       "name": "Liquid Signet",
-      "version": "b7da9f75ea1d3da7a0b761cd7f18d81500bb1011",
+      "version": "bf81d90968d080a20e97b76c2a2431baa9a8f9a1",
       "description": "Elements/Liquid sidechain in slot 24.",
       "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
       "port": 29443,
@@ -716,7 +716,7 @@
       "dependencies": ["bitcoind", "enforcer"],
       "startup_log_patterns": ["Done loading"],
       "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/liquid-signet-b7da9f75/", "linux-x86_64": "", "macos-x86_64": "", "macos-arm64": "liquid-signet-b7da9f75-macos-arm64.tar.gz", "windows-x86_64": ""}}},
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-bf81d909/", "linux-x86_64": "liquid-signet-elements-bf81d909-linux-x86_64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-bf81d909-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-bf81d909-win64.zip"}}},
       "hashes": {}
     },
     "zside": {

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -706,7 +706,7 @@
       "type": "sidechain",
       "slot": 24,
       "name": "Liquid Signet",
-      "version": "bf81d90968d080a20e97b76c2a2431baa9a8f9a1",
+      "version": "3d19db429089e3dd52c8b0607a7bc2c636997008",
       "description": "Elements/Liquid sidechain in slot 24.",
       "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
       "port": 29443,
@@ -716,8 +716,12 @@
       "dependencies": ["bitcoind", "enforcer"],
       "startup_log_patterns": ["Done loading"],
       "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-bf81d909/", "linux-x86_64": "liquid-signet-elements-bf81d909-linux-x86_64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-bf81d909-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-bf81d909-win64.zip"}}},
-      "hashes": {}
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-3d19db42/", "linux-x86_64": "liquid-signet-elements-3d19db42-linux-x86_64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-3d19db42-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-3d19db42-win64.zip"}}},
+      "hashes": {
+        "linux-x86_64": {"sha256": "901547336876ba713992c858c4de363f174183e581f6636486fd543ed0f7504b", "size": 193470451},
+        "macos-arm64": {"sha256": "777be45360ccba962e6063b50171d2d3cacf04f04891805575ed9f2ab2550857", "size": 13011574},
+        "windows-x86_64": {"sha256": "15e14b43a9c11239b85f1e5203a4d7bfdaad4671908572df0eead8da2a7d4a12", "size": 22355070}
+      }
     },
     "zside": {
       "type": "sidechain",


### PR DESCRIPTION
## Summary
- point the liquid-signet download config at the new elements-bf81d909 release
- add Linux x86_64, Windows win64, and macOS arm64 artifacts
- add a chains_config migration so existing installs move from the old mac-only liquid-signet release to the new Elements release

## Verification
- jq empty sail_ui/assets/chains_config.json sail_ui/assets/migrations/006_chains_config.json sidechain-orchestrator/chains_config.json sidechain-orchestrator/config/chains_config.json
- go test . -run 'TestConfig|TestCoreVariant' (from sidechain-orchestrator)
- go test ./config -run 'Test' (from sidechain-orchestrator)
- curl -I -L --fail for all three release assets