### PR TITLE
fix: BitWindow M4 vote preference wraps sidechain slot 256 to slot 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ vendor/
 # Build artifacts
 sidechain-orchestrator/orchestratorctl
 sidechain-orchestrator/orchestratord
+
+# Orchestration harness artifacts
+.omo/

--- a/bitwindow/server/api/bitdrive/bitdrive.go
+++ b/bitwindow/server/api/bitdrive/bitdrive.go
@@ -185,7 +185,7 @@ func (s *Server) ScanForFiles(ctx context.Context, req *connect.Request[emptypb.
 			Encrypted: metadata.Encrypted,
 			Timestamp: metadata.Timestamp,
 			FileType:  metadata.FileType,
-			Filename:  fmt.Sprintf("%d.%s", metadata.Timestamp, metadata.FileType),
+			Filename:  fmt.Sprintf("%d_%s.%s", metadata.Timestamp, opReturn.TxID, metadata.FileType),
 		})
 	}
 

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -566,7 +566,16 @@ func (s *Server) GetSyncInfo(ctx context.Context, req *connect.Request[emptypb.E
 
 // SetTransactionNote implements bitwindowdv1connect.BitwindowdServiceHandler.
 func (s *Server) SetTransactionNote(ctx context.Context, req *connect.Request[pb.SetTransactionNoteRequest]) (*connect.Response[emptypb.Empty], error) {
-	if err := transactions.SetNote(ctx, s.db, req.Msg.Txid, req.Msg.Note); err != nil {
+	// Notes are private, wallet-local metadata. Scope them to the wallet the
+	// user is currently viewing (the active wallet) so a note written here does
+	// not surface in another wallet's transaction list.
+	activeWallet, err := s.walletEngine.GetActiveWallet(ctx)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msg("could not get active wallet")
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	if err := transactions.SetNote(ctx, s.db, activeWallet.ID, req.Msg.Txid, req.Msg.Note); err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not set transaction note")
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -625,6 +634,14 @@ func (s *Server) ExportLabels(ctx context.Context, req *connect.Request[emptypb.
 
 // ImportLabels implements bitwindowdv1connect.BitwindowdServiceHandler.
 func (s *Server) ImportLabels(ctx context.Context, req *connect.Request[pb.ImportLabelsRequest]) (*connect.Response[pb.ImportLabelsResponse], error) {
+	// Transaction notes are wallet-scoped; BIP329 tx labels carry only a txid,
+	// so import them into the wallet the user is currently viewing.
+	activeWallet, err := s.walletEngine.GetActiveWallet(ctx)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msg("could not get active wallet")
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
 	labels, skipped := bip329.Decode(req.Msg.Jsonl)
 
 	resp := &pb.ImportLabelsResponse{Skipped: int64(skipped)}
@@ -647,7 +664,7 @@ func (s *Server) ImportLabels(ctx context.Context, req *connect.Request[pb.Impor
 			resp.ImportedAddresses++
 
 		case bip329.TypeTx:
-			if err := transactions.SetNote(ctx, s.db, ref, l.Label); err != nil {
+			if err := transactions.SetNote(ctx, s.db, activeWallet.ID, ref, l.Label); err != nil {
 				zerolog.Ctx(ctx).Error().Err(err).Str("ref", ref).Msg("could not import transaction note")
 				resp.Skipped++
 				continue

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -337,7 +337,15 @@ func (s *Server) CancelDenial(
 	ctx context.Context,
 	req *connect.Request[pb.CancelDenialRequest],
 ) (*connect.Response[emptypb.Empty], error) {
-	err := deniability.Cancel(ctx, s.db, req.Msg.Id, "cancelled by user")
+	// Scope the mutation to the active wallet so one wallet cannot cancel
+	// another wallet's deniability plan.
+	activeWallet, err := s.walletEngine.GetActiveWallet(ctx)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msg("could not get active wallet")
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	err = deniability.Cancel(ctx, s.db, activeWallet.ID, req.Msg.Id, "cancelled by user")
 	if err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not cancel denial")
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -350,7 +358,15 @@ func (s *Server) PauseDenial(
 	ctx context.Context,
 	req *connect.Request[pb.PauseDenialRequest],
 ) (*connect.Response[emptypb.Empty], error) {
-	err := deniability.Pause(ctx, s.db, req.Msg.Id)
+	// Scope the mutation to the active wallet so one wallet cannot pause
+	// another wallet's deniability plan.
+	activeWallet, err := s.walletEngine.GetActiveWallet(ctx)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msg("could not get active wallet")
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	err = deniability.Pause(ctx, s.db, activeWallet.ID, req.Msg.Id)
 	if err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not pause denial")
 		return nil, err
@@ -363,7 +379,15 @@ func (s *Server) ResumeDenial(
 	ctx context.Context,
 	req *connect.Request[pb.ResumeDenialRequest],
 ) (*connect.Response[emptypb.Empty], error) {
-	err := deniability.Resume(ctx, s.db, req.Msg.Id)
+	// Scope the mutation to the active wallet so one wallet cannot resume
+	// another wallet's deniability plan.
+	activeWallet, err := s.walletEngine.GetActiveWallet(ctx)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msg("could not get active wallet")
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	err = deniability.Resume(ctx, s.db, activeWallet.ID, req.Msg.Id)
 	if err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not resume denial")
 		return nil, err

--- a/bitwindow/server/api/bitwindowd/bitwindowd_test.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd_test.go
@@ -1271,6 +1271,75 @@ func TestService_ResumeDenial(t *testing.T) {
 	})
 }
 
+// TestService_DenialMutations_WalletScoped asserts that the Cancel/Pause/Resume
+// RPC handlers only mutate the active wallet's plans. The test harness resolves
+// the active wallet to "test-wallet-id-1234"; here we plant a denial owned by a
+// different wallet and confirm each mutation is rejected and leaves it untouched.
+func TestService_DenialMutations_WalletScoped(t *testing.T) {
+	t.Parallel()
+
+	const otherWallet = "other-wallet-id"
+
+	t.Run("cannot cancel another wallet's denial", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		db := database.Test(t)
+		cli := v1connect.NewBitwindowdServiceClient(apitests.API(t, db))
+
+		denial, err := deniability.Create(ctx, db, otherWallet, "othertxid", 0, time.Hour, 3, nil)
+		require.NoError(t, err)
+
+		_, err = cli.CancelDenial(ctx, connect.NewRequest(&v1.CancelDenialRequest{Id: denial.ID}))
+		require.Error(t, err)
+
+		got, err := deniability.Get(ctx, db, denial.ID)
+		require.NoError(t, err)
+		assert.Nil(t, got.CancelledAt)
+		require.NotNil(t, got.WalletID)
+		assert.Equal(t, otherWallet, *got.WalletID)
+	})
+
+	t.Run("cannot pause another wallet's denial", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		db := database.Test(t)
+		cli := v1connect.NewBitwindowdServiceClient(apitests.API(t, db))
+
+		denial, err := deniability.Create(ctx, db, otherWallet, "othertxid", 0, time.Hour, 3, nil)
+		require.NoError(t, err)
+
+		_, err = cli.PauseDenial(ctx, connect.NewRequest(&v1.PauseDenialRequest{Id: denial.ID}))
+		require.Error(t, err)
+
+		got, err := deniability.Get(ctx, db, denial.ID)
+		require.NoError(t, err)
+		assert.Nil(t, got.PausedAt)
+	})
+
+	t.Run("cannot resume another wallet's denial", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		db := database.Test(t)
+		cli := v1connect.NewBitwindowdServiceClient(apitests.API(t, db))
+
+		denial, err := deniability.Create(ctx, db, otherWallet, "othertxid", 0, time.Hour, 3, nil)
+		require.NoError(t, err)
+
+		// Pause it as its owner so there is a paused plan to attempt to resume.
+		require.NoError(t, deniability.Pause(ctx, db, otherWallet, denial.ID))
+
+		_, err = cli.ResumeDenial(ctx, connect.NewRequest(&v1.ResumeDenialRequest{Id: denial.ID}))
+		require.Error(t, err)
+
+		got, err := deniability.Get(ctx, db, denial.ID)
+		require.NoError(t, err)
+		assert.NotNil(t, got.PausedAt)
+	})
+}
+
 func TestService_ListBlocks(t *testing.T) {
 	t.Parallel()
 

--- a/bitwindow/server/api/m4/m4.go
+++ b/bitwindow/server/api/m4/m4.go
@@ -105,6 +105,11 @@ func (s *Server) SetVotePreference(
 		return nil, fmt.Errorf("invalid vote type: %s", req.Msg.VoteType)
 	}
 
+	// Validate sidechain slot (0-255) before narrowing to uint8
+	if req.Msg.SidechainSlot > 255 {
+		return nil, fmt.Errorf("invalid sidechain slot: %d (must be 0-255)", req.Msg.SidechainSlot)
+	}
+
 	var bundleHash *string
 	if req.Msg.BundleHash != nil {
 		bundleHash = req.Msg.BundleHash

--- a/bitwindow/server/api/m4/m4_test.go
+++ b/bitwindow/server/api/m4/m4_test.go
@@ -195,6 +195,25 @@ func TestService_SetVotePreference(t *testing.T) {
 		require.Len(t, prefs.Msg.Preferences, 1)
 		assert.Equal(t, uint32(255), prefs.Msg.Preferences[0].SidechainSlot)
 	})
+
+	t.Run("out-of-range sidechain slot (256) returns error and does not wrap", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.Test(t)
+		cli := m4v1connect.NewM4ServiceClient(apitests.API(t, db))
+
+		// Slot 256 overflows uint8 and would wrap to slot 0 without validation.
+		_, err := cli.SetVotePreference(context.Background(), connect.NewRequest(&m4pb.SetVotePreferenceRequest{
+			SidechainSlot: 256,
+			VoteType:      "alarm",
+		}))
+		require.Error(t, err)
+
+		// No preference should have been stored for the wrapped slot 0.
+		prefs, err := cli.GetVotePreferences(context.Background(), connect.NewRequest(&m4pb.GetVotePreferencesRequest{}))
+		require.NoError(t, err)
+		assert.Empty(t, prefs.Msg.Preferences)
+	})
 }
 
 func TestService_GetM4History(t *testing.T) {

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -2486,8 +2486,8 @@ func (s *Server) DeleteCheque(ctx context.Context, c *connect.Request[pb.DeleteC
 	}
 
 	// Only allow deletion of unfunded or swept cheques
-	// Funded but not swept = still has money, can't delete
-	if cheque.IsFunded() && cheque.SweptTxid == nil {
+	// Any recorded incoming funds (full or partial) but not swept = still has money, can't delete
+	if (cheque.IsFunded() || cheque.IsPartiallyFunded()) && cheque.SweptTxid == nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot delete funded cheque"))
 	}
 

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -895,7 +895,7 @@ func (s *Server) ListTransactions(ctx context.Context, c *connect.Request[pb.Lis
 			return nil, fmt.Errorf("enforcer/wallet: could not list addressbook: %w", err)
 		}
 
-		notes, err := transactions.List(ctx, s.database)
+		notes, err := transactions.ListByWallet(ctx, s.database, walletId)
 		if err != nil {
 			return nil, fmt.Errorf("enforcer/wallet: could not list transactions: %w", err)
 		}
@@ -972,7 +972,7 @@ func (s *Server) ListTransactions(ctx context.Context, c *connect.Request[pb.Lis
 			}
 			return ""
 		}
-		notes, err := transactions.List(ctx, s.database)
+		notes, err := transactions.ListByWallet(ctx, s.database, walletId)
 		if err != nil {
 			return nil, fmt.Errorf("electrum: could not list notes: %w", err)
 		}
@@ -1039,7 +1039,7 @@ func (s *Server) ListTransactions(ctx context.Context, c *connect.Request[pb.Lis
 		return nil, fmt.Errorf("list addressbook: %w", err)
 	}
 
-	notes, err := transactions.List(ctx, s.database)
+	notes, err := transactions.ListByWallet(ctx, s.database, walletId)
 	if err != nil {
 		return nil, fmt.Errorf("list transactions: %w", err)
 	}

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -2,12 +2,14 @@ package api_wallet_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"connectrpc.com/connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	walletv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1"
 	walletv1connect "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1/walletv1connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
 	mainchainv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
@@ -214,6 +216,106 @@ func TestService_DeleteCheque(t *testing.T) {
 		// A non-existent cheque must surface as NotFound, not a leaked
 		// "no rows" internal error.
 		require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	})
+}
+
+// TestService_DeleteChequeFundingGuard pins the server-side deletion guard:
+// a cheque with any recorded incoming funds (partial or full) that has not
+// been swept must not be deletable, because its row still represents real
+// money at the derived address. Once swept, the row is safe to remove.
+func TestService_DeleteChequeFundingGuard(t *testing.T) {
+	t.Parallel()
+
+	// deleteChequeClient stands up an API server with the permissive bitcoind
+	// mock the cheque engine bootstrap needs, and hands back both a client and
+	// the backing database so the test can seed cheque funding state directly.
+	deleteChequeClient := func(t *testing.T) (walletv1connect.WalletServiceClient, *sql.DB) {
+		t.Helper()
+
+		ctrl := gomock.NewController(t)
+		db := database.Test(t)
+
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		mockBitcoind.EXPECT().
+			ListWallets(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.ListWalletsResponse]{
+				Msg: &bitcoindv1alpha.ListWalletsResponse{Wallets: []string{}},
+			}, nil).AnyTimes()
+		mockBitcoind.EXPECT().
+			CreateWallet(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.CreateWalletResponse]{
+				Msg: &bitcoindv1alpha.CreateWalletResponse{Name: "cheque_watch"},
+			}, nil).AnyTimes()
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, db, apitests.WithBitcoind(mockBitcoind)))
+		return cli, db
+	}
+
+	t.Run("partially funded unswept cheque cannot be deleted", func(t *testing.T) {
+		t.Parallel()
+
+		cli, db := deleteChequeClient(t)
+
+		// Cheque expects 1 BTC but only 0.5 BTC arrived: partially funded, unswept.
+		chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qpartialdelete000000000000000000000000000")
+		require.NoError(t, err)
+		require.NoError(t, cheques.UpdateFunding(context.Background(), db, testWalletID, chequeID,
+			[]string{"partial0partial0partial0partial0partial0partial0partial0partial0"}, 50_000_000))
+
+		_, err = cli.DeleteCheque(context.Background(), connect.NewRequest(&walletv1.DeleteChequeRequest{
+			WalletId: testWalletID,
+			Id:       chequeID,
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+		// The row must survive — its recorded funds are still unswept.
+		_, err = cheques.Get(context.Background(), db, testWalletID, chequeID)
+		require.NoError(t, err)
+	})
+
+	t.Run("fully funded unswept cheque cannot be deleted", func(t *testing.T) {
+		t.Parallel()
+
+		cli, db := deleteChequeClient(t)
+
+		chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qfulldelete0000000000000000000000000000000")
+		require.NoError(t, err)
+		require.NoError(t, cheques.UpdateFunding(context.Background(), db, testWalletID, chequeID,
+			[]string{"full0000full0000full0000full0000full0000full0000full0000full0000"}, 100_000_000))
+
+		_, err = cli.DeleteCheque(context.Background(), connect.NewRequest(&walletv1.DeleteChequeRequest{
+			WalletId: testWalletID,
+			Id:       chequeID,
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+		_, err = cheques.Get(context.Background(), db, testWalletID, chequeID)
+		require.NoError(t, err)
+	})
+
+	t.Run("swept cheque can be deleted", func(t *testing.T) {
+		t.Parallel()
+
+		cli, db := deleteChequeClient(t)
+
+		chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qsweptdelete000000000000000000000000000000")
+		require.NoError(t, err)
+		require.NoError(t, cheques.UpdateFunding(context.Background(), db, testWalletID, chequeID,
+			[]string{"swept000swept000swept000swept000swept000swept000swept000swept000"}, 100_000_000))
+		require.NoError(t, cheques.UpdateSwept(context.Background(), db, testWalletID, chequeID,
+			"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef0"))
+
+		_, err = cli.DeleteCheque(context.Background(), connect.NewRequest(&walletv1.DeleteChequeRequest{
+			WalletId: testWalletID,
+			Id:       chequeID,
+		}))
+		require.NoError(t, err)
+
+		// Once swept, the row is gone.
+		_, err = cheques.Get(context.Background(), db, testWalletID, chequeID)
+		require.ErrorIs(t, err, sql.ErrNoRows)
 	})
 }
 

--- a/bitwindow/server/database/migrations/040_transaction_notes_wallet_id.sql
+++ b/bitwindow/server/database/migrations/040_transaction_notes_wallet_id.sql
@@ -1,0 +1,16 @@
+-- Scope transaction notes by wallet so a note written while viewing one wallet
+-- does not surface in another wallet's transaction list. The old table keyed
+-- notes on txid alone, which is shared across wallets. SQLite cannot change a
+-- table's primary key in place, so recreate it with a composite
+-- (wallet_id, txid) primary key.
+
+CREATE TABLE IF NOT EXISTS transaction_notes_new (
+    wallet_id TEXT NOT NULL,
+    txid TEXT NOT NULL,
+    note TEXT NOT NULL,
+    set_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (wallet_id, txid)
+);
+
+DROP TABLE IF EXISTS transaction_notes;
+ALTER TABLE transaction_notes_new RENAME TO transaction_notes;

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -208,6 +208,14 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 		if err := p.purgeCoinNewsAtOrAbove(ctx, lastProcessedHeight+1); err != nil {
 			return fmt.Errorf("purge coinnews on reorg: %w", err)
 		}
+
+		// Same for the M4 SCDB (M3 proposals, M4 votes, withdrawal bundles):
+		// persistM3Message inserts bundles idempotently, so a proposal that
+		// existed only in an orphaned block would otherwise survive the replay
+		// as 'pending' and GenerateM4Bytes would vote on the stale bundle.
+		if err := p.m4Engine.PurgeReorgedState(ctx, lastProcessedHeight+1); err != nil {
+			return fmt.Errorf("purge m4 scdb on reorg: %w", err)
+		}
 	}
 
 	const batchSize = 30

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -503,8 +503,10 @@ func (e *BitDriveEngine) SaveFile(ctx context.Context, txid string, content []by
 		return nil
 	}
 
-	// Generate filename
-	filename := fmt.Sprintf("%d.%s", metadata.Timestamp, metadata.FileType)
+	// Generate filename. The txid is included so that two distinct
+	// transactions sharing the same timestamp and file type do not collide
+	// on the same local path and overwrite each other.
+	filename := fmt.Sprintf("%d_%s.%s", metadata.Timestamp, txid, metadata.FileType)
 	filePath := filepath.Join(e.bitdriveDir, filename)
 
 	// Write file

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -2,9 +2,13 @@ package engines
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/bitdrive"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestOpenDir_CreatesDirectory(t *testing.T) {
@@ -41,5 +45,76 @@ func TestGetDir(t *testing.T) {
 	}
 	if got := engine.GetDir(); got != "/some/path" {
 		t.Fatalf("expected /some/path, got %s", got)
+	}
+}
+
+// TestSaveFile_SameSecondNoCollision verifies that two distinct transactions
+// sharing an identical timestamp and file type are written to distinct local
+// paths, so neither overwrites the other on disk.
+func TestSaveFile_SameSecondNoCollision(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`
+		CREATE TABLE bitdrive_files (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			txid TEXT NOT NULL UNIQUE,
+			filename TEXT NOT NULL,
+			file_type TEXT NOT NULL,
+			size_bytes INTEGER NOT NULL,
+			encrypted INTEGER NOT NULL DEFAULT 0,
+			timestamp INTEGER NOT NULL,
+			created_at INTEGER NOT NULL
+		)
+	`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	engine := &BitDriveEngine{
+		db:          db,
+		bitdriveDir: t.TempDir(),
+	}
+
+	meta := &ParsedMetadata{Timestamp: 1700000000, FileType: "txt"}
+
+	if err := engine.SaveFile(ctx, "txid-first", []byte("first file"), meta); err != nil {
+		t.Fatalf("save first file: %v", err)
+	}
+	if err := engine.SaveFile(ctx, "txid-second", []byte("second file"), meta); err != nil {
+		t.Fatalf("save second file: %v", err)
+	}
+
+	first, err := bitdrive.GetByTxID(ctx, db, "txid-first")
+	if err != nil || first == nil {
+		t.Fatalf("get first record: %v", err)
+	}
+	second, err := bitdrive.GetByTxID(ctx, db, "txid-second")
+	if err != nil || second == nil {
+		t.Fatalf("get second record: %v", err)
+	}
+
+	if first.Filename == second.Filename {
+		t.Fatalf("expected distinct filenames, both were %q", first.Filename)
+	}
+
+	firstContent, err := engine.GetFileContent(ctx, first.Filename)
+	if err != nil {
+		t.Fatalf("read first content: %v", err)
+	}
+	secondContent, err := engine.GetFileContent(ctx, second.Filename)
+	if err != nil {
+		t.Fatalf("read second content: %v", err)
+	}
+
+	if string(firstContent) != "first file" {
+		t.Fatalf("first file was overwritten: got %q", firstContent)
+	}
+	if string(secondContent) != "second file" {
+		t.Fatalf("second file content wrong: got %q", secondContent)
 	}
 }

--- a/bitwindow/server/engines/deniability_engine.go
+++ b/bitwindow/server/engines/deniability_engine.go
@@ -189,7 +189,7 @@ func (e *DeniabilityEngine) cancelIfUTXOIsGone(ctx context.Context, walletUTXOs 
 		})
 
 		if !utxoExists {
-			if err := deniability.Cancel(ctx, e.db, denial.ID, "cancelled due to UTXO being moved"); err != nil {
+			if err := deniability.Cancel(ctx, e.db, walletId, denial.ID, "cancelled due to UTXO being moved"); err != nil {
 				return fmt.Errorf("cancel denial %d: %w", denial.ID, err)
 			}
 
@@ -244,7 +244,7 @@ func (e *DeniabilityEngine) ProcessUTXO(ctx context.Context, utxo *pb.ListUnspen
 		reason := "utxo is too small to split"
 		logger.Warn().Msg("cancelling denial due to insufficient UTXO amount")
 
-		if err := deniability.Cancel(ctx, e.db, denial.ID, reason); err != nil {
+		if err := deniability.Cancel(ctx, e.db, lo.FromPtr(denial.WalletID), denial.ID, reason); err != nil {
 			return fmt.Errorf("cancel denial: %w", err)
 		}
 		return nil

--- a/bitwindow/server/engines/m4_engine.go
+++ b/bitwindow/server/engines/m4_engine.go
@@ -468,6 +468,34 @@ func (e *M4Engine) updateBundleStates(ctx context.Context) error {
 	return nil
 }
 
+// PurgeReorgedState deletes every SCDB row derived from a block at or above
+// `fromHeight`. Called when the engine detects a reorg and replays a height
+// range: persistM3Message / persistM4Message insert idempotently
+// (ON CONFLICT DO NOTHING/UPDATE), so without this purge an M3 withdrawal-bundle
+// proposal that existed only in an orphaned block survives the replay as a
+// 'pending' bundle and GenerateM4Bytes votes on it. Mirrors
+// purgeCoinNewsAtOrAbove for the M4 tables.
+func (e *M4Engine) PurgeReorgedState(ctx context.Context, fromHeight uint32) error {
+	tx, err := e.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmts := []string{
+		`DELETE FROM m4_votes         WHERE m4_message_id IN (SELECT id FROM m4_messages WHERE block_height >= ?)`,
+		`DELETE FROM m4_messages      WHERE block_height >= ?`,
+		`DELETE FROM m3_messages      WHERE block_height >= ?`,
+		`DELETE FROM withdrawal_bundles WHERE first_seen_height >= ?`,
+	}
+	for _, q := range stmts {
+		if _, err := tx.ExecContext(ctx, q, fromHeight); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 // GetWithdrawalBundles returns active withdrawal bundles for a sidechain
 func (e *M4Engine) GetWithdrawalBundles(ctx context.Context, sidechainSlot *uint8) ([]m4.WithdrawalBundle, error) {
 	query := `

--- a/bitwindow/server/engines/m4_engine_reorg_test.go
+++ b/bitwindow/server/engines/m4_engine_reorg_test.go
@@ -1,0 +1,56 @@
+package engines
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/m4"
+)
+
+// TestM4Engine_PurgeReorgedState_DropsOrphanedBundles verifies that a
+// withdrawal-bundle proposal seen only in an orphaned block does not survive a
+// same-height reorg replay: PurgeReorgedState drops the bundle first seen at or
+// above the replay height, while a bundle first seen below it is untouched.
+// Without the purge the orphan lingers as 'pending' and GenerateM4Bytes votes
+// on it.
+func TestM4Engine_PurgeReorgedState_DropsOrphanedBundles(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	e := NewM4Engine(database.Test(t))
+
+	blockTime := time.Date(2026, 6, 16, 4, 30, 0, 0, time.UTC)
+
+	// Bundle first seen below the reorg window — must survive.
+	require.NoError(t, e.persistM3Message(ctx, &m4.M3Message{
+		BlockHeight:   90,
+		BlockHash:     "old",
+		BlockTime:     blockTime,
+		SidechainSlot: 0,
+		BundleHash:    "aaaa",
+	}))
+
+	// Orphaned bundle first seen only in the block we're about to replay.
+	require.NoError(t, e.persistM3Message(ctx, &m4.M3Message{
+		BlockHeight:   100,
+		BlockHash:     "orphan",
+		BlockTime:     blockTime,
+		SidechainSlot: 0,
+		BundleHash:    "bbbb",
+	}))
+
+	before, err := e.GetWithdrawalBundles(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, before, 2)
+
+	// Reorg replays from height 100 downward through the rewind window.
+	require.NoError(t, e.PurgeReorgedState(ctx, 100))
+
+	after, err := e.GetWithdrawalBundles(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	require.Equal(t, "aaaa", after[0].BundleHash)
+}

--- a/bitwindow/server/models/deniability/deniability.go
+++ b/bitwindow/server/models/deniability/deniability.go
@@ -266,14 +266,15 @@ func listExecutions(ctx context.Context, db *sql.DB, denialID int64) ([]Executed
 	return executions, nil
 }
 
-// Cancel marks a deniability plan as cancelled
-func Cancel(ctx context.Context, db *sql.DB, id int64, reason string) error {
+// Cancel marks a deniability plan as cancelled. The update is scoped to
+// walletID so one wallet cannot cancel another wallet's plan.
+func Cancel(ctx context.Context, db *sql.DB, walletID string, id int64, reason string) error {
 	rows, err := db.ExecContext(ctx, `
 		UPDATE denials
 			SET cancelled_at = ?,
 			cancelled_reason = ?
-		WHERE id = ?
-	`, time.Now(), reason, id)
+		WHERE id = ? AND wallet_id = ?
+	`, time.Now(), reason, id, walletID)
 	if err != nil {
 		return fmt.Errorf("could not cancel deniability: %w", err)
 	}
@@ -285,13 +286,14 @@ func Cancel(ctx context.Context, db *sql.DB, id int64, reason string) error {
 	return nil
 }
 
-// Pause marks a deniability plan as paused
-func Pause(ctx context.Context, db *sql.DB, id int64) error {
+// Pause marks a deniability plan as paused. The update is scoped to walletID
+// so one wallet cannot pause another wallet's plan.
+func Pause(ctx context.Context, db *sql.DB, walletID string, id int64) error {
 	rows, err := db.ExecContext(ctx, `
 		UPDATE denials
 			SET paused_at = ?
-		WHERE id = ? AND paused_at IS NULL AND cancelled_at IS NULL
-	`, time.Now(), id)
+		WHERE id = ? AND wallet_id = ? AND paused_at IS NULL AND cancelled_at IS NULL
+	`, time.Now(), id, walletID)
 	if err != nil {
 		return fmt.Errorf("could not pause deniability: %w", err)
 	}
@@ -303,13 +305,14 @@ func Pause(ctx context.Context, db *sql.DB, id int64) error {
 	return nil
 }
 
-// Resume resumes a paused deniability plan
-func Resume(ctx context.Context, db *sql.DB, id int64) error {
+// Resume resumes a paused deniability plan. The update is scoped to walletID
+// so one wallet cannot resume another wallet's plan.
+func Resume(ctx context.Context, db *sql.DB, walletID string, id int64) error {
 	rows, err := db.ExecContext(ctx, `
 		UPDATE denials
 			SET paused_at = NULL
-		WHERE id = ? AND paused_at IS NOT NULL
-	`, id)
+		WHERE id = ? AND wallet_id = ? AND paused_at IS NOT NULL
+	`, id, walletID)
 	if err != nil {
 		return fmt.Errorf("could not resume deniability: %w", err)
 	}

--- a/bitwindow/server/models/deniability/deniability_test.go
+++ b/bitwindow/server/models/deniability/deniability_test.go
@@ -119,7 +119,7 @@ func TestDeniability(t *testing.T) {
 
 		// Cancel the denial
 		reason := "test cancellation"
-		err = Cancel(ctx, db, denialID, reason)
+		err = Cancel(ctx, db, "test-wallet", denialID, reason)
 		require.NoError(t, err)
 
 		// Verify the cancellation

--- a/bitwindow/server/models/multisig/multisig.go
+++ b/bitwindow/server/models/multisig/multisig.go
@@ -874,9 +874,10 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 			return fmt.Errorf("save group %s: %w", g.ID, err)
 		}
 
-		// Import keys
+		// Import keys — always replace so a restored group never inherits a
+		// prior group's keys when the backup omits/empties the field.
+		var keys []Key
 		if keysRaw, ok := gj["keys"].([]interface{}); ok {
-			var keys []Key
 			for i, kr := range keysRaw {
 				kd, ok := kr.(map[string]interface{})
 				if !ok {
@@ -893,14 +894,14 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 					SortOrder:      i,
 				})
 			}
-			if err := s.ReplaceKeysForGroup(ctx, g.ID, keys); err != nil {
-				return fmt.Errorf("replace keys for %s: %w", g.ID, err)
-			}
+		}
+		if err := s.ReplaceKeysForGroup(ctx, g.ID, keys); err != nil {
+			return fmt.Errorf("replace keys for %s: %w", g.ID, err)
 		}
 
-		// Import addresses
+		// Import addresses — always replace so stale addresses don't survive.
+		var addrs []Address
 		if addrData, ok := gj["addresses"].(map[string]interface{}); ok {
-			var addrs []Address
 			for _, addrType := range []string{"receive", "change"} {
 				if addrList, ok := addrData[addrType].([]interface{}); ok {
 					for _, ad := range addrList {
@@ -918,26 +919,22 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 					}
 				}
 			}
-			if len(addrs) > 0 {
-				if err := s.ReplaceAddresses(ctx, g.ID, addrs); err != nil {
-					return fmt.Errorf("replace addresses for %s: %w", g.ID, err)
-				}
-			}
+		}
+		if err := s.ReplaceAddresses(ctx, g.ID, addrs); err != nil {
+			return fmt.Errorf("replace addresses for %s: %w", g.ID, err)
 		}
 
-		// Import transaction IDs
+		// Import transaction IDs — always replace so stale tx links don't survive.
+		var ids []string
 		if txIDs, ok := gj["transaction_ids"].([]interface{}); ok {
-			var ids []string
 			for _, id := range txIDs {
 				if s, ok := id.(string); ok {
 					ids = append(ids, s)
 				}
 			}
-			if len(ids) > 0 {
-				if err := s.ReplaceGroupTransactionIDs(ctx, g.ID, ids); err != nil {
-					return fmt.Errorf("replace tx ids for %s: %w", g.ID, err)
-				}
-			}
+		}
+		if err := s.ReplaceGroupTransactionIDs(ctx, g.ID, ids); err != nil {
+			return fmt.Errorf("replace tx ids for %s: %w", g.ID, err)
 		}
 	}
 

--- a/bitwindow/server/models/transactions/transactions.go
+++ b/bitwindow/server/models/transactions/transactions.go
@@ -10,9 +10,10 @@ import (
 )
 
 type TransactionNote struct {
-	TxID  string
-	Note  string
-	SetAt time.Time
+	WalletID string
+	TxID     string
+	Note     string
+	SetAt    time.Time
 }
 
 func Get(ctx context.Context, db *sql.DB, txid string) (TransactionNote, error) {
@@ -27,7 +28,7 @@ func Get(ctx context.Context, db *sql.DB, txid string) (TransactionNote, error) 
 }
 
 func List(ctx context.Context, db *sql.DB) ([]TransactionNote, error) {
-	rows, err := db.QueryContext(ctx, `SELECT txid, note, set_at FROM transaction_notes`)
+	rows, err := db.QueryContext(ctx, `SELECT wallet_id, txid, note, set_at FROM transaction_notes`)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +37,7 @@ func List(ctx context.Context, db *sql.DB) ([]TransactionNote, error) {
 	var notes []TransactionNote
 	for rows.Next() {
 		var note TransactionNote
-		err := rows.Scan(&note.TxID, &note.Note, &note.SetAt)
+		err := rows.Scan(&note.WalletID, &note.TxID, &note.Note, &note.SetAt)
 		if err != nil {
 			return nil, err
 		}
@@ -46,16 +47,42 @@ func List(ctx context.Context, db *sql.DB) ([]TransactionNote, error) {
 	return notes, rows.Err()
 }
 
-func SetNote(ctx context.Context, db *sql.DB, txid string, note string) error {
+// ListByWallet returns only the notes belonging to walletID. Transaction
+// listings are wallet-scoped, so a note written while viewing one wallet must
+// not surface in another wallet's list.
+func ListByWallet(ctx context.Context, db *sql.DB, walletID string) ([]TransactionNote, error) {
+	rows, err := db.QueryContext(ctx, `SELECT wallet_id, txid, note, set_at FROM transaction_notes WHERE wallet_id = ?`, walletID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var notes []TransactionNote
+	for rows.Next() {
+		var note TransactionNote
+		err := rows.Scan(&note.WalletID, &note.TxID, &note.Note, &note.SetAt)
+		if err != nil {
+			return nil, err
+		}
+
+		notes = append(notes, note)
+	}
+	return notes, rows.Err()
+}
+
+func SetNote(ctx context.Context, db *sql.DB, walletID string, txid string, note string) error {
+	if walletID == "" {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("wallet_id cannot be empty"))
+	}
 	if txid == "" {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("txid cannot be empty"))
 	}
 
 	rows, err := db.ExecContext(ctx, `
-		INSERT INTO transaction_notes (txid, note) 
-		VALUES (?, ?)
-		ON CONFLICT(txid) DO UPDATE SET note = ?, set_at = CURRENT_TIMESTAMP`,
-		txid, note, note)
+		INSERT INTO transaction_notes (wallet_id, txid, note)
+		VALUES (?, ?, ?)
+		ON CONFLICT(wallet_id, txid) DO UPDATE SET note = ?, set_at = CURRENT_TIMESTAMP`,
+		walletID, txid, note, note)
 
 	if rows, _ := rows.RowsAffected(); rows == 0 {
 		return connect.NewError(connect.CodeNotFound, fmt.Errorf("transaction note not found"))

--- a/sidechain-orchestrator/api/bip47_send.go
+++ b/sidechain-orchestrator/api/bip47_send.go
@@ -100,7 +100,13 @@ func (h *WalletHandler) expandBip47Destinations(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("read bip47 state: %w", err))
 	}
-	if state != nil && state.NotificationTxID != nil {
+	// A persisted NotificationTxID only proves the recipient was notified while
+	// that tx is still live on-chain or in the mempool. If it was reorged out,
+	// RBF-replaced, or dropped, we must re-notify — otherwise this send pays a
+	// derived address the recipient can never discover. Revalidate against the
+	// chain before trusting the stored txid.
+	if state != nil && state.NotificationTxID != nil &&
+		h.bip47NotificationLive(ctx, walletID, *state.NotificationTxID) {
 		return expansion, nil
 	}
 
@@ -110,6 +116,18 @@ func (h *WalletHandler) expandBip47Destinations(
 	}
 	expansion.notificationTxHex = rawHex
 	return expansion, nil
+}
+
+// bip47NotificationLive reports whether a previously broadcast notification tx
+// is still discoverable on the chain the wallet uses (confirmed or in the
+// mempool). A stored NotificationTxID that no longer resolves — reorged out,
+// RBF-replaced, or dropped — must not be trusted as proof of notification, so
+// the caller re-notifies. A lookup error is treated as "not live": re-notifying
+// is safe (the recipient de-dupes) and preserves the recipient's ability to
+// discover the payment address.
+func (h *WalletHandler) bip47NotificationLive(ctx context.Context, walletID, txid string) bool {
+	tx, err := h.engine.ChainForWallet(walletID).GetRawTransaction(ctx, txid)
+	return err == nil && tx != nil
 }
 
 // buildBip47NotificationTx assembles the unsigned notification transaction by


### PR DESCRIPTION
## Summary

Added upper-bound (>255) validation to M4 SetVotePreference before the uint8 narrowing cast so slot 256 is rejected instead of wrapping to slot 0, plus a regression subtest.

## The bug

BitWindow M4 vote preference wraps sidechain slot 256 to slot 0

Severity: Low. Finding (access-controlled): https://giaki3003.tech/#/findings/20260619-0638-kimiclaw-confirm-openclaw-drivechain-frontends-m4-sidechain-slot-wrap

## Stack

Part of a stacked series for `drivechain-frontends` (fix 8 of 19). Builds on https://github.com/LayerTwo-Labs/drivechain-frontends/pull/1882 — best merged bottom-up; I'll rebase to keep each diff minimal as earlier ones land.