### PR TITLE
fix: BitWindow notification engine truncates satoshi amounts from float64 BTC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ vendor/
 # Build artifacts
 sidechain-orchestrator/orchestratorctl
 sidechain-orchestrator/orchestratord
+
+# Orchestration harness artifacts
+.omo/

--- a/bitwindow/server/api/bitdrive/bitdrive.go
+++ b/bitwindow/server/api/bitdrive/bitdrive.go
@@ -185,7 +185,7 @@ func (s *Server) ScanForFiles(ctx context.Context, req *connect.Request[emptypb.
 			Encrypted: metadata.Encrypted,
 			Timestamp: metadata.Timestamp,
 			FileType:  metadata.FileType,
-			Filename:  fmt.Sprintf("%d.%s", metadata.Timestamp, metadata.FileType),
+			Filename:  fmt.Sprintf("%d_%s.%s", metadata.Timestamp, opReturn.TxID, metadata.FileType),
 		})
 	}
 

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -566,7 +566,16 @@ func (s *Server) GetSyncInfo(ctx context.Context, req *connect.Request[emptypb.E
 
 // SetTransactionNote implements bitwindowdv1connect.BitwindowdServiceHandler.
 func (s *Server) SetTransactionNote(ctx context.Context, req *connect.Request[pb.SetTransactionNoteRequest]) (*connect.Response[emptypb.Empty], error) {
-	if err := transactions.SetNote(ctx, s.db, req.Msg.Txid, req.Msg.Note); err != nil {
+	// Notes are private, wallet-local metadata. Scope them to the wallet the
+	// user is currently viewing (the active wallet) so a note written here does
+	// not surface in another wallet's transaction list.
+	activeWallet, err := s.walletEngine.GetActiveWallet(ctx)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msg("could not get active wallet")
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	if err := transactions.SetNote(ctx, s.db, activeWallet.ID, req.Msg.Txid, req.Msg.Note); err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not set transaction note")
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -625,6 +634,14 @@ func (s *Server) ExportLabels(ctx context.Context, req *connect.Request[emptypb.
 
 // ImportLabels implements bitwindowdv1connect.BitwindowdServiceHandler.
 func (s *Server) ImportLabels(ctx context.Context, req *connect.Request[pb.ImportLabelsRequest]) (*connect.Response[pb.ImportLabelsResponse], error) {
+	// Transaction notes are wallet-scoped; BIP329 tx labels carry only a txid,
+	// so import them into the wallet the user is currently viewing.
+	activeWallet, err := s.walletEngine.GetActiveWallet(ctx)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msg("could not get active wallet")
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
 	labels, skipped := bip329.Decode(req.Msg.Jsonl)
 
 	resp := &pb.ImportLabelsResponse{Skipped: int64(skipped)}
@@ -647,7 +664,7 @@ func (s *Server) ImportLabels(ctx context.Context, req *connect.Request[pb.Impor
 			resp.ImportedAddresses++
 
 		case bip329.TypeTx:
-			if err := transactions.SetNote(ctx, s.db, ref, l.Label); err != nil {
+			if err := transactions.SetNote(ctx, s.db, activeWallet.ID, ref, l.Label); err != nil {
 				zerolog.Ctx(ctx).Error().Err(err).Str("ref", ref).Msg("could not import transaction note")
 				resp.Skipped++
 				continue

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -337,7 +337,15 @@ func (s *Server) CancelDenial(
 	ctx context.Context,
 	req *connect.Request[pb.CancelDenialRequest],
 ) (*connect.Response[emptypb.Empty], error) {
-	err := deniability.Cancel(ctx, s.db, req.Msg.Id, "cancelled by user")
+	// Scope the mutation to the active wallet so one wallet cannot cancel
+	// another wallet's deniability plan.
+	activeWallet, err := s.walletEngine.GetActiveWallet(ctx)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msg("could not get active wallet")
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	err = deniability.Cancel(ctx, s.db, activeWallet.ID, req.Msg.Id, "cancelled by user")
 	if err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not cancel denial")
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -350,7 +358,15 @@ func (s *Server) PauseDenial(
 	ctx context.Context,
 	req *connect.Request[pb.PauseDenialRequest],
 ) (*connect.Response[emptypb.Empty], error) {
-	err := deniability.Pause(ctx, s.db, req.Msg.Id)
+	// Scope the mutation to the active wallet so one wallet cannot pause
+	// another wallet's deniability plan.
+	activeWallet, err := s.walletEngine.GetActiveWallet(ctx)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msg("could not get active wallet")
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	err = deniability.Pause(ctx, s.db, activeWallet.ID, req.Msg.Id)
 	if err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not pause denial")
 		return nil, err
@@ -363,7 +379,15 @@ func (s *Server) ResumeDenial(
 	ctx context.Context,
 	req *connect.Request[pb.ResumeDenialRequest],
 ) (*connect.Response[emptypb.Empty], error) {
-	err := deniability.Resume(ctx, s.db, req.Msg.Id)
+	// Scope the mutation to the active wallet so one wallet cannot resume
+	// another wallet's deniability plan.
+	activeWallet, err := s.walletEngine.GetActiveWallet(ctx)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msg("could not get active wallet")
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	err = deniability.Resume(ctx, s.db, activeWallet.ID, req.Msg.Id)
 	if err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not resume denial")
 		return nil, err

--- a/bitwindow/server/api/bitwindowd/bitwindowd_test.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd_test.go
@@ -1271,6 +1271,75 @@ func TestService_ResumeDenial(t *testing.T) {
 	})
 }
 
+// TestService_DenialMutations_WalletScoped asserts that the Cancel/Pause/Resume
+// RPC handlers only mutate the active wallet's plans. The test harness resolves
+// the active wallet to "test-wallet-id-1234"; here we plant a denial owned by a
+// different wallet and confirm each mutation is rejected and leaves it untouched.
+func TestService_DenialMutations_WalletScoped(t *testing.T) {
+	t.Parallel()
+
+	const otherWallet = "other-wallet-id"
+
+	t.Run("cannot cancel another wallet's denial", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		db := database.Test(t)
+		cli := v1connect.NewBitwindowdServiceClient(apitests.API(t, db))
+
+		denial, err := deniability.Create(ctx, db, otherWallet, "othertxid", 0, time.Hour, 3, nil)
+		require.NoError(t, err)
+
+		_, err = cli.CancelDenial(ctx, connect.NewRequest(&v1.CancelDenialRequest{Id: denial.ID}))
+		require.Error(t, err)
+
+		got, err := deniability.Get(ctx, db, denial.ID)
+		require.NoError(t, err)
+		assert.Nil(t, got.CancelledAt)
+		require.NotNil(t, got.WalletID)
+		assert.Equal(t, otherWallet, *got.WalletID)
+	})
+
+	t.Run("cannot pause another wallet's denial", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		db := database.Test(t)
+		cli := v1connect.NewBitwindowdServiceClient(apitests.API(t, db))
+
+		denial, err := deniability.Create(ctx, db, otherWallet, "othertxid", 0, time.Hour, 3, nil)
+		require.NoError(t, err)
+
+		_, err = cli.PauseDenial(ctx, connect.NewRequest(&v1.PauseDenialRequest{Id: denial.ID}))
+		require.Error(t, err)
+
+		got, err := deniability.Get(ctx, db, denial.ID)
+		require.NoError(t, err)
+		assert.Nil(t, got.PausedAt)
+	})
+
+	t.Run("cannot resume another wallet's denial", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		db := database.Test(t)
+		cli := v1connect.NewBitwindowdServiceClient(apitests.API(t, db))
+
+		denial, err := deniability.Create(ctx, db, otherWallet, "othertxid", 0, time.Hour, 3, nil)
+		require.NoError(t, err)
+
+		// Pause it as its owner so there is a paused plan to attempt to resume.
+		require.NoError(t, deniability.Pause(ctx, db, otherWallet, denial.ID))
+
+		_, err = cli.ResumeDenial(ctx, connect.NewRequest(&v1.ResumeDenialRequest{Id: denial.ID}))
+		require.Error(t, err)
+
+		got, err := deniability.Get(ctx, db, denial.ID)
+		require.NoError(t, err)
+		assert.NotNil(t, got.PausedAt)
+	})
+}
+
 func TestService_ListBlocks(t *testing.T) {
 	t.Parallel()
 

--- a/bitwindow/server/api/m4/m4.go
+++ b/bitwindow/server/api/m4/m4.go
@@ -105,6 +105,11 @@ func (s *Server) SetVotePreference(
 		return nil, fmt.Errorf("invalid vote type: %s", req.Msg.VoteType)
 	}
 
+	// Validate sidechain slot (0-255) before narrowing to uint8
+	if req.Msg.SidechainSlot > 255 {
+		return nil, fmt.Errorf("invalid sidechain slot: %d (must be 0-255)", req.Msg.SidechainSlot)
+	}
+
 	var bundleHash *string
 	if req.Msg.BundleHash != nil {
 		bundleHash = req.Msg.BundleHash

--- a/bitwindow/server/api/m4/m4_test.go
+++ b/bitwindow/server/api/m4/m4_test.go
@@ -195,6 +195,25 @@ func TestService_SetVotePreference(t *testing.T) {
 		require.Len(t, prefs.Msg.Preferences, 1)
 		assert.Equal(t, uint32(255), prefs.Msg.Preferences[0].SidechainSlot)
 	})
+
+	t.Run("out-of-range sidechain slot (256) returns error and does not wrap", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.Test(t)
+		cli := m4v1connect.NewM4ServiceClient(apitests.API(t, db))
+
+		// Slot 256 overflows uint8 and would wrap to slot 0 without validation.
+		_, err := cli.SetVotePreference(context.Background(), connect.NewRequest(&m4pb.SetVotePreferenceRequest{
+			SidechainSlot: 256,
+			VoteType:      "alarm",
+		}))
+		require.Error(t, err)
+
+		// No preference should have been stored for the wrapped slot 0.
+		prefs, err := cli.GetVotePreferences(context.Background(), connect.NewRequest(&m4pb.GetVotePreferencesRequest{}))
+		require.NoError(t, err)
+		assert.Empty(t, prefs.Msg.Preferences)
+	})
 }
 
 func TestService_GetM4History(t *testing.T) {

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -2248,7 +2248,7 @@ func (s *Server) CheckChequeFunding(ctx context.Context, c *connect.Request[pb.C
 		}
 
 		// Convert BTC to satoshis
-		amountSats := uint64(totalAmount * 100000000)
+		amountSats := uint64(math.Round(totalAmount * 100000000))
 
 		// Always update — handles new fundings arriving after first one
 		if err := cheques.UpdateFunding(ctx, s.database, walletId, c.Msg.Id, txids, amountSats); err != nil {
@@ -2372,7 +2372,7 @@ func (s *Server) SweepCheque(ctx context.Context, c *connect.Request[pb.SweepChe
 	totalAmountBTC := lo.SumBy(utxos.Msg.Unspent, func(utxo *corepb.UnspentOutput) float64 {
 		return utxo.Amount
 	})
-	totalAmount := uint64(totalAmountBTC * 1e8)
+	totalAmount := uint64(math.Round(totalAmountBTC * 1e8))
 
 	// Set fee rate
 	feeSatPerVbyte := c.Msg.FeeSatPerVbyte
@@ -2550,7 +2550,7 @@ func (s *Server) buildSweepTx(
 	// Calculate total amount in satoshis
 	var totalSats uint64
 	for _, utxo := range utxos {
-		totalSats += uint64(utxo.Amount * 1e8)
+		totalSats += uint64(math.Round(utxo.Amount * 1e8))
 	}
 
 	// Estimate transaction size (P2WPKH input is ~68 vbytes, P2WPKH output is ~31 vbytes, overhead ~11 vbytes)
@@ -2626,10 +2626,10 @@ func (s *Server) signSweepTx(
 		witnessScript, err := txscript.WitnessSignature(
 			tx, txscript.NewTxSigHashes(tx, txscript.NewCannedPrevOutputFetcher(
 				sourcePkScript,
-				int64(utxo.Amount*1e8),
+				int64(math.Round(utxo.Amount*1e8)),
 			)),
 			i,
-			int64(utxo.Amount*1e8),
+			int64(math.Round(utxo.Amount*1e8)),
 			sourcePkScript,
 			txscript.SigHashAll,
 			wif.PrivKey,

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -2486,8 +2486,8 @@ func (s *Server) DeleteCheque(ctx context.Context, c *connect.Request[pb.DeleteC
 	}
 
 	// Only allow deletion of unfunded or swept cheques
-	// Funded but not swept = still has money, can't delete
-	if cheque.IsFunded() && cheque.SweptTxid == nil {
+	// Any recorded incoming funds (full or partial) but not swept = still has money, can't delete
+	if (cheque.IsFunded() || cheque.IsPartiallyFunded()) && cheque.SweptTxid == nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot delete funded cheque"))
 	}
 

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -895,7 +895,7 @@ func (s *Server) ListTransactions(ctx context.Context, c *connect.Request[pb.Lis
 			return nil, fmt.Errorf("enforcer/wallet: could not list addressbook: %w", err)
 		}
 
-		notes, err := transactions.List(ctx, s.database)
+		notes, err := transactions.ListByWallet(ctx, s.database, walletId)
 		if err != nil {
 			return nil, fmt.Errorf("enforcer/wallet: could not list transactions: %w", err)
 		}
@@ -972,7 +972,7 @@ func (s *Server) ListTransactions(ctx context.Context, c *connect.Request[pb.Lis
 			}
 			return ""
 		}
-		notes, err := transactions.List(ctx, s.database)
+		notes, err := transactions.ListByWallet(ctx, s.database, walletId)
 		if err != nil {
 			return nil, fmt.Errorf("electrum: could not list notes: %w", err)
 		}
@@ -1039,7 +1039,7 @@ func (s *Server) ListTransactions(ctx context.Context, c *connect.Request[pb.Lis
 		return nil, fmt.Errorf("list addressbook: %w", err)
 	}
 
-	notes, err := transactions.List(ctx, s.database)
+	notes, err := transactions.ListByWallet(ctx, s.database, walletId)
 	if err != nil {
 		return nil, fmt.Errorf("list transactions: %w", err)
 	}

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -2,12 +2,14 @@ package api_wallet_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"connectrpc.com/connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	walletv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1"
 	walletv1connect "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1/walletv1connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
 	mainchainv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
@@ -214,6 +216,106 @@ func TestService_DeleteCheque(t *testing.T) {
 		// A non-existent cheque must surface as NotFound, not a leaked
 		// "no rows" internal error.
 		require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	})
+}
+
+// TestService_DeleteChequeFundingGuard pins the server-side deletion guard:
+// a cheque with any recorded incoming funds (partial or full) that has not
+// been swept must not be deletable, because its row still represents real
+// money at the derived address. Once swept, the row is safe to remove.
+func TestService_DeleteChequeFundingGuard(t *testing.T) {
+	t.Parallel()
+
+	// deleteChequeClient stands up an API server with the permissive bitcoind
+	// mock the cheque engine bootstrap needs, and hands back both a client and
+	// the backing database so the test can seed cheque funding state directly.
+	deleteChequeClient := func(t *testing.T) (walletv1connect.WalletServiceClient, *sql.DB) {
+		t.Helper()
+
+		ctrl := gomock.NewController(t)
+		db := database.Test(t)
+
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		mockBitcoind.EXPECT().
+			ListWallets(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.ListWalletsResponse]{
+				Msg: &bitcoindv1alpha.ListWalletsResponse{Wallets: []string{}},
+			}, nil).AnyTimes()
+		mockBitcoind.EXPECT().
+			CreateWallet(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.CreateWalletResponse]{
+				Msg: &bitcoindv1alpha.CreateWalletResponse{Name: "cheque_watch"},
+			}, nil).AnyTimes()
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, db, apitests.WithBitcoind(mockBitcoind)))
+		return cli, db
+	}
+
+	t.Run("partially funded unswept cheque cannot be deleted", func(t *testing.T) {
+		t.Parallel()
+
+		cli, db := deleteChequeClient(t)
+
+		// Cheque expects 1 BTC but only 0.5 BTC arrived: partially funded, unswept.
+		chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qpartialdelete000000000000000000000000000")
+		require.NoError(t, err)
+		require.NoError(t, cheques.UpdateFunding(context.Background(), db, testWalletID, chequeID,
+			[]string{"partial0partial0partial0partial0partial0partial0partial0partial0"}, 50_000_000))
+
+		_, err = cli.DeleteCheque(context.Background(), connect.NewRequest(&walletv1.DeleteChequeRequest{
+			WalletId: testWalletID,
+			Id:       chequeID,
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+		// The row must survive — its recorded funds are still unswept.
+		_, err = cheques.Get(context.Background(), db, testWalletID, chequeID)
+		require.NoError(t, err)
+	})
+
+	t.Run("fully funded unswept cheque cannot be deleted", func(t *testing.T) {
+		t.Parallel()
+
+		cli, db := deleteChequeClient(t)
+
+		chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qfulldelete0000000000000000000000000000000")
+		require.NoError(t, err)
+		require.NoError(t, cheques.UpdateFunding(context.Background(), db, testWalletID, chequeID,
+			[]string{"full0000full0000full0000full0000full0000full0000full0000full0000"}, 100_000_000))
+
+		_, err = cli.DeleteCheque(context.Background(), connect.NewRequest(&walletv1.DeleteChequeRequest{
+			WalletId: testWalletID,
+			Id:       chequeID,
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+		_, err = cheques.Get(context.Background(), db, testWalletID, chequeID)
+		require.NoError(t, err)
+	})
+
+	t.Run("swept cheque can be deleted", func(t *testing.T) {
+		t.Parallel()
+
+		cli, db := deleteChequeClient(t)
+
+		chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, "tb1qsweptdelete000000000000000000000000000000")
+		require.NoError(t, err)
+		require.NoError(t, cheques.UpdateFunding(context.Background(), db, testWalletID, chequeID,
+			[]string{"swept000swept000swept000swept000swept000swept000swept000swept000"}, 100_000_000))
+		require.NoError(t, cheques.UpdateSwept(context.Background(), db, testWalletID, chequeID,
+			"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef0"))
+
+		_, err = cli.DeleteCheque(context.Background(), connect.NewRequest(&walletv1.DeleteChequeRequest{
+			WalletId: testWalletID,
+			Id:       chequeID,
+		}))
+		require.NoError(t, err)
+
+		// Once swept, the row is gone.
+		_, err = cheques.Get(context.Background(), db, testWalletID, chequeID)
+		require.ErrorIs(t, err, sql.ErrNoRows)
 	})
 }
 

--- a/bitwindow/server/database/migrations/040_transaction_notes_wallet_id.sql
+++ b/bitwindow/server/database/migrations/040_transaction_notes_wallet_id.sql
@@ -1,0 +1,16 @@
+-- Scope transaction notes by wallet so a note written while viewing one wallet
+-- does not surface in another wallet's transaction list. The old table keyed
+-- notes on txid alone, which is shared across wallets. SQLite cannot change a
+-- table's primary key in place, so recreate it with a composite
+-- (wallet_id, txid) primary key.
+
+CREATE TABLE IF NOT EXISTS transaction_notes_new (
+    wallet_id TEXT NOT NULL,
+    txid TEXT NOT NULL,
+    note TEXT NOT NULL,
+    set_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (wallet_id, txid)
+);
+
+DROP TABLE IF EXISTS transaction_notes;
+ALTER TABLE transaction_notes_new RENAME TO transaction_notes;

--- a/bitwindow/server/database/migrations/041_denials_unique_active.sql
+++ b/bitwindow/server/database/migrations/041_denials_unique_active.sql
@@ -1,0 +1,11 @@
+-- Enforce at most one ACTIVE (cancelled_at IS NULL) denial per UTXO.
+--
+-- The table-level UNIQUE(initial_txid, initial_vout, cancelled_at) constraint
+-- does not achieve this: SQLite treats NULL as distinct in UNIQUE indexes, so
+-- multiple rows with cancelled_at IS NULL sharing the same (initial_txid,
+-- initial_vout) are each considered unique and admitted. A partial unique index
+-- over just the active rows closes the gap while still allowing a cancelled
+-- plan for the same UTXO to be recreated.
+CREATE UNIQUE INDEX IF NOT EXISTS uk_active_denial_utxo
+    ON denials(initial_txid, initial_vout)
+    WHERE cancelled_at IS NULL;

--- a/bitwindow/server/engines/backup_engine.go
+++ b/bitwindow/server/engines/backup_engine.go
@@ -185,22 +185,15 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 		log.Info().Msg("restore: wrote metadata.json")
 	}
 
-	// Import multisig data into DB
-	if multisigJSON != nil {
-		if err := e.multisigStore.ImportFromJSON(ctx, multisigJSON); err != nil {
-			log.Warn().Err(err).Msg("restore: failed to import multisig data")
-		} else {
-			log.Info().Msg("restore: imported multisig data")
+	// Import multisig group data and transaction data into the DB atomically so
+	// a failure in either leaves no partial wallet state (e.g. committed
+	// group→transaction links pointing at transactions that never got imported).
+	// The error is propagated so a failed restore is not reported as a success.
+	if multisigJSON != nil || txJSON != nil {
+		if err := e.multisigStore.ImportBackupAtomic(ctx, multisigJSON, txJSON); err != nil {
+			return fmt.Errorf("import multisig data: %w", err)
 		}
-	}
-
-	// Import transaction data into DB
-	if txJSON != nil {
-		if err := e.multisigStore.ImportTransactionsFromJSON(ctx, txJSON); err != nil {
-			log.Warn().Err(err).Msg("restore: failed to import transactions")
-		} else {
-			log.Info().Msg("restore: imported transactions")
-		}
+		log.Info().Msg("restore: imported multisig data")
 	}
 
 	return nil

--- a/bitwindow/server/engines/backup_engine_restore_atomic_test.go
+++ b/bitwindow/server/engines/backup_engine_restore_atomic_test.go
@@ -1,0 +1,132 @@
+package engines
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/multisig"
+)
+
+// TestRestoreBackup_MalformedTransactionsRollsBack verifies that when a ZIP
+// backup carries valid multisig group data but a malformed transactions.json,
+// RestoreBackup returns an error (rather than swallowing it) and leaves no
+// partial DB state — in particular no committed group→transaction links that
+// reference transactions which never got imported (orphan link rows).
+func TestRestoreBackup_MalformedTransactionsRollsBack(t *testing.T) {
+	db := database.Test(t)
+	e := &BackupEngine{
+		db:            db,
+		walletDir:     t.TempDir(),
+		multisigStore: multisig.NewStore(db),
+	}
+
+	walletData, _ := json.Marshal(map[string]interface{}{"master": "seed", "l1": "key"})
+
+	msData, _ := json.Marshal(map[string]interface{}{
+		"groups": []interface{}{
+			map[string]interface{}{
+				"id":   "grp-1",
+				"name": "g1",
+				"n":    1,
+				"m":    1,
+				"keys": []interface{}{
+					map[string]interface{}{"owner": "me", "xpub": "xpub-1", "path": "m/0"},
+				},
+				"addresses": map[string]interface{}{
+					"receive": []interface{}{
+						map[string]interface{}{"index": 0, "address": "addr-1", "used": false},
+					},
+				},
+				"transaction_ids": []interface{}{"orphan-tx"},
+			},
+		},
+	})
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, _ := zw.Create("wallet.json")
+	_, _ = w.Write(walletData)
+	w, _ = zw.Create("multisig/multisig.json")
+	_, _ = w.Write(msData)
+	w, _ = zw.Create("transactions.json")
+	_, _ = w.Write([]byte("[{ this is not valid json"))
+	_ = zw.Close()
+
+	err := e.RestoreBackup(testCtx(), buf.Bytes(), "backup.zip")
+	if err == nil {
+		t.Fatal("expected error from malformed transactions.json, got nil")
+	}
+
+	// The failed transaction import must roll the whole restore back: no groups
+	// and no group→transaction links should have been committed.
+	var groups, links int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM multisig_groups`).Scan(&groups); err != nil {
+		t.Fatalf("count groups: %v", err)
+	}
+	if groups != 0 {
+		t.Fatalf("expected 0 groups after rolled-back restore, got %d", groups)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM multisig_group_transactions`).Scan(&links); err != nil {
+		t.Fatalf("count links: %v", err)
+	}
+	if links != 0 {
+		t.Fatalf("expected 0 group->tx links after rolled-back restore, got %d", links)
+	}
+}
+
+// TestRestoreBackup_ValidBackupImportsAtomically is the control: a well-formed
+// backup restores successfully with the group and its transaction both present
+// and the link resolving to a real transaction.
+func TestRestoreBackup_ValidBackupImportsAtomically(t *testing.T) {
+	db := database.Test(t)
+	e := &BackupEngine{
+		db:            db,
+		walletDir:     t.TempDir(),
+		multisigStore: multisig.NewStore(db),
+	}
+
+	walletData, _ := json.Marshal(map[string]interface{}{"master": "seed", "l1": "key"})
+
+	msData, _ := json.Marshal(map[string]interface{}{
+		"groups": []interface{}{
+			map[string]interface{}{
+				"id":              "grp-1",
+				"name":            "g1",
+				"n":               1,
+				"m":               1,
+				"transaction_ids": []interface{}{"tx-1"},
+			},
+		},
+	})
+
+	txData, _ := json.Marshal([]interface{}{
+		map[string]interface{}{"id": "tx-1", "groupId": "grp-1", "status": "confirmed", "type": "deposit"},
+	})
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, _ := zw.Create("wallet.json")
+	_, _ = w.Write(walletData)
+	w, _ = zw.Create("multisig/multisig.json")
+	_, _ = w.Write(msData)
+	w, _ = zw.Create("transactions.json")
+	_, _ = w.Write(txData)
+	_ = zw.Close()
+
+	if err := e.RestoreBackup(testCtx(), buf.Bytes(), "backup.zip"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var orphans int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM multisig_group_transactions gt
+		WHERE gt.transaction_id NOT IN (SELECT id FROM multisig_transactions)`).Scan(&orphans); err != nil {
+		t.Fatalf("count orphan links: %v", err)
+	}
+	if orphans != 0 {
+		t.Fatalf("expected 0 orphan links after valid restore, got %d", orphans)
+	}
+}

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -208,6 +208,14 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 		if err := p.purgeCoinNewsAtOrAbove(ctx, lastProcessedHeight+1); err != nil {
 			return fmt.Errorf("purge coinnews on reorg: %w", err)
 		}
+
+		// Same for the M4 SCDB (M3 proposals, M4 votes, withdrawal bundles):
+		// persistM3Message inserts bundles idempotently, so a proposal that
+		// existed only in an orphaned block would otherwise survive the replay
+		// as 'pending' and GenerateM4Bytes would vote on the stale bundle.
+		if err := p.m4Engine.PurgeReorgedState(ctx, lastProcessedHeight+1); err != nil {
+			return fmt.Errorf("purge m4 scdb on reorg: %w", err)
+		}
 	}
 
 	const batchSize = 30

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
 	"database/sql"
@@ -32,6 +33,11 @@ const (
 
 	// Authentication tag size (8 bytes from HMAC-SHA256)
 	AuthTagSize = 8
+
+	// Per-file random nonce size (bytes). Prepended to the ciphertext body and
+	// mixed into the keystream seed so two files sharing a timestamp and file
+	// type never reuse the XOR keystream (two-time pad).
+	NonceSize = 16
 
 	// Metadata size (1 byte flags + 4 bytes timestamp + 4 bytes file type)
 	MetadataSize = 9
@@ -194,18 +200,22 @@ func DetectFileType(content []byte) string {
 }
 
 // DeriveKeyStream derives a keystream for XOR encryption
-// Uses SHA256(seed || counter) where seed = SHA256(privateKeyHex:timestamp:fileType)
-func (e *BitDriveEngine) DeriveKeyStream(ctx context.Context, timestamp uint32, fileType string, length int) ([]byte, error) {
+// Uses SHA256(seed || counter) where seed = SHA256(privateKeyHex:timestamp:fileType: || nonce).
+// The per-file random nonce guarantees that two files sharing a timestamp and
+// file type never derive the same keystream.
+func (e *BitDriveEngine) DeriveKeyStream(ctx context.Context, nonce []byte, timestamp uint32, fileType string, length int) ([]byte, error) {
 	// Get the encryption key
 	privateKeyHex, err := e.getEncryptionPrivateKey(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get encryption key: %w", err)
 	}
 
-	// Create seed: SHA256(privateKeyHex:timestamp:fileType)
-	seedInput := fmt.Sprintf("%s:%d:%s", privateKeyHex, timestamp, fileType)
-	seedHash := sha256.Sum256([]byte(seedInput))
-	seed := seedHash[:]
+	// Create seed: SHA256(privateKeyHex:timestamp:fileType: || nonce)
+	seedInput := fmt.Sprintf("%s:%d:%s:", privateKeyHex, timestamp, fileType)
+	seedHasher := sha256.New()
+	seedHasher.Write([]byte(seedInput))
+	seedHasher.Write(nonce)
+	seed := seedHasher.Sum(nil)
 
 	// Generate keystream using counter mode
 	result := make([]byte, length)
@@ -349,10 +359,19 @@ func (e *BitDriveEngine) getAuthKey(_ context.Context) ([]byte, error) {
 	return privKey.Serialize(), nil
 }
 
-// Encrypt encrypts content using XOR with derived keystream and appends HMAC auth tag
+// Encrypt encrypts content using XOR with derived keystream and appends HMAC auth tag.
+// The output layout is: nonce (NonceSize) || ciphertext || tag (AuthTagSize). The
+// random per-file nonce is mixed into the keystream so repeated (timestamp, fileType)
+// tuples never reuse the keystream.
 func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp uint32, fileType string) ([]byte, error) {
+	// Generate a random per-file nonce
+	nonce := make([]byte, NonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+
 	// Generate keystream
-	keyStream, err := e.DeriveKeyStream(ctx, timestamp, fileType, len(content))
+	keyStream, err := e.DeriveKeyStream(ctx, nonce, timestamp, fileType, len(content))
 	if err != nil {
 		return nil, fmt.Errorf("derive keystream: %w", err)
 	}
@@ -364,42 +383,47 @@ func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp 
 	}
 
 	// Generate truncated authentication tag (first 8 bytes of HMAC-SHA256)
+	// over the nonce and ciphertext so nonce tampering is also detected.
 	authKey, err := e.getAuthKey(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get auth key: %w", err)
 	}
 
 	mac := hmac.New(sha256.New, authKey)
+	mac.Write(nonce)
 	mac.Write(encrypted)
 	fullTag := mac.Sum(nil)
 	tag := fullTag[:AuthTagSize]
 
-	// Combine encrypted content with tag
-	result := make([]byte, len(encrypted)+len(tag))
-	copy(result, encrypted)
-	copy(result[len(encrypted):], tag)
+	// Combine nonce, encrypted content, and tag
+	result := make([]byte, NonceSize+len(encrypted)+len(tag))
+	copy(result, nonce)
+	copy(result[NonceSize:], encrypted)
+	copy(result[NonceSize+len(encrypted):], tag)
 
 	return result, nil
 }
 
 // Decrypt verifies the HMAC auth tag and decrypts content
 func (e *BitDriveEngine) Decrypt(ctx context.Context, encryptedData []byte, timestamp uint32, fileType string) ([]byte, error) {
-	if len(encryptedData) <= AuthTagSize {
+	if len(encryptedData) <= NonceSize+AuthTagSize {
 		return nil, fmt.Errorf("encrypted data too short")
 	}
 
-	// Extract content and tag
-	contentLen := len(encryptedData) - AuthTagSize
-	encryptedContent := encryptedData[:contentLen]
-	receivedTag := encryptedData[contentLen:]
+	// Extract nonce, content, and tag
+	nonce := encryptedData[:NonceSize]
+	contentLen := len(encryptedData) - NonceSize - AuthTagSize
+	encryptedContent := encryptedData[NonceSize : NonceSize+contentLen]
+	receivedTag := encryptedData[NonceSize+contentLen:]
 
-	// Verify authentication tag
+	// Verify authentication tag over the nonce and ciphertext
 	authKey, err := e.getAuthKey(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get auth key: %w", err)
 	}
 
 	mac := hmac.New(sha256.New, authKey)
+	mac.Write(nonce)
 	mac.Write(encryptedContent)
 	fullTag := mac.Sum(nil)
 	calculatedTag := fullTag[:AuthTagSize]
@@ -410,7 +434,7 @@ func (e *BitDriveEngine) Decrypt(ctx context.Context, encryptedData []byte, time
 	}
 
 	// Generate keystream
-	keyStream, err := e.DeriveKeyStream(ctx, timestamp, fileType, contentLen)
+	keyStream, err := e.DeriveKeyStream(ctx, nonce, timestamp, fileType, contentLen)
 	if err != nil {
 		return nil, fmt.Errorf("derive keystream: %w", err)
 	}

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -503,8 +503,10 @@ func (e *BitDriveEngine) SaveFile(ctx context.Context, txid string, content []by
 		return nil
 	}
 
-	// Generate filename
-	filename := fmt.Sprintf("%d.%s", metadata.Timestamp, metadata.FileType)
+	// Generate filename. The txid is included so that two distinct
+	// transactions sharing the same timestamp and file type do not collide
+	// on the same local path and overwrite each other.
+	filename := fmt.Sprintf("%d_%s.%s", metadata.Timestamp, txid, metadata.FileType)
 	filePath := filepath.Join(e.bitdriveDir, filename)
 
 	// Write file

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -2,9 +2,13 @@ package engines
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/bitdrive"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestOpenDir_CreatesDirectory(t *testing.T) {
@@ -41,5 +45,76 @@ func TestGetDir(t *testing.T) {
 	}
 	if got := engine.GetDir(); got != "/some/path" {
 		t.Fatalf("expected /some/path, got %s", got)
+	}
+}
+
+// TestSaveFile_SameSecondNoCollision verifies that two distinct transactions
+// sharing an identical timestamp and file type are written to distinct local
+// paths, so neither overwrites the other on disk.
+func TestSaveFile_SameSecondNoCollision(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`
+		CREATE TABLE bitdrive_files (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			txid TEXT NOT NULL UNIQUE,
+			filename TEXT NOT NULL,
+			file_type TEXT NOT NULL,
+			size_bytes INTEGER NOT NULL,
+			encrypted INTEGER NOT NULL DEFAULT 0,
+			timestamp INTEGER NOT NULL,
+			created_at INTEGER NOT NULL
+		)
+	`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	engine := &BitDriveEngine{
+		db:          db,
+		bitdriveDir: t.TempDir(),
+	}
+
+	meta := &ParsedMetadata{Timestamp: 1700000000, FileType: "txt"}
+
+	if err := engine.SaveFile(ctx, "txid-first", []byte("first file"), meta); err != nil {
+		t.Fatalf("save first file: %v", err)
+	}
+	if err := engine.SaveFile(ctx, "txid-second", []byte("second file"), meta); err != nil {
+		t.Fatalf("save second file: %v", err)
+	}
+
+	first, err := bitdrive.GetByTxID(ctx, db, "txid-first")
+	if err != nil || first == nil {
+		t.Fatalf("get first record: %v", err)
+	}
+	second, err := bitdrive.GetByTxID(ctx, db, "txid-second")
+	if err != nil || second == nil {
+		t.Fatalf("get second record: %v", err)
+	}
+
+	if first.Filename == second.Filename {
+		t.Fatalf("expected distinct filenames, both were %q", first.Filename)
+	}
+
+	firstContent, err := engine.GetFileContent(ctx, first.Filename)
+	if err != nil {
+		t.Fatalf("read first content: %v", err)
+	}
+	secondContent, err := engine.GetFileContent(ctx, second.Filename)
+	if err != nil {
+		t.Fatalf("read second content: %v", err)
+	}
+
+	if string(firstContent) != "first file" {
+		t.Fatalf("first file was overwritten: got %q", firstContent)
+	}
+	if string(secondContent) != "second file" {
+		t.Fatalf("second file content wrong: got %q", secondContent)
 	}
 }

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -1,6 +1,7 @@
 package engines
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/bitdrive"
+	"github.com/btcsuite/btcd/chaincfg"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -45,6 +47,113 @@ func TestGetDir(t *testing.T) {
 	}
 	if got := engine.GetDir(); got != "/some/path" {
 		t.Fatalf("expected /some/path, got %s", got)
+	}
+}
+
+// newEncryptTestEngine builds a BitDriveEngine backed by an on-disk unencrypted
+// wallet.json holding a single enforcer wallet, so Encrypt/Decrypt can derive
+// their keys via WalletEngine.GetEnforcerSeed.
+func newEncryptTestEngine(t *testing.T) *BitDriveEngine {
+	t.Helper()
+
+	walletDir := t.TempDir()
+	walletJSON := `{
+		"version": 1,
+		"activeWalletId": "test-enforcer",
+		"wallets": [
+			{
+				"id": "test-enforcer",
+				"name": "enforcer",
+				"wallet_type": "enforcer",
+				"master": {
+					"seed_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+				}
+			}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(walletDir, "wallet.json"), []byte(walletJSON), 0644); err != nil {
+		t.Fatalf("write wallet.json: %v", err)
+	}
+
+	walletEngine := &WalletEngine{
+		walletDir:   walletDir,
+		chainParams: &chaincfg.SigNetParams,
+	}
+	return &BitDriveEngine{
+		walletEngine: walletEngine,
+		chainParams:  &chaincfg.SigNetParams,
+	}
+}
+
+// TestEncrypt_SameTimestampSameFileType_NoKeystreamReuse verifies that two files
+// encrypted under an identical (timestamp, fileType) tuple derive distinct
+// keystreams, so the ciphertext is not a two-time pad, while still round-tripping
+// through Decrypt.
+func TestEncrypt_SameTimestampSameFileType_NoKeystreamReuse(t *testing.T) {
+	ctx := context.Background()
+	engine := newEncryptTestEngine(t)
+
+	const timestamp = uint32(1800000000)
+	const fileType = "txt"
+
+	plainA := []byte("BitDrive keystream reuse probe payload block AAAA")
+	plainB := []byte("BitDrive keystream reuse probe payload block BBBB")
+
+	cipherA, err := engine.Encrypt(ctx, plainA, timestamp, fileType)
+	if err != nil {
+		t.Fatalf("encrypt A: %v", err)
+	}
+	cipherB, err := engine.Encrypt(ctx, plainB, timestamp, fileType)
+	if err != nil {
+		t.Fatalf("encrypt B: %v", err)
+	}
+
+	// Strip the nonce prefix and auth tag suffix to isolate the XOR bodies.
+	bodyA := cipherA[NonceSize : len(cipherA)-AuthTagSize]
+	bodyB := cipherB[NonceSize : len(cipherB)-AuthTagSize]
+	if len(bodyA) != len(plainA) || len(bodyB) != len(plainB) {
+		t.Fatalf("unexpected body lengths: %d, %d", len(bodyA), len(bodyB))
+	}
+
+	// Two-time-pad refutation: with a per-file nonce the two encryptions use
+	// distinct keystreams, so bodyA XOR bodyB must NOT equal plainA XOR plainB.
+	twoTimePad := true
+	for i := range bodyA {
+		if bodyA[i]^bodyB[i] != plainA[i]^plainB[i] {
+			twoTimePad = false
+			break
+		}
+	}
+	if twoTimePad {
+		t.Fatal("keystream reused: bodyA XOR bodyB == plainA XOR plainB (two-time pad)")
+	}
+
+	// Encrypting the SAME plaintext twice must also yield distinct ciphertext
+	// bodies, proving the keystream is randomized per file rather than derived
+	// solely from (timestamp, fileType).
+	cipherA2, err := engine.Encrypt(ctx, plainA, timestamp, fileType)
+	if err != nil {
+		t.Fatalf("encrypt A again: %v", err)
+	}
+	bodyA2 := cipherA2[NonceSize : len(cipherA2)-AuthTagSize]
+	if bytes.Equal(bodyA, bodyA2) {
+		t.Fatal("identical plaintext produced identical ciphertext body: keystream not randomized")
+	}
+
+	// Both ciphertexts must still round-trip through Decrypt.
+	gotA, err := engine.Decrypt(ctx, cipherA, timestamp, fileType)
+	if err != nil {
+		t.Fatalf("decrypt A: %v", err)
+	}
+	if !bytes.Equal(gotA, plainA) {
+		t.Fatalf("decrypt A mismatch: got %q want %q", gotA, plainA)
+	}
+	gotB, err := engine.Decrypt(ctx, cipherB, timestamp, fileType)
+	if err != nil {
+		t.Fatalf("decrypt B: %v", err)
+	}
+	if !bytes.Equal(gotB, plainB) {
+		t.Fatalf("decrypt B mismatch: got %q want %q", gotB, plainB)
 	}
 }
 

--- a/bitwindow/server/engines/cheque_engine.go
+++ b/bitwindow/server/engines/cheque_engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -221,7 +222,7 @@ func (e *ChequeEngine) ScanForFunds(ctx context.Context, walletId string, bitcoi
 			}
 
 			// Convert BTC to satoshis
-			amountSats := uint64(totalAmount * 100000000)
+			amountSats := uint64(math.Round(totalAmount * 100000000))
 
 			recoveries = append(recoveries, ChequeRecovery{
 				Index:   i,

--- a/bitwindow/server/engines/deniability_engine.go
+++ b/bitwindow/server/engines/deniability_engine.go
@@ -189,7 +189,7 @@ func (e *DeniabilityEngine) cancelIfUTXOIsGone(ctx context.Context, walletUTXOs 
 		})
 
 		if !utxoExists {
-			if err := deniability.Cancel(ctx, e.db, denial.ID, "cancelled due to UTXO being moved"); err != nil {
+			if err := deniability.Cancel(ctx, e.db, walletId, denial.ID, "cancelled due to UTXO being moved"); err != nil {
 				return fmt.Errorf("cancel denial %d: %w", denial.ID, err)
 			}
 
@@ -244,7 +244,7 @@ func (e *DeniabilityEngine) ProcessUTXO(ctx context.Context, utxo *pb.ListUnspen
 		reason := "utxo is too small to split"
 		logger.Warn().Msg("cancelling denial due to insufficient UTXO amount")
 
-		if err := deniability.Cancel(ctx, e.db, denial.ID, reason); err != nil {
+		if err := deniability.Cancel(ctx, e.db, lo.FromPtr(denial.WalletID), denial.ID, reason); err != nil {
 			return fmt.Errorf("cancel denial: %w", err)
 		}
 		return nil

--- a/bitwindow/server/engines/m4_engine.go
+++ b/bitwindow/server/engines/m4_engine.go
@@ -468,6 +468,34 @@ func (e *M4Engine) updateBundleStates(ctx context.Context) error {
 	return nil
 }
 
+// PurgeReorgedState deletes every SCDB row derived from a block at or above
+// `fromHeight`. Called when the engine detects a reorg and replays a height
+// range: persistM3Message / persistM4Message insert idempotently
+// (ON CONFLICT DO NOTHING/UPDATE), so without this purge an M3 withdrawal-bundle
+// proposal that existed only in an orphaned block survives the replay as a
+// 'pending' bundle and GenerateM4Bytes votes on it. Mirrors
+// purgeCoinNewsAtOrAbove for the M4 tables.
+func (e *M4Engine) PurgeReorgedState(ctx context.Context, fromHeight uint32) error {
+	tx, err := e.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmts := []string{
+		`DELETE FROM m4_votes         WHERE m4_message_id IN (SELECT id FROM m4_messages WHERE block_height >= ?)`,
+		`DELETE FROM m4_messages      WHERE block_height >= ?`,
+		`DELETE FROM m3_messages      WHERE block_height >= ?`,
+		`DELETE FROM withdrawal_bundles WHERE first_seen_height >= ?`,
+	}
+	for _, q := range stmts {
+		if _, err := tx.ExecContext(ctx, q, fromHeight); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 // GetWithdrawalBundles returns active withdrawal bundles for a sidechain
 func (e *M4Engine) GetWithdrawalBundles(ctx context.Context, sidechainSlot *uint8) ([]m4.WithdrawalBundle, error) {
 	query := `

--- a/bitwindow/server/engines/m4_engine_reorg_test.go
+++ b/bitwindow/server/engines/m4_engine_reorg_test.go
@@ -1,0 +1,56 @@
+package engines
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/m4"
+)
+
+// TestM4Engine_PurgeReorgedState_DropsOrphanedBundles verifies that a
+// withdrawal-bundle proposal seen only in an orphaned block does not survive a
+// same-height reorg replay: PurgeReorgedState drops the bundle first seen at or
+// above the replay height, while a bundle first seen below it is untouched.
+// Without the purge the orphan lingers as 'pending' and GenerateM4Bytes votes
+// on it.
+func TestM4Engine_PurgeReorgedState_DropsOrphanedBundles(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	e := NewM4Engine(database.Test(t))
+
+	blockTime := time.Date(2026, 6, 16, 4, 30, 0, 0, time.UTC)
+
+	// Bundle first seen below the reorg window — must survive.
+	require.NoError(t, e.persistM3Message(ctx, &m4.M3Message{
+		BlockHeight:   90,
+		BlockHash:     "old",
+		BlockTime:     blockTime,
+		SidechainSlot: 0,
+		BundleHash:    "aaaa",
+	}))
+
+	// Orphaned bundle first seen only in the block we're about to replay.
+	require.NoError(t, e.persistM3Message(ctx, &m4.M3Message{
+		BlockHeight:   100,
+		BlockHash:     "orphan",
+		BlockTime:     blockTime,
+		SidechainSlot: 0,
+		BundleHash:    "bbbb",
+	}))
+
+	before, err := e.GetWithdrawalBundles(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, before, 2)
+
+	// Reorg replays from height 100 downward through the rewind window.
+	require.NoError(t, e.PurgeReorgedState(ctx, 100))
+
+	after, err := e.GetWithdrawalBundles(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	require.Equal(t, "aaaa", after[0].BundleHash)
+}

--- a/bitwindow/server/engines/notification_engine.go
+++ b/bitwindow/server/engines/notification_engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -249,7 +250,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, tran
 					Transaction: &notificationv1.TransactionEvent{
 						Type:          notificationv1.TransactionEvent_TYPE_RECEIVED,
 						Txid:          txid,
-						AmountSats:    uint64(tx.Amount * 100000000),
+						AmountSats:    uint64(math.Round(tx.Amount * 100000000)),
 						Confirmations: confirmations,
 					},
 				},
@@ -271,7 +272,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, tran
 					Transaction: &notificationv1.TransactionEvent{
 						Type:          notificationv1.TransactionEvent_TYPE_SENT,
 						Txid:          txid,
-						AmountSats:    uint64(-tx.Amount * 100000000),
+						AmountSats:    uint64(math.Round(-tx.Amount * 100000000)),
 						Confirmations: confirmations,
 					},
 				},
@@ -299,7 +300,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, tran
 					Transaction: &notificationv1.TransactionEvent{
 						Type:          notificationv1.TransactionEvent_TYPE_CONFIRMED,
 						Txid:          txid,
-						AmountSats:    uint64(tx.Amount * 100000000),
+						AmountSats:    uint64(math.Round(tx.Amount * 100000000)),
 						Confirmations: confirmations,
 					},
 				},

--- a/bitwindow/server/models/deniability/deniability.go
+++ b/bitwindow/server/models/deniability/deniability.go
@@ -266,14 +266,15 @@ func listExecutions(ctx context.Context, db *sql.DB, denialID int64) ([]Executed
 	return executions, nil
 }
 
-// Cancel marks a deniability plan as cancelled
-func Cancel(ctx context.Context, db *sql.DB, id int64, reason string) error {
+// Cancel marks a deniability plan as cancelled. The update is scoped to
+// walletID so one wallet cannot cancel another wallet's plan.
+func Cancel(ctx context.Context, db *sql.DB, walletID string, id int64, reason string) error {
 	rows, err := db.ExecContext(ctx, `
 		UPDATE denials
 			SET cancelled_at = ?,
 			cancelled_reason = ?
-		WHERE id = ?
-	`, time.Now(), reason, id)
+		WHERE id = ? AND wallet_id = ?
+	`, time.Now(), reason, id, walletID)
 	if err != nil {
 		return fmt.Errorf("could not cancel deniability: %w", err)
 	}
@@ -285,13 +286,14 @@ func Cancel(ctx context.Context, db *sql.DB, id int64, reason string) error {
 	return nil
 }
 
-// Pause marks a deniability plan as paused
-func Pause(ctx context.Context, db *sql.DB, id int64) error {
+// Pause marks a deniability plan as paused. The update is scoped to walletID
+// so one wallet cannot pause another wallet's plan.
+func Pause(ctx context.Context, db *sql.DB, walletID string, id int64) error {
 	rows, err := db.ExecContext(ctx, `
 		UPDATE denials
 			SET paused_at = ?
-		WHERE id = ? AND paused_at IS NULL AND cancelled_at IS NULL
-	`, time.Now(), id)
+		WHERE id = ? AND wallet_id = ? AND paused_at IS NULL AND cancelled_at IS NULL
+	`, time.Now(), id, walletID)
 	if err != nil {
 		return fmt.Errorf("could not pause deniability: %w", err)
 	}
@@ -303,13 +305,14 @@ func Pause(ctx context.Context, db *sql.DB, id int64) error {
 	return nil
 }
 
-// Resume resumes a paused deniability plan
-func Resume(ctx context.Context, db *sql.DB, id int64) error {
+// Resume resumes a paused deniability plan. The update is scoped to walletID
+// so one wallet cannot resume another wallet's plan.
+func Resume(ctx context.Context, db *sql.DB, walletID string, id int64) error {
 	rows, err := db.ExecContext(ctx, `
 		UPDATE denials
 			SET paused_at = NULL
-		WHERE id = ? AND paused_at IS NOT NULL
-	`, id)
+		WHERE id = ? AND wallet_id = ? AND paused_at IS NOT NULL
+	`, id, walletID)
 	if err != nil {
 		return fmt.Errorf("could not resume deniability: %w", err)
 	}

--- a/bitwindow/server/models/deniability/deniability_test.go
+++ b/bitwindow/server/models/deniability/deniability_test.go
@@ -34,6 +34,42 @@ func TestDeniability(t *testing.T) {
 		require.Equal(t, numHops, denial.NumHops)
 	})
 
+	t.Run("Create rejects duplicate active denial for same UTXO", func(t *testing.T) {
+		t.Parallel()
+		db := database.Test(t)
+
+		txid := gofakeit.UUID()
+		vout := gofakeit.Int32()
+
+		// First active denial for the UTXO succeeds.
+		_, err := Create(ctx, db, "test-wallet", txid, vout, 1*time.Hour, 3, nil)
+		require.NoError(t, err)
+
+		// A second active denial for the same UTXO must be rejected. SQLite's
+		// NULL-distinct semantics previously let the
+		// UNIQUE(initial_txid, initial_vout, cancelled_at) constraint admit
+		// duplicate rows with cancelled_at IS NULL.
+		_, err = Create(ctx, db, "test-wallet", txid, vout, 1*time.Hour, 3, nil)
+		require.Error(t, err)
+
+		var active int
+		err = db.QueryRow(`
+			SELECT COUNT(*) FROM denials
+			WHERE initial_txid = ? AND initial_vout = ? AND cancelled_at IS NULL
+		`, txid, vout).Scan(&active)
+		require.NoError(t, err)
+		require.Equal(t, 1, active)
+
+		// Cancelling the active plan frees the UTXO so a fresh plan can be created.
+		var id int64
+		err = db.QueryRow(`SELECT id FROM denials WHERE initial_txid = ? AND initial_vout = ?`, txid, vout).Scan(&id)
+		require.NoError(t, err)
+		require.NoError(t, Cancel(ctx, db, "test-wallet", id, "test"))
+
+		_, err = Create(ctx, db, "test-wallet", txid, vout, 1*time.Hour, 3, nil)
+		require.NoError(t, err)
+	})
+
 	t.Run("RecordExecution", func(t *testing.T) {
 		t.Parallel()
 		db := database.Test(t)

--- a/bitwindow/server/models/deniability/deniability_test.go
+++ b/bitwindow/server/models/deniability/deniability_test.go
@@ -119,7 +119,7 @@ func TestDeniability(t *testing.T) {
 
 		// Cancel the denial
 		reason := "test cancellation"
-		err = Cancel(ctx, db, denialID, reason)
+		err = Cancel(ctx, db, "test-wallet", denialID, reason)
 		require.NoError(t, err)
 
 		// Verify the cancellation

--- a/bitwindow/server/models/multisig/multisig.go
+++ b/bitwindow/server/models/multisig/multisig.go
@@ -667,7 +667,11 @@ func (s *Store) ListSoloKeys(ctx context.Context) ([]SoloKey, error) {
 }
 
 func (s *Store) AddSoloKey(ctx context.Context, k SoloKey) error {
-	_, err := s.db.ExecContext(ctx, `
+	return addSoloKeyOn(ctx, s.db, k)
+}
+
+func addSoloKeyOn(ctx context.Context, e execer, k SoloKey) error {
+	_, err := e.ExecContext(ctx, `
 		INSERT OR IGNORE INTO multisig_solo_keys (xpub, derivation_path, fingerprint, origin_path, owner)
 		VALUES (?, ?, ?, ?, ?)`, k.Xpub, k.DerivationPath, nullStr(k.Fingerprint), nullStr(k.OriginPath), nullStr(k.Owner))
 	return err
@@ -836,6 +840,19 @@ func (s *Store) SaveTransactionAtomic(ctx context.Context, p SaveTransactionAtom
 
 // ImportFromJSON imports groups + solo_keys from the old multisig.json format.
 func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if err := importFromJSONOn(ctx, tx, data); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func importFromJSONOn(ctx context.Context, e execer, data []byte) error {
 	var raw struct {
 		Groups   []json.RawMessage        `json:"groups"`
 		SoloKeys []map[string]interface{} `json:"solo_keys"`
@@ -870,7 +887,7 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 			continue
 		}
 
-		if err := s.SaveGroup(ctx, g); err != nil {
+		if err := saveGroupOn(ctx, e, g); err != nil {
 			return fmt.Errorf("save group %s: %w", g.ID, err)
 		}
 
@@ -895,7 +912,7 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 				})
 			}
 		}
-		if err := s.ReplaceKeysForGroup(ctx, g.ID, keys); err != nil {
+		if err := replaceKeysForGroupOn(ctx, e, g.ID, keys); err != nil {
 			return fmt.Errorf("replace keys for %s: %w", g.ID, err)
 		}
 
@@ -920,7 +937,7 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 				}
 			}
 		}
-		if err := s.ReplaceAddresses(ctx, g.ID, addrs); err != nil {
+		if err := replaceAddressesOn(ctx, e, g.ID, addrs); err != nil {
 			return fmt.Errorf("replace addresses for %s: %w", g.ID, err)
 		}
 
@@ -933,14 +950,14 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 				}
 			}
 		}
-		if err := s.ReplaceGroupTransactionIDs(ctx, g.ID, ids); err != nil {
+		if err := replaceGroupTransactionIDsOn(ctx, e, g.ID, ids); err != nil {
 			return fmt.Errorf("replace tx ids for %s: %w", g.ID, err)
 		}
 	}
 
 	// Import solo keys
 	for _, sk := range raw.SoloKeys {
-		if err := s.AddSoloKey(ctx, SoloKey{
+		if err := addSoloKeyOn(ctx, e, SoloKey{
 			Xpub:           getString(sk, "xpub"),
 			DerivationPath: getString(sk, "path"),
 			Fingerprint:    getString(sk, "fingerprint"),
@@ -956,6 +973,19 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 
 // ImportTransactionsFromJSON imports transactions from the old transactions.json format.
 func (s *Store) ImportTransactionsFromJSON(ctx context.Context, data []byte) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if err := importTransactionsFromJSONOn(ctx, tx, data); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func importTransactionsFromJSONOn(ctx context.Context, e execer, data []byte) error {
 	var txns []map[string]interface{}
 	if err := json.Unmarshal(data, &txns); err != nil {
 		return fmt.Errorf("unmarshal: %w", err)
@@ -1028,7 +1058,7 @@ func (s *Store) ImportTransactionsFromJSON(ctx context.Context, data []byte) err
 			continue
 		}
 
-		if err := s.SaveTransaction(ctx, t); err != nil {
+		if err := saveTransactionOn(ctx, e, t); err != nil {
 			return fmt.Errorf("save tx %s: %w", t.ID, err)
 		}
 
@@ -1056,7 +1086,7 @@ func (s *Store) ImportTransactionsFromJSON(ctx context.Context, data []byte) err
 				})
 			}
 			if len(psbts) > 0 {
-				if err := s.ReplaceTxKeyPSBTs(ctx, t.ID, psbts); err != nil {
+				if err := replaceTxKeyPSBTsOn(ctx, e, t.ID, psbts); err != nil {
 					return fmt.Errorf("replace key psbts for tx %s: %w", t.ID, err)
 				}
 			}
@@ -1080,7 +1110,7 @@ func (s *Store) ImportTransactionsFromJSON(ctx context.Context, data []byte) err
 				})
 			}
 			if len(txInputs) > 0 {
-				if err := s.ReplaceTxInputs(ctx, t.ID, txInputs); err != nil {
+				if err := replaceTxInputsOn(ctx, e, t.ID, txInputs); err != nil {
 					return fmt.Errorf("replace inputs for tx %s: %w", t.ID, err)
 				}
 			}
@@ -1088,6 +1118,33 @@ func (s *Store) ImportTransactionsFromJSON(ctx context.Context, data []byte) err
 	}
 
 	return nil
+}
+
+// ImportBackupAtomic imports the multisig group data and transaction data from a
+// restored backup in a single database transaction. If either import fails the
+// whole operation is rolled back, so a malformed or partially-writable backup
+// never leaves committed groups/keys/addresses/links pointing at absent
+// transactions (orphan link rows). Either payload may be nil to skip it.
+func (s *Store) ImportBackupAtomic(ctx context.Context, multisigJSON, txJSON []byte) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if multisigJSON != nil {
+		if err := importFromJSONOn(ctx, tx, multisigJSON); err != nil {
+			return fmt.Errorf("import multisig data: %w", err)
+		}
+	}
+
+	if txJSON != nil {
+		if err := importTransactionsFromJSONOn(ctx, tx, txJSON); err != nil {
+			return fmt.Errorf("import transactions: %w", err)
+		}
+	}
+
+	return tx.Commit()
 }
 
 // ─── helpers ───────────────────────────────────────────────────────

--- a/bitwindow/server/models/multisig/multisig.go
+++ b/bitwindow/server/models/multisig/multisig.go
@@ -874,9 +874,10 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 			return fmt.Errorf("save group %s: %w", g.ID, err)
 		}
 
-		// Import keys
+		// Import keys — always replace so a restored group never inherits a
+		// prior group's keys when the backup omits/empties the field.
+		var keys []Key
 		if keysRaw, ok := gj["keys"].([]interface{}); ok {
-			var keys []Key
 			for i, kr := range keysRaw {
 				kd, ok := kr.(map[string]interface{})
 				if !ok {
@@ -893,14 +894,14 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 					SortOrder:      i,
 				})
 			}
-			if err := s.ReplaceKeysForGroup(ctx, g.ID, keys); err != nil {
-				return fmt.Errorf("replace keys for %s: %w", g.ID, err)
-			}
+		}
+		if err := s.ReplaceKeysForGroup(ctx, g.ID, keys); err != nil {
+			return fmt.Errorf("replace keys for %s: %w", g.ID, err)
 		}
 
-		// Import addresses
+		// Import addresses — always replace so stale addresses don't survive.
+		var addrs []Address
 		if addrData, ok := gj["addresses"].(map[string]interface{}); ok {
-			var addrs []Address
 			for _, addrType := range []string{"receive", "change"} {
 				if addrList, ok := addrData[addrType].([]interface{}); ok {
 					for _, ad := range addrList {
@@ -918,26 +919,22 @@ func (s *Store) ImportFromJSON(ctx context.Context, data []byte) error {
 					}
 				}
 			}
-			if len(addrs) > 0 {
-				if err := s.ReplaceAddresses(ctx, g.ID, addrs); err != nil {
-					return fmt.Errorf("replace addresses for %s: %w", g.ID, err)
-				}
-			}
+		}
+		if err := s.ReplaceAddresses(ctx, g.ID, addrs); err != nil {
+			return fmt.Errorf("replace addresses for %s: %w", g.ID, err)
 		}
 
-		// Import transaction IDs
+		// Import transaction IDs — always replace so stale tx links don't survive.
+		var ids []string
 		if txIDs, ok := gj["transaction_ids"].([]interface{}); ok {
-			var ids []string
 			for _, id := range txIDs {
 				if s, ok := id.(string); ok {
 					ids = append(ids, s)
 				}
 			}
-			if len(ids) > 0 {
-				if err := s.ReplaceGroupTransactionIDs(ctx, g.ID, ids); err != nil {
-					return fmt.Errorf("replace tx ids for %s: %w", g.ID, err)
-				}
-			}
+		}
+		if err := s.ReplaceGroupTransactionIDs(ctx, g.ID, ids); err != nil {
+			return fmt.Errorf("replace tx ids for %s: %w", g.ID, err)
 		}
 	}
 

--- a/bitwindow/server/models/transactions/transactions.go
+++ b/bitwindow/server/models/transactions/transactions.go
@@ -10,9 +10,10 @@ import (
 )
 
 type TransactionNote struct {
-	TxID  string
-	Note  string
-	SetAt time.Time
+	WalletID string
+	TxID     string
+	Note     string
+	SetAt    time.Time
 }
 
 func Get(ctx context.Context, db *sql.DB, txid string) (TransactionNote, error) {
@@ -27,7 +28,7 @@ func Get(ctx context.Context, db *sql.DB, txid string) (TransactionNote, error) 
 }
 
 func List(ctx context.Context, db *sql.DB) ([]TransactionNote, error) {
-	rows, err := db.QueryContext(ctx, `SELECT txid, note, set_at FROM transaction_notes`)
+	rows, err := db.QueryContext(ctx, `SELECT wallet_id, txid, note, set_at FROM transaction_notes`)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +37,7 @@ func List(ctx context.Context, db *sql.DB) ([]TransactionNote, error) {
 	var notes []TransactionNote
 	for rows.Next() {
 		var note TransactionNote
-		err := rows.Scan(&note.TxID, &note.Note, &note.SetAt)
+		err := rows.Scan(&note.WalletID, &note.TxID, &note.Note, &note.SetAt)
 		if err != nil {
 			return nil, err
 		}
@@ -46,16 +47,42 @@ func List(ctx context.Context, db *sql.DB) ([]TransactionNote, error) {
 	return notes, rows.Err()
 }
 
-func SetNote(ctx context.Context, db *sql.DB, txid string, note string) error {
+// ListByWallet returns only the notes belonging to walletID. Transaction
+// listings are wallet-scoped, so a note written while viewing one wallet must
+// not surface in another wallet's list.
+func ListByWallet(ctx context.Context, db *sql.DB, walletID string) ([]TransactionNote, error) {
+	rows, err := db.QueryContext(ctx, `SELECT wallet_id, txid, note, set_at FROM transaction_notes WHERE wallet_id = ?`, walletID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var notes []TransactionNote
+	for rows.Next() {
+		var note TransactionNote
+		err := rows.Scan(&note.WalletID, &note.TxID, &note.Note, &note.SetAt)
+		if err != nil {
+			return nil, err
+		}
+
+		notes = append(notes, note)
+	}
+	return notes, rows.Err()
+}
+
+func SetNote(ctx context.Context, db *sql.DB, walletID string, txid string, note string) error {
+	if walletID == "" {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("wallet_id cannot be empty"))
+	}
 	if txid == "" {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("txid cannot be empty"))
 	}
 
 	rows, err := db.ExecContext(ctx, `
-		INSERT INTO transaction_notes (txid, note) 
-		VALUES (?, ?)
-		ON CONFLICT(txid) DO UPDATE SET note = ?, set_at = CURRENT_TIMESTAMP`,
-		txid, note, note)
+		INSERT INTO transaction_notes (wallet_id, txid, note)
+		VALUES (?, ?, ?)
+		ON CONFLICT(wallet_id, txid) DO UPDATE SET note = ?, set_at = CURRENT_TIMESTAMP`,
+		walletID, txid, note, note)
 
 	if rows, _ := rows.RowsAffected(); rows == 0 {
 		return connect.NewError(connect.CodeNotFound, fmt.Errorf("transaction note not found"))

--- a/sidechain-orchestrator/api/bip47_send.go
+++ b/sidechain-orchestrator/api/bip47_send.go
@@ -100,7 +100,13 @@ func (h *WalletHandler) expandBip47Destinations(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("read bip47 state: %w", err))
 	}
-	if state != nil && state.NotificationTxID != nil {
+	// A persisted NotificationTxID only proves the recipient was notified while
+	// that tx is still live on-chain or in the mempool. If it was reorged out,
+	// RBF-replaced, or dropped, we must re-notify — otherwise this send pays a
+	// derived address the recipient can never discover. Revalidate against the
+	// chain before trusting the stored txid.
+	if state != nil && state.NotificationTxID != nil &&
+		h.bip47NotificationLive(ctx, walletID, *state.NotificationTxID) {
 		return expansion, nil
 	}
 
@@ -110,6 +116,18 @@ func (h *WalletHandler) expandBip47Destinations(
 	}
 	expansion.notificationTxHex = rawHex
 	return expansion, nil
+}
+
+// bip47NotificationLive reports whether a previously broadcast notification tx
+// is still discoverable on the chain the wallet uses (confirmed or in the
+// mempool). A stored NotificationTxID that no longer resolves — reorged out,
+// RBF-replaced, or dropped — must not be trusted as proof of notification, so
+// the caller re-notifies. A lookup error is treated as "not live": re-notifying
+// is safe (the recipient de-dupes) and preserves the recipient's ability to
+// discover the payment address.
+func (h *WalletHandler) bip47NotificationLive(ctx context.Context, walletID, txid string) bool {
+	tx, err := h.engine.ChainForWallet(walletID).GetRawTransaction(ctx, txid)
+	return err == nil && tx != nil
 }
 
 // buildBip47NotificationTx assembles the unsigned notification transaction by


### PR DESCRIPTION
## Summary

Wrapped the three `uint64(... * 100000000)` conversions in `notification_engine.go`'s `processWalletTransactions` with `math.Round` (and added the `math` import) so received/sent/confirmed notification AmountSats no longer truncates a satoshi.

## The bug

BitWindow notification engine truncates satoshi amounts from float64 BTC

Severity: Low. Finding (access-controlled): https://giaki3003.tech/#/findings/20260620-1314-glmclaw-confirm-kimiclaw-drivechain-frontends-bitwindow-notification-float-truncation

## Stack

Part of a stacked series for `drivechain-frontends` (fix 13 of 19). Builds on https://github.com/LayerTwo-Labs/drivechain-frontends/pull/1887 — best merged bottom-up; I'll rebase to keep each diff minimal as earlier ones land.