### PR TITLE
ci: fix release build sqlitemigrate + signing identity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,6 +217,11 @@ jobs:
           if [ -d "sidechain-orchestrator" ]; then
             cp -r sidechain-orchestrator "$BUILD_DIR/"
           fi
+          # Copy sqlitemigrate: both sidechain-orchestrator (../sqlitemigrate) and
+          # bitwindow/server (../../sqlitemigrate) replace-resolve to $BUILD_DIR/sqlitemigrate
+          if [ -d "sqlitemigrate" ]; then
+            cp -r sqlitemigrate "$BUILD_DIR/"
+          fi
           # Copy coinnews/codec for bitwindow's Go module replace directive
           if [ -d "coinnews/codec" ]; then
             mkdir -p "$BUILD_DIR/coinnews"
@@ -311,14 +316,16 @@ jobs:
           echo "Setting key partition list"
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" ~/Library/Keychains/build.keychain
 
-          # Find the Common Name of the certificate we just imported
-          security find-certificate -a -p build.keychain > certificate.pem
-          cert_subject=$(openssl x509 -in certificate.pem -noout -subject)
-          echo Certificate subject: "'$cert_subject'"
-
-          cn_part=$(grep -o 'CN = "[^"]*"' <<< "$cert_subject")
-          cn_value=$(sed 's/CN = "\(.*\)"/\1/' <<< "$cn_part")
-          echo "Determined code sign identity"
+          # Read the signing identity straight from the keychain. This is immune to
+          # OpenSSL subject-format differences across runner images (CN=x vs CN = "x").
+          cn_value=$(security find-identity -v -p codesigning build.keychain \
+            | sed -n 's/.*"\(.*\)".*/\1/p' | head -1)
+          if [ -z "$cn_value" ]; then
+            echo "No codesigning identity found in keychain" >&2
+            security find-identity -v -p codesigning build.keychain >&2
+            exit 1
+          fi
+          echo "Determined code sign identity: '$cn_value'"
 
           # Create notarization API key file in the build directory
           echo "Creating notarization API key file in ${{ env.BUILD_DIR }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
       - "sail_ui/**"
       - "drivechain_lints/**"
       - "sidechain-orchestrator/**"
+      - "sqlitemigrate/**"
       - "bitwindow/**"
       - "thunder/**"
       - "truthcoin/**"
@@ -44,6 +45,7 @@ jobs:
               - 'thunder/**'
               - 'sail_ui/**'
               - 'sidechain-orchestrator/**'
+              - 'sqlitemigrate/**'
               - 'drivechain_lints/**'
               - '.github/workflows/**'
             truthcoin:
@@ -51,6 +53,7 @@ jobs:
               - 'truthcoin/**'
               - 'sail_ui/**'
               - 'sidechain-orchestrator/**'
+              - 'sqlitemigrate/**'
               - 'drivechain_lints/**'
               - '.github/workflows/**'
             photon:
@@ -58,6 +61,7 @@ jobs:
               - 'photon/**'
               - 'sail_ui/**'
               - 'sidechain-orchestrator/**'
+              - 'sqlitemigrate/**'
               - 'drivechain_lints/**'
               - '.github/workflows/**'
             bitnames:
@@ -65,6 +69,7 @@ jobs:
               - 'bitnames/**'
               - 'sail_ui/**'
               - 'sidechain-orchestrator/**'
+              - 'sqlitemigrate/**'
               - 'drivechain_lints/**'
               - '.github/workflows/**'
             bitassets:
@@ -72,6 +77,7 @@ jobs:
               - 'bitassets/**'
               - 'sail_ui/**'
               - 'sidechain-orchestrator/**'
+              - 'sqlitemigrate/**'
               - 'drivechain_lints/**'
               - '.github/workflows/**'
             zside:
@@ -79,6 +85,7 @@ jobs:
               - 'zside/**'
               - 'sail_ui/**'
               - 'sidechain-orchestrator/**'
+              - 'sqlitemigrate/**'
               - 'drivechain_lints/**'
               - '.github/workflows/**'
             coinshift:
@@ -86,6 +93,7 @@ jobs:
               - 'coinshift/**'
               - 'sail_ui/**'
               - 'sidechain-orchestrator/**'
+              - 'sqlitemigrate/**'
               - 'drivechain_lints/**'
               - '.github/workflows/**'
             bitwindow:
@@ -93,6 +101,7 @@ jobs:
               - 'bitwindow/**'
               - 'sail_ui/**'
               - 'sidechain-orchestrator/**'
+              - 'sqlitemigrate/**'
               - 'drivechain_lints/**'
               - '.github/workflows/**'
 

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.274
+version: 1.0.275
 
 environment:
   sdk: 3.12.0

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.274
+version: 1.0.275
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.133
+version: 0.2.134
 
 environment:
   sdk: 3.12.0

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.147
+version: 1.0.148
 
 environment:
   sdk: 3.12.0

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.276
+version: 1.0.277
 
 environment:
   sdk: 3.12.0

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.147
+version: 1.0.148
 
 environment:
   sdk: 3.12.0

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.274
+version: 1.0.275
 
 environment:
   sdk: 3.12.0


### PR DESCRIPTION
Copies sqlitemigrate into the build directory so the sidechain-orchestrator and bitwindow/server replace directives resolve, and reads the macOS signing identity from the keychain instead of parsing the OpenSSL certificate subject, which varied between runner images and broke signing.