### PR TITLE
dart: fix master CI broken by dependency bumps

### DIFF
--- a/bitassets/pubspec.lock
+++ b/bitassets/pubspec.lock
@@ -1209,10 +1209,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.6.0"
   vector_graphics:
     dependency: transitive
     description:

--- a/bitnames/pubspec.lock
+++ b/bitnames/pubspec.lock
@@ -1209,10 +1209,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.6.0"
   vector_graphics:
     dependency: transitive
     description:

--- a/bitwindow/pubspec.lock
+++ b/bitwindow/pubspec.lock
@@ -956,26 +956,26 @@ packages:
     dependency: "direct dev"
     description:
       name: patrol
-      sha256: "1cb54197ba329a81cb0f7dca1ffae3b6425b4ea514a63b60dec9dbb9d662c866"
+      sha256: f43fda9425e90c0e69d2dac9e495e3a3036a22a550466365b4720fa4dd53d6ae
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.1"
+    version: "4.6.1"
   patrol_finders:
     dependency: transitive
     description:
       name: patrol_finders
-      sha256: "8608cdacaab90a3b00ecd7b09df11f13a62b01dea13c211b9f13fd86854e103a"
+      sha256: "34e75a59df653dc9e6fc6c0caa469b950b18aaa538aaf859f756b52f937f0da8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.0"
+    version: "3.5.0"
   patrol_log:
     dependency: transitive
     description:
       name: patrol_log
-      sha256: "1f5b6f7e1d9feaab7a60eef31e34a83a6168d754e5c0336006a4f50fb5f27526"
+      sha256: "080608c3402480e18f7dce5a7ee17bf2e23fc191eedffb73a8a635506ce6d4bf"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.0"
+    version: "0.9.1"
   pdf:
     dependency: "direct main"
     description:
@@ -1518,4 +1518,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.12.0"
-  flutter: ">=3.44.0"
+  flutter: "3.44.0"

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -80,7 +80,8 @@ dev_dependencies:
   auto_route_generator: ^10.4.0
   build_runner: ^2.15.0
   flutter_launcher_icons: ^0.14.4
-  patrol: ^4.7.1
+  # Pinned: 4.7.1 fails to build on macOS with "module 'PatrolImpl' not found".
+  patrol: 4.6.1
   integration_test:
     sdk: flutter
 

--- a/coinshift/pubspec.lock
+++ b/coinshift/pubspec.lock
@@ -1209,10 +1209,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.6.0"
   vector_graphics:
     dependency: transitive
     description:

--- a/photon/pubspec.lock
+++ b/photon/pubspec.lock
@@ -1209,10 +1209,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.6.0"
   vector_graphics:
     dependency: transitive
     description:

--- a/thunder/pubspec.lock
+++ b/thunder/pubspec.lock
@@ -1209,10 +1209,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.6.0"
   vector_graphics:
     dependency: transitive
     description:

--- a/truthcoin/pubspec.lock
+++ b/truthcoin/pubspec.lock
@@ -1209,10 +1209,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.6.0"
   vector_graphics:
     dependency: transitive
     description:

--- a/zside/pubspec.lock
+++ b/zside/pubspec.lock
@@ -1209,10 +1209,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.6.0"
   vector_graphics:
     dependency: transitive
     description:


### PR DESCRIPTION
Two dependency bumps broke the build on master. This fixes both.

The uuid bump in sail_ui updated sail_ui's own lockfile but not the lockfiles of the seven apps that use sail_ui, so the step that checks lockfiles are up to date fails for thunder, bitnames, bitassets, coinshift, photon, truthcoin and zside. Those seven lockfiles are refreshed here; the only change is the uuid version.

The patrol bump to 4.7.1 does not build on macOS at all, failing with "module 'PatrolImpl' not found", which makes the mac end to end test time out waiting for a daemon that never starts. That bump was merged even though its own mac end to end check had already failed. Patrol is pinned back to 4.6.1 with a note saying why, rather than left on a caret range, because a caret range resolves straight back to 4.7.1.