### PR TITLE
bitwindow: multisig wallet creation and signing

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.275
+version: 1.0.276
 
 environment:
   sdk: 3.12.0

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.275
+version: 1.0.276
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/lib/pages/wallet/wallet_receive.dart
+++ b/bitwindow/lib/pages/wallet/wallet_receive.dart
@@ -42,24 +42,27 @@ class ReceiveTab extends StatelessWidget {
                         mainAxisSize: MainAxisSize.min,
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          SailDropdownButton<wmpb.AddressType>(
-                            value: model.addressType,
-                            onChanged: (type) {
-                              if (type != null) {
-                                model.setAddressType(type);
-                              }
-                            },
-                            items: const [
-                              SailDropdownItem(
-                                value: wmpb.AddressType.ADDRESS_TYPE_SEGWIT,
-                                label: 'Segwit (bech32)',
-                              ),
-                              SailDropdownItem(
-                                value: wmpb.AddressType.ADDRESS_TYPE_TAPROOT,
-                                label: 'Taproot (bech32m)',
-                              ),
-                            ],
-                          ),
+                          // Multisig wallets have a single address kind fixed by
+                          // their descriptor, so there's no address type to choose.
+                          if (!model.isMultisigWallet)
+                            SailDropdownButton<wmpb.AddressType>(
+                              value: model.addressType,
+                              onChanged: (type) {
+                                if (type != null) {
+                                  model.setAddressType(type);
+                                }
+                              },
+                              items: const [
+                                SailDropdownItem(
+                                  value: wmpb.AddressType.ADDRESS_TYPE_SEGWIT,
+                                  label: 'Segwit (bech32)',
+                                ),
+                                SailDropdownItem(
+                                  value: wmpb.AddressType.ADDRESS_TYPE_TAPROOT,
+                                  label: 'Taproot (bech32m)',
+                                ),
+                              ],
+                            ),
                           SailRow(
                             spacing: SailStyleValues.padding08,
                             children: [
@@ -386,14 +389,22 @@ class ReceivePageViewModel extends BaseViewModel {
   wmpb.AddressType get addressType => transactionsProvider.addressType;
   Future<void> setAddressType(wmpb.AddressType type) => transactionsProvider.setAddressType(type);
 
-  /// Watch-only wallets in BitWindow only carry a BIP84 xpub today, not the
-  /// BIP47 branch needed to derive a payment code. Hide the BIP47 card for
-  /// them so the receive tab doesn't show an indefinite spinner over a row
-  /// the user can't actually populate.
+  /// BIP47 payment codes derive from a single master seed and a single-key
+  /// receive branch, so they don't apply to watch-only wallets (no seed) or
+  /// multisig wallets (no single seed; funds land on multisig script addresses).
+  /// Hide the BIP47 card for both so the receive tab doesn't show a row the user
+  /// can't populate.
   bool get hideBip47 {
     final reader = GetIt.I.get<WalletReaderProvider>();
     final active = reader.activeWallet;
-    return active != null && active.isWatchOnly;
+    return active != null && (active.isWatchOnly || active.isMultisig);
+  }
+
+  /// A multisig wallet's address kind is fixed by its descriptor, so the receive
+  /// tab shows no address-type selector.
+  bool get isMultisigWallet {
+    final active = GetIt.I.get<WalletReaderProvider>().activeWallet;
+    return active != null && active.isMultisig;
   }
 
   List<ReceiveAddress> get receiveAddresses => transactionsProvider.receiveAddresses.toList();

--- a/bitwindow/lib/pages/wallet/wallet_send.dart
+++ b/bitwindow/lib/pages/wallet/wallet_send.dart
@@ -10,6 +10,7 @@ import 'package:bitwindow/providers/coin_selection_provider.dart';
 import 'package:bitwindow/pages/wallet/widgets/fee_rate_chart.dart';
 import 'package:bitwindow/utils/bitcoin_uri.dart';
 import 'package:bitwindow/widgets/airgap_psbt_dialog.dart';
+import 'package:bitwindow/widgets/multisig_sign_modal.dart';
 import 'package:bitwindow/utils/coin_selection.dart';
 import 'package:bitwindow/utils/explorer_url.dart';
 import 'package:bitwindow/utils/fee_estimation.dart';
@@ -602,6 +603,15 @@ class SendPageViewModel extends BaseViewModel {
   }
 
   Future<void> sendTransaction(BuildContext context) async {
+    // Multisig never auto-signs: build the PSBT and open the signing panel,
+    // where each on-disk keystore signs explicitly and broadcast happens once
+    // the threshold is met.
+    final activeWallet = _walletReader.activeWallet;
+    if (activeWallet != null && activeWallet.isMultisig) {
+      await _startMultisigSign(context, activeWallet);
+      return;
+    }
+
     setBusy(true);
 
     // Check if all recipients have an address
@@ -669,6 +679,25 @@ class SendPageViewModel extends BaseViewModel {
       await addressBookProvider.fetch();
       await balanceProvider.fetch();
     }
+  }
+
+  /// Build the PSBT for a multisig send and open the per-keystore signing
+  /// panel. Reuses the airgap PSBT builder (validates recipients/fee and calls
+  /// createPsbt) — the wallet's held keystores then sign in the panel.
+  Future<void> _startMultisigSign(BuildContext context, WalletData wallet) async {
+    final psbt = await buildUnsignedPsbtForAirgap(context);
+    if (psbt == null || !context.mounted) return;
+    await showThemedDialog(
+      context: context,
+      builder: (context) => MultisigSignModal(
+        walletId: wallet.id,
+        initialPsbt: psbt,
+        multisig: wallet.multisig!,
+      ),
+    );
+    await clearAll();
+    await transactionsProvider.fetch();
+    await balanceProvider.fetch();
   }
 
   /// Build an unsigned PSBT from the current recipients/fee/coin-selection for

--- a/bitwindow/lib/pages/welcome/create_another_wallet_page.dart
+++ b/bitwindow/lib/pages/welcome/create_another_wallet_page.dart
@@ -2,6 +2,7 @@ import 'dart:convert' show utf8;
 import 'dart:math';
 
 import 'package:auto_route/auto_route.dart';
+import 'package:bitwindow/pages/welcome/multisig_config_step.dart';
 import 'package:bitwindow/routing/router.dart';
 import 'package:convert/convert.dart' show hex;
 import 'package:crypto/crypto.dart' show sha256;
@@ -18,7 +19,7 @@ class CreateAnotherWalletPage extends StatefulWidget {
 }
 
 /// How the wallet's seed or keys are sourced.
-enum WalletSetupMethod { generate, importSeed, importDescriptor }
+enum WalletSetupMethod { generate, importSeed, importDescriptor, multisig }
 
 /// Which backend serves the wallet. The provider and how keys are sourced are
 /// orthogonal — any provider can run any method (including watch-only).
@@ -41,6 +42,8 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
   String _xpubOrDescriptor = '';
   String _mnemonic = '';
   String _entropyMnemonic = '';
+  // The assembled multisig configuration (cosigners + held seeds + descriptors).
+  MultisigWalletSpec? _multisigSpec;
   bool _isCreating = false;
 
   final TextEditingController _nameController = TextEditingController();
@@ -98,6 +101,26 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
 
     try {
       final walletProvider = GetIt.I.get<WalletWriterProvider>();
+
+      // Multisig: the wizard assembled cosigners (with held seeds); the backend
+      // stores them and derives the descriptor. Signs through the same PSBT path
+      // as any other electrum wallet.
+      if (_method == WalletSetupMethod.multisig) {
+        final spec = _multisigSpec!;
+        await walletProvider.createMultisigWallet(
+          name: _walletName,
+          gradient: _selectedGradient!,
+          m: spec.m,
+          n: spec.n,
+          scriptType: spec.scriptType,
+          cosigners: spec.toCosignerInputs(),
+        );
+        if (mounted) {
+          await showMultisigExportDialog(context, receive: spec.receiveDescriptor, change: spec.changeDescriptor);
+          await GetIt.I.get<AppRouter>().replaceAll([const RootRoute()]);
+        }
+        return;
+      }
 
       final descriptor = _method == WalletSetupMethod.importDescriptor ? _xpubOrDescriptor : null;
       // A null mnemonic on the spendable path means "backend generates a fresh
@@ -169,13 +192,23 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
           _nextStep();
         },
       ),
-      _ProviderStep(
-        selectedProvider: _provider,
-        onProviderSelected: (provider) {
-          setState(() => _provider = provider);
-          _nextStep();
-        },
-      ),
+      // Multisig is electrum-only (signing lives in the electrum backend), so it
+      // skips the provider step and configures cosigners right after the method.
+      if (_method == WalletSetupMethod.multisig)
+        MultisigConfigStep(
+          onConfigured: (spec) {
+            setState(() => _multisigSpec = spec);
+            _nextStep();
+          },
+        ),
+      if (_method != WalletSetupMethod.multisig)
+        _ProviderStep(
+          selectedProvider: _provider,
+          onProviderSelected: (provider) {
+            setState(() => _provider = provider);
+            _nextStep();
+          },
+        ),
       if (_method == WalletSetupMethod.generate)
         _GenerateModeStep(
           onModeSelected: (mode) {
@@ -213,7 +246,7 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
         derivationPathController: _derivationPathController,
         // Derivation override only applies to seed-backed wallets; a watch-only
         // descriptor import carries its own path.
-        showDerivation: _method != WalletSetupMethod.importDescriptor,
+        showDerivation: _method != WalletSetupMethod.importDescriptor && _method != WalletSetupMethod.multisig,
         onNext: () {
           setState(() => _walletName = _nameController.text.trim());
           _nextStep();
@@ -317,6 +350,13 @@ class _MethodStep extends StatelessWidget {
                     icon: SailSVGAsset.iconSearch,
                     isSelected: selectedMethod == WalletSetupMethod.importDescriptor,
                     onTap: () => onMethodSelected(WalletSetupMethod.importDescriptor),
+                  ),
+                  _MethodCard(
+                    title: 'Create a multisig wallet',
+                    description: 'Build an m-of-n wallet from cosigner keys',
+                    icon: SailSVGAsset.iconWallet,
+                    isSelected: selectedMethod == WalletSetupMethod.multisig,
+                    onTap: () => onMethodSelected(WalletSetupMethod.multisig),
                   ),
                 ],
               ),

--- a/bitwindow/lib/pages/welcome/multisig_config_step.dart
+++ b/bitwindow/lib/pages/welcome/multisig_config_step.dart
@@ -1,0 +1,1249 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bitwindow/providers/hd_wallet_provider.dart';
+import 'package:bitwindow/widgets/ur_qr_scanner.dart' show urCameraScanSupported;
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:sail_ui/gen/multisiglounge/v1/multisiglounge.pb.dart' as mlpb;
+import 'package:sail_ui/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+import 'package:sail_ui/sail_ui.dart';
+
+bool _isMainnet() => GetIt.I.get<BitcoinConfProvider>().network == BitcoinNetwork.BITCOIN_NETWORK_MAINNET;
+
+enum CosignerSource { software, xpub, file, qr }
+
+/// One cosigner in the multisig policy. A key is [isFilled] once it has an xpub.
+/// A cosigner with a [mnemonic] is held on disk and can sign; the rest are
+/// watch-only signed elsewhere.
+class CosignerKeystore {
+  String owner;
+  String xpub = '';
+  String derivationPath = ''; // full, e.g. m/48'/1'/0'/2' (empty for a bare pasted xpub)
+  String? fingerprint; // 8 hex chars
+  String? originPath; // without leading m/, e.g. 48'/1'/0'/2'
+  String? mnemonic; // present => held on disk, this wallet can sign with it
+  String? passphrase; // optional BIP39 passphrase for mnemonic
+  bool isWallet = false;
+  CosignerSource? source;
+
+  CosignerKeystore({required this.owner});
+
+  bool get isFilled => xpub.isNotEmpty;
+  bool get held => mnemonic != null && mnemonic!.isNotEmpty;
+}
+
+class MultisigWalletSpec {
+  final int m;
+  final int n;
+  final String scriptType;
+  final List<CosignerKeystore> cosigners;
+  final String receiveDescriptor;
+  final String changeDescriptor;
+
+  const MultisigWalletSpec({
+    required this.m,
+    required this.n,
+    required this.scriptType,
+    required this.cosigners,
+    required this.receiveDescriptor,
+    required this.changeDescriptor,
+  });
+
+  List<wmpb.MultisigCosignerInput> toCosignerInputs() {
+    return cosigners
+        .map(
+          (c) => wmpb.MultisigCosignerInput(
+            xpub: c.xpub,
+            originPath: c.originPath ?? '',
+            fingerprint: c.fingerprint ?? '',
+            mnemonic: c.mnemonic ?? '',
+            passphrase: c.passphrase ?? '',
+          ),
+        )
+        .toList();
+  }
+}
+
+bool isPlausibleXpub(String input) {
+  return RegExp(r'^[xyztuvYZUV]pub[1-9A-HJ-NP-Za-km-z]{50,120}$').hasMatch(input.trim());
+}
+
+({String xpub, String? fingerprint, String? originPath}) parseKeyExpression(String raw) {
+  final trimmed = raw.trim();
+  final m = RegExp(r'^\[([0-9a-fA-F]{8})/(.+?)\](.+)$').firstMatch(trimmed);
+  if (m != null) {
+    return (xpub: m.group(3)!.trim(), fingerprint: m.group(1), originPath: m.group(2));
+  }
+  return (xpub: trimmed, fingerprint: null, originPath: null);
+}
+
+class MultisigConfigStep extends StatefulWidget {
+  final void Function(MultisigWalletSpec spec) onConfigured;
+
+  const MultisigConfigStep({required this.onConfigured, super.key});
+
+  @override
+  State<MultisigConfigStep> createState() => _MultisigConfigStepState();
+}
+
+class _MultisigConfigStepState extends State<MultisigConfigStep> {
+  static const int _maxCosigners = 15;
+
+  int _threshold = 2; // m
+  int _total = 3; // n
+  String _scriptType = 'wsh'; // wsh | sh-wsh | sh
+  int _selectedTab = 0;
+  bool _building = false;
+  String? _error;
+  late List<CosignerKeystore> _keystores;
+
+  @override
+  void initState() {
+    super.initState();
+    _keystores = List.generate(_total, (i) => CosignerKeystore(owner: 'Keystore ${i + 1}'));
+  }
+
+  void _onSliderChanged(RangeValues v) {
+    setState(() {
+      _threshold = v.start.round().clamp(1, _maxCosigners);
+      _total = v.end.round().clamp(1, _maxCosigners);
+      if (_threshold > _total) _threshold = _total;
+      _resizeKeystores();
+    });
+  }
+
+  // Grow/shrink the keystore list to match n, preserving already-filled slots.
+  void _resizeKeystores() {
+    if (_total > _keystores.length) {
+      for (var i = _keystores.length; i < _total; i++) {
+        _keystores.add(CosignerKeystore(owner: 'Keystore ${i + 1}'));
+      }
+    } else if (_total < _keystores.length) {
+      _keystores = _keystores.sublist(0, _total);
+    }
+    if (_selectedTab >= _total) _selectedTab = _total - 1;
+  }
+
+  String get _descriptorPreview {
+    final parts = List.generate(_total, (i) {
+      final k = _keystores[i];
+      if (!k.isFilled) return k.owner.replaceAll(' ', '');
+      return '${k.xpub.substring(0, 8)}…';
+    });
+    if (_scriptType == 'tr') {
+      return 'tr(sortedmulti_a($_threshold,${parts.join(',')}))';
+    }
+    final inner = 'sortedmulti($_threshold,${parts.join(',')})';
+    switch (_scriptType) {
+      case 'sh':
+        return 'sh($inner)';
+      case 'sh-wsh':
+        return 'sh(wsh($inner))';
+      default:
+        return 'wsh($inner)';
+    }
+  }
+
+  bool get _allFilled => _keystores.every((k) => k.isFilled);
+
+  Future<void> _next() async {
+    setState(() => _error = null);
+
+    if (!_allFilled) {
+      setState(() => _error = 'Add a key to every cosigner slot');
+      return;
+    }
+    final xpubs = _keystores.map((k) => k.xpub).toSet();
+    if (xpubs.length != _keystores.length) {
+      setState(() => _error = 'Each cosigner must use a different key');
+      return;
+    }
+
+    setState(() => _building = true);
+    try {
+      final group = mlpb.MultisigGroup(
+        m: _threshold,
+        n: _total,
+        keys: _keystores.map(
+          (k) => mlpb.MultisigKey(
+            xpub: k.xpub,
+            derivationPath: k.derivationPath,
+            fingerprint: k.fingerprint ?? '',
+            originPath: k.originPath ?? '',
+            isWallet: k.isWallet,
+          ),
+        ),
+      );
+
+      final resp = await GetIt.I.get<OrchestratorRPC>().multisigLounge.buildDescriptors(
+        group,
+        scriptType: _scriptType,
+      );
+      widget.onConfigured(
+        MultisigWalletSpec(
+          m: _threshold,
+          n: _total,
+          scriptType: _scriptType,
+          cosigners: List.of(_keystores),
+          receiveDescriptor: resp.receiveDescriptor,
+          changeDescriptor: resp.changeDescriptor,
+        ),
+      );
+    } catch (e) {
+      setState(() => _error = 'Failed to build descriptor: $e');
+    } finally {
+      if (mounted) setState(() => _building = false);
+    }
+  }
+
+  void _setKeystore(int index, CosignerKeystore k) {
+    setState(() => _keystores[index] = k);
+  }
+
+  void _clearKeystore(int index) {
+    setState(() => _keystores[index] = CosignerKeystore(owner: 'Keystore ${index + 1}'));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+        child: SizedBox(
+          width: 900,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SailText.primary24('Create a multisig wallet', bold: true),
+              const SizedBox(height: 4),
+              SailText.secondary13(
+                'Add a keystore for each cosigner. Software keystores hold their seed on disk and sign here; '
+                'the rest are signed elsewhere. Importable into Bitcoin Core and Sparrow.',
+              ),
+              const SizedBox(height: 24),
+              _settingsSection(context),
+              const SizedBox(height: 24),
+              _scriptPolicySection(context),
+              const SizedBox(height: 24),
+              _keystoresSection(context),
+              if (_error != null) ...[
+                const SizedBox(height: 12),
+                SailText.secondary12(_error!, color: SailTheme.of(context).colors.error),
+              ],
+              const SizedBox(height: 24),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  SailButton(
+                    label: 'Next',
+                    loading: _building,
+                    disabled: !_allFilled,
+                    onPressed: () async => _next(),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _settingsSection(BuildContext context) {
+    return SailCard(
+      title: 'Settings',
+      child: Padding(
+        padding: const EdgeInsets.only(top: SailStyleValues.padding08),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _labeledRow('Policy Type', _policyDropdown(context)),
+                  const SizedBox(height: 12),
+                  _labeledRow('Script Type', _scriptDropdown(context)),
+                ],
+              ),
+            ),
+            const SizedBox(width: 32),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SailText.secondary13('Cosigners'),
+                  const SizedBox(height: 4),
+                  SliderTheme(
+                    data: SliderThemeData(
+                      activeTrackColor: SailTheme.of(context).colors.primary,
+                      thumbColor: SailTheme.of(context).colors.primary,
+                    ),
+                    child: RangeSlider(
+                      min: 1,
+                      max: _maxCosigners.toDouble(),
+                      divisions: _maxCosigners - 1,
+                      values: RangeValues(_threshold.toDouble(), _total.toDouble()),
+                      labels: RangeLabels('$_threshold', '$_total'),
+                      onChanged: _onSliderChanged,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  SailText.primary15('M of N:  $_threshold / $_total', bold: true),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _labeledRow(String label, Widget field) {
+    return Row(
+      children: [
+        SizedBox(width: 110, child: SailText.secondary13(label)),
+        Expanded(child: field),
+      ],
+    );
+  }
+
+  Widget _policyDropdown(BuildContext context) {
+    return SailDropdownButton<String>(
+      value: 'multi',
+      onChanged: (v) async {
+        if (v == 'single') {
+          showSailToast(
+            context,
+            'Use the single-signature wallet flow instead',
+            variant: SailToastVariant.info,
+          );
+        }
+      },
+      items: const [
+        SailDropdownItem<String>(value: 'multi', label: 'Multi Signature'),
+        SailDropdownItem<String>(value: 'single', label: 'Single Signature'),
+      ],
+    );
+  }
+
+  Widget _scriptDropdown(BuildContext context) {
+    return SailDropdownButton<String>(
+      value: _scriptType,
+      onChanged: (v) async {
+        if (v != null) setState(() => _scriptType = v);
+      },
+      items: const [
+        SailDropdownItem<String>(value: 'wsh', label: 'Native Segwit (P2WSH)'),
+        SailDropdownItem<String>(value: 'tr', label: 'Taproot (P2TR)'),
+        SailDropdownItem<String>(value: 'sh-wsh', label: 'Nested Segwit (P2SH-P2WSH)'),
+        SailDropdownItem<String>(value: 'sh', label: 'Legacy (P2SH)'),
+      ],
+    );
+  }
+
+  Widget _scriptPolicySection(BuildContext context) {
+    return SailCard(
+      title: 'Script Policy',
+      child: Padding(
+        padding: const EdgeInsets.only(top: SailStyleValues.padding08),
+        child: Row(
+          children: [
+            SizedBox(width: 110, child: SailText.secondary13('Descriptor')),
+            Expanded(
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                decoration: BoxDecoration(
+                  color: SailTheme.of(context).colors.backgroundSecondary,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: SailText.primary13(_descriptorPreview, monospace: true),
+              ),
+            ),
+            const SizedBox(width: 8),
+            SailButton(
+              label: 'Import file',
+              variant: ButtonVariant.secondary,
+              small: true,
+              onPressed: () async => _importConfigFile(context),
+            ),
+            const SizedBox(width: 8),
+            SailButton(
+              label: 'Edit…',
+              variant: ButtonVariant.secondary,
+              small: true,
+              onPressed: () async => _editDescriptor(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _importConfigFile(BuildContext context) async {
+    setState(() => _error = null);
+    try {
+      final result = await FilePicker.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['txt', 'json', 'conf'],
+        dialogTitle: 'Import multisig config',
+      );
+      if (result == null || result.files.isEmpty) return;
+      final path = result.files.first.path;
+      if (path == null) {
+        setState(() => _error = 'Could not read the selected file');
+        return;
+      }
+      final fileContent = await File(path).readAsString();
+      if (!context.mounted) return;
+      await _applyConfig(context, fileContent);
+    } catch (e) {
+      setState(() => _error = 'Failed to import config: $e');
+    }
+  }
+
+  Future<void> _editDescriptor(BuildContext context) async {
+    final content = await showThemedDialog<String>(
+      context: context,
+      builder: (context) => const _EditDescriptorDialog(),
+    );
+    if (content == null || content.trim().isEmpty) return;
+    if (!context.mounted) return;
+    await _applyConfig(context, content.trim());
+  }
+
+  Future<void> _applyConfig(BuildContext context, String content) async {
+    final held = _keystores.where((k) => k.held).length;
+    if (held > 0) {
+      final ok = await showThemedDialog<bool>(
+        context: context,
+        builder: (context) => SailModal(
+          constraints: const BoxConstraints(maxWidth: 480),
+          child: SailCard(
+            title: 'Replace keystores?',
+            subtitle: 'This replaces all cosigners and discards $held software keystore(s) whose seed is held on disk.',
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                SailButton(
+                  label: 'Cancel',
+                  variant: ButtonVariant.ghost,
+                  onPressed: () async => Navigator.of(context).pop(false),
+                ),
+                const SizedBox(width: 8),
+                SailButton(
+                  label: 'Replace',
+                  onPressed: () async => Navigator.of(context).pop(true),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      if (ok != true) return;
+    }
+
+    setState(() {
+      _error = null;
+      _building = true;
+    });
+    try {
+      final resp = await GetIt.I.get<OrchestratorRPC>().wallet.parseMultisigConfig(content);
+      setState(() {
+        _threshold = resp.m;
+        _total = resp.n;
+        if (resp.scriptType.isNotEmpty) _scriptType = resp.scriptType;
+        _keystores = resp.cosigners.asMap().entries.map((e) {
+          final c = e.value;
+          return CosignerKeystore(owner: 'Keystore ${e.key + 1}')
+            ..xpub = c.xpub
+            ..fingerprint = c.fingerprint.isEmpty ? null : c.fingerprint
+            ..originPath = c.originPath.isEmpty ? null : c.originPath
+            ..derivationPath = c.originPath.isEmpty ? '' : 'm/${c.originPath}'
+            ..source = CosignerSource.xpub;
+        }).toList();
+        if (_selectedTab >= _total) _selectedTab = _total - 1;
+      });
+    } catch (e) {
+      setState(() => _error = 'Could not parse descriptor: $e');
+    } finally {
+      if (mounted) setState(() => _building = false);
+    }
+  }
+
+  Widget _keystoresSection(BuildContext context) {
+    return SailCard(
+      title: 'Keystores',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: List.generate(_total, (i) => _tabChip(context, i)),
+          ),
+          const SizedBox(height: 16),
+          _keystoreBody(context, _selectedTab),
+        ],
+      ),
+    );
+  }
+
+  Widget _tabChip(BuildContext context, int i) {
+    final selected = i == _selectedTab;
+    final filled = _keystores[i].isFilled;
+    final theme = SailTheme.of(context);
+    return SailTappable(
+      onTap: () async => setState(() => _selectedTab = i),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        decoration: BoxDecoration(
+          color: selected ? theme.colors.primary.withValues(alpha: 0.12) : theme.colors.background,
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(color: selected ? theme.colors.primary : theme.colors.border),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (filled) ...[
+              SailSVG.icon(SailSVGAsset.iconSuccess, width: 12, color: theme.colors.success),
+              const SizedBox(width: 6),
+            ],
+            SailText.secondary13('Keystore ${i + 1}'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _keystoreBody(BuildContext context, int index) {
+    final k = _keystores[index];
+    if (k.isFilled) return _filledKeystore(context, index, k);
+    return _sourcePicker(context, index);
+  }
+
+  Widget _filledKeystore(BuildContext context, int index, CosignerKeystore k) {
+    final theme = SailTheme.of(context);
+    return SailCard(
+      shadowSize: ShadowSize.none,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  SailText.primary15(k.owner, bold: true),
+                  const SizedBox(width: 12),
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                    decoration: BoxDecoration(
+                      color: (k.held ? theme.colors.primary : theme.colors.orange).withValues(
+                        alpha: 0.1,
+                      ),
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: SailText.secondary12(
+                      k.held ? 'On disk (can sign)' : 'Watch-only',
+                      color: k.held ? theme.colors.primary : theme.colors.orange,
+                    ),
+                  ),
+                ],
+              ),
+              SailButton(
+                label: 'Remove',
+                variant: ButtonVariant.ghost,
+                small: true,
+                onPressed: () async => _clearKeystore(index),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (k.fingerprint != null && k.originPath != null)
+            SailText.secondary12('Origin: [${k.fingerprint}/${k.originPath}]'),
+          SailText.secondary12('xPub: ${k.xpub}', monospace: true),
+        ],
+      ),
+    );
+  }
+
+  Widget _sourcePicker(BuildContext context, int index) {
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: [
+        _sourceCard(
+          context,
+          icon: SailSVGAsset.iconWallet,
+          title: 'Create New Software Wallet',
+          subtitle: 'Generate or import a seed, held on disk to sign',
+          onTap: () async => _addSoftwareKeystore(context, index),
+        ),
+        _sourceCard(
+          context,
+          icon: SailSVGAsset.iconSearch,
+          title: 'xPub / Watch Only',
+          subtitle: 'Paste an extended public key',
+          onTap: () async => _addFromPaste(context, index),
+        ),
+        _sourceCard(
+          context,
+          icon: SailSVGAsset.iconRestart,
+          title: 'Import File',
+          subtitle: 'Coldcard / JSON export',
+          onTap: () async => _addFromFile(context, index),
+        ),
+        _sourceCard(
+          context,
+          icon: SailSVGAsset.iconWallet,
+          title: 'Scan QR',
+          subtitle: urCameraScanSupported ? 'Airgapped key QR' : 'Camera not available here',
+          enabled: urCameraScanSupported,
+          onTap: () async => _addFromQr(context, index),
+        ),
+      ],
+    );
+  }
+
+  Widget _sourceCard(
+    BuildContext context, {
+    required SailSVGAsset icon,
+    required String title,
+    required String subtitle,
+    required Future<void> Function() onTap,
+    bool enabled = true,
+  }) {
+    final theme = SailTheme.of(context);
+    return Opacity(
+      opacity: enabled ? 1 : 0.5,
+      child: SailTappable(
+        onTap: enabled ? () async => onTap() : null,
+        child: Container(
+          width: 190,
+          height: 120,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: theme.colors.background,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: theme.colors.border),
+          ),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SailSVG.icon(icon, width: 28, color: theme.colors.text),
+              const SizedBox(height: 12),
+              SailText.primary13(title, bold: true),
+              const SizedBox(height: 4),
+              SailText.secondary12(subtitle, textAlign: TextAlign.center),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // Derivation path for the chosen script type (BIP48 script-type level for
+  // segwit, BIP45 for legacy P2SH). The slot index is the account, so each
+  // software keystore gets a distinct key.
+  String _bip48Path(int index, bool mainnet) {
+    final coin = mainnet ? "0'" : "1'";
+    return switch (_scriptType) {
+      'sh' => "m/45'/$index'",
+      'sh-wsh' => "m/48'/$coin/$index'/1'",
+      'tr' => "m/48'/$coin/$index'/3'",
+      _ => "m/48'/$coin/$index'/2'",
+    };
+  }
+
+  Future<void> _addSoftwareKeystore(BuildContext context, int index) async {
+    setState(() => _error = null);
+    final seed = await showThemedDialog<SoftwareSeed>(
+      context: context,
+      builder: (context) => const _SoftwareKeystoreDialog(),
+    );
+    if (seed == null || seed.mnemonic.isEmpty) return;
+
+    // Derive the cosigner's account xpub from the seed + passphrase, so the xpub
+    // matches the backend's MnemonicToSeed(mnemonic, passphrase).
+    final hd = GetIt.I.get<HDWalletProvider>();
+    final mainnet = _isMainnet();
+    final path = _bip48Path(index, mainnet);
+    final info = await hd.deriveExtendedKeyInfo(seed.mnemonic, path, mainnet, seed.passphrase);
+    final xpub = info['xpub'];
+    if (xpub == null || xpub.isEmpty) {
+      setState(() => _error = 'Failed to derive a key from that seed');
+      return;
+    }
+    // Use the path the key was actually derived from, so the stored origin can
+    // never disagree with the derived xpub (and the exported descriptor).
+    final derivedPath = info['derivation_path'] ?? path;
+    _setKeystore(
+      index,
+      CosignerKeystore(owner: 'Keystore ${index + 1}')
+        ..xpub = xpub
+        ..mnemonic = seed.mnemonic
+        ..passphrase = seed.passphrase.isEmpty ? null : seed.passphrase
+        ..derivationPath = derivedPath
+        ..originPath = derivedPath.startsWith('m/') ? derivedPath.substring(2) : derivedPath
+        ..fingerprint = info['fingerprint']
+        ..isWallet = true
+        ..source = CosignerSource.software,
+    );
+  }
+
+  Future<void> _addFromPaste(BuildContext context, int index) async {
+    final k = await showThemedDialog<CosignerKeystore>(
+      context: context,
+      builder: (context) => _PasteXpubDialog(defaultOwner: 'Keystore ${index + 1}'),
+    );
+    if (k != null) _setKeystore(index, k);
+  }
+
+  Future<void> _addFromFile(BuildContext context, int index) async {
+    setState(() => _error = null);
+    try {
+      final result = await FilePicker.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['json', 'conf', 'txt'],
+        dialogTitle: 'Select cosigner key file',
+      );
+      if (result == null || result.files.isEmpty) return;
+      final path = result.files.first.path;
+      if (path == null) {
+        setState(() => _error = 'Could not read the selected file');
+        return;
+      }
+      final content = await File(path).readAsString();
+      final parsed = _parseKeyFile(content);
+      if (parsed == null) {
+        setState(() => _error = 'No extended public key found in that file');
+        return;
+      }
+      _setKeystore(
+        index,
+        parsed..owner = parsed.owner.isEmpty ? 'Keystore ${index + 1}' : parsed.owner,
+      );
+    } catch (e) {
+      setState(() => _error = 'Failed to import file: $e');
+    }
+  }
+
+  Future<void> _addFromQr(BuildContext context, int index) async {
+    final raw = await showThemedDialog<String>(
+      context: context,
+      builder: (context) => const _XpubQrScannerDialog(),
+    );
+    if (raw == null) return;
+    final k = _keystoreFromRaw(raw, 'Keystore ${index + 1}');
+    if (k == null) {
+      setState(() => _error = 'Scanned code is not an extended public key');
+      return;
+    }
+    _setKeystore(index, k);
+  }
+}
+
+/// Builds a keystore from a raw "[fp/origin]xpub" or bare xpub string, or null
+/// if it is not a plausible extended key.
+CosignerKeystore? _keystoreFromRaw(String raw, String owner) {
+  final parsed = parseKeyExpression(raw);
+  if (!isPlausibleXpub(parsed.xpub)) return null;
+  return CosignerKeystore(owner: owner)
+    ..xpub = parsed.xpub
+    ..fingerprint = parsed.fingerprint
+    ..originPath = parsed.originPath
+    ..derivationPath = parsed.originPath != null ? 'm/${parsed.originPath}' : ''
+    ..isWallet = false
+    ..source = CosignerSource.qr;
+}
+
+/// Parses a JSON key export (Coldcard-style fields) into a keystore, or null.
+CosignerKeystore? _parseKeyFile(String content) {
+  try {
+    final json = jsonDecode(content) as Map<String, dynamic>;
+    final xpub = (json['xpub'] ?? json['extended_public_key'] ?? json['pubkey'] ?? '') as String;
+    if (!isPlausibleXpub(xpub)) return null;
+    final path = (json['path'] ?? json['derivation_path'] ?? json['bip32_path'] ?? '') as String;
+    final origin =
+        (json['origin_path'] ?? json['origin'] ?? (path.startsWith('m/') ? path.substring(2) : path)) as String;
+    return CosignerKeystore(owner: (json['owner'] ?? json['name'] ?? '') as String)
+      ..xpub = xpub
+      ..derivationPath = path
+      ..originPath = origin.isEmpty ? null : origin
+      ..fingerprint = (json['fingerprint'] ?? json['master_fingerprint']) as String?
+      ..isWallet = false
+      ..source = CosignerSource.file;
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Shows the finished multisig wallet's descriptors so the user can back them
+/// up or import the wallet into Bitcoin Core as watch-only.
+Future<void> showMultisigExportDialog(
+  BuildContext context, {
+  required String receive,
+  required String change,
+}) {
+  final importCommand =
+      "importdescriptors '["
+      '{"desc":"$receive","active":true,"internal":false,"timestamp":"now","range":[0,999]},'
+      '{"desc":"$change","active":true,"internal":true,"timestamp":"now","range":[0,999]}'
+      "]'";
+
+  Widget field(String label, String value) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            SailText.secondary13(label),
+            SailButton(
+              label: 'Copy',
+              variant: ButtonVariant.ghost,
+              small: true,
+              onPressed: () async {
+                await Clipboard.setData(ClipboardData(text: value));
+                if (context.mounted) {
+                  showSailToast(context, 'Copied', variant: SailToastVariant.success);
+                }
+              },
+            ),
+          ],
+        ),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: SailTheme.of(context).colors.backgroundSecondary,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: SailText.secondary12(value, monospace: true),
+        ),
+      ],
+    );
+  }
+
+  return showThemedDialog<void>(
+    context: context,
+    builder: (context) => SailModal(
+      constraints: const BoxConstraints(maxWidth: 640, maxHeight: 640),
+      child: SailCard(
+        title: 'Multisig wallet created',
+        subtitle: 'Back up these descriptors. Paste the command into Bitcoin Core to watch this wallet there.',
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // The descriptors are long, so scroll them and keep Done pinned.
+            Flexible(
+              child: SingleChildScrollView(
+                child: SailColumn(
+                  spacing: SailStyleValues.padding16,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    field('Receive descriptor', receive),
+                    field('Change descriptor', change),
+                    field('Bitcoin Core import', importCommand),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                SailButton(label: 'Done', onPressed: () async => Navigator.of(context).pop()),
+              ],
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+/// A software keystore's seed and optional BIP39 passphrase.
+class SoftwareSeed {
+  final String mnemonic;
+  final String passphrase;
+  const SoftwareSeed(this.mnemonic, this.passphrase);
+}
+
+/// Dialog to add a software keystore: generate a fresh seed (shown once for
+/// backup) or import an existing one, with an optional BIP39 passphrase.
+class _SoftwareKeystoreDialog extends StatefulWidget {
+  const _SoftwareKeystoreDialog();
+
+  @override
+  State<_SoftwareKeystoreDialog> createState() => _SoftwareKeystoreDialogState();
+}
+
+class _SoftwareKeystoreDialogState extends State<_SoftwareKeystoreDialog> {
+  HDWalletProvider get _hd => GetIt.I.get<HDWalletProvider>();
+  final TextEditingController _import = TextEditingController();
+  final TextEditingController _passphrase = TextEditingController();
+  String? _generated;
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _import.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _import.dispose();
+    _passphrase.dispose();
+    super.dispose();
+  }
+
+  Widget _passphraseField() {
+    return SailTextField(
+      label: 'BIP39 passphrase (optional)',
+      controller: _passphrase,
+      hintText: 'Leave blank for none',
+      size: TextFieldSize.small,
+    );
+  }
+
+  bool _isValidMnemonic(String s) {
+    final words = s.trim().split(RegExp(r'\s+')).where((w) => w.isNotEmpty).toList();
+    return const {12, 15, 18, 21, 24}.contains(words.length);
+  }
+
+  Future<void> _generate() async {
+    setState(() => _busy = true);
+    try {
+      final m = await _hd.generateRandomMnemonic();
+      if (m.isEmpty) {
+        setState(() => _error = 'Failed to generate a seed');
+        return;
+      }
+      setState(() => _generated = m);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SailModal(
+      constraints: const BoxConstraints(maxWidth: 560),
+      child: SailCard(
+        title: 'Software keystore',
+        subtitle: 'The seed is stored on disk so this wallet can sign for this cosigner.',
+        error: _error,
+        child: SailColumn(
+          spacing: SailStyleValues.padding16,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (_generated == null) ...[
+              SailTextField(
+                label: 'Import an existing seed phrase',
+                controller: _import,
+                hintText: 'word1 word2 word3 ...  (12 or 24 words)',
+                size: TextFieldSize.small,
+                minLines: 2,
+                maxLines: 3,
+              ),
+              _passphraseField(),
+              Row(
+                children: [
+                  SailButton(
+                    label: 'Generate new seed',
+                    variant: ButtonVariant.secondary,
+                    loading: _busy,
+                    onPressed: () async => _generate(),
+                  ),
+                  const Spacer(),
+                  SailButton(
+                    label: 'Import',
+                    disabled: !_isValidMnemonic(_import.text),
+                    onPressed: () async {
+                      if (!_isValidMnemonic(_import.text)) {
+                        setState(() => _error = 'Enter a 12 or 24-word seed phrase');
+                        return;
+                      }
+                      Navigator.of(
+                        context,
+                      ).pop(SoftwareSeed(_import.text.trim(), _passphrase.text));
+                    },
+                  ),
+                ],
+              ),
+            ] else ...[
+              SailText.secondary13(
+                "Write these words down and keep them safe — they control this cosigner's funds.",
+                color: SailTheme.of(context).colors.orange,
+              ),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: SailTheme.of(context).colors.backgroundSecondary,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: SailText.primary13(_generated!, monospace: true),
+              ),
+              _passphraseField(),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  SailButton(
+                    label: 'Back',
+                    variant: ButtonVariant.ghost,
+                    onPressed: () async => setState(() => _generated = null),
+                  ),
+                  const SizedBox(width: 8),
+                  SailButton(
+                    label: 'Use this seed',
+                    onPressed: () async => Navigator.of(context).pop(SoftwareSeed(_generated!, _passphrase.text)),
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EditDescriptorDialog extends StatefulWidget {
+  const _EditDescriptorDialog();
+
+  @override
+  State<_EditDescriptorDialog> createState() => _EditDescriptorDialogState();
+}
+
+class _EditDescriptorDialogState extends State<_EditDescriptorDialog> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SailModal(
+      constraints: const BoxConstraints(maxWidth: 640),
+      child: SailCard(
+        title: 'Edit wallet output descriptor',
+        subtitle: 'The wallet configuration is specified in the output descriptor.',
+        child: SailColumn(
+          spacing: SailStyleValues.padding16,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SailTextField(
+              controller: _controller,
+              hintText: "wsh(sortedmulti(2,[fp/48'/1'/0'/2']tpub.../0/*,...))",
+              size: TextFieldSize.small,
+              minLines: 4,
+              maxLines: 8,
+              suffixWidget: SailButton(
+                label: 'Paste',
+                variant: ButtonVariant.ghost,
+                small: true,
+                onPressed: () async {
+                  final data = await Clipboard.getData(Clipboard.kTextPlain);
+                  if (data?.text != null) _controller.text = data!.text!.trim();
+                },
+              ),
+            ),
+            Row(
+              children: [
+                SailButton(
+                  label: 'Scan QR',
+                  variant: ButtonVariant.secondary,
+                  small: true,
+                  onPressed: () async {
+                    final raw = await showThemedDialog<String>(
+                      context: context,
+                      builder: (context) => const _XpubQrScannerDialog(),
+                    );
+                    if (raw != null) _controller.text = raw;
+                  },
+                ),
+                const Spacer(),
+                SailButton(
+                  label: 'Cancel',
+                  variant: ButtonVariant.ghost,
+                  onPressed: () async => Navigator.of(context).pop(),
+                ),
+                const SizedBox(width: 8),
+                SailButton(
+                  label: 'OK',
+                  onPressed: () async => Navigator.of(context).pop(_controller.text.trim()),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Dialog to paste an xpub (optionally as "[fp/origin]xpub"), with an owner name.
+class _PasteXpubDialog extends StatefulWidget {
+  final String defaultOwner;
+  const _PasteXpubDialog({required this.defaultOwner});
+
+  @override
+  State<_PasteXpubDialog> createState() => _PasteXpubDialogState();
+}
+
+class _PasteXpubDialogState extends State<_PasteXpubDialog> {
+  late final TextEditingController _owner = TextEditingController(text: widget.defaultOwner);
+  final TextEditingController _key = TextEditingController();
+  String? _error;
+
+  @override
+  void dispose() {
+    _owner.dispose();
+    _key.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SailModal(
+      constraints: const BoxConstraints(maxWidth: 560),
+      child: SailCard(
+        title: 'Paste extended public key',
+        subtitle: 'An xpub / Zpub, or the full [fingerprint/origin]xpub form',
+        error: _error,
+        child: SailColumn(
+          spacing: SailStyleValues.padding16,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SailTextField(
+              label: 'Owner name',
+              controller: _owner,
+              hintText: 'Cosigner name',
+              size: TextFieldSize.small,
+            ),
+            SailTextField(
+              label: 'Extended public key',
+              controller: _key,
+              hintText: "[d34db33f/48'/1'/0'/2']tpub...  or  tpub...",
+              size: TextFieldSize.small,
+              minLines: 2,
+              maxLines: 4,
+              suffixWidget: SailButton(
+                label: 'Paste',
+                variant: ButtonVariant.ghost,
+                small: true,
+                onPressed: () async {
+                  final data = await Clipboard.getData(Clipboard.kTextPlain);
+                  if (data?.text != null) _key.text = data!.text!.trim();
+                },
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                SailButton(
+                  label: 'Cancel',
+                  variant: ButtonVariant.ghost,
+                  onPressed: () async => Navigator.of(context).pop(),
+                ),
+                const SizedBox(width: 8),
+                SailButton(
+                  label: 'Add',
+                  onPressed: () async {
+                    final k = _keystoreFromRaw(_key.text, _owner.text.trim());
+                    if (k == null) {
+                      setState(() => _error = 'That is not a valid extended public key');
+                      return;
+                    }
+                    k.source = CosignerSource.xpub;
+                    Navigator.of(context).pop(k);
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Dialog that scans a single QR frame containing an xpub or descriptor string.
+class _XpubQrScannerDialog extends StatefulWidget {
+  const _XpubQrScannerDialog();
+
+  @override
+  State<_XpubQrScannerDialog> createState() => _XpubQrScannerDialogState();
+}
+
+class _XpubQrScannerDialogState extends State<_XpubQrScannerDialog> {
+  final MobileScannerController _controller = MobileScannerController(
+    formats: const [BarcodeFormat.qrCode],
+  );
+  bool _done = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onDetect(BarcodeCapture capture) {
+    if (_done) return;
+    for (final b in capture.barcodes) {
+      final raw = b.rawValue;
+      if (raw == null || raw.isEmpty) continue;
+      _done = true;
+      Navigator.of(context).pop(raw.trim());
+      return;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SailModal(
+      constraints: const BoxConstraints(maxWidth: 420),
+      child: SailCard(
+        title: 'Scan key QR',
+        child: SailColumn(
+          spacing: SailStyleValues.padding16,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (urCameraScanSupported)
+              SizedBox(
+                width: 320,
+                height: 320,
+                child: MobileScanner(controller: _controller, onDetect: _onDetect),
+              )
+            else
+              SailText.secondary13('Camera scanning is not available on this platform.'),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                SailButton(
+                  label: 'Cancel',
+                  variant: ButtonVariant.ghost,
+                  onPressed: () async => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/bitwindow/lib/providers/hd_wallet_provider.dart
+++ b/bitwindow/lib/providers/hd_wallet_provider.dart
@@ -217,7 +217,12 @@ class HDWalletProvider extends ChangeNotifier {
     }
   }
 
-  Future<Map<String, String>> deriveExtendedKeyInfo(String mnemonic, String path, [bool isMainnet = false]) async {
+  Future<Map<String, String>> deriveExtendedKeyInfo(
+    String mnemonic,
+    String path, [
+    bool isMainnet = false,
+    String passphrase = '',
+  ]) async {
     try {
       String adjustedPath = path;
       if (isMainnet && path.contains("'1'/")) {
@@ -226,7 +231,7 @@ class HDWalletProvider extends ChangeNotifier {
         adjustedPath = path.replaceAll("'0'/", "'1'/");
       }
 
-      final mnemonicObj = Mnemonic.fromSentence(mnemonic, Language.english);
+      final mnemonicObj = Mnemonic.fromSentence(mnemonic, Language.english, passphrase: passphrase);
       final seedHex = hex.encode(mnemonicObj.seed);
       final chain = Chain.seed(seedHex);
 
@@ -390,6 +395,9 @@ class HDWalletProvider extends ChangeNotifier {
         'publicKey': pubKeyHex,
         'address': address,
         'wif': wif,
+        // The path the key was actually derived from (after any network fixup),
+        // so callers store an origin that matches the derived xpub.
+        'derivation_path': adjustedPath,
       };
     } catch (e) {
       return {};

--- a/bitwindow/lib/widgets/multisig_sign_modal.dart
+++ b/bitwindow/lib/widgets/multisig_sign_modal.dart
@@ -1,0 +1,330 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sail_ui/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+import 'package:sail_ui/sail_ui.dart';
+
+class MultisigSignModal extends StatefulWidget {
+  final String walletId;
+  final String initialPsbt;
+  final wmpb.MultisigInfo multisig;
+
+  const MultisigSignModal({
+    super.key,
+    required this.walletId,
+    required this.initialPsbt,
+    required this.multisig,
+  });
+
+  @override
+  State<MultisigSignModal> createState() => _MultisigSignModalState();
+}
+
+class _MultisigSignModalState extends State<MultisigSignModal> {
+  OrchestratorWalletRPC get _wallet => GetIt.I.get<OrchestratorRPC>().wallet;
+
+  late String _psbt = widget.initialPsbt;
+  int _signatures = 0;
+  bool _finalizable = false;
+  List<bool> _signed = const [];
+  bool _busy = false;
+  String? _error;
+  String? _broadcastTxid;
+
+  int get _threshold => widget.multisig.m;
+  List<wmpb.MultisigCosignerInfo> get _cosigners => widget.multisig.cosigners;
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshStatus();
+  }
+
+  bool _cosignerSigned(int i) => i < _signed.length && _signed[i];
+
+  Future<void> _refreshStatus() async {
+    final forPsbt = _psbt;
+    try {
+      final s = await _wallet.multisigPsbtStatus(walletId: widget.walletId, psbtBase64: forPsbt);
+      if (!mounted || forPsbt != _psbt) return;
+      setState(() {
+        _signatures = s.signatures;
+        _finalizable = s.finalizable;
+        _signed = s.cosignerSigned;
+      });
+    } catch (e) {
+      if (mounted) setState(() => _error = 'Failed to read signing status: $e');
+    }
+  }
+
+  Future<void> _run(Future<void> Function() action) async {
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      await action();
+    } catch (e) {
+      setState(() => _error = '$e');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _signCosigner(int index) => _run(() async {
+    final signed = await _wallet.signPsbtWithCosigner(
+      walletId: widget.walletId,
+      psbtBase64: _psbt,
+      cosignerXpub: _cosigners[index].xpub,
+    );
+    _psbt = signed;
+    await _refreshStatus();
+  });
+
+  Future<void> _importSignedPsbt() async {
+    final imported = await showThemedDialog<String>(
+      context: context,
+      builder: (context) => const _ImportPsbtDialog(),
+    );
+    if (imported == null || imported.isEmpty) return;
+    await _run(() async {
+      final combined = await _wallet.combinePsbt(psbtsBase64: [_psbt, imported]);
+      _psbt = combined;
+      await _refreshStatus();
+    });
+  }
+
+  Future<void> _copyPsbt() async {
+    await Clipboard.setData(ClipboardData(text: _psbt));
+    if (mounted) showSailToast(context, 'PSBT copied', variant: SailToastVariant.success);
+  }
+
+  Future<void> _broadcast() => _run(() async {
+    final hex = await _wallet.finalizePsbt(psbtBase64: _psbt);
+    final txid = await _wallet.broadcastTransaction(walletId: widget.walletId, txHex: hex);
+    setState(() => _broadcastTxid = txid);
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SailModal(
+      constraints: const BoxConstraints(maxWidth: 640, maxHeight: 720),
+      child: SailCard(
+        title: 'Sign transaction',
+        subtitle: '$_signatures of $_threshold signatures',
+        error: _error,
+        child: SingleChildScrollView(
+          child: SailColumn(
+            spacing: SailStyleValues.padding16,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (_broadcastTxid != null)
+                _broadcastSuccess(context)
+              else ...[
+                _progressBar(context),
+                ..._cosigners.asMap().entries.map((e) => _cosignerRow(context, e.key, e.value)),
+                const SizedBox(height: 4),
+                _actions(context),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _progressBar(BuildContext context) {
+    final theme = SailTheme.of(context);
+    final fraction = _threshold == 0 ? 0.0 : (_signatures / _threshold).clamp(0.0, 1.0);
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(4),
+      child: LinearProgressIndicator(
+        value: fraction,
+        minHeight: 6,
+        backgroundColor: theme.colors.backgroundSecondary,
+        valueColor: AlwaysStoppedAnimation(
+          _finalizable ? theme.colors.success : theme.colors.primary,
+        ),
+      ),
+    );
+  }
+
+  Widget _cosignerRow(BuildContext context, int i, wmpb.MultisigCosignerInfo c) {
+    final theme = SailTheme.of(context);
+    final signed = _cosignerSigned(i);
+    return SailCard(
+      shadowSize: ShadowSize.none,
+      child: Row(
+        children: [
+          SailSVG.icon(
+            signed ? SailSVGAsset.iconSuccess : SailSVGAsset.iconWallet,
+            width: 18,
+            color: signed ? theme.colors.success : theme.colors.textSecondary,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    SailText.primary13('Cosigner ${i + 1}', bold: true),
+                    const SizedBox(width: 8),
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                      decoration: BoxDecoration(
+                        color: (c.held ? theme.colors.primary : theme.colors.orange).withValues(
+                          alpha: 0.1,
+                        ),
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      child: SailText.secondary12(
+                        c.held ? 'On disk' : 'Watch-only',
+                        color: c.held ? theme.colors.primary : theme.colors.orange,
+                      ),
+                    ),
+                  ],
+                ),
+                if (c.fingerprint.isNotEmpty) SailText.secondary12('Fingerprint: ${c.fingerprint}', monospace: true),
+              ],
+            ),
+          ),
+          if (c.held && !signed)
+            SailButton(
+              label: 'Sign',
+              small: true,
+              loading: _busy,
+              onPressed: () async => _signCosigner(i),
+            )
+          else
+            SailText.secondary12(
+              signed ? 'Signed' : 'Signs elsewhere',
+              color: signed ? theme.colors.success : theme.colors.textSecondary,
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _actions(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      alignment: WrapAlignment.end,
+      children: [
+        SailButton(
+          label: 'Copy PSBT',
+          variant: ButtonVariant.ghost,
+          onPressed: () async => _copyPsbt(),
+        ),
+        SailButton(
+          label: 'Import signed PSBT',
+          variant: ButtonVariant.secondary,
+          onPressed: () async => _importSignedPsbt(),
+        ),
+        SailButton(
+          label: 'Broadcast',
+          disabled: !_finalizable,
+          loading: _busy,
+          onPressed: () async => _broadcast(),
+        ),
+      ],
+    );
+  }
+
+  Widget _broadcastSuccess(BuildContext context) {
+    return SailColumn(
+      spacing: SailStyleValues.padding16,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            SailSVG.icon(
+              SailSVGAsset.iconSuccess,
+              width: 20,
+              color: SailTheme.of(context).colors.success,
+            ),
+            const SizedBox(width: 8),
+            SailText.primary15('Transaction broadcast', bold: true),
+          ],
+        ),
+        SailText.secondary12(_broadcastTxid!, monospace: true),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            SailButton(
+              label: 'Done',
+              onPressed: () async => Navigator.of(context).pop(_broadcastTxid),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+/// Small dialog to paste a base64 PSBT that another cosigner signed.
+class _ImportPsbtDialog extends StatefulWidget {
+  const _ImportPsbtDialog();
+
+  @override
+  State<_ImportPsbtDialog> createState() => _ImportPsbtDialogState();
+}
+
+class _ImportPsbtDialogState extends State<_ImportPsbtDialog> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SailModal(
+      constraints: const BoxConstraints(maxWidth: 560),
+      child: SailCard(
+        title: 'Import signed PSBT',
+        subtitle: 'Paste the base64 PSBT a cosigner signed elsewhere',
+        child: SailColumn(
+          spacing: SailStyleValues.padding16,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SailTextField(
+              controller: _controller,
+              hintText: 'cHNidP8B...',
+              size: TextFieldSize.small,
+              minLines: 3,
+              maxLines: 6,
+              suffixWidget: SailButton(
+                label: 'Paste',
+                variant: ButtonVariant.ghost,
+                small: true,
+                onPressed: () async {
+                  final data = await Clipboard.getData(Clipboard.kTextPlain);
+                  if (data?.text != null) _controller.text = data!.text!.trim();
+                },
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                SailButton(
+                  label: 'Cancel',
+                  variant: ButtonVariant.ghost,
+                  onPressed: () async => Navigator.of(context).pop(),
+                ),
+                const SizedBox(width: 8),
+                SailButton(
+                  label: 'Import',
+                  onPressed: () async => Navigator.of(context).pop(_controller.text.trim()),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.134
+version: 0.2.135
 
 environment:
   sdk: 3.12.0

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.148
+version: 1.0.149
 
 environment:
   sdk: 3.12.0

--- a/sail_ui/lib/gen/multisiglounge/v1/multisiglounge.pb.dart
+++ b/sail_ui/lib/gen/multisiglounge/v1/multisiglounge.pb.dart
@@ -1905,10 +1905,14 @@ class MultisigGroup extends $pb.GeneratedMessage {
 class BuildDescriptorsRequest extends $pb.GeneratedMessage {
   factory BuildDescriptorsRequest({
     MultisigGroup? group,
+    $core.String? scriptType,
   }) {
     final $result = create();
     if (group != null) {
       $result.group = group;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
     }
     return $result;
   }
@@ -1918,6 +1922,7 @@ class BuildDescriptorsRequest extends $pb.GeneratedMessage {
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BuildDescriptorsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'multisiglounge.v1'), createEmptyInstance: create)
     ..aOM<MultisigGroup>(1, _omitFieldNames ? '' : 'group', subBuilder: MultisigGroup.create)
+    ..aOS(2, _omitFieldNames ? '' : 'scriptType')
     ..hasRequiredFields = false
   ;
 
@@ -1952,6 +1957,17 @@ class BuildDescriptorsRequest extends $pb.GeneratedMessage {
   void clearGroup() => clearField(1);
   @$pb.TagNumber(1)
   MultisigGroup ensureGroup() => $_ensure(0);
+
+  /// Multisig script type: "wsh" (native P2WSH, default), "sh-wsh" (nested
+  /// P2SH-P2WSH), or "sh" (legacy P2SH). Empty means native P2WSH.
+  @$pb.TagNumber(2)
+  $core.String get scriptType => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set scriptType($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasScriptType() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearScriptType() => clearField(2);
 }
 
 class BuildDescriptorsResponse extends $pb.GeneratedMessage {

--- a/sail_ui/lib/gen/multisiglounge/v1/multisiglounge.pbjson.dart
+++ b/sail_ui/lib/gen/multisiglounge/v1/multisiglounge.pbjson.dart
@@ -381,13 +381,15 @@ const BuildDescriptorsRequest$json = {
   '1': 'BuildDescriptorsRequest',
   '2': [
     {'1': 'group', '3': 1, '4': 1, '5': 11, '6': '.multisiglounge.v1.MultisigGroup', '10': 'group'},
+    {'1': 'script_type', '3': 2, '4': 1, '5': 9, '10': 'scriptType'},
   ],
 };
 
 /// Descriptor for `BuildDescriptorsRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List buildDescriptorsRequestDescriptor = $convert.base64Decode(
     'ChdCdWlsZERlc2NyaXB0b3JzUmVxdWVzdBI2CgVncm91cBgBIAEoCzIgLm11bHRpc2lnbG91bm'
-    'dlLnYxLk11bHRpc2lnR3JvdXBSBWdyb3Vw');
+    'dlLnYxLk11bHRpc2lnR3JvdXBSBWdyb3VwEh8KC3NjcmlwdF90eXBlGAIgASgJUgpzY3JpcHRU'
+    'eXBl');
 
 @$core.Deprecated('Use buildDescriptorsResponseDescriptor instead')
 const BuildDescriptorsResponse$json = {

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.connect.client.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.connect.client.dart
@@ -301,6 +301,42 @@ extension type WalletManagerServiceClient (connect.Transport _transport) {
     );
   }
 
+  Future<walletmanagerv1walletmanager.CreateMultisigWalletResponse> createMultisigWallet(
+    walletmanagerv1walletmanager.CreateMultisigWalletRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.WalletManagerService.createMultisigWallet,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
+  /// ParseMultisigConfig parses a descriptor or a wallet-config file (Coldcard
+  /// text / Sparrow / Specter / Caravan JSON) into an m-of-n policy + cosigners.
+  Future<walletmanagerv1walletmanager.ParseMultisigConfigResponse> parseMultisigConfig(
+    walletmanagerv1walletmanager.ParseMultisigConfigRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.WalletManagerService.parseMultisigConfig,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
   /// Core wallet management
   Future<walletmanagerv1walletmanager.CreateBitcoinCoreWalletResponse> createBitcoinCoreWallet(
     walletmanagerv1walletmanager.CreateBitcoinCoreWalletRequest input, {
@@ -564,6 +600,25 @@ extension type WalletManagerServiceClient (connect.Transport _transport) {
     );
   }
 
+  /// SignPsbtWithCosigner signs a multisig PSBT with a single held cosigner's key
+  /// (per-keystore signing), leaving the other legs for their own signers.
+  Future<walletmanagerv1walletmanager.SignPsbtWithCosignerResponse> signPsbtWithCosigner(
+    walletmanagerv1walletmanager.SignPsbtWithCosignerRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.WalletManagerService.signPsbtWithCosigner,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
   Future<walletmanagerv1walletmanager.CombinePsbtResponse> combinePsbt(
     walletmanagerv1walletmanager.CombinePsbtRequest input, {
     connect.Headers? headers,
@@ -590,6 +645,44 @@ extension type WalletManagerServiceClient (connect.Transport _transport) {
   }) {
     return connect.Client(_transport).unary(
       specs.WalletManagerService.finalizePsbt,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
+  /// MultisigPsbtStatus reports signing progress for a multisig wallet's PSBT:
+  /// signature count, whether it can be finalized, and which cosigners signed.
+  Future<walletmanagerv1walletmanager.MultisigPsbtStatusResponse> multisigPsbtStatus(
+    walletmanagerv1walletmanager.MultisigPsbtStatusRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.WalletManagerService.multisigPsbtStatus,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
+  /// BroadcastTransaction broadcasts a finalized raw transaction over the
+  /// wallet's chain source and returns its txid.
+  Future<walletmanagerv1walletmanager.BroadcastTransactionResponse> broadcastTransaction(
+    walletmanagerv1walletmanager.BroadcastTransactionRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.WalletManagerService.broadcastTransaction,
       input,
       signal: signal,
       headers: headers,

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.connect.spec.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.connect.spec.dart
@@ -133,6 +133,22 @@ abstract final class WalletManagerService {
     walletmanagerv1walletmanager.CreateElectrumWalletResponse.new,
   );
 
+  static const createMultisigWallet = connect.Spec(
+    '/$name/CreateMultisigWallet',
+    connect.StreamType.unary,
+    walletmanagerv1walletmanager.CreateMultisigWalletRequest.new,
+    walletmanagerv1walletmanager.CreateMultisigWalletResponse.new,
+  );
+
+  /// ParseMultisigConfig parses a descriptor or a wallet-config file (Coldcard
+  /// text / Sparrow / Specter / Caravan JSON) into an m-of-n policy + cosigners.
+  static const parseMultisigConfig = connect.Spec(
+    '/$name/ParseMultisigConfig',
+    connect.StreamType.unary,
+    walletmanagerv1walletmanager.ParseMultisigConfigRequest.new,
+    walletmanagerv1walletmanager.ParseMultisigConfigResponse.new,
+  );
+
   /// Core wallet management
   static const createBitcoinCoreWallet = connect.Spec(
     '/$name/CreateBitcoinCoreWallet',
@@ -246,6 +262,15 @@ abstract final class WalletManagerService {
     walletmanagerv1walletmanager.SignPsbtResponse.new,
   );
 
+  /// SignPsbtWithCosigner signs a multisig PSBT with a single held cosigner's key
+  /// (per-keystore signing), leaving the other legs for their own signers.
+  static const signPsbtWithCosigner = connect.Spec(
+    '/$name/SignPsbtWithCosigner',
+    connect.StreamType.unary,
+    walletmanagerv1walletmanager.SignPsbtWithCosignerRequest.new,
+    walletmanagerv1walletmanager.SignPsbtWithCosignerResponse.new,
+  );
+
   static const combinePsbt = connect.Spec(
     '/$name/CombinePsbt',
     connect.StreamType.unary,
@@ -258,6 +283,24 @@ abstract final class WalletManagerService {
     connect.StreamType.unary,
     walletmanagerv1walletmanager.FinalizePsbtRequest.new,
     walletmanagerv1walletmanager.FinalizePsbtResponse.new,
+  );
+
+  /// MultisigPsbtStatus reports signing progress for a multisig wallet's PSBT:
+  /// signature count, whether it can be finalized, and which cosigners signed.
+  static const multisigPsbtStatus = connect.Spec(
+    '/$name/MultisigPsbtStatus',
+    connect.StreamType.unary,
+    walletmanagerv1walletmanager.MultisigPsbtStatusRequest.new,
+    walletmanagerv1walletmanager.MultisigPsbtStatusResponse.new,
+  );
+
+  /// BroadcastTransaction broadcasts a finalized raw transaction over the
+  /// wallet's chain source and returns its txid.
+  static const broadcastTransaction = connect.Spec(
+    '/$name/BroadcastTransaction',
+    connect.StreamType.unary,
+    walletmanagerv1walletmanager.BroadcastTransactionRequest.new,
+    walletmanagerv1walletmanager.BroadcastTransactionResponse.new,
   );
 
   /// Seed access for cheque engine

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -753,6 +753,7 @@ class WalletMetadata extends $pb.GeneratedMessage {
     $core.String? l1Mnemonic,
     $core.Iterable<SidechainStarter>? sidechains,
     $core.bool? watchOnly,
+    MultisigInfo? multisig,
   }) {
     final $result = create();
     if (id != null) {
@@ -785,6 +786,9 @@ class WalletMetadata extends $pb.GeneratedMessage {
     if (watchOnly != null) {
       $result.watchOnly = watchOnly;
     }
+    if (multisig != null) {
+      $result.multisig = multisig;
+    }
     return $result;
   }
   WalletMetadata._() : super();
@@ -802,6 +806,7 @@ class WalletMetadata extends $pb.GeneratedMessage {
     ..aOS(8, _omitFieldNames ? '' : 'l1Mnemonic')
     ..pc<SidechainStarter>(9, _omitFieldNames ? '' : 'sidechains', $pb.PbFieldType.PM, subBuilder: SidechainStarter.create)
     ..aOB(10, _omitFieldNames ? '' : 'watchOnly')
+    ..aOM<MultisigInfo>(11, _omitFieldNames ? '' : 'multisig', subBuilder: MultisigInfo.create)
     ..hasRequiredFields = false
   ;
 
@@ -915,6 +920,197 @@ class WalletMetadata extends $pb.GeneratedMessage {
   $core.bool hasWatchOnly() => $_has(9);
   @$pb.TagNumber(10)
   void clearWatchOnly() => clearField(10);
+
+  /// Multisig policy, present only for multisig wallets. Cosigner private
+  /// material is never exposed here — only public data and a held flag.
+  @$pb.TagNumber(11)
+  MultisigInfo get multisig => $_getN(10);
+  @$pb.TagNumber(11)
+  set multisig(MultisigInfo v) { setField(11, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasMultisig() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearMultisig() => clearField(11);
+  @$pb.TagNumber(11)
+  MultisigInfo ensureMultisig() => $_ensure(10);
+}
+
+class MultisigInfo extends $pb.GeneratedMessage {
+  factory MultisigInfo({
+    $core.int? m,
+    $core.int? n,
+    $core.String? scriptType,
+    $core.Iterable<MultisigCosignerInfo>? cosigners,
+  }) {
+    final $result = create();
+    if (m != null) {
+      $result.m = m;
+    }
+    if (n != null) {
+      $result.n = n;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    if (cosigners != null) {
+      $result.cosigners.addAll(cosigners);
+    }
+    return $result;
+  }
+  MultisigInfo._() : super();
+  factory MultisigInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MultisigInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MultisigInfo', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'm', $pb.PbFieldType.OU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'n', $pb.PbFieldType.OU3)
+    ..aOS(3, _omitFieldNames ? '' : 'scriptType')
+    ..pc<MultisigCosignerInfo>(4, _omitFieldNames ? '' : 'cosigners', $pb.PbFieldType.PM, subBuilder: MultisigCosignerInfo.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MultisigInfo clone() => MultisigInfo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MultisigInfo copyWith(void Function(MultisigInfo) updates) => super.copyWith((message) => updates(message as MultisigInfo)) as MultisigInfo;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MultisigInfo create() => MultisigInfo._();
+  MultisigInfo createEmptyInstance() => create();
+  static $pb.PbList<MultisigInfo> createRepeated() => $pb.PbList<MultisigInfo>();
+  @$core.pragma('dart2js:noInline')
+  static MultisigInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MultisigInfo>(create);
+  static MultisigInfo? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get m => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set m($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasM() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearM() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get n => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set n($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasN() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearN() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get scriptType => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set scriptType($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasScriptType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearScriptType() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<MultisigCosignerInfo> get cosigners => $_getList(3);
+}
+
+class MultisigCosignerInfo extends $pb.GeneratedMessage {
+  factory MultisigCosignerInfo({
+    $core.String? xpub,
+    $core.String? fingerprint,
+    $core.String? originPath,
+    $core.bool? held,
+  }) {
+    final $result = create();
+    if (xpub != null) {
+      $result.xpub = xpub;
+    }
+    if (fingerprint != null) {
+      $result.fingerprint = fingerprint;
+    }
+    if (originPath != null) {
+      $result.originPath = originPath;
+    }
+    if (held != null) {
+      $result.held = held;
+    }
+    return $result;
+  }
+  MultisigCosignerInfo._() : super();
+  factory MultisigCosignerInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MultisigCosignerInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MultisigCosignerInfo', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'xpub')
+    ..aOS(2, _omitFieldNames ? '' : 'fingerprint')
+    ..aOS(3, _omitFieldNames ? '' : 'originPath')
+    ..aOB(4, _omitFieldNames ? '' : 'held')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MultisigCosignerInfo clone() => MultisigCosignerInfo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MultisigCosignerInfo copyWith(void Function(MultisigCosignerInfo) updates) => super.copyWith((message) => updates(message as MultisigCosignerInfo)) as MultisigCosignerInfo;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MultisigCosignerInfo create() => MultisigCosignerInfo._();
+  MultisigCosignerInfo createEmptyInstance() => create();
+  static $pb.PbList<MultisigCosignerInfo> createRepeated() => $pb.PbList<MultisigCosignerInfo>();
+  @$core.pragma('dart2js:noInline')
+  static MultisigCosignerInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MultisigCosignerInfo>(create);
+  static MultisigCosignerInfo? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get xpub => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set xpub($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasXpub() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearXpub() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get fingerprint => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set fingerprint($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFingerprint() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFingerprint() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get originPath => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set originPath($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasOriginPath() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearOriginPath() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.bool get held => $_getBF(3);
+  @$pb.TagNumber(4)
+  set held($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasHeld() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearHeld() => clearField(4);
 }
 
 class SidechainStarter extends $pb.GeneratedMessage {
@@ -2497,6 +2693,510 @@ class CreateElectrumWalletResponse extends $pb.GeneratedMessage {
   void clearWalletId() => clearField(1);
 }
 
+/// MultisigCosignerInput is one leg of a multisig wallet. A cosigner with a
+/// mnemonic or xprv is held on disk (this wallet signs with it); one with only
+/// an xpub is a watch-only leg signed elsewhere.
+class MultisigCosignerInput extends $pb.GeneratedMessage {
+  factory MultisigCosignerInput({
+    $core.String? xpub,
+    $core.String? originPath,
+    $core.String? fingerprint,
+    $core.String? mnemonic,
+    $core.String? xprv,
+    $core.String? passphrase,
+  }) {
+    final $result = create();
+    if (xpub != null) {
+      $result.xpub = xpub;
+    }
+    if (originPath != null) {
+      $result.originPath = originPath;
+    }
+    if (fingerprint != null) {
+      $result.fingerprint = fingerprint;
+    }
+    if (mnemonic != null) {
+      $result.mnemonic = mnemonic;
+    }
+    if (xprv != null) {
+      $result.xprv = xprv;
+    }
+    if (passphrase != null) {
+      $result.passphrase = passphrase;
+    }
+    return $result;
+  }
+  MultisigCosignerInput._() : super();
+  factory MultisigCosignerInput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MultisigCosignerInput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MultisigCosignerInput', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'xpub')
+    ..aOS(2, _omitFieldNames ? '' : 'originPath')
+    ..aOS(3, _omitFieldNames ? '' : 'fingerprint')
+    ..aOS(4, _omitFieldNames ? '' : 'mnemonic')
+    ..aOS(5, _omitFieldNames ? '' : 'xprv')
+    ..aOS(6, _omitFieldNames ? '' : 'passphrase')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MultisigCosignerInput clone() => MultisigCosignerInput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MultisigCosignerInput copyWith(void Function(MultisigCosignerInput) updates) => super.copyWith((message) => updates(message as MultisigCosignerInput)) as MultisigCosignerInput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MultisigCosignerInput create() => MultisigCosignerInput._();
+  MultisigCosignerInput createEmptyInstance() => create();
+  static $pb.PbList<MultisigCosignerInput> createRepeated() => $pb.PbList<MultisigCosignerInput>();
+  @$core.pragma('dart2js:noInline')
+  static MultisigCosignerInput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MultisigCosignerInput>(create);
+  static MultisigCosignerInput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get xpub => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set xpub($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasXpub() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearXpub() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get originPath => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set originPath($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasOriginPath() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearOriginPath() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get fingerprint => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set fingerprint($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasFingerprint() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearFingerprint() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get mnemonic => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set mnemonic($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMnemonic() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMnemonic() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.String get xprv => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set xprv($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasXprv() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearXprv() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.String get passphrase => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set passphrase($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasPassphrase() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearPassphrase() => clearField(6);
+}
+
+class CreateMultisigWalletRequest extends $pb.GeneratedMessage {
+  factory CreateMultisigWalletRequest({
+    $core.String? name,
+    $core.String? gradientJson,
+    $core.int? m,
+    $core.int? n,
+    $core.String? scriptType,
+    $core.Iterable<MultisigCosignerInput>? cosigners,
+  }) {
+    final $result = create();
+    if (name != null) {
+      $result.name = name;
+    }
+    if (gradientJson != null) {
+      $result.gradientJson = gradientJson;
+    }
+    if (m != null) {
+      $result.m = m;
+    }
+    if (n != null) {
+      $result.n = n;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    if (cosigners != null) {
+      $result.cosigners.addAll(cosigners);
+    }
+    return $result;
+  }
+  CreateMultisigWalletRequest._() : super();
+  factory CreateMultisigWalletRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateMultisigWalletRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateMultisigWalletRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOS(2, _omitFieldNames ? '' : 'gradientJson')
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'm', $pb.PbFieldType.OU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'n', $pb.PbFieldType.OU3)
+    ..aOS(5, _omitFieldNames ? '' : 'scriptType')
+    ..pc<MultisigCosignerInput>(6, _omitFieldNames ? '' : 'cosigners', $pb.PbFieldType.PM, subBuilder: MultisigCosignerInput.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CreateMultisigWalletRequest clone() => CreateMultisigWalletRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateMultisigWalletRequest copyWith(void Function(CreateMultisigWalletRequest) updates) => super.copyWith((message) => updates(message as CreateMultisigWalletRequest)) as CreateMultisigWalletRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CreateMultisigWalletRequest create() => CreateMultisigWalletRequest._();
+  CreateMultisigWalletRequest createEmptyInstance() => create();
+  static $pb.PbList<CreateMultisigWalletRequest> createRepeated() => $pb.PbList<CreateMultisigWalletRequest>();
+  @$core.pragma('dart2js:noInline')
+  static CreateMultisigWalletRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateMultisigWalletRequest>(create);
+  static CreateMultisigWalletRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get gradientJson => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set gradientJson($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasGradientJson() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearGradientJson() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get m => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set m($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasM() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearM() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get n => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set n($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasN() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearN() => clearField(4);
+
+  /// "wsh" (native P2WSH, default), "sh-wsh" (nested P2SH-P2WSH), or "sh"
+  /// (legacy P2SH).
+  @$pb.TagNumber(5)
+  $core.String get scriptType => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set scriptType($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasScriptType() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearScriptType() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<MultisigCosignerInput> get cosigners => $_getList(5);
+}
+
+class CreateMultisigWalletResponse extends $pb.GeneratedMessage {
+  factory CreateMultisigWalletResponse({
+    $core.String? walletId,
+  }) {
+    final $result = create();
+    if (walletId != null) {
+      $result.walletId = walletId;
+    }
+    return $result;
+  }
+  CreateMultisigWalletResponse._() : super();
+  factory CreateMultisigWalletResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateMultisigWalletResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateMultisigWalletResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'walletId')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CreateMultisigWalletResponse clone() => CreateMultisigWalletResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateMultisigWalletResponse copyWith(void Function(CreateMultisigWalletResponse) updates) => super.copyWith((message) => updates(message as CreateMultisigWalletResponse)) as CreateMultisigWalletResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CreateMultisigWalletResponse create() => CreateMultisigWalletResponse._();
+  CreateMultisigWalletResponse createEmptyInstance() => create();
+  static $pb.PbList<CreateMultisigWalletResponse> createRepeated() => $pb.PbList<CreateMultisigWalletResponse>();
+  @$core.pragma('dart2js:noInline')
+  static CreateMultisigWalletResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateMultisigWalletResponse>(create);
+  static CreateMultisigWalletResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get walletId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set walletId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWalletId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWalletId() => clearField(1);
+}
+
+class ParseMultisigConfigRequest extends $pb.GeneratedMessage {
+  factory ParseMultisigConfigRequest({
+    $core.String? content,
+  }) {
+    final $result = create();
+    if (content != null) {
+      $result.content = content;
+    }
+    return $result;
+  }
+  ParseMultisigConfigRequest._() : super();
+  factory ParseMultisigConfigRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ParseMultisigConfigRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ParseMultisigConfigRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'content')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ParseMultisigConfigRequest clone() => ParseMultisigConfigRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ParseMultisigConfigRequest copyWith(void Function(ParseMultisigConfigRequest) updates) => super.copyWith((message) => updates(message as ParseMultisigConfigRequest)) as ParseMultisigConfigRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ParseMultisigConfigRequest create() => ParseMultisigConfigRequest._();
+  ParseMultisigConfigRequest createEmptyInstance() => create();
+  static $pb.PbList<ParseMultisigConfigRequest> createRepeated() => $pb.PbList<ParseMultisigConfigRequest>();
+  @$core.pragma('dart2js:noInline')
+  static ParseMultisigConfigRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ParseMultisigConfigRequest>(create);
+  static ParseMultisigConfigRequest? _defaultInstance;
+
+  /// An output descriptor or a wallet-config file's contents.
+  @$pb.TagNumber(1)
+  $core.String get content => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set content($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasContent() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearContent() => clearField(1);
+}
+
+class ParsedCosigner extends $pb.GeneratedMessage {
+  factory ParsedCosigner({
+    $core.String? xpub,
+    $core.String? fingerprint,
+    $core.String? originPath,
+  }) {
+    final $result = create();
+    if (xpub != null) {
+      $result.xpub = xpub;
+    }
+    if (fingerprint != null) {
+      $result.fingerprint = fingerprint;
+    }
+    if (originPath != null) {
+      $result.originPath = originPath;
+    }
+    return $result;
+  }
+  ParsedCosigner._() : super();
+  factory ParsedCosigner.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ParsedCosigner.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ParsedCosigner', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'xpub')
+    ..aOS(2, _omitFieldNames ? '' : 'fingerprint')
+    ..aOS(3, _omitFieldNames ? '' : 'originPath')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ParsedCosigner clone() => ParsedCosigner()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ParsedCosigner copyWith(void Function(ParsedCosigner) updates) => super.copyWith((message) => updates(message as ParsedCosigner)) as ParsedCosigner;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ParsedCosigner create() => ParsedCosigner._();
+  ParsedCosigner createEmptyInstance() => create();
+  static $pb.PbList<ParsedCosigner> createRepeated() => $pb.PbList<ParsedCosigner>();
+  @$core.pragma('dart2js:noInline')
+  static ParsedCosigner getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ParsedCosigner>(create);
+  static ParsedCosigner? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get xpub => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set xpub($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasXpub() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearXpub() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get fingerprint => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set fingerprint($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFingerprint() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFingerprint() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get originPath => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set originPath($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasOriginPath() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearOriginPath() => clearField(3);
+}
+
+class ParseMultisigConfigResponse extends $pb.GeneratedMessage {
+  factory ParseMultisigConfigResponse({
+    $core.int? m,
+    $core.int? n,
+    $core.String? scriptType,
+    $core.Iterable<ParsedCosigner>? cosigners,
+  }) {
+    final $result = create();
+    if (m != null) {
+      $result.m = m;
+    }
+    if (n != null) {
+      $result.n = n;
+    }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
+    if (cosigners != null) {
+      $result.cosigners.addAll(cosigners);
+    }
+    return $result;
+  }
+  ParseMultisigConfigResponse._() : super();
+  factory ParseMultisigConfigResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ParseMultisigConfigResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ParseMultisigConfigResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'm', $pb.PbFieldType.OU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'n', $pb.PbFieldType.OU3)
+    ..aOS(3, _omitFieldNames ? '' : 'scriptType')
+    ..pc<ParsedCosigner>(4, _omitFieldNames ? '' : 'cosigners', $pb.PbFieldType.PM, subBuilder: ParsedCosigner.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ParseMultisigConfigResponse clone() => ParseMultisigConfigResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ParseMultisigConfigResponse copyWith(void Function(ParseMultisigConfigResponse) updates) => super.copyWith((message) => updates(message as ParseMultisigConfigResponse)) as ParseMultisigConfigResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ParseMultisigConfigResponse create() => ParseMultisigConfigResponse._();
+  ParseMultisigConfigResponse createEmptyInstance() => create();
+  static $pb.PbList<ParseMultisigConfigResponse> createRepeated() => $pb.PbList<ParseMultisigConfigResponse>();
+  @$core.pragma('dart2js:noInline')
+  static ParseMultisigConfigResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ParseMultisigConfigResponse>(create);
+  static ParseMultisigConfigResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get m => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set m($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasM() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearM() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get n => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set n($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasN() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearN() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get scriptType => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set scriptType($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasScriptType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearScriptType() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<ParsedCosigner> get cosigners => $_getList(3);
+}
+
 class CreateBitcoinCoreWalletRequest extends $pb.GeneratedMessage {
   factory CreateBitcoinCoreWalletRequest({
     $core.String? walletId,
@@ -3596,6 +4296,134 @@ class SignPsbtResponse extends $pb.GeneratedMessage {
   void clearPsbtBase64() => clearField(1);
 }
 
+class SignPsbtWithCosignerRequest extends $pb.GeneratedMessage {
+  factory SignPsbtWithCosignerRequest({
+    $core.String? walletId,
+    $core.String? psbtBase64,
+    $core.String? cosignerXpub,
+  }) {
+    final $result = create();
+    if (walletId != null) {
+      $result.walletId = walletId;
+    }
+    if (psbtBase64 != null) {
+      $result.psbtBase64 = psbtBase64;
+    }
+    if (cosignerXpub != null) {
+      $result.cosignerXpub = cosignerXpub;
+    }
+    return $result;
+  }
+  SignPsbtWithCosignerRequest._() : super();
+  factory SignPsbtWithCosignerRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignPsbtWithCosignerRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignPsbtWithCosignerRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'walletId')
+    ..aOS(2, _omitFieldNames ? '' : 'psbtBase64')
+    ..aOS(3, _omitFieldNames ? '' : 'cosignerXpub')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SignPsbtWithCosignerRequest clone() => SignPsbtWithCosignerRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignPsbtWithCosignerRequest copyWith(void Function(SignPsbtWithCosignerRequest) updates) => super.copyWith((message) => updates(message as SignPsbtWithCosignerRequest)) as SignPsbtWithCosignerRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SignPsbtWithCosignerRequest create() => SignPsbtWithCosignerRequest._();
+  SignPsbtWithCosignerRequest createEmptyInstance() => create();
+  static $pb.PbList<SignPsbtWithCosignerRequest> createRepeated() => $pb.PbList<SignPsbtWithCosignerRequest>();
+  @$core.pragma('dart2js:noInline')
+  static SignPsbtWithCosignerRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignPsbtWithCosignerRequest>(create);
+  static SignPsbtWithCosignerRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get walletId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set walletId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWalletId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWalletId() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get psbtBase64 => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set psbtBase64($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPsbtBase64() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPsbtBase64() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get cosignerXpub => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set cosignerXpub($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCosignerXpub() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCosignerXpub() => clearField(3);
+}
+
+class SignPsbtWithCosignerResponse extends $pb.GeneratedMessage {
+  factory SignPsbtWithCosignerResponse({
+    $core.String? psbtBase64,
+  }) {
+    final $result = create();
+    if (psbtBase64 != null) {
+      $result.psbtBase64 = psbtBase64;
+    }
+    return $result;
+  }
+  SignPsbtWithCosignerResponse._() : super();
+  factory SignPsbtWithCosignerResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SignPsbtWithCosignerResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignPsbtWithCosignerResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'psbtBase64')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SignPsbtWithCosignerResponse clone() => SignPsbtWithCosignerResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SignPsbtWithCosignerResponse copyWith(void Function(SignPsbtWithCosignerResponse) updates) => super.copyWith((message) => updates(message as SignPsbtWithCosignerResponse)) as SignPsbtWithCosignerResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SignPsbtWithCosignerResponse create() => SignPsbtWithCosignerResponse._();
+  SignPsbtWithCosignerResponse createEmptyInstance() => create();
+  static $pb.PbList<SignPsbtWithCosignerResponse> createRepeated() => $pb.PbList<SignPsbtWithCosignerResponse>();
+  @$core.pragma('dart2js:noInline')
+  static SignPsbtWithCosignerResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignPsbtWithCosignerResponse>(create);
+  static SignPsbtWithCosignerResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get psbtBase64 => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set psbtBase64($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPsbtBase64() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPsbtBase64() => clearField(1);
+}
+
 class CombinePsbtRequest extends $pb.GeneratedMessage {
   factory CombinePsbtRequest({
     $core.Iterable<$core.String>? psbtBase64,
@@ -3788,6 +4616,271 @@ class FinalizePsbtResponse extends $pb.GeneratedMessage {
   $core.bool hasRawTxHex() => $_has(0);
   @$pb.TagNumber(1)
   void clearRawTxHex() => clearField(1);
+}
+
+class MultisigPsbtStatusRequest extends $pb.GeneratedMessage {
+  factory MultisigPsbtStatusRequest({
+    $core.String? walletId,
+    $core.String? psbtBase64,
+  }) {
+    final $result = create();
+    if (walletId != null) {
+      $result.walletId = walletId;
+    }
+    if (psbtBase64 != null) {
+      $result.psbtBase64 = psbtBase64;
+    }
+    return $result;
+  }
+  MultisigPsbtStatusRequest._() : super();
+  factory MultisigPsbtStatusRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MultisigPsbtStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MultisigPsbtStatusRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'walletId')
+    ..aOS(2, _omitFieldNames ? '' : 'psbtBase64')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MultisigPsbtStatusRequest clone() => MultisigPsbtStatusRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MultisigPsbtStatusRequest copyWith(void Function(MultisigPsbtStatusRequest) updates) => super.copyWith((message) => updates(message as MultisigPsbtStatusRequest)) as MultisigPsbtStatusRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MultisigPsbtStatusRequest create() => MultisigPsbtStatusRequest._();
+  MultisigPsbtStatusRequest createEmptyInstance() => create();
+  static $pb.PbList<MultisigPsbtStatusRequest> createRepeated() => $pb.PbList<MultisigPsbtStatusRequest>();
+  @$core.pragma('dart2js:noInline')
+  static MultisigPsbtStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MultisigPsbtStatusRequest>(create);
+  static MultisigPsbtStatusRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get walletId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set walletId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWalletId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWalletId() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get psbtBase64 => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set psbtBase64($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPsbtBase64() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPsbtBase64() => clearField(2);
+}
+
+class MultisigPsbtStatusResponse extends $pb.GeneratedMessage {
+  factory MultisigPsbtStatusResponse({
+    $core.int? threshold,
+    $core.int? signatures,
+    $core.bool? finalizable,
+    $core.Iterable<$core.bool>? cosignerSigned,
+  }) {
+    final $result = create();
+    if (threshold != null) {
+      $result.threshold = threshold;
+    }
+    if (signatures != null) {
+      $result.signatures = signatures;
+    }
+    if (finalizable != null) {
+      $result.finalizable = finalizable;
+    }
+    if (cosignerSigned != null) {
+      $result.cosignerSigned.addAll(cosignerSigned);
+    }
+    return $result;
+  }
+  MultisigPsbtStatusResponse._() : super();
+  factory MultisigPsbtStatusResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MultisigPsbtStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MultisigPsbtStatusResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'threshold', $pb.PbFieldType.OU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'signatures', $pb.PbFieldType.OU3)
+    ..aOB(3, _omitFieldNames ? '' : 'finalizable')
+    ..p<$core.bool>(4, _omitFieldNames ? '' : 'cosignerSigned', $pb.PbFieldType.KB)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MultisigPsbtStatusResponse clone() => MultisigPsbtStatusResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MultisigPsbtStatusResponse copyWith(void Function(MultisigPsbtStatusResponse) updates) => super.copyWith((message) => updates(message as MultisigPsbtStatusResponse)) as MultisigPsbtStatusResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MultisigPsbtStatusResponse create() => MultisigPsbtStatusResponse._();
+  MultisigPsbtStatusResponse createEmptyInstance() => create();
+  static $pb.PbList<MultisigPsbtStatusResponse> createRepeated() => $pb.PbList<MultisigPsbtStatusResponse>();
+  @$core.pragma('dart2js:noInline')
+  static MultisigPsbtStatusResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MultisigPsbtStatusResponse>(create);
+  static MultisigPsbtStatusResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get threshold => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set threshold($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasThreshold() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearThreshold() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get signatures => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set signatures($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasSignatures() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSignatures() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get finalizable => $_getBF(2);
+  @$pb.TagNumber(3)
+  set finalizable($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasFinalizable() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearFinalizable() => clearField(3);
+
+  /// Aligned to the wallet's cosigners; true where that cosigner has signed.
+  @$pb.TagNumber(4)
+  $core.List<$core.bool> get cosignerSigned => $_getList(3);
+}
+
+class BroadcastTransactionRequest extends $pb.GeneratedMessage {
+  factory BroadcastTransactionRequest({
+    $core.String? walletId,
+    $core.String? txHex,
+  }) {
+    final $result = create();
+    if (walletId != null) {
+      $result.walletId = walletId;
+    }
+    if (txHex != null) {
+      $result.txHex = txHex;
+    }
+    return $result;
+  }
+  BroadcastTransactionRequest._() : super();
+  factory BroadcastTransactionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BroadcastTransactionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BroadcastTransactionRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'walletId')
+    ..aOS(2, _omitFieldNames ? '' : 'txHex')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BroadcastTransactionRequest clone() => BroadcastTransactionRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BroadcastTransactionRequest copyWith(void Function(BroadcastTransactionRequest) updates) => super.copyWith((message) => updates(message as BroadcastTransactionRequest)) as BroadcastTransactionRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BroadcastTransactionRequest create() => BroadcastTransactionRequest._();
+  BroadcastTransactionRequest createEmptyInstance() => create();
+  static $pb.PbList<BroadcastTransactionRequest> createRepeated() => $pb.PbList<BroadcastTransactionRequest>();
+  @$core.pragma('dart2js:noInline')
+  static BroadcastTransactionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BroadcastTransactionRequest>(create);
+  static BroadcastTransactionRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get walletId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set walletId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWalletId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWalletId() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get txHex => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set txHex($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTxHex() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTxHex() => clearField(2);
+}
+
+class BroadcastTransactionResponse extends $pb.GeneratedMessage {
+  factory BroadcastTransactionResponse({
+    $core.String? txid,
+  }) {
+    final $result = create();
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    return $result;
+  }
+  BroadcastTransactionResponse._() : super();
+  factory BroadcastTransactionResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BroadcastTransactionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BroadcastTransactionResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'txid')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BroadcastTransactionResponse clone() => BroadcastTransactionResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BroadcastTransactionResponse copyWith(void Function(BroadcastTransactionResponse) updates) => super.copyWith((message) => updates(message as BroadcastTransactionResponse)) as BroadcastTransactionResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BroadcastTransactionResponse create() => BroadcastTransactionResponse._();
+  BroadcastTransactionResponse createEmptyInstance() => create();
+  static $pb.PbList<BroadcastTransactionResponse> createRepeated() => $pb.PbList<BroadcastTransactionResponse>();
+  @$core.pragma('dart2js:noInline')
+  static BroadcastTransactionResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BroadcastTransactionResponse>(create);
+  static BroadcastTransactionResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get txid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set txid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxid() => clearField(1);
 }
 
 class ListTransactionsRequest extends $pb.GeneratedMessage {
@@ -7283,6 +8376,12 @@ class WalletManagerServiceApi {
   $async.Future<CreateElectrumWalletResponse> createElectrumWallet($pb.ClientContext? ctx, CreateElectrumWalletRequest request) =>
     _client.invoke<CreateElectrumWalletResponse>(ctx, 'WalletManagerService', 'CreateElectrumWallet', request, CreateElectrumWalletResponse())
   ;
+  $async.Future<CreateMultisigWalletResponse> createMultisigWallet($pb.ClientContext? ctx, CreateMultisigWalletRequest request) =>
+    _client.invoke<CreateMultisigWalletResponse>(ctx, 'WalletManagerService', 'CreateMultisigWallet', request, CreateMultisigWalletResponse())
+  ;
+  $async.Future<ParseMultisigConfigResponse> parseMultisigConfig($pb.ClientContext? ctx, ParseMultisigConfigRequest request) =>
+    _client.invoke<ParseMultisigConfigResponse>(ctx, 'WalletManagerService', 'ParseMultisigConfig', request, ParseMultisigConfigResponse())
+  ;
   $async.Future<CreateBitcoinCoreWalletResponse> createBitcoinCoreWallet($pb.ClientContext? ctx, CreateBitcoinCoreWalletRequest request) =>
     _client.invoke<CreateBitcoinCoreWalletResponse>(ctx, 'WalletManagerService', 'CreateBitcoinCoreWallet', request, CreateBitcoinCoreWalletResponse())
   ;
@@ -7328,11 +8427,20 @@ class WalletManagerServiceApi {
   $async.Future<SignPsbtResponse> signPsbt($pb.ClientContext? ctx, SignPsbtRequest request) =>
     _client.invoke<SignPsbtResponse>(ctx, 'WalletManagerService', 'SignPsbt', request, SignPsbtResponse())
   ;
+  $async.Future<SignPsbtWithCosignerResponse> signPsbtWithCosigner($pb.ClientContext? ctx, SignPsbtWithCosignerRequest request) =>
+    _client.invoke<SignPsbtWithCosignerResponse>(ctx, 'WalletManagerService', 'SignPsbtWithCosigner', request, SignPsbtWithCosignerResponse())
+  ;
   $async.Future<CombinePsbtResponse> combinePsbt($pb.ClientContext? ctx, CombinePsbtRequest request) =>
     _client.invoke<CombinePsbtResponse>(ctx, 'WalletManagerService', 'CombinePsbt', request, CombinePsbtResponse())
   ;
   $async.Future<FinalizePsbtResponse> finalizePsbt($pb.ClientContext? ctx, FinalizePsbtRequest request) =>
     _client.invoke<FinalizePsbtResponse>(ctx, 'WalletManagerService', 'FinalizePsbt', request, FinalizePsbtResponse())
+  ;
+  $async.Future<MultisigPsbtStatusResponse> multisigPsbtStatus($pb.ClientContext? ctx, MultisigPsbtStatusRequest request) =>
+    _client.invoke<MultisigPsbtStatusResponse>(ctx, 'WalletManagerService', 'MultisigPsbtStatus', request, MultisigPsbtStatusResponse())
+  ;
+  $async.Future<BroadcastTransactionResponse> broadcastTransaction($pb.ClientContext? ctx, BroadcastTransactionRequest request) =>
+    _client.invoke<BroadcastTransactionResponse>(ctx, 'WalletManagerService', 'BroadcastTransaction', request, BroadcastTransactionResponse())
   ;
   $async.Future<GetWalletSeedResponse> getWalletSeed($pb.ClientContext? ctx, GetWalletSeedRequest request) =>
     _client.invoke<GetWalletSeedResponse>(ctx, 'WalletManagerService', 'GetWalletSeed', request, GetWalletSeedResponse())

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -262,6 +262,7 @@ const WalletMetadata$json = {
     {'1': 'l1_mnemonic', '3': 8, '4': 1, '5': 9, '10': 'l1Mnemonic'},
     {'1': 'sidechains', '3': 9, '4': 3, '5': 11, '6': '.walletmanager.v1.SidechainStarter', '10': 'sidechains'},
     {'1': 'watch_only', '3': 10, '4': 1, '5': 8, '10': 'watchOnly'},
+    {'1': 'multisig', '3': 11, '4': 1, '5': 11, '6': '.walletmanager.v1.MultisigInfo', '10': 'multisig'},
   ],
 };
 
@@ -274,7 +275,42 @@ final $typed_data.Uint8List walletMetadataDescriptor = $convert.base64Decode(
     'ZW50Q29kZRInCg9tYXN0ZXJfbW5lbW9uaWMYByABKAlSDm1hc3Rlck1uZW1vbmljEh8KC2wxX2'
     '1uZW1vbmljGAggASgJUgpsMU1uZW1vbmljEkIKCnNpZGVjaGFpbnMYCSADKAsyIi53YWxsZXRt'
     'YW5hZ2VyLnYxLlNpZGVjaGFpblN0YXJ0ZXJSCnNpZGVjaGFpbnMSHQoKd2F0Y2hfb25seRgKIA'
-    'EoCFIJd2F0Y2hPbmx5');
+    'EoCFIJd2F0Y2hPbmx5EjoKCG11bHRpc2lnGAsgASgLMh4ud2FsbGV0bWFuYWdlci52MS5NdWx0'
+    'aXNpZ0luZm9SCG11bHRpc2ln');
+
+@$core.Deprecated('Use multisigInfoDescriptor instead')
+const MultisigInfo$json = {
+  '1': 'MultisigInfo',
+  '2': [
+    {'1': 'm', '3': 1, '4': 1, '5': 13, '10': 'm'},
+    {'1': 'n', '3': 2, '4': 1, '5': 13, '10': 'n'},
+    {'1': 'script_type', '3': 3, '4': 1, '5': 9, '10': 'scriptType'},
+    {'1': 'cosigners', '3': 4, '4': 3, '5': 11, '6': '.walletmanager.v1.MultisigCosignerInfo', '10': 'cosigners'},
+  ],
+};
+
+/// Descriptor for `MultisigInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List multisigInfoDescriptor = $convert.base64Decode(
+    'CgxNdWx0aXNpZ0luZm8SDAoBbRgBIAEoDVIBbRIMCgFuGAIgASgNUgFuEh8KC3NjcmlwdF90eX'
+    'BlGAMgASgJUgpzY3JpcHRUeXBlEkQKCWNvc2lnbmVycxgEIAMoCzImLndhbGxldG1hbmFnZXIu'
+    'djEuTXVsdGlzaWdDb3NpZ25lckluZm9SCWNvc2lnbmVycw==');
+
+@$core.Deprecated('Use multisigCosignerInfoDescriptor instead')
+const MultisigCosignerInfo$json = {
+  '1': 'MultisigCosignerInfo',
+  '2': [
+    {'1': 'xpub', '3': 1, '4': 1, '5': 9, '10': 'xpub'},
+    {'1': 'fingerprint', '3': 2, '4': 1, '5': 9, '10': 'fingerprint'},
+    {'1': 'origin_path', '3': 3, '4': 1, '5': 9, '10': 'originPath'},
+    {'1': 'held', '3': 4, '4': 1, '5': 8, '10': 'held'},
+  ],
+};
+
+/// Descriptor for `MultisigCosignerInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List multisigCosignerInfoDescriptor = $convert.base64Decode(
+    'ChRNdWx0aXNpZ0Nvc2lnbmVySW5mbxISCgR4cHViGAEgASgJUgR4cHViEiAKC2ZpbmdlcnByaW'
+    '50GAIgASgJUgtmaW5nZXJwcmludBIfCgtvcmlnaW5fcGF0aBgDIAEoCVIKb3JpZ2luUGF0aBIS'
+    'CgRoZWxkGAQgASgIUgRoZWxk');
 
 @$core.Deprecated('Use sidechainStarterDescriptor instead')
 const SidechainStarter$json = {
@@ -623,6 +659,103 @@ final $typed_data.Uint8List createElectrumWalletResponseDescriptor = $convert.ba
     'ChxDcmVhdGVFbGVjdHJ1bVdhbGxldFJlc3BvbnNlEhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbG'
     'V0SWQ=');
 
+@$core.Deprecated('Use multisigCosignerInputDescriptor instead')
+const MultisigCosignerInput$json = {
+  '1': 'MultisigCosignerInput',
+  '2': [
+    {'1': 'xpub', '3': 1, '4': 1, '5': 9, '10': 'xpub'},
+    {'1': 'origin_path', '3': 2, '4': 1, '5': 9, '10': 'originPath'},
+    {'1': 'fingerprint', '3': 3, '4': 1, '5': 9, '10': 'fingerprint'},
+    {'1': 'mnemonic', '3': 4, '4': 1, '5': 9, '10': 'mnemonic'},
+    {'1': 'xprv', '3': 5, '4': 1, '5': 9, '10': 'xprv'},
+    {'1': 'passphrase', '3': 6, '4': 1, '5': 9, '10': 'passphrase'},
+  ],
+};
+
+/// Descriptor for `MultisigCosignerInput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List multisigCosignerInputDescriptor = $convert.base64Decode(
+    'ChVNdWx0aXNpZ0Nvc2lnbmVySW5wdXQSEgoEeHB1YhgBIAEoCVIEeHB1YhIfCgtvcmlnaW5fcG'
+    'F0aBgCIAEoCVIKb3JpZ2luUGF0aBIgCgtmaW5nZXJwcmludBgDIAEoCVILZmluZ2VycHJpbnQS'
+    'GgoIbW5lbW9uaWMYBCABKAlSCG1uZW1vbmljEhIKBHhwcnYYBSABKAlSBHhwcnYSHgoKcGFzc3'
+    'BocmFzZRgGIAEoCVIKcGFzc3BocmFzZQ==');
+
+@$core.Deprecated('Use createMultisigWalletRequestDescriptor instead')
+const CreateMultisigWalletRequest$json = {
+  '1': 'CreateMultisigWalletRequest',
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'gradient_json', '3': 2, '4': 1, '5': 9, '10': 'gradientJson'},
+    {'1': 'm', '3': 3, '4': 1, '5': 13, '10': 'm'},
+    {'1': 'n', '3': 4, '4': 1, '5': 13, '10': 'n'},
+    {'1': 'script_type', '3': 5, '4': 1, '5': 9, '10': 'scriptType'},
+    {'1': 'cosigners', '3': 6, '4': 3, '5': 11, '6': '.walletmanager.v1.MultisigCosignerInput', '10': 'cosigners'},
+  ],
+};
+
+/// Descriptor for `CreateMultisigWalletRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List createMultisigWalletRequestDescriptor = $convert.base64Decode(
+    'ChtDcmVhdGVNdWx0aXNpZ1dhbGxldFJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIjCg1ncm'
+    'FkaWVudF9qc29uGAIgASgJUgxncmFkaWVudEpzb24SDAoBbRgDIAEoDVIBbRIMCgFuGAQgASgN'
+    'UgFuEh8KC3NjcmlwdF90eXBlGAUgASgJUgpzY3JpcHRUeXBlEkUKCWNvc2lnbmVycxgGIAMoCz'
+    'InLndhbGxldG1hbmFnZXIudjEuTXVsdGlzaWdDb3NpZ25lcklucHV0Ugljb3NpZ25lcnM=');
+
+@$core.Deprecated('Use createMultisigWalletResponseDescriptor instead')
+const CreateMultisigWalletResponse$json = {
+  '1': 'CreateMultisigWalletResponse',
+  '2': [
+    {'1': 'wallet_id', '3': 1, '4': 1, '5': 9, '10': 'walletId'},
+  ],
+};
+
+/// Descriptor for `CreateMultisigWalletResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List createMultisigWalletResponseDescriptor = $convert.base64Decode(
+    'ChxDcmVhdGVNdWx0aXNpZ1dhbGxldFJlc3BvbnNlEhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbG'
+    'V0SWQ=');
+
+@$core.Deprecated('Use parseMultisigConfigRequestDescriptor instead')
+const ParseMultisigConfigRequest$json = {
+  '1': 'ParseMultisigConfigRequest',
+  '2': [
+    {'1': 'content', '3': 1, '4': 1, '5': 9, '10': 'content'},
+  ],
+};
+
+/// Descriptor for `ParseMultisigConfigRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List parseMultisigConfigRequestDescriptor = $convert.base64Decode(
+    'ChpQYXJzZU11bHRpc2lnQ29uZmlnUmVxdWVzdBIYCgdjb250ZW50GAEgASgJUgdjb250ZW50');
+
+@$core.Deprecated('Use parsedCosignerDescriptor instead')
+const ParsedCosigner$json = {
+  '1': 'ParsedCosigner',
+  '2': [
+    {'1': 'xpub', '3': 1, '4': 1, '5': 9, '10': 'xpub'},
+    {'1': 'fingerprint', '3': 2, '4': 1, '5': 9, '10': 'fingerprint'},
+    {'1': 'origin_path', '3': 3, '4': 1, '5': 9, '10': 'originPath'},
+  ],
+};
+
+/// Descriptor for `ParsedCosigner`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List parsedCosignerDescriptor = $convert.base64Decode(
+    'Cg5QYXJzZWRDb3NpZ25lchISCgR4cHViGAEgASgJUgR4cHViEiAKC2ZpbmdlcnByaW50GAIgAS'
+    'gJUgtmaW5nZXJwcmludBIfCgtvcmlnaW5fcGF0aBgDIAEoCVIKb3JpZ2luUGF0aA==');
+
+@$core.Deprecated('Use parseMultisigConfigResponseDescriptor instead')
+const ParseMultisigConfigResponse$json = {
+  '1': 'ParseMultisigConfigResponse',
+  '2': [
+    {'1': 'm', '3': 1, '4': 1, '5': 13, '10': 'm'},
+    {'1': 'n', '3': 2, '4': 1, '5': 13, '10': 'n'},
+    {'1': 'script_type', '3': 3, '4': 1, '5': 9, '10': 'scriptType'},
+    {'1': 'cosigners', '3': 4, '4': 3, '5': 11, '6': '.walletmanager.v1.ParsedCosigner', '10': 'cosigners'},
+  ],
+};
+
+/// Descriptor for `ParseMultisigConfigResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List parseMultisigConfigResponseDescriptor = $convert.base64Decode(
+    'ChtQYXJzZU11bHRpc2lnQ29uZmlnUmVzcG9uc2USDAoBbRgBIAEoDVIBbRIMCgFuGAIgASgNUg'
+    'FuEh8KC3NjcmlwdF90eXBlGAMgASgJUgpzY3JpcHRUeXBlEj4KCWNvc2lnbmVycxgEIAMoCzIg'
+    'LndhbGxldG1hbmFnZXIudjEuUGFyc2VkQ29zaWduZXJSCWNvc2lnbmVycw==');
+
 @$core.Deprecated('Use createBitcoinCoreWalletRequestDescriptor instead')
 const CreateBitcoinCoreWalletRequest$json = {
   '1': 'CreateBitcoinCoreWalletRequest',
@@ -891,6 +1024,35 @@ const SignPsbtResponse$json = {
 final $typed_data.Uint8List signPsbtResponseDescriptor = $convert.base64Decode(
     'ChBTaWduUHNidFJlc3BvbnNlEh8KC3BzYnRfYmFzZTY0GAEgASgJUgpwc2J0QmFzZTY0');
 
+@$core.Deprecated('Use signPsbtWithCosignerRequestDescriptor instead')
+const SignPsbtWithCosignerRequest$json = {
+  '1': 'SignPsbtWithCosignerRequest',
+  '2': [
+    {'1': 'wallet_id', '3': 1, '4': 1, '5': 9, '10': 'walletId'},
+    {'1': 'psbt_base64', '3': 2, '4': 1, '5': 9, '10': 'psbtBase64'},
+    {'1': 'cosigner_xpub', '3': 3, '4': 1, '5': 9, '10': 'cosignerXpub'},
+  ],
+};
+
+/// Descriptor for `SignPsbtWithCosignerRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List signPsbtWithCosignerRequestDescriptor = $convert.base64Decode(
+    'ChtTaWduUHNidFdpdGhDb3NpZ25lclJlcXVlc3QSGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZX'
+    'RJZBIfCgtwc2J0X2Jhc2U2NBgCIAEoCVIKcHNidEJhc2U2NBIjCg1jb3NpZ25lcl94cHViGAMg'
+    'ASgJUgxjb3NpZ25lclhwdWI=');
+
+@$core.Deprecated('Use signPsbtWithCosignerResponseDescriptor instead')
+const SignPsbtWithCosignerResponse$json = {
+  '1': 'SignPsbtWithCosignerResponse',
+  '2': [
+    {'1': 'psbt_base64', '3': 1, '4': 1, '5': 9, '10': 'psbtBase64'},
+  ],
+};
+
+/// Descriptor for `SignPsbtWithCosignerResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List signPsbtWithCosignerResponseDescriptor = $convert.base64Decode(
+    'ChxTaWduUHNidFdpdGhDb3NpZ25lclJlc3BvbnNlEh8KC3BzYnRfYmFzZTY0GAEgASgJUgpwc2'
+    'J0QmFzZTY0');
+
 @$core.Deprecated('Use combinePsbtRequestDescriptor instead')
 const CombinePsbtRequest$json = {
   '1': 'CombinePsbtRequest',
@@ -938,6 +1100,63 @@ const FinalizePsbtResponse$json = {
 /// Descriptor for `FinalizePsbtResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List finalizePsbtResponseDescriptor = $convert.base64Decode(
     'ChRGaW5hbGl6ZVBzYnRSZXNwb25zZRIcCgpyYXdfdHhfaGV4GAEgASgJUghyYXdUeEhleA==');
+
+@$core.Deprecated('Use multisigPsbtStatusRequestDescriptor instead')
+const MultisigPsbtStatusRequest$json = {
+  '1': 'MultisigPsbtStatusRequest',
+  '2': [
+    {'1': 'wallet_id', '3': 1, '4': 1, '5': 9, '10': 'walletId'},
+    {'1': 'psbt_base64', '3': 2, '4': 1, '5': 9, '10': 'psbtBase64'},
+  ],
+};
+
+/// Descriptor for `MultisigPsbtStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List multisigPsbtStatusRequestDescriptor = $convert.base64Decode(
+    'ChlNdWx0aXNpZ1BzYnRTdGF0dXNSZXF1ZXN0EhsKCXdhbGxldF9pZBgBIAEoCVIId2FsbGV0SW'
+    'QSHwoLcHNidF9iYXNlNjQYAiABKAlSCnBzYnRCYXNlNjQ=');
+
+@$core.Deprecated('Use multisigPsbtStatusResponseDescriptor instead')
+const MultisigPsbtStatusResponse$json = {
+  '1': 'MultisigPsbtStatusResponse',
+  '2': [
+    {'1': 'threshold', '3': 1, '4': 1, '5': 13, '10': 'threshold'},
+    {'1': 'signatures', '3': 2, '4': 1, '5': 13, '10': 'signatures'},
+    {'1': 'finalizable', '3': 3, '4': 1, '5': 8, '10': 'finalizable'},
+    {'1': 'cosigner_signed', '3': 4, '4': 3, '5': 8, '10': 'cosignerSigned'},
+  ],
+};
+
+/// Descriptor for `MultisigPsbtStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List multisigPsbtStatusResponseDescriptor = $convert.base64Decode(
+    'ChpNdWx0aXNpZ1BzYnRTdGF0dXNSZXNwb25zZRIcCgl0aHJlc2hvbGQYASABKA1SCXRocmVzaG'
+    '9sZBIeCgpzaWduYXR1cmVzGAIgASgNUgpzaWduYXR1cmVzEiAKC2ZpbmFsaXphYmxlGAMgASgI'
+    'UgtmaW5hbGl6YWJsZRInCg9jb3NpZ25lcl9zaWduZWQYBCADKAhSDmNvc2lnbmVyU2lnbmVk');
+
+@$core.Deprecated('Use broadcastTransactionRequestDescriptor instead')
+const BroadcastTransactionRequest$json = {
+  '1': 'BroadcastTransactionRequest',
+  '2': [
+    {'1': 'wallet_id', '3': 1, '4': 1, '5': 9, '10': 'walletId'},
+    {'1': 'tx_hex', '3': 2, '4': 1, '5': 9, '10': 'txHex'},
+  ],
+};
+
+/// Descriptor for `BroadcastTransactionRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List broadcastTransactionRequestDescriptor = $convert.base64Decode(
+    'ChtCcm9hZGNhc3RUcmFuc2FjdGlvblJlcXVlc3QSGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZX'
+    'RJZBIVCgZ0eF9oZXgYAiABKAlSBXR4SGV4');
+
+@$core.Deprecated('Use broadcastTransactionResponseDescriptor instead')
+const BroadcastTransactionResponse$json = {
+  '1': 'BroadcastTransactionResponse',
+  '2': [
+    {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
+  ],
+};
+
+/// Descriptor for `BroadcastTransactionResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List broadcastTransactionResponseDescriptor = $convert.base64Decode(
+    'ChxCcm9hZGNhc3RUcmFuc2FjdGlvblJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQ=');
 
 @$core.Deprecated('Use listTransactionsRequestDescriptor instead')
 const ListTransactionsRequest$json = {
@@ -1630,6 +1849,8 @@ const $core.Map<$core.String, $core.dynamic> WalletManagerServiceBase$json = {
     {'1': 'RestoreWalletBackupStream', '2': '.walletmanager.v1.RestoreWalletBackupRequest', '3': '.walletmanager.v1.RestoreWalletBackupProgressResponse', '6': true},
     {'1': 'CreateWatchOnlyWallet', '2': '.walletmanager.v1.CreateWatchOnlyWalletRequest', '3': '.walletmanager.v1.CreateWatchOnlyWalletResponse'},
     {'1': 'CreateElectrumWallet', '2': '.walletmanager.v1.CreateElectrumWalletRequest', '3': '.walletmanager.v1.CreateElectrumWalletResponse'},
+    {'1': 'CreateMultisigWallet', '2': '.walletmanager.v1.CreateMultisigWalletRequest', '3': '.walletmanager.v1.CreateMultisigWalletResponse'},
+    {'1': 'ParseMultisigConfig', '2': '.walletmanager.v1.ParseMultisigConfigRequest', '3': '.walletmanager.v1.ParseMultisigConfigResponse'},
     {'1': 'CreateBitcoinCoreWallet', '2': '.walletmanager.v1.CreateBitcoinCoreWalletRequest', '3': '.walletmanager.v1.CreateBitcoinCoreWalletResponse'},
     {'1': 'EnsureCoreWallets', '2': '.walletmanager.v1.EnsureCoreWalletsRequest', '3': '.walletmanager.v1.EnsureCoreWalletsResponse'},
     {'1': 'GetBalance', '2': '.walletmanager.v1.GetBalanceRequest', '3': '.walletmanager.v1.GetBalanceResponse'},
@@ -1645,8 +1866,11 @@ const $core.Map<$core.String, $core.dynamic> WalletManagerServiceBase$json = {
     {'1': 'DeriveAddresses', '2': '.walletmanager.v1.DeriveAddressesRequest', '3': '.walletmanager.v1.DeriveAddressesResponse'},
     {'1': 'CreatePsbt', '2': '.walletmanager.v1.CreatePsbtRequest', '3': '.walletmanager.v1.CreatePsbtResponse'},
     {'1': 'SignPsbt', '2': '.walletmanager.v1.SignPsbtRequest', '3': '.walletmanager.v1.SignPsbtResponse'},
+    {'1': 'SignPsbtWithCosigner', '2': '.walletmanager.v1.SignPsbtWithCosignerRequest', '3': '.walletmanager.v1.SignPsbtWithCosignerResponse'},
     {'1': 'CombinePsbt', '2': '.walletmanager.v1.CombinePsbtRequest', '3': '.walletmanager.v1.CombinePsbtResponse'},
     {'1': 'FinalizePsbt', '2': '.walletmanager.v1.FinalizePsbtRequest', '3': '.walletmanager.v1.FinalizePsbtResponse'},
+    {'1': 'MultisigPsbtStatus', '2': '.walletmanager.v1.MultisigPsbtStatusRequest', '3': '.walletmanager.v1.MultisigPsbtStatusResponse'},
+    {'1': 'BroadcastTransaction', '2': '.walletmanager.v1.BroadcastTransactionRequest', '3': '.walletmanager.v1.BroadcastTransactionResponse'},
     {'1': 'GetWalletSeed', '2': '.walletmanager.v1.GetWalletSeedRequest', '3': '.walletmanager.v1.GetWalletSeedResponse'},
     {'1': 'ListCoreVariants', '2': '.walletmanager.v1.ListCoreVariantsRequest', '3': '.walletmanager.v1.ListCoreVariantsResponse'},
     {'1': 'GetCoreVariant', '2': '.walletmanager.v1.GetCoreVariantRequest', '3': '.walletmanager.v1.GetCoreVariantResponse'},
@@ -1681,6 +1905,8 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> WalletMana
   '.walletmanager.v1.ListWalletsResponse': ListWalletsResponse$json,
   '.walletmanager.v1.WalletMetadata': WalletMetadata$json,
   '.walletmanager.v1.SidechainStarter': SidechainStarter$json,
+  '.walletmanager.v1.MultisigInfo': MultisigInfo$json,
+  '.walletmanager.v1.MultisigCosignerInfo': MultisigCosignerInfo$json,
   '.walletmanager.v1.SwitchWalletRequest': SwitchWalletRequest$json,
   '.walletmanager.v1.SwitchWalletResponse': SwitchWalletResponse$json,
   '.walletmanager.v1.UpdateWalletMetadataRequest': UpdateWalletMetadataRequest$json,
@@ -1704,6 +1930,12 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> WalletMana
   '.walletmanager.v1.CreateWatchOnlyWalletResponse': CreateWatchOnlyWalletResponse$json,
   '.walletmanager.v1.CreateElectrumWalletRequest': CreateElectrumWalletRequest$json,
   '.walletmanager.v1.CreateElectrumWalletResponse': CreateElectrumWalletResponse$json,
+  '.walletmanager.v1.CreateMultisigWalletRequest': CreateMultisigWalletRequest$json,
+  '.walletmanager.v1.MultisigCosignerInput': MultisigCosignerInput$json,
+  '.walletmanager.v1.CreateMultisigWalletResponse': CreateMultisigWalletResponse$json,
+  '.walletmanager.v1.ParseMultisigConfigRequest': ParseMultisigConfigRequest$json,
+  '.walletmanager.v1.ParseMultisigConfigResponse': ParseMultisigConfigResponse$json,
+  '.walletmanager.v1.ParsedCosigner': ParsedCosigner$json,
   '.walletmanager.v1.CreateBitcoinCoreWalletRequest': CreateBitcoinCoreWalletRequest$json,
   '.walletmanager.v1.CreateBitcoinCoreWalletResponse': CreateBitcoinCoreWalletResponse$json,
   '.walletmanager.v1.EnsureCoreWalletsRequest': EnsureCoreWalletsRequest$json,
@@ -1743,10 +1975,16 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> WalletMana
   '.walletmanager.v1.CreatePsbtResponse': CreatePsbtResponse$json,
   '.walletmanager.v1.SignPsbtRequest': SignPsbtRequest$json,
   '.walletmanager.v1.SignPsbtResponse': SignPsbtResponse$json,
+  '.walletmanager.v1.SignPsbtWithCosignerRequest': SignPsbtWithCosignerRequest$json,
+  '.walletmanager.v1.SignPsbtWithCosignerResponse': SignPsbtWithCosignerResponse$json,
   '.walletmanager.v1.CombinePsbtRequest': CombinePsbtRequest$json,
   '.walletmanager.v1.CombinePsbtResponse': CombinePsbtResponse$json,
   '.walletmanager.v1.FinalizePsbtRequest': FinalizePsbtRequest$json,
   '.walletmanager.v1.FinalizePsbtResponse': FinalizePsbtResponse$json,
+  '.walletmanager.v1.MultisigPsbtStatusRequest': MultisigPsbtStatusRequest$json,
+  '.walletmanager.v1.MultisigPsbtStatusResponse': MultisigPsbtStatusResponse$json,
+  '.walletmanager.v1.BroadcastTransactionRequest': BroadcastTransactionRequest$json,
+  '.walletmanager.v1.BroadcastTransactionResponse': BroadcastTransactionResponse$json,
   '.walletmanager.v1.GetWalletSeedRequest': GetWalletSeedRequest$json,
   '.walletmanager.v1.GetWalletSeedResponse': GetWalletSeedResponse$json,
   '.walletmanager.v1.ListCoreVariantsRequest': ListCoreVariantsRequest$json,
@@ -1806,56 +2044,67 @@ final $typed_data.Uint8List walletManagerServiceDescriptor = $convert.base64Deco
     'IuLndhbGxldG1hbmFnZXIudjEuQ3JlYXRlV2F0Y2hPbmx5V2FsbGV0UmVxdWVzdBovLndhbGxl'
     'dG1hbmFnZXIudjEuQ3JlYXRlV2F0Y2hPbmx5V2FsbGV0UmVzcG9uc2USdQoUQ3JlYXRlRWxlY3'
     'RydW1XYWxsZXQSLS53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZUVsZWN0cnVtV2FsbGV0UmVxdWVz'
-    'dBouLndhbGxldG1hbmFnZXIudjEuQ3JlYXRlRWxlY3RydW1XYWxsZXRSZXNwb25zZRJ+ChdDcm'
-    'VhdGVCaXRjb2luQ29yZVdhbGxldBIwLndhbGxldG1hbmFnZXIudjEuQ3JlYXRlQml0Y29pbkNv'
-    'cmVXYWxsZXRSZXF1ZXN0GjEud2FsbGV0bWFuYWdlci52MS5DcmVhdGVCaXRjb2luQ29yZVdhbG'
-    'xldFJlc3BvbnNlEmwKEUVuc3VyZUNvcmVXYWxsZXRzEioud2FsbGV0bWFuYWdlci52MS5FbnN1'
-    'cmVDb3JlV2FsbGV0c1JlcXVlc3QaKy53YWxsZXRtYW5hZ2VyLnYxLkVuc3VyZUNvcmVXYWxsZX'
-    'RzUmVzcG9uc2USVwoKR2V0QmFsYW5jZRIjLndhbGxldG1hbmFnZXIudjEuR2V0QmFsYW5jZVJl'
-    'cXVlc3QaJC53YWxsZXRtYW5hZ2VyLnYxLkdldEJhbGFuY2VSZXNwb25zZRJgCg1HZXROZXdBZG'
-    'RyZXNzEiYud2FsbGV0bWFuYWdlci52MS5HZXROZXdBZGRyZXNzUmVxdWVzdBonLndhbGxldG1h'
-    'bmFnZXIudjEuR2V0TmV3QWRkcmVzc1Jlc3BvbnNlEmYKD1NlbmRUcmFuc2FjdGlvbhIoLndhbG'
-    'xldG1hbmFnZXIudjEuU2VuZFRyYW5zYWN0aW9uUmVxdWVzdBopLndhbGxldG1hbmFnZXIudjEu'
-    'U2VuZFRyYW5zYWN0aW9uUmVzcG9uc2USaQoQTGlzdFRyYW5zYWN0aW9ucxIpLndhbGxldG1hbm'
-    'FnZXIudjEuTGlzdFRyYW5zYWN0aW9uc1JlcXVlc3QaKi53YWxsZXRtYW5hZ2VyLnYxLkxpc3RU'
-    'cmFuc2FjdGlvbnNSZXNwb25zZRJaCgtMaXN0VW5zcGVudBIkLndhbGxldG1hbmFnZXIudjEuTG'
-    'lzdFVuc3BlbnRSZXF1ZXN0GiUud2FsbGV0bWFuYWdlci52MS5MaXN0VW5zcGVudFJlc3BvbnNl'
-    'EnUKFExpc3RSZWNlaXZlQWRkcmVzc2VzEi0ud2FsbGV0bWFuYWdlci52MS5MaXN0UmVjZWl2ZU'
-    'FkZHJlc3Nlc1JlcXVlc3QaLi53YWxsZXRtYW5hZ2VyLnYxLkxpc3RSZWNlaXZlQWRkcmVzc2Vz'
-    'UmVzcG9uc2USeAoVR2V0VHJhbnNhY3Rpb25EZXRhaWxzEi4ud2FsbGV0bWFuYWdlci52MS5HZX'
-    'RUcmFuc2FjdGlvbkRldGFpbHNSZXF1ZXN0Gi8ud2FsbGV0bWFuYWdlci52MS5HZXRUcmFuc2Fj'
-    'dGlvbkRldGFpbHNSZXNwb25zZRJsChFEZWNvZGVUcmFuc2FjdGlvbhIqLndhbGxldG1hbmFnZX'
-    'IudjEuRGVjb2RlVHJhbnNhY3Rpb25SZXF1ZXN0Gisud2FsbGV0bWFuYWdlci52MS5EZWNvZGVU'
-    'cmFuc2FjdGlvblJlc3BvbnNlEk4KB0J1bXBGZWUSIC53YWxsZXRtYW5hZ2VyLnYxLkJ1bXBGZW'
-    'VSZXF1ZXN0GiEud2FsbGV0bWFuYWdlci52MS5CdW1wRmVlUmVzcG9uc2USVwoKQ3JlYXRlQ3Bm'
-    'cBIjLndhbGxldG1hbmFnZXIudjEuQ3JlYXRlQ3BmcFJlcXVlc3QaJC53YWxsZXRtYW5hZ2VyLn'
-    'YxLkNyZWF0ZUNwZnBSZXNwb25zZRJmCg9EZXJpdmVBZGRyZXNzZXMSKC53YWxsZXRtYW5hZ2Vy'
-    'LnYxLkRlcml2ZUFkZHJlc3Nlc1JlcXVlc3QaKS53YWxsZXRtYW5hZ2VyLnYxLkRlcml2ZUFkZH'
-    'Jlc3Nlc1Jlc3BvbnNlElcKCkNyZWF0ZVBzYnQSIy53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZVBz'
-    'YnRSZXF1ZXN0GiQud2FsbGV0bWFuYWdlci52MS5DcmVhdGVQc2J0UmVzcG9uc2USUQoIU2lnbl'
-    'BzYnQSIS53YWxsZXRtYW5hZ2VyLnYxLlNpZ25Qc2J0UmVxdWVzdBoiLndhbGxldG1hbmFnZXIu'
-    'djEuU2lnblBzYnRSZXNwb25zZRJaCgtDb21iaW5lUHNidBIkLndhbGxldG1hbmFnZXIudjEuQ2'
-    '9tYmluZVBzYnRSZXF1ZXN0GiUud2FsbGV0bWFuYWdlci52MS5Db21iaW5lUHNidFJlc3BvbnNl'
-    'El0KDEZpbmFsaXplUHNidBIlLndhbGxldG1hbmFnZXIudjEuRmluYWxpemVQc2J0UmVxdWVzdB'
-    'omLndhbGxldG1hbmFnZXIudjEuRmluYWxpemVQc2J0UmVzcG9uc2USYAoNR2V0V2FsbGV0U2Vl'
-    'ZBImLndhbGxldG1hbmFnZXIudjEuR2V0V2FsbGV0U2VlZFJlcXVlc3QaJy53YWxsZXRtYW5hZ2'
-    'VyLnYxLkdldFdhbGxldFNlZWRSZXNwb25zZRJpChBMaXN0Q29yZVZhcmlhbnRzEikud2FsbGV0'
-    'bWFuYWdlci52MS5MaXN0Q29yZVZhcmlhbnRzUmVxdWVzdBoqLndhbGxldG1hbmFnZXIudjEuTG'
-    'lzdENvcmVWYXJpYW50c1Jlc3BvbnNlEmMKDkdldENvcmVWYXJpYW50Eicud2FsbGV0bWFuYWdl'
-    'ci52MS5HZXRDb3JlVmFyaWFudFJlcXVlc3QaKC53YWxsZXRtYW5hZ2VyLnYxLkdldENvcmVWYX'
-    'JpYW50UmVzcG9uc2USYwoOU2V0Q29yZVZhcmlhbnQSJy53YWxsZXRtYW5hZ2VyLnYxLlNldENv'
-    'cmVWYXJpYW50UmVxdWVzdBooLndhbGxldG1hbmFnZXIudjEuU2V0Q29yZVZhcmlhbnRSZXNwb2'
-    '5zZRJsChFHZXRUZXN0U2lkZWNoYWlucxIqLndhbGxldG1hbmFnZXIudjEuR2V0VGVzdFNpZGVj'
-    'aGFpbnNSZXF1ZXN0Gisud2FsbGV0bWFuYWdlci52MS5HZXRUZXN0U2lkZWNoYWluc1Jlc3Bvbn'
-    'NlEmwKEVNldFRlc3RTaWRlY2hhaW5zEioud2FsbGV0bWFuYWdlci52MS5TZXRUZXN0U2lkZWNo'
-    'YWluc1JlcXVlc3QaKy53YWxsZXRtYW5hZ2VyLnYxLlNldFRlc3RTaWRlY2hhaW5zUmVzcG9uc2'
-    'USbAoRR2V0RWxlY3RydW1TZXJ2ZXISKi53YWxsZXRtYW5hZ2VyLnYxLkdldEVsZWN0cnVtU2Vy'
-    'dmVyUmVxdWVzdBorLndhbGxldG1hbmFnZXIudjEuR2V0RWxlY3RydW1TZXJ2ZXJSZXNwb25zZR'
-    'JsChFTZXRFbGVjdHJ1bVNlcnZlchIqLndhbGxldG1hbmFnZXIudjEuU2V0RWxlY3RydW1TZXJ2'
-    'ZXJSZXF1ZXN0Gisud2FsbGV0bWFuYWdlci52MS5TZXRFbGVjdHJ1bVNlcnZlclJlc3BvbnNlEl'
-    '0KDEdldFRvckNvbmZpZxIlLndhbGxldG1hbmFnZXIudjEuR2V0VG9yQ29uZmlnUmVxdWVzdBom'
-    'LndhbGxldG1hbmFnZXIudjEuR2V0VG9yQ29uZmlnUmVzcG9uc2USXQoMU2V0VG9yQ29uZmlnEi'
-    'Uud2FsbGV0bWFuYWdlci52MS5TZXRUb3JDb25maWdSZXF1ZXN0GiYud2FsbGV0bWFuYWdlci52'
-    'MS5TZXRUb3JDb25maWdSZXNwb25zZRJWCg9XYXRjaFdhbGxldERhdGESFi5nb29nbGUucHJvdG'
-    '9idWYuRW1wdHkaKS53YWxsZXRtYW5hZ2VyLnYxLldhdGNoV2FsbGV0RGF0YVJlc3BvbnNlMAE=');
+    'dBouLndhbGxldG1hbmFnZXIudjEuQ3JlYXRlRWxlY3RydW1XYWxsZXRSZXNwb25zZRJ1ChRDcm'
+    'VhdGVNdWx0aXNpZ1dhbGxldBItLndhbGxldG1hbmFnZXIudjEuQ3JlYXRlTXVsdGlzaWdXYWxs'
+    'ZXRSZXF1ZXN0Gi4ud2FsbGV0bWFuYWdlci52MS5DcmVhdGVNdWx0aXNpZ1dhbGxldFJlc3Bvbn'
+    'NlEnIKE1BhcnNlTXVsdGlzaWdDb25maWcSLC53YWxsZXRtYW5hZ2VyLnYxLlBhcnNlTXVsdGlz'
+    'aWdDb25maWdSZXF1ZXN0Gi0ud2FsbGV0bWFuYWdlci52MS5QYXJzZU11bHRpc2lnQ29uZmlnUm'
+    'VzcG9uc2USfgoXQ3JlYXRlQml0Y29pbkNvcmVXYWxsZXQSMC53YWxsZXRtYW5hZ2VyLnYxLkNy'
+    'ZWF0ZUJpdGNvaW5Db3JlV2FsbGV0UmVxdWVzdBoxLndhbGxldG1hbmFnZXIudjEuQ3JlYXRlQm'
+    'l0Y29pbkNvcmVXYWxsZXRSZXNwb25zZRJsChFFbnN1cmVDb3JlV2FsbGV0cxIqLndhbGxldG1h'
+    'bmFnZXIudjEuRW5zdXJlQ29yZVdhbGxldHNSZXF1ZXN0Gisud2FsbGV0bWFuYWdlci52MS5Fbn'
+    'N1cmVDb3JlV2FsbGV0c1Jlc3BvbnNlElcKCkdldEJhbGFuY2USIy53YWxsZXRtYW5hZ2VyLnYx'
+    'LkdldEJhbGFuY2VSZXF1ZXN0GiQud2FsbGV0bWFuYWdlci52MS5HZXRCYWxhbmNlUmVzcG9uc2'
+    'USYAoNR2V0TmV3QWRkcmVzcxImLndhbGxldG1hbmFnZXIudjEuR2V0TmV3QWRkcmVzc1JlcXVl'
+    'c3QaJy53YWxsZXRtYW5hZ2VyLnYxLkdldE5ld0FkZHJlc3NSZXNwb25zZRJmCg9TZW5kVHJhbn'
+    'NhY3Rpb24SKC53YWxsZXRtYW5hZ2VyLnYxLlNlbmRUcmFuc2FjdGlvblJlcXVlc3QaKS53YWxs'
+    'ZXRtYW5hZ2VyLnYxLlNlbmRUcmFuc2FjdGlvblJlc3BvbnNlEmkKEExpc3RUcmFuc2FjdGlvbn'
+    'MSKS53YWxsZXRtYW5hZ2VyLnYxLkxpc3RUcmFuc2FjdGlvbnNSZXF1ZXN0Gioud2FsbGV0bWFu'
+    'YWdlci52MS5MaXN0VHJhbnNhY3Rpb25zUmVzcG9uc2USWgoLTGlzdFVuc3BlbnQSJC53YWxsZX'
+    'RtYW5hZ2VyLnYxLkxpc3RVbnNwZW50UmVxdWVzdBolLndhbGxldG1hbmFnZXIudjEuTGlzdFVu'
+    'c3BlbnRSZXNwb25zZRJ1ChRMaXN0UmVjZWl2ZUFkZHJlc3NlcxItLndhbGxldG1hbmFnZXIudj'
+    'EuTGlzdFJlY2VpdmVBZGRyZXNzZXNSZXF1ZXN0Gi4ud2FsbGV0bWFuYWdlci52MS5MaXN0UmVj'
+    'ZWl2ZUFkZHJlc3Nlc1Jlc3BvbnNlEngKFUdldFRyYW5zYWN0aW9uRGV0YWlscxIuLndhbGxldG'
+    '1hbmFnZXIudjEuR2V0VHJhbnNhY3Rpb25EZXRhaWxzUmVxdWVzdBovLndhbGxldG1hbmFnZXIu'
+    'djEuR2V0VHJhbnNhY3Rpb25EZXRhaWxzUmVzcG9uc2USbAoRRGVjb2RlVHJhbnNhY3Rpb24SKi'
+    '53YWxsZXRtYW5hZ2VyLnYxLkRlY29kZVRyYW5zYWN0aW9uUmVxdWVzdBorLndhbGxldG1hbmFn'
+    'ZXIudjEuRGVjb2RlVHJhbnNhY3Rpb25SZXNwb25zZRJOCgdCdW1wRmVlEiAud2FsbGV0bWFuYW'
+    'dlci52MS5CdW1wRmVlUmVxdWVzdBohLndhbGxldG1hbmFnZXIudjEuQnVtcEZlZVJlc3BvbnNl'
+    'ElcKCkNyZWF0ZUNwZnASIy53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZUNwZnBSZXF1ZXN0GiQud2'
+    'FsbGV0bWFuYWdlci52MS5DcmVhdGVDcGZwUmVzcG9uc2USZgoPRGVyaXZlQWRkcmVzc2VzEigu'
+    'd2FsbGV0bWFuYWdlci52MS5EZXJpdmVBZGRyZXNzZXNSZXF1ZXN0Gikud2FsbGV0bWFuYWdlci'
+    '52MS5EZXJpdmVBZGRyZXNzZXNSZXNwb25zZRJXCgpDcmVhdGVQc2J0EiMud2FsbGV0bWFuYWdl'
+    'ci52MS5DcmVhdGVQc2J0UmVxdWVzdBokLndhbGxldG1hbmFnZXIudjEuQ3JlYXRlUHNidFJlc3'
+    'BvbnNlElEKCFNpZ25Qc2J0EiEud2FsbGV0bWFuYWdlci52MS5TaWduUHNidFJlcXVlc3QaIi53'
+    'YWxsZXRtYW5hZ2VyLnYxLlNpZ25Qc2J0UmVzcG9uc2USdQoUU2lnblBzYnRXaXRoQ29zaWduZX'
+    'ISLS53YWxsZXRtYW5hZ2VyLnYxLlNpZ25Qc2J0V2l0aENvc2lnbmVyUmVxdWVzdBouLndhbGxl'
+    'dG1hbmFnZXIudjEuU2lnblBzYnRXaXRoQ29zaWduZXJSZXNwb25zZRJaCgtDb21iaW5lUHNidB'
+    'IkLndhbGxldG1hbmFnZXIudjEuQ29tYmluZVBzYnRSZXF1ZXN0GiUud2FsbGV0bWFuYWdlci52'
+    'MS5Db21iaW5lUHNidFJlc3BvbnNlEl0KDEZpbmFsaXplUHNidBIlLndhbGxldG1hbmFnZXIudj'
+    'EuRmluYWxpemVQc2J0UmVxdWVzdBomLndhbGxldG1hbmFnZXIudjEuRmluYWxpemVQc2J0UmVz'
+    'cG9uc2USbwoSTXVsdGlzaWdQc2J0U3RhdHVzEisud2FsbGV0bWFuYWdlci52MS5NdWx0aXNpZ1'
+    'BzYnRTdGF0dXNSZXF1ZXN0Giwud2FsbGV0bWFuYWdlci52MS5NdWx0aXNpZ1BzYnRTdGF0dXNS'
+    'ZXNwb25zZRJ1ChRCcm9hZGNhc3RUcmFuc2FjdGlvbhItLndhbGxldG1hbmFnZXIudjEuQnJvYW'
+    'RjYXN0VHJhbnNhY3Rpb25SZXF1ZXN0Gi4ud2FsbGV0bWFuYWdlci52MS5Ccm9hZGNhc3RUcmFu'
+    'c2FjdGlvblJlc3BvbnNlEmAKDUdldFdhbGxldFNlZWQSJi53YWxsZXRtYW5hZ2VyLnYxLkdldF'
+    'dhbGxldFNlZWRSZXF1ZXN0Gicud2FsbGV0bWFuYWdlci52MS5HZXRXYWxsZXRTZWVkUmVzcG9u'
+    'c2USaQoQTGlzdENvcmVWYXJpYW50cxIpLndhbGxldG1hbmFnZXIudjEuTGlzdENvcmVWYXJpYW'
+    '50c1JlcXVlc3QaKi53YWxsZXRtYW5hZ2VyLnYxLkxpc3RDb3JlVmFyaWFudHNSZXNwb25zZRJj'
+    'Cg5HZXRDb3JlVmFyaWFudBInLndhbGxldG1hbmFnZXIudjEuR2V0Q29yZVZhcmlhbnRSZXF1ZX'
+    'N0Gigud2FsbGV0bWFuYWdlci52MS5HZXRDb3JlVmFyaWFudFJlc3BvbnNlEmMKDlNldENvcmVW'
+    'YXJpYW50Eicud2FsbGV0bWFuYWdlci52MS5TZXRDb3JlVmFyaWFudFJlcXVlc3QaKC53YWxsZX'
+    'RtYW5hZ2VyLnYxLlNldENvcmVWYXJpYW50UmVzcG9uc2USbAoRR2V0VGVzdFNpZGVjaGFpbnMS'
+    'Ki53YWxsZXRtYW5hZ2VyLnYxLkdldFRlc3RTaWRlY2hhaW5zUmVxdWVzdBorLndhbGxldG1hbm'
+    'FnZXIudjEuR2V0VGVzdFNpZGVjaGFpbnNSZXNwb25zZRJsChFTZXRUZXN0U2lkZWNoYWlucxIq'
+    'LndhbGxldG1hbmFnZXIudjEuU2V0VGVzdFNpZGVjaGFpbnNSZXF1ZXN0Gisud2FsbGV0bWFuYW'
+    'dlci52MS5TZXRUZXN0U2lkZWNoYWluc1Jlc3BvbnNlEmwKEUdldEVsZWN0cnVtU2VydmVyEiou'
+    'd2FsbGV0bWFuYWdlci52MS5HZXRFbGVjdHJ1bVNlcnZlclJlcXVlc3QaKy53YWxsZXRtYW5hZ2'
+    'VyLnYxLkdldEVsZWN0cnVtU2VydmVyUmVzcG9uc2USbAoRU2V0RWxlY3RydW1TZXJ2ZXISKi53'
+    'YWxsZXRtYW5hZ2VyLnYxLlNldEVsZWN0cnVtU2VydmVyUmVxdWVzdBorLndhbGxldG1hbmFnZX'
+    'IudjEuU2V0RWxlY3RydW1TZXJ2ZXJSZXNwb25zZRJdCgxHZXRUb3JDb25maWcSJS53YWxsZXRt'
+    'YW5hZ2VyLnYxLkdldFRvckNvbmZpZ1JlcXVlc3QaJi53YWxsZXRtYW5hZ2VyLnYxLkdldFRvck'
+    'NvbmZpZ1Jlc3BvbnNlEl0KDFNldFRvckNvbmZpZxIlLndhbGxldG1hbmFnZXIudjEuU2V0VG9y'
+    'Q29uZmlnUmVxdWVzdBomLndhbGxldG1hbmFnZXIudjEuU2V0VG9yQ29uZmlnUmVzcG9uc2USVg'
+    'oPV2F0Y2hXYWxsZXREYXRhEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5Gikud2FsbGV0bWFuYWdl'
+    'ci52MS5XYXRjaFdhbGxldERhdGFSZXNwb25zZTAB');
 

--- a/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbserver.dart
+++ b/sail_ui/lib/gen/walletmanager/v1/walletmanager.pbserver.dart
@@ -39,6 +39,8 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
   $async.Future<$15.RestoreWalletBackupProgressResponse> restoreWalletBackupStream($pb.ServerContext ctx, $15.RestoreWalletBackupRequest request);
   $async.Future<$15.CreateWatchOnlyWalletResponse> createWatchOnlyWallet($pb.ServerContext ctx, $15.CreateWatchOnlyWalletRequest request);
   $async.Future<$15.CreateElectrumWalletResponse> createElectrumWallet($pb.ServerContext ctx, $15.CreateElectrumWalletRequest request);
+  $async.Future<$15.CreateMultisigWalletResponse> createMultisigWallet($pb.ServerContext ctx, $15.CreateMultisigWalletRequest request);
+  $async.Future<$15.ParseMultisigConfigResponse> parseMultisigConfig($pb.ServerContext ctx, $15.ParseMultisigConfigRequest request);
   $async.Future<$15.CreateBitcoinCoreWalletResponse> createBitcoinCoreWallet($pb.ServerContext ctx, $15.CreateBitcoinCoreWalletRequest request);
   $async.Future<$15.EnsureCoreWalletsResponse> ensureCoreWallets($pb.ServerContext ctx, $15.EnsureCoreWalletsRequest request);
   $async.Future<$15.GetBalanceResponse> getBalance($pb.ServerContext ctx, $15.GetBalanceRequest request);
@@ -54,8 +56,11 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
   $async.Future<$15.DeriveAddressesResponse> deriveAddresses($pb.ServerContext ctx, $15.DeriveAddressesRequest request);
   $async.Future<$15.CreatePsbtResponse> createPsbt($pb.ServerContext ctx, $15.CreatePsbtRequest request);
   $async.Future<$15.SignPsbtResponse> signPsbt($pb.ServerContext ctx, $15.SignPsbtRequest request);
+  $async.Future<$15.SignPsbtWithCosignerResponse> signPsbtWithCosigner($pb.ServerContext ctx, $15.SignPsbtWithCosignerRequest request);
   $async.Future<$15.CombinePsbtResponse> combinePsbt($pb.ServerContext ctx, $15.CombinePsbtRequest request);
   $async.Future<$15.FinalizePsbtResponse> finalizePsbt($pb.ServerContext ctx, $15.FinalizePsbtRequest request);
+  $async.Future<$15.MultisigPsbtStatusResponse> multisigPsbtStatus($pb.ServerContext ctx, $15.MultisigPsbtStatusRequest request);
+  $async.Future<$15.BroadcastTransactionResponse> broadcastTransaction($pb.ServerContext ctx, $15.BroadcastTransactionRequest request);
   $async.Future<$15.GetWalletSeedResponse> getWalletSeed($pb.ServerContext ctx, $15.GetWalletSeedRequest request);
   $async.Future<$15.ListCoreVariantsResponse> listCoreVariants($pb.ServerContext ctx, $15.ListCoreVariantsRequest request);
   $async.Future<$15.GetCoreVariantResponse> getCoreVariant($pb.ServerContext ctx, $15.GetCoreVariantRequest request);
@@ -87,6 +92,8 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
       case 'RestoreWalletBackupStream': return $15.RestoreWalletBackupRequest();
       case 'CreateWatchOnlyWallet': return $15.CreateWatchOnlyWalletRequest();
       case 'CreateElectrumWallet': return $15.CreateElectrumWalletRequest();
+      case 'CreateMultisigWallet': return $15.CreateMultisigWalletRequest();
+      case 'ParseMultisigConfig': return $15.ParseMultisigConfigRequest();
       case 'CreateBitcoinCoreWallet': return $15.CreateBitcoinCoreWalletRequest();
       case 'EnsureCoreWallets': return $15.EnsureCoreWalletsRequest();
       case 'GetBalance': return $15.GetBalanceRequest();
@@ -102,8 +109,11 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
       case 'DeriveAddresses': return $15.DeriveAddressesRequest();
       case 'CreatePsbt': return $15.CreatePsbtRequest();
       case 'SignPsbt': return $15.SignPsbtRequest();
+      case 'SignPsbtWithCosigner': return $15.SignPsbtWithCosignerRequest();
       case 'CombinePsbt': return $15.CombinePsbtRequest();
       case 'FinalizePsbt': return $15.FinalizePsbtRequest();
+      case 'MultisigPsbtStatus': return $15.MultisigPsbtStatusRequest();
+      case 'BroadcastTransaction': return $15.BroadcastTransactionRequest();
       case 'GetWalletSeed': return $15.GetWalletSeedRequest();
       case 'ListCoreVariants': return $15.ListCoreVariantsRequest();
       case 'GetCoreVariant': return $15.GetCoreVariantRequest();
@@ -138,6 +148,8 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
       case 'RestoreWalletBackupStream': return this.restoreWalletBackupStream(ctx, request as $15.RestoreWalletBackupRequest);
       case 'CreateWatchOnlyWallet': return this.createWatchOnlyWallet(ctx, request as $15.CreateWatchOnlyWalletRequest);
       case 'CreateElectrumWallet': return this.createElectrumWallet(ctx, request as $15.CreateElectrumWalletRequest);
+      case 'CreateMultisigWallet': return this.createMultisigWallet(ctx, request as $15.CreateMultisigWalletRequest);
+      case 'ParseMultisigConfig': return this.parseMultisigConfig(ctx, request as $15.ParseMultisigConfigRequest);
       case 'CreateBitcoinCoreWallet': return this.createBitcoinCoreWallet(ctx, request as $15.CreateBitcoinCoreWalletRequest);
       case 'EnsureCoreWallets': return this.ensureCoreWallets(ctx, request as $15.EnsureCoreWalletsRequest);
       case 'GetBalance': return this.getBalance(ctx, request as $15.GetBalanceRequest);
@@ -153,8 +165,11 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
       case 'DeriveAddresses': return this.deriveAddresses(ctx, request as $15.DeriveAddressesRequest);
       case 'CreatePsbt': return this.createPsbt(ctx, request as $15.CreatePsbtRequest);
       case 'SignPsbt': return this.signPsbt(ctx, request as $15.SignPsbtRequest);
+      case 'SignPsbtWithCosigner': return this.signPsbtWithCosigner(ctx, request as $15.SignPsbtWithCosignerRequest);
       case 'CombinePsbt': return this.combinePsbt(ctx, request as $15.CombinePsbtRequest);
       case 'FinalizePsbt': return this.finalizePsbt(ctx, request as $15.FinalizePsbtRequest);
+      case 'MultisigPsbtStatus': return this.multisigPsbtStatus(ctx, request as $15.MultisigPsbtStatusRequest);
+      case 'BroadcastTransaction': return this.broadcastTransaction(ctx, request as $15.BroadcastTransactionRequest);
       case 'GetWalletSeed': return this.getWalletSeed(ctx, request as $15.GetWalletSeedRequest);
       case 'ListCoreVariants': return this.listCoreVariants(ctx, request as $15.ListCoreVariantsRequest);
       case 'GetCoreVariant': return this.getCoreVariant(ctx, request as $15.GetCoreVariantRequest);

--- a/sail_ui/lib/models/wallet_data.dart
+++ b/sail_ui/lib/models/wallet_data.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:sail_ui/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
 import 'package:uuid/uuid.dart';
 import 'package:sail_ui/sail_ui.dart';
 
@@ -27,6 +28,12 @@ class WalletData {
   // Not persisted — populated only from the proto, not from wallet.json.
   final String bip47PaymentCode;
 
+  /// Multisig policy for a multisig wallet, from the WatchWalletData stream.
+  /// Null for non-multisig wallets. Not persisted (proto-only).
+  final wmpb.MultisigInfo? multisig;
+
+  bool get isMultisig => multisig != null;
+
   WalletData({
     required this.version,
     required this.master,
@@ -40,6 +47,7 @@ class WalletData {
     this.isElectrum = false,
     this.isWatchOnly = false,
     this.bip47PaymentCode = '',
+    this.multisig,
   });
 
   Map<String, dynamic> toJson() {

--- a/sail_ui/lib/providers/wallet_reader_provider.dart
+++ b/sail_ui/lib/providers/wallet_reader_provider.dart
@@ -153,6 +153,7 @@ class WalletReaderProvider extends ChangeNotifier {
         isElectrum: protoWallet.walletType == wmpb.WalletType.WALLET_TYPE_ELECTRUM,
         isWatchOnly: protoWallet.watchOnly,
         bip47PaymentCode: protoWallet.bip47PaymentCode,
+        multisig: protoWallet.hasMultisig() ? protoWallet.multisig : null,
       );
     }).toList();
 

--- a/sail_ui/lib/providers/wallet_writer_provider.dart
+++ b/sail_ui/lib/providers/wallet_writer_provider.dart
@@ -7,6 +7,7 @@ import 'package:dart_bip32_bip44/dart_bip32_bip44.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
+import 'package:sail_ui/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
 import 'package:sail_ui/sail_ui.dart';
 
 /// Wallet writer provider backed by orchestrator's WalletManagerService.
@@ -120,6 +121,36 @@ class WalletWriterProvider extends ChangeNotifier {
       notifyListeners();
     } catch (e) {
       _logger.e('createElectrumWallet: failed: $e');
+      rethrow;
+    }
+  }
+
+  /// Creates an m-of-n multisig electrum wallet. Cosigners carrying a mnemonic
+  /// or xprv are held on disk and can sign; the rest are watch-only legs.
+  Future<void> createMultisigWallet({
+    required String name,
+    required WalletGradient gradient,
+    required int m,
+    required int n,
+    required String scriptType,
+    required List<wmpb.MultisigCosignerInput> cosigners,
+  }) async {
+    try {
+      final resp = await _client.createMultisigWallet(
+        name: name,
+        gradientJson: gradient.toJsonString(),
+        m: m,
+        n: n,
+        scriptType: scriptType,
+        cosigners: cosigners,
+      );
+
+      _logger.i('createMultisigWallet: created via backend, id=${resp.walletId}');
+
+      await _walletReader.init();
+      notifyListeners();
+    } catch (e) {
+      _logger.e('createMultisigWallet: failed: $e');
       rethrow;
     }
   }

--- a/sail_ui/lib/rpcs/orchestrator_multisig_lounge_rpc.dart
+++ b/sail_ui/lib/rpcs/orchestrator_multisig_lounge_rpc.dart
@@ -12,8 +12,8 @@ class OrchestratorMultisigLoungeRPC {
     _client = MultisigLoungeServiceClient(unary);
   }
 
-  Future<mlpb.BuildDescriptorsResponse> buildDescriptors(mlpb.MultisigGroup group) {
-    return _client.buildDescriptors(mlpb.BuildDescriptorsRequest(group: group));
+  Future<mlpb.BuildDescriptorsResponse> buildDescriptors(mlpb.MultisigGroup group, {String scriptType = ''}) {
+    return _client.buildDescriptors(mlpb.BuildDescriptorsRequest(group: group, scriptType: scriptType));
   }
 
   Future<mlpb.ValidatePsbtResponse> validatePsbt({

--- a/sail_ui/lib/rpcs/orchestrator_wallet_rpc.dart
+++ b/sail_ui/lib/rpcs/orchestrator_wallet_rpc.dart
@@ -128,6 +128,34 @@ class OrchestratorWalletRPC {
     );
   }
 
+  /// Creates an m-of-n multisig electrum wallet. Cosigners carrying a mnemonic
+  /// or xprv are held on disk and can sign; the rest are watch-only legs.
+  Future<wmpb.CreateMultisigWalletResponse> createMultisigWallet({
+    required String name,
+    required String gradientJson,
+    required int m,
+    required int n,
+    required String scriptType,
+    required List<wmpb.MultisigCosignerInput> cosigners,
+  }) {
+    return _unaryClient.createMultisigWallet(
+      wmpb.CreateMultisigWalletRequest(
+        name: name,
+        gradientJson: gradientJson,
+        m: m,
+        n: n,
+        scriptType: scriptType,
+        cosigners: cosigners,
+      ),
+    );
+  }
+
+  /// Parses a descriptor or wallet-config file into a multisig policy +
+  /// cosigners, for the editable-descriptor and import-config flows.
+  Future<wmpb.ParseMultisigConfigResponse> parseMultisigConfig(String content) {
+    return _unaryClient.parseMultisigConfig(wmpb.ParseMultisigConfigRequest(content: content));
+  }
+
   Future<wmpb.SwitchWalletResponse> switchWallet(String walletId) {
     return _unaryClient.switchWallet(wmpb.SwitchWalletRequest(walletId: walletId));
   }
@@ -261,6 +289,23 @@ class OrchestratorWalletRPC {
   }
 
   /// Merge multiple PSBTs (e.g. the original plus an externally signed copy).
+  /// Signs a multisig PSBT with a single held cosigner's key (per-keystore
+  /// signing). Returns the updated PSBT with that cosigner's signature added.
+  Future<String> signPsbtWithCosigner({
+    required String walletId,
+    required String psbtBase64,
+    required String cosignerXpub,
+  }) async {
+    final response = await _unaryClient.signPsbtWithCosigner(
+      wmpb.SignPsbtWithCosignerRequest(
+        walletId: walletId,
+        psbtBase64: psbtBase64,
+        cosignerXpub: cosignerXpub,
+      ),
+    );
+    return response.psbtBase64;
+  }
+
   Future<String> combinePsbt({required List<String> psbtsBase64}) async {
     final response = await _unaryClient.combinePsbt(
       wmpb.CombinePsbtRequest(psbtBase64: psbtsBase64),
@@ -274,6 +319,25 @@ class OrchestratorWalletRPC {
       wmpb.FinalizePsbtRequest(psbtBase64: psbtBase64),
     );
     return response.rawTxHex;
+  }
+
+  /// Reports a multisig PSBT's signing progress: signature count, whether it
+  /// can be finalized, and which cosigners have signed.
+  Future<wmpb.MultisigPsbtStatusResponse> multisigPsbtStatus({
+    required String walletId,
+    required String psbtBase64,
+  }) {
+    return _unaryClient.multisigPsbtStatus(
+      wmpb.MultisigPsbtStatusRequest(walletId: walletId, psbtBase64: psbtBase64),
+    );
+  }
+
+  /// Broadcasts a finalized raw transaction over the wallet's chain.
+  Future<String> broadcastTransaction({required String walletId, required String txHex}) async {
+    final response = await _unaryClient.broadcastTransaction(
+      wmpb.BroadcastTransactionRequest(walletId: walletId, txHex: txHex),
+    );
+    return response.txid;
   }
 
   Future<wmpb.ListTransactionsResponse> listTransactions({

--- a/sidechain-orchestrator/api/multisiglounge_handler.go
+++ b/sidechain-orchestrator/api/multisiglounge_handler.go
@@ -112,7 +112,7 @@ func (h *MultisigLoungeHandler) BuildDescriptors(
 	if group == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errMissingGroup)
 	}
-	receive, change, err := wallet.BuildMultisigLoungeDescriptors(protoToLoungeGroup(group))
+	receive, change, err := wallet.BuildMultisigLoungeDescriptorsTyped(protoToLoungeGroup(group), req.Msg.GetScriptType())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -179,7 +180,9 @@ func (h *WalletHandler) ListWallets(ctx context.Context, req *connect.Request[pb
 		// and noisy (it errors on the empty seed); skip it. Advertise only for
 		// BIP47-capable backends (Core + electrum), the wallets the engine watches.
 		var bip47Code string
-		if !w.IsWatchOnly() && h.bip47Capable(w.ID) {
+		// BIP47 derives from a single master seed, which multisig and watch-only
+		// wallets don't have — skip them rather than derive from an empty seed.
+		if w.Master.SeedHex != "" && !w.IsWatchOnly() && h.bip47Capable(w.ID) {
 			code, err := wallet.Bip47PaymentCodeFromSeed(w.Master.SeedHex, h.bip47NetParams())
 			if err != nil {
 				h.svc.Log().Error().Err(err).Str("wallet_id", w.ID).Msg("ListWallets: bip47 derivation failed")
@@ -194,6 +197,7 @@ func (h *WalletHandler) ListWallets(ctx context.Context, req *connect.Request[pb
 			GradientJson:     gradientJSON,
 			CreatedAt:        w.CreatedAt.Format(time.RFC3339),
 			Bip47PaymentCode: bip47Code,
+			Multisig:         multisigInfoProto(&w),
 		}
 	}
 	return connect.NewResponse(&pb.ListWalletsResponse{
@@ -370,6 +374,147 @@ func (h *WalletHandler) CreateElectrumWallet(ctx context.Context, req *connect.R
 	return connect.NewResponse(&pb.CreateElectrumWalletResponse{
 		WalletId: w.ID,
 	}), nil
+}
+
+func (h *WalletHandler) CreateMultisigWallet(ctx context.Context, req *connect.Request[pb.CreateMultisigWalletRequest]) (*connect.Response[pb.CreateMultisigWalletResponse], error) {
+	if h.engine == nil || !h.engine.ElectrumConfigured() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("multisig wallets are not supported on this network"))
+	}
+	net := h.engine.Network()
+	cosigners := make([]wallet.MultisigCosigner, 0, len(req.Msg.Cosigners))
+	for _, c := range req.Msg.Cosigners {
+		xpub := c.Xpub
+		// For a held cosigner, derive the authoritative xpub from its seed +
+		// passphrase so the stored (watch-only) key can never disagree with the
+		// signing key — the wallet always watches exactly what it can sign.
+		if c.Mnemonic != "" {
+			seedHex := hex.EncodeToString(wallet.MnemonicToSeed(c.Mnemonic, c.Passphrase))
+			_, derived, err := wallet.DeriveAccountXprv(seedHex, "m/"+c.OriginPath, net)
+			if err != nil {
+				return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("derive cosigner xpub: %w", err))
+			}
+			xpub = derived
+		}
+		cosigners = append(cosigners, wallet.MultisigCosigner{
+			Xpub:        xpub,
+			OriginPath:  c.OriginPath,
+			Fingerprint: c.Fingerprint,
+			Mnemonic:    c.Mnemonic,
+			Passphrase:  c.Passphrase,
+			Xprv:        c.Xprv,
+		})
+	}
+	w, err := h.svc.CreateElectrumMultisig(
+		req.Msg.Name,
+		json.RawMessage(req.Msg.GradientJson),
+		int(req.Msg.M),
+		int(req.Msg.N),
+		req.Msg.ScriptType,
+		cosigners,
+	)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&pb.CreateMultisigWalletResponse{WalletId: w.ID}), nil
+}
+
+// multisigInfoProto exposes a wallet's multisig policy to the frontend. Private
+// cosigner material (mnemonic/xprv) is never included — only public data and a
+// held flag.
+func multisigInfoProto(w *wallet.WalletData) *pb.MultisigInfo {
+	if w.Multisig == nil {
+		return nil
+	}
+	cosigners := make([]*pb.MultisigCosignerInfo, 0, len(w.Multisig.Cosigners))
+	for _, c := range w.Multisig.Cosigners {
+		cosigners = append(cosigners, &pb.MultisigCosignerInfo{
+			Xpub:        c.Xpub,
+			Fingerprint: c.Fingerprint,
+			OriginPath:  c.OriginPath,
+			Held:        c.Held(),
+		})
+	}
+	return &pb.MultisigInfo{
+		M:          uint32(w.Multisig.M),
+		N:          uint32(w.Multisig.N),
+		ScriptType: w.MultisigScriptType(),
+		Cosigners:  cosigners,
+	}
+}
+
+func (h *WalletHandler) ParseMultisigConfig(ctx context.Context, req *connect.Request[pb.ParseMultisigConfigRequest]) (*connect.Response[pb.ParseMultisigConfigResponse], error) {
+	m, n, scriptType, cosigners, err := wallet.ParseMultisigConfig(req.Msg.Content)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	pbCosigners := make([]*pb.ParsedCosigner, 0, len(cosigners))
+	for _, c := range cosigners {
+		pbCosigners = append(pbCosigners, &pb.ParsedCosigner{
+			Xpub:        c.Xpub,
+			Fingerprint: c.Fingerprint,
+			OriginPath:  c.OriginPath,
+		})
+	}
+	return connect.NewResponse(&pb.ParseMultisigConfigResponse{
+		M:          uint32(m),
+		N:          uint32(n),
+		ScriptType: scriptType,
+		Cosigners:  pbCosigners,
+	}), nil
+}
+
+func (h *WalletHandler) SignPsbtWithCosigner(ctx context.Context, req *connect.Request[pb.SignPsbtWithCosignerRequest]) (*connect.Response[pb.SignPsbtWithCosignerResponse], error) {
+	if err := h.requireEngine(); err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	walletID, err := h.engine.ResolveWalletID(req.Msg.WalletId)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	out, err := h.engine.SignPSBTWithCosigner(ctx, walletID, req.Msg.PsbtBase64, req.Msg.CosignerXpub)
+	if err != nil {
+		return nil, rpcError(err)
+	}
+	return connect.NewResponse(&pb.SignPsbtWithCosignerResponse{PsbtBase64: out}), nil
+}
+
+func (h *WalletHandler) MultisigPsbtStatus(ctx context.Context, req *connect.Request[pb.MultisigPsbtStatusRequest]) (*connect.Response[pb.MultisigPsbtStatusResponse], error) {
+	w := h.svc.GetWalletByID(req.Msg.WalletId)
+	if w == nil {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("wallet %s not found", req.Msg.WalletId))
+	}
+	if w.Multisig == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is not a multisig wallet"))
+	}
+	status, err := wallet.MultisigPsbtSigningStatus(req.Msg.PsbtBase64, w.Multisig.Cosigners)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	return connect.NewResponse(&pb.MultisigPsbtStatusResponse{
+		Threshold:      uint32(w.Multisig.M),
+		Signatures:     uint32(status.Signatures),
+		Finalizable:    status.Finalizable,
+		CosignerSigned: status.CosignerSigned,
+	}), nil
+}
+
+func (h *WalletHandler) BroadcastTransaction(ctx context.Context, req *connect.Request[pb.BroadcastTransactionRequest]) (*connect.Response[pb.BroadcastTransactionResponse], error) {
+	if err := h.requireEngine(); err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	walletID, err := h.engine.ResolveWalletID(req.Msg.WalletId)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	txid, err := h.engine.ChainForWallet(walletID).Broadcast(ctx, req.Msg.TxHex)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("broadcast: %w", err))
+	}
+	if rerr := h.engine.RefreshElectrumScan(ctx, walletID); rerr != nil {
+		h.svc.Log().Warn().Err(rerr).Str("wallet_id", walletID).Msg("refresh scan after broadcast failed")
+	}
+	return connect.NewResponse(&pb.BroadcastTransactionResponse{Txid: txid}), nil
 }
 
 // ============================================================================
@@ -1246,7 +1391,9 @@ func buildWatchWalletDataResponse(wallets []wallet.WalletData, activeID string, 
 		// code is advertised only for BIP47-capable backends (Core + electrum),
 		// the same wallets the inbound engine watches.
 		var bip47Code string
-		if !w.IsWatchOnly() && bip47Capable(w.ID) {
+		// BIP47 derives from a single master seed, which multisig and watch-only
+		// wallets don't have — skip them rather than derive from an empty seed.
+		if w.Master.SeedHex != "" && !w.IsWatchOnly() && bip47Capable(w.ID) {
 			code, err := wallet.Bip47PaymentCodeFromSeed(w.Master.SeedHex, netParams)
 			if err != nil && onBip47Err != nil {
 				onBip47Err(w.ID, err)
@@ -1261,6 +1408,7 @@ func buildWatchWalletDataResponse(wallets []wallet.WalletData, activeID string, 
 			GradientJson:     gradientJSON,
 			CreatedAt:        w.CreatedAt.Format(time.RFC3339),
 			Bip47PaymentCode: bip47Code,
+			Multisig:         multisigInfoProto(&w),
 		}
 		// Starter material lives only on the enforcer wallet (L1 mnemonic and
 		// sidechain starters are derived from its seed). Attach it to that

--- a/sidechain-orchestrator/gen/multisiglounge/v1/multisiglounge.pb.go
+++ b/sidechain-orchestrator/gen/multisiglounge/v1/multisiglounge.pb.go
@@ -1475,8 +1475,11 @@ func (x *MultisigGroup) GetKeys() []*MultisigKey {
 }
 
 type BuildDescriptorsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Group         *MultisigGroup         `protobuf:"bytes,1,opt,name=group,proto3" json:"group,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Group *MultisigGroup         `protobuf:"bytes,1,opt,name=group,proto3" json:"group,omitempty"`
+	// Multisig script type: "wsh" (native P2WSH, default), "sh-wsh" (nested
+	// P2SH-P2WSH), or "sh" (legacy P2SH). Empty means native P2WSH.
+	ScriptType    string `protobuf:"bytes,2,opt,name=script_type,json=scriptType,proto3" json:"script_type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1516,6 +1519,13 @@ func (x *BuildDescriptorsRequest) GetGroup() *MultisigGroup {
 		return x.Group
 	}
 	return nil
+}
+
+func (x *BuildDescriptorsRequest) GetScriptType() string {
+	if x != nil {
+		return x.ScriptType
+	}
+	return ""
 }
 
 type BuildDescriptorsResponse struct {
@@ -1831,9 +1841,11 @@ const file_multisiglounge_v1_multisiglounge_proto_rawDesc = "" +
 	"\rMultisigGroup\x12\f\n" +
 	"\x01m\x18\x01 \x01(\rR\x01m\x12\f\n" +
 	"\x01n\x18\x02 \x01(\rR\x01n\x122\n" +
-	"\x04keys\x18\x03 \x03(\v2\x1e.multisiglounge.v1.MultisigKeyR\x04keys\"Q\n" +
+	"\x04keys\x18\x03 \x03(\v2\x1e.multisiglounge.v1.MultisigKeyR\x04keys\"r\n" +
 	"\x17BuildDescriptorsRequest\x126\n" +
-	"\x05group\x18\x01 \x01(\v2 .multisiglounge.v1.MultisigGroupR\x05group\"v\n" +
+	"\x05group\x18\x01 \x01(\v2 .multisiglounge.v1.MultisigGroupR\x05group\x12\x1f\n" +
+	"\vscript_type\x18\x02 \x01(\tR\n" +
+	"scriptType\"v\n" +
 	"\x18BuildDescriptorsResponse\x12-\n" +
 	"\x12receive_descriptor\x18\x01 \x01(\tR\x11receiveDescriptor\x12+\n" +
 	"\x11change_descriptor\x18\x02 \x01(\tR\x10changeDescriptor\"\x93\x01\n" +

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -894,7 +894,10 @@ type WalletMetadata struct {
 	L1Mnemonic     string              `protobuf:"bytes,8,opt,name=l1_mnemonic,json=l1Mnemonic,proto3" json:"l1_mnemonic,omitempty"`
 	Sidechains     []*SidechainStarter `protobuf:"bytes,9,rep,name=sidechains,proto3" json:"sidechains,omitempty"`
 	// Watch-only wallets track an external xpub/descriptor; no spending key.
-	WatchOnly     bool `protobuf:"varint,10,opt,name=watch_only,json=watchOnly,proto3" json:"watch_only,omitempty"`
+	WatchOnly bool `protobuf:"varint,10,opt,name=watch_only,json=watchOnly,proto3" json:"watch_only,omitempty"`
+	// Multisig policy, present only for multisig wallets. Cosigner private
+	// material is never exposed here — only public data and a held flag.
+	Multisig      *MultisigInfo `protobuf:"bytes,11,opt,name=multisig,proto3" json:"multisig,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -999,6 +1002,149 @@ func (x *WalletMetadata) GetWatchOnly() bool {
 	return false
 }
 
+func (x *WalletMetadata) GetMultisig() *MultisigInfo {
+	if x != nil {
+		return x.Multisig
+	}
+	return nil
+}
+
+type MultisigInfo struct {
+	state         protoimpl.MessageState  `protogen:"open.v1"`
+	M             uint32                  `protobuf:"varint,1,opt,name=m,proto3" json:"m,omitempty"`                                    // threshold
+	N             uint32                  `protobuf:"varint,2,opt,name=n,proto3" json:"n,omitempty"`                                    // total cosigners
+	ScriptType    string                  `protobuf:"bytes,3,opt,name=script_type,json=scriptType,proto3" json:"script_type,omitempty"` // wsh | sh-wsh | sh
+	Cosigners     []*MultisigCosignerInfo `protobuf:"bytes,4,rep,name=cosigners,proto3" json:"cosigners,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MultisigInfo) Reset() {
+	*x = MultisigInfo{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MultisigInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MultisigInfo) ProtoMessage() {}
+
+func (x *MultisigInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MultisigInfo.ProtoReflect.Descriptor instead.
+func (*MultisigInfo) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *MultisigInfo) GetM() uint32 {
+	if x != nil {
+		return x.M
+	}
+	return 0
+}
+
+func (x *MultisigInfo) GetN() uint32 {
+	if x != nil {
+		return x.N
+	}
+	return 0
+}
+
+func (x *MultisigInfo) GetScriptType() string {
+	if x != nil {
+		return x.ScriptType
+	}
+	return ""
+}
+
+func (x *MultisigInfo) GetCosigners() []*MultisigCosignerInfo {
+	if x != nil {
+		return x.Cosigners
+	}
+	return nil
+}
+
+type MultisigCosignerInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Xpub          string                 `protobuf:"bytes,1,opt,name=xpub,proto3" json:"xpub,omitempty"`
+	Fingerprint   string                 `protobuf:"bytes,2,opt,name=fingerprint,proto3" json:"fingerprint,omitempty"`
+	OriginPath    string                 `protobuf:"bytes,3,opt,name=origin_path,json=originPath,proto3" json:"origin_path,omitempty"`
+	Held          bool                   `protobuf:"varint,4,opt,name=held,proto3" json:"held,omitempty"` // this wallet holds the key and can sign for this cosigner
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MultisigCosignerInfo) Reset() {
+	*x = MultisigCosignerInfo{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MultisigCosignerInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MultisigCosignerInfo) ProtoMessage() {}
+
+func (x *MultisigCosignerInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MultisigCosignerInfo.ProtoReflect.Descriptor instead.
+func (*MultisigCosignerInfo) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *MultisigCosignerInfo) GetXpub() string {
+	if x != nil {
+		return x.Xpub
+	}
+	return ""
+}
+
+func (x *MultisigCosignerInfo) GetFingerprint() string {
+	if x != nil {
+		return x.Fingerprint
+	}
+	return ""
+}
+
+func (x *MultisigCosignerInfo) GetOriginPath() string {
+	if x != nil {
+		return x.OriginPath
+	}
+	return ""
+}
+
+func (x *MultisigCosignerInfo) GetHeld() bool {
+	if x != nil {
+		return x.Held
+	}
+	return false
+}
+
 type SidechainStarter struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Slot          int32                  `protobuf:"varint,1,opt,name=slot,proto3" json:"slot,omitempty"`
@@ -1010,7 +1156,7 @@ type SidechainStarter struct {
 
 func (x *SidechainStarter) Reset() {
 	*x = SidechainStarter{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[15]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1022,7 +1168,7 @@ func (x *SidechainStarter) String() string {
 func (*SidechainStarter) ProtoMessage() {}
 
 func (x *SidechainStarter) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[15]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1035,7 +1181,7 @@ func (x *SidechainStarter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SidechainStarter.ProtoReflect.Descriptor instead.
 func (*SidechainStarter) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{15}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SidechainStarter) GetSlot() int32 {
@@ -1067,7 +1213,7 @@ type ListWalletsRequest struct {
 
 func (x *ListWalletsRequest) Reset() {
 	*x = ListWalletsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[16]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1079,7 +1225,7 @@ func (x *ListWalletsRequest) String() string {
 func (*ListWalletsRequest) ProtoMessage() {}
 
 func (x *ListWalletsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[16]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1092,7 +1238,7 @@ func (x *ListWalletsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWalletsRequest.ProtoReflect.Descriptor instead.
 func (*ListWalletsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{16}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{18}
 }
 
 type ListWalletsResponse struct {
@@ -1105,7 +1251,7 @@ type ListWalletsResponse struct {
 
 func (x *ListWalletsResponse) Reset() {
 	*x = ListWalletsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[17]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1117,7 +1263,7 @@ func (x *ListWalletsResponse) String() string {
 func (*ListWalletsResponse) ProtoMessage() {}
 
 func (x *ListWalletsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[17]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1130,7 +1276,7 @@ func (x *ListWalletsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWalletsResponse.ProtoReflect.Descriptor instead.
 func (*ListWalletsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{17}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ListWalletsResponse) GetWallets() []*WalletMetadata {
@@ -1156,7 +1302,7 @@ type SwitchWalletRequest struct {
 
 func (x *SwitchWalletRequest) Reset() {
 	*x = SwitchWalletRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[18]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1168,7 +1314,7 @@ func (x *SwitchWalletRequest) String() string {
 func (*SwitchWalletRequest) ProtoMessage() {}
 
 func (x *SwitchWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[18]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1181,7 +1327,7 @@ func (x *SwitchWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SwitchWalletRequest.ProtoReflect.Descriptor instead.
 func (*SwitchWalletRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{18}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SwitchWalletRequest) GetWalletId() string {
@@ -1199,7 +1345,7 @@ type SwitchWalletResponse struct {
 
 func (x *SwitchWalletResponse) Reset() {
 	*x = SwitchWalletResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[19]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1211,7 +1357,7 @@ func (x *SwitchWalletResponse) String() string {
 func (*SwitchWalletResponse) ProtoMessage() {}
 
 func (x *SwitchWalletResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[19]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1224,7 +1370,7 @@ func (x *SwitchWalletResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SwitchWalletResponse.ProtoReflect.Descriptor instead.
 func (*SwitchWalletResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{19}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{21}
 }
 
 type UpdateWalletMetadataRequest struct {
@@ -1238,7 +1384,7 @@ type UpdateWalletMetadataRequest struct {
 
 func (x *UpdateWalletMetadataRequest) Reset() {
 	*x = UpdateWalletMetadataRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[20]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1250,7 +1396,7 @@ func (x *UpdateWalletMetadataRequest) String() string {
 func (*UpdateWalletMetadataRequest) ProtoMessage() {}
 
 func (x *UpdateWalletMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[20]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1263,7 +1409,7 @@ func (x *UpdateWalletMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateWalletMetadataRequest.ProtoReflect.Descriptor instead.
 func (*UpdateWalletMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{20}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *UpdateWalletMetadataRequest) GetWalletId() string {
@@ -1295,7 +1441,7 @@ type UpdateWalletMetadataResponse struct {
 
 func (x *UpdateWalletMetadataResponse) Reset() {
 	*x = UpdateWalletMetadataResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[21]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1307,7 +1453,7 @@ func (x *UpdateWalletMetadataResponse) String() string {
 func (*UpdateWalletMetadataResponse) ProtoMessage() {}
 
 func (x *UpdateWalletMetadataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[21]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1320,7 +1466,7 @@ func (x *UpdateWalletMetadataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateWalletMetadataResponse.ProtoReflect.Descriptor instead.
 func (*UpdateWalletMetadataResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{21}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{23}
 }
 
 type DeleteWalletRequest struct {
@@ -1332,7 +1478,7 @@ type DeleteWalletRequest struct {
 
 func (x *DeleteWalletRequest) Reset() {
 	*x = DeleteWalletRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[22]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1344,7 +1490,7 @@ func (x *DeleteWalletRequest) String() string {
 func (*DeleteWalletRequest) ProtoMessage() {}
 
 func (x *DeleteWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[22]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1357,7 +1503,7 @@ func (x *DeleteWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWalletRequest.ProtoReflect.Descriptor instead.
 func (*DeleteWalletRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{22}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *DeleteWalletRequest) GetWalletId() string {
@@ -1375,7 +1521,7 @@ type DeleteWalletResponse struct {
 
 func (x *DeleteWalletResponse) Reset() {
 	*x = DeleteWalletResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[23]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1387,7 +1533,7 @@ func (x *DeleteWalletResponse) String() string {
 func (*DeleteWalletResponse) ProtoMessage() {}
 
 func (x *DeleteWalletResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[23]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1400,7 +1546,7 @@ func (x *DeleteWalletResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWalletResponse.ProtoReflect.Descriptor instead.
 func (*DeleteWalletResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{23}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{25}
 }
 
 type DeleteAllWalletsRequest struct {
@@ -1411,7 +1557,7 @@ type DeleteAllWalletsRequest struct {
 
 func (x *DeleteAllWalletsRequest) Reset() {
 	*x = DeleteAllWalletsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[24]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1423,7 +1569,7 @@ func (x *DeleteAllWalletsRequest) String() string {
 func (*DeleteAllWalletsRequest) ProtoMessage() {}
 
 func (x *DeleteAllWalletsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[24]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1436,7 +1582,7 @@ func (x *DeleteAllWalletsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAllWalletsRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAllWalletsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{24}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{26}
 }
 
 type DeleteAllWalletsResponse struct {
@@ -1447,7 +1593,7 @@ type DeleteAllWalletsResponse struct {
 
 func (x *DeleteAllWalletsResponse) Reset() {
 	*x = DeleteAllWalletsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[25]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1459,7 +1605,7 @@ func (x *DeleteAllWalletsResponse) String() string {
 func (*DeleteAllWalletsResponse) ProtoMessage() {}
 
 func (x *DeleteAllWalletsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[25]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1472,7 +1618,7 @@ func (x *DeleteAllWalletsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAllWalletsResponse.ProtoReflect.Descriptor instead.
 func (*DeleteAllWalletsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{25}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{27}
 }
 
 type BalanceSnapshot struct {
@@ -1488,7 +1634,7 @@ type BalanceSnapshot struct {
 
 func (x *BalanceSnapshot) Reset() {
 	*x = BalanceSnapshot{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[26]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1500,7 +1646,7 @@ func (x *BalanceSnapshot) String() string {
 func (*BalanceSnapshot) ProtoMessage() {}
 
 func (x *BalanceSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[26]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1513,7 +1659,7 @@ func (x *BalanceSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BalanceSnapshot.ProtoReflect.Descriptor instead.
 func (*BalanceSnapshot) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{26}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *BalanceSnapshot) GetBinary() v1.BinaryType {
@@ -1562,7 +1708,7 @@ type BackupWalletSummary struct {
 
 func (x *BackupWalletSummary) Reset() {
 	*x = BackupWalletSummary{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[27]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1574,7 +1720,7 @@ func (x *BackupWalletSummary) String() string {
 func (*BackupWalletSummary) ProtoMessage() {}
 
 func (x *BackupWalletSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[27]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1587,7 +1733,7 @@ func (x *BackupWalletSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupWalletSummary.ProtoReflect.Descriptor instead.
 func (*BackupWalletSummary) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{27}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *BackupWalletSummary) GetId() string {
@@ -1629,7 +1775,7 @@ type WalletBackup struct {
 
 func (x *WalletBackup) Reset() {
 	*x = WalletBackup{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[28]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1641,7 +1787,7 @@ func (x *WalletBackup) String() string {
 func (*WalletBackup) ProtoMessage() {}
 
 func (x *WalletBackup) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[28]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1654,7 +1800,7 @@ func (x *WalletBackup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletBackup.ProtoReflect.Descriptor instead.
 func (*WalletBackup) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{28}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *WalletBackup) GetBackupId() string {
@@ -1735,7 +1881,7 @@ type ListWalletBackupsRequest struct {
 
 func (x *ListWalletBackupsRequest) Reset() {
 	*x = ListWalletBackupsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[29]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1747,7 +1893,7 @@ func (x *ListWalletBackupsRequest) String() string {
 func (*ListWalletBackupsRequest) ProtoMessage() {}
 
 func (x *ListWalletBackupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[29]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1760,7 +1906,7 @@ func (x *ListWalletBackupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWalletBackupsRequest.ProtoReflect.Descriptor instead.
 func (*ListWalletBackupsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{29}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{31}
 }
 
 type ListWalletBackupsResponse struct {
@@ -1772,7 +1918,7 @@ type ListWalletBackupsResponse struct {
 
 func (x *ListWalletBackupsResponse) Reset() {
 	*x = ListWalletBackupsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[30]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1784,7 +1930,7 @@ func (x *ListWalletBackupsResponse) String() string {
 func (*ListWalletBackupsResponse) ProtoMessage() {}
 
 func (x *ListWalletBackupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[30]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1797,7 +1943,7 @@ func (x *ListWalletBackupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWalletBackupsResponse.ProtoReflect.Descriptor instead.
 func (*ListWalletBackupsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{30}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ListWalletBackupsResponse) GetBackups() []*WalletBackup {
@@ -1817,7 +1963,7 @@ type RestoreWalletBackupRequest struct {
 
 func (x *RestoreWalletBackupRequest) Reset() {
 	*x = RestoreWalletBackupRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[31]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1829,7 +1975,7 @@ func (x *RestoreWalletBackupRequest) String() string {
 func (*RestoreWalletBackupRequest) ProtoMessage() {}
 
 func (x *RestoreWalletBackupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[31]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1842,7 +1988,7 @@ func (x *RestoreWalletBackupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreWalletBackupRequest.ProtoReflect.Descriptor instead.
 func (*RestoreWalletBackupRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{31}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *RestoreWalletBackupRequest) GetBackupId() string {
@@ -1867,7 +2013,7 @@ type RestoreWalletBackupResponse struct {
 
 func (x *RestoreWalletBackupResponse) Reset() {
 	*x = RestoreWalletBackupResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[32]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1879,7 +2025,7 @@ func (x *RestoreWalletBackupResponse) String() string {
 func (*RestoreWalletBackupResponse) ProtoMessage() {}
 
 func (x *RestoreWalletBackupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[32]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1892,7 +2038,7 @@ func (x *RestoreWalletBackupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreWalletBackupResponse.ProtoReflect.Descriptor instead.
 func (*RestoreWalletBackupResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{32}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{34}
 }
 
 type RestoreWalletBackupStep struct {
@@ -1905,7 +2051,7 @@ type RestoreWalletBackupStep struct {
 
 func (x *RestoreWalletBackupStep) Reset() {
 	*x = RestoreWalletBackupStep{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[33]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1917,7 +2063,7 @@ func (x *RestoreWalletBackupStep) String() string {
 func (*RestoreWalletBackupStep) ProtoMessage() {}
 
 func (x *RestoreWalletBackupStep) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[33]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1930,7 +2076,7 @@ func (x *RestoreWalletBackupStep) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreWalletBackupStep.ProtoReflect.Descriptor instead.
 func (*RestoreWalletBackupStep) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{33}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *RestoreWalletBackupStep) GetStepId() string {
@@ -1959,7 +2105,7 @@ type RestoreWalletBackupProgressStatus struct {
 
 func (x *RestoreWalletBackupProgressStatus) Reset() {
 	*x = RestoreWalletBackupProgressStatus{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[34]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1971,7 +2117,7 @@ func (x *RestoreWalletBackupProgressStatus) String() string {
 func (*RestoreWalletBackupProgressStatus) ProtoMessage() {}
 
 func (x *RestoreWalletBackupProgressStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[34]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1984,7 +2130,7 @@ func (x *RestoreWalletBackupProgressStatus) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use RestoreWalletBackupProgressStatus.ProtoReflect.Descriptor instead.
 func (*RestoreWalletBackupProgressStatus) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{34}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *RestoreWalletBackupProgressStatus) GetStepId() string {
@@ -2025,7 +2171,7 @@ type RestoreWalletBackupProgressResponse struct {
 
 func (x *RestoreWalletBackupProgressResponse) Reset() {
 	*x = RestoreWalletBackupProgressResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[35]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2037,7 +2183,7 @@ func (x *RestoreWalletBackupProgressResponse) String() string {
 func (*RestoreWalletBackupProgressResponse) ProtoMessage() {}
 
 func (x *RestoreWalletBackupProgressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[35]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2050,7 +2196,7 @@ func (x *RestoreWalletBackupProgressResponse) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use RestoreWalletBackupProgressResponse.ProtoReflect.Descriptor instead.
 func (*RestoreWalletBackupProgressResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{35}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *RestoreWalletBackupProgressResponse) GetSteps() []*RestoreWalletBackupStep {
@@ -2078,7 +2224,7 @@ type CreateWatchOnlyWalletRequest struct {
 
 func (x *CreateWatchOnlyWalletRequest) Reset() {
 	*x = CreateWatchOnlyWalletRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[36]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2090,7 +2236,7 @@ func (x *CreateWatchOnlyWalletRequest) String() string {
 func (*CreateWatchOnlyWalletRequest) ProtoMessage() {}
 
 func (x *CreateWatchOnlyWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[36]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2103,7 +2249,7 @@ func (x *CreateWatchOnlyWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWatchOnlyWalletRequest.ProtoReflect.Descriptor instead.
 func (*CreateWatchOnlyWalletRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{36}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *CreateWatchOnlyWalletRequest) GetName() string {
@@ -2136,7 +2282,7 @@ type CreateWatchOnlyWalletResponse struct {
 
 func (x *CreateWatchOnlyWalletResponse) Reset() {
 	*x = CreateWatchOnlyWalletResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[37]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2148,7 +2294,7 @@ func (x *CreateWatchOnlyWalletResponse) String() string {
 func (*CreateWatchOnlyWalletResponse) ProtoMessage() {}
 
 func (x *CreateWatchOnlyWalletResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[37]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2161,7 +2307,7 @@ func (x *CreateWatchOnlyWalletResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWatchOnlyWalletResponse.ProtoReflect.Descriptor instead.
 func (*CreateWatchOnlyWalletResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{37}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *CreateWatchOnlyWalletResponse) GetWalletId() string {
@@ -2201,7 +2347,7 @@ type CreateElectrumWalletRequest struct {
 
 func (x *CreateElectrumWalletRequest) Reset() {
 	*x = CreateElectrumWalletRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[38]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2213,7 +2359,7 @@ func (x *CreateElectrumWalletRequest) String() string {
 func (*CreateElectrumWalletRequest) ProtoMessage() {}
 
 func (x *CreateElectrumWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[38]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2226,7 +2372,7 @@ func (x *CreateElectrumWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateElectrumWalletRequest.ProtoReflect.Descriptor instead.
 func (*CreateElectrumWalletRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{38}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *CreateElectrumWalletRequest) GetName() string {
@@ -2294,7 +2440,7 @@ type CreateElectrumWalletResponse struct {
 
 func (x *CreateElectrumWalletResponse) Reset() {
 	*x = CreateElectrumWalletResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[39]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2306,7 +2452,7 @@ func (x *CreateElectrumWalletResponse) String() string {
 func (*CreateElectrumWalletResponse) ProtoMessage() {}
 
 func (x *CreateElectrumWalletResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[39]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2319,7 +2465,7 @@ func (x *CreateElectrumWalletResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateElectrumWalletResponse.ProtoReflect.Descriptor instead.
 func (*CreateElectrumWalletResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{39}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *CreateElectrumWalletResponse) GetWalletId() string {
@@ -2327,6 +2473,396 @@ func (x *CreateElectrumWalletResponse) GetWalletId() string {
 		return x.WalletId
 	}
 	return ""
+}
+
+// MultisigCosignerInput is one leg of a multisig wallet. A cosigner with a
+// mnemonic or xprv is held on disk (this wallet signs with it); one with only
+// an xpub is a watch-only leg signed elsewhere.
+type MultisigCosignerInput struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Xpub          string                 `protobuf:"bytes,1,opt,name=xpub,proto3" json:"xpub,omitempty"`
+	OriginPath    string                 `protobuf:"bytes,2,opt,name=origin_path,json=originPath,proto3" json:"origin_path,omitempty"` // without leading m/, e.g. "48'/1'/0'/2'"
+	Fingerprint   string                 `protobuf:"bytes,3,opt,name=fingerprint,proto3" json:"fingerprint,omitempty"`                 // master key fingerprint, 8 hex chars
+	Mnemonic      string                 `protobuf:"bytes,4,opt,name=mnemonic,proto3" json:"mnemonic,omitempty"`                       // held: BIP39 seed, stored so the wallet can sign
+	Xprv          string                 `protobuf:"bytes,5,opt,name=xprv,proto3" json:"xprv,omitempty"`                               // held: account-level xprv, alternative to mnemonic
+	Passphrase    string                 `protobuf:"bytes,6,opt,name=passphrase,proto3" json:"passphrase,omitempty"`                   // optional BIP39 passphrase for mnemonic
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MultisigCosignerInput) Reset() {
+	*x = MultisigCosignerInput{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MultisigCosignerInput) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MultisigCosignerInput) ProtoMessage() {}
+
+func (x *MultisigCosignerInput) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MultisigCosignerInput.ProtoReflect.Descriptor instead.
+func (*MultisigCosignerInput) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *MultisigCosignerInput) GetXpub() string {
+	if x != nil {
+		return x.Xpub
+	}
+	return ""
+}
+
+func (x *MultisigCosignerInput) GetOriginPath() string {
+	if x != nil {
+		return x.OriginPath
+	}
+	return ""
+}
+
+func (x *MultisigCosignerInput) GetFingerprint() string {
+	if x != nil {
+		return x.Fingerprint
+	}
+	return ""
+}
+
+func (x *MultisigCosignerInput) GetMnemonic() string {
+	if x != nil {
+		return x.Mnemonic
+	}
+	return ""
+}
+
+func (x *MultisigCosignerInput) GetXprv() string {
+	if x != nil {
+		return x.Xprv
+	}
+	return ""
+}
+
+func (x *MultisigCosignerInput) GetPassphrase() string {
+	if x != nil {
+		return x.Passphrase
+	}
+	return ""
+}
+
+type CreateMultisigWalletRequest struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Name         string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	GradientJson string                 `protobuf:"bytes,2,opt,name=gradient_json,json=gradientJson,proto3" json:"gradient_json,omitempty"`
+	M            uint32                 `protobuf:"varint,3,opt,name=m,proto3" json:"m,omitempty"` // threshold (signatures required)
+	N            uint32                 `protobuf:"varint,4,opt,name=n,proto3" json:"n,omitempty"` // total cosigners
+	// "wsh" (native P2WSH, default), "sh-wsh" (nested P2SH-P2WSH), or "sh"
+	// (legacy P2SH).
+	ScriptType    string                   `protobuf:"bytes,5,opt,name=script_type,json=scriptType,proto3" json:"script_type,omitempty"`
+	Cosigners     []*MultisigCosignerInput `protobuf:"bytes,6,rep,name=cosigners,proto3" json:"cosigners,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateMultisigWalletRequest) Reset() {
+	*x = CreateMultisigWalletRequest{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateMultisigWalletRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateMultisigWalletRequest) ProtoMessage() {}
+
+func (x *CreateMultisigWalletRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateMultisigWalletRequest.ProtoReflect.Descriptor instead.
+func (*CreateMultisigWalletRequest) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *CreateMultisigWalletRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *CreateMultisigWalletRequest) GetGradientJson() string {
+	if x != nil {
+		return x.GradientJson
+	}
+	return ""
+}
+
+func (x *CreateMultisigWalletRequest) GetM() uint32 {
+	if x != nil {
+		return x.M
+	}
+	return 0
+}
+
+func (x *CreateMultisigWalletRequest) GetN() uint32 {
+	if x != nil {
+		return x.N
+	}
+	return 0
+}
+
+func (x *CreateMultisigWalletRequest) GetScriptType() string {
+	if x != nil {
+		return x.ScriptType
+	}
+	return ""
+}
+
+func (x *CreateMultisigWalletRequest) GetCosigners() []*MultisigCosignerInput {
+	if x != nil {
+		return x.Cosigners
+	}
+	return nil
+}
+
+type CreateMultisigWalletResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	WalletId      string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateMultisigWalletResponse) Reset() {
+	*x = CreateMultisigWalletResponse{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateMultisigWalletResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateMultisigWalletResponse) ProtoMessage() {}
+
+func (x *CreateMultisigWalletResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateMultisigWalletResponse.ProtoReflect.Descriptor instead.
+func (*CreateMultisigWalletResponse) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *CreateMultisigWalletResponse) GetWalletId() string {
+	if x != nil {
+		return x.WalletId
+	}
+	return ""
+}
+
+type ParseMultisigConfigRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// An output descriptor or a wallet-config file's contents.
+	Content       string `protobuf:"bytes,1,opt,name=content,proto3" json:"content,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ParseMultisigConfigRequest) Reset() {
+	*x = ParseMultisigConfigRequest{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ParseMultisigConfigRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ParseMultisigConfigRequest) ProtoMessage() {}
+
+func (x *ParseMultisigConfigRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ParseMultisigConfigRequest.ProtoReflect.Descriptor instead.
+func (*ParseMultisigConfigRequest) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *ParseMultisigConfigRequest) GetContent() string {
+	if x != nil {
+		return x.Content
+	}
+	return ""
+}
+
+type ParsedCosigner struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Xpub          string                 `protobuf:"bytes,1,opt,name=xpub,proto3" json:"xpub,omitempty"`
+	Fingerprint   string                 `protobuf:"bytes,2,opt,name=fingerprint,proto3" json:"fingerprint,omitempty"`
+	OriginPath    string                 `protobuf:"bytes,3,opt,name=origin_path,json=originPath,proto3" json:"origin_path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ParsedCosigner) Reset() {
+	*x = ParsedCosigner{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ParsedCosigner) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ParsedCosigner) ProtoMessage() {}
+
+func (x *ParsedCosigner) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ParsedCosigner.ProtoReflect.Descriptor instead.
+func (*ParsedCosigner) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *ParsedCosigner) GetXpub() string {
+	if x != nil {
+		return x.Xpub
+	}
+	return ""
+}
+
+func (x *ParsedCosigner) GetFingerprint() string {
+	if x != nil {
+		return x.Fingerprint
+	}
+	return ""
+}
+
+func (x *ParsedCosigner) GetOriginPath() string {
+	if x != nil {
+		return x.OriginPath
+	}
+	return ""
+}
+
+type ParseMultisigConfigResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	M             uint32                 `protobuf:"varint,1,opt,name=m,proto3" json:"m,omitempty"`
+	N             uint32                 `protobuf:"varint,2,opt,name=n,proto3" json:"n,omitempty"`
+	ScriptType    string                 `protobuf:"bytes,3,opt,name=script_type,json=scriptType,proto3" json:"script_type,omitempty"` // wsh | sh-wsh | sh
+	Cosigners     []*ParsedCosigner      `protobuf:"bytes,4,rep,name=cosigners,proto3" json:"cosigners,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ParseMultisigConfigResponse) Reset() {
+	*x = ParseMultisigConfigResponse{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ParseMultisigConfigResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ParseMultisigConfigResponse) ProtoMessage() {}
+
+func (x *ParseMultisigConfigResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ParseMultisigConfigResponse.ProtoReflect.Descriptor instead.
+func (*ParseMultisigConfigResponse) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *ParseMultisigConfigResponse) GetM() uint32 {
+	if x != nil {
+		return x.M
+	}
+	return 0
+}
+
+func (x *ParseMultisigConfigResponse) GetN() uint32 {
+	if x != nil {
+		return x.N
+	}
+	return 0
+}
+
+func (x *ParseMultisigConfigResponse) GetScriptType() string {
+	if x != nil {
+		return x.ScriptType
+	}
+	return ""
+}
+
+func (x *ParseMultisigConfigResponse) GetCosigners() []*ParsedCosigner {
+	if x != nil {
+		return x.Cosigners
+	}
+	return nil
 }
 
 type CreateBitcoinCoreWalletRequest struct {
@@ -2338,7 +2874,7 @@ type CreateBitcoinCoreWalletRequest struct {
 
 func (x *CreateBitcoinCoreWalletRequest) Reset() {
 	*x = CreateBitcoinCoreWalletRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[40]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2350,7 +2886,7 @@ func (x *CreateBitcoinCoreWalletRequest) String() string {
 func (*CreateBitcoinCoreWalletRequest) ProtoMessage() {}
 
 func (x *CreateBitcoinCoreWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[40]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2363,7 +2899,7 @@ func (x *CreateBitcoinCoreWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateBitcoinCoreWalletRequest.ProtoReflect.Descriptor instead.
 func (*CreateBitcoinCoreWalletRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{40}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *CreateBitcoinCoreWalletRequest) GetWalletId() string {
@@ -2382,7 +2918,7 @@ type CreateBitcoinCoreWalletResponse struct {
 
 func (x *CreateBitcoinCoreWalletResponse) Reset() {
 	*x = CreateBitcoinCoreWalletResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[41]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2394,7 +2930,7 @@ func (x *CreateBitcoinCoreWalletResponse) String() string {
 func (*CreateBitcoinCoreWalletResponse) ProtoMessage() {}
 
 func (x *CreateBitcoinCoreWalletResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[41]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2407,7 +2943,7 @@ func (x *CreateBitcoinCoreWalletResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateBitcoinCoreWalletResponse.ProtoReflect.Descriptor instead.
 func (*CreateBitcoinCoreWalletResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{41}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *CreateBitcoinCoreWalletResponse) GetCoreWalletName() string {
@@ -2425,7 +2961,7 @@ type EnsureCoreWalletsRequest struct {
 
 func (x *EnsureCoreWalletsRequest) Reset() {
 	*x = EnsureCoreWalletsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[42]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2437,7 +2973,7 @@ func (x *EnsureCoreWalletsRequest) String() string {
 func (*EnsureCoreWalletsRequest) ProtoMessage() {}
 
 func (x *EnsureCoreWalletsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[42]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2450,7 +2986,7 @@ func (x *EnsureCoreWalletsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnsureCoreWalletsRequest.ProtoReflect.Descriptor instead.
 func (*EnsureCoreWalletsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{42}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{50}
 }
 
 type EnsureCoreWalletsResponse struct {
@@ -2462,7 +2998,7 @@ type EnsureCoreWalletsResponse struct {
 
 func (x *EnsureCoreWalletsResponse) Reset() {
 	*x = EnsureCoreWalletsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[43]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2474,7 +3010,7 @@ func (x *EnsureCoreWalletsResponse) String() string {
 func (*EnsureCoreWalletsResponse) ProtoMessage() {}
 
 func (x *EnsureCoreWalletsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[43]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2487,7 +3023,7 @@ func (x *EnsureCoreWalletsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnsureCoreWalletsResponse.ProtoReflect.Descriptor instead.
 func (*EnsureCoreWalletsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{43}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *EnsureCoreWalletsResponse) GetSyncedCount() int32 {
@@ -2506,7 +3042,7 @@ type GetBalanceRequest struct {
 
 func (x *GetBalanceRequest) Reset() {
 	*x = GetBalanceRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[44]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2518,7 +3054,7 @@ func (x *GetBalanceRequest) String() string {
 func (*GetBalanceRequest) ProtoMessage() {}
 
 func (x *GetBalanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[44]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2531,7 +3067,7 @@ func (x *GetBalanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBalanceRequest.ProtoReflect.Descriptor instead.
 func (*GetBalanceRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{44}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *GetBalanceRequest) GetWalletId() string {
@@ -2551,7 +3087,7 @@ type GetBalanceResponse struct {
 
 func (x *GetBalanceResponse) Reset() {
 	*x = GetBalanceResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[45]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2563,7 +3099,7 @@ func (x *GetBalanceResponse) String() string {
 func (*GetBalanceResponse) ProtoMessage() {}
 
 func (x *GetBalanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[45]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2576,7 +3112,7 @@ func (x *GetBalanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBalanceResponse.ProtoReflect.Descriptor instead.
 func (*GetBalanceResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{45}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *GetBalanceResponse) GetConfirmedSats() float64 {
@@ -2603,7 +3139,7 @@ type GetNewAddressRequest struct {
 
 func (x *GetNewAddressRequest) Reset() {
 	*x = GetNewAddressRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[46]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2615,7 +3151,7 @@ func (x *GetNewAddressRequest) String() string {
 func (*GetNewAddressRequest) ProtoMessage() {}
 
 func (x *GetNewAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[46]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2628,7 +3164,7 @@ func (x *GetNewAddressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNewAddressRequest.ProtoReflect.Descriptor instead.
 func (*GetNewAddressRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{46}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *GetNewAddressRequest) GetWalletId() string {
@@ -2655,7 +3191,7 @@ type GetNewAddressResponse struct {
 
 func (x *GetNewAddressResponse) Reset() {
 	*x = GetNewAddressResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[47]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2667,7 +3203,7 @@ func (x *GetNewAddressResponse) String() string {
 func (*GetNewAddressResponse) ProtoMessage() {}
 
 func (x *GetNewAddressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[47]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2680,7 +3216,7 @@ func (x *GetNewAddressResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNewAddressResponse.ProtoReflect.Descriptor instead.
 func (*GetNewAddressResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{47}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *GetNewAddressResponse) GetAddress() string {
@@ -2727,7 +3263,7 @@ type SendTransactionRequest struct {
 
 func (x *SendTransactionRequest) Reset() {
 	*x = SendTransactionRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[48]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2739,7 +3275,7 @@ func (x *SendTransactionRequest) String() string {
 func (*SendTransactionRequest) ProtoMessage() {}
 
 func (x *SendTransactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[48]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2752,7 +3288,7 @@ func (x *SendTransactionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendTransactionRequest.ProtoReflect.Descriptor instead.
 func (*SendTransactionRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{48}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *SendTransactionRequest) GetWalletId() string {
@@ -2834,7 +3370,7 @@ type SendTransactionResponse struct {
 
 func (x *SendTransactionResponse) Reset() {
 	*x = SendTransactionResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[49]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2846,7 +3382,7 @@ func (x *SendTransactionResponse) String() string {
 func (*SendTransactionResponse) ProtoMessage() {}
 
 func (x *SendTransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[49]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2859,7 +3395,7 @@ func (x *SendTransactionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendTransactionResponse.ProtoReflect.Descriptor instead.
 func (*SendTransactionResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{49}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *SendTransactionResponse) GetTxid() string {
@@ -2880,7 +3416,7 @@ type RawOutput struct {
 
 func (x *RawOutput) Reset() {
 	*x = RawOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[50]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2892,7 +3428,7 @@ func (x *RawOutput) String() string {
 func (*RawOutput) ProtoMessage() {}
 
 func (x *RawOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[50]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2905,7 +3441,7 @@ func (x *RawOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RawOutput.ProtoReflect.Descriptor instead.
 func (*RawOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{50}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *RawOutput) GetValueSats() int64 {
@@ -2936,7 +3472,7 @@ type ExternalInput struct {
 
 func (x *ExternalInput) Reset() {
 	*x = ExternalInput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[51]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2948,7 +3484,7 @@ func (x *ExternalInput) String() string {
 func (*ExternalInput) ProtoMessage() {}
 
 func (x *ExternalInput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[51]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2961,7 +3497,7 @@ func (x *ExternalInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExternalInput.ProtoReflect.Descriptor instead.
 func (*ExternalInput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{51}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *ExternalInput) GetTxid() string {
@@ -3009,7 +3545,7 @@ type CreatePsbtRequest struct {
 
 func (x *CreatePsbtRequest) Reset() {
 	*x = CreatePsbtRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[52]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3021,7 +3557,7 @@ func (x *CreatePsbtRequest) String() string {
 func (*CreatePsbtRequest) ProtoMessage() {}
 
 func (x *CreatePsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[52]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3034,7 +3570,7 @@ func (x *CreatePsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreatePsbtRequest.ProtoReflect.Descriptor instead.
 func (*CreatePsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{52}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *CreatePsbtRequest) GetWalletId() string {
@@ -3109,7 +3645,7 @@ type CreatePsbtResponse struct {
 
 func (x *CreatePsbtResponse) Reset() {
 	*x = CreatePsbtResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[53]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3121,7 +3657,7 @@ func (x *CreatePsbtResponse) String() string {
 func (*CreatePsbtResponse) ProtoMessage() {}
 
 func (x *CreatePsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[53]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3134,7 +3670,7 @@ func (x *CreatePsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreatePsbtResponse.ProtoReflect.Descriptor instead.
 func (*CreatePsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{53}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *CreatePsbtResponse) GetPsbtBase64() string {
@@ -3154,7 +3690,7 @@ type SignPsbtRequest struct {
 
 func (x *SignPsbtRequest) Reset() {
 	*x = SignPsbtRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[54]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3166,7 +3702,7 @@ func (x *SignPsbtRequest) String() string {
 func (*SignPsbtRequest) ProtoMessage() {}
 
 func (x *SignPsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[54]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3179,7 +3715,7 @@ func (x *SignPsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignPsbtRequest.ProtoReflect.Descriptor instead.
 func (*SignPsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{54}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *SignPsbtRequest) GetWalletId() string {
@@ -3205,7 +3741,7 @@ type SignPsbtResponse struct {
 
 func (x *SignPsbtResponse) Reset() {
 	*x = SignPsbtResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[55]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3217,7 +3753,7 @@ func (x *SignPsbtResponse) String() string {
 func (*SignPsbtResponse) ProtoMessage() {}
 
 func (x *SignPsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[55]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3230,10 +3766,114 @@ func (x *SignPsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignPsbtResponse.ProtoReflect.Descriptor instead.
 func (*SignPsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{55}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *SignPsbtResponse) GetPsbtBase64() string {
+	if x != nil {
+		return x.PsbtBase64
+	}
+	return ""
+}
+
+type SignPsbtWithCosignerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	WalletId      string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	PsbtBase64    string                 `protobuf:"bytes,2,opt,name=psbt_base64,json=psbtBase64,proto3" json:"psbt_base64,omitempty"`
+	CosignerXpub  string                 `protobuf:"bytes,3,opt,name=cosigner_xpub,json=cosignerXpub,proto3" json:"cosigner_xpub,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignPsbtWithCosignerRequest) Reset() {
+	*x = SignPsbtWithCosignerRequest{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[64]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignPsbtWithCosignerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignPsbtWithCosignerRequest) ProtoMessage() {}
+
+func (x *SignPsbtWithCosignerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[64]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignPsbtWithCosignerRequest.ProtoReflect.Descriptor instead.
+func (*SignPsbtWithCosignerRequest) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{64}
+}
+
+func (x *SignPsbtWithCosignerRequest) GetWalletId() string {
+	if x != nil {
+		return x.WalletId
+	}
+	return ""
+}
+
+func (x *SignPsbtWithCosignerRequest) GetPsbtBase64() string {
+	if x != nil {
+		return x.PsbtBase64
+	}
+	return ""
+}
+
+func (x *SignPsbtWithCosignerRequest) GetCosignerXpub() string {
+	if x != nil {
+		return x.CosignerXpub
+	}
+	return ""
+}
+
+type SignPsbtWithCosignerResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PsbtBase64    string                 `protobuf:"bytes,1,opt,name=psbt_base64,json=psbtBase64,proto3" json:"psbt_base64,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignPsbtWithCosignerResponse) Reset() {
+	*x = SignPsbtWithCosignerResponse{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[65]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignPsbtWithCosignerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignPsbtWithCosignerResponse) ProtoMessage() {}
+
+func (x *SignPsbtWithCosignerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[65]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignPsbtWithCosignerResponse.ProtoReflect.Descriptor instead.
+func (*SignPsbtWithCosignerResponse) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{65}
+}
+
+func (x *SignPsbtWithCosignerResponse) GetPsbtBase64() string {
 	if x != nil {
 		return x.PsbtBase64
 	}
@@ -3249,7 +3889,7 @@ type CombinePsbtRequest struct {
 
 func (x *CombinePsbtRequest) Reset() {
 	*x = CombinePsbtRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[56]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3261,7 +3901,7 @@ func (x *CombinePsbtRequest) String() string {
 func (*CombinePsbtRequest) ProtoMessage() {}
 
 func (x *CombinePsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[56]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3274,7 +3914,7 @@ func (x *CombinePsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CombinePsbtRequest.ProtoReflect.Descriptor instead.
 func (*CombinePsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{56}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *CombinePsbtRequest) GetPsbtBase64() []string {
@@ -3293,7 +3933,7 @@ type CombinePsbtResponse struct {
 
 func (x *CombinePsbtResponse) Reset() {
 	*x = CombinePsbtResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[57]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3305,7 +3945,7 @@ func (x *CombinePsbtResponse) String() string {
 func (*CombinePsbtResponse) ProtoMessage() {}
 
 func (x *CombinePsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[57]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3318,7 +3958,7 @@ func (x *CombinePsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CombinePsbtResponse.ProtoReflect.Descriptor instead.
 func (*CombinePsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{57}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *CombinePsbtResponse) GetPsbtBase64() string {
@@ -3337,7 +3977,7 @@ type FinalizePsbtRequest struct {
 
 func (x *FinalizePsbtRequest) Reset() {
 	*x = FinalizePsbtRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[58]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3349,7 +3989,7 @@ func (x *FinalizePsbtRequest) String() string {
 func (*FinalizePsbtRequest) ProtoMessage() {}
 
 func (x *FinalizePsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[58]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3362,7 +4002,7 @@ func (x *FinalizePsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinalizePsbtRequest.ProtoReflect.Descriptor instead.
 func (*FinalizePsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{58}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *FinalizePsbtRequest) GetPsbtBase64() string {
@@ -3381,7 +4021,7 @@ type FinalizePsbtResponse struct {
 
 func (x *FinalizePsbtResponse) Reset() {
 	*x = FinalizePsbtResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[59]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3393,7 +4033,7 @@ func (x *FinalizePsbtResponse) String() string {
 func (*FinalizePsbtResponse) ProtoMessage() {}
 
 func (x *FinalizePsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[59]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3406,12 +4046,229 @@ func (x *FinalizePsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinalizePsbtResponse.ProtoReflect.Descriptor instead.
 func (*FinalizePsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{59}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *FinalizePsbtResponse) GetRawTxHex() string {
 	if x != nil {
 		return x.RawTxHex
+	}
+	return ""
+}
+
+type MultisigPsbtStatusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	WalletId      string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	PsbtBase64    string                 `protobuf:"bytes,2,opt,name=psbt_base64,json=psbtBase64,proto3" json:"psbt_base64,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MultisigPsbtStatusRequest) Reset() {
+	*x = MultisigPsbtStatusRequest{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[70]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MultisigPsbtStatusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MultisigPsbtStatusRequest) ProtoMessage() {}
+
+func (x *MultisigPsbtStatusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[70]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MultisigPsbtStatusRequest.ProtoReflect.Descriptor instead.
+func (*MultisigPsbtStatusRequest) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{70}
+}
+
+func (x *MultisigPsbtStatusRequest) GetWalletId() string {
+	if x != nil {
+		return x.WalletId
+	}
+	return ""
+}
+
+func (x *MultisigPsbtStatusRequest) GetPsbtBase64() string {
+	if x != nil {
+		return x.PsbtBase64
+	}
+	return ""
+}
+
+type MultisigPsbtStatusResponse struct {
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	Threshold   uint32                 `protobuf:"varint,1,opt,name=threshold,proto3" json:"threshold,omitempty"`   // signatures required (m)
+	Signatures  uint32                 `protobuf:"varint,2,opt,name=signatures,proto3" json:"signatures,omitempty"` // signatures present (max across inputs)
+	Finalizable bool                   `protobuf:"varint,3,opt,name=finalizable,proto3" json:"finalizable,omitempty"`
+	// Aligned to the wallet's cosigners; true where that cosigner has signed.
+	CosignerSigned []bool `protobuf:"varint,4,rep,packed,name=cosigner_signed,json=cosignerSigned,proto3" json:"cosigner_signed,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *MultisigPsbtStatusResponse) Reset() {
+	*x = MultisigPsbtStatusResponse{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[71]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MultisigPsbtStatusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MultisigPsbtStatusResponse) ProtoMessage() {}
+
+func (x *MultisigPsbtStatusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[71]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MultisigPsbtStatusResponse.ProtoReflect.Descriptor instead.
+func (*MultisigPsbtStatusResponse) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{71}
+}
+
+func (x *MultisigPsbtStatusResponse) GetThreshold() uint32 {
+	if x != nil {
+		return x.Threshold
+	}
+	return 0
+}
+
+func (x *MultisigPsbtStatusResponse) GetSignatures() uint32 {
+	if x != nil {
+		return x.Signatures
+	}
+	return 0
+}
+
+func (x *MultisigPsbtStatusResponse) GetFinalizable() bool {
+	if x != nil {
+		return x.Finalizable
+	}
+	return false
+}
+
+func (x *MultisigPsbtStatusResponse) GetCosignerSigned() []bool {
+	if x != nil {
+		return x.CosignerSigned
+	}
+	return nil
+}
+
+type BroadcastTransactionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	WalletId      string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	TxHex         string                 `protobuf:"bytes,2,opt,name=tx_hex,json=txHex,proto3" json:"tx_hex,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BroadcastTransactionRequest) Reset() {
+	*x = BroadcastTransactionRequest{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[72]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BroadcastTransactionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BroadcastTransactionRequest) ProtoMessage() {}
+
+func (x *BroadcastTransactionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[72]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BroadcastTransactionRequest.ProtoReflect.Descriptor instead.
+func (*BroadcastTransactionRequest) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{72}
+}
+
+func (x *BroadcastTransactionRequest) GetWalletId() string {
+	if x != nil {
+		return x.WalletId
+	}
+	return ""
+}
+
+func (x *BroadcastTransactionRequest) GetTxHex() string {
+	if x != nil {
+		return x.TxHex
+	}
+	return ""
+}
+
+type BroadcastTransactionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Txid          string                 `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BroadcastTransactionResponse) Reset() {
+	*x = BroadcastTransactionResponse{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[73]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BroadcastTransactionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BroadcastTransactionResponse) ProtoMessage() {}
+
+func (x *BroadcastTransactionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[73]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BroadcastTransactionResponse.ProtoReflect.Descriptor instead.
+func (*BroadcastTransactionResponse) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{73}
+}
+
+func (x *BroadcastTransactionResponse) GetTxid() string {
+	if x != nil {
+		return x.Txid
 	}
 	return ""
 }
@@ -3426,7 +4283,7 @@ type ListTransactionsRequest struct {
 
 func (x *ListTransactionsRequest) Reset() {
 	*x = ListTransactionsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[60]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3438,7 +4295,7 @@ func (x *ListTransactionsRequest) String() string {
 func (*ListTransactionsRequest) ProtoMessage() {}
 
 func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[60]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3451,7 +4308,7 @@ func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsRequest.ProtoReflect.Descriptor instead.
 func (*ListTransactionsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{60}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *ListTransactionsRequest) GetWalletId() string {
@@ -3489,7 +4346,7 @@ type TransactionEntry struct {
 
 func (x *TransactionEntry) Reset() {
 	*x = TransactionEntry{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[61]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3501,7 +4358,7 @@ func (x *TransactionEntry) String() string {
 func (*TransactionEntry) ProtoMessage() {}
 
 func (x *TransactionEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[61]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3514,7 +4371,7 @@ func (x *TransactionEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionEntry.ProtoReflect.Descriptor instead.
 func (*TransactionEntry) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{61}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *TransactionEntry) GetTxid() string {
@@ -3617,7 +4474,7 @@ type ListTransactionsResponse struct {
 
 func (x *ListTransactionsResponse) Reset() {
 	*x = ListTransactionsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[62]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3629,7 +4486,7 @@ func (x *ListTransactionsResponse) String() string {
 func (*ListTransactionsResponse) ProtoMessage() {}
 
 func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[62]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3642,7 +4499,7 @@ func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsResponse.ProtoReflect.Descriptor instead.
 func (*ListTransactionsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{62}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *ListTransactionsResponse) GetTransactions() []*TransactionEntry {
@@ -3661,7 +4518,7 @@ type ListUnspentRequest struct {
 
 func (x *ListUnspentRequest) Reset() {
 	*x = ListUnspentRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[63]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3673,7 +4530,7 @@ func (x *ListUnspentRequest) String() string {
 func (*ListUnspentRequest) ProtoMessage() {}
 
 func (x *ListUnspentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[63]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3686,7 +4543,7 @@ func (x *ListUnspentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUnspentRequest.ProtoReflect.Descriptor instead.
 func (*ListUnspentRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{63}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *ListUnspentRequest) GetWalletId() string {
@@ -3717,7 +4574,7 @@ type UnspentOutput struct {
 
 func (x *UnspentOutput) Reset() {
 	*x = UnspentOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[64]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3729,7 +4586,7 @@ func (x *UnspentOutput) String() string {
 func (*UnspentOutput) ProtoMessage() {}
 
 func (x *UnspentOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[64]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3742,7 +4599,7 @@ func (x *UnspentOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnspentOutput.ProtoReflect.Descriptor instead.
 func (*UnspentOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{64}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *UnspentOutput) GetTxid() string {
@@ -3831,7 +4688,7 @@ type ListUnspentResponse struct {
 
 func (x *ListUnspentResponse) Reset() {
 	*x = ListUnspentResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[65]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3843,7 +4700,7 @@ func (x *ListUnspentResponse) String() string {
 func (*ListUnspentResponse) ProtoMessage() {}
 
 func (x *ListUnspentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[65]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3856,7 +4713,7 @@ func (x *ListUnspentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUnspentResponse.ProtoReflect.Descriptor instead.
 func (*ListUnspentResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{65}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *ListUnspentResponse) GetUtxos() []*UnspentOutput {
@@ -3875,7 +4732,7 @@ type ListReceiveAddressesRequest struct {
 
 func (x *ListReceiveAddressesRequest) Reset() {
 	*x = ListReceiveAddressesRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[66]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3887,7 +4744,7 @@ func (x *ListReceiveAddressesRequest) String() string {
 func (*ListReceiveAddressesRequest) ProtoMessage() {}
 
 func (x *ListReceiveAddressesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[66]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3900,7 +4757,7 @@ func (x *ListReceiveAddressesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListReceiveAddressesRequest.ProtoReflect.Descriptor instead.
 func (*ListReceiveAddressesRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{66}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *ListReceiveAddressesRequest) GetWalletId() string {
@@ -3924,7 +4781,7 @@ type ReceiveAddress struct {
 
 func (x *ReceiveAddress) Reset() {
 	*x = ReceiveAddress{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[67]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3936,7 +4793,7 @@ func (x *ReceiveAddress) String() string {
 func (*ReceiveAddress) ProtoMessage() {}
 
 func (x *ReceiveAddress) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[67]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3949,7 +4806,7 @@ func (x *ReceiveAddress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAddress.ProtoReflect.Descriptor instead.
 func (*ReceiveAddress) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{67}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *ReceiveAddress) GetAddress() string {
@@ -4003,7 +4860,7 @@ type ListReceiveAddressesResponse struct {
 
 func (x *ListReceiveAddressesResponse) Reset() {
 	*x = ListReceiveAddressesResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[68]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4015,7 +4872,7 @@ func (x *ListReceiveAddressesResponse) String() string {
 func (*ListReceiveAddressesResponse) ProtoMessage() {}
 
 func (x *ListReceiveAddressesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[68]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4028,7 +4885,7 @@ func (x *ListReceiveAddressesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListReceiveAddressesResponse.ProtoReflect.Descriptor instead.
 func (*ListReceiveAddressesResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{68}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *ListReceiveAddressesResponse) GetAddresses() []*ReceiveAddress {
@@ -4048,7 +4905,7 @@ type GetTransactionDetailsRequest struct {
 
 func (x *GetTransactionDetailsRequest) Reset() {
 	*x = GetTransactionDetailsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[69]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4060,7 +4917,7 @@ func (x *GetTransactionDetailsRequest) String() string {
 func (*GetTransactionDetailsRequest) ProtoMessage() {}
 
 func (x *GetTransactionDetailsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[69]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4073,7 +4930,7 @@ func (x *GetTransactionDetailsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionDetailsRequest.ProtoReflect.Descriptor instead.
 func (*GetTransactionDetailsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{69}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *GetTransactionDetailsRequest) GetWalletId() string {
@@ -4114,7 +4971,7 @@ type GetTransactionDetailsResponse struct {
 
 func (x *GetTransactionDetailsResponse) Reset() {
 	*x = GetTransactionDetailsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[70]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4126,7 +4983,7 @@ func (x *GetTransactionDetailsResponse) String() string {
 func (*GetTransactionDetailsResponse) ProtoMessage() {}
 
 func (x *GetTransactionDetailsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[70]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4139,7 +4996,7 @@ func (x *GetTransactionDetailsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionDetailsResponse.ProtoReflect.Descriptor instead.
 func (*GetTransactionDetailsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{70}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *GetTransactionDetailsResponse) GetTransaction() *TransactionEntry {
@@ -4272,7 +5129,7 @@ type TransactionInput struct {
 
 func (x *TransactionInput) Reset() {
 	*x = TransactionInput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[71]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4284,7 +5141,7 @@ func (x *TransactionInput) String() string {
 func (*TransactionInput) ProtoMessage() {}
 
 func (x *TransactionInput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[71]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4297,7 +5154,7 @@ func (x *TransactionInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionInput.ProtoReflect.Descriptor instead.
 func (*TransactionInput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{71}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *TransactionInput) GetIndex() int32 {
@@ -4384,7 +5241,7 @@ type TransactionOutput struct {
 
 func (x *TransactionOutput) Reset() {
 	*x = TransactionOutput{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[72]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4396,7 +5253,7 @@ func (x *TransactionOutput) String() string {
 func (*TransactionOutput) ProtoMessage() {}
 
 func (x *TransactionOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[72]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4409,7 +5266,7 @@ func (x *TransactionOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionOutput.ProtoReflect.Descriptor instead.
 func (*TransactionOutput) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{72}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *TransactionOutput) GetIndex() int32 {
@@ -4471,7 +5328,7 @@ type DecodeTransactionRequest struct {
 
 func (x *DecodeTransactionRequest) Reset() {
 	*x = DecodeTransactionRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[73]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4483,7 +5340,7 @@ func (x *DecodeTransactionRequest) String() string {
 func (*DecodeTransactionRequest) ProtoMessage() {}
 
 func (x *DecodeTransactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[73]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4496,7 +5353,7 @@ func (x *DecodeTransactionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DecodeTransactionRequest.ProtoReflect.Descriptor instead.
 func (*DecodeTransactionRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{73}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *DecodeTransactionRequest) GetInput() string {
@@ -4542,7 +5399,7 @@ type DecodeTransactionResponse struct {
 
 func (x *DecodeTransactionResponse) Reset() {
 	*x = DecodeTransactionResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[74]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4554,7 +5411,7 @@ func (x *DecodeTransactionResponse) String() string {
 func (*DecodeTransactionResponse) ProtoMessage() {}
 
 func (x *DecodeTransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[74]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4567,7 +5424,7 @@ func (x *DecodeTransactionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DecodeTransactionResponse.ProtoReflect.Descriptor instead.
 func (*DecodeTransactionResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{74}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *DecodeTransactionResponse) GetForm() DecodedForm {
@@ -4707,7 +5564,7 @@ type BumpFeeRequest struct {
 
 func (x *BumpFeeRequest) Reset() {
 	*x = BumpFeeRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[75]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4719,7 +5576,7 @@ func (x *BumpFeeRequest) String() string {
 func (*BumpFeeRequest) ProtoMessage() {}
 
 func (x *BumpFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[75]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4732,7 +5589,7 @@ func (x *BumpFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeRequest.ProtoReflect.Descriptor instead.
 func (*BumpFeeRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{75}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *BumpFeeRequest) GetWalletId() string {
@@ -4765,7 +5622,7 @@ type BumpFeeResponse struct {
 
 func (x *BumpFeeResponse) Reset() {
 	*x = BumpFeeResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[76]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4777,7 +5634,7 @@ func (x *BumpFeeResponse) String() string {
 func (*BumpFeeResponse) ProtoMessage() {}
 
 func (x *BumpFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[76]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4790,7 +5647,7 @@ func (x *BumpFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeResponse.ProtoReflect.Descriptor instead.
 func (*BumpFeeResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{76}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *BumpFeeResponse) GetNewTxid() string {
@@ -4812,7 +5669,7 @@ type CreateCpfpRequest struct {
 
 func (x *CreateCpfpRequest) Reset() {
 	*x = CreateCpfpRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[77]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4824,7 +5681,7 @@ func (x *CreateCpfpRequest) String() string {
 func (*CreateCpfpRequest) ProtoMessage() {}
 
 func (x *CreateCpfpRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[77]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4837,7 +5694,7 @@ func (x *CreateCpfpRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCpfpRequest.ProtoReflect.Descriptor instead.
 func (*CreateCpfpRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{77}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *CreateCpfpRequest) GetWalletId() string {
@@ -4877,7 +5734,7 @@ type CreateCpfpResponse struct {
 
 func (x *CreateCpfpResponse) Reset() {
 	*x = CreateCpfpResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[78]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4889,7 +5746,7 @@ func (x *CreateCpfpResponse) String() string {
 func (*CreateCpfpResponse) ProtoMessage() {}
 
 func (x *CreateCpfpResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[78]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4902,7 +5759,7 @@ func (x *CreateCpfpResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCpfpResponse.ProtoReflect.Descriptor instead.
 func (*CreateCpfpResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{78}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *CreateCpfpResponse) GetChildTxid() string {
@@ -4923,7 +5780,7 @@ type DeriveAddressesRequest struct {
 
 func (x *DeriveAddressesRequest) Reset() {
 	*x = DeriveAddressesRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[79]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4935,7 +5792,7 @@ func (x *DeriveAddressesRequest) String() string {
 func (*DeriveAddressesRequest) ProtoMessage() {}
 
 func (x *DeriveAddressesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[79]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4948,7 +5805,7 @@ func (x *DeriveAddressesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeriveAddressesRequest.ProtoReflect.Descriptor instead.
 func (*DeriveAddressesRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{79}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *DeriveAddressesRequest) GetWalletId() string {
@@ -4981,7 +5838,7 @@ type DeriveAddressesResponse struct {
 
 func (x *DeriveAddressesResponse) Reset() {
 	*x = DeriveAddressesResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[80]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4993,7 +5850,7 @@ func (x *DeriveAddressesResponse) String() string {
 func (*DeriveAddressesResponse) ProtoMessage() {}
 
 func (x *DeriveAddressesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[80]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5006,7 +5863,7 @@ func (x *DeriveAddressesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeriveAddressesResponse.ProtoReflect.Descriptor instead.
 func (*DeriveAddressesResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{80}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *DeriveAddressesResponse) GetAddresses() []string {
@@ -5025,7 +5882,7 @@ type GetWalletSeedRequest struct {
 
 func (x *GetWalletSeedRequest) Reset() {
 	*x = GetWalletSeedRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[81]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5037,7 +5894,7 @@ func (x *GetWalletSeedRequest) String() string {
 func (*GetWalletSeedRequest) ProtoMessage() {}
 
 func (x *GetWalletSeedRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[81]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5050,7 +5907,7 @@ func (x *GetWalletSeedRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletSeedRequest.ProtoReflect.Descriptor instead.
 func (*GetWalletSeedRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{81}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *GetWalletSeedRequest) GetWalletId() string {
@@ -5071,7 +5928,7 @@ type GetWalletSeedResponse struct {
 
 func (x *GetWalletSeedResponse) Reset() {
 	*x = GetWalletSeedResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[82]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5083,7 +5940,7 @@ func (x *GetWalletSeedResponse) String() string {
 func (*GetWalletSeedResponse) ProtoMessage() {}
 
 func (x *GetWalletSeedResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[82]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5096,7 +5953,7 @@ func (x *GetWalletSeedResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletSeedResponse.ProtoReflect.Descriptor instead.
 func (*GetWalletSeedResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{82}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *GetWalletSeedResponse) GetSeedHex() string {
@@ -5121,7 +5978,7 @@ type ListCoreVariantsRequest struct {
 
 func (x *ListCoreVariantsRequest) Reset() {
 	*x = ListCoreVariantsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[83]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5133,7 +5990,7 @@ func (x *ListCoreVariantsRequest) String() string {
 func (*ListCoreVariantsRequest) ProtoMessage() {}
 
 func (x *ListCoreVariantsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[83]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5146,7 +6003,7 @@ func (x *ListCoreVariantsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCoreVariantsRequest.ProtoReflect.Descriptor instead.
 func (*ListCoreVariantsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{83}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{97}
 }
 
 type CoreVariant struct {
@@ -5160,7 +6017,7 @@ type CoreVariant struct {
 
 func (x *CoreVariant) Reset() {
 	*x = CoreVariant{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[84]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5172,7 +6029,7 @@ func (x *CoreVariant) String() string {
 func (*CoreVariant) ProtoMessage() {}
 
 func (x *CoreVariant) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[84]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5185,7 +6042,7 @@ func (x *CoreVariant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoreVariant.ProtoReflect.Descriptor instead.
 func (*CoreVariant) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{84}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *CoreVariant) GetId() string {
@@ -5219,7 +6076,7 @@ type ListCoreVariantsResponse struct {
 
 func (x *ListCoreVariantsResponse) Reset() {
 	*x = ListCoreVariantsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[85]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5231,7 +6088,7 @@ func (x *ListCoreVariantsResponse) String() string {
 func (*ListCoreVariantsResponse) ProtoMessage() {}
 
 func (x *ListCoreVariantsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[85]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5244,7 +6101,7 @@ func (x *ListCoreVariantsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCoreVariantsResponse.ProtoReflect.Descriptor instead.
 func (*ListCoreVariantsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{85}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *ListCoreVariantsResponse) GetVariants() []*CoreVariant {
@@ -5269,7 +6126,7 @@ type GetCoreVariantRequest struct {
 
 func (x *GetCoreVariantRequest) Reset() {
 	*x = GetCoreVariantRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[86]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5281,7 +6138,7 @@ func (x *GetCoreVariantRequest) String() string {
 func (*GetCoreVariantRequest) ProtoMessage() {}
 
 func (x *GetCoreVariantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[86]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5294,7 +6151,7 @@ func (x *GetCoreVariantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreVariantRequest.ProtoReflect.Descriptor instead.
 func (*GetCoreVariantRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{86}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{100}
 }
 
 type GetCoreVariantResponse struct {
@@ -5306,7 +6163,7 @@ type GetCoreVariantResponse struct {
 
 func (x *GetCoreVariantResponse) Reset() {
 	*x = GetCoreVariantResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[87]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5318,7 +6175,7 @@ func (x *GetCoreVariantResponse) String() string {
 func (*GetCoreVariantResponse) ProtoMessage() {}
 
 func (x *GetCoreVariantResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[87]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5331,7 +6188,7 @@ func (x *GetCoreVariantResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreVariantResponse.ProtoReflect.Descriptor instead.
 func (*GetCoreVariantResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{87}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *GetCoreVariantResponse) GetId() string {
@@ -5350,7 +6207,7 @@ type SetCoreVariantRequest struct {
 
 func (x *SetCoreVariantRequest) Reset() {
 	*x = SetCoreVariantRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[88]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5362,7 +6219,7 @@ func (x *SetCoreVariantRequest) String() string {
 func (*SetCoreVariantRequest) ProtoMessage() {}
 
 func (x *SetCoreVariantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[88]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5375,7 +6232,7 @@ func (x *SetCoreVariantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCoreVariantRequest.ProtoReflect.Descriptor instead.
 func (*SetCoreVariantRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{88}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *SetCoreVariantRequest) GetId() string {
@@ -5393,7 +6250,7 @@ type SetCoreVariantResponse struct {
 
 func (x *SetCoreVariantResponse) Reset() {
 	*x = SetCoreVariantResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[89]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5405,7 +6262,7 @@ func (x *SetCoreVariantResponse) String() string {
 func (*SetCoreVariantResponse) ProtoMessage() {}
 
 func (x *SetCoreVariantResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[89]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5418,7 +6275,7 @@ func (x *SetCoreVariantResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCoreVariantResponse.ProtoReflect.Descriptor instead.
 func (*SetCoreVariantResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{89}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{103}
 }
 
 type GetTestSidechainsRequest struct {
@@ -5429,7 +6286,7 @@ type GetTestSidechainsRequest struct {
 
 func (x *GetTestSidechainsRequest) Reset() {
 	*x = GetTestSidechainsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[90]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5441,7 +6298,7 @@ func (x *GetTestSidechainsRequest) String() string {
 func (*GetTestSidechainsRequest) ProtoMessage() {}
 
 func (x *GetTestSidechainsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[90]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5454,7 +6311,7 @@ func (x *GetTestSidechainsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTestSidechainsRequest.ProtoReflect.Descriptor instead.
 func (*GetTestSidechainsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{90}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{104}
 }
 
 type GetTestSidechainsResponse struct {
@@ -5466,7 +6323,7 @@ type GetTestSidechainsResponse struct {
 
 func (x *GetTestSidechainsResponse) Reset() {
 	*x = GetTestSidechainsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[91]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5478,7 +6335,7 @@ func (x *GetTestSidechainsResponse) String() string {
 func (*GetTestSidechainsResponse) ProtoMessage() {}
 
 func (x *GetTestSidechainsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[91]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5491,7 +6348,7 @@ func (x *GetTestSidechainsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTestSidechainsResponse.ProtoReflect.Descriptor instead.
 func (*GetTestSidechainsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{91}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *GetTestSidechainsResponse) GetEnabled() bool {
@@ -5510,7 +6367,7 @@ type SetTestSidechainsRequest struct {
 
 func (x *SetTestSidechainsRequest) Reset() {
 	*x = SetTestSidechainsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[92]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5522,7 +6379,7 @@ func (x *SetTestSidechainsRequest) String() string {
 func (*SetTestSidechainsRequest) ProtoMessage() {}
 
 func (x *SetTestSidechainsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[92]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5535,7 +6392,7 @@ func (x *SetTestSidechainsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTestSidechainsRequest.ProtoReflect.Descriptor instead.
 func (*SetTestSidechainsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{92}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *SetTestSidechainsRequest) GetEnabled() bool {
@@ -5553,7 +6410,7 @@ type SetTestSidechainsResponse struct {
 
 func (x *SetTestSidechainsResponse) Reset() {
 	*x = SetTestSidechainsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[93]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5565,7 +6422,7 @@ func (x *SetTestSidechainsResponse) String() string {
 func (*SetTestSidechainsResponse) ProtoMessage() {}
 
 func (x *SetTestSidechainsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[93]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5578,7 +6435,7 @@ func (x *SetTestSidechainsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTestSidechainsResponse.ProtoReflect.Descriptor instead.
 func (*SetTestSidechainsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{93}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{107}
 }
 
 type GetElectrumServerRequest struct {
@@ -5589,7 +6446,7 @@ type GetElectrumServerRequest struct {
 
 func (x *GetElectrumServerRequest) Reset() {
 	*x = GetElectrumServerRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[94]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5601,7 +6458,7 @@ func (x *GetElectrumServerRequest) String() string {
 func (*GetElectrumServerRequest) ProtoMessage() {}
 
 func (x *GetElectrumServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[94]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5614,7 +6471,7 @@ func (x *GetElectrumServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetElectrumServerRequest.ProtoReflect.Descriptor instead.
 func (*GetElectrumServerRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{94}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{108}
 }
 
 type GetElectrumServerResponse struct {
@@ -5631,7 +6488,7 @@ type GetElectrumServerResponse struct {
 
 func (x *GetElectrumServerResponse) Reset() {
 	*x = GetElectrumServerResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[95]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5643,7 +6500,7 @@ func (x *GetElectrumServerResponse) String() string {
 func (*GetElectrumServerResponse) ProtoMessage() {}
 
 func (x *GetElectrumServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[95]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5656,7 +6513,7 @@ func (x *GetElectrumServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetElectrumServerResponse.ProtoReflect.Descriptor instead.
 func (*GetElectrumServerResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{95}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *GetElectrumServerResponse) GetUrl() string {
@@ -5690,7 +6547,7 @@ type SetElectrumServerRequest struct {
 
 func (x *SetElectrumServerRequest) Reset() {
 	*x = SetElectrumServerRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[96]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5702,7 +6559,7 @@ func (x *SetElectrumServerRequest) String() string {
 func (*SetElectrumServerRequest) ProtoMessage() {}
 
 func (x *SetElectrumServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[96]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5715,7 +6572,7 @@ func (x *SetElectrumServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetElectrumServerRequest.ProtoReflect.Descriptor instead.
 func (*SetElectrumServerRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{96}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *SetElectrumServerRequest) GetUrl() string {
@@ -5737,7 +6594,7 @@ type SetElectrumServerResponse struct {
 
 func (x *SetElectrumServerResponse) Reset() {
 	*x = SetElectrumServerResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[97]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5749,7 +6606,7 @@ func (x *SetElectrumServerResponse) String() string {
 func (*SetElectrumServerResponse) ProtoMessage() {}
 
 func (x *SetElectrumServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[97]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5762,7 +6619,7 @@ func (x *SetElectrumServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetElectrumServerResponse.ProtoReflect.Descriptor instead.
 func (*SetElectrumServerResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{97}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *SetElectrumServerResponse) GetUrl() string {
@@ -5787,7 +6644,7 @@ type GetTorConfigRequest struct {
 
 func (x *GetTorConfigRequest) Reset() {
 	*x = GetTorConfigRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[98]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5799,7 +6656,7 @@ func (x *GetTorConfigRequest) String() string {
 func (*GetTorConfigRequest) ProtoMessage() {}
 
 func (x *GetTorConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[98]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5812,7 +6669,7 @@ func (x *GetTorConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTorConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetTorConfigRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{98}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{112}
 }
 
 type GetTorConfigResponse struct {
@@ -5829,7 +6686,7 @@ type GetTorConfigResponse struct {
 
 func (x *GetTorConfigResponse) Reset() {
 	*x = GetTorConfigResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[99]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5841,7 +6698,7 @@ func (x *GetTorConfigResponse) String() string {
 func (*GetTorConfigResponse) ProtoMessage() {}
 
 func (x *GetTorConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[99]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5854,7 +6711,7 @@ func (x *GetTorConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTorConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetTorConfigResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{99}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *GetTorConfigResponse) GetEnabled() bool {
@@ -5890,7 +6747,7 @@ type SetTorConfigRequest struct {
 
 func (x *SetTorConfigRequest) Reset() {
 	*x = SetTorConfigRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[100]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5902,7 +6759,7 @@ func (x *SetTorConfigRequest) String() string {
 func (*SetTorConfigRequest) ProtoMessage() {}
 
 func (x *SetTorConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[100]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5915,7 +6772,7 @@ func (x *SetTorConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTorConfigRequest.ProtoReflect.Descriptor instead.
 func (*SetTorConfigRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{100}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *SetTorConfigRequest) GetEnabled() bool {
@@ -5945,7 +6802,7 @@ type SetTorConfigResponse struct {
 
 func (x *SetTorConfigResponse) Reset() {
 	*x = SetTorConfigResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[101]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5957,7 +6814,7 @@ func (x *SetTorConfigResponse) String() string {
 func (*SetTorConfigResponse) ProtoMessage() {}
 
 func (x *SetTorConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[101]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5970,7 +6827,7 @@ func (x *SetTorConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTorConfigResponse.ProtoReflect.Descriptor instead.
 func (*SetTorConfigResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{101}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *SetTorConfigResponse) GetEnabled() bool {
@@ -6019,7 +6876,7 @@ type WatchWalletDataResponse struct {
 
 func (x *WatchWalletDataResponse) Reset() {
 	*x = WatchWalletDataResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[102]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6031,7 +6888,7 @@ func (x *WatchWalletDataResponse) String() string {
 func (*WatchWalletDataResponse) ProtoMessage() {}
 
 func (x *WatchWalletDataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[102]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6044,7 +6901,7 @@ func (x *WatchWalletDataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchWalletDataResponse.ProtoReflect.Descriptor instead.
 func (*WatchWalletDataResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{102}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *WatchWalletDataResponse) GetHasWallet() bool {
@@ -6148,7 +7005,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x16ChangePasswordResponse\"5\n" +
 	"\x17RemoveEncryptionRequest\x12\x1a\n" +
 	"\bpassword\x18\x01 \x01(\tR\bpassword\"\x1a\n" +
-	"\x18RemoveEncryptionResponse\"\x92\x03\n" +
+	"\x18RemoveEncryptionResponse\"\xce\x03\n" +
 	"\x0eWalletMetadata\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12=\n" +
@@ -6166,7 +7023,20 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"sidechains\x12\x1d\n" +
 	"\n" +
 	"watch_only\x18\n" +
-	" \x01(\bR\twatchOnly\"V\n" +
+	" \x01(\bR\twatchOnly\x12:\n" +
+	"\bmultisig\x18\v \x01(\v2\x1e.walletmanager.v1.MultisigInfoR\bmultisig\"\x91\x01\n" +
+	"\fMultisigInfo\x12\f\n" +
+	"\x01m\x18\x01 \x01(\rR\x01m\x12\f\n" +
+	"\x01n\x18\x02 \x01(\rR\x01n\x12\x1f\n" +
+	"\vscript_type\x18\x03 \x01(\tR\n" +
+	"scriptType\x12D\n" +
+	"\tcosigners\x18\x04 \x03(\v2&.walletmanager.v1.MultisigCosignerInfoR\tcosigners\"\x81\x01\n" +
+	"\x14MultisigCosignerInfo\x12\x12\n" +
+	"\x04xpub\x18\x01 \x01(\tR\x04xpub\x12 \n" +
+	"\vfingerprint\x18\x02 \x01(\tR\vfingerprint\x12\x1f\n" +
+	"\vorigin_path\x18\x03 \x01(\tR\n" +
+	"originPath\x12\x12\n" +
+	"\x04held\x18\x04 \x01(\bR\x04held\"V\n" +
 	"\x10SidechainStarter\x12\x12\n" +
 	"\x04slot\x18\x01 \x01(\x05R\x04slot\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1a\n" +
@@ -6249,7 +7119,40 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\aaccount\x18\a \x01(\rR\aaccount\x12'\n" +
 	"\x0fderivation_path\x18\b \x01(\tR\x0ederivationPath\";\n" +
 	"\x1cCreateElectrumWalletResponse\x12\x1b\n" +
-	"\twallet_id\x18\x01 \x01(\tR\bwalletId\"=\n" +
+	"\twallet_id\x18\x01 \x01(\tR\bwalletId\"\xbe\x01\n" +
+	"\x15MultisigCosignerInput\x12\x12\n" +
+	"\x04xpub\x18\x01 \x01(\tR\x04xpub\x12\x1f\n" +
+	"\vorigin_path\x18\x02 \x01(\tR\n" +
+	"originPath\x12 \n" +
+	"\vfingerprint\x18\x03 \x01(\tR\vfingerprint\x12\x1a\n" +
+	"\bmnemonic\x18\x04 \x01(\tR\bmnemonic\x12\x12\n" +
+	"\x04xprv\x18\x05 \x01(\tR\x04xprv\x12\x1e\n" +
+	"\n" +
+	"passphrase\x18\x06 \x01(\tR\n" +
+	"passphrase\"\xda\x01\n" +
+	"\x1bCreateMultisigWalletRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12#\n" +
+	"\rgradient_json\x18\x02 \x01(\tR\fgradientJson\x12\f\n" +
+	"\x01m\x18\x03 \x01(\rR\x01m\x12\f\n" +
+	"\x01n\x18\x04 \x01(\rR\x01n\x12\x1f\n" +
+	"\vscript_type\x18\x05 \x01(\tR\n" +
+	"scriptType\x12E\n" +
+	"\tcosigners\x18\x06 \x03(\v2'.walletmanager.v1.MultisigCosignerInputR\tcosigners\";\n" +
+	"\x1cCreateMultisigWalletResponse\x12\x1b\n" +
+	"\twallet_id\x18\x01 \x01(\tR\bwalletId\"6\n" +
+	"\x1aParseMultisigConfigRequest\x12\x18\n" +
+	"\acontent\x18\x01 \x01(\tR\acontent\"g\n" +
+	"\x0eParsedCosigner\x12\x12\n" +
+	"\x04xpub\x18\x01 \x01(\tR\x04xpub\x12 \n" +
+	"\vfingerprint\x18\x02 \x01(\tR\vfingerprint\x12\x1f\n" +
+	"\vorigin_path\x18\x03 \x01(\tR\n" +
+	"originPath\"\x9a\x01\n" +
+	"\x1bParseMultisigConfigResponse\x12\f\n" +
+	"\x01m\x18\x01 \x01(\rR\x01m\x12\f\n" +
+	"\x01n\x18\x02 \x01(\rR\x01n\x12\x1f\n" +
+	"\vscript_type\x18\x03 \x01(\tR\n" +
+	"scriptType\x12>\n" +
+	"\tcosigners\x18\x04 \x03(\v2 .walletmanager.v1.ParsedCosignerR\tcosigners\"=\n" +
 	"\x1eCreateBitcoinCoreWalletRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\"K\n" +
 	"\x1fCreateBitcoinCoreWalletResponse\x12(\n" +
@@ -6320,6 +7223,14 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"psbtBase64\"3\n" +
 	"\x10SignPsbtResponse\x12\x1f\n" +
 	"\vpsbt_base64\x18\x01 \x01(\tR\n" +
+	"psbtBase64\"\x80\x01\n" +
+	"\x1bSignPsbtWithCosignerRequest\x12\x1b\n" +
+	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x1f\n" +
+	"\vpsbt_base64\x18\x02 \x01(\tR\n" +
+	"psbtBase64\x12#\n" +
+	"\rcosigner_xpub\x18\x03 \x01(\tR\fcosignerXpub\"?\n" +
+	"\x1cSignPsbtWithCosignerResponse\x12\x1f\n" +
+	"\vpsbt_base64\x18\x01 \x01(\tR\n" +
 	"psbtBase64\"5\n" +
 	"\x12CombinePsbtRequest\x12\x1f\n" +
 	"\vpsbt_base64\x18\x01 \x03(\tR\n" +
@@ -6332,7 +7243,23 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"psbtBase64\"4\n" +
 	"\x14FinalizePsbtResponse\x12\x1c\n" +
 	"\n" +
-	"raw_tx_hex\x18\x01 \x01(\tR\brawTxHex\"L\n" +
+	"raw_tx_hex\x18\x01 \x01(\tR\brawTxHex\"Y\n" +
+	"\x19MultisigPsbtStatusRequest\x12\x1b\n" +
+	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x1f\n" +
+	"\vpsbt_base64\x18\x02 \x01(\tR\n" +
+	"psbtBase64\"\xa5\x01\n" +
+	"\x1aMultisigPsbtStatusResponse\x12\x1c\n" +
+	"\tthreshold\x18\x01 \x01(\rR\tthreshold\x12\x1e\n" +
+	"\n" +
+	"signatures\x18\x02 \x01(\rR\n" +
+	"signatures\x12 \n" +
+	"\vfinalizable\x18\x03 \x01(\bR\vfinalizable\x12'\n" +
+	"\x0fcosigner_signed\x18\x04 \x03(\bR\x0ecosignerSigned\"Q\n" +
+	"\x1bBroadcastTransactionRequest\x12\x1b\n" +
+	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x15\n" +
+	"\x06tx_hex\x18\x02 \x01(\tR\x05txHex\"2\n" +
+	"\x1cBroadcastTransactionResponse\x12\x12\n" +
+	"\x04txid\x18\x01 \x01(\tR\x04txid\"L\n" +
 	"\x17ListTransactionsRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x14\n" +
 	"\x05count\x18\x02 \x01(\x05R\x05count\"\xf1\x02\n" +
@@ -6561,7 +7488,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x18DECODED_FORM_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11DECODED_FORM_TXID\x10\x01\x12\x17\n" +
 	"\x13DECODED_FORM_RAW_TX\x10\x02\x12\x15\n" +
-	"\x11DECODED_FORM_PSBT\x10\x032\xb5$\n" +
+	"\x11DECODED_FORM_PSBT\x10\x032\xff(\n" +
 	"\x14WalletManagerService\x12f\n" +
 	"\x0fGetWalletStatus\x12(.walletmanager.v1.GetWalletStatusRequest\x1a).walletmanager.v1.GetWalletStatusResponse\x12c\n" +
 	"\x0eGenerateWallet\x12'.walletmanager.v1.GenerateWalletRequest\x1a(.walletmanager.v1.GenerateWalletResponse\x12]\n" +
@@ -6580,7 +7507,9 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x13RestoreWalletBackup\x12,.walletmanager.v1.RestoreWalletBackupRequest\x1a-.walletmanager.v1.RestoreWalletBackupResponse\x12\x82\x01\n" +
 	"\x19RestoreWalletBackupStream\x12,.walletmanager.v1.RestoreWalletBackupRequest\x1a5.walletmanager.v1.RestoreWalletBackupProgressResponse0\x01\x12x\n" +
 	"\x15CreateWatchOnlyWallet\x12..walletmanager.v1.CreateWatchOnlyWalletRequest\x1a/.walletmanager.v1.CreateWatchOnlyWalletResponse\x12u\n" +
-	"\x14CreateElectrumWallet\x12-.walletmanager.v1.CreateElectrumWalletRequest\x1a..walletmanager.v1.CreateElectrumWalletResponse\x12~\n" +
+	"\x14CreateElectrumWallet\x12-.walletmanager.v1.CreateElectrumWalletRequest\x1a..walletmanager.v1.CreateElectrumWalletResponse\x12u\n" +
+	"\x14CreateMultisigWallet\x12-.walletmanager.v1.CreateMultisigWalletRequest\x1a..walletmanager.v1.CreateMultisigWalletResponse\x12r\n" +
+	"\x13ParseMultisigConfig\x12,.walletmanager.v1.ParseMultisigConfigRequest\x1a-.walletmanager.v1.ParseMultisigConfigResponse\x12~\n" +
 	"\x17CreateBitcoinCoreWallet\x120.walletmanager.v1.CreateBitcoinCoreWalletRequest\x1a1.walletmanager.v1.CreateBitcoinCoreWalletResponse\x12l\n" +
 	"\x11EnsureCoreWallets\x12*.walletmanager.v1.EnsureCoreWalletsRequest\x1a+.walletmanager.v1.EnsureCoreWalletsResponse\x12W\n" +
 	"\n" +
@@ -6598,9 +7527,12 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x0fDeriveAddresses\x12(.walletmanager.v1.DeriveAddressesRequest\x1a).walletmanager.v1.DeriveAddressesResponse\x12W\n" +
 	"\n" +
 	"CreatePsbt\x12#.walletmanager.v1.CreatePsbtRequest\x1a$.walletmanager.v1.CreatePsbtResponse\x12Q\n" +
-	"\bSignPsbt\x12!.walletmanager.v1.SignPsbtRequest\x1a\".walletmanager.v1.SignPsbtResponse\x12Z\n" +
+	"\bSignPsbt\x12!.walletmanager.v1.SignPsbtRequest\x1a\".walletmanager.v1.SignPsbtResponse\x12u\n" +
+	"\x14SignPsbtWithCosigner\x12-.walletmanager.v1.SignPsbtWithCosignerRequest\x1a..walletmanager.v1.SignPsbtWithCosignerResponse\x12Z\n" +
 	"\vCombinePsbt\x12$.walletmanager.v1.CombinePsbtRequest\x1a%.walletmanager.v1.CombinePsbtResponse\x12]\n" +
-	"\fFinalizePsbt\x12%.walletmanager.v1.FinalizePsbtRequest\x1a&.walletmanager.v1.FinalizePsbtResponse\x12`\n" +
+	"\fFinalizePsbt\x12%.walletmanager.v1.FinalizePsbtRequest\x1a&.walletmanager.v1.FinalizePsbtResponse\x12o\n" +
+	"\x12MultisigPsbtStatus\x12+.walletmanager.v1.MultisigPsbtStatusRequest\x1a,.walletmanager.v1.MultisigPsbtStatusResponse\x12u\n" +
+	"\x14BroadcastTransaction\x12-.walletmanager.v1.BroadcastTransactionRequest\x1a..walletmanager.v1.BroadcastTransactionResponse\x12`\n" +
 	"\rGetWalletSeed\x12&.walletmanager.v1.GetWalletSeedRequest\x1a'.walletmanager.v1.GetWalletSeedResponse\x12i\n" +
 	"\x10ListCoreVariants\x12).walletmanager.v1.ListCoreVariantsRequest\x1a*.walletmanager.v1.ListCoreVariantsResponse\x12c\n" +
 	"\x0eGetCoreVariant\x12'.walletmanager.v1.GetCoreVariantRequest\x1a(.walletmanager.v1.GetCoreVariantResponse\x12c\n" +
@@ -6627,7 +7559,7 @@ func file_walletmanager_v1_walletmanager_proto_rawDescGZIP() []byte {
 }
 
 var file_walletmanager_v1_walletmanager_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_walletmanager_v1_walletmanager_proto_msgTypes = make([]protoimpl.MessageInfo, 105)
+var file_walletmanager_v1_walletmanager_proto_msgTypes = make([]protoimpl.MessageInfo, 119)
 var file_walletmanager_v1_walletmanager_proto_goTypes = []any{
 	(WalletType)(0),                             // 0: walletmanager.v1.WalletType
 	(RestoreWalletBackupStepState)(0),           // 1: walletmanager.v1.RestoreWalletBackupStepState
@@ -6648,229 +7580,257 @@ var file_walletmanager_v1_walletmanager_proto_goTypes = []any{
 	(*RemoveEncryptionRequest)(nil),             // 16: walletmanager.v1.RemoveEncryptionRequest
 	(*RemoveEncryptionResponse)(nil),            // 17: walletmanager.v1.RemoveEncryptionResponse
 	(*WalletMetadata)(nil),                      // 18: walletmanager.v1.WalletMetadata
-	(*SidechainStarter)(nil),                    // 19: walletmanager.v1.SidechainStarter
-	(*ListWalletsRequest)(nil),                  // 20: walletmanager.v1.ListWalletsRequest
-	(*ListWalletsResponse)(nil),                 // 21: walletmanager.v1.ListWalletsResponse
-	(*SwitchWalletRequest)(nil),                 // 22: walletmanager.v1.SwitchWalletRequest
-	(*SwitchWalletResponse)(nil),                // 23: walletmanager.v1.SwitchWalletResponse
-	(*UpdateWalletMetadataRequest)(nil),         // 24: walletmanager.v1.UpdateWalletMetadataRequest
-	(*UpdateWalletMetadataResponse)(nil),        // 25: walletmanager.v1.UpdateWalletMetadataResponse
-	(*DeleteWalletRequest)(nil),                 // 26: walletmanager.v1.DeleteWalletRequest
-	(*DeleteWalletResponse)(nil),                // 27: walletmanager.v1.DeleteWalletResponse
-	(*DeleteAllWalletsRequest)(nil),             // 28: walletmanager.v1.DeleteAllWalletsRequest
-	(*DeleteAllWalletsResponse)(nil),            // 29: walletmanager.v1.DeleteAllWalletsResponse
-	(*BalanceSnapshot)(nil),                     // 30: walletmanager.v1.BalanceSnapshot
-	(*BackupWalletSummary)(nil),                 // 31: walletmanager.v1.BackupWalletSummary
-	(*WalletBackup)(nil),                        // 32: walletmanager.v1.WalletBackup
-	(*ListWalletBackupsRequest)(nil),            // 33: walletmanager.v1.ListWalletBackupsRequest
-	(*ListWalletBackupsResponse)(nil),           // 34: walletmanager.v1.ListWalletBackupsResponse
-	(*RestoreWalletBackupRequest)(nil),          // 35: walletmanager.v1.RestoreWalletBackupRequest
-	(*RestoreWalletBackupResponse)(nil),         // 36: walletmanager.v1.RestoreWalletBackupResponse
-	(*RestoreWalletBackupStep)(nil),             // 37: walletmanager.v1.RestoreWalletBackupStep
-	(*RestoreWalletBackupProgressStatus)(nil),   // 38: walletmanager.v1.RestoreWalletBackupProgressStatus
-	(*RestoreWalletBackupProgressResponse)(nil), // 39: walletmanager.v1.RestoreWalletBackupProgressResponse
-	(*CreateWatchOnlyWalletRequest)(nil),        // 40: walletmanager.v1.CreateWatchOnlyWalletRequest
-	(*CreateWatchOnlyWalletResponse)(nil),       // 41: walletmanager.v1.CreateWatchOnlyWalletResponse
-	(*CreateElectrumWalletRequest)(nil),         // 42: walletmanager.v1.CreateElectrumWalletRequest
-	(*CreateElectrumWalletResponse)(nil),        // 43: walletmanager.v1.CreateElectrumWalletResponse
-	(*CreateBitcoinCoreWalletRequest)(nil),      // 44: walletmanager.v1.CreateBitcoinCoreWalletRequest
-	(*CreateBitcoinCoreWalletResponse)(nil),     // 45: walletmanager.v1.CreateBitcoinCoreWalletResponse
-	(*EnsureCoreWalletsRequest)(nil),            // 46: walletmanager.v1.EnsureCoreWalletsRequest
-	(*EnsureCoreWalletsResponse)(nil),           // 47: walletmanager.v1.EnsureCoreWalletsResponse
-	(*GetBalanceRequest)(nil),                   // 48: walletmanager.v1.GetBalanceRequest
-	(*GetBalanceResponse)(nil),                  // 49: walletmanager.v1.GetBalanceResponse
-	(*GetNewAddressRequest)(nil),                // 50: walletmanager.v1.GetNewAddressRequest
-	(*GetNewAddressResponse)(nil),               // 51: walletmanager.v1.GetNewAddressResponse
-	(*SendTransactionRequest)(nil),              // 52: walletmanager.v1.SendTransactionRequest
-	(*SendTransactionResponse)(nil),             // 53: walletmanager.v1.SendTransactionResponse
-	(*RawOutput)(nil),                           // 54: walletmanager.v1.RawOutput
-	(*ExternalInput)(nil),                       // 55: walletmanager.v1.ExternalInput
-	(*CreatePsbtRequest)(nil),                   // 56: walletmanager.v1.CreatePsbtRequest
-	(*CreatePsbtResponse)(nil),                  // 57: walletmanager.v1.CreatePsbtResponse
-	(*SignPsbtRequest)(nil),                     // 58: walletmanager.v1.SignPsbtRequest
-	(*SignPsbtResponse)(nil),                    // 59: walletmanager.v1.SignPsbtResponse
-	(*CombinePsbtRequest)(nil),                  // 60: walletmanager.v1.CombinePsbtRequest
-	(*CombinePsbtResponse)(nil),                 // 61: walletmanager.v1.CombinePsbtResponse
-	(*FinalizePsbtRequest)(nil),                 // 62: walletmanager.v1.FinalizePsbtRequest
-	(*FinalizePsbtResponse)(nil),                // 63: walletmanager.v1.FinalizePsbtResponse
-	(*ListTransactionsRequest)(nil),             // 64: walletmanager.v1.ListTransactionsRequest
-	(*TransactionEntry)(nil),                    // 65: walletmanager.v1.TransactionEntry
-	(*ListTransactionsResponse)(nil),            // 66: walletmanager.v1.ListTransactionsResponse
-	(*ListUnspentRequest)(nil),                  // 67: walletmanager.v1.ListUnspentRequest
-	(*UnspentOutput)(nil),                       // 68: walletmanager.v1.UnspentOutput
-	(*ListUnspentResponse)(nil),                 // 69: walletmanager.v1.ListUnspentResponse
-	(*ListReceiveAddressesRequest)(nil),         // 70: walletmanager.v1.ListReceiveAddressesRequest
-	(*ReceiveAddress)(nil),                      // 71: walletmanager.v1.ReceiveAddress
-	(*ListReceiveAddressesResponse)(nil),        // 72: walletmanager.v1.ListReceiveAddressesResponse
-	(*GetTransactionDetailsRequest)(nil),        // 73: walletmanager.v1.GetTransactionDetailsRequest
-	(*GetTransactionDetailsResponse)(nil),       // 74: walletmanager.v1.GetTransactionDetailsResponse
-	(*TransactionInput)(nil),                    // 75: walletmanager.v1.TransactionInput
-	(*TransactionOutput)(nil),                   // 76: walletmanager.v1.TransactionOutput
-	(*DecodeTransactionRequest)(nil),            // 77: walletmanager.v1.DecodeTransactionRequest
-	(*DecodeTransactionResponse)(nil),           // 78: walletmanager.v1.DecodeTransactionResponse
-	(*BumpFeeRequest)(nil),                      // 79: walletmanager.v1.BumpFeeRequest
-	(*BumpFeeResponse)(nil),                     // 80: walletmanager.v1.BumpFeeResponse
-	(*CreateCpfpRequest)(nil),                   // 81: walletmanager.v1.CreateCpfpRequest
-	(*CreateCpfpResponse)(nil),                  // 82: walletmanager.v1.CreateCpfpResponse
-	(*DeriveAddressesRequest)(nil),              // 83: walletmanager.v1.DeriveAddressesRequest
-	(*DeriveAddressesResponse)(nil),             // 84: walletmanager.v1.DeriveAddressesResponse
-	(*GetWalletSeedRequest)(nil),                // 85: walletmanager.v1.GetWalletSeedRequest
-	(*GetWalletSeedResponse)(nil),               // 86: walletmanager.v1.GetWalletSeedResponse
-	(*ListCoreVariantsRequest)(nil),             // 87: walletmanager.v1.ListCoreVariantsRequest
-	(*CoreVariant)(nil),                         // 88: walletmanager.v1.CoreVariant
-	(*ListCoreVariantsResponse)(nil),            // 89: walletmanager.v1.ListCoreVariantsResponse
-	(*GetCoreVariantRequest)(nil),               // 90: walletmanager.v1.GetCoreVariantRequest
-	(*GetCoreVariantResponse)(nil),              // 91: walletmanager.v1.GetCoreVariantResponse
-	(*SetCoreVariantRequest)(nil),               // 92: walletmanager.v1.SetCoreVariantRequest
-	(*SetCoreVariantResponse)(nil),              // 93: walletmanager.v1.SetCoreVariantResponse
-	(*GetTestSidechainsRequest)(nil),            // 94: walletmanager.v1.GetTestSidechainsRequest
-	(*GetTestSidechainsResponse)(nil),           // 95: walletmanager.v1.GetTestSidechainsResponse
-	(*SetTestSidechainsRequest)(nil),            // 96: walletmanager.v1.SetTestSidechainsRequest
-	(*SetTestSidechainsResponse)(nil),           // 97: walletmanager.v1.SetTestSidechainsResponse
-	(*GetElectrumServerRequest)(nil),            // 98: walletmanager.v1.GetElectrumServerRequest
-	(*GetElectrumServerResponse)(nil),           // 99: walletmanager.v1.GetElectrumServerResponse
-	(*SetElectrumServerRequest)(nil),            // 100: walletmanager.v1.SetElectrumServerRequest
-	(*SetElectrumServerResponse)(nil),           // 101: walletmanager.v1.SetElectrumServerResponse
-	(*GetTorConfigRequest)(nil),                 // 102: walletmanager.v1.GetTorConfigRequest
-	(*GetTorConfigResponse)(nil),                // 103: walletmanager.v1.GetTorConfigResponse
-	(*SetTorConfigRequest)(nil),                 // 104: walletmanager.v1.SetTorConfigRequest
-	(*SetTorConfigResponse)(nil),                // 105: walletmanager.v1.SetTorConfigResponse
-	(*WatchWalletDataResponse)(nil),             // 106: walletmanager.v1.WatchWalletDataResponse
-	nil,                                         // 107: walletmanager.v1.SendTransactionRequest.DestinationsEntry
-	nil,                                         // 108: walletmanager.v1.CreatePsbtRequest.DestinationsEntry
-	(v1.BinaryType)(0),                          // 109: orchestrator.v1.BinaryType
-	(*timestamppb.Timestamp)(nil),               // 110: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                       // 111: google.protobuf.Empty
+	(*MultisigInfo)(nil),                        // 19: walletmanager.v1.MultisigInfo
+	(*MultisigCosignerInfo)(nil),                // 20: walletmanager.v1.MultisigCosignerInfo
+	(*SidechainStarter)(nil),                    // 21: walletmanager.v1.SidechainStarter
+	(*ListWalletsRequest)(nil),                  // 22: walletmanager.v1.ListWalletsRequest
+	(*ListWalletsResponse)(nil),                 // 23: walletmanager.v1.ListWalletsResponse
+	(*SwitchWalletRequest)(nil),                 // 24: walletmanager.v1.SwitchWalletRequest
+	(*SwitchWalletResponse)(nil),                // 25: walletmanager.v1.SwitchWalletResponse
+	(*UpdateWalletMetadataRequest)(nil),         // 26: walletmanager.v1.UpdateWalletMetadataRequest
+	(*UpdateWalletMetadataResponse)(nil),        // 27: walletmanager.v1.UpdateWalletMetadataResponse
+	(*DeleteWalletRequest)(nil),                 // 28: walletmanager.v1.DeleteWalletRequest
+	(*DeleteWalletResponse)(nil),                // 29: walletmanager.v1.DeleteWalletResponse
+	(*DeleteAllWalletsRequest)(nil),             // 30: walletmanager.v1.DeleteAllWalletsRequest
+	(*DeleteAllWalletsResponse)(nil),            // 31: walletmanager.v1.DeleteAllWalletsResponse
+	(*BalanceSnapshot)(nil),                     // 32: walletmanager.v1.BalanceSnapshot
+	(*BackupWalletSummary)(nil),                 // 33: walletmanager.v1.BackupWalletSummary
+	(*WalletBackup)(nil),                        // 34: walletmanager.v1.WalletBackup
+	(*ListWalletBackupsRequest)(nil),            // 35: walletmanager.v1.ListWalletBackupsRequest
+	(*ListWalletBackupsResponse)(nil),           // 36: walletmanager.v1.ListWalletBackupsResponse
+	(*RestoreWalletBackupRequest)(nil),          // 37: walletmanager.v1.RestoreWalletBackupRequest
+	(*RestoreWalletBackupResponse)(nil),         // 38: walletmanager.v1.RestoreWalletBackupResponse
+	(*RestoreWalletBackupStep)(nil),             // 39: walletmanager.v1.RestoreWalletBackupStep
+	(*RestoreWalletBackupProgressStatus)(nil),   // 40: walletmanager.v1.RestoreWalletBackupProgressStatus
+	(*RestoreWalletBackupProgressResponse)(nil), // 41: walletmanager.v1.RestoreWalletBackupProgressResponse
+	(*CreateWatchOnlyWalletRequest)(nil),        // 42: walletmanager.v1.CreateWatchOnlyWalletRequest
+	(*CreateWatchOnlyWalletResponse)(nil),       // 43: walletmanager.v1.CreateWatchOnlyWalletResponse
+	(*CreateElectrumWalletRequest)(nil),         // 44: walletmanager.v1.CreateElectrumWalletRequest
+	(*CreateElectrumWalletResponse)(nil),        // 45: walletmanager.v1.CreateElectrumWalletResponse
+	(*MultisigCosignerInput)(nil),               // 46: walletmanager.v1.MultisigCosignerInput
+	(*CreateMultisigWalletRequest)(nil),         // 47: walletmanager.v1.CreateMultisigWalletRequest
+	(*CreateMultisigWalletResponse)(nil),        // 48: walletmanager.v1.CreateMultisigWalletResponse
+	(*ParseMultisigConfigRequest)(nil),          // 49: walletmanager.v1.ParseMultisigConfigRequest
+	(*ParsedCosigner)(nil),                      // 50: walletmanager.v1.ParsedCosigner
+	(*ParseMultisigConfigResponse)(nil),         // 51: walletmanager.v1.ParseMultisigConfigResponse
+	(*CreateBitcoinCoreWalletRequest)(nil),      // 52: walletmanager.v1.CreateBitcoinCoreWalletRequest
+	(*CreateBitcoinCoreWalletResponse)(nil),     // 53: walletmanager.v1.CreateBitcoinCoreWalletResponse
+	(*EnsureCoreWalletsRequest)(nil),            // 54: walletmanager.v1.EnsureCoreWalletsRequest
+	(*EnsureCoreWalletsResponse)(nil),           // 55: walletmanager.v1.EnsureCoreWalletsResponse
+	(*GetBalanceRequest)(nil),                   // 56: walletmanager.v1.GetBalanceRequest
+	(*GetBalanceResponse)(nil),                  // 57: walletmanager.v1.GetBalanceResponse
+	(*GetNewAddressRequest)(nil),                // 58: walletmanager.v1.GetNewAddressRequest
+	(*GetNewAddressResponse)(nil),               // 59: walletmanager.v1.GetNewAddressResponse
+	(*SendTransactionRequest)(nil),              // 60: walletmanager.v1.SendTransactionRequest
+	(*SendTransactionResponse)(nil),             // 61: walletmanager.v1.SendTransactionResponse
+	(*RawOutput)(nil),                           // 62: walletmanager.v1.RawOutput
+	(*ExternalInput)(nil),                       // 63: walletmanager.v1.ExternalInput
+	(*CreatePsbtRequest)(nil),                   // 64: walletmanager.v1.CreatePsbtRequest
+	(*CreatePsbtResponse)(nil),                  // 65: walletmanager.v1.CreatePsbtResponse
+	(*SignPsbtRequest)(nil),                     // 66: walletmanager.v1.SignPsbtRequest
+	(*SignPsbtResponse)(nil),                    // 67: walletmanager.v1.SignPsbtResponse
+	(*SignPsbtWithCosignerRequest)(nil),         // 68: walletmanager.v1.SignPsbtWithCosignerRequest
+	(*SignPsbtWithCosignerResponse)(nil),        // 69: walletmanager.v1.SignPsbtWithCosignerResponse
+	(*CombinePsbtRequest)(nil),                  // 70: walletmanager.v1.CombinePsbtRequest
+	(*CombinePsbtResponse)(nil),                 // 71: walletmanager.v1.CombinePsbtResponse
+	(*FinalizePsbtRequest)(nil),                 // 72: walletmanager.v1.FinalizePsbtRequest
+	(*FinalizePsbtResponse)(nil),                // 73: walletmanager.v1.FinalizePsbtResponse
+	(*MultisigPsbtStatusRequest)(nil),           // 74: walletmanager.v1.MultisigPsbtStatusRequest
+	(*MultisigPsbtStatusResponse)(nil),          // 75: walletmanager.v1.MultisigPsbtStatusResponse
+	(*BroadcastTransactionRequest)(nil),         // 76: walletmanager.v1.BroadcastTransactionRequest
+	(*BroadcastTransactionResponse)(nil),        // 77: walletmanager.v1.BroadcastTransactionResponse
+	(*ListTransactionsRequest)(nil),             // 78: walletmanager.v1.ListTransactionsRequest
+	(*TransactionEntry)(nil),                    // 79: walletmanager.v1.TransactionEntry
+	(*ListTransactionsResponse)(nil),            // 80: walletmanager.v1.ListTransactionsResponse
+	(*ListUnspentRequest)(nil),                  // 81: walletmanager.v1.ListUnspentRequest
+	(*UnspentOutput)(nil),                       // 82: walletmanager.v1.UnspentOutput
+	(*ListUnspentResponse)(nil),                 // 83: walletmanager.v1.ListUnspentResponse
+	(*ListReceiveAddressesRequest)(nil),         // 84: walletmanager.v1.ListReceiveAddressesRequest
+	(*ReceiveAddress)(nil),                      // 85: walletmanager.v1.ReceiveAddress
+	(*ListReceiveAddressesResponse)(nil),        // 86: walletmanager.v1.ListReceiveAddressesResponse
+	(*GetTransactionDetailsRequest)(nil),        // 87: walletmanager.v1.GetTransactionDetailsRequest
+	(*GetTransactionDetailsResponse)(nil),       // 88: walletmanager.v1.GetTransactionDetailsResponse
+	(*TransactionInput)(nil),                    // 89: walletmanager.v1.TransactionInput
+	(*TransactionOutput)(nil),                   // 90: walletmanager.v1.TransactionOutput
+	(*DecodeTransactionRequest)(nil),            // 91: walletmanager.v1.DecodeTransactionRequest
+	(*DecodeTransactionResponse)(nil),           // 92: walletmanager.v1.DecodeTransactionResponse
+	(*BumpFeeRequest)(nil),                      // 93: walletmanager.v1.BumpFeeRequest
+	(*BumpFeeResponse)(nil),                     // 94: walletmanager.v1.BumpFeeResponse
+	(*CreateCpfpRequest)(nil),                   // 95: walletmanager.v1.CreateCpfpRequest
+	(*CreateCpfpResponse)(nil),                  // 96: walletmanager.v1.CreateCpfpResponse
+	(*DeriveAddressesRequest)(nil),              // 97: walletmanager.v1.DeriveAddressesRequest
+	(*DeriveAddressesResponse)(nil),             // 98: walletmanager.v1.DeriveAddressesResponse
+	(*GetWalletSeedRequest)(nil),                // 99: walletmanager.v1.GetWalletSeedRequest
+	(*GetWalletSeedResponse)(nil),               // 100: walletmanager.v1.GetWalletSeedResponse
+	(*ListCoreVariantsRequest)(nil),             // 101: walletmanager.v1.ListCoreVariantsRequest
+	(*CoreVariant)(nil),                         // 102: walletmanager.v1.CoreVariant
+	(*ListCoreVariantsResponse)(nil),            // 103: walletmanager.v1.ListCoreVariantsResponse
+	(*GetCoreVariantRequest)(nil),               // 104: walletmanager.v1.GetCoreVariantRequest
+	(*GetCoreVariantResponse)(nil),              // 105: walletmanager.v1.GetCoreVariantResponse
+	(*SetCoreVariantRequest)(nil),               // 106: walletmanager.v1.SetCoreVariantRequest
+	(*SetCoreVariantResponse)(nil),              // 107: walletmanager.v1.SetCoreVariantResponse
+	(*GetTestSidechainsRequest)(nil),            // 108: walletmanager.v1.GetTestSidechainsRequest
+	(*GetTestSidechainsResponse)(nil),           // 109: walletmanager.v1.GetTestSidechainsResponse
+	(*SetTestSidechainsRequest)(nil),            // 110: walletmanager.v1.SetTestSidechainsRequest
+	(*SetTestSidechainsResponse)(nil),           // 111: walletmanager.v1.SetTestSidechainsResponse
+	(*GetElectrumServerRequest)(nil),            // 112: walletmanager.v1.GetElectrumServerRequest
+	(*GetElectrumServerResponse)(nil),           // 113: walletmanager.v1.GetElectrumServerResponse
+	(*SetElectrumServerRequest)(nil),            // 114: walletmanager.v1.SetElectrumServerRequest
+	(*SetElectrumServerResponse)(nil),           // 115: walletmanager.v1.SetElectrumServerResponse
+	(*GetTorConfigRequest)(nil),                 // 116: walletmanager.v1.GetTorConfigRequest
+	(*GetTorConfigResponse)(nil),                // 117: walletmanager.v1.GetTorConfigResponse
+	(*SetTorConfigRequest)(nil),                 // 118: walletmanager.v1.SetTorConfigRequest
+	(*SetTorConfigResponse)(nil),                // 119: walletmanager.v1.SetTorConfigResponse
+	(*WatchWalletDataResponse)(nil),             // 120: walletmanager.v1.WatchWalletDataResponse
+	nil,                                         // 121: walletmanager.v1.SendTransactionRequest.DestinationsEntry
+	nil,                                         // 122: walletmanager.v1.CreatePsbtRequest.DestinationsEntry
+	(v1.BinaryType)(0),                          // 123: orchestrator.v1.BinaryType
+	(*timestamppb.Timestamp)(nil),               // 124: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                       // 125: google.protobuf.Empty
 }
 var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	0,   // 0: walletmanager.v1.WalletMetadata.wallet_type:type_name -> walletmanager.v1.WalletType
-	19,  // 1: walletmanager.v1.WalletMetadata.sidechains:type_name -> walletmanager.v1.SidechainStarter
-	18,  // 2: walletmanager.v1.ListWalletsResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
-	109, // 3: walletmanager.v1.BalanceSnapshot.binary:type_name -> orchestrator.v1.BinaryType
-	110, // 4: walletmanager.v1.BalanceSnapshot.updated_at:type_name -> google.protobuf.Timestamp
-	110, // 5: walletmanager.v1.WalletBackup.created_at:type_name -> google.protobuf.Timestamp
-	31,  // 6: walletmanager.v1.WalletBackup.wallets:type_name -> walletmanager.v1.BackupWalletSummary
-	30,  // 7: walletmanager.v1.WalletBackup.latest_known_balance:type_name -> walletmanager.v1.BalanceSnapshot
-	32,  // 8: walletmanager.v1.ListWalletBackupsResponse.backups:type_name -> walletmanager.v1.WalletBackup
-	1,   // 9: walletmanager.v1.RestoreWalletBackupProgressStatus.state:type_name -> walletmanager.v1.RestoreWalletBackupStepState
-	37,  // 10: walletmanager.v1.RestoreWalletBackupProgressResponse.steps:type_name -> walletmanager.v1.RestoreWalletBackupStep
-	38,  // 11: walletmanager.v1.RestoreWalletBackupProgressResponse.status:type_name -> walletmanager.v1.RestoreWalletBackupProgressStatus
-	2,   // 12: walletmanager.v1.GetNewAddressRequest.address_type:type_name -> walletmanager.v1.AddressType
-	107, // 13: walletmanager.v1.SendTransactionRequest.destinations:type_name -> walletmanager.v1.SendTransactionRequest.DestinationsEntry
-	68,  // 14: walletmanager.v1.SendTransactionRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
-	54,  // 15: walletmanager.v1.SendTransactionRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
-	55,  // 16: walletmanager.v1.SendTransactionRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
-	108, // 17: walletmanager.v1.CreatePsbtRequest.destinations:type_name -> walletmanager.v1.CreatePsbtRequest.DestinationsEntry
-	68,  // 18: walletmanager.v1.CreatePsbtRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
-	54,  // 19: walletmanager.v1.CreatePsbtRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
-	55,  // 20: walletmanager.v1.CreatePsbtRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
-	65,  // 21: walletmanager.v1.ListTransactionsResponse.transactions:type_name -> walletmanager.v1.TransactionEntry
-	110, // 22: walletmanager.v1.UnspentOutput.received_at:type_name -> google.protobuf.Timestamp
-	68,  // 23: walletmanager.v1.ListUnspentResponse.utxos:type_name -> walletmanager.v1.UnspentOutput
-	71,  // 24: walletmanager.v1.ListReceiveAddressesResponse.addresses:type_name -> walletmanager.v1.ReceiveAddress
-	65,  // 25: walletmanager.v1.GetTransactionDetailsResponse.transaction:type_name -> walletmanager.v1.TransactionEntry
-	75,  // 26: walletmanager.v1.GetTransactionDetailsResponse.inputs:type_name -> walletmanager.v1.TransactionInput
-	76,  // 27: walletmanager.v1.GetTransactionDetailsResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
-	3,   // 28: walletmanager.v1.DecodeTransactionResponse.form:type_name -> walletmanager.v1.DecodedForm
-	75,  // 29: walletmanager.v1.DecodeTransactionResponse.inputs:type_name -> walletmanager.v1.TransactionInput
-	76,  // 30: walletmanager.v1.DecodeTransactionResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
-	88,  // 31: walletmanager.v1.ListCoreVariantsResponse.variants:type_name -> walletmanager.v1.CoreVariant
-	18,  // 32: walletmanager.v1.WatchWalletDataResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
-	4,   // 33: walletmanager.v1.WalletManagerService.GetWalletStatus:input_type -> walletmanager.v1.GetWalletStatusRequest
-	6,   // 34: walletmanager.v1.WalletManagerService.GenerateWallet:input_type -> walletmanager.v1.GenerateWalletRequest
-	8,   // 35: walletmanager.v1.WalletManagerService.UnlockWallet:input_type -> walletmanager.v1.UnlockWalletRequest
-	10,  // 36: walletmanager.v1.WalletManagerService.LockWallet:input_type -> walletmanager.v1.LockWalletRequest
-	12,  // 37: walletmanager.v1.WalletManagerService.EncryptWallet:input_type -> walletmanager.v1.EncryptWalletRequest
-	14,  // 38: walletmanager.v1.WalletManagerService.ChangePassword:input_type -> walletmanager.v1.ChangePasswordRequest
-	16,  // 39: walletmanager.v1.WalletManagerService.RemoveEncryption:input_type -> walletmanager.v1.RemoveEncryptionRequest
-	20,  // 40: walletmanager.v1.WalletManagerService.ListWallets:input_type -> walletmanager.v1.ListWalletsRequest
-	22,  // 41: walletmanager.v1.WalletManagerService.SwitchWallet:input_type -> walletmanager.v1.SwitchWalletRequest
-	24,  // 42: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:input_type -> walletmanager.v1.UpdateWalletMetadataRequest
-	26,  // 43: walletmanager.v1.WalletManagerService.DeleteWallet:input_type -> walletmanager.v1.DeleteWalletRequest
-	28,  // 44: walletmanager.v1.WalletManagerService.DeleteAllWallets:input_type -> walletmanager.v1.DeleteAllWalletsRequest
-	33,  // 45: walletmanager.v1.WalletManagerService.ListWalletBackups:input_type -> walletmanager.v1.ListWalletBackupsRequest
-	35,  // 46: walletmanager.v1.WalletManagerService.RestoreWalletBackup:input_type -> walletmanager.v1.RestoreWalletBackupRequest
-	35,  // 47: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:input_type -> walletmanager.v1.RestoreWalletBackupRequest
-	40,  // 48: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:input_type -> walletmanager.v1.CreateWatchOnlyWalletRequest
-	42,  // 49: walletmanager.v1.WalletManagerService.CreateElectrumWallet:input_type -> walletmanager.v1.CreateElectrumWalletRequest
-	44,  // 50: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:input_type -> walletmanager.v1.CreateBitcoinCoreWalletRequest
-	46,  // 51: walletmanager.v1.WalletManagerService.EnsureCoreWallets:input_type -> walletmanager.v1.EnsureCoreWalletsRequest
-	48,  // 52: walletmanager.v1.WalletManagerService.GetBalance:input_type -> walletmanager.v1.GetBalanceRequest
-	50,  // 53: walletmanager.v1.WalletManagerService.GetNewAddress:input_type -> walletmanager.v1.GetNewAddressRequest
-	52,  // 54: walletmanager.v1.WalletManagerService.SendTransaction:input_type -> walletmanager.v1.SendTransactionRequest
-	64,  // 55: walletmanager.v1.WalletManagerService.ListTransactions:input_type -> walletmanager.v1.ListTransactionsRequest
-	67,  // 56: walletmanager.v1.WalletManagerService.ListUnspent:input_type -> walletmanager.v1.ListUnspentRequest
-	70,  // 57: walletmanager.v1.WalletManagerService.ListReceiveAddresses:input_type -> walletmanager.v1.ListReceiveAddressesRequest
-	73,  // 58: walletmanager.v1.WalletManagerService.GetTransactionDetails:input_type -> walletmanager.v1.GetTransactionDetailsRequest
-	77,  // 59: walletmanager.v1.WalletManagerService.DecodeTransaction:input_type -> walletmanager.v1.DecodeTransactionRequest
-	79,  // 60: walletmanager.v1.WalletManagerService.BumpFee:input_type -> walletmanager.v1.BumpFeeRequest
-	81,  // 61: walletmanager.v1.WalletManagerService.CreateCpfp:input_type -> walletmanager.v1.CreateCpfpRequest
-	83,  // 62: walletmanager.v1.WalletManagerService.DeriveAddresses:input_type -> walletmanager.v1.DeriveAddressesRequest
-	56,  // 63: walletmanager.v1.WalletManagerService.CreatePsbt:input_type -> walletmanager.v1.CreatePsbtRequest
-	58,  // 64: walletmanager.v1.WalletManagerService.SignPsbt:input_type -> walletmanager.v1.SignPsbtRequest
-	60,  // 65: walletmanager.v1.WalletManagerService.CombinePsbt:input_type -> walletmanager.v1.CombinePsbtRequest
-	62,  // 66: walletmanager.v1.WalletManagerService.FinalizePsbt:input_type -> walletmanager.v1.FinalizePsbtRequest
-	85,  // 67: walletmanager.v1.WalletManagerService.GetWalletSeed:input_type -> walletmanager.v1.GetWalletSeedRequest
-	87,  // 68: walletmanager.v1.WalletManagerService.ListCoreVariants:input_type -> walletmanager.v1.ListCoreVariantsRequest
-	90,  // 69: walletmanager.v1.WalletManagerService.GetCoreVariant:input_type -> walletmanager.v1.GetCoreVariantRequest
-	92,  // 70: walletmanager.v1.WalletManagerService.SetCoreVariant:input_type -> walletmanager.v1.SetCoreVariantRequest
-	94,  // 71: walletmanager.v1.WalletManagerService.GetTestSidechains:input_type -> walletmanager.v1.GetTestSidechainsRequest
-	96,  // 72: walletmanager.v1.WalletManagerService.SetTestSidechains:input_type -> walletmanager.v1.SetTestSidechainsRequest
-	98,  // 73: walletmanager.v1.WalletManagerService.GetElectrumServer:input_type -> walletmanager.v1.GetElectrumServerRequest
-	100, // 74: walletmanager.v1.WalletManagerService.SetElectrumServer:input_type -> walletmanager.v1.SetElectrumServerRequest
-	102, // 75: walletmanager.v1.WalletManagerService.GetTorConfig:input_type -> walletmanager.v1.GetTorConfigRequest
-	104, // 76: walletmanager.v1.WalletManagerService.SetTorConfig:input_type -> walletmanager.v1.SetTorConfigRequest
-	111, // 77: walletmanager.v1.WalletManagerService.WatchWalletData:input_type -> google.protobuf.Empty
-	5,   // 78: walletmanager.v1.WalletManagerService.GetWalletStatus:output_type -> walletmanager.v1.GetWalletStatusResponse
-	7,   // 79: walletmanager.v1.WalletManagerService.GenerateWallet:output_type -> walletmanager.v1.GenerateWalletResponse
-	9,   // 80: walletmanager.v1.WalletManagerService.UnlockWallet:output_type -> walletmanager.v1.UnlockWalletResponse
-	11,  // 81: walletmanager.v1.WalletManagerService.LockWallet:output_type -> walletmanager.v1.LockWalletResponse
-	13,  // 82: walletmanager.v1.WalletManagerService.EncryptWallet:output_type -> walletmanager.v1.EncryptWalletResponse
-	15,  // 83: walletmanager.v1.WalletManagerService.ChangePassword:output_type -> walletmanager.v1.ChangePasswordResponse
-	17,  // 84: walletmanager.v1.WalletManagerService.RemoveEncryption:output_type -> walletmanager.v1.RemoveEncryptionResponse
-	21,  // 85: walletmanager.v1.WalletManagerService.ListWallets:output_type -> walletmanager.v1.ListWalletsResponse
-	23,  // 86: walletmanager.v1.WalletManagerService.SwitchWallet:output_type -> walletmanager.v1.SwitchWalletResponse
-	25,  // 87: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:output_type -> walletmanager.v1.UpdateWalletMetadataResponse
-	27,  // 88: walletmanager.v1.WalletManagerService.DeleteWallet:output_type -> walletmanager.v1.DeleteWalletResponse
-	29,  // 89: walletmanager.v1.WalletManagerService.DeleteAllWallets:output_type -> walletmanager.v1.DeleteAllWalletsResponse
-	34,  // 90: walletmanager.v1.WalletManagerService.ListWalletBackups:output_type -> walletmanager.v1.ListWalletBackupsResponse
-	36,  // 91: walletmanager.v1.WalletManagerService.RestoreWalletBackup:output_type -> walletmanager.v1.RestoreWalletBackupResponse
-	39,  // 92: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:output_type -> walletmanager.v1.RestoreWalletBackupProgressResponse
-	41,  // 93: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:output_type -> walletmanager.v1.CreateWatchOnlyWalletResponse
-	43,  // 94: walletmanager.v1.WalletManagerService.CreateElectrumWallet:output_type -> walletmanager.v1.CreateElectrumWalletResponse
-	45,  // 95: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:output_type -> walletmanager.v1.CreateBitcoinCoreWalletResponse
-	47,  // 96: walletmanager.v1.WalletManagerService.EnsureCoreWallets:output_type -> walletmanager.v1.EnsureCoreWalletsResponse
-	49,  // 97: walletmanager.v1.WalletManagerService.GetBalance:output_type -> walletmanager.v1.GetBalanceResponse
-	51,  // 98: walletmanager.v1.WalletManagerService.GetNewAddress:output_type -> walletmanager.v1.GetNewAddressResponse
-	53,  // 99: walletmanager.v1.WalletManagerService.SendTransaction:output_type -> walletmanager.v1.SendTransactionResponse
-	66,  // 100: walletmanager.v1.WalletManagerService.ListTransactions:output_type -> walletmanager.v1.ListTransactionsResponse
-	69,  // 101: walletmanager.v1.WalletManagerService.ListUnspent:output_type -> walletmanager.v1.ListUnspentResponse
-	72,  // 102: walletmanager.v1.WalletManagerService.ListReceiveAddresses:output_type -> walletmanager.v1.ListReceiveAddressesResponse
-	74,  // 103: walletmanager.v1.WalletManagerService.GetTransactionDetails:output_type -> walletmanager.v1.GetTransactionDetailsResponse
-	78,  // 104: walletmanager.v1.WalletManagerService.DecodeTransaction:output_type -> walletmanager.v1.DecodeTransactionResponse
-	80,  // 105: walletmanager.v1.WalletManagerService.BumpFee:output_type -> walletmanager.v1.BumpFeeResponse
-	82,  // 106: walletmanager.v1.WalletManagerService.CreateCpfp:output_type -> walletmanager.v1.CreateCpfpResponse
-	84,  // 107: walletmanager.v1.WalletManagerService.DeriveAddresses:output_type -> walletmanager.v1.DeriveAddressesResponse
-	57,  // 108: walletmanager.v1.WalletManagerService.CreatePsbt:output_type -> walletmanager.v1.CreatePsbtResponse
-	59,  // 109: walletmanager.v1.WalletManagerService.SignPsbt:output_type -> walletmanager.v1.SignPsbtResponse
-	61,  // 110: walletmanager.v1.WalletManagerService.CombinePsbt:output_type -> walletmanager.v1.CombinePsbtResponse
-	63,  // 111: walletmanager.v1.WalletManagerService.FinalizePsbt:output_type -> walletmanager.v1.FinalizePsbtResponse
-	86,  // 112: walletmanager.v1.WalletManagerService.GetWalletSeed:output_type -> walletmanager.v1.GetWalletSeedResponse
-	89,  // 113: walletmanager.v1.WalletManagerService.ListCoreVariants:output_type -> walletmanager.v1.ListCoreVariantsResponse
-	91,  // 114: walletmanager.v1.WalletManagerService.GetCoreVariant:output_type -> walletmanager.v1.GetCoreVariantResponse
-	93,  // 115: walletmanager.v1.WalletManagerService.SetCoreVariant:output_type -> walletmanager.v1.SetCoreVariantResponse
-	95,  // 116: walletmanager.v1.WalletManagerService.GetTestSidechains:output_type -> walletmanager.v1.GetTestSidechainsResponse
-	97,  // 117: walletmanager.v1.WalletManagerService.SetTestSidechains:output_type -> walletmanager.v1.SetTestSidechainsResponse
-	99,  // 118: walletmanager.v1.WalletManagerService.GetElectrumServer:output_type -> walletmanager.v1.GetElectrumServerResponse
-	101, // 119: walletmanager.v1.WalletManagerService.SetElectrumServer:output_type -> walletmanager.v1.SetElectrumServerResponse
-	103, // 120: walletmanager.v1.WalletManagerService.GetTorConfig:output_type -> walletmanager.v1.GetTorConfigResponse
-	105, // 121: walletmanager.v1.WalletManagerService.SetTorConfig:output_type -> walletmanager.v1.SetTorConfigResponse
-	106, // 122: walletmanager.v1.WalletManagerService.WatchWalletData:output_type -> walletmanager.v1.WatchWalletDataResponse
-	78,  // [78:123] is the sub-list for method output_type
-	33,  // [33:78] is the sub-list for method input_type
-	33,  // [33:33] is the sub-list for extension type_name
-	33,  // [33:33] is the sub-list for extension extendee
-	0,   // [0:33] is the sub-list for field type_name
+	21,  // 1: walletmanager.v1.WalletMetadata.sidechains:type_name -> walletmanager.v1.SidechainStarter
+	19,  // 2: walletmanager.v1.WalletMetadata.multisig:type_name -> walletmanager.v1.MultisigInfo
+	20,  // 3: walletmanager.v1.MultisigInfo.cosigners:type_name -> walletmanager.v1.MultisigCosignerInfo
+	18,  // 4: walletmanager.v1.ListWalletsResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
+	123, // 5: walletmanager.v1.BalanceSnapshot.binary:type_name -> orchestrator.v1.BinaryType
+	124, // 6: walletmanager.v1.BalanceSnapshot.updated_at:type_name -> google.protobuf.Timestamp
+	124, // 7: walletmanager.v1.WalletBackup.created_at:type_name -> google.protobuf.Timestamp
+	33,  // 8: walletmanager.v1.WalletBackup.wallets:type_name -> walletmanager.v1.BackupWalletSummary
+	32,  // 9: walletmanager.v1.WalletBackup.latest_known_balance:type_name -> walletmanager.v1.BalanceSnapshot
+	34,  // 10: walletmanager.v1.ListWalletBackupsResponse.backups:type_name -> walletmanager.v1.WalletBackup
+	1,   // 11: walletmanager.v1.RestoreWalletBackupProgressStatus.state:type_name -> walletmanager.v1.RestoreWalletBackupStepState
+	39,  // 12: walletmanager.v1.RestoreWalletBackupProgressResponse.steps:type_name -> walletmanager.v1.RestoreWalletBackupStep
+	40,  // 13: walletmanager.v1.RestoreWalletBackupProgressResponse.status:type_name -> walletmanager.v1.RestoreWalletBackupProgressStatus
+	46,  // 14: walletmanager.v1.CreateMultisigWalletRequest.cosigners:type_name -> walletmanager.v1.MultisigCosignerInput
+	50,  // 15: walletmanager.v1.ParseMultisigConfigResponse.cosigners:type_name -> walletmanager.v1.ParsedCosigner
+	2,   // 16: walletmanager.v1.GetNewAddressRequest.address_type:type_name -> walletmanager.v1.AddressType
+	121, // 17: walletmanager.v1.SendTransactionRequest.destinations:type_name -> walletmanager.v1.SendTransactionRequest.DestinationsEntry
+	82,  // 18: walletmanager.v1.SendTransactionRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
+	62,  // 19: walletmanager.v1.SendTransactionRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
+	63,  // 20: walletmanager.v1.SendTransactionRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
+	122, // 21: walletmanager.v1.CreatePsbtRequest.destinations:type_name -> walletmanager.v1.CreatePsbtRequest.DestinationsEntry
+	82,  // 22: walletmanager.v1.CreatePsbtRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
+	62,  // 23: walletmanager.v1.CreatePsbtRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
+	63,  // 24: walletmanager.v1.CreatePsbtRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
+	79,  // 25: walletmanager.v1.ListTransactionsResponse.transactions:type_name -> walletmanager.v1.TransactionEntry
+	124, // 26: walletmanager.v1.UnspentOutput.received_at:type_name -> google.protobuf.Timestamp
+	82,  // 27: walletmanager.v1.ListUnspentResponse.utxos:type_name -> walletmanager.v1.UnspentOutput
+	85,  // 28: walletmanager.v1.ListReceiveAddressesResponse.addresses:type_name -> walletmanager.v1.ReceiveAddress
+	79,  // 29: walletmanager.v1.GetTransactionDetailsResponse.transaction:type_name -> walletmanager.v1.TransactionEntry
+	89,  // 30: walletmanager.v1.GetTransactionDetailsResponse.inputs:type_name -> walletmanager.v1.TransactionInput
+	90,  // 31: walletmanager.v1.GetTransactionDetailsResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
+	3,   // 32: walletmanager.v1.DecodeTransactionResponse.form:type_name -> walletmanager.v1.DecodedForm
+	89,  // 33: walletmanager.v1.DecodeTransactionResponse.inputs:type_name -> walletmanager.v1.TransactionInput
+	90,  // 34: walletmanager.v1.DecodeTransactionResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
+	102, // 35: walletmanager.v1.ListCoreVariantsResponse.variants:type_name -> walletmanager.v1.CoreVariant
+	18,  // 36: walletmanager.v1.WatchWalletDataResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
+	4,   // 37: walletmanager.v1.WalletManagerService.GetWalletStatus:input_type -> walletmanager.v1.GetWalletStatusRequest
+	6,   // 38: walletmanager.v1.WalletManagerService.GenerateWallet:input_type -> walletmanager.v1.GenerateWalletRequest
+	8,   // 39: walletmanager.v1.WalletManagerService.UnlockWallet:input_type -> walletmanager.v1.UnlockWalletRequest
+	10,  // 40: walletmanager.v1.WalletManagerService.LockWallet:input_type -> walletmanager.v1.LockWalletRequest
+	12,  // 41: walletmanager.v1.WalletManagerService.EncryptWallet:input_type -> walletmanager.v1.EncryptWalletRequest
+	14,  // 42: walletmanager.v1.WalletManagerService.ChangePassword:input_type -> walletmanager.v1.ChangePasswordRequest
+	16,  // 43: walletmanager.v1.WalletManagerService.RemoveEncryption:input_type -> walletmanager.v1.RemoveEncryptionRequest
+	22,  // 44: walletmanager.v1.WalletManagerService.ListWallets:input_type -> walletmanager.v1.ListWalletsRequest
+	24,  // 45: walletmanager.v1.WalletManagerService.SwitchWallet:input_type -> walletmanager.v1.SwitchWalletRequest
+	26,  // 46: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:input_type -> walletmanager.v1.UpdateWalletMetadataRequest
+	28,  // 47: walletmanager.v1.WalletManagerService.DeleteWallet:input_type -> walletmanager.v1.DeleteWalletRequest
+	30,  // 48: walletmanager.v1.WalletManagerService.DeleteAllWallets:input_type -> walletmanager.v1.DeleteAllWalletsRequest
+	35,  // 49: walletmanager.v1.WalletManagerService.ListWalletBackups:input_type -> walletmanager.v1.ListWalletBackupsRequest
+	37,  // 50: walletmanager.v1.WalletManagerService.RestoreWalletBackup:input_type -> walletmanager.v1.RestoreWalletBackupRequest
+	37,  // 51: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:input_type -> walletmanager.v1.RestoreWalletBackupRequest
+	42,  // 52: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:input_type -> walletmanager.v1.CreateWatchOnlyWalletRequest
+	44,  // 53: walletmanager.v1.WalletManagerService.CreateElectrumWallet:input_type -> walletmanager.v1.CreateElectrumWalletRequest
+	47,  // 54: walletmanager.v1.WalletManagerService.CreateMultisigWallet:input_type -> walletmanager.v1.CreateMultisigWalletRequest
+	49,  // 55: walletmanager.v1.WalletManagerService.ParseMultisigConfig:input_type -> walletmanager.v1.ParseMultisigConfigRequest
+	52,  // 56: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:input_type -> walletmanager.v1.CreateBitcoinCoreWalletRequest
+	54,  // 57: walletmanager.v1.WalletManagerService.EnsureCoreWallets:input_type -> walletmanager.v1.EnsureCoreWalletsRequest
+	56,  // 58: walletmanager.v1.WalletManagerService.GetBalance:input_type -> walletmanager.v1.GetBalanceRequest
+	58,  // 59: walletmanager.v1.WalletManagerService.GetNewAddress:input_type -> walletmanager.v1.GetNewAddressRequest
+	60,  // 60: walletmanager.v1.WalletManagerService.SendTransaction:input_type -> walletmanager.v1.SendTransactionRequest
+	78,  // 61: walletmanager.v1.WalletManagerService.ListTransactions:input_type -> walletmanager.v1.ListTransactionsRequest
+	81,  // 62: walletmanager.v1.WalletManagerService.ListUnspent:input_type -> walletmanager.v1.ListUnspentRequest
+	84,  // 63: walletmanager.v1.WalletManagerService.ListReceiveAddresses:input_type -> walletmanager.v1.ListReceiveAddressesRequest
+	87,  // 64: walletmanager.v1.WalletManagerService.GetTransactionDetails:input_type -> walletmanager.v1.GetTransactionDetailsRequest
+	91,  // 65: walletmanager.v1.WalletManagerService.DecodeTransaction:input_type -> walletmanager.v1.DecodeTransactionRequest
+	93,  // 66: walletmanager.v1.WalletManagerService.BumpFee:input_type -> walletmanager.v1.BumpFeeRequest
+	95,  // 67: walletmanager.v1.WalletManagerService.CreateCpfp:input_type -> walletmanager.v1.CreateCpfpRequest
+	97,  // 68: walletmanager.v1.WalletManagerService.DeriveAddresses:input_type -> walletmanager.v1.DeriveAddressesRequest
+	64,  // 69: walletmanager.v1.WalletManagerService.CreatePsbt:input_type -> walletmanager.v1.CreatePsbtRequest
+	66,  // 70: walletmanager.v1.WalletManagerService.SignPsbt:input_type -> walletmanager.v1.SignPsbtRequest
+	68,  // 71: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:input_type -> walletmanager.v1.SignPsbtWithCosignerRequest
+	70,  // 72: walletmanager.v1.WalletManagerService.CombinePsbt:input_type -> walletmanager.v1.CombinePsbtRequest
+	72,  // 73: walletmanager.v1.WalletManagerService.FinalizePsbt:input_type -> walletmanager.v1.FinalizePsbtRequest
+	74,  // 74: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:input_type -> walletmanager.v1.MultisigPsbtStatusRequest
+	76,  // 75: walletmanager.v1.WalletManagerService.BroadcastTransaction:input_type -> walletmanager.v1.BroadcastTransactionRequest
+	99,  // 76: walletmanager.v1.WalletManagerService.GetWalletSeed:input_type -> walletmanager.v1.GetWalletSeedRequest
+	101, // 77: walletmanager.v1.WalletManagerService.ListCoreVariants:input_type -> walletmanager.v1.ListCoreVariantsRequest
+	104, // 78: walletmanager.v1.WalletManagerService.GetCoreVariant:input_type -> walletmanager.v1.GetCoreVariantRequest
+	106, // 79: walletmanager.v1.WalletManagerService.SetCoreVariant:input_type -> walletmanager.v1.SetCoreVariantRequest
+	108, // 80: walletmanager.v1.WalletManagerService.GetTestSidechains:input_type -> walletmanager.v1.GetTestSidechainsRequest
+	110, // 81: walletmanager.v1.WalletManagerService.SetTestSidechains:input_type -> walletmanager.v1.SetTestSidechainsRequest
+	112, // 82: walletmanager.v1.WalletManagerService.GetElectrumServer:input_type -> walletmanager.v1.GetElectrumServerRequest
+	114, // 83: walletmanager.v1.WalletManagerService.SetElectrumServer:input_type -> walletmanager.v1.SetElectrumServerRequest
+	116, // 84: walletmanager.v1.WalletManagerService.GetTorConfig:input_type -> walletmanager.v1.GetTorConfigRequest
+	118, // 85: walletmanager.v1.WalletManagerService.SetTorConfig:input_type -> walletmanager.v1.SetTorConfigRequest
+	125, // 86: walletmanager.v1.WalletManagerService.WatchWalletData:input_type -> google.protobuf.Empty
+	5,   // 87: walletmanager.v1.WalletManagerService.GetWalletStatus:output_type -> walletmanager.v1.GetWalletStatusResponse
+	7,   // 88: walletmanager.v1.WalletManagerService.GenerateWallet:output_type -> walletmanager.v1.GenerateWalletResponse
+	9,   // 89: walletmanager.v1.WalletManagerService.UnlockWallet:output_type -> walletmanager.v1.UnlockWalletResponse
+	11,  // 90: walletmanager.v1.WalletManagerService.LockWallet:output_type -> walletmanager.v1.LockWalletResponse
+	13,  // 91: walletmanager.v1.WalletManagerService.EncryptWallet:output_type -> walletmanager.v1.EncryptWalletResponse
+	15,  // 92: walletmanager.v1.WalletManagerService.ChangePassword:output_type -> walletmanager.v1.ChangePasswordResponse
+	17,  // 93: walletmanager.v1.WalletManagerService.RemoveEncryption:output_type -> walletmanager.v1.RemoveEncryptionResponse
+	23,  // 94: walletmanager.v1.WalletManagerService.ListWallets:output_type -> walletmanager.v1.ListWalletsResponse
+	25,  // 95: walletmanager.v1.WalletManagerService.SwitchWallet:output_type -> walletmanager.v1.SwitchWalletResponse
+	27,  // 96: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:output_type -> walletmanager.v1.UpdateWalletMetadataResponse
+	29,  // 97: walletmanager.v1.WalletManagerService.DeleteWallet:output_type -> walletmanager.v1.DeleteWalletResponse
+	31,  // 98: walletmanager.v1.WalletManagerService.DeleteAllWallets:output_type -> walletmanager.v1.DeleteAllWalletsResponse
+	36,  // 99: walletmanager.v1.WalletManagerService.ListWalletBackups:output_type -> walletmanager.v1.ListWalletBackupsResponse
+	38,  // 100: walletmanager.v1.WalletManagerService.RestoreWalletBackup:output_type -> walletmanager.v1.RestoreWalletBackupResponse
+	41,  // 101: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:output_type -> walletmanager.v1.RestoreWalletBackupProgressResponse
+	43,  // 102: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:output_type -> walletmanager.v1.CreateWatchOnlyWalletResponse
+	45,  // 103: walletmanager.v1.WalletManagerService.CreateElectrumWallet:output_type -> walletmanager.v1.CreateElectrumWalletResponse
+	48,  // 104: walletmanager.v1.WalletManagerService.CreateMultisigWallet:output_type -> walletmanager.v1.CreateMultisigWalletResponse
+	51,  // 105: walletmanager.v1.WalletManagerService.ParseMultisigConfig:output_type -> walletmanager.v1.ParseMultisigConfigResponse
+	53,  // 106: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:output_type -> walletmanager.v1.CreateBitcoinCoreWalletResponse
+	55,  // 107: walletmanager.v1.WalletManagerService.EnsureCoreWallets:output_type -> walletmanager.v1.EnsureCoreWalletsResponse
+	57,  // 108: walletmanager.v1.WalletManagerService.GetBalance:output_type -> walletmanager.v1.GetBalanceResponse
+	59,  // 109: walletmanager.v1.WalletManagerService.GetNewAddress:output_type -> walletmanager.v1.GetNewAddressResponse
+	61,  // 110: walletmanager.v1.WalletManagerService.SendTransaction:output_type -> walletmanager.v1.SendTransactionResponse
+	80,  // 111: walletmanager.v1.WalletManagerService.ListTransactions:output_type -> walletmanager.v1.ListTransactionsResponse
+	83,  // 112: walletmanager.v1.WalletManagerService.ListUnspent:output_type -> walletmanager.v1.ListUnspentResponse
+	86,  // 113: walletmanager.v1.WalletManagerService.ListReceiveAddresses:output_type -> walletmanager.v1.ListReceiveAddressesResponse
+	88,  // 114: walletmanager.v1.WalletManagerService.GetTransactionDetails:output_type -> walletmanager.v1.GetTransactionDetailsResponse
+	92,  // 115: walletmanager.v1.WalletManagerService.DecodeTransaction:output_type -> walletmanager.v1.DecodeTransactionResponse
+	94,  // 116: walletmanager.v1.WalletManagerService.BumpFee:output_type -> walletmanager.v1.BumpFeeResponse
+	96,  // 117: walletmanager.v1.WalletManagerService.CreateCpfp:output_type -> walletmanager.v1.CreateCpfpResponse
+	98,  // 118: walletmanager.v1.WalletManagerService.DeriveAddresses:output_type -> walletmanager.v1.DeriveAddressesResponse
+	65,  // 119: walletmanager.v1.WalletManagerService.CreatePsbt:output_type -> walletmanager.v1.CreatePsbtResponse
+	67,  // 120: walletmanager.v1.WalletManagerService.SignPsbt:output_type -> walletmanager.v1.SignPsbtResponse
+	69,  // 121: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:output_type -> walletmanager.v1.SignPsbtWithCosignerResponse
+	71,  // 122: walletmanager.v1.WalletManagerService.CombinePsbt:output_type -> walletmanager.v1.CombinePsbtResponse
+	73,  // 123: walletmanager.v1.WalletManagerService.FinalizePsbt:output_type -> walletmanager.v1.FinalizePsbtResponse
+	75,  // 124: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:output_type -> walletmanager.v1.MultisigPsbtStatusResponse
+	77,  // 125: walletmanager.v1.WalletManagerService.BroadcastTransaction:output_type -> walletmanager.v1.BroadcastTransactionResponse
+	100, // 126: walletmanager.v1.WalletManagerService.GetWalletSeed:output_type -> walletmanager.v1.GetWalletSeedResponse
+	103, // 127: walletmanager.v1.WalletManagerService.ListCoreVariants:output_type -> walletmanager.v1.ListCoreVariantsResponse
+	105, // 128: walletmanager.v1.WalletManagerService.GetCoreVariant:output_type -> walletmanager.v1.GetCoreVariantResponse
+	107, // 129: walletmanager.v1.WalletManagerService.SetCoreVariant:output_type -> walletmanager.v1.SetCoreVariantResponse
+	109, // 130: walletmanager.v1.WalletManagerService.GetTestSidechains:output_type -> walletmanager.v1.GetTestSidechainsResponse
+	111, // 131: walletmanager.v1.WalletManagerService.SetTestSidechains:output_type -> walletmanager.v1.SetTestSidechainsResponse
+	113, // 132: walletmanager.v1.WalletManagerService.GetElectrumServer:output_type -> walletmanager.v1.GetElectrumServerResponse
+	115, // 133: walletmanager.v1.WalletManagerService.SetElectrumServer:output_type -> walletmanager.v1.SetElectrumServerResponse
+	117, // 134: walletmanager.v1.WalletManagerService.GetTorConfig:output_type -> walletmanager.v1.GetTorConfigResponse
+	119, // 135: walletmanager.v1.WalletManagerService.SetTorConfig:output_type -> walletmanager.v1.SetTorConfigResponse
+	120, // 136: walletmanager.v1.WalletManagerService.WatchWalletData:output_type -> walletmanager.v1.WatchWalletDataResponse
+	87,  // [87:137] is the sub-list for method output_type
+	37,  // [37:87] is the sub-list for method input_type
+	37,  // [37:37] is the sub-list for extension type_name
+	37,  // [37:37] is the sub-list for extension extendee
+	0,   // [0:37] is the sub-list for field type_name
 }
 
 func init() { file_walletmanager_v1_walletmanager_proto_init() }
@@ -6884,7 +7844,7 @@ func file_walletmanager_v1_walletmanager_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_walletmanager_v1_walletmanager_proto_rawDesc), len(file_walletmanager_v1_walletmanager_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   105,
+			NumMessages:   119,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect/walletmanager.connect.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect/walletmanager.connect.go
@@ -85,6 +85,12 @@ const (
 	// WalletManagerServiceCreateElectrumWalletProcedure is the fully-qualified name of the
 	// WalletManagerService's CreateElectrumWallet RPC.
 	WalletManagerServiceCreateElectrumWalletProcedure = "/walletmanager.v1.WalletManagerService/CreateElectrumWallet"
+	// WalletManagerServiceCreateMultisigWalletProcedure is the fully-qualified name of the
+	// WalletManagerService's CreateMultisigWallet RPC.
+	WalletManagerServiceCreateMultisigWalletProcedure = "/walletmanager.v1.WalletManagerService/CreateMultisigWallet"
+	// WalletManagerServiceParseMultisigConfigProcedure is the fully-qualified name of the
+	// WalletManagerService's ParseMultisigConfig RPC.
+	WalletManagerServiceParseMultisigConfigProcedure = "/walletmanager.v1.WalletManagerService/ParseMultisigConfig"
 	// WalletManagerServiceCreateBitcoinCoreWalletProcedure is the fully-qualified name of the
 	// WalletManagerService's CreateBitcoinCoreWallet RPC.
 	WalletManagerServiceCreateBitcoinCoreWalletProcedure = "/walletmanager.v1.WalletManagerService/CreateBitcoinCoreWallet"
@@ -130,12 +136,21 @@ const (
 	// WalletManagerServiceSignPsbtProcedure is the fully-qualified name of the WalletManagerService's
 	// SignPsbt RPC.
 	WalletManagerServiceSignPsbtProcedure = "/walletmanager.v1.WalletManagerService/SignPsbt"
+	// WalletManagerServiceSignPsbtWithCosignerProcedure is the fully-qualified name of the
+	// WalletManagerService's SignPsbtWithCosigner RPC.
+	WalletManagerServiceSignPsbtWithCosignerProcedure = "/walletmanager.v1.WalletManagerService/SignPsbtWithCosigner"
 	// WalletManagerServiceCombinePsbtProcedure is the fully-qualified name of the
 	// WalletManagerService's CombinePsbt RPC.
 	WalletManagerServiceCombinePsbtProcedure = "/walletmanager.v1.WalletManagerService/CombinePsbt"
 	// WalletManagerServiceFinalizePsbtProcedure is the fully-qualified name of the
 	// WalletManagerService's FinalizePsbt RPC.
 	WalletManagerServiceFinalizePsbtProcedure = "/walletmanager.v1.WalletManagerService/FinalizePsbt"
+	// WalletManagerServiceMultisigPsbtStatusProcedure is the fully-qualified name of the
+	// WalletManagerService's MultisigPsbtStatus RPC.
+	WalletManagerServiceMultisigPsbtStatusProcedure = "/walletmanager.v1.WalletManagerService/MultisigPsbtStatus"
+	// WalletManagerServiceBroadcastTransactionProcedure is the fully-qualified name of the
+	// WalletManagerService's BroadcastTransaction RPC.
+	WalletManagerServiceBroadcastTransactionProcedure = "/walletmanager.v1.WalletManagerService/BroadcastTransaction"
 	// WalletManagerServiceGetWalletSeedProcedure is the fully-qualified name of the
 	// WalletManagerService's GetWalletSeed RPC.
 	WalletManagerServiceGetWalletSeedProcedure = "/walletmanager.v1.WalletManagerService/GetWalletSeed"
@@ -193,6 +208,10 @@ type WalletManagerServiceClient interface {
 	// Create an electrum wallet: keys are generated locally, but no local Bitcoin
 	// Core or enforcer runs — chain data is served remotely via the datasource.
 	CreateElectrumWallet(context.Context, *connect.Request[v1.CreateElectrumWalletRequest]) (*connect.Response[v1.CreateElectrumWalletResponse], error)
+	CreateMultisigWallet(context.Context, *connect.Request[v1.CreateMultisigWalletRequest]) (*connect.Response[v1.CreateMultisigWalletResponse], error)
+	// ParseMultisigConfig parses a descriptor or a wallet-config file (Coldcard
+	// text / Sparrow / Specter / Caravan JSON) into an m-of-n policy + cosigners.
+	ParseMultisigConfig(context.Context, *connect.Request[v1.ParseMultisigConfigRequest]) (*connect.Response[v1.ParseMultisigConfigResponse], error)
 	// Core wallet management
 	CreateBitcoinCoreWallet(context.Context, *connect.Request[v1.CreateBitcoinCoreWalletRequest]) (*connect.Response[v1.CreateBitcoinCoreWalletResponse], error)
 	EnsureCoreWallets(context.Context, *connect.Request[v1.EnsureCoreWalletsRequest]) (*connect.Response[v1.EnsureCoreWalletsResponse], error)
@@ -216,8 +235,17 @@ type WalletManagerServiceClient interface {
 	// wallets only.
 	CreatePsbt(context.Context, *connect.Request[v1.CreatePsbtRequest]) (*connect.Response[v1.CreatePsbtResponse], error)
 	SignPsbt(context.Context, *connect.Request[v1.SignPsbtRequest]) (*connect.Response[v1.SignPsbtResponse], error)
+	// SignPsbtWithCosigner signs a multisig PSBT with a single held cosigner's key
+	// (per-keystore signing), leaving the other legs for their own signers.
+	SignPsbtWithCosigner(context.Context, *connect.Request[v1.SignPsbtWithCosignerRequest]) (*connect.Response[v1.SignPsbtWithCosignerResponse], error)
 	CombinePsbt(context.Context, *connect.Request[v1.CombinePsbtRequest]) (*connect.Response[v1.CombinePsbtResponse], error)
 	FinalizePsbt(context.Context, *connect.Request[v1.FinalizePsbtRequest]) (*connect.Response[v1.FinalizePsbtResponse], error)
+	// MultisigPsbtStatus reports signing progress for a multisig wallet's PSBT:
+	// signature count, whether it can be finalized, and which cosigners signed.
+	MultisigPsbtStatus(context.Context, *connect.Request[v1.MultisigPsbtStatusRequest]) (*connect.Response[v1.MultisigPsbtStatusResponse], error)
+	// BroadcastTransaction broadcasts a finalized raw transaction over the
+	// wallet's chain source and returns its txid.
+	BroadcastTransaction(context.Context, *connect.Request[v1.BroadcastTransactionRequest]) (*connect.Response[v1.BroadcastTransactionResponse], error)
 	// Seed access for cheque engine
 	GetWalletSeed(context.Context, *connect.Request[v1.GetWalletSeedRequest]) (*connect.Response[v1.GetWalletSeedResponse], error)
 	// Bitcoin Core variant selection (untouched / touched / knots).
@@ -352,6 +380,18 @@ func NewWalletManagerServiceClient(httpClient connect.HTTPClient, baseURL string
 			connect.WithSchema(walletManagerServiceMethods.ByName("CreateElectrumWallet")),
 			connect.WithClientOptions(opts...),
 		),
+		createMultisigWallet: connect.NewClient[v1.CreateMultisigWalletRequest, v1.CreateMultisigWalletResponse](
+			httpClient,
+			baseURL+WalletManagerServiceCreateMultisigWalletProcedure,
+			connect.WithSchema(walletManagerServiceMethods.ByName("CreateMultisigWallet")),
+			connect.WithClientOptions(opts...),
+		),
+		parseMultisigConfig: connect.NewClient[v1.ParseMultisigConfigRequest, v1.ParseMultisigConfigResponse](
+			httpClient,
+			baseURL+WalletManagerServiceParseMultisigConfigProcedure,
+			connect.WithSchema(walletManagerServiceMethods.ByName("ParseMultisigConfig")),
+			connect.WithClientOptions(opts...),
+		),
 		createBitcoinCoreWallet: connect.NewClient[v1.CreateBitcoinCoreWalletRequest, v1.CreateBitcoinCoreWalletResponse](
 			httpClient,
 			baseURL+WalletManagerServiceCreateBitcoinCoreWalletProcedure,
@@ -442,6 +482,12 @@ func NewWalletManagerServiceClient(httpClient connect.HTTPClient, baseURL string
 			connect.WithSchema(walletManagerServiceMethods.ByName("SignPsbt")),
 			connect.WithClientOptions(opts...),
 		),
+		signPsbtWithCosigner: connect.NewClient[v1.SignPsbtWithCosignerRequest, v1.SignPsbtWithCosignerResponse](
+			httpClient,
+			baseURL+WalletManagerServiceSignPsbtWithCosignerProcedure,
+			connect.WithSchema(walletManagerServiceMethods.ByName("SignPsbtWithCosigner")),
+			connect.WithClientOptions(opts...),
+		),
 		combinePsbt: connect.NewClient[v1.CombinePsbtRequest, v1.CombinePsbtResponse](
 			httpClient,
 			baseURL+WalletManagerServiceCombinePsbtProcedure,
@@ -452,6 +498,18 @@ func NewWalletManagerServiceClient(httpClient connect.HTTPClient, baseURL string
 			httpClient,
 			baseURL+WalletManagerServiceFinalizePsbtProcedure,
 			connect.WithSchema(walletManagerServiceMethods.ByName("FinalizePsbt")),
+			connect.WithClientOptions(opts...),
+		),
+		multisigPsbtStatus: connect.NewClient[v1.MultisigPsbtStatusRequest, v1.MultisigPsbtStatusResponse](
+			httpClient,
+			baseURL+WalletManagerServiceMultisigPsbtStatusProcedure,
+			connect.WithSchema(walletManagerServiceMethods.ByName("MultisigPsbtStatus")),
+			connect.WithClientOptions(opts...),
+		),
+		broadcastTransaction: connect.NewClient[v1.BroadcastTransactionRequest, v1.BroadcastTransactionResponse](
+			httpClient,
+			baseURL+WalletManagerServiceBroadcastTransactionProcedure,
+			connect.WithSchema(walletManagerServiceMethods.ByName("BroadcastTransaction")),
 			connect.WithClientOptions(opts...),
 		),
 		getWalletSeed: connect.NewClient[v1.GetWalletSeedRequest, v1.GetWalletSeedResponse](
@@ -542,6 +600,8 @@ type walletManagerServiceClient struct {
 	restoreWalletBackupStream *connect.Client[v1.RestoreWalletBackupRequest, v1.RestoreWalletBackupProgressResponse]
 	createWatchOnlyWallet     *connect.Client[v1.CreateWatchOnlyWalletRequest, v1.CreateWatchOnlyWalletResponse]
 	createElectrumWallet      *connect.Client[v1.CreateElectrumWalletRequest, v1.CreateElectrumWalletResponse]
+	createMultisigWallet      *connect.Client[v1.CreateMultisigWalletRequest, v1.CreateMultisigWalletResponse]
+	parseMultisigConfig       *connect.Client[v1.ParseMultisigConfigRequest, v1.ParseMultisigConfigResponse]
 	createBitcoinCoreWallet   *connect.Client[v1.CreateBitcoinCoreWalletRequest, v1.CreateBitcoinCoreWalletResponse]
 	ensureCoreWallets         *connect.Client[v1.EnsureCoreWalletsRequest, v1.EnsureCoreWalletsResponse]
 	getBalance                *connect.Client[v1.GetBalanceRequest, v1.GetBalanceResponse]
@@ -557,8 +617,11 @@ type walletManagerServiceClient struct {
 	deriveAddresses           *connect.Client[v1.DeriveAddressesRequest, v1.DeriveAddressesResponse]
 	createPsbt                *connect.Client[v1.CreatePsbtRequest, v1.CreatePsbtResponse]
 	signPsbt                  *connect.Client[v1.SignPsbtRequest, v1.SignPsbtResponse]
+	signPsbtWithCosigner      *connect.Client[v1.SignPsbtWithCosignerRequest, v1.SignPsbtWithCosignerResponse]
 	combinePsbt               *connect.Client[v1.CombinePsbtRequest, v1.CombinePsbtResponse]
 	finalizePsbt              *connect.Client[v1.FinalizePsbtRequest, v1.FinalizePsbtResponse]
+	multisigPsbtStatus        *connect.Client[v1.MultisigPsbtStatusRequest, v1.MultisigPsbtStatusResponse]
+	broadcastTransaction      *connect.Client[v1.BroadcastTransactionRequest, v1.BroadcastTransactionResponse]
 	getWalletSeed             *connect.Client[v1.GetWalletSeedRequest, v1.GetWalletSeedResponse]
 	listCoreVariants          *connect.Client[v1.ListCoreVariantsRequest, v1.ListCoreVariantsResponse]
 	getCoreVariant            *connect.Client[v1.GetCoreVariantRequest, v1.GetCoreVariantResponse]
@@ -657,6 +720,16 @@ func (c *walletManagerServiceClient) CreateElectrumWallet(ctx context.Context, r
 	return c.createElectrumWallet.CallUnary(ctx, req)
 }
 
+// CreateMultisigWallet calls walletmanager.v1.WalletManagerService.CreateMultisigWallet.
+func (c *walletManagerServiceClient) CreateMultisigWallet(ctx context.Context, req *connect.Request[v1.CreateMultisigWalletRequest]) (*connect.Response[v1.CreateMultisigWalletResponse], error) {
+	return c.createMultisigWallet.CallUnary(ctx, req)
+}
+
+// ParseMultisigConfig calls walletmanager.v1.WalletManagerService.ParseMultisigConfig.
+func (c *walletManagerServiceClient) ParseMultisigConfig(ctx context.Context, req *connect.Request[v1.ParseMultisigConfigRequest]) (*connect.Response[v1.ParseMultisigConfigResponse], error) {
+	return c.parseMultisigConfig.CallUnary(ctx, req)
+}
+
 // CreateBitcoinCoreWallet calls walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet.
 func (c *walletManagerServiceClient) CreateBitcoinCoreWallet(ctx context.Context, req *connect.Request[v1.CreateBitcoinCoreWalletRequest]) (*connect.Response[v1.CreateBitcoinCoreWalletResponse], error) {
 	return c.createBitcoinCoreWallet.CallUnary(ctx, req)
@@ -732,6 +805,11 @@ func (c *walletManagerServiceClient) SignPsbt(ctx context.Context, req *connect.
 	return c.signPsbt.CallUnary(ctx, req)
 }
 
+// SignPsbtWithCosigner calls walletmanager.v1.WalletManagerService.SignPsbtWithCosigner.
+func (c *walletManagerServiceClient) SignPsbtWithCosigner(ctx context.Context, req *connect.Request[v1.SignPsbtWithCosignerRequest]) (*connect.Response[v1.SignPsbtWithCosignerResponse], error) {
+	return c.signPsbtWithCosigner.CallUnary(ctx, req)
+}
+
 // CombinePsbt calls walletmanager.v1.WalletManagerService.CombinePsbt.
 func (c *walletManagerServiceClient) CombinePsbt(ctx context.Context, req *connect.Request[v1.CombinePsbtRequest]) (*connect.Response[v1.CombinePsbtResponse], error) {
 	return c.combinePsbt.CallUnary(ctx, req)
@@ -740,6 +818,16 @@ func (c *walletManagerServiceClient) CombinePsbt(ctx context.Context, req *conne
 // FinalizePsbt calls walletmanager.v1.WalletManagerService.FinalizePsbt.
 func (c *walletManagerServiceClient) FinalizePsbt(ctx context.Context, req *connect.Request[v1.FinalizePsbtRequest]) (*connect.Response[v1.FinalizePsbtResponse], error) {
 	return c.finalizePsbt.CallUnary(ctx, req)
+}
+
+// MultisigPsbtStatus calls walletmanager.v1.WalletManagerService.MultisigPsbtStatus.
+func (c *walletManagerServiceClient) MultisigPsbtStatus(ctx context.Context, req *connect.Request[v1.MultisigPsbtStatusRequest]) (*connect.Response[v1.MultisigPsbtStatusResponse], error) {
+	return c.multisigPsbtStatus.CallUnary(ctx, req)
+}
+
+// BroadcastTransaction calls walletmanager.v1.WalletManagerService.BroadcastTransaction.
+func (c *walletManagerServiceClient) BroadcastTransaction(ctx context.Context, req *connect.Request[v1.BroadcastTransactionRequest]) (*connect.Response[v1.BroadcastTransactionResponse], error) {
+	return c.broadcastTransaction.CallUnary(ctx, req)
 }
 
 // GetWalletSeed calls walletmanager.v1.WalletManagerService.GetWalletSeed.
@@ -820,6 +908,10 @@ type WalletManagerServiceHandler interface {
 	// Create an electrum wallet: keys are generated locally, but no local Bitcoin
 	// Core or enforcer runs — chain data is served remotely via the datasource.
 	CreateElectrumWallet(context.Context, *connect.Request[v1.CreateElectrumWalletRequest]) (*connect.Response[v1.CreateElectrumWalletResponse], error)
+	CreateMultisigWallet(context.Context, *connect.Request[v1.CreateMultisigWalletRequest]) (*connect.Response[v1.CreateMultisigWalletResponse], error)
+	// ParseMultisigConfig parses a descriptor or a wallet-config file (Coldcard
+	// text / Sparrow / Specter / Caravan JSON) into an m-of-n policy + cosigners.
+	ParseMultisigConfig(context.Context, *connect.Request[v1.ParseMultisigConfigRequest]) (*connect.Response[v1.ParseMultisigConfigResponse], error)
 	// Core wallet management
 	CreateBitcoinCoreWallet(context.Context, *connect.Request[v1.CreateBitcoinCoreWalletRequest]) (*connect.Response[v1.CreateBitcoinCoreWalletResponse], error)
 	EnsureCoreWallets(context.Context, *connect.Request[v1.EnsureCoreWalletsRequest]) (*connect.Response[v1.EnsureCoreWalletsResponse], error)
@@ -843,8 +935,17 @@ type WalletManagerServiceHandler interface {
 	// wallets only.
 	CreatePsbt(context.Context, *connect.Request[v1.CreatePsbtRequest]) (*connect.Response[v1.CreatePsbtResponse], error)
 	SignPsbt(context.Context, *connect.Request[v1.SignPsbtRequest]) (*connect.Response[v1.SignPsbtResponse], error)
+	// SignPsbtWithCosigner signs a multisig PSBT with a single held cosigner's key
+	// (per-keystore signing), leaving the other legs for their own signers.
+	SignPsbtWithCosigner(context.Context, *connect.Request[v1.SignPsbtWithCosignerRequest]) (*connect.Response[v1.SignPsbtWithCosignerResponse], error)
 	CombinePsbt(context.Context, *connect.Request[v1.CombinePsbtRequest]) (*connect.Response[v1.CombinePsbtResponse], error)
 	FinalizePsbt(context.Context, *connect.Request[v1.FinalizePsbtRequest]) (*connect.Response[v1.FinalizePsbtResponse], error)
+	// MultisigPsbtStatus reports signing progress for a multisig wallet's PSBT:
+	// signature count, whether it can be finalized, and which cosigners signed.
+	MultisigPsbtStatus(context.Context, *connect.Request[v1.MultisigPsbtStatusRequest]) (*connect.Response[v1.MultisigPsbtStatusResponse], error)
+	// BroadcastTransaction broadcasts a finalized raw transaction over the
+	// wallet's chain source and returns its txid.
+	BroadcastTransaction(context.Context, *connect.Request[v1.BroadcastTransactionRequest]) (*connect.Response[v1.BroadcastTransactionResponse], error)
 	// Seed access for cheque engine
 	GetWalletSeed(context.Context, *connect.Request[v1.GetWalletSeedRequest]) (*connect.Response[v1.GetWalletSeedResponse], error)
 	// Bitcoin Core variant selection (untouched / touched / knots).
@@ -975,6 +1076,18 @@ func NewWalletManagerServiceHandler(svc WalletManagerServiceHandler, opts ...con
 		connect.WithSchema(walletManagerServiceMethods.ByName("CreateElectrumWallet")),
 		connect.WithHandlerOptions(opts...),
 	)
+	walletManagerServiceCreateMultisigWalletHandler := connect.NewUnaryHandler(
+		WalletManagerServiceCreateMultisigWalletProcedure,
+		svc.CreateMultisigWallet,
+		connect.WithSchema(walletManagerServiceMethods.ByName("CreateMultisigWallet")),
+		connect.WithHandlerOptions(opts...),
+	)
+	walletManagerServiceParseMultisigConfigHandler := connect.NewUnaryHandler(
+		WalletManagerServiceParseMultisigConfigProcedure,
+		svc.ParseMultisigConfig,
+		connect.WithSchema(walletManagerServiceMethods.ByName("ParseMultisigConfig")),
+		connect.WithHandlerOptions(opts...),
+	)
 	walletManagerServiceCreateBitcoinCoreWalletHandler := connect.NewUnaryHandler(
 		WalletManagerServiceCreateBitcoinCoreWalletProcedure,
 		svc.CreateBitcoinCoreWallet,
@@ -1065,6 +1178,12 @@ func NewWalletManagerServiceHandler(svc WalletManagerServiceHandler, opts ...con
 		connect.WithSchema(walletManagerServiceMethods.ByName("SignPsbt")),
 		connect.WithHandlerOptions(opts...),
 	)
+	walletManagerServiceSignPsbtWithCosignerHandler := connect.NewUnaryHandler(
+		WalletManagerServiceSignPsbtWithCosignerProcedure,
+		svc.SignPsbtWithCosigner,
+		connect.WithSchema(walletManagerServiceMethods.ByName("SignPsbtWithCosigner")),
+		connect.WithHandlerOptions(opts...),
+	)
 	walletManagerServiceCombinePsbtHandler := connect.NewUnaryHandler(
 		WalletManagerServiceCombinePsbtProcedure,
 		svc.CombinePsbt,
@@ -1075,6 +1194,18 @@ func NewWalletManagerServiceHandler(svc WalletManagerServiceHandler, opts ...con
 		WalletManagerServiceFinalizePsbtProcedure,
 		svc.FinalizePsbt,
 		connect.WithSchema(walletManagerServiceMethods.ByName("FinalizePsbt")),
+		connect.WithHandlerOptions(opts...),
+	)
+	walletManagerServiceMultisigPsbtStatusHandler := connect.NewUnaryHandler(
+		WalletManagerServiceMultisigPsbtStatusProcedure,
+		svc.MultisigPsbtStatus,
+		connect.WithSchema(walletManagerServiceMethods.ByName("MultisigPsbtStatus")),
+		connect.WithHandlerOptions(opts...),
+	)
+	walletManagerServiceBroadcastTransactionHandler := connect.NewUnaryHandler(
+		WalletManagerServiceBroadcastTransactionProcedure,
+		svc.BroadcastTransaction,
+		connect.WithSchema(walletManagerServiceMethods.ByName("BroadcastTransaction")),
 		connect.WithHandlerOptions(opts...),
 	)
 	walletManagerServiceGetWalletSeedHandler := connect.NewUnaryHandler(
@@ -1179,6 +1310,10 @@ func NewWalletManagerServiceHandler(svc WalletManagerServiceHandler, opts ...con
 			walletManagerServiceCreateWatchOnlyWalletHandler.ServeHTTP(w, r)
 		case WalletManagerServiceCreateElectrumWalletProcedure:
 			walletManagerServiceCreateElectrumWalletHandler.ServeHTTP(w, r)
+		case WalletManagerServiceCreateMultisigWalletProcedure:
+			walletManagerServiceCreateMultisigWalletHandler.ServeHTTP(w, r)
+		case WalletManagerServiceParseMultisigConfigProcedure:
+			walletManagerServiceParseMultisigConfigHandler.ServeHTTP(w, r)
 		case WalletManagerServiceCreateBitcoinCoreWalletProcedure:
 			walletManagerServiceCreateBitcoinCoreWalletHandler.ServeHTTP(w, r)
 		case WalletManagerServiceEnsureCoreWalletsProcedure:
@@ -1209,10 +1344,16 @@ func NewWalletManagerServiceHandler(svc WalletManagerServiceHandler, opts ...con
 			walletManagerServiceCreatePsbtHandler.ServeHTTP(w, r)
 		case WalletManagerServiceSignPsbtProcedure:
 			walletManagerServiceSignPsbtHandler.ServeHTTP(w, r)
+		case WalletManagerServiceSignPsbtWithCosignerProcedure:
+			walletManagerServiceSignPsbtWithCosignerHandler.ServeHTTP(w, r)
 		case WalletManagerServiceCombinePsbtProcedure:
 			walletManagerServiceCombinePsbtHandler.ServeHTTP(w, r)
 		case WalletManagerServiceFinalizePsbtProcedure:
 			walletManagerServiceFinalizePsbtHandler.ServeHTTP(w, r)
+		case WalletManagerServiceMultisigPsbtStatusProcedure:
+			walletManagerServiceMultisigPsbtStatusHandler.ServeHTTP(w, r)
+		case WalletManagerServiceBroadcastTransactionProcedure:
+			walletManagerServiceBroadcastTransactionHandler.ServeHTTP(w, r)
 		case WalletManagerServiceGetWalletSeedProcedure:
 			walletManagerServiceGetWalletSeedHandler.ServeHTTP(w, r)
 		case WalletManagerServiceListCoreVariantsProcedure:
@@ -1312,6 +1453,14 @@ func (UnimplementedWalletManagerServiceHandler) CreateElectrumWallet(context.Con
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.CreateElectrumWallet is not implemented"))
 }
 
+func (UnimplementedWalletManagerServiceHandler) CreateMultisigWallet(context.Context, *connect.Request[v1.CreateMultisigWalletRequest]) (*connect.Response[v1.CreateMultisigWalletResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.CreateMultisigWallet is not implemented"))
+}
+
+func (UnimplementedWalletManagerServiceHandler) ParseMultisigConfig(context.Context, *connect.Request[v1.ParseMultisigConfigRequest]) (*connect.Response[v1.ParseMultisigConfigResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.ParseMultisigConfig is not implemented"))
+}
+
 func (UnimplementedWalletManagerServiceHandler) CreateBitcoinCoreWallet(context.Context, *connect.Request[v1.CreateBitcoinCoreWalletRequest]) (*connect.Response[v1.CreateBitcoinCoreWalletResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet is not implemented"))
 }
@@ -1372,12 +1521,24 @@ func (UnimplementedWalletManagerServiceHandler) SignPsbt(context.Context, *conne
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.SignPsbt is not implemented"))
 }
 
+func (UnimplementedWalletManagerServiceHandler) SignPsbtWithCosigner(context.Context, *connect.Request[v1.SignPsbtWithCosignerRequest]) (*connect.Response[v1.SignPsbtWithCosignerResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.SignPsbtWithCosigner is not implemented"))
+}
+
 func (UnimplementedWalletManagerServiceHandler) CombinePsbt(context.Context, *connect.Request[v1.CombinePsbtRequest]) (*connect.Response[v1.CombinePsbtResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.CombinePsbt is not implemented"))
 }
 
 func (UnimplementedWalletManagerServiceHandler) FinalizePsbt(context.Context, *connect.Request[v1.FinalizePsbtRequest]) (*connect.Response[v1.FinalizePsbtResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.FinalizePsbt is not implemented"))
+}
+
+func (UnimplementedWalletManagerServiceHandler) MultisigPsbtStatus(context.Context, *connect.Request[v1.MultisigPsbtStatusRequest]) (*connect.Response[v1.MultisigPsbtStatusResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.MultisigPsbtStatus is not implemented"))
+}
+
+func (UnimplementedWalletManagerServiceHandler) BroadcastTransaction(context.Context, *connect.Request[v1.BroadcastTransactionRequest]) (*connect.Response[v1.BroadcastTransactionResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.BroadcastTransaction is not implemented"))
 }
 
 func (UnimplementedWalletManagerServiceHandler) GetWalletSeed(context.Context, *connect.Request[v1.GetWalletSeedRequest]) (*connect.Response[v1.GetWalletSeedResponse], error) {

--- a/sidechain-orchestrator/proto/multisiglounge/v1/multisiglounge.proto
+++ b/sidechain-orchestrator/proto/multisiglounge/v1/multisiglounge.proto
@@ -230,6 +230,9 @@ message MultisigGroup {
 
 message BuildDescriptorsRequest {
   MultisigGroup group = 1;
+  // Multisig script type: "wsh" (native P2WSH, default), "sh-wsh" (nested
+  // P2SH-P2WSH), or "sh" (legacy P2SH). Empty means native P2WSH.
+  string script_type = 2;
 }
 
 message BuildDescriptorsResponse {

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -27,6 +27,10 @@ service WalletManagerService {
   // Create an electrum wallet: keys are generated locally, but no local Bitcoin
   // Core or enforcer runs — chain data is served remotely via the datasource.
   rpc CreateElectrumWallet(CreateElectrumWalletRequest) returns (CreateElectrumWalletResponse);
+  rpc CreateMultisigWallet(CreateMultisigWalletRequest) returns (CreateMultisigWalletResponse);
+  // ParseMultisigConfig parses a descriptor or a wallet-config file (Coldcard
+  // text / Sparrow / Specter / Caravan JSON) into an m-of-n policy + cosigners.
+  rpc ParseMultisigConfig(ParseMultisigConfigRequest) returns (ParseMultisigConfigResponse);
 
   // Core wallet management
   rpc CreateBitcoinCoreWallet(CreateBitcoinCoreWalletRequest) returns (CreateBitcoinCoreWalletResponse);
@@ -53,8 +57,17 @@ service WalletManagerService {
   // wallets only.
   rpc CreatePsbt(CreatePsbtRequest) returns (CreatePsbtResponse);
   rpc SignPsbt(SignPsbtRequest) returns (SignPsbtResponse);
+  // SignPsbtWithCosigner signs a multisig PSBT with a single held cosigner's key
+  // (per-keystore signing), leaving the other legs for their own signers.
+  rpc SignPsbtWithCosigner(SignPsbtWithCosignerRequest) returns (SignPsbtWithCosignerResponse);
   rpc CombinePsbt(CombinePsbtRequest) returns (CombinePsbtResponse);
   rpc FinalizePsbt(FinalizePsbtRequest) returns (FinalizePsbtResponse);
+  // MultisigPsbtStatus reports signing progress for a multisig wallet's PSBT:
+  // signature count, whether it can be finalized, and which cosigners signed.
+  rpc MultisigPsbtStatus(MultisigPsbtStatusRequest) returns (MultisigPsbtStatusResponse);
+  // BroadcastTransaction broadcasts a finalized raw transaction over the
+  // wallet's chain source and returns its txid.
+  rpc BroadcastTransaction(BroadcastTransactionRequest) returns (BroadcastTransactionResponse);
 
   // Seed access for cheque engine
   rpc GetWalletSeed(GetWalletSeedRequest) returns (GetWalletSeedResponse);
@@ -187,6 +200,24 @@ message WalletMetadata {
 
   // Watch-only wallets track an external xpub/descriptor; no spending key.
   bool watch_only = 10;
+
+  // Multisig policy, present only for multisig wallets. Cosigner private
+  // material is never exposed here — only public data and a held flag.
+  MultisigInfo multisig = 11;
+}
+
+message MultisigInfo {
+  uint32 m = 1; // threshold
+  uint32 n = 2; // total cosigners
+  string script_type = 3; // wsh | sh-wsh | sh
+  repeated MultisigCosignerInfo cosigners = 4;
+}
+
+message MultisigCosignerInfo {
+  string xpub = 1;
+  string fingerprint = 2;
+  string origin_path = 3;
+  bool held = 4; // this wallet holds the key and can sign for this cosigner
 }
 
 message SidechainStarter {
@@ -337,6 +368,51 @@ message CreateElectrumWalletResponse {
   string wallet_id = 1;
 }
 
+// MultisigCosignerInput is one leg of a multisig wallet. A cosigner with a
+// mnemonic or xprv is held on disk (this wallet signs with it); one with only
+// an xpub is a watch-only leg signed elsewhere.
+message MultisigCosignerInput {
+  string xpub = 1;
+  string origin_path = 2; // without leading m/, e.g. "48'/1'/0'/2'"
+  string fingerprint = 3; // master key fingerprint, 8 hex chars
+  string mnemonic = 4;    // held: BIP39 seed, stored so the wallet can sign
+  string xprv = 5;        // held: account-level xprv, alternative to mnemonic
+  string passphrase = 6;  // optional BIP39 passphrase for mnemonic
+}
+
+message CreateMultisigWalletRequest {
+  string name = 1;
+  string gradient_json = 2;
+  uint32 m = 3; // threshold (signatures required)
+  uint32 n = 4; // total cosigners
+  // "wsh" (native P2WSH, default), "sh-wsh" (nested P2SH-P2WSH), or "sh"
+  // (legacy P2SH).
+  string script_type = 5;
+  repeated MultisigCosignerInput cosigners = 6;
+}
+
+message CreateMultisigWalletResponse {
+  string wallet_id = 1;
+}
+
+message ParseMultisigConfigRequest {
+  // An output descriptor or a wallet-config file's contents.
+  string content = 1;
+}
+
+message ParsedCosigner {
+  string xpub = 1;
+  string fingerprint = 2;
+  string origin_path = 3;
+}
+
+message ParseMultisigConfigResponse {
+  uint32 m = 1;
+  uint32 n = 2;
+  string script_type = 3; // wsh | sh-wsh | sh
+  repeated ParsedCosigner cosigners = 4;
+}
+
 // ============================================================================
 // Core Wallet Management
 // ============================================================================
@@ -453,6 +529,16 @@ message SignPsbtResponse {
   string psbt_base64 = 1;
 }
 
+message SignPsbtWithCosignerRequest {
+  string wallet_id = 1;
+  string psbt_base64 = 2;
+  string cosigner_xpub = 3;
+}
+
+message SignPsbtWithCosignerResponse {
+  string psbt_base64 = 1;
+}
+
 message CombinePsbtRequest {
   repeated string psbt_base64 = 1;
 }
@@ -467,6 +553,28 @@ message FinalizePsbtRequest {
 
 message FinalizePsbtResponse {
   string raw_tx_hex = 1;
+}
+
+message MultisigPsbtStatusRequest {
+  string wallet_id = 1;
+  string psbt_base64 = 2;
+}
+
+message MultisigPsbtStatusResponse {
+  uint32 threshold = 1;  // signatures required (m)
+  uint32 signatures = 2; // signatures present (max across inputs)
+  bool finalizable = 3;
+  // Aligned to the wallet's cosigners; true where that cosigner has signed.
+  repeated bool cosigner_signed = 4;
+}
+
+message BroadcastTransactionRequest {
+  string wallet_id = 1;
+  string tx_hex = 2;
+}
+
+message BroadcastTransactionResponse {
+  string txid = 1;
 }
 
 

--- a/sidechain-orchestrator/wallet/descriptor.go
+++ b/sidechain-orchestrator/wallet/descriptor.go
@@ -73,11 +73,15 @@ func ParseDescriptor(s string) (*Descriptor, error) {
 		}
 		return parseSingleSig(ScriptNestedSegwit, inner, "wpkh(")
 	case strings.HasPrefix(body, "tr("):
-		// Key-path only: a script tree (comma or brace inside) is unsupported.
 		inner, err := unwrap(body, "tr(")
 		if err != nil {
 			return nil, err
 		}
+		// tr(internal,sortedmulti_a(...)): taproot script-path multisig.
+		if strings.Contains(inner, "sortedmulti_a(") {
+			return parseTaprootMultisig(inner)
+		}
+		// Otherwise key-path only: any other script tree is unsupported.
 		if strings.ContainsAny(inner, ",{") {
 			return nil, errors.New("tr() with a script tree is not supported (key-path only)")
 		}
@@ -210,6 +214,8 @@ func (d *Descriptor) String() (string, error) {
 		body = fmt.Sprintf("sh(sortedmulti(%d,%s))", d.Threshold, strings.Join(exprs, ","))
 	case ScriptMultisigNested:
 		body = fmt.Sprintf("sh(wsh(sortedmulti(%d,%s)))", d.Threshold, strings.Join(exprs, ","))
+	case ScriptMultisigTaproot:
+		body = fmt.Sprintf("tr(%s,sortedmulti_a(%d,%s))", numsInternalKeyHex, d.Threshold, strings.Join(exprs, ","))
 	default:
 		return "", fmt.Errorf("cannot serialize script kind %s", d.Kind)
 	}
@@ -229,7 +235,7 @@ func (d *Descriptor) DeriveScript(change bool, index uint32, net *chaincfg.Param
 		chain = 1
 	}
 
-	if d.Kind.isMultisig() {
+	if d.Kind.isMultisig() || d.Kind.isTaprootMultisig() {
 		pubs := make([]*btcec.PublicKey, len(d.Keys))
 		for i, k := range d.Keys {
 			pub, err := deriveChildPub(k.Account, chain, index)
@@ -361,6 +367,45 @@ func deriveChild(account *hdkeychain.ExtendedKey, chain, index uint32) (*hdkeych
 
 // parseMultisig parses the sortedmulti wrappers — wsh (P2WSH), sh(wsh (P2SH-P2WSH),
 // and sh (legacy P2SH) — into a multisig descriptor with the matching kind.
+// parseTaprootMultisig parses the inside of a tr(): "<internal>,sortedmulti_a(m,keys)".
+// The internal key is the unspendable NUMS point; only the sortedmulti_a policy is
+// retained, since derivation re-commits the leaf under the NUMS key.
+func parseTaprootMultisig(inner string) (*Descriptor, error) {
+	sep := strings.Index(inner, ",sortedmulti_a(")
+	if sep < 0 {
+		return nil, errors.New("invalid tr(sortedmulti_a) descriptor")
+	}
+	// Only the fixed NUMS internal key is supported; anything else would derive
+	// under a different taproot output key than we sign for.
+	if internal := strings.TrimSpace(inner[:sep]); !strings.EqualFold(internal, numsInternalKeyHex) {
+		return nil, fmt.Errorf("unsupported taproot internal key %q (only the NUMS point is supported)", internal)
+	}
+	args, err := unwrap(inner[sep+1:], "sortedmulti_a(")
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(args, ",")
+	if len(parts) < 2 {
+		return nil, errors.New("sortedmulti_a needs a threshold and at least one key")
+	}
+	threshold, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return nil, fmt.Errorf("multisig threshold: %w", err)
+	}
+	keys := make([]DescriptorKey, 0, len(parts)-1)
+	for _, p := range parts[1:] {
+		k, err := parseKeyExpr(p)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, k)
+	}
+	if threshold < 1 || threshold > len(keys) {
+		return nil, fmt.Errorf("multisig threshold %d out of range for %d keys", threshold, len(keys))
+	}
+	return &Descriptor{Kind: ScriptMultisigTaproot, Threshold: threshold, Keys: keys}, nil
+}
+
 func parseMultisig(body string) (*Descriptor, error) {
 	var kind ScriptKind
 	var inner string

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -97,20 +97,22 @@ func NewElectrumBackend(svc *Service, client ChainDataSource, network *chaincfg.
 // scannedAddr is one derived (or watched) address with its key and current
 // funding stats.
 type scannedAddr struct {
-	address       string
-	priv          *btcec.PrivateKey
-	pub           *btcec.PublicKey
-	scriptPubKey  []byte
-	redeem        []byte              // P2SH-P2WPKH redeem (nested segwit)
-	witnessScript []byte              // P2WSH multisig script
-	multisigPrivs []*btcec.PrivateKey // multisig: the keys this wallet holds
-	tapInternal   *btcec.PublicKey    // taproot internal key
-	kind          ScriptKind
-	change        bool
-	index         uint32
-	hdPath        string
-	derivations   []keyDerivation // PSBT key-derivation records (signer key matching)
-	stats         EsploraAddressStats
+	address         string
+	priv            *btcec.PrivateKey
+	pub             *btcec.PublicKey
+	scriptPubKey    []byte
+	redeem          []byte              // P2SH-P2WPKH redeem (nested segwit)
+	witnessScript   []byte              // P2WSH multisig script
+	multisigPrivs   []*btcec.PrivateKey // multisig: the keys this wallet holds
+	tapInternal     *btcec.PublicKey    // taproot internal key
+	tapLeafScript   []byte              // tr sortedmulti_a: the tapleaf multi_a script
+	tapControlBlock []byte              // tr sortedmulti_a: the leaf's control block
+	kind            ScriptKind
+	change          bool
+	index           uint32
+	hdPath          string
+	derivations     []keyDerivation // PSBT key-derivation records (signer key matching)
+	stats           EsploraAddressStats
 	// utxos and txs are the address's chain data, fetched alongside stats and
 	// cached on the scan so balance/utxo/history reads never re-hit Esplora.
 	// Both are empty for an unused address.
@@ -358,6 +360,12 @@ func (p *ElectrumBackend) NextReceiveAddress(ctx context.Context, walletID strin
 	// ScriptUnknown is the default sentinel ("the wallet's natural kind").
 	target := kind
 	if target == ScriptUnknown {
+		target = w.scriptKind()
+	}
+	// A multisig wallet has exactly one address kind — the one its descriptor
+	// defines. A single-sig address type (native-segwit/taproot/…) doesn't apply,
+	// so always serve the wallet's own kind instead of rejecting the request.
+	if w.Multisig != nil {
 		target = w.scriptKind()
 	}
 	// Serving a kind the wallet doesn't derive would yield an address it can
@@ -899,6 +907,69 @@ func (p *ElectrumBackend) SignPSBT(ctx context.Context, walletID, psbtBase64 str
 	return packet.B64Encode()
 }
 
+// SignPSBTWithCosigner signs a multisig PSBT with a single held cosigner's key
+// (identified by xpub), leaving the other legs for their own signers. It derives
+// each input's signing key at the exact path the PSBT records, so no chain scan
+// is needed — the per-keystore "Sign" action.
+func (p *ElectrumBackend) SignPSBTWithCosigner(ctx context.Context, walletID, psbtBase64, cosignerXpub string) (string, error) {
+	if err := p.requireElectrum(walletID); err != nil {
+		return "", err
+	}
+	w := p.svc.GetWalletByID(walletID)
+	if w == nil || w.Multisig == nil {
+		return "", errors.New("wallet is not a multisig wallet")
+	}
+	packet, err := decodePSBTBase64(psbtBase64)
+	if err != nil {
+		return "", err
+	}
+	desc, err := p.multisigSigningDescriptorFor(w, cosignerXpub)
+	if err != nil {
+		return "", err
+	}
+	inputs := make([]psbtInput, len(packet.Inputs))
+	for i := range packet.Inputs {
+		change, index, ok := chainIndexFromInput(packet.Inputs[i])
+		if !ok {
+			return "", fmt.Errorf("psbt input %d has no derivation path to sign from", i)
+		}
+		sa, err := p.deriveAddr(desc, change, index)
+		if err != nil {
+			return "", err
+		}
+		out := prevOutForInput(packet, i)
+		if out == nil {
+			return "", fmt.Errorf("psbt input %d missing prevout", i)
+		}
+		inputs[i] = psbtInput{
+			outpoint: packet.UnsignedTx.TxIn[i].PreviousOutPoint,
+			amount:   out.Value,
+			addr:     sa,
+		}
+	}
+	if _, err := signPSBT(packet, inputs, p.network); err != nil {
+		return "", err
+	}
+	return packet.B64Encode()
+}
+
+// chainIndexFromInput reads (change, index) from a PSBT input's BIP32 derivation
+// path — its last two elements are the chain (0/1) and address index. Handles
+// both the ECDSA (Bip32Derivation) and taproot (TaprootBip32Derivation) forms.
+func chainIndexFromInput(in psbt.PInput) (change bool, index uint32, ok bool) {
+	for _, d := range in.Bip32Derivation {
+		if len(d.Bip32Path) >= 2 {
+			return d.Bip32Path[len(d.Bip32Path)-2] == 1, d.Bip32Path[len(d.Bip32Path)-1], true
+		}
+	}
+	for _, d := range in.TaprootBip32Derivation {
+		if len(d.Bip32Path) >= 2 {
+			return d.Bip32Path[len(d.Bip32Path)-2] == 1, d.Bip32Path[len(d.Bip32Path)-1], true
+		}
+	}
+	return false, 0, false
+}
+
 // CombinePSBT merges signatures from several base64 PSBTs of the same tx.
 func (p *ElectrumBackend) CombinePSBT(psbtsBase64 []string) (string, error) {
 	if len(psbtsBase64) == 0 {
@@ -1280,6 +1351,9 @@ func (p *ElectrumBackend) walletDescriptorFor(w *WalletData, kind ScriptKind) (*
 	if p.network == nil {
 		return nil, errors.New("no chain params for this network; cannot derive electrum wallet")
 	}
+	if w.Multisig != nil {
+		return p.multisigSigningDescriptor(w)
+	}
 	if w.Master.SeedHex != "" {
 		ap, err := accountPathFor(w, kind, p.network)
 		if err != nil {
@@ -1296,6 +1370,68 @@ func (p *ElectrumBackend) walletDescriptorFor(w *WalletData, kind ScriptKind) (*
 		return nil, err
 	}
 	return ParseDescriptor(desc)
+}
+
+// multisigSigningDescriptor builds the wallet's multisig descriptor, substituting
+// each held cosigner's account xprv for its xpub (so deriveAddr yields signing
+// keys) while external legs stay xpubs. The resulting descriptor derives the same
+// addresses as the watch-only one and is signed through the same PSBT path as any
+// other input — held keys are just signers that happen to live on disk.
+func (p *ElectrumBackend) multisigSigningDescriptor(w *WalletData) (*Descriptor, error) {
+	return p.multisigSigningDescriptorFor(w, "")
+}
+
+// multisigSigningDescriptorFor builds the multisig descriptor with held cosigners
+// substituted as their xprv. When onlyXpub is non-empty, only that cosigner's
+// xprv is substituted (the rest stay xpubs), so signing adds a single cosigner's
+// signature — the per-keystore signing path.
+func (p *ElectrumBackend) multisigSigningDescriptorFor(w *WalletData, onlyXpub string) (*Descriptor, error) {
+	ms := w.Multisig
+	if ms == nil {
+		return nil, errors.New("wallet has no multisig config")
+	}
+	group := MultisigLoungeGroup{M: ms.M, N: ms.N}
+	signWithXprv := map[string]string{}
+	for _, c := range ms.Cosigners {
+		group.Keys = append(group.Keys, MultisigLoungeKey{
+			Xpub:        c.Xpub,
+			Fingerprint: c.Fingerprint,
+			OriginPath:  c.OriginPath,
+			// Emit a [fingerprint/origin] prefix whenever we have the origin, so
+			// every cosigner's key-origin lands in the PSBT (needed to attribute
+			// signatures and for external-wallet interop) — not just held keys.
+			IsWallet: c.Fingerprint != "" && c.OriginPath != "",
+		})
+		if !c.Held() {
+			continue
+		}
+		if onlyXpub != "" && c.Xpub != onlyXpub {
+			continue
+		}
+		xprv := c.Xprv
+		if xprv == "" {
+			seedHex := hex.EncodeToString(MnemonicToSeed(c.Mnemonic, c.Passphrase))
+			x, _, err := DeriveAccountXprv(seedHex, "m/"+c.OriginPath, p.network)
+			if err != nil {
+				return nil, fmt.Errorf("derive cosigner xprv: %w", err)
+			}
+			xprv = x
+		}
+		signWithXprv[c.Xpub] = xprv
+	}
+
+	scriptType := multisigTypeString(w.scriptKind())
+	var receive string
+	var err error
+	if len(signWithXprv) > 0 {
+		receive, _, err = BuildMultisigSigningDescriptorsTyped(group, signWithXprv, scriptType)
+	} else {
+		receive, _, err = BuildMultisigLoungeDescriptorsTyped(group, scriptType)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return ParseDescriptor(receive)
 }
 
 // deriveAddr resolves one address of a descriptor, enriching it with the signing
@@ -1323,6 +1459,19 @@ func (p *ElectrumBackend) deriveAddr(d *Descriptor, change bool, index uint32) (
 	}
 	if d.Kind.isMultisig() {
 		a.witnessScript = ds.witnessScript
+		for _, k := range d.Keys {
+			priv, ok, err := deriveChildPrivIfPossible(k.Account, chainIndex(change), index)
+			if err != nil {
+				return scannedAddr{}, err
+			}
+			if ok {
+				a.multisigPrivs = append(a.multisigPrivs, priv)
+			}
+		}
+	} else if d.Kind.isTaprootMultisig() {
+		a.tapInternal = ds.tapInternal
+		a.tapLeafScript = ds.tapLeafScript
+		a.tapControlBlock = ds.tapControlBlock
 		for _, k := range d.Keys {
 			priv, ok, err := deriveChildPrivIfPossible(k.Account, chainIndex(change), index)
 			if err != nil {

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -1347,7 +1347,7 @@ func TestElectrumScanPersistsAcrossRestart(t *testing.T) {
 
 	// The next call this session is served from the in-memory cache: no new
 	// block has arrived, so it does not re-query Esplora and returns the same
-	// balance (Sparrow-style scan-once-refresh-on-block).
+	// balance.
 	confirmed3, _, err := p2.Balance(ctx, w.ID)
 	require.NoError(t, err)
 	assert.InDelta(t, 0.0025, confirmed3, 1e-9, "served from warm cache while tip unchanged")
@@ -1551,4 +1551,418 @@ func computeVsize(tx *wire.MsgTx) int64 {
 	totalSize := int64(full.Len())
 	weight := baseSize*3 + totalSize
 	return (weight + 3) / 4
+}
+
+// multisigTestCosigner builds a cosigner from the test mnemonic at
+// m/48'/1'/account'/2' (BIP48 native-segwit multisig). held=true stores the
+// mnemonic so the wallet can sign with this leg.
+func multisigTestCosigner(t *testing.T, net *chaincfg.Params, account int, held bool) MultisigCosigner {
+	t.Helper()
+	seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, ""))
+	origin := fmt.Sprintf("48'/1'/%d'/2'", account)
+	_, xpub, err := DeriveAccountXprv(seedHex, "m/"+origin, net)
+	require.NoError(t, err)
+
+	seed, err := hex.DecodeString(seedHex)
+	require.NoError(t, err)
+	master, err := hdkeychain.NewMaster(seed, net)
+	require.NoError(t, err)
+	mpub, err := master.ECPubKey()
+	require.NoError(t, err)
+	fp := hex.EncodeToString(btcutil.Hash160(mpub.SerializeCompressed())[:4])
+
+	c := MultisigCosigner{Xpub: xpub, OriginPath: origin, Fingerprint: fp}
+	if held {
+		c.Mnemonic = testMnemonic
+	}
+	return c
+}
+
+// TestElectrumMultisigHeldKeysSignAndBroadcast proves the core of local multisig
+// signing: a 2-of-3 wallet that holds two cosigner keys derives its signing
+// descriptor, populates both signing keys on the address, and — because two held
+// keys meet the threshold — signs a send to completion and broadcasts it with no
+// external cosigner. Signing goes through the same PSBT path as single-sig.
+func TestElectrumMultisigHeldKeysSignAndBroadcast(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	net := &chaincfg.SigNetParams
+
+	cosigners := []MultisigCosigner{
+		multisigTestCosigner(t, net, 0, true),  // held
+		multisigTestCosigner(t, net, 1, true),  // held
+		multisigTestCosigner(t, net, 2, false), // watch-only leg
+	}
+	w, err := svc.CreateElectrumMultisig("MS 2of3", nil, 2, 3, "wsh", cosigners)
+	require.NoError(t, err)
+	require.False(t, w.IsWatchOnly(), "holding two keys, the wallet must be signable")
+
+	fake := newFakeEsplora()
+	p := NewElectrumBackend(svc, fake, net, zerolog.New(zerolog.NewTestWriter(t)))
+
+	d, err := p.walletDescriptor(w)
+	require.NoError(t, err)
+	require.True(t, d.Kind.isMultisig())
+	require.Equal(t, 2, d.Threshold)
+
+	recv, err := p.deriveAddr(d, false, 0)
+	require.NoError(t, err)
+	require.NotNil(t, recv.witnessScript)
+	require.Len(t, recv.multisigPrivs, 2, "wallet holds two of three cosigner keys")
+	require.True(t, strings.HasPrefix(recv.address, "tb1q"))
+
+	fake.stats[recv.address] = EsploraAddressStats{
+		Address:    recv.address,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 200_000, TxCount: 1},
+	}
+	fake.utxos[recv.address] = []EsploraUTXO{{
+		TxID: "2222222222222222222222222222222222222222222222222222222222222222",
+		Vout: 0, Value: 200_000,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}
+
+	dest := "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+	_, err = p.Send(ctx, w.ID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FeeRateSatPerVB:  2,
+	})
+	require.NoError(t, err)
+	require.Len(t, fake.broadcast, 1, "two held keys meet the 2-of-3 threshold; send broadcasts")
+}
+
+// TestElectrumMultisigPsbtStatus proves the per-cosigner signing status used by
+// the sign panel: an unsigned PSBT reports zero signatures, and after the wallet
+// signs with its two held keys the status reports two signatures, finalizable,
+// and the two held cosigners (not the watch-only leg) credited — even though all
+// three share a master fingerprint and differ only by derivation path.
+func TestElectrumMultisigPsbtStatus(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	net := &chaincfg.SigNetParams
+
+	cosigners := []MultisigCosigner{
+		multisigTestCosigner(t, net, 0, true),
+		multisigTestCosigner(t, net, 1, true),
+		multisigTestCosigner(t, net, 2, false),
+	}
+	w, err := svc.CreateElectrumMultisig("MS status", nil, 2, 3, "wsh", cosigners)
+	require.NoError(t, err)
+
+	fake := newFakeEsplora()
+	p := NewElectrumBackend(svc, fake, net, zerolog.New(zerolog.NewTestWriter(t)))
+
+	d, err := p.walletDescriptor(w)
+	require.NoError(t, err)
+	recv, err := p.deriveAddr(d, false, 0)
+	require.NoError(t, err)
+
+	fake.stats[recv.address] = EsploraAddressStats{
+		Address:    recv.address,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 200_000, TxCount: 1},
+	}
+	fake.utxos[recv.address] = []EsploraUTXO{{
+		TxID: "3333333333333333333333333333333333333333333333333333333333333333",
+		Vout: 0, Value: 200_000,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}
+
+	psbt, err := p.CreatePSBT(ctx, w.ID, SendRequest{
+		DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000},
+		FeeRateSatPerVB:  2,
+	})
+	require.NoError(t, err)
+
+	before, err := MultisigPsbtSigningStatus(psbt, cosigners)
+	require.NoError(t, err)
+	assert.Equal(t, 0, before.Signatures)
+	assert.False(t, before.Finalizable)
+	assert.Equal(t, []bool{false, false, false}, before.CosignerSigned)
+
+	signed, err := p.SignPSBT(ctx, w.ID, psbt)
+	require.NoError(t, err)
+
+	after, err := MultisigPsbtSigningStatus(signed, cosigners)
+	require.NoError(t, err)
+	assert.Equal(t, 2, after.Signatures)
+	assert.True(t, after.Finalizable)
+	assert.Equal(t, []bool{true, true, false}, after.CosignerSigned, "the two held cosigners signed; the watch-only leg did not")
+}
+
+// TestElectrumMultisigPerCosignerSign proves per-keystore signing: signing with
+// one cosigner at a time adds exactly one signature each, and after two the PSBT
+// is finalizable — the sign-panel's per-keystore Sign buttons.
+func TestElectrumMultisigPerCosignerSign(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	net := &chaincfg.SigNetParams
+
+	cosigners := []MultisigCosigner{
+		multisigTestCosigner(t, net, 0, true),
+		multisigTestCosigner(t, net, 1, true),
+		multisigTestCosigner(t, net, 2, false),
+	}
+	w, err := svc.CreateElectrumMultisig("MS per-key", nil, 2, 3, "wsh", cosigners)
+	require.NoError(t, err)
+
+	fake := newFakeEsplora()
+	p := NewElectrumBackend(svc, fake, net, zerolog.New(zerolog.NewTestWriter(t)))
+	d, err := p.walletDescriptor(w)
+	require.NoError(t, err)
+	recv, err := p.deriveAddr(d, false, 0)
+	require.NoError(t, err)
+	fake.stats[recv.address] = EsploraAddressStats{
+		Address: recv.address, ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 200_000, TxCount: 1},
+	}
+	fake.utxos[recv.address] = []EsploraUTXO{{
+		TxID: "4444444444444444444444444444444444444444444444444444444444444444",
+		Vout: 0, Value: 200_000, Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}
+
+	psbt, err := p.CreatePSBT(ctx, w.ID, SendRequest{
+		DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000},
+		FeeRateSatPerVB:  2,
+	})
+	require.NoError(t, err)
+
+	// Sign with cosigner 0 only -> one signature, not finalizable.
+	psbt, err = p.SignPSBTWithCosigner(ctx, w.ID, psbt, cosigners[0].Xpub)
+	require.NoError(t, err)
+	s1, err := MultisigPsbtSigningStatus(psbt, cosigners)
+	require.NoError(t, err)
+	assert.Equal(t, 1, s1.Signatures)
+	assert.False(t, s1.Finalizable)
+	assert.Equal(t, []bool{true, false, false}, s1.CosignerSigned)
+
+	// Sign with cosigner 1 -> two signatures, finalizable.
+	psbt, err = p.SignPSBTWithCosigner(ctx, w.ID, psbt, cosigners[1].Xpub)
+	require.NoError(t, err)
+	s2, err := MultisigPsbtSigningStatus(psbt, cosigners)
+	require.NoError(t, err)
+	assert.Equal(t, 2, s2.Signatures)
+	assert.True(t, s2.Finalizable)
+	assert.Equal(t, []bool{true, true, false}, s2.CosignerSigned)
+}
+
+// TestElectrumMultisigPassphraseChangesAddresses proves a held cosigner's BIP39
+// passphrase feeds derivation: the same seed with a passphrase yields a
+// different signing address, so the passphrase is honored end to end.
+func TestElectrumMultisigPassphraseChangesAddresses(t *testing.T) {
+	svc := newTestService(t)
+	net := &chaincfg.SigNetParams
+
+	base := []MultisigCosigner{
+		multisigTestCosigner(t, net, 0, true),
+		multisigTestCosigner(t, net, 1, false),
+		multisigTestCosigner(t, net, 2, false),
+	}
+	w1, err := svc.CreateElectrumMultisig("nopass", nil, 2, 3, "wsh", base)
+	require.NoError(t, err)
+
+	// Same cosigners, but cosigner 0 now carries a passphrase and its stored xpub
+	// is re-derived accordingly (mirrors what the frontend sends).
+	seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, "trezor"))
+	_, xpub, err := DeriveAccountXprv(seedHex, "m/48'/1'/0'/2'", net)
+	require.NoError(t, err)
+	withPass := []MultisigCosigner{
+		{Xpub: xpub, OriginPath: "48'/1'/0'/2'", Fingerprint: base[0].Fingerprint, Mnemonic: testMnemonic, Passphrase: "trezor"},
+		base[1], base[2],
+	}
+	w2, err := svc.CreateElectrumMultisig("withpass", nil, 2, 3, "wsh", withPass)
+	require.NoError(t, err)
+
+	p := NewElectrumBackend(svc, newFakeEsplora(), net, zerolog.New(zerolog.NewTestWriter(t)))
+	d1, err := p.walletDescriptor(w1)
+	require.NoError(t, err)
+	a1, err := p.deriveAddr(d1, false, 0)
+	require.NoError(t, err)
+	d2, err := p.walletDescriptor(w2)
+	require.NoError(t, err)
+	a2, err := p.deriveAddr(d2, false, 0)
+	require.NoError(t, err)
+	assert.NotEqual(t, a1.address, a2.address, "a passphrase must change the derived multisig address")
+}
+
+// TestElectrumTaprootMultisigSignFinalizeValid proves the taproot (BIP342
+// sortedmulti_a) path end to end: a 2-of-3 tr() wallet derives a P2TR address,
+// signs one cosigner at a time, finalizes, and the resulting witness satisfies
+// the consensus script engine — the funds-safety gate.
+func TestElectrumTaprootMultisigSignFinalizeValid(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	net := &chaincfg.SigNetParams
+
+	cosigners := []MultisigCosigner{
+		multisigTestCosigner(t, net, 0, true),
+		multisigTestCosigner(t, net, 1, true),
+		multisigTestCosigner(t, net, 2, false),
+	}
+	w, err := svc.CreateElectrumMultisig("tr 2of3", nil, 2, 3, "tr", cosigners)
+	require.NoError(t, err)
+	require.False(t, w.IsWatchOnly())
+	require.Equal(t, "multisig-taproot", w.ScriptType)
+
+	fake := newFakeEsplora()
+	p := NewElectrumBackend(svc, fake, net, zerolog.New(zerolog.NewTestWriter(t)))
+	d, err := p.walletDescriptor(w)
+	require.NoError(t, err)
+	require.True(t, d.Kind.isTaprootMultisig())
+	recv, err := p.deriveAddr(d, false, 0)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(recv.address, "tb1p"), "want P2TR, got %s", recv.address)
+	require.Len(t, recv.multisigPrivs, 2)
+
+	const fundTxid = "5555555555555555555555555555555555555555555555555555555555555555"
+	const fundAmt = int64(200_000)
+	fake.stats[recv.address] = EsploraAddressStats{Address: recv.address, ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: fundAmt, TxCount: 1}}
+	fake.utxos[recv.address] = []EsploraUTXO{{TxID: fundTxid, Vout: 0, Value: fundAmt, Status: EsploraStatus{Confirmed: true, BlockHeight: 100}}}
+
+	psbtB64, err := p.CreatePSBT(ctx, w.ID, SendRequest{
+		DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000},
+		FeeRateSatPerVB:  2,
+	})
+	require.NoError(t, err)
+
+	psbtB64, err = p.SignPSBTWithCosigner(ctx, w.ID, psbtB64, cosigners[0].Xpub)
+	require.NoError(t, err)
+	st1, err := MultisigPsbtSigningStatus(psbtB64, cosigners)
+	require.NoError(t, err)
+	assert.Equal(t, 1, st1.Signatures)
+	assert.False(t, st1.Finalizable)
+
+	psbtB64, err = p.SignPSBTWithCosigner(ctx, w.ID, psbtB64, cosigners[1].Xpub)
+	require.NoError(t, err)
+	st2, err := MultisigPsbtSigningStatus(psbtB64, cosigners)
+	require.NoError(t, err)
+	assert.Equal(t, 2, st2.Signatures)
+	assert.True(t, st2.Finalizable)
+	assert.Equal(t, []bool{true, true, false}, st2.CosignerSigned)
+
+	packet, err := decodePSBTBase64(psbtB64)
+	require.NoError(t, err)
+	rawHex, err := finalizeAndExtract(packet)
+	require.NoError(t, err)
+	rawBytes, err := hex.DecodeString(rawHex)
+	require.NoError(t, err)
+	var tx wire.MsgTx
+	require.NoError(t, tx.Deserialize(bytes.NewReader(rawBytes)))
+
+	prevOut := wire.NewTxOut(fundAmt, recv.scriptPubKey)
+	fetcher := txscript.NewMultiPrevOutFetcher(map[wire.OutPoint]*wire.TxOut{
+		tx.TxIn[0].PreviousOutPoint: prevOut,
+	})
+	sigHashes := txscript.NewTxSigHashes(&tx, fetcher)
+	vm, err := txscript.NewEngine(recv.scriptPubKey, &tx, 0, txscript.StandardVerifyFlags, nil, sigHashes, fundAmt, fetcher)
+	require.NoError(t, err)
+	require.NoError(t, vm.Execute(), "finalized taproot multisig witness must satisfy the script")
+}
+
+// validateFinalizedInput0 runs input 0 of a finalized raw tx through the
+// consensus script engine against its prevout, returning any failure.
+func validateFinalizedInput0(t *testing.T, rawHex string, prevScript []byte, amt int64) {
+	t.Helper()
+	rawBytes, err := hex.DecodeString(rawHex)
+	require.NoError(t, err)
+	var tx wire.MsgTx
+	require.NoError(t, tx.Deserialize(bytes.NewReader(rawBytes)))
+	prevOut := wire.NewTxOut(amt, prevScript)
+	fetcher := txscript.NewMultiPrevOutFetcher(map[wire.OutPoint]*wire.TxOut{tx.TxIn[0].PreviousOutPoint: prevOut})
+	sh := txscript.NewTxSigHashes(&tx, fetcher)
+	vm, err := txscript.NewEngine(prevScript, &tx, 0, txscript.StandardVerifyFlags, nil, sh, amt, fetcher)
+	require.NoError(t, err)
+	require.NoError(t, vm.Execute(), "finalized witness must satisfy the script")
+}
+
+// TestElectrumTaprootMultisigHoldAllKeysCapsAtThreshold covers the over-sign bug:
+// a 2-of-3 taproot wallet that holds ALL three keys signs three times, but the
+// finalizer must cap the witness at exactly m (2) so the multi_a <m> OP_NUMEQUAL
+// holds and the tx is valid.
+func TestElectrumTaprootMultisigHoldAllKeysCapsAtThreshold(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	net := &chaincfg.SigNetParams
+	cosigners := []MultisigCosigner{
+		multisigTestCosigner(t, net, 0, true),
+		multisigTestCosigner(t, net, 1, true),
+		multisigTestCosigner(t, net, 2, true), // hold ALL three
+	}
+	w, err := svc.CreateElectrumMultisig("tr all", nil, 2, 3, "tr", cosigners)
+	require.NoError(t, err)
+	fake := newFakeEsplora()
+	p := NewElectrumBackend(svc, fake, net, zerolog.New(zerolog.NewTestWriter(t)))
+	d, _ := p.walletDescriptor(w)
+	recv, _ := p.deriveAddr(d, false, 0)
+	require.Len(t, recv.multisigPrivs, 3)
+	const amt = int64(200_000)
+	fake.stats[recv.address] = EsploraAddressStats{Address: recv.address, ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: amt, TxCount: 1}}
+	fake.utxos[recv.address] = []EsploraUTXO{{TxID: "6666666666666666666666666666666666666666666666666666666666666666", Vout: 0, Value: amt, Status: EsploraStatus{Confirmed: true, BlockHeight: 100}}}
+
+	psbt, err := p.CreatePSBT(ctx, w.ID, SendRequest{DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000}, FeeRateSatPerVB: 2})
+	require.NoError(t, err)
+	psbt, err = p.SignPSBT(ctx, w.ID, psbt) // signs with all three held keys
+	require.NoError(t, err)
+	st, err := MultisigPsbtSigningStatus(psbt, cosigners)
+	require.NoError(t, err)
+	assert.Equal(t, 3, st.Signatures) // three sigs collected...
+	packet, err := decodePSBTBase64(psbt)
+	require.NoError(t, err)
+	rawHex, err := finalizeAndExtract(packet) // ...but the witness is capped at 2
+	require.NoError(t, err)
+	validateFinalizedInput0(t, rawHex, recv.scriptPubKey, amt)
+}
+
+// TestElectrumTaprootMultisigCombine covers the combinePSBT bug: two cosigners
+// each sign their own copy of the same PSBT, and CombinePSBT must merge both
+// tapscript signatures so the result finalizes to a valid tx.
+func TestElectrumTaprootMultisigCombine(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	net := &chaincfg.SigNetParams
+	cosigners := []MultisigCosigner{
+		multisigTestCosigner(t, net, 0, true),
+		multisigTestCosigner(t, net, 1, true),
+		multisigTestCosigner(t, net, 2, false),
+	}
+	w, err := svc.CreateElectrumMultisig("tr combine", nil, 2, 3, "tr", cosigners)
+	require.NoError(t, err)
+	fake := newFakeEsplora()
+	p := NewElectrumBackend(svc, fake, net, zerolog.New(zerolog.NewTestWriter(t)))
+	d, _ := p.walletDescriptor(w)
+	recv, _ := p.deriveAddr(d, false, 0)
+	const amt = int64(200_000)
+	fake.stats[recv.address] = EsploraAddressStats{Address: recv.address, ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: amt, TxCount: 1}}
+	fake.utxos[recv.address] = []EsploraUTXO{{TxID: "7777777777777777777777777777777777777777777777777777777777777777", Vout: 0, Value: amt, Status: EsploraStatus{Confirmed: true, BlockHeight: 100}}}
+
+	base, err := p.CreatePSBT(ctx, w.ID, SendRequest{DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000}, FeeRateSatPerVB: 2})
+	require.NoError(t, err)
+	// Each cosigner signs their OWN copy of the same base PSBT.
+	copyA, err := p.SignPSBTWithCosigner(ctx, w.ID, base, cosigners[0].Xpub)
+	require.NoError(t, err)
+	copyB, err := p.SignPSBTWithCosigner(ctx, w.ID, base, cosigners[1].Xpub)
+	require.NoError(t, err)
+	combined, err := p.CombinePSBT([]string{copyA, copyB})
+	require.NoError(t, err)
+	st, err := MultisigPsbtSigningStatus(combined, cosigners)
+	require.NoError(t, err)
+	assert.Equal(t, 2, st.Signatures, "combine must merge both cosigners' tapscript sigs")
+	assert.True(t, st.Finalizable)
+	packet, err := decodePSBTBase64(combined)
+	require.NoError(t, err)
+	rawHex, err := finalizeAndExtract(packet)
+	require.NoError(t, err)
+	validateFinalizedInput0(t, rawHex, recv.scriptPubKey, amt)
+}
+
+// TestParseTaprootMultisigRejectsNonNUMS covers the internal-key check: a taproot
+// multisig descriptor with a non-NUMS internal key must be rejected, not silently
+// re-derived under NUMS.
+func TestParseTaprootMultisigRejectsNonNUMS(t *testing.T) {
+	group, _ := loungeTestKeys(t)
+	good, _, err := BuildMultisigLoungeDescriptorsTyped(group, "tr")
+	require.NoError(t, err)
+	_, _, _, _, err = ParseMultisigConfig(good)
+	require.NoError(t, err)
+	// Swap the NUMS internal key for a different (arbitrary) x-only key.
+	bad := strings.Replace(good, numsInternalKeyHex, "0000000000000000000000000000000000000000000000000000000000000001", 1)
+	_, _, _, _, err = ParseMultisigConfig(bad)
+	require.Error(t, err, "a non-NUMS taproot internal key must be rejected")
 }

--- a/sidechain-orchestrator/wallet/engine.go
+++ b/sidechain-orchestrator/wallet/engine.go
@@ -93,6 +93,15 @@ func (e *WalletEngine) SignPSBT(ctx context.Context, walletID, psbtBase64 string
 	return eb.SignPSBT(ctx, walletID, psbtBase64)
 }
 
+// SignPSBTWithCosigner adds a single multisig cosigner's signature to a PSBT.
+func (e *WalletEngine) SignPSBTWithCosigner(ctx context.Context, walletID, psbtBase64, cosignerXpub string) (string, error) {
+	eb, err := e.electrumBackend()
+	if err != nil {
+		return "", err
+	}
+	return eb.SignPSBTWithCosigner(ctx, walletID, psbtBase64, cosignerXpub)
+}
+
 // CombinePSBT merges cosigner PSBTs of the same transaction.
 func (e *WalletEngine) CombinePSBT(psbtsBase64 []string) (string, error) {
 	eb, err := e.electrumBackend()
@@ -109,6 +118,15 @@ func (e *WalletEngine) FinalizePSBT(psbtBase64 string) (string, error) {
 		return "", err
 	}
 	return eb.FinalizePSBT(psbtBase64)
+}
+
+func (e *WalletEngine) RefreshElectrumScan(ctx context.Context, walletID string) error {
+	eb, err := e.electrumBackend()
+	if err != nil {
+		return nil
+	}
+	_, err = eb.scan(ctx, walletID, false)
+	return err
 }
 
 // ElectrumServerURL returns the electrum wallet's current Esplora endpoint.

--- a/sidechain-orchestrator/wallet/multisig_config_import.go
+++ b/sidechain-orchestrator/wallet/multisig_config_import.go
@@ -1,0 +1,170 @@
+package wallet
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// scriptTypeFromFormat maps a wallet-config address/format label (P2WSH,
+// P2SH-P2WSH, P2SH) to the descriptor script-type string.
+func scriptTypeFromFormat(s string) string {
+	switch strings.ToUpper(strings.ReplaceAll(s, " ", "")) {
+	case "P2SH":
+		return "sh"
+	case "P2SH-P2WSH", "P2WSH-P2SH":
+		return "sh-wsh"
+	case "P2TR":
+		return "tr"
+	default:
+		return "wsh"
+	}
+}
+
+// normalizeCosignerXpub rewrites a SLIP-0132 extended key (Zpub/Ypub/…) to its
+// canonical xpub/tpub so parsed cosigners sort and store consistently.
+func normalizeCosignerXpub(x string) (string, error) {
+	canonical, _, _, err := normalizeExtendedKey(strings.TrimSpace(x))
+	if err != nil {
+		return "", err
+	}
+	return canonical, nil
+}
+
+func stripMasterPrefix(path string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(path, "m/"), "M/")
+}
+
+func isHexFingerprint(s string) bool {
+	if len(s) != 8 {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
+}
+
+// parseColdcardConfig parses a Coldcard-style multisig text config:
+//
+//	Name: ...
+//	Policy: 2 of 3
+//	Derivation: m/48'/0'/0'/2'
+//	Format: P2WSH
+//	<XFP>: <xpub>
+func parseColdcardConfig(content string) (m, n int, scriptType string, cosigners []MultisigCosigner, err error) {
+	scriptType = "wsh"
+	derivation := ""
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, val, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
+		switch strings.ToLower(key) {
+		case "policy":
+			fields := strings.Fields(val) // "2 of 3"
+			if len(fields) >= 3 {
+				m, _ = strconv.Atoi(fields[0])
+				n, _ = strconv.Atoi(fields[2])
+			}
+		case "derivation":
+			derivation = stripMasterPrefix(val)
+		case "format":
+			scriptType = scriptTypeFromFormat(val)
+		case "name":
+			// display name only
+		default:
+			if isHexFingerprint(key) {
+				xpub, nerr := normalizeCosignerXpub(val)
+				if nerr != nil {
+					continue // an 8-hex key whose value is not an xpub is not a cosigner line
+				}
+				cosigners = append(cosigners, MultisigCosigner{
+					Xpub:        xpub,
+					Fingerprint: strings.ToLower(key),
+					OriginPath:  derivation,
+				})
+			}
+		}
+	}
+	if len(cosigners) == 0 {
+		return 0, 0, "", nil, errors.New("no cosigner keys found in config")
+	}
+	if n == 0 {
+		n = len(cosigners)
+	}
+	if m < 1 || m > n {
+		return 0, 0, "", nil, fmt.Errorf("invalid policy %d-of-%d", m, n)
+	}
+	if len(cosigners) != n {
+		return 0, 0, "", nil, fmt.Errorf("policy declares %d cosigners but %d keys are listed", n, len(cosigners))
+	}
+	return m, n, scriptType, cosigners, nil
+}
+
+// parseMultisigJSON parses a Sparrow/Specter export (carries a descriptor) or a
+// Caravan config (quorum + extendedPublicKeys).
+func parseMultisigJSON(content string) (m, n int, scriptType string, cosigners []MultisigCosigner, err error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(content), &raw); err != nil {
+		return 0, 0, "", nil, fmt.Errorf("parse json config: %w", err)
+	}
+	// Sparrow/Specter exports usually carry the output descriptor directly.
+	for _, field := range []string{"descriptor", "recv_descriptor", "receive_descriptor"} {
+		if v, ok := raw[field]; ok {
+			var s string
+			if json.Unmarshal(v, &s) == nil && strings.Contains(s, "(") {
+				return ParseMultisigDescriptor(s)
+			}
+		}
+	}
+	if _, ok := raw["extendedPublicKeys"]; ok {
+		return parseCaravanJSON(content)
+	}
+	return 0, 0, "", nil, errors.New("unrecognized JSON multisig config")
+}
+
+func parseCaravanJSON(content string) (m, n int, scriptType string, cosigners []MultisigCosigner, err error) {
+	var cfg struct {
+		AddressType string `json:"addressType"`
+		Quorum      struct {
+			RequiredSigners int `json:"requiredSigners"`
+			TotalSigners    int `json:"totalSigners"`
+		} `json:"quorum"`
+		ExtendedPublicKeys []struct {
+			XFP       string `json:"xfp"`
+			Bip32Path string `json:"bip32Path"`
+			Xpub      string `json:"xpub"`
+		} `json:"extendedPublicKeys"`
+	}
+	if err := json.Unmarshal([]byte(content), &cfg); err != nil {
+		return 0, 0, "", nil, fmt.Errorf("parse caravan config: %w", err)
+	}
+	scriptType = scriptTypeFromFormat(cfg.AddressType)
+	for _, k := range cfg.ExtendedPublicKeys {
+		xpub, nerr := normalizeCosignerXpub(k.Xpub)
+		if nerr != nil {
+			return 0, 0, "", nil, fmt.Errorf("cosigner %s: %w", k.XFP, nerr)
+		}
+		cosigners = append(cosigners, MultisigCosigner{
+			Xpub:        xpub,
+			Fingerprint: strings.ToLower(k.XFP),
+			OriginPath:  stripMasterPrefix(k.Bip32Path),
+		})
+	}
+	m, n = cfg.Quorum.RequiredSigners, cfg.Quorum.TotalSigners
+	if n == 0 {
+		n = len(cosigners)
+	}
+	if m < 1 || m > n || len(cosigners) != n {
+		return 0, 0, "", nil, fmt.Errorf("invalid caravan config: %d-of-%d with %d keys", m, n, len(cosigners))
+	}
+	return m, n, scriptType, cosigners, nil
+}

--- a/sidechain-orchestrator/wallet/multisiglounge.go
+++ b/sidechain-orchestrator/wallet/multisiglounge.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sort"
@@ -53,6 +54,67 @@ func sortKeysByBIP67(keys []MultisigLoungeKey) []MultisigLoungeKey {
 // (xpub-string) sort, so every cosigner ranges over the same chain/index. This
 // must derive the same address set as the signing descriptor, or spends break.
 func BuildMultisigLoungeDescriptors(g MultisigLoungeGroup) (receive, change string, err error) {
+	return BuildMultisigLoungeDescriptorsTyped(g, "")
+}
+
+// multisigScriptKind maps a descriptor script-type string (as sent by the
+// frontend) to a ScriptKind. An empty/unknown value defaults to native P2WSH.
+func multisigScriptKind(scriptType string) ScriptKind {
+	switch scriptType {
+	case "sh", "legacy", "p2sh":
+		return ScriptMultisigP2SH
+	case "sh-wsh", "nested", "p2sh-p2wsh":
+		return ScriptMultisigNested
+	case "tr", "taproot", "p2tr":
+		return ScriptMultisigTaproot
+	default:
+		return ScriptMultisig
+	}
+}
+
+// multisigTypeString maps a multisig ScriptKind back to its descriptor
+// script-type string ("wsh", "sh-wsh", or "sh").
+func multisigTypeString(k ScriptKind) string {
+	switch k {
+	case ScriptMultisigP2SH:
+		return "sh"
+	case ScriptMultisigNested:
+		return "sh-wsh"
+	case ScriptMultisigTaproot:
+		return "tr"
+	default:
+		return "wsh"
+	}
+}
+
+// multisigDescriptorBody assembles the full descriptor body for a policy: the
+// tr(NUMS,sortedmulti_a(...)) form for taproot, or the sh/wsh sortedmulti wrapper
+// otherwise. parts are the per-key expressions (already including their ranges).
+func multisigDescriptorBody(kind ScriptKind, m int, parts []string) string {
+	joined := strings.Join(parts, ",")
+	if kind == ScriptMultisigTaproot {
+		return fmt.Sprintf("tr(%s,sortedmulti_a(%d,%s))", numsInternalKeyHex, m, joined)
+	}
+	return wrapMultisig(kind, fmt.Sprintf("sortedmulti(%d,%s)", m, joined))
+}
+
+// wrapMultisig wraps a bare "sortedmulti(...)" body in the script-kind's outer
+// descriptor: sh() for legacy P2SH, sh(wsh()) for nested, wsh() for native.
+func wrapMultisig(kind ScriptKind, inner string) string {
+	switch kind {
+	case ScriptMultisigP2SH:
+		return "sh(" + inner + ")"
+	case ScriptMultisigNested:
+		return "sh(wsh(" + inner + "))"
+	default:
+		return "wsh(" + inner + ")"
+	}
+}
+
+// BuildMultisigLoungeDescriptorsTyped is BuildMultisigLoungeDescriptors for a
+// chosen multisig script type ("wsh", "sh-wsh", or "sh"); an empty type is
+// native P2WSH.
+func BuildMultisigLoungeDescriptorsTyped(g MultisigLoungeGroup, scriptType string) (receive, change string, err error) {
 	if g.M < 1 {
 		return "", "", fmt.Errorf("invalid threshold m=%d", g.M)
 	}
@@ -60,6 +122,7 @@ func BuildMultisigLoungeDescriptors(g MultisigLoungeGroup) (receive, change stri
 		return "", "", errors.New("group has no keys")
 	}
 
+	kind := multisigScriptKind(scriptType)
 	sorted := sortKeysByBIP67(g.Keys)
 	receiveParts := make([]string, len(sorted))
 	changeParts := make([]string, len(sorted))
@@ -71,8 +134,8 @@ func BuildMultisigLoungeDescriptors(g MultisigLoungeGroup) (receive, change stri
 		changeParts[i] = k.keyDescriptor() + "/1/*"
 	}
 
-	receiveBody := fmt.Sprintf("wsh(sortedmulti(%d,%s))", g.M, strings.Join(receiveParts, ","))
-	changeBody := fmt.Sprintf("wsh(sortedmulti(%d,%s))", g.M, strings.Join(changeParts, ","))
+	receiveBody := multisigDescriptorBody(kind, g.M, receiveParts)
+	changeBody := multisigDescriptorBody(kind, g.M, changeParts)
 
 	receive, err = AddDescriptorChecksum(receiveBody)
 	if err != nil {
@@ -99,6 +162,13 @@ func BuildMultisigLoungeDescriptors(g MultisigLoungeGroup) (receive, change stri
 // map keep their xpub (cosigners). Descriptors carry no checksum — bitcoind
 // accepts unchecksummed descriptors and adds its own.
 func BuildMultisigSigningDescriptors(g MultisigLoungeGroup, signWithXprv map[string]string) (receive, change string, err error) {
+	return BuildMultisigSigningDescriptorsTyped(g, signWithXprv, "")
+}
+
+// BuildMultisigSigningDescriptorsTyped is BuildMultisigSigningDescriptors for a
+// chosen multisig script type ("wsh", "sh-wsh", or "sh"); an empty type is
+// native P2WSH.
+func BuildMultisigSigningDescriptorsTyped(g MultisigLoungeGroup, signWithXprv map[string]string, scriptType string) (receive, change string, err error) {
 	if g.M < 1 {
 		return "", "", fmt.Errorf("invalid threshold m=%d", g.M)
 	}
@@ -109,6 +179,7 @@ func BuildMultisigSigningDescriptors(g MultisigLoungeGroup, signWithXprv map[str
 		return "", "", errors.New("no signing keys provided")
 	}
 
+	kind := multisigScriptKind(scriptType)
 	sorted := sortKeysByBIP67(g.Keys)
 	receiveParts := make([]string, len(sorted))
 	changeParts := make([]string, len(sorted))
@@ -130,8 +201,8 @@ func BuildMultisigSigningDescriptors(g MultisigLoungeGroup, signWithXprv map[str
 		return "", "", errors.New("none of the signing keys matched a group key")
 	}
 
-	receive = fmt.Sprintf("wsh(sortedmulti(%d,%s))", g.M, strings.Join(receiveParts, ","))
-	change = fmt.Sprintf("wsh(sortedmulti(%d,%s))", g.M, strings.Join(changeParts, ","))
+	receive = multisigDescriptorBody(kind, g.M, receiveParts)
+	change = multisigDescriptorBody(kind, g.M, changeParts)
 	return receive, change, nil
 }
 
@@ -177,6 +248,14 @@ func ValidateMultisigPsbt(psbtBase64 string, requiredSigs int, group *MultisigLo
 		}
 	}
 
+	// Taproot script-path multisig keeps signatures in TaprootScriptSpendSig and
+	// is finalizable at exactly its multi_a threshold.
+	for i := range packet.Inputs {
+		if len(packet.Inputs[i].TaprootLeafScript) > 0 {
+			return validateTaprootMultisigPsbt(packet, requiredSigs), nil
+		}
+	}
+
 	maxSigs := 0
 	allMeetThreshold := true
 	for i := range packet.Inputs {
@@ -202,6 +281,138 @@ func ValidateMultisigPsbt(psbtBase64 string, requiredSigs int, group *MultisigLo
 		IsComplete:     allMeetThreshold,
 		Finalizable:    finalizable,
 	}, nil
+}
+
+// ParseMultisigConfig parses a multisig wallet definition — an output descriptor,
+// a Coldcard text config, or a Sparrow/Specter/Caravan JSON export — into its
+// threshold, script type, and cosigners.
+func ParseMultisigConfig(content string) (m, n int, scriptType string, cosigners []MultisigCosigner, err error) {
+	trimmed := strings.TrimSpace(content)
+	switch {
+	case strings.HasPrefix(trimmed, "{"):
+		return parseMultisigJSON(trimmed)
+	case strings.HasPrefix(trimmed, "wsh(") || strings.HasPrefix(trimmed, "sh(") || strings.HasPrefix(trimmed, "tr("):
+		return ParseMultisigDescriptor(trimmed)
+	default:
+		return parseColdcardConfig(trimmed)
+	}
+}
+
+// ParseMultisigDescriptor parses a wsh/sh/sh-wsh sortedmulti descriptor into its
+// threshold, script type, and watch-only cosigners (public keys + key origins).
+func ParseMultisigDescriptor(descriptor string) (m, n int, scriptType string, cosigners []MultisigCosigner, err error) {
+	d, err := ParseDescriptor(strings.TrimSpace(descriptor))
+	if err != nil {
+		return 0, 0, "", nil, err
+	}
+	if !d.Kind.isMultisig() && !d.Kind.isTaprootMultisig() {
+		return 0, 0, "", nil, errors.New("not a multisig descriptor")
+	}
+	cosigners = make([]MultisigCosigner, 0, len(d.Keys))
+	for _, k := range d.Keys {
+		acct := k.Account
+		if acct.IsPrivate() {
+			pub, nerr := acct.Neuter()
+			if nerr != nil {
+				return 0, 0, "", nil, fmt.Errorf("neuter key: %w", nerr)
+			}
+			acct = pub
+		}
+		fp, origin := splitOrigin(k.Origin)
+		cosigners = append(cosigners, MultisigCosigner{
+			Xpub:        acct.String(),
+			Fingerprint: fp,
+			OriginPath:  origin,
+		})
+	}
+	return d.Threshold, len(d.Keys), multisigTypeString(d.Kind), cosigners, nil
+}
+
+// splitOrigin splits a descriptor key origin "fingerprint/path" into its parts,
+// normalizing hardened markers (h/H) to "'". Empty when there is no origin.
+func splitOrigin(origin string) (fingerprint, path string) {
+	if origin == "" {
+		return "", ""
+	}
+	origin = strings.ReplaceAll(origin, "h", "'")
+	origin = strings.ReplaceAll(origin, "H", "'")
+	if fp, path, found := strings.Cut(origin, "/"); found {
+		return fp, path
+	}
+	return origin, ""
+}
+
+// MultisigSigningStatus reports a PSBT's signing progress for a multisig wallet.
+type MultisigSigningStatus struct {
+	Signatures     int    // max partial-signature count across inputs
+	Finalizable    bool   // the finalizer can produce a complete transaction
+	CosignerSigned []bool // aligned to the cosigners; true where that leg signed
+}
+
+// MultisigPsbtSigningStatus decodes a PSBT and reports the signature count,
+// whether it can be finalized, and which cosigners have signed. A cosigner is
+// credited when one of its origin's pubkeys (fingerprint + origin-path prefix)
+// carries a partial signature, so cosigners sharing a master fingerprint are
+// still told apart by their derivation path.
+func MultisigPsbtSigningStatus(psbtBase64 string, cosigners []MultisigCosigner) (MultisigSigningStatus, error) {
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(psbtBase64))
+	if err != nil {
+		return MultisigSigningStatus{}, fmt.Errorf("decode base64 psbt: %w", err)
+	}
+	packet, err := psbt.NewFromRawBytes(strings.NewReader(string(raw)), false)
+	if err != nil {
+		return MultisigSigningStatus{}, fmt.Errorf("parse psbt: %w", err)
+	}
+
+	// Taproot script-path multisig carries its signatures in a different field set.
+	for i := range packet.Inputs {
+		if len(packet.Inputs[i].TaprootLeafScript) > 0 {
+			return taprootMultisigStatus(packet, cosigners)
+		}
+	}
+
+	maxSigs := 0
+	signedPub := map[string]bool{}
+	for i := range packet.Inputs {
+		if n := len(packet.Inputs[i].PartialSigs); n > maxSigs {
+			maxSigs = n
+		}
+		for _, ps := range packet.Inputs[i].PartialSigs {
+			signedPub[hex.EncodeToString(ps.PubKey)] = true
+		}
+	}
+
+	finalizable := false
+	if clone, err := clonePacket(packet); err == nil {
+		if err := psbt.MaybeFinalizeAll(clone); err == nil {
+			finalizable = clone.IsComplete()
+		}
+	}
+
+	cosignerSigned := make([]bool, len(cosigners))
+	for ci, c := range cosigners {
+		fp, path, ok := parseOrigin(c.Fingerprint + "/" + c.OriginPath)
+		if !ok {
+			continue
+		}
+		origins := []keyOrigin{{fingerprint: fp, path: path}}
+		for i := range packet.Inputs {
+			for _, d := range packet.Inputs[i].Bip32Derivation {
+				if !signedPub[hex.EncodeToString(d.PubKey)] {
+					continue
+				}
+				if originMatches(d.MasterKeyFingerprint, d.Bip32Path, origins) {
+					cosignerSigned[ci] = true
+					break
+				}
+			}
+			if cosignerSigned[ci] {
+				break
+			}
+		}
+	}
+
+	return MultisigSigningStatus{Signatures: maxSigs, Finalizable: finalizable, CosignerSigned: cosignerSigned}, nil
 }
 
 // keyOrigin is one cosigner's master fingerprint plus account-level origin path,
@@ -238,6 +449,14 @@ func groupKeyOrigins(g MultisigLoungeGroup) ([]keyOrigin, error) {
 // (fingerprint + account path prefix). Derivation-independent — it matches on the
 // origin metadata the PSBT carries, not on re-derived addresses.
 func verifyInputBelongsToGroup(in psbt.PInput, origins []keyOrigin) error {
+	if len(in.TaprootBip32Derivation) > 0 {
+		for _, d := range in.TaprootBip32Derivation {
+			if !originMatches(d.MasterKeyFingerprint, d.Bip32Path, origins) {
+				return errors.New("does not belong to the multisig group (foreign input rejected)")
+			}
+		}
+		return nil
+	}
 	if len(in.Bip32Derivation) == 0 {
 		return errors.New("has no BIP32 derivation records; cannot verify it belongs to the group")
 	}

--- a/sidechain-orchestrator/wallet/multisiglounge_test.go
+++ b/sidechain-orchestrator/wallet/multisiglounge_test.go
@@ -76,6 +76,33 @@ func TestBuildDescriptorsGoldenParity(t *testing.T) {
 	assert.Equal(t, wantChange, change)
 }
 
+// TestBuildDescriptorsScriptTypes verifies the typed builder emits the correct
+// outer wrapper per multisig script type, and that the receive descriptor
+// round-trips through ParseDescriptor (the form the watch-only path parses).
+func TestBuildDescriptorsScriptTypes(t *testing.T) {
+	group, _ := loungeTestKeys(t)
+	cases := []struct {
+		scriptType string
+		prefix     string
+	}{
+		{"wsh", "wsh(sortedmulti("},
+		{"sh-wsh", "sh(wsh(sortedmulti("},
+		{"sh", "sh(sortedmulti("},
+		{"tr", "tr("},
+	}
+	for _, tc := range cases {
+		t.Run(tc.scriptType, func(t *testing.T) {
+			receive, change, err := BuildMultisigLoungeDescriptorsTyped(group, tc.scriptType)
+			require.NoError(t, err)
+			assert.True(t, strings.HasPrefix(receive, tc.prefix), "receive %q", receive)
+			assert.True(t, strings.HasPrefix(change, tc.prefix), "change %q", change)
+			// The receive descriptor must parse; change (/1/*) is derived from it.
+			_, err = ParseDescriptor(receive)
+			require.NoError(t, err)
+		})
+	}
+}
+
 // TestBuildDescriptorsBIP67Order asserts the key descriptors are emitted in
 // ascending xpub-string order regardless of input order, matching the Dart
 // _sortKeysByBIP67 (which sorts by xpub string, not serialized pubkey).
@@ -717,4 +744,71 @@ func TestMultisigSignMultiOwnedKeyE2E(t *testing.T) {
 	var afterBalance float64
 	rt.walletRPC(t, "ms", &afterBalance, "getbalance")
 	require.Less(t, afterBalance, msBalance, "balance must drop after the single-call multi-key spend")
+}
+
+// TestParseMultisigDescriptorRoundTrip parses a built watch-only descriptor back
+// into its policy + cosigners, matching the original group.
+func TestParseMultisigDescriptorRoundTrip(t *testing.T) {
+	group, _ := loungeTestKeys(t)
+	receive, _, err := BuildMultisigLoungeDescriptorsTyped(group, "wsh")
+	require.NoError(t, err)
+
+	m, n, scriptType, cosigners, err := ParseMultisigConfig(receive)
+	require.NoError(t, err)
+	assert.Equal(t, 2, m)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, "wsh", scriptType)
+	require.Len(t, cosigners, 3)
+	// Every parsed cosigner xpub must be one of the group's keys, with its origin.
+	groupXpubs := map[string]bool{}
+	for _, k := range group.Keys {
+		groupXpubs[k.Xpub] = true
+	}
+	for _, c := range cosigners {
+		assert.True(t, groupXpubs[c.Xpub], "parsed xpub %s must be a group key", c.Xpub)
+		assert.Equal(t, "73c5da0a", c.Fingerprint)
+		assert.Contains(t, c.OriginPath, "48'/1'/0'/")
+	}
+}
+
+// TestParseColdcardAndCaravanConfig parses a Coldcard text config and a Caravan
+// JSON export into the same 2-of-3 policy + cosigners, normalizing SLIP-132 keys.
+func TestParseColdcardAndCaravanConfig(t *testing.T) {
+	group, _ := loungeTestKeys(t) // tpub cosigners at 48'/1'/0'/{2,3,4}'
+	k := group.Keys
+
+	coldcard := "# Coldcard Multisig setup file\n" +
+		"Name: Test\n" +
+		"Policy: 2 of 3\n" +
+		"Derivation: m/48'/1'/0'/2'\n" +
+		"Format: P2WSH\n\n" +
+		"73C5DA0A: " + k[0].Xpub + "\n" +
+		"73C5DA0A: " + k[1].Xpub + "\n" +
+		"73C5DA0A: " + k[2].Xpub + "\n"
+
+	m, n, scriptType, cosigners, err := ParseMultisigConfig(coldcard)
+	require.NoError(t, err)
+	assert.Equal(t, 2, m)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, "wsh", scriptType)
+	require.Len(t, cosigners, 3)
+	assert.Equal(t, k[0].Xpub, cosigners[0].Xpub)
+	assert.Equal(t, "73c5da0a", cosigners[0].Fingerprint)
+	assert.Equal(t, "48'/1'/0'/2'", cosigners[0].OriginPath)
+
+	caravan := fmt.Sprintf(`{"name":"t","addressType":"P2WSH",`+
+		`"quorum":{"requiredSigners":2,"totalSigners":3},`+
+		`"extendedPublicKeys":[`+
+		`{"xfp":"73C5DA0A","bip32Path":"m/48'/1'/0'/2'","xpub":"%s"},`+
+		`{"xfp":"73C5DA0A","bip32Path":"m/48'/1'/0'/3'","xpub":"%s"},`+
+		`{"xfp":"73C5DA0A","bip32Path":"m/48'/1'/0'/4'","xpub":"%s"}]}`,
+		k[0].Xpub, k[1].Xpub, k[2].Xpub)
+
+	m2, n2, st2, cos2, err := ParseMultisigConfig(caravan)
+	require.NoError(t, err)
+	assert.Equal(t, 2, m2)
+	assert.Equal(t, 3, n2)
+	assert.Equal(t, "wsh", st2)
+	require.Len(t, cos2, 3)
+	assert.Equal(t, "48'/1'/0'/4'", cos2[2].OriginPath)
 }

--- a/sidechain-orchestrator/wallet/psbt.go
+++ b/sidechain-orchestrator/wallet/psbt.go
@@ -41,7 +41,7 @@ type keyDerivation struct {
 // in/out is non-nil.
 func addBip32Derivations(in *psbt.PInput, out *psbt.POutput, kind ScriptKind, ds []keyDerivation) {
 	for _, kd := range ds {
-		if kind == ScriptTaproot {
+		if kind == ScriptTaproot || kind.isTaprootMultisig() {
 			tap := &psbt.TaprootBip32Derivation{
 				XOnlyPubKey:          schnorr.SerializePubKey(kd.pub),
 				LeafHashes:           [][]byte{},
@@ -144,10 +144,15 @@ func buildPSBT(inputs []psbtInput, outputs []TxOutSpec, net *chaincfg.Params, pr
 		}
 		if in.addr.kind == ScriptTaproot {
 			packet.Inputs[i].TaprootInternalKey = schnorr.SerializePubKey(in.addr.tapInternal)
-		} else if err := updater.AddInSighashType(txscript.SigHashAll, i); err != nil {
-			return nil, err
+			addBip32Derivations(&packet.Inputs[i], nil, in.addr.kind, in.addr.derivations)
+		} else if in.addr.kind.isTaprootMultisig() {
+			addTaprootMultisigInputFields(&packet.Inputs[i], in.addr)
+		} else {
+			if err := updater.AddInSighashType(txscript.SigHashAll, i); err != nil {
+				return nil, err
+			}
+			addBip32Derivations(&packet.Inputs[i], nil, in.addr.kind, in.addr.derivations)
 		}
-		addBip32Derivations(&packet.Inputs[i], nil, in.addr.kind, in.addr.derivations)
 	}
 
 	// Mark owned change outputs so a signer can verify them as its own.
@@ -203,6 +208,9 @@ func signPSBTInput(
 ) (int, error) {
 	if in.addr.kind.isMultisig() {
 		return signMultisigInput(packet, i, in, tx, sigHashes, net)
+	}
+	if in.addr.kind.isTaprootMultisig() {
+		return signTaprootMultisigInput(packet, i, in, tx, sigHashes)
 	}
 	priv := in.addr.priv
 	if priv == nil {
@@ -265,6 +273,15 @@ func prevOutForInput(packet *psbt.Packet, i int) *wire.TxOut {
 
 // finalizeAndExtract finalizes a fully-signed PSBT and returns the raw tx hex.
 func finalizeAndExtract(packet *psbt.Packet) (string, error) {
+	// tr(sortedmulti_a) inputs are finalized by assembling the tapscript witness
+	// ourselves; the generic finalizer then sees them as already final.
+	for i := range packet.Inputs {
+		if len(packet.Inputs[i].TaprootLeafScript) > 0 {
+			if err := finalizeTaprootMultisigInput(packet, i); err != nil {
+				return "", fmt.Errorf("finalize taproot multisig input %d: %w", i, err)
+			}
+		}
+	}
 	if err := psbt.MaybeFinalizeAll(packet); err != nil {
 		return "", fmt.Errorf("finalize psbt: %w", err)
 	}
@@ -371,6 +388,35 @@ func combinePSBT(base *psbt.Packet, others ...*psbt.Packet) error {
 			}
 			if bi.TaprootKeySpendSig == nil && len(oi.TaprootKeySpendSig) > 0 {
 				bi.TaprootKeySpendSig = oi.TaprootKeySpendSig
+			}
+			// Taproot script-path (multi_a) multisig: merge each cosigner's
+			// tapscript signature and the leaf/derivation metadata, so the
+			// sign-a-copy-each-then-combine flow reaches the threshold.
+			for _, s := range oi.TaprootScriptSpendSig {
+				if !hasTapScriptSig(bi.TaprootScriptSpendSig, s.XOnlyPubKey, s.LeafHash) {
+					bi.TaprootScriptSpendSig = append(bi.TaprootScriptSpendSig, s)
+				}
+			}
+			if len(bi.TaprootLeafScript) == 0 {
+				bi.TaprootLeafScript = oi.TaprootLeafScript
+			}
+			if len(bi.TaprootInternalKey) == 0 {
+				bi.TaprootInternalKey = oi.TaprootInternalKey
+			}
+			if len(bi.TaprootMerkleRoot) == 0 {
+				bi.TaprootMerkleRoot = oi.TaprootMerkleRoot
+			}
+			for _, d := range oi.TaprootBip32Derivation {
+				found := false
+				for _, e := range bi.TaprootBip32Derivation {
+					if bytes.Equal(e.XOnlyPubKey, d.XOnlyPubKey) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					bi.TaprootBip32Derivation = append(bi.TaprootBip32Derivation, d)
+				}
 			}
 		}
 	}

--- a/sidechain-orchestrator/wallet/scripttype.go
+++ b/sidechain-orchestrator/wallet/scripttype.go
@@ -19,19 +19,27 @@ import (
 type ScriptKind int
 
 const (
-	ScriptUnknown        ScriptKind = iota
-	ScriptLegacy                    // P2PKH, BIP44 (purpose 44')
-	ScriptNestedSegwit              // P2SH-P2WPKH, BIP49 (purpose 49')
-	ScriptNativeSegwit              // P2WPKH, BIP84 (purpose 84')
-	ScriptTaproot                   // P2TR key-path, BIP86 (purpose 86')
-	ScriptMultisig                  // wsh(sortedmulti): P2WSH
-	ScriptMultisigP2SH              // sh(sortedmulti): legacy P2SH
-	ScriptMultisigNested            // sh(wsh(sortedmulti)): P2SH-P2WSH
+	ScriptUnknown         ScriptKind = iota
+	ScriptLegacy                     // P2PKH, BIP44 (purpose 44')
+	ScriptNestedSegwit               // P2SH-P2WPKH, BIP49 (purpose 49')
+	ScriptNativeSegwit               // P2WPKH, BIP84 (purpose 84')
+	ScriptTaproot                    // P2TR key-path, BIP86 (purpose 86')
+	ScriptMultisig                   // wsh(sortedmulti): P2WSH
+	ScriptMultisigP2SH               // sh(sortedmulti): legacy P2SH
+	ScriptMultisigNested             // sh(wsh(sortedmulti)): P2SH-P2WSH
+	ScriptMultisigTaproot            // tr(NUMS,sortedmulti_a): P2TR script path
 )
 
-// isMultisig reports whether the kind is one of the sortedmulti wrappers.
+// isMultisig reports whether the kind is one of the P2WSH/P2SH sortedmulti
+// wrappers (signed with ECDSA partial sigs). Taproot multisig is separate.
 func (k ScriptKind) isMultisig() bool {
 	return k == ScriptMultisig || k == ScriptMultisigP2SH || k == ScriptMultisigNested
+}
+
+// isTaprootMultisig reports whether the kind is a tr(sortedmulti_a) script-path
+// multisig (signed with BIP342 tapscript schnorr signatures).
+func (k ScriptKind) isTaprootMultisig() bool {
+	return k == ScriptMultisigTaproot
 }
 
 // isNonWitness reports whether spending an input of this kind needs the full
@@ -88,6 +96,8 @@ func parseScriptKind(s string) ScriptKind {
 		return ScriptMultisigP2SH
 	case "multisig-nested":
 		return ScriptMultisigNested
+	case "multisig-taproot":
+		return ScriptMultisigTaproot
 	default:
 		return ScriptNativeSegwit
 	}
@@ -109,6 +119,8 @@ func (k ScriptKind) String() string {
 		return "multisig-p2sh"
 	case ScriptMultisigNested:
 		return "multisig-nested"
+	case ScriptMultisigTaproot:
+		return "multisig-taproot"
 	default:
 		return "unknown"
 	}
@@ -117,11 +129,13 @@ func (k ScriptKind) String() string {
 // derivedScript is the fully resolved output for one address: its encoded
 // address, scriptPubKey, and the auxiliary scripts/keys a signer needs.
 type derivedScript struct {
-	address       btcutil.Address
-	scriptPubKey  []byte
-	redeemScript  []byte // P2SH-P2WPKH: the witness program wrapped by the P2SH
-	witnessScript []byte // P2WSH multisig: the k-of-n script
-	tapInternal   *btcec.PublicKey
+	address         btcutil.Address
+	scriptPubKey    []byte
+	redeemScript    []byte // P2SH-P2WPKH: the witness program wrapped by the P2SH
+	witnessScript   []byte // P2WSH multisig: the k-of-n script
+	tapLeafScript   []byte // tr sortedmulti_a: the tapleaf multi_a script
+	tapControlBlock []byte // tr sortedmulti_a: the leaf's control block
+	tapInternal     *btcec.PublicKey
 }
 
 // singleSigOutput builds the address and scripts for one compressed pubkey
@@ -207,6 +221,10 @@ func multisigWitnessScript(threshold int, pubs []*btcec.PublicKey, net *chaincfg
 // the given multisig kind: P2WSH (native), P2SH (legacy), or P2SH-P2WSH (nested).
 // The k-of-n script is the witness/redeem script depending on the wrapper.
 func multisigOutput(kind ScriptKind, threshold int, pubs []*btcec.PublicKey, net *chaincfg.Params) (derivedScript, error) {
+	if kind == ScriptMultisigTaproot {
+		return taprootMultisigOutput(threshold, pubs, net)
+	}
+
 	ms, err := multisigWitnessScript(threshold, pubs, net)
 	if err != nil {
 		return derivedScript{}, err

--- a/sidechain-orchestrator/wallet/scripttype_taproot.go
+++ b/sidechain-orchestrator/wallet/scripttype_taproot.go
@@ -1,0 +1,391 @@
+package wallet
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// numsInternalKeyHex is the BIP341 nothing-up-my-sleeve point H (x-only), used
+// as the unspendable taproot internal key for script-path-only multisig wallets,
+// matching Bitcoin Core's tr(sortedmulti_a) convention.
+const numsInternalKeyHex = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+
+func numsInternalKey() (*btcec.PublicKey, error) {
+	b, err := hex.DecodeString(numsInternalKeyHex)
+	if err != nil {
+		return nil, err
+	}
+	return schnorr.ParsePubKey(b)
+}
+
+// multiAScript builds a BIP342 sortedmulti_a tapleaf script for a k-of-n policy:
+// x-only pubkeys sorted lexicographically, checked with CHECKSIG/CHECKSIGADD,
+// then <k> OP_NUMEQUAL.
+func multiAScript(threshold int, pubs []*btcec.PublicKey) ([]byte, error) {
+	xonly := make([][]byte, len(pubs))
+	for i, p := range pubs {
+		xonly[i] = schnorr.SerializePubKey(p)
+	}
+	sort.Slice(xonly, func(i, j int) bool { return bytesLess(xonly[i], xonly[j]) })
+
+	b := txscript.NewScriptBuilder()
+	for i, x := range xonly {
+		b.AddData(x)
+		if i == 0 {
+			b.AddOp(txscript.OP_CHECKSIG)
+		} else {
+			b.AddOp(txscript.OP_CHECKSIGADD)
+		}
+	}
+	b.AddInt64(int64(threshold))
+	b.AddOp(txscript.OP_NUMEQUAL)
+	return b.Script()
+}
+
+// taprootMultisigOutput builds the P2TR output for a sortedmulti_a policy: the
+// tapleaf multi_a script committed under the NUMS internal key. The returned
+// derivedScript carries the leaf script + control block needed to sign/finalize.
+func taprootMultisigOutput(threshold int, pubs []*btcec.PublicKey, net *chaincfg.Params) (derivedScript, error) {
+	internal, err := numsInternalKey()
+	if err != nil {
+		return derivedScript{}, err
+	}
+	leafScript, err := multiAScript(threshold, pubs)
+	if err != nil {
+		return derivedScript{}, err
+	}
+	leaf := txscript.NewBaseTapLeaf(leafScript)
+	tree := txscript.AssembleTaprootScriptTree(leaf)
+	root := tree.RootNode.TapHash()
+	outputKey := txscript.ComputeTaprootOutputKey(internal, root[:])
+	addr, err := btcutil.NewAddressTaproot(schnorr.SerializePubKey(outputKey), net)
+	if err != nil {
+		return derivedScript{}, err
+	}
+	script, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		return derivedScript{}, err
+	}
+	ctrl := tree.LeafMerkleProofs[0].ToControlBlock(internal)
+	ctrlBytes, err := ctrl.ToBytes()
+	if err != nil {
+		return derivedScript{}, err
+	}
+	return derivedScript{
+		address:         addr,
+		scriptPubKey:    script,
+		tapInternal:     internal,
+		tapLeafScript:   leafScript,
+		tapControlBlock: ctrlBytes,
+	}, nil
+}
+
+// parseMultiAPubkeys extracts the ordered 32-byte x-only pubkeys from a multi_a
+// tapleaf script (each pushed before its CHECKSIG/CHECKSIGADD).
+func parseMultiAPubkeys(script []byte) ([][]byte, error) {
+	tokenizer := txscript.MakeScriptTokenizer(0, script)
+	var pubs [][]byte
+	for tokenizer.Next() {
+		if len(tokenizer.Data()) == 32 {
+			pubs = append(pubs, tokenizer.Data())
+		}
+	}
+	if err := tokenizer.Err(); err != nil {
+		return nil, err
+	}
+	if len(pubs) == 0 {
+		return nil, errors.New("no pubkeys in multi_a script")
+	}
+	return pubs, nil
+}
+
+// validateTaprootMultisigPsbt reports a taproot multisig PSBT's signature
+// progress for the lounge validator: count from TaprootScriptSpendSig, complete
+// at requiredSigs, finalizable when every input reaches its multi_a threshold.
+func validateTaprootMultisigPsbt(packet *psbt.Packet, requiredSigs int) MultisigPsbtValidation {
+	maxSigs := 0
+	allMeet := true
+	finalizable := true
+	anyTaproot := false
+	for i := range packet.Inputs {
+		n := len(packet.Inputs[i].TaprootScriptSpendSig)
+		if n > maxSigs {
+			maxSigs = n
+		}
+		if n < requiredSigs {
+			allMeet = false
+		}
+		if len(packet.Inputs[i].TaprootLeafScript) > 0 {
+			anyTaproot = true
+			m, err := multiAThreshold(packet.Inputs[i].TaprootLeafScript[0].Script)
+			if err != nil || n < m {
+				finalizable = false
+			}
+		}
+	}
+	if !anyTaproot {
+		finalizable = false
+	}
+	return MultisigPsbtValidation{
+		HasSignatures:  maxSigs > 0,
+		SignatureCount: maxSigs,
+		IsComplete:     allMeet,
+		Finalizable:    finalizable,
+	}
+}
+
+// multiAThreshold reads the k threshold from a multi_a tapleaf script (the value
+// pushed just before OP_NUMEQUAL). Only small-int thresholds (1..16) are used.
+func multiAThreshold(script []byte) (int, error) {
+	tokenizer := txscript.MakeScriptTokenizer(0, script)
+	var prevOpcode byte
+	var prevData []byte
+	havePrev := false
+	for tokenizer.Next() {
+		if tokenizer.Opcode() == txscript.OP_NUMEQUAL {
+			if !havePrev {
+				return 0, errors.New("cannot read multi_a threshold")
+			}
+			if prevOpcode >= txscript.OP_1 && prevOpcode <= txscript.OP_16 {
+				return int(prevOpcode-txscript.OP_1) + 1, nil
+			}
+			// Thresholds above 16 are encoded as a script-number data push.
+			if n := scriptNumToInt(prevData); n >= 1 {
+				return n, nil
+			}
+			return 0, errors.New("cannot read multi_a threshold")
+		}
+		prevOpcode = tokenizer.Opcode()
+		prevData = tokenizer.Data()
+		havePrev = true
+	}
+	if err := tokenizer.Err(); err != nil {
+		return 0, err
+	}
+	return 0, errors.New("multi_a script missing OP_NUMEQUAL")
+}
+
+// scriptNumToInt decodes a minimal little-endian script number (as pushed by the
+// script builder for thresholds > 16). Returns 0 for an empty or over-long push.
+func scriptNumToInt(b []byte) int {
+	if len(b) == 0 || len(b) > 4 {
+		return 0
+	}
+	n := 0
+	for i, c := range b {
+		n |= int(c) << (8 * i)
+	}
+	if b[len(b)-1]&0x80 != 0 { // negative — not a valid threshold
+		return 0
+	}
+	return n
+}
+
+// hasTapScriptSig reports whether a tapscript signature for the given x-only
+// pubkey and leaf already exists on the input.
+func hasTapScriptSig(sigs []*psbt.TaprootScriptSpendSig, xonly, leafHash []byte) bool {
+	for _, s := range sigs {
+		if bytes.Equal(s.XOnlyPubKey, xonly) && bytes.Equal(s.LeafHash, leafHash) {
+			return true
+		}
+	}
+	return false
+}
+
+// signTaprootMultisigInput adds this wallet's BIP342 tapscript signature(s) to a
+// tr(sortedmulti_a) input for each held key. Returns 1 if it contributed a
+// signature, 0 if it holds none of the input's keys.
+func signTaprootMultisigInput(
+	packet *psbt.Packet,
+	i int,
+	in psbtInput,
+	tx *wire.MsgTx,
+	sigHashes *txscript.TxSigHashes,
+) (int, error) {
+	if len(in.addr.multisigPrivs) == 0 {
+		return 0, nil
+	}
+	if in.addr.tapLeafScript == nil {
+		return 0, errors.New("taproot multisig input missing its leaf script")
+	}
+	leaf := txscript.NewBaseTapLeaf(in.addr.tapLeafScript)
+	leafHash := leaf.TapHash()
+	added := false
+	for _, priv := range in.addr.multisigPrivs {
+		xonly := schnorr.SerializePubKey(priv.PubKey())
+		if hasTapScriptSig(packet.Inputs[i].TaprootScriptSpendSig, xonly, leafHash[:]) {
+			continue
+		}
+		sig, err := txscript.RawTxInTapscriptSignature(
+			tx, sigHashes, i, in.amount, in.addr.scriptPubKey, leaf, txscript.SigHashDefault, priv,
+		)
+		if err != nil {
+			return 0, err
+		}
+		packet.Inputs[i].TaprootScriptSpendSig = append(packet.Inputs[i].TaprootScriptSpendSig, &psbt.TaprootScriptSpendSig{
+			XOnlyPubKey: xonly,
+			LeafHash:    leafHash[:],
+			Signature:   sig,
+			SigHash:     txscript.SigHashDefault,
+		})
+		added = true
+	}
+	if added {
+		return 1, nil
+	}
+	return 0, nil
+}
+
+// finalizeTaprootMultisigInput assembles the witness for a tr(sortedmulti_a)
+// input from its collected tapscript signatures and marks the input final. The
+// witness stack is the signatures in reverse pubkey order (empty where a
+// cosigner has not signed), then the leaf script, then the control block.
+func finalizeTaprootMultisigInput(packet *psbt.Packet, i int) error {
+	in := &packet.Inputs[i]
+	if len(in.TaprootLeafScript) == 0 {
+		return errors.New("taproot multisig input missing its leaf script")
+	}
+	leafScript := in.TaprootLeafScript[0].Script
+	controlBlock := in.TaprootLeafScript[0].ControlBlock
+	pubs, err := parseMultiAPubkeys(leafScript)
+	if err != nil {
+		return err
+	}
+	threshold, err := multiAThreshold(leafScript)
+	if err != nil {
+		return err
+	}
+	sigByPub := make(map[string][]byte, len(in.TaprootScriptSpendSig))
+	for _, s := range in.TaprootScriptSpendSig {
+		sigByPub[hex.EncodeToString(s.XOnlyPubKey)] = s.Signature
+	}
+
+	// A multi_a leaf ends in <m> OP_NUMEQUAL — the witness must carry EXACTLY m
+	// signatures. Refuse an under-signed input, and cap an over-signed one at m
+	// (empty the extra slots), or the script evaluates false and the tx is dead.
+	available := 0
+	for _, p := range pubs {
+		if _, ok := sigByPub[hex.EncodeToString(p)]; ok {
+			available++
+		}
+	}
+	if available < threshold {
+		return fmt.Errorf("taproot multisig input has %d of %d required signatures", available, threshold)
+	}
+
+	used := 0
+	stack := make([][]byte, 0, len(pubs)+2)
+	for k := len(pubs) - 1; k >= 0; k-- {
+		if sig, ok := sigByPub[hex.EncodeToString(pubs[k])]; ok && used < threshold {
+			stack = append(stack, sig)
+			used++
+		} else {
+			stack = append(stack, []byte{})
+		}
+	}
+	stack = append(stack, leafScript, controlBlock)
+
+	var buf bytes.Buffer
+	if err := wire.WriteVarInt(&buf, 0, uint64(len(stack))); err != nil {
+		return err
+	}
+	for _, item := range stack {
+		if err := wire.WriteVarBytes(&buf, 0, item); err != nil {
+			return err
+		}
+	}
+	in.FinalScriptWitness = buf.Bytes()
+	return nil
+}
+
+// addTaprootMultisigInputFields populates the PSBT taproot script-path fields for
+// a tr(sortedmulti_a) input: internal key, merkle root, the leaf script + control
+// block, and each cosigner's x-only BIP32 derivation (so signatures can be
+// attributed and external signers can match their key).
+func addTaprootMultisigInputFields(in *psbt.PInput, sa scannedAddr) {
+	in.TaprootInternalKey = schnorr.SerializePubKey(sa.tapInternal)
+	leaf := txscript.NewBaseTapLeaf(sa.tapLeafScript)
+	leafHash := leaf.TapHash()
+	in.TaprootMerkleRoot = leafHash[:]
+	in.TaprootLeafScript = []*psbt.TaprootTapLeafScript{{
+		ControlBlock: sa.tapControlBlock,
+		Script:       sa.tapLeafScript,
+		LeafVersion:  txscript.BaseLeafVersion,
+	}}
+	for _, d := range sa.derivations {
+		in.TaprootBip32Derivation = append(in.TaprootBip32Derivation, &psbt.TaprootBip32Derivation{
+			XOnlyPubKey:          schnorr.SerializePubKey(d.pub),
+			LeafHashes:           [][]byte{leafHash[:]},
+			MasterKeyFingerprint: d.fingerprint,
+			Bip32Path:            d.path,
+		})
+	}
+}
+
+// taprootMultisigStatus reports a tr(sortedmulti_a) PSBT's signature count,
+// finalizability, and which cosigners (by x-only pubkey + fingerprint/origin)
+// have signed. Mirrors MultisigPsbtSigningStatus for the taproot path.
+func taprootMultisigStatus(packet *psbt.Packet, cosigners []MultisigCosigner) (MultisigSigningStatus, error) {
+	maxSigs := 0
+	signedPub := map[string]bool{}
+	for i := range packet.Inputs {
+		if n := len(packet.Inputs[i].TaprootScriptSpendSig); n > maxSigs {
+			maxSigs = n
+		}
+		for _, s := range packet.Inputs[i].TaprootScriptSpendSig {
+			signedPub[hex.EncodeToString(s.XOnlyPubKey)] = true
+		}
+	}
+
+	// Finalizable means every taproot input has at least its threshold of
+	// tapscript signatures (an assembled witness with empty slots always
+	// serializes, so a threshold check is what matters).
+	finalizable := true
+	anyTaproot := false
+	for i := range packet.Inputs {
+		if len(packet.Inputs[i].TaprootLeafScript) == 0 {
+			continue
+		}
+		anyTaproot = true
+		m, err := multiAThreshold(packet.Inputs[i].TaprootLeafScript[0].Script)
+		if err != nil || len(packet.Inputs[i].TaprootScriptSpendSig) < m {
+			finalizable = false
+		}
+	}
+	if !anyTaproot {
+		finalizable = false
+	}
+
+	cosignerSigned := make([]bool, len(cosigners))
+	for ci, c := range cosigners {
+		fp, path, ok := parseOrigin(c.Fingerprint + "/" + c.OriginPath)
+		if !ok {
+			continue
+		}
+		origins := []keyOrigin{{fingerprint: fp, path: path}}
+	inputs:
+		for i := range packet.Inputs {
+			for _, d := range packet.Inputs[i].TaprootBip32Derivation {
+				if !signedPub[hex.EncodeToString(d.XOnlyPubKey)] {
+					continue
+				}
+				if originMatches(d.MasterKeyFingerprint, d.Bip32Path, origins) {
+					cosignerSigned[ci] = true
+					break inputs
+				}
+			}
+		}
+	}
+	return MultisigSigningStatus{Signatures: maxSigs, Finalizable: finalizable, CosignerSigned: cosignerSigned}, nil
+}

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -751,6 +751,61 @@ func (s *Service) createElectrumWatchOnly(name string, gradient json.RawMessage,
 	return &wallet, nil
 }
 
+// CreateElectrumMultisig creates an m-of-n multisig electrum wallet. Cosigners
+// carrying a mnemonic or xprv are held on disk and can sign; the rest are
+// watch-only legs. scriptType is "wsh" (native P2WSH, default), "sh-wsh"
+// (nested), or "sh" (legacy P2SH). The wallet monitors and signs through the
+// same descriptor + PSBT path as any other electrum wallet.
+func (s *Service) CreateElectrumMultisig(
+	name string,
+	gradient json.RawMessage,
+	m, n int,
+	scriptType string,
+	cosigners []MultisigCosigner,
+) (*WalletData, error) {
+	if m < 1 || m > n {
+		return nil, fmt.Errorf("invalid threshold %d-of-%d", m, n)
+	}
+	if len(cosigners) != n {
+		return nil, fmt.Errorf("expected %d cosigners, got %d", n, len(cosigners))
+	}
+	for i, c := range cosigners {
+		if c.Xpub == "" {
+			return nil, fmt.Errorf("cosigner %d has no xpub", i)
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.locked() {
+		return nil, fmt.Errorf("wallet is locked, unlock before creating a wallet")
+	}
+
+	walletID := generateWalletID()
+	wallet := WalletData{
+		Version:    1,
+		Master:     MasterWallet{SeedHex: ""},
+		L1:         L1Wallet{Mnemonic: ""},
+		Sidechains: []SidechainWallet{},
+		ID:         walletID,
+		Name:       name,
+		Gradient:   gradient,
+		CreatedAt:  time.Now(),
+		WalletType: WalletTypeElectrum,
+		ScriptType: multisigScriptKind(scriptType).String(),
+		Multisig:   &MultisigWalletData{M: m, N: n, Cosigners: cosigners},
+	}
+
+	s.wallets = append(s.wallets, wallet)
+	s.activeWalletID = walletID
+	if err := s.saveWalletFile(); err != nil {
+		return nil, fmt.Errorf("save multisig electrum wallet: %w", err)
+	}
+	s.log.Info().Str("id", walletID).Int("m", m).Int("n", n).Msg("multisig electrum wallet created")
+	return &wallet, nil
+}
+
 // CreateWatchOnlyWallet creates a watch-only wallet from an xpub or descriptor.
 // Dart: WalletWriterProvider.createWatchOnlyWallet (L156-214)
 func (s *Service) CreateWatchOnlyWallet(name, xpubOrDescriptor, gradientJSON string) error {

--- a/sidechain-orchestrator/wallet/sizes.go
+++ b/sidechain-orchestrator/wallet/sizes.go
@@ -38,9 +38,25 @@ func walletInputVsize(d *Descriptor) int {
 		return multisigInputVsize(d.Threshold, len(d.Keys), true)
 	case ScriptMultisigP2SH:
 		return p2shMultisigInputVsize(d.Threshold, len(d.Keys))
+	case ScriptMultisigTaproot:
+		return taprootMultisigInputVsize(d.Threshold, len(d.Keys))
 	default:
 		return inputVsize(d.Kind)
 	}
+}
+
+// taprootMultisigInputVsize estimates the vsize of spending a tr(sortedmulti_a)
+// input: a P2TR base plus the witness-discounted script-path stack of m 64-byte
+// schnorr sigs, (n-m) empty slots, the multi_a leaf script, and the control block.
+func taprootMultisigInputVsize(threshold, nKeys int) int {
+	leafScript := nKeys*33 + 3 // <32-byte key push> per key, then <m> OP_NUMEQUAL
+	witness := 1 +             // stack item count
+		threshold*65 + // m signatures (1-byte len + 64-byte schnorr)
+		(nKeys - threshold) + // (n-m) empty slots (1 byte each)
+		(1 + leafScript) + // leaf script push
+		(1 + 33) // control block (single leaf: version + 32-byte internal key)
+	base := 32 + 4 + 4 + 1 // outpoint + sequence + empty scriptSig len
+	return base + (witness+3)/4
 }
 
 // multisigInputVsize estimates the vbytes to spend a P2WSH (or, when nested, a
@@ -96,7 +112,7 @@ func scriptPubKeyLen(kind ScriptKind) int {
 		return 25 // P2PKH
 	case ScriptNestedSegwit, ScriptMultisigP2SH, ScriptMultisigNested:
 		return 23 // P2SH
-	case ScriptTaproot, ScriptMultisig:
+	case ScriptTaproot, ScriptMultisig, ScriptMultisigTaproot:
 		return 34 // P2TR / P2WSH
 	default:
 		return 22 // P2WPKH

--- a/sidechain-orchestrator/wallet/types.go
+++ b/sidechain-orchestrator/wallet/types.go
@@ -45,6 +45,43 @@ type WalletData struct {
 	// wallet imports the single descriptor matching that purpose. Empty means
 	// the standard purposes at AccountIndex.
 	DerivationPath string `json:"derivation_path,omitempty"`
+	// Multisig, when set, makes this an m-of-n multisig wallet. Cosigners that
+	// carry a mnemonic or xprv are held on disk and can sign; the rest are
+	// watch-only legs.
+	Multisig *MultisigWalletData `json:"multisig,omitempty"`
+}
+
+// MultisigWalletData is the multisig policy stored in wallet.json. The wallet's
+// ScriptType field carries the script kind (multisig / multisig-nested /
+// multisig-p2sh); this holds the threshold and the cosigner keys.
+type MultisigWalletData struct {
+	M         int                `json:"m"`
+	N         int                `json:"n"`
+	Cosigners []MultisigCosigner `json:"cosigners"`
+}
+
+// MultisigCosigner is one leg of a multisig wallet. A cosigner with a Mnemonic
+// or Xprv is held on disk (this wallet can sign with it); one with only an Xpub
+// is a watch-only leg signed elsewhere.
+type MultisigCosigner struct {
+	Xpub        string `json:"xpub"`
+	OriginPath  string `json:"origin_path,omitempty"` // without leading m/
+	Fingerprint string `json:"fingerprint,omitempty"`
+	Mnemonic    string `json:"mnemonic,omitempty"`
+	Passphrase  string `json:"passphrase,omitempty"` // optional BIP39 passphrase for Mnemonic
+	Xprv        string `json:"xprv,omitempty"`       // account-level xprv, if imported directly
+}
+
+// Held reports whether this wallet holds the cosigner's private key.
+func (c MultisigCosigner) Held() bool { return c.Mnemonic != "" || c.Xprv != "" }
+
+// MultisigScriptType returns the wallet's multisig script-type string ("wsh",
+// "sh-wsh", or "sh"), or empty for a non-multisig wallet.
+func (w *WalletData) MultisigScriptType() string {
+	if w.Multisig == nil {
+		return ""
+	}
+	return multisigTypeString(w.scriptKind())
 }
 
 // scriptKind maps the wallet's stored script type to a ScriptKind, defaulting
@@ -63,6 +100,8 @@ func (w *WalletData) scriptKind() ScriptKind {
 		return ScriptMultisigP2SH
 	case "multisig-nested":
 		return ScriptMultisigNested
+	case "multisig-taproot":
+		return ScriptMultisigTaproot
 	default:
 		return ScriptNativeSegwit
 	}
@@ -72,6 +111,16 @@ func (w *WalletData) scriptKind() ScriptKind {
 // orthogonal capability to the backend type (Core or electrum): a wallet is
 // watch-only iff it carries an xpub/descriptor payload instead of a seed.
 func (w *WalletData) IsWatchOnly() bool {
+	if w.Multisig != nil {
+		// A multisig wallet can sign as soon as it holds one cosigner's key; it
+		// is watch-only only when every leg is external.
+		for _, c := range w.Multisig.Cosigners {
+			if c.Held() {
+				return false
+			}
+		}
+		return true
+	}
 	return len(w.WatchOnly) > 0
 }
 

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.277
+version: 1.0.278
 
 environment:
   sdk: 3.12.0

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.148
+version: 1.0.149
 
 environment:
   sdk: 3.12.0

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.275
+version: 1.0.276
 
 environment:
   sdk: 3.12.0


### PR DESCRIPTION
Adds multisig wallets to bitwindow. You build one from cosigner keys the way Sparrow does — a policy, a script type, and a keystore per cosigner — or import a whole wallet config (Coldcard text, or Sparrow/Specter/Caravan JSON) or paste an output descriptor. Software keystores hold their seed on disk so the wallet can sign locally; other cosigners are watch-only legs signed elsewhere.

Native segwit, nested segwit, legacy, and taproot (sortedmulti_a) script types are all supported. The wallet monitors over Electrum and its descriptor imports into Bitcoin Core as watch-only. Spending never auto-signs: it builds a PSBT and opens a signing panel where each on-disk keystore signs in turn, external signatures can be imported and combined, and it broadcasts once the threshold is met. Add a BIP39 passphrase per software keystore if you want one.