### PR TITLE
Update Elements node binaries for macOS, Linux, and Windows

### DIFF
--- a/sail_ui/assets/chains_config.json
+++ b/sail_ui/assets/chains_config.json
@@ -718,7 +718,7 @@
       "type": "sidechain",
       "slot": 24,
       "name": "Liquid Signet",
-      "version": "b7da9f75ea1d3da7a0b761cd7f18d81500bb1011",
+      "version": "bf8e9e1e5a6453b3a0573ff57cf9c92b2b3afe2b",
       "description": "Elements/Liquid sidechain in slot 24.",
       "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
       "port": 29443,
@@ -728,8 +728,12 @@
       "dependencies": ["bitcoind", "enforcer"],
       "startup_log_patterns": ["Done loading"],
       "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/liquid-signet-b7da9f75/", "linux-x86_64": "", "macos-x86_64": "", "macos-arm64": "liquid-signet-b7da9f75-macos-arm64.tar.gz", "windows-x86_64": ""}}},
-      "hashes": {}
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-bf8e9e1e/", "linux-x86_64": "liquid-signet-elements-bf8e9e1e-linux-x86_64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-bf8e9e1e-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-bf8e9e1e-windows-x86_64.zip"}}},
+      "hashes": {
+        "linux-x86_64": {"sha256": "f2856ad2aa3101699fce6c6c14d90ef1979515d051e704702aa4da826572cb7c", "size": 8080595},
+        "macos-arm64": {"sha256": "483f6a99aa22caad4dc29f2a692bd16f65ecd0048305d4bd77f12a4df39fde79", "size": 7428848},
+        "windows-x86_64": {"sha256": "76e837f4c5f4f07062cc3813f0a4a16adfaaae3ba5334b6ebc917410354ebedf", "size": 8644377}
+      }
     },
     "zside": {
       "type": "sidechain",

--- a/sail_ui/assets/migrations/008_chains_config.json
+++ b/sail_ui/assets/migrations/008_chains_config.json
@@ -1,0 +1,35 @@
+{
+  "version": 8,
+  "migration": "patch",
+  "binaries": {
+    "liquid-signet": {
+      "version": "bf8e9e1e5a6453b3a0573ff57cf9c92b2b3afe2b",
+      "download": {
+        "binary": "liquid-signet",
+        "files": {
+          "default": {
+            "base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-bf8e9e1e/",
+            "linux-x86_64": "liquid-signet-elements-bf8e9e1e-linux-x86_64.tar.gz",
+            "macos-x86_64": "",
+            "macos-arm64": "liquid-signet-elements-bf8e9e1e-macos-arm64.tar.gz",
+            "windows-x86_64": "liquid-signet-elements-bf8e9e1e-windows-x86_64.zip"
+          }
+        }
+      },
+      "hashes": {
+        "linux-x86_64": {
+          "sha256": "f2856ad2aa3101699fce6c6c14d90ef1979515d051e704702aa4da826572cb7c",
+          "size": 8080595
+        },
+        "macos-arm64": {
+          "sha256": "483f6a99aa22caad4dc29f2a692bd16f65ecd0048305d4bd77f12a4df39fde79",
+          "size": 7428848
+        },
+        "windows-x86_64": {
+          "sha256": "76e837f4c5f4f07062cc3813f0a4a16adfaaae3ba5334b6ebc917410354ebedf",
+          "size": 8644377
+        }
+      }
+    }
+  }
+}

--- a/sail_ui/lib/config/sidechains.dart
+++ b/sail_ui/lib/config/sidechains.dart
@@ -166,7 +166,7 @@ abstract class Sidechain extends Binary {
 class LiquidSignet extends Sidechain {
   LiquidSignet({
     super.name = 'Liquid Signet',
-    super.version = 'b7da9f75ea1d3da7a0b761cd7f18d81500bb1011',
+    super.version = 'bf8e9e1e5a6453b3a0573ff57cf9c92b2b3afe2b',
     super.description = 'Elements/Liquid sidechain',
     super.repoUrl = 'https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation',
     DirectoryConfig? directories,

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -718,7 +718,7 @@
       "type": "sidechain",
       "slot": 24,
       "name": "Liquid Signet",
-      "version": "b7da9f75ea1d3da7a0b761cd7f18d81500bb1011",
+      "version": "bf8e9e1e5a6453b3a0573ff57cf9c92b2b3afe2b",
       "description": "Elements/Liquid sidechain in slot 24.",
       "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
       "port": 29443,
@@ -728,8 +728,12 @@
       "dependencies": ["bitcoind", "enforcer"],
       "startup_log_patterns": ["Done loading"],
       "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/liquid-signet-b7da9f75/", "linux-x86_64": "", "macos-x86_64": "", "macos-arm64": "liquid-signet-b7da9f75-macos-arm64.tar.gz", "windows-x86_64": ""}}},
-      "hashes": {}
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-bf8e9e1e/", "linux-x86_64": "liquid-signet-elements-bf8e9e1e-linux-x86_64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-bf8e9e1e-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-bf8e9e1e-windows-x86_64.zip"}}},
+      "hashes": {
+        "linux-x86_64": {"sha256": "f2856ad2aa3101699fce6c6c14d90ef1979515d051e704702aa4da826572cb7c", "size": 8080595},
+        "macos-arm64": {"sha256": "483f6a99aa22caad4dc29f2a692bd16f65ecd0048305d4bd77f12a4df39fde79", "size": 7428848},
+        "windows-x86_64": {"sha256": "76e837f4c5f4f07062cc3813f0a4a16adfaaae3ba5334b6ebc917410354ebedf", "size": 8644377}
+      }
     },
     "zside": {
       "type": "sidechain",

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -718,7 +718,7 @@
       "type": "sidechain",
       "slot": 24,
       "name": "Liquid Signet",
-      "version": "b7da9f75ea1d3da7a0b761cd7f18d81500bb1011",
+      "version": "bf8e9e1e5a6453b3a0573ff57cf9c92b2b3afe2b",
       "description": "Elements/Liquid sidechain in slot 24.",
       "repo_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation",
       "port": 29443,
@@ -728,8 +728,12 @@
       "dependencies": ["bitcoind", "enforcer"],
       "startup_log_patterns": ["Done loading"],
       "directories": {"binary": {"default": {"linux": "liquid-signet", "macos": "liquid-signet", "windows": "liquid-signet"}}, "flutter_frontend": {}},
-      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/liquid-signet-b7da9f75/", "linux-x86_64": "", "macos-x86_64": "", "macos-arm64": "liquid-signet-b7da9f75-macos-arm64.tar.gz", "windows-x86_64": ""}}},
-      "hashes": {}
+      "download": {"binary": "liquid-signet", "files": {"default": {"base_url": "https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/download/elements-bf8e9e1e/", "linux-x86_64": "liquid-signet-elements-bf8e9e1e-linux-x86_64.tar.gz", "macos-x86_64": "", "macos-arm64": "liquid-signet-elements-bf8e9e1e-macos-arm64.tar.gz", "windows-x86_64": "liquid-signet-elements-bf8e9e1e-windows-x86_64.zip"}}},
+      "hashes": {
+        "linux-x86_64": {"sha256": "f2856ad2aa3101699fce6c6c14d90ef1979515d051e704702aa4da826572cb7c", "size": 8080595},
+        "macos-arm64": {"sha256": "483f6a99aa22caad4dc29f2a692bd16f65ecd0048305d4bd77f12a4df39fde79", "size": 7428848},
+        "windows-x86_64": {"sha256": "76e837f4c5f4f07062cc3813f0a4a16adfaaae3ba5334b6ebc917410354ebedf", "size": 8644377}
+      }
     },
     "zside": {
       "type": "sidechain",


### PR DESCRIPTION
## Summary

- update Liquid Signet/Elements downloads to release `elements-bf8e9e1e`
- add Linux x86_64, macOS arm64, and Windows x86_64 release assets
- pin each artifact's SHA-256 digest and byte size
- migrate existing Bitwindow configurations to the new release

## Why

The previous configuration only provided a macOS arm64 binary. This release supplies all three supported platforms from the same source revision and includes the fresh-data-directory startup fix.

## Validation

- confirmed all release asset names and sizes through the GitHub release API
- verified all three config copies are identical
- validated all modified JSON
- ran `scripts/check-migrations.sh`
- ran `go test ./...` in `sidechain-orchestrator`
- ran `git diff --check`

Elements release: https://github.com/ekulkisnek/liquid-drivechain-signet-adaptation/releases/tag/elements-bf8e9e1e
