### PR TITLE
Build BitNames messaging protocol and storage foundations

### DIFF
--- a/bitnames/lib/pages/tabs/messaging_page.dart
+++ b/bitnames/lib/pages/tabs/messaging_page.dart
@@ -53,123 +53,142 @@ class _MessagingTabPageState extends State<MessagingTabPage> {
   @override
   Widget build(BuildContext context) {
     return QtPage(
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Encrypt Card
-          Expanded(
-            child: SailCard(
-              title: 'Encrypt',
-              subtitle: 'Encrypt a message for a BitName or pubkey',
-              error: encryptError,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  SailTextField(
-                    label: "Receiver's BitName or Encryption Pubkey (Bech32m)",
-                    hintText: 'Enter a BitName or a pubkey',
-                    controller: encryptPubkeyController,
-                    suffixWidget: _hasBitnamesEncryptMatch ? SailSVG.icon(SailSVGAsset.iconSuccess, height: 20) : null,
-                  ),
-                  const SizedBox(height: 16),
-                  SailTextField(
-                    label: 'Plaintext message:',
-                    hintText: 'Enter a message to encrypt',
-                    controller: encryptMessageController,
-                    minLines: 3,
-                    maxLines: 6,
-                  ),
-                  const SizedBox(height: 16),
-                  SailButton(
-                    label: 'Encrypt',
-                    onPressed: handleEncrypt,
-                    loading: encryptLoading,
-                  ),
-                  if (encryptResult != null)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 12),
-                      child: SailText.secondary13(
-                        encryptResult!,
-                        monospace: true,
-                      ),
-                    ),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(width: 24),
-          // Decrypt Card
-          Expanded(
-            child: SailCard(
-              title: 'Decrypt',
-              subtitle: 'Decrypt a message using your pubkey',
-              error: decryptError,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  SailTextField(
-                    label: "Receiver's BitName or Encryption Pubkey (Bech32m)",
-                    hintText: 'Enter a BitName or a pubkey',
-                    controller: decryptPubkeyController,
-                    suffixWidget: _hasBitnamesDecryptMatch ? SailSVG.icon(SailSVGAsset.iconSuccess, height: 20) : null,
-                  ),
-                  const SizedBox(height: 16),
-                  SailTextField(
-                    label: 'Ciphertext message (hex):',
-                    hintText: 'Enter a ciphertext message',
-                    controller: decryptMessageController,
-                    minLines: 3,
-                    maxLines: 6,
-                  ),
-                  const SizedBox(height: 16),
-                  SailButton(
-                    label: 'Decrypt',
-                    onPressed: handleDecrypt,
-                    loading: decryptLoading,
-                  ),
-                  if (decryptResult != null)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 12),
-                      child: SailText.secondary13(
-                        decryptResult!,
-                        monospace: true,
-                      ),
-                    ),
-                ],
-              ),
-            ),
-          ),
-        ],
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final encrypt = _encryptCard(), decrypt = _decryptCard();
+          if (constraints.maxWidth < 800) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [encrypt, const SizedBox(height: 24), decrypt],
+            );
+          }
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(child: encrypt),
+              const SizedBox(width: 24),
+              Expanded(child: decrypt),
+            ],
+          );
+        },
       ),
     );
   }
 
-  /// Resolves the input to an encryption pubkey
-  /// Input can be: username, blake3 hash, or direct encryption key
-  String? _resolveEncryptionKey(String input) {
-    if (input.isEmpty) {
-      return null;
-    }
+  Widget _encryptCard() => SailCard(
+    title: 'Encrypt',
+    subtitle: 'Encrypt a message for a BitName or pubkey',
+    error: encryptError,
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SailTextField(
+          label: "Recipient's BitName or encryption pubkey (Bech32m)",
+          hintText: 'Enter a BitName or pubkey',
+          controller: encryptPubkeyController,
+          suffixWidget: _hasBitnamesEncryptMatch ? SailSVG.icon(SailSVGAsset.iconSuccess, height: 20) : null,
+        ),
+        const SizedBox(height: 16),
+        SailTextField(
+          label: 'Plaintext message',
+          hintText: 'Enter a message to encrypt',
+          controller: encryptMessageController,
+          minLines: 3,
+          maxLines: 6,
+        ),
+        const SizedBox(height: 16),
+        SailButton(
+          label: 'Encrypt',
+          onPressed: handleEncrypt,
+          loading: encryptLoading,
+        ),
+        if (encryptResult != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 12),
+            child: ResultRow(
+              label: 'Ciphertext',
+              value: encryptResult!,
+              monospace: true,
+              copyable: true,
+            ),
+          ),
+      ],
+    ),
+  );
 
+  Widget _decryptCard() => SailCard(
+    title: 'Decrypt',
+    subtitle: 'Decrypt a message sent to one of your BitNames',
+    error: decryptError,
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SailTextField(
+          label: 'Your BitName or encryption pubkey (Bech32m)',
+          hintText: 'Enter your receiving BitName or pubkey',
+          controller: decryptPubkeyController,
+          suffixWidget: _hasBitnamesDecryptMatch ? SailSVG.icon(SailSVGAsset.iconSuccess, height: 20) : null,
+        ),
+        const SizedBox(height: 16),
+        SailTextField(
+          label: 'Ciphertext message (hex)',
+          hintText: 'Enter a ciphertext message',
+          controller: decryptMessageController,
+          minLines: 3,
+          maxLines: 6,
+        ),
+        const SizedBox(height: 16),
+        SailButton(
+          label: 'Decrypt',
+          onPressed: handleDecrypt,
+          loading: decryptLoading,
+        ),
+        if (decryptResult != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 12),
+            child: ResultRow(
+              label: 'Plaintext',
+              value: decryptResult!,
+              copyable: true,
+            ),
+          ),
+      ],
+    ),
+  );
+
+  BitnameEntry? _resolveBitName(String input) {
     final trimmedInput = input.trim();
+    if (trimmedInput.isEmpty) return null;
 
-    // then check if input is a blake3 hash match
     var existingEntryMatch = bitnamesProvider.entries
-        .where((entry) => entry.hash == blake3Hex(utf8.encode(trimmedInput)).toLowerCase())
+        .where(
+          (entry) => entry.hash == blake3Hex(utf8.encode(trimmedInput)).toLowerCase(),
+        )
         .firstOrNull;
-
-    if (existingEntryMatch != null) {
-      // we found a plaintext match! save it to disk for easy access later
-      unawaited(bitnamesProvider.saveHashNameMapping(trimmedInput));
-    }
-
-    // First, check if input is already a direct hash match in bitnames
     existingEntryMatch ??= bitnamesProvider.entries
-        .where((entry) => entry.hash.toLowerCase() == trimmedInput.toLowerCase())
+        .where(
+          (entry) => entry.hash.toLowerCase() == trimmedInput.toLowerCase(),
+        )
         .firstOrNull;
+    return existingEntryMatch;
+  }
 
-    // If no bitname match found, assume input is a direct encryption key
-    return existingEntryMatch?.details.encryptionPubkey;
+  String? _resolveEncryptionKey(String input) => _resolveBitName(input)?.details.encryptionPubkey;
+
+  String _requireEncryptionKey(String input) {
+    final trimmed = input.trim(), entry = _resolveBitName(input);
+    if (entry != null) {
+      final key = entry.details.encryptionPubkey;
+      if (key == null) {
+        throw const FormatException(
+          'This BitName has no encryption key. Its owner must add one before messaging.',
+        );
+      }
+      if (!RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(trimmed)) unawaited(bitnamesProvider.saveHashNameMapping(trimmed));
+      return key;
+    }
+    if (trimmed.isEmpty) throw const FormatException('Enter a BitName or encryption pubkey.');
+    return trimmed;
   }
 
   Future<void> handleEncrypt() async {
@@ -180,21 +199,17 @@ class _MessagingTabPageState extends State<MessagingTabPage> {
     });
 
     try {
-      final resolvedKey = _resolveEncryptionKey(encryptPubkeyController.text) ?? encryptPubkeyController.text.trim();
-      if (resolvedKey.isEmpty) {
-        setState(() => encryptError = 'Must enter a valid pubkey');
-        return;
-      }
-
+      final resolvedKey = _requireEncryptionKey(encryptPubkeyController.text);
       final ciphertext = await rpc.encryptMsg(
-        msg: encryptMessageController.text.trim(),
+        msg: encryptMessageController.text,
         encryptionPubkey: resolvedKey,
       );
+      if (!mounted) return;
       setState(() => encryptResult = ciphertext);
     } catch (e) {
-      setState(() => encryptError = e.toString());
+      if (mounted) setState(() => encryptError = _friendlyError(e));
     } finally {
-      setState(() => encryptLoading = false);
+      if (mounted) setState(() => encryptLoading = false);
     }
   }
 
@@ -206,26 +221,26 @@ class _MessagingTabPageState extends State<MessagingTabPage> {
     });
 
     try {
-      final resolvedKey = _resolveEncryptionKey(decryptPubkeyController.text) ?? decryptPubkeyController.text.trim();
-      if (resolvedKey.isEmpty) {
-        setState(() => decryptError = 'Must enter a valid pubkey');
-        return;
-      }
-
+      final resolvedKey = _requireEncryptionKey(decryptPubkeyController.text);
       final plaintext = await rpc.decryptMsg(
         ciphertext: decryptMessageController.text.trim(),
         encryptionPubkey: resolvedKey,
       );
+      if (!mounted) return;
       setState(() => decryptResult = plaintext);
     } catch (e) {
-      setState(() => decryptError = e.toString());
+      if (mounted) setState(() => decryptError = _friendlyError(e));
     } finally {
-      setState(() => decryptLoading = false);
+      if (mounted) setState(() => decryptLoading = false);
     }
   }
 
+  String _friendlyError(Object error) => error is FormatException
+      ? error.message.toString()
+      : 'Request failed. Check the BitNames connection and try again.';
+
   void _onChange() {
-    setState(() {});
+    if (mounted) setState(() {});
   }
 
   @override

--- a/bitnames/lib/pages/tabs/reserve_register_page.dart
+++ b/bitnames/lib/pages/tabs/reserve_register_page.dart
@@ -174,6 +174,12 @@ class BitnamesTabPage extends StatelessWidget {
                                   hintText: 'Enter IPv6 address',
                                   controller: model.ipv6Controller,
                                 ),
+                                SailTextField(
+                                  label: 'Introduction fee (sats)',
+                                  hintText: '1000',
+                                  controller: model.paymailFeeController,
+                                  textFieldType: TextFieldType.number,
+                                ),
                                 SailCheckbox(
                                   label: 'Set Encryption Pubkey',
                                   value: model.useEncryptionKey,
@@ -208,6 +214,9 @@ class BitnamesTabPage extends StatelessWidget {
                                   label: 'Register',
                                   onPressed: () => model.registerBitname(context),
                                   loading: model.registerLoading,
+                                  disabled:
+                                      (model.useEncryptionKey && model.encryptionKey == null) ||
+                                      (model.useSigningKey && model.signingKey == null),
                                 ),
                               ],
                             ),
@@ -426,6 +435,7 @@ class BitnamesViewModel extends BaseViewModel {
   // Register state
   bool registerLoading = false;
   String? registerError;
+  bool _disposed = false;
 
   // New state variables
   bool useEncryptionKey = false;
@@ -447,20 +457,20 @@ class BitnamesViewModel extends BaseViewModel {
     encryptionKey = null;
     signingKey = null;
 
-    while (encryptionKey == null || signingKey == null) {
+    while (!_disposed && (encryptionKey == null || signingKey == null)) {
       try {
         if (encryptionKey == null) {
           encryptionKey = await bitnamesRPC.getNewEncryptionKey();
-          notifyListeners();
+          if (!_disposed) notifyListeners();
         }
 
         if (signingKey == null) {
           signingKey = await bitnamesRPC.getNewVerifyingKey();
-          notifyListeners();
+          if (!_disposed) notifyListeners();
         }
       } catch (e) {
         // If there's an error, wait a bit before retrying
-        await Future.delayed(const Duration(milliseconds: 500));
+        if (!_disposed) await Future.delayed(const Duration(milliseconds: 500));
       }
     }
   }
@@ -568,13 +578,21 @@ class BitnamesViewModel extends BaseViewModel {
       return;
     }
 
-    final name = registerNameController.text.trim();
+    final name = registerNameController.text.trim().toLowerCase();
     final commitment = commitmentController.text.trim().isEmpty ? null : commitmentController.text.trim();
     final ipv4 = ipv4Controller.text.trim().isEmpty ? null : ipv4Controller.text.trim();
     final ipv6 = ipv6Controller.text.trim().isEmpty ? null : ipv6Controller.text.trim();
+    final paymailFee = int.tryParse(
+      paymailFeeController.text.trim().isEmpty ? '1000' : paymailFeeController.text.trim(),
+    );
 
     if (name.isEmpty) {
       registerError = 'Name cannot be empty';
+      notifyListeners();
+      return;
+    }
+    if (paymailFee == null || paymailFee < 0) {
+      registerError = 'Introduction fee must be zero or greater';
       notifyListeners();
       return;
     }
@@ -605,7 +623,7 @@ class BitnamesViewModel extends BaseViewModel {
         BitNameData(
           commitment: commitment,
           encryptionPubkey: useEncryptionKey ? encryptionKey : null,
-          paymailFeeSats: 1000,
+          paymailFeeSats: paymailFee,
           signingPubkey: useSigningKey ? signingKey : null,
           socketAddrV4: ipv4,
           socketAddrV6: ipv6,
@@ -626,6 +644,7 @@ class BitnamesViewModel extends BaseViewModel {
       commitmentController.clear();
       ipv4Controller.clear();
       ipv6Controller.clear();
+      paymailFeeController.clear();
       useEncryptionKey = false;
       useSigningKey = false;
 
@@ -639,6 +658,7 @@ class BitnamesViewModel extends BaseViewModel {
 
   @override
   void dispose() {
+    _disposed = true;
     searchController.dispose();
     reserveNameController.dispose();
     registerNameController.dispose();

--- a/bitnames/lib/providers/bitnames_provider.dart
+++ b/bitnames/lib/providers/bitnames_provider.dart
@@ -22,14 +22,21 @@ class BitnamesProvider extends ChangeNotifier {
 
   BitnamesProvider() {
     rpc.addListener(fetch);
-    fetch();
+    _initialize();
     _startRetryTimer();
+  }
+
+  Future<void> _initialize() async {
+    hashNameMapping = await clientSettings.getValue(HashNameMappingSetting()) as HashNameMappingSetting;
+    notifyListeners();
+    await fetch();
   }
 
   /// Save a new hash-name mapping
   Future<void> saveHashNameMapping(String name, {bool isMine = false}) async {
     final hash = blake3Hex(utf8.encode(name));
-    final newMappings = Map<String, HashMapping>.from(hashNameMapping.value);
+    final stored = await clientSettings.getValue(HashNameMappingSetting());
+    final newMappings = Map<String, HashMapping>.from(stored.value);
     newMappings[hash] = HashMapping(name: name, isMine: isMine);
     hashNameMapping = HashNameMappingSetting(newValue: newMappings);
     await clientSettings.setValue(hashNameMapping);
@@ -47,7 +54,7 @@ class BitnamesProvider extends ChangeNotifier {
 
     _retryTimer?.cancel();
     _retryTimer = Timer.periodic(const Duration(milliseconds: 500), (timer) {
-      if (entries.isNotEmpty && initialized) {
+      if (initialized) {
         timer.cancel();
         _retryTimer = null;
         return;
@@ -77,7 +84,18 @@ class BitnamesProvider extends ChangeNotifier {
   bool _listEquals(List<BitnameEntry> a, List<BitnameEntry> b) {
     if (a.length != b.length) return false;
     for (int i = 0; i < a.length; i++) {
-      if (a[i].hash != b[i].hash || a[i].plaintextName != b[i].plaintextName) return false;
+      final x = a[i], y = b[i], xd = x.details, yd = y.details;
+      if (x.hash != y.hash ||
+          x.plaintextName != y.plaintextName ||
+          xd.seqId != yd.seqId ||
+          xd.commitment != yd.commitment ||
+          xd.socketAddrV4 != yd.socketAddrV4 ||
+          xd.socketAddrV6 != yd.socketAddrV6 ||
+          xd.encryptionPubkey != yd.encryptionPubkey ||
+          xd.signingPubkey != yd.signingPubkey ||
+          xd.paymailFeeSats != yd.paymailFeeSats) {
+        return false;
+      }
     }
     return true;
   }

--- a/bitwindow/lib/models/bitintroduction_protocol.dart
+++ b/bitwindow/lib/models/bitintroduction_protocol.dart
@@ -1,0 +1,333 @@
+import 'dart:convert';
+import 'package:thirds/blake3.dart';
+
+const bitIntroductionProtocol = 'bitintroduction';
+const bitIntroductionProtocolVersion = 1;
+
+enum BitIntroductionKind {
+  introduction('introduction'),
+  acceptance('acceptance'),
+  message('message');
+
+  const BitIntroductionKind(this.wireName);
+  final String wireName;
+  static BitIntroductionKind fromWireName(String value) {
+    for (final kind in values) {
+      if (kind.wireName == value) return kind;
+    }
+    throw FormatException('Unsupported BitIntroduction kind: $value');
+  }
+}
+
+class BitMessageProfile {
+  BitMessageProfile({
+    required String bitNameHash,
+    required this.signingPublicKey,
+    required this.encryptionPublicKey,
+    Iterable<Uri> directEndpoints = const [],
+    Iterable<Uri> torEndpoints = const [],
+    this.paymailFeeSats,
+    Map<String, dynamic>? commitmentManifest,
+  }) : bitNameHash = _bitNameHash(bitNameHash),
+       directEndpoints = List.unmodifiable(_endpoints(directEndpoints, false)),
+       torEndpoints = List.unmodifiable(_endpoints(torEndpoints, true)),
+       commitmentManifest = commitmentManifest == null ? null : _immutableJsonObject(commitmentManifest) {
+    _notEmpty(signingPublicKey, 'signingPublicKey');
+    _notEmpty(encryptionPublicKey, 'encryptionPublicKey');
+    if (paymailFeeSats != null && paymailFeeSats! < 0) {
+      throw ArgumentError.value(paymailFeeSats, 'paymailFeeSats', 'must be non-negative');
+    }
+  }
+
+  final String bitNameHash, signingPublicKey, encryptionPublicKey;
+  final List<Uri> directEndpoints, torEndpoints;
+  final int? paymailFeeSats;
+  final Map<String, dynamic>? commitmentManifest;
+
+  factory BitMessageProfile.fromJson(Map<String, dynamic> json) => BitMessageProfile(
+    bitNameHash: _string(json, 'bitname_hash'),
+    signingPublicKey: _string(json, 'signing_public_key'),
+    encryptionPublicKey: _string(json, 'encryption_public_key'),
+    directEndpoints: _uriList(json['direct_endpoints'], 'direct_endpoints'),
+    torEndpoints: _uriList(json['tor_endpoints'], 'tor_endpoints'),
+    paymailFeeSats: _optionalInt(json, 'paymail_fee_sats'),
+    commitmentManifest: switch (json['commitment_manifest']) {
+      final Map value => Map<String, dynamic>.from(value),
+      null => null,
+      _ => throw const FormatException('commitment_manifest must be an object'),
+    },
+  );
+
+  Map<String, dynamic> toCommitmentPayloadJson() => {
+    'bitname_hash': bitNameHash,
+    'signing_public_key': signingPublicKey,
+    'encryption_public_key': encryptionPublicKey,
+    'direct_endpoints': directEndpoints.map((uri) => '$uri').toList(),
+    'tor_endpoints': torEndpoints.map((uri) => '$uri').toList(),
+    if (paymailFeeSats != null) 'paymail_fee_sats': paymailFeeSats,
+  };
+
+  Map<String, dynamic> toJson() => {
+    ...toCommitmentPayloadJson(),
+    if (commitmentManifest != null) 'commitment_manifest': _cloneJsonObject(commitmentManifest!),
+  };
+
+  BitMessageProfile withCommitmentManifest(
+    Map<String, dynamic>? manifest,
+  ) => BitMessageProfile(
+    bitNameHash: bitNameHash,
+    signingPublicKey: signingPublicKey,
+    encryptionPublicKey: encryptionPublicKey,
+    directEndpoints: directEndpoints,
+    torEndpoints: torEndpoints,
+    paymailFeeSats: paymailFeeSats,
+    commitmentManifest: manifest,
+  );
+}
+
+class VerifiedBitMessageProfile {
+  VerifiedBitMessageProfile.verified({
+    required this.profile,
+    required String onChainCommitment,
+    required this.verificationReference,
+    bool Function(BitMessageProfile profile, String commitment)? commitmentVerifier,
+  }) : onChainCommitment = onChainCommitment.trim().toLowerCase() {
+    if (!_hashPattern.hasMatch(this.onChainCommitment)) {
+      throw ArgumentError.value(onChainCommitment, 'onChainCommitment', 'must be a 32-byte hexadecimal hash');
+    }
+    if (!(commitmentVerifier?.call(profile, this.onChainCommitment) ??
+        bitMessageProfileCommitment(profile) == this.onChainCommitment)) {
+      throw ArgumentError.value(onChainCommitment, 'onChainCommitment', 'does not commit to the canonical profile');
+    }
+    _notEmpty(verificationReference, 'verificationReference');
+  }
+
+  final BitMessageProfile profile;
+  final String onChainCommitment, verificationReference;
+  String get bitNameHash => profile.bitNameHash;
+  String get bitNameCommit => onChainCommitment;
+  String get signingPublicKey => profile.signingPublicKey;
+  String get encryptionPublicKey => profile.encryptionPublicKey;
+  List<Uri> get directEndpoints => profile.directEndpoints;
+  List<Uri> get torEndpoints => profile.torEndpoints;
+  int? get paymailFeeSats => profile.paymailFeeSats;
+}
+
+String bitMessageProfileCommitment(BitMessageProfile profile) => blake3Hex(
+  utf8.encode(
+    canonicalJsonEncode(profile.toCommitmentPayloadJson()),
+  ),
+);
+
+class BitIntroductionPayload {
+  BitIntroductionPayload({
+    this.version = bitIntroductionProtocolVersion,
+    required this.id,
+    required this.kind,
+    required String senderBitNameHash,
+    required String recipientBitNameHash,
+    required DateTime timestamp,
+    required this.body,
+    this.inReplyTo,
+    this.replyProfile,
+  }) : senderBitNameHash = _bitNameHash(senderBitNameHash),
+       recipientBitNameHash = _bitNameHash(recipientBitNameHash),
+       timestamp = timestamp.toUtc() {
+    if (version != bitIntroductionProtocolVersion) {
+      throw ArgumentError.value(version, 'version', 'unsupported protocol version');
+    }
+    _boundedId(id, 'id');
+    if (inReplyTo != null) _boundedId(inReplyTo!, 'inReplyTo');
+    if (kind == BitIntroductionKind.acceptance && inReplyTo == null) {
+      throw ArgumentError('Acceptance messages must reference the introduction ID');
+    }
+    if (replyProfile != null && replyProfile!.bitNameHash != this.senderBitNameHash) {
+      throw ArgumentError('replyProfile must belong to senderBitNameHash');
+    }
+  }
+
+  final int version;
+  final String id, senderBitNameHash, recipientBitNameHash, body;
+  final BitIntroductionKind kind;
+  final DateTime timestamp;
+  final String? inReplyTo;
+  final BitMessageProfile? replyProfile;
+
+  factory BitIntroductionPayload.fromJson(Map<String, dynamic> json) {
+    final protocol = _string(json, 'protocol');
+    if (protocol != bitIntroductionProtocol) throw FormatException('Unsupported protocol: $protocol');
+    final reply = json['reply_profile'];
+    if (reply != null && reply is! Map) throw const FormatException('reply_profile must be an object');
+    final parent = json['in_reply_to'];
+    if (parent != null && parent is! String) throw const FormatException('in_reply_to must be a string');
+    return BitIntroductionPayload(
+      version: _integer(json, 'version'),
+      id: _string(json, 'id'),
+      kind: BitIntroductionKind.fromWireName(_string(json, 'kind')),
+      senderBitNameHash: _string(json, 'sender_bitname_hash'),
+      recipientBitNameHash: _string(json, 'recipient_bitname_hash'),
+      timestamp: DateTime.fromMillisecondsSinceEpoch(_integer(json, 'timestamp_ms'), isUtc: true),
+      body: _string(json, 'body', empty: true),
+      inReplyTo: parent as String?,
+      replyProfile: reply == null ? null : BitMessageProfile.fromJson(Map<String, dynamic>.from(reply)),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'protocol': bitIntroductionProtocol,
+    'version': version,
+    'id': id,
+    'kind': kind.wireName,
+    'sender_bitname_hash': senderBitNameHash,
+    'recipient_bitname_hash': recipientBitNameHash,
+    'timestamp_ms': timestamp.millisecondsSinceEpoch,
+    'body': body,
+    if (inReplyTo != null) 'in_reply_to': inReplyTo,
+    if (replyProfile != null) 'reply_profile': replyProfile!.toJson(),
+  };
+}
+
+class SignedBitIntroductionEnvelope {
+  SignedBitIntroductionEnvelope({required this.payload, required this.signature}) {
+    _notEmpty(signature, 'signature');
+  }
+
+  final BitIntroductionPayload payload;
+  final String signature;
+  String get signedPayload => canonicalJsonEncode(payload.toJson());
+
+  factory SignedBitIntroductionEnvelope.fromJson(Map<String, dynamic> json) {
+    final payload = json['payload'];
+    if (payload is! Map) throw const FormatException('payload must be an object');
+    return SignedBitIntroductionEnvelope(
+      payload: BitIntroductionPayload.fromJson(Map<String, dynamic>.from(payload)),
+      signature: _string(json, 'signature'),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {'payload': payload.toJson(), 'signature': signature};
+}
+
+class BitMessageWire {
+  BitMessageWire({required String recipientBitNameHash, required this.ciphertext})
+    : recipientBitNameHash = _bitNameHash(recipientBitNameHash) {
+    _notEmpty(ciphertext, 'ciphertext');
+  }
+
+  final String recipientBitNameHash, ciphertext;
+
+  factory BitMessageWire.fromJson(Map<String, dynamic> json) => BitMessageWire(
+    recipientBitNameHash: _string(json, 'recipient_bitname_hash'),
+    ciphertext: _string(json, 'ciphertext'),
+  );
+
+  Map<String, dynamic> toJson() => {'recipient_bitname_hash': recipientBitNameHash, 'ciphertext': ciphertext};
+}
+
+String canonicalJsonEncode(Object? value) {
+  if (value == null) return 'null';
+  if (value is String) return jsonEncode(value);
+  if (value is bool) return '$value';
+  if (value is int) return '$value';
+  if (value is num) throw ArgumentError.value(value, 'value', 'canonical signed JSON only permits integer numbers');
+  if (value is List) return '[${value.map(canonicalJsonEncode).join(',')}]';
+  if (value is Map) {
+    final entries = value.entries.map((entry) {
+      if (entry.key is! String) {
+        throw ArgumentError.value(entry.key, 'key', 'canonical JSON object keys must be strings');
+      }
+      return MapEntry(entry.key as String, entry.value);
+    }).toList()..sort((a, b) => a.key.compareTo(b.key));
+    return '{${entries.map((e) => '${jsonEncode(e.key)}:${canonicalJsonEncode(e.value)}').join(',')}}';
+  }
+  throw ArgumentError.value(value, 'value', 'not a JSON value');
+}
+
+final _hashPattern = RegExp(r'^[0-9a-f]{64}$');
+
+Map<String, dynamic> _cloneJsonObject(Map<String, dynamic> value) {
+  try {
+    return Map<String, dynamic>.from(
+      jsonDecode(jsonEncode(value)) as Map,
+    );
+  } catch (_) {
+    throw const FormatException('commitment_manifest must contain JSON data');
+  }
+}
+
+Map<String, dynamic> _immutableJsonObject(Map<String, dynamic> value) {
+  Object? freeze(Object? item) => switch (item) {
+    final Map map => Map<String, dynamic>.unmodifiable(
+      map.map((key, value) => MapEntry('$key', freeze(value))),
+    ),
+    final List list => List<Object?>.unmodifiable(list.map(freeze)),
+    _ => item,
+  };
+  return freeze(_cloneJsonObject(value))! as Map<String, dynamic>;
+}
+
+String _bitNameHash(String value) {
+  final hash = value.trim().toLowerCase();
+  if (!_hashPattern.hasMatch(hash)) {
+    throw ArgumentError.value(value, 'bitNameHash', 'must be a 32-byte hexadecimal hash');
+  }
+  return hash;
+}
+
+void _notEmpty(String value, String name) {
+  if (value.trim().isEmpty) throw ArgumentError.value(value, name, 'must not be empty');
+}
+
+void _boundedId(String value, String name) {
+  if (value.trim().isEmpty || value.length > 256) {
+    throw ArgumentError.value(value, name, 'must contain 1-256 characters');
+  }
+}
+
+List<Uri> _endpoints(Iterable<Uri> input, bool tor) {
+  final unique = <String, Uri>{};
+  for (final endpoint in input) {
+    final scheme = endpoint.scheme.toLowerCase();
+    final host = endpoint.host.toLowerCase();
+    final basicInvalid = !endpoint.hasScheme || host.isEmpty || endpoint.hasFragment || endpoint.userInfo.isNotEmpty;
+    final routeInvalid = tor
+        ? scheme != 'http' || !host.endsWith('.onion')
+        : !{'http', 'https'}.contains(scheme) || host.endsWith('.onion');
+    if (basicInvalid || routeInvalid) {
+      throw ArgumentError.value(endpoint, tor ? 'torEndpoints' : 'directEndpoints', 'invalid endpoint');
+    }
+    var path = endpoint.path.isEmpty ? '/' : endpoint.path;
+    if (!path.endsWith('/')) path += '/';
+    final normalized = endpoint.replace(scheme: scheme, host: host, path: path);
+    unique['$normalized'] = normalized;
+  }
+  final keys = unique.keys.toList()..sort();
+  return keys.map((key) => unique[key]!).toList();
+}
+
+List<Uri> _uriList(dynamic value, String field) {
+  if (value == null) return const [];
+  if (value is! List) throw FormatException('$field must be an array');
+  return value.map((item) {
+    if (item is! String) throw FormatException('$field entries must be strings');
+    final uri = Uri.tryParse(item);
+    if (uri == null) throw FormatException('$field contains an invalid URI');
+    return uri;
+  }).toList();
+}
+
+String _string(Map<String, dynamic> json, String field, {bool empty = false}) {
+  final value = json[field];
+  if (value is! String || (!empty && value.trim().isEmpty)) {
+    throw FormatException('$field must be ${empty ? 'a string' : 'a non-empty string'}');
+  }
+  return value;
+}
+
+int _integer(Map<String, dynamic> json, String field) {
+  final value = json[field];
+  if (value is! int) throw FormatException('$field must be an integer');
+  return value;
+}
+
+int? _optionalInt(Map<String, dynamic> json, String field) => json[field] == null ? null : _integer(json, field);

--- a/bitwindow/lib/models/bitnames_commitment.dart
+++ b/bitwindow/lib/models/bitnames_commitment.dart
@@ -1,0 +1,580 @@
+import 'dart:convert';
+
+import 'package:bitwindow/models/bitintroduction_protocol.dart';
+import 'package:thirds/blake3.dart';
+
+const bitNamesCommitmentManifestProtocol = 'bitnames-commitment-manifest';
+const bitNamesCommitmentManifestVersion = 1;
+const bitNamesApplicationCommitmentProtocol = 'bitnames-application-commitment';
+const bitIntroductionCommitmentNamespace = 'org.layertwolabs.bitintroduction';
+const bitIntroductionCommitmentPurpose = 'reply-profile';
+const bitIntroductionCommitmentVersion = 1;
+const bitNamesCommitmentChain = 'bip300:2:bitnames';
+const bitNamesCommitmentMaxBytes = 16 * 1024;
+
+enum BitNamesCommitmentActivation {
+  legacyCompatible,
+  namespacedV1,
+}
+
+enum BitNamesProfileCommitmentKind {
+  empty,
+  legacy,
+  namespaced,
+  unknown,
+  malformed,
+  wrongNetwork,
+  conflict,
+}
+
+class BitNamesCommitmentAssessment {
+  const BitNamesCommitmentAssessment(
+    this.kind,
+    this.summary,
+    this.details, {
+    this.manifest,
+  });
+
+  final BitNamesProfileCommitmentKind kind;
+  final String summary;
+  final String details;
+  final BitNamesCommitmentManifest? manifest;
+
+  bool get verified => kind == BitNamesProfileCommitmentKind.legacy || kind == BitNamesProfileCommitmentKind.namespaced;
+  bool get writable => kind == BitNamesProfileCommitmentKind.empty || verified;
+}
+
+class BitNamesCommitmentConflict implements Exception {
+  const BitNamesCommitmentConflict(this.message);
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class BitNamesCommitmentManifest {
+  BitNamesCommitmentManifest._(this._json);
+
+  final Map<String, dynamic> _json;
+
+  String get network => _json['network'] as String;
+  String get bitNameHash => _json['bitname_hash'] as String;
+  Map<String, dynamic> get applications => _cloneObject(_json['applications'] as Map);
+  Map<String, dynamic> toJson() => _cloneObject(_json);
+  String get commitment => blake3Hex(utf8.encode(canonicalJsonEncode(_json)));
+
+  factory BitNamesCommitmentManifest.parse(
+    Map<String, dynamic> source,
+  ) {
+    final json = _cloneObject(source);
+    _boundedCanonical(json);
+    if (json['protocol'] != bitNamesCommitmentManifestProtocol) {
+      throw const FormatException(
+        'unsupported BitNames commitment protocol',
+      );
+    }
+    if (json['version'] != bitNamesCommitmentManifestVersion) {
+      throw const FormatException(
+        'unsupported BitNames commitment manifest version',
+      );
+    }
+    if (!_hasExactKeys(json, const {
+      'protocol',
+      'version',
+      'network',
+      'bitname_hash',
+      'applications',
+    })) {
+      throw const FormatException(
+        'BitNames commitment manifest v1 has unknown or missing fields',
+      );
+    }
+    final network = json['network'];
+    if (network is! String || bitNamesCommitmentNetwork(network) != network) {
+      throw const FormatException(
+        'invalid BitNames commitment network',
+      );
+    }
+    final bitNameHash = json['bitname_hash'];
+    if (bitNameHash is! String || !_hashPattern.hasMatch(bitNameHash)) {
+      throw const FormatException(
+        'invalid BitName commitment identity',
+      );
+    }
+    final applications = json['applications'];
+    if (applications is! Map || applications.isEmpty || applications.length > 32) {
+      throw const FormatException(
+        'BitNames commitment applications must contain 1 to 32 entries',
+      );
+    }
+    for (final entry in applications.entries) {
+      if (entry.key is! String || !_namespacePattern.hasMatch(entry.key as String)) {
+        throw const FormatException(
+          'invalid BitNames application namespace',
+        );
+      }
+      if (entry.value is! Map) {
+        throw const FormatException(
+          'BitNames application commitment must be an object',
+        );
+      }
+      final application = Map<String, dynamic>.from(
+        entry.value as Map,
+      );
+      if (application['version'] is! int ||
+          (application['version'] as int) < 1 ||
+          (application['version'] as int) > 0x7fffffff ||
+          application['purpose'] is! String ||
+          !_purposePattern.hasMatch(application['purpose'] as String) ||
+          application['commitment'] is! String ||
+          !_hashPattern.hasMatch(
+            application['commitment'] as String,
+          ) ||
+          application['data'] is! Map) {
+        throw const FormatException(
+          'invalid BitNames application commitment entry',
+        );
+      }
+    }
+    return BitNamesCommitmentManifest._(json);
+  }
+
+  factory BitNamesCommitmentManifest.forReplyProfile(
+    BitMessageProfile profile, {
+    required String network,
+    BitNamesCommitmentManifest? base,
+  }) {
+    final scope = bitNamesCommitmentNetwork(network);
+    if (base != null) {
+      if (base.network != scope || base.bitNameHash != profile.bitNameHash) {
+        throw const BitNamesCommitmentConflict(
+          'The existing commitment manifest belongs to another network or BitName',
+        );
+      }
+      final existing = base.applications[bitIntroductionCommitmentNamespace];
+      if (existing is Map &&
+          (existing['version'] != bitIntroductionCommitmentVersion ||
+              existing['purpose'] != bitIntroductionCommitmentPurpose)) {
+        throw const BitNamesCommitmentConflict(
+          'The BitIntroduction namespace uses an unknown version and was preserved',
+        );
+      }
+    }
+    final payload = profile.toCommitmentPayloadJson();
+    final applications = base?.applications ?? <String, dynamic>{};
+    applications[bitIntroductionCommitmentNamespace] = {
+      'version': bitIntroductionCommitmentVersion,
+      'purpose': bitIntroductionCommitmentPurpose,
+      'commitment': bitNamesApplicationCommitment(
+        namespace: bitIntroductionCommitmentNamespace,
+        purpose: bitIntroductionCommitmentPurpose,
+        network: scope,
+        bitNameHash: profile.bitNameHash,
+        payload: payload,
+      ),
+      'data': payload,
+    };
+    return BitNamesCommitmentManifest.parse({
+      'protocol': bitNamesCommitmentManifestProtocol,
+      'version': bitNamesCommitmentManifestVersion,
+      'network': scope,
+      'bitname_hash': profile.bitNameHash,
+      'applications': applications,
+    });
+  }
+
+  BitMessageProfile replyProfile() {
+    final raw = applications[bitIntroductionCommitmentNamespace];
+    if (raw is! Map) {
+      throw const FormatException(
+        'manifest has no BitIntroduction commitment',
+      );
+    }
+    final entry = Map<String, dynamic>.from(raw);
+    if (entry['version'] != bitIntroductionCommitmentVersion || entry['purpose'] != bitIntroductionCommitmentPurpose) {
+      throw const FormatException(
+        'unsupported BitIntroduction commitment version or purpose',
+      );
+    }
+    if (!_hasExactKeys(entry, const {
+      'version',
+      'purpose',
+      'commitment',
+      'data',
+    })) {
+      throw const FormatException(
+        'BitIntroduction commitment v1 has unknown or missing fields',
+      );
+    }
+    final data = entry['data'];
+    if (data is! Map) {
+      throw const FormatException(
+        'BitIntroduction commitment data is malformed',
+      );
+    }
+    final profile = BitMessageProfile.fromJson(
+      Map<String, dynamic>.from(data),
+    );
+    if (profile.bitNameHash != bitNameHash) {
+      throw const FormatException(
+        'BitIntroduction profile belongs to another BitName',
+      );
+    }
+    final expected = bitNamesApplicationCommitment(
+      namespace: bitIntroductionCommitmentNamespace,
+      purpose: bitIntroductionCommitmentPurpose,
+      network: network,
+      bitNameHash: bitNameHash,
+      payload: profile.toCommitmentPayloadJson(),
+    );
+    if (entry['commitment'] != expected ||
+        canonicalJsonEncode(data) !=
+            canonicalJsonEncode(
+              profile.toCommitmentPayloadJson(),
+            )) {
+      throw const FormatException(
+        'BitIntroduction commitment data does not match its leaf',
+      );
+    }
+    return profile.withCommitmentManifest(toJson());
+  }
+}
+
+class BitNamesCommitmentWritePlan {
+  const BitNamesCommitmentWritePlan({
+    required this.profile,
+    required this.commitment,
+    required this.kind,
+    required this.migratesLegacy,
+    required this.preservedApplications,
+  });
+
+  final BitMessageProfile profile;
+  final String commitment;
+  final BitNamesProfileCommitmentKind kind;
+  final bool migratesLegacy;
+  final int preservedApplications;
+
+  String get summary => switch (kind) {
+    BitNamesProfileCommitmentKind.namespaced =>
+      migratesLegacy
+          ? 'Migrating the legacy reply profile into the namespaced v1 manifest'
+          : 'Publishing a namespaced v1 reply-profile commitment',
+    _ => 'Publishing a legacy-compatible reply-profile commitment',
+  };
+}
+
+class BitNamesCommitmentPlanner {
+  const BitNamesCommitmentPlanner({
+    required this.network,
+    required this.activation,
+  });
+
+  final String network;
+  final BitNamesCommitmentActivation activation;
+
+  BitNamesCommitmentAssessment assess({
+    required String? onChainCommitment,
+    BitMessageProfile? knownProfile,
+  }) => assessBitMessageProfileCommitment(
+    profile: knownProfile,
+    onChainCommitment: onChainCommitment,
+    network: network,
+  );
+
+  BitNamesCommitmentWritePlan plan({
+    required BitMessageProfile profile,
+    required String? currentCommitment,
+    BitMessageProfile? knownProfile,
+  }) {
+    final baseProfile = profile.withCommitmentManifest(null);
+    final assessment = assess(
+      onChainCommitment: currentCommitment,
+      knownProfile: knownProfile ?? baseProfile,
+    );
+    if (!assessment.writable) {
+      throw BitNamesCommitmentConflict(assessment.details);
+    }
+    final existingNamespaced = assessment.kind == BitNamesProfileCommitmentKind.namespaced;
+    final useNamespaced =
+        existingNamespaced ||
+        _isSelfConsistentNamespacedProfile(knownProfile, network) ||
+        activation == BitNamesCommitmentActivation.namespacedV1;
+    if (!useNamespaced) {
+      return BitNamesCommitmentWritePlan(
+        profile: baseProfile,
+        commitment: bitMessageProfileCommitment(baseProfile),
+        kind: BitNamesProfileCommitmentKind.legacy,
+        migratesLegacy: false,
+        preservedApplications: 0,
+      );
+    }
+    final manifest = BitNamesCommitmentManifest.forReplyProfile(
+      baseProfile,
+      network: network,
+      base: assessment.manifest,
+    );
+    final committedProfile = baseProfile.withCommitmentManifest(manifest.toJson());
+    return BitNamesCommitmentWritePlan(
+      profile: committedProfile,
+      commitment: manifest.commitment,
+      kind: BitNamesProfileCommitmentKind.namespaced,
+      migratesLegacy: assessment.kind == BitNamesProfileCommitmentKind.legacy,
+      preservedApplications: manifest.applications.length - 1,
+    );
+  }
+}
+
+bool _isSelfConsistentNamespacedProfile(
+  BitMessageProfile? profile,
+  String network,
+) {
+  if (profile?.commitmentManifest == null) return false;
+  try {
+    final manifest = BitNamesCommitmentManifest.parse(
+      profile!.commitmentManifest!,
+    );
+    return assessBitMessageProfileCommitment(
+          profile: profile,
+          onChainCommitment: manifest.commitment,
+          network: network,
+        ).kind ==
+        BitNamesProfileCommitmentKind.namespaced;
+  } catch (_) {
+    return false;
+  }
+}
+
+BitNamesCommitmentAssessment assessBitMessageProfileCommitment({
+  required BitMessageProfile? profile,
+  required String? onChainCommitment,
+  required String network,
+}) {
+  if (onChainCommitment == null) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.empty,
+      'No application commitment is set',
+      'BitWindow can publish without replacing another application.',
+    );
+  }
+  final commitment = onChainCommitment.trim().toLowerCase();
+  if (!_hashPattern.hasMatch(commitment)) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.malformed,
+      'The on-chain commitment is malformed',
+      'BitWindow will not replace a malformed or ambiguous commitment.',
+    );
+  }
+  if (profile == null) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.unknown,
+      'Another or unknown application commitment is present',
+      'BitWindow cannot authenticate its contents, so publishing is blocked to preserve it.',
+    );
+  }
+  final manifestJson = profile.commitmentManifest;
+  if (manifestJson == null) {
+    if (bitMessageProfileCommitment(profile) == commitment) {
+      return const BitNamesCommitmentAssessment(
+        BitNamesProfileCommitmentKind.legacy,
+        'Legacy BitIntroduction reply profile',
+        'This commitment is recognized and remains verifiable.',
+      );
+    }
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.conflict,
+      'The commitment was replaced',
+      'The saved reply profile no longer matches on-chain state; BitWindow will not overwrite it.',
+    );
+  }
+
+  String manifestCommitment;
+  try {
+    _boundedCanonical(manifestJson);
+    manifestCommitment = blake3Hex(
+      utf8.encode(canonicalJsonEncode(manifestJson)),
+    );
+  } catch (_) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.malformed,
+      'The saved commitment proof is malformed',
+      'BitWindow cannot authenticate this manifest and will not replace the on-chain commitment.',
+    );
+  }
+  if (manifestCommitment != commitment) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.conflict,
+      'The commitment was replaced',
+      'The saved manifest no longer matches on-chain state; BitWindow will not overwrite it.',
+    );
+  }
+  if (manifestJson['protocol'] != bitNamesCommitmentManifestProtocol ||
+      manifestJson['version'] != bitNamesCommitmentManifestVersion) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.unknown,
+      'Unknown commitment manifest version',
+      'The authenticated bytes are preserved, but this BitWindow version will not interpret or overwrite them.',
+    );
+  }
+  try {
+    final manifest = BitNamesCommitmentManifest.parse(manifestJson);
+    if (manifest.network != bitNamesCommitmentNetwork(network)) {
+      return const BitNamesCommitmentAssessment(
+        BitNamesProfileCommitmentKind.wrongNetwork,
+        'Reply profile belongs to another network',
+        'Cross-network commitment replay was rejected.',
+      );
+    }
+    final committed = manifest.replyProfile();
+    if (canonicalJsonEncode(
+          committed.toCommitmentPayloadJson(),
+        ) !=
+        canonicalJsonEncode(
+          profile.toCommitmentPayloadJson(),
+        )) {
+      return const BitNamesCommitmentAssessment(
+        BitNamesProfileCommitmentKind.conflict,
+        'Reply-profile commitment data differs',
+        'The manifest is authenticated but does not describe the supplied reply profile.',
+      );
+    }
+    return BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.namespaced,
+      'Namespaced BitIntroduction v1 commitment',
+      'The manifest is authenticated for ${manifest.network} and preserves ${manifest.applications.length - 1} other application namespace(s).',
+      manifest: manifest,
+    );
+  } catch (_) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.malformed,
+      'The commitment manifest is invalid',
+      'BitWindow will not interpret or replace invalid authenticated application data.',
+    );
+  }
+}
+
+String bitNamesApplicationCommitment({
+  required String namespace,
+  required String purpose,
+  required String network,
+  required String bitNameHash,
+  required Map<String, dynamic> payload,
+  int version = bitIntroductionCommitmentVersion,
+}) {
+  if (!_namespacePattern.hasMatch(namespace) ||
+      !_purposePattern.hasMatch(purpose) ||
+      !_hashPattern.hasMatch(bitNameHash) ||
+      version < 1 ||
+      version > 0x7fffffff) {
+    throw const FormatException(
+      'invalid application commitment domain',
+    );
+  }
+  final preimage = {
+    'protocol': bitNamesApplicationCommitmentProtocol,
+    'version': version,
+    'network': bitNamesCommitmentNetwork(network),
+    'bitname_hash': bitNameHash,
+    'namespace': namespace,
+    'purpose': purpose,
+    'payload': _cloneObject(payload),
+  };
+  _boundedCanonical(preimage);
+  return blake3Hex(
+    utf8.encode(canonicalJsonEncode(preimage)),
+  );
+}
+
+String bitNamesCommitmentNetwork(String network) {
+  final normalized = network.trim().toLowerCase();
+  final full = normalized.startsWith('$bitNamesCommitmentChain:') ? normalized : '$bitNamesCommitmentChain:$normalized';
+  final suffix = full.substring(
+    bitNamesCommitmentChain.length + 1,
+  );
+  if (!_networkPattern.hasMatch(suffix)) {
+    throw const FormatException(
+      'invalid BitNames commitment network',
+    );
+  }
+  return full;
+}
+
+String bitNamesAuthoritativeProfileCommitment(
+  BitMessageProfile profile,
+) {
+  final manifest = profile.commitmentManifest;
+  return manifest == null
+      ? bitMessageProfileCommitment(profile)
+      : BitNamesCommitmentManifest.parse(
+          manifest,
+        ).commitment;
+}
+
+Map<String, dynamic> bitNamesCommitResponse(
+  BitMessageProfile profile,
+) {
+  final manifest = profile.commitmentManifest;
+  return manifest == null
+      ? profile.toCommitmentPayloadJson()
+      : BitNamesCommitmentManifest.parse(
+          manifest,
+        ).toJson();
+}
+
+BitMessageProfile bitNamesProfileFromCommitResponse(
+  Map<String, dynamic> response,
+) {
+  if (response['protocol'] == bitNamesCommitmentManifestProtocol) {
+    return BitNamesCommitmentManifest.parse(
+      response,
+    ).replyProfile();
+  }
+  final profile = BitMessageProfile.fromJson(response);
+  if (profile.commitmentManifest != null) {
+    throw const FormatException(
+      'legacy profile response cannot carry a manifest wrapper',
+    );
+  }
+  return profile;
+}
+
+final _hashPattern = RegExp(r'^[0-9a-f]{64}$');
+final _namespacePattern = RegExp(
+  r'^(?=.{3,127}$)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$',
+);
+final _purposePattern = RegExp(
+  r'^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$',
+);
+final _networkPattern = RegExp(
+  r'^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$',
+);
+
+bool _hasExactKeys(Map value, Set<String> keys) => value.length == keys.length && value.keys.every(keys.contains);
+
+Map<String, dynamic> _cloneObject(Map source) {
+  try {
+    return Map<String, dynamic>.from(
+      jsonDecode(jsonEncode(source)) as Map,
+    );
+  } catch (_) {
+    throw const FormatException(
+      'commitment data must be a JSON object',
+    );
+  }
+}
+
+void _boundedCanonical(Map<String, dynamic> value) {
+  late final List<int> encoded;
+  try {
+    encoded = utf8.encode(canonicalJsonEncode(value));
+  } on ArgumentError {
+    throw const FormatException(
+      'commitment data must use canonical JSON values',
+    );
+  }
+  if (encoded.length > bitNamesCommitmentMaxBytes) {
+    throw const FormatException(
+      'BitNames commitment manifest exceeds 16 KiB',
+    );
+  }
+}

--- a/bitwindow/lib/models/bitnames_recovery.dart
+++ b/bitwindow/lib/models/bitnames_recovery.dart
@@ -1,0 +1,426 @@
+enum BitnamesChainHealthState {
+  unknown,
+  disconnected,
+  synced,
+  waitingForBlock,
+  recovering,
+  stalled,
+  error,
+}
+
+class BitnamesChainSnapshot {
+  const BitnamesChainSnapshot({
+    this.state = BitnamesChainHealthState.unknown,
+    this.enforcerHeight,
+    this.enforcerHash,
+    this.bitnamesMainchainHash,
+    this.sidechainHeight,
+    this.sidechainHash,
+    this.peerCount,
+    this.observedAt,
+    this.lastProgressAt,
+    this.lastReconciledAt,
+    this.recoveryAttempts = 0,
+    this.recoveryTip,
+    this.error,
+  });
+
+  final BitnamesChainHealthState state;
+  final int? enforcerHeight;
+  final String? enforcerHash;
+  final String? bitnamesMainchainHash;
+  final int? sidechainHeight;
+  final String? sidechainHash;
+  final int? peerCount;
+  final DateTime? observedAt;
+  final DateTime? lastProgressAt;
+  final DateTime? lastReconciledAt;
+  final int recoveryAttempts;
+  final String? recoveryTip;
+  final String? error;
+
+  bool get mutationSafe =>
+      state == BitnamesChainHealthState.synced || state == BitnamesChainHealthState.waitingForBlock;
+  bool get needsAttention =>
+      state == BitnamesChainHealthState.stalled ||
+      state == BitnamesChainHealthState.error ||
+      state == BitnamesChainHealthState.disconnected;
+
+  String get summary => switch (state) {
+    BitnamesChainHealthState.unknown => 'Checking BitNames chain progress…',
+    BitnamesChainHealthState.disconnected => 'BitNames or its enforcer is disconnected',
+    BitnamesChainHealthState.synced => 'BitNames is operational • sidechain block ${sidechainHeight ?? 'unknown'}',
+    BitnamesChainHealthState.waitingForBlock => 'Transaction submitted • waiting for a BitNames miner and BMM block',
+    BitnamesChainHealthState.recovering => 'BitNames RPC failed • restarting it once and reconciling',
+    BitnamesChainHealthState.stalled =>
+      'BitNames has not produced a sidechain block • submitted transactions remain pending',
+    BitnamesChainHealthState.error => 'Could not verify BitNames chain progress',
+  };
+
+  String get details {
+    final enforcer = '${enforcerHeight ?? '?'} • ${_short(enforcerHash)}';
+    final observed = _short(bitnamesMainchainHash);
+    final sidechain = '${sidechainHeight ?? '?'} • ${_short(sidechainHash)}';
+    final parts = [
+      'Enforcer tip $enforcer',
+      'Sidechain tip BMM-verified in mainchain block $observed',
+      'BitNames sidechain $sidechain',
+      if (peerCount != null) '$peerCount peer${peerCount == 1 ? '' : 's'}',
+      if (lastProgressAt != null) 'last progress ${lastProgressAt!.toIso8601String()}',
+      if (error != null) error!,
+    ];
+    return parts.join(' • ');
+  }
+
+  BitnamesChainSnapshot copyWith({
+    BitnamesChainHealthState? state,
+    int? enforcerHeight,
+    String? enforcerHash,
+    String? bitnamesMainchainHash,
+    int? sidechainHeight,
+    String? sidechainHash,
+    int? peerCount,
+    DateTime? observedAt,
+    DateTime? lastProgressAt,
+    DateTime? lastReconciledAt,
+    int? recoveryAttempts,
+    String? recoveryTip,
+    String? error,
+    bool clearRecoveryTip = false,
+    bool clearError = false,
+  }) {
+    return BitnamesChainSnapshot(
+      state: state ?? this.state,
+      enforcerHeight: enforcerHeight ?? this.enforcerHeight,
+      enforcerHash: enforcerHash ?? this.enforcerHash,
+      bitnamesMainchainHash: bitnamesMainchainHash ?? this.bitnamesMainchainHash,
+      sidechainHeight: sidechainHeight ?? this.sidechainHeight,
+      sidechainHash: sidechainHash ?? this.sidechainHash,
+      peerCount: peerCount ?? this.peerCount,
+      observedAt: observedAt ?? this.observedAt,
+      lastProgressAt: lastProgressAt ?? this.lastProgressAt,
+      lastReconciledAt: lastReconciledAt ?? this.lastReconciledAt,
+      recoveryAttempts: recoveryAttempts ?? this.recoveryAttempts,
+      recoveryTip: clearRecoveryTip ? null : recoveryTip ?? this.recoveryTip,
+      error: clearError ? null : error ?? this.error,
+    );
+  }
+
+  factory BitnamesChainSnapshot.fromJson(Map<String, dynamic> json) {
+    return BitnamesChainSnapshot(
+      state: BitnamesChainHealthState.values.firstWhere(
+        (value) => value.name == json['state'],
+        orElse: () => BitnamesChainHealthState.unknown,
+      ),
+      enforcerHeight: json['enforcer_height'] as int?,
+      enforcerHash: json['enforcer_hash'] as String?,
+      bitnamesMainchainHash: json['bitnames_mainchain_hash'] as String?,
+      sidechainHeight: json['sidechain_height'] as int?,
+      sidechainHash: json['sidechain_hash'] as String?,
+      peerCount: json['peer_count'] as int?,
+      observedAt: _date(json['observed_at']),
+      lastProgressAt: _date(json['last_progress_at']),
+      lastReconciledAt: _date(json['last_reconciled_at']),
+      recoveryAttempts: json['recovery_attempts'] as int? ?? 0,
+      recoveryTip: json['recovery_tip'] as String?,
+      error: json['error'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'state': state.name,
+    if (enforcerHeight != null) 'enforcer_height': enforcerHeight,
+    if (enforcerHash != null) 'enforcer_hash': enforcerHash,
+    if (bitnamesMainchainHash != null) 'bitnames_mainchain_hash': bitnamesMainchainHash,
+    if (sidechainHeight != null) 'sidechain_height': sidechainHeight,
+    if (sidechainHash != null) 'sidechain_hash': sidechainHash,
+    if (peerCount != null) 'peer_count': peerCount,
+    if (observedAt != null) 'observed_at': observedAt!.millisecondsSinceEpoch,
+    if (lastProgressAt != null) 'last_progress_at': lastProgressAt!.millisecondsSinceEpoch,
+    if (lastReconciledAt != null) 'last_reconciled_at': lastReconciledAt!.millisecondsSinceEpoch,
+    'recovery_attempts': recoveryAttempts,
+    if (recoveryTip != null) 'recovery_tip': recoveryTip,
+    if (error != null) 'error': error,
+  };
+}
+
+class BitnamesChainObservation {
+  const BitnamesChainObservation({
+    required this.enforcerHeight,
+    required this.enforcerHash,
+    required this.bitnamesMainchainHash,
+    required this.sidechainHeight,
+    required this.sidechainHash,
+    required this.peerCount,
+    this.waitingForBlock = false,
+  });
+
+  final int enforcerHeight;
+  final String enforcerHash;
+  final String bitnamesMainchainHash;
+  final int sidechainHeight;
+  final String sidechainHash;
+  final int peerCount;
+  final bool waitingForBlock;
+}
+
+class BitnamesChainRecoveryDecision {
+  const BitnamesChainRecoveryDecision({
+    required this.snapshot,
+    this.restartBitnames = false,
+    this.reconcile = false,
+  });
+
+  final BitnamesChainSnapshot snapshot;
+  final bool restartBitnames;
+  final bool reconcile;
+}
+
+class BitnamesChainRecovery {
+  const BitnamesChainRecovery({
+    this.stallAfter = const Duration(seconds: 90),
+    this.maxAutomaticRestarts = 1,
+  });
+
+  final Duration stallAfter;
+  final int maxAutomaticRestarts;
+
+  BitnamesChainRecoveryDecision disconnected(
+    BitnamesChainSnapshot previous,
+    DateTime now,
+  ) {
+    return BitnamesChainRecoveryDecision(
+      snapshot: previous.copyWith(
+        state: BitnamesChainHealthState.disconnected,
+        observedAt: now,
+      ),
+    );
+  }
+
+  BitnamesChainRecoveryDecision failed(
+    BitnamesChainSnapshot previous,
+    DateTime now,
+    Object error,
+  ) {
+    final canRestart = previous.recoveryAttempts < maxAutomaticRestarts;
+    return BitnamesChainRecoveryDecision(
+      snapshot: previous.copyWith(
+        state: canRestart ? BitnamesChainHealthState.recovering : BitnamesChainHealthState.error,
+        observedAt: now,
+        recoveryAttempts: canRestart ? previous.recoveryAttempts + 1 : previous.recoveryAttempts,
+        error: '$error',
+      ),
+      restartBitnames: canRestart,
+    );
+  }
+
+  BitnamesChainRecoveryDecision observe(
+    BitnamesChainSnapshot previous,
+    BitnamesChainObservation observation,
+    DateTime now,
+  ) {
+    final bitnamesProgressed =
+        previous.bitnamesMainchainHash != observation.bitnamesMainchainHash ||
+        previous.sidechainHeight != observation.sidechainHeight ||
+        previous.sidechainHash != observation.sidechainHash;
+    final firstObservation = previous.observedAt == null;
+    final lastProgress = firstObservation || bitnamesProgressed
+        ? now
+        : previous.lastProgressAt ?? previous.observedAt ?? now;
+    final state = !observation.waitingForBlock
+        ? BitnamesChainHealthState.synced
+        : now.difference(lastProgress) < stallAfter
+        ? BitnamesChainHealthState.waitingForBlock
+        : BitnamesChainHealthState.stalled;
+    return BitnamesChainRecoveryDecision(
+      snapshot: _snapshot(
+        observation,
+        now,
+        lastProgress,
+        state,
+        recoveryAttempts: 0,
+      ),
+      reconcile: true,
+    );
+  }
+
+  BitnamesChainSnapshot _snapshot(
+    BitnamesChainObservation observation,
+    DateTime now,
+    DateTime lastProgress,
+    BitnamesChainHealthState state, {
+    required int recoveryAttempts,
+    String? recoveryTip,
+  }) {
+    return BitnamesChainSnapshot(
+      state: state,
+      enforcerHeight: observation.enforcerHeight,
+      enforcerHash: observation.enforcerHash,
+      bitnamesMainchainHash: observation.bitnamesMainchainHash,
+      sidechainHeight: observation.sidechainHeight,
+      sidechainHash: observation.sidechainHash,
+      peerCount: observation.peerCount,
+      observedAt: now,
+      lastProgressAt: lastProgress,
+      recoveryAttempts: recoveryAttempts,
+      recoveryTip: recoveryTip,
+    );
+  }
+}
+
+enum BitnamesOperationType {
+  registration,
+  profilePublication,
+}
+
+enum BitnamesOperationPhase {
+  prepared,
+  reservationSubmitting,
+  reservationSubmitted,
+  registrationSubmitting,
+  registrationSubmitted,
+  profileSubmitting,
+  profileSubmitted,
+  confirmed,
+  paused,
+  failed,
+  cancelled,
+}
+
+class BitnamesOperation {
+  const BitnamesOperation({
+    required this.id,
+    required this.type,
+    required this.phase,
+    required this.bitnameHash,
+    required this.createdAt,
+    required this.updatedAt,
+    this.plaintextName,
+    this.reservationTxid,
+    this.txid,
+    this.introductionFeeSats,
+    this.encryptionPubkey,
+    this.signingPubkey,
+    this.profile,
+    this.lastObservedSidechainHeight,
+    this.attempts = 0,
+    this.maySpend = false,
+    this.lastError,
+  });
+
+  final String id;
+  final BitnamesOperationType type;
+  final BitnamesOperationPhase phase;
+  final String bitnameHash;
+  final String? plaintextName;
+  final String? reservationTxid;
+  final String? txid;
+  final int? introductionFeeSats;
+  final String? encryptionPubkey;
+  final String? signingPubkey;
+  final Map<String, dynamic>? profile;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final int? lastObservedSidechainHeight;
+  final int attempts;
+  final bool maySpend;
+  final String? lastError;
+
+  bool get terminal =>
+      phase == BitnamesOperationPhase.confirmed ||
+      phase == BitnamesOperationPhase.failed ||
+      phase == BitnamesOperationPhase.cancelled;
+  bool get uncertain =>
+      phase == BitnamesOperationPhase.reservationSubmitting ||
+      phase == BitnamesOperationPhase.registrationSubmitting ||
+      phase == BitnamesOperationPhase.profileSubmitting;
+
+  BitnamesOperation copyWith({
+    BitnamesOperationPhase? phase,
+    String? reservationTxid,
+    String? txid,
+    int? introductionFeeSats,
+    String? encryptionPubkey,
+    String? signingPubkey,
+    Map<String, dynamic>? profile,
+    DateTime? updatedAt,
+    int? lastObservedSidechainHeight,
+    int? attempts,
+    bool? maySpend,
+    String? lastError,
+    bool clearError = false,
+  }) {
+    return BitnamesOperation(
+      id: id,
+      type: type,
+      phase: phase ?? this.phase,
+      bitnameHash: bitnameHash,
+      plaintextName: plaintextName,
+      reservationTxid: reservationTxid ?? this.reservationTxid,
+      txid: txid ?? this.txid,
+      introductionFeeSats: introductionFeeSats ?? this.introductionFeeSats,
+      encryptionPubkey: encryptionPubkey ?? this.encryptionPubkey,
+      signingPubkey: signingPubkey ?? this.signingPubkey,
+      profile: profile ?? this.profile,
+      createdAt: createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      lastObservedSidechainHeight: lastObservedSidechainHeight ?? this.lastObservedSidechainHeight,
+      attempts: attempts ?? this.attempts,
+      maySpend: maySpend ?? this.maySpend,
+      lastError: clearError ? null : lastError ?? this.lastError,
+    );
+  }
+
+  factory BitnamesOperation.fromJson(Map<String, dynamic> json) {
+    return BitnamesOperation(
+      id: json['id'] as String,
+      type: BitnamesOperationType.values.firstWhere(
+        (value) => value.name == json['type'],
+      ),
+      phase: BitnamesOperationPhase.values.firstWhere(
+        (value) => value.name == json['phase'],
+      ),
+      bitnameHash: json['bitname_hash'] as String,
+      plaintextName: json['plaintext_name'] as String?,
+      reservationTxid: json['reservation_txid'] as String?,
+      txid: json['txid'] as String?,
+      introductionFeeSats: json['introduction_fee_sats'] as int?,
+      encryptionPubkey: json['encryption_pubkey'] as String?,
+      signingPubkey: json['signing_pubkey'] as String?,
+      profile: json['profile'] is Map ? Map<String, dynamic>.from(json['profile'] as Map) : null,
+      createdAt: _date(json['created_at'])!,
+      updatedAt: _date(json['updated_at'])!,
+      lastObservedSidechainHeight: json['last_observed_sidechain_height'] as int?,
+      attempts: json['attempts'] as int? ?? 0,
+      maySpend: json['may_spend'] == true,
+      lastError: json['last_error'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'type': type.name,
+    'phase': phase.name,
+    'bitname_hash': bitnameHash,
+    if (plaintextName != null) 'plaintext_name': plaintextName,
+    if (reservationTxid != null) 'reservation_txid': reservationTxid,
+    if (txid != null) 'txid': txid,
+    if (introductionFeeSats != null) 'introduction_fee_sats': introductionFeeSats,
+    if (encryptionPubkey != null) 'encryption_pubkey': encryptionPubkey,
+    if (signingPubkey != null) 'signing_pubkey': signingPubkey,
+    if (profile != null) 'profile': profile,
+    'created_at': createdAt.millisecondsSinceEpoch,
+    'updated_at': updatedAt.millisecondsSinceEpoch,
+    if (lastObservedSidechainHeight != null) 'last_observed_sidechain_height': lastObservedSidechainHeight,
+    'attempts': attempts,
+    'may_spend': maySpend,
+    if (lastError != null) 'last_error': lastError,
+  };
+}
+
+DateTime? _date(Object? value) => value is int ? DateTime.fromMillisecondsSinceEpoch(value) : null;
+
+String _short(String? value) {
+  if (value == null || value.isEmpty) return 'unknown';
+  return value.length <= 12 ? value : '${value.substring(0, 12)}…';
+}

--- a/bitwindow/lib/services/bitintroduction_codec.dart
+++ b/bitwindow/lib/services/bitintroduction_codec.dart
@@ -1,0 +1,180 @@
+import 'dart:convert';
+
+import 'package:bitwindow/models/bitintroduction_protocol.dart';
+
+abstract interface class BitIntroductionSigningBackend {
+  Future<String> sign({required String signingPublicKey, required String payload});
+}
+
+abstract interface class BitIntroductionSignatureBackend {
+  Future<bool> verify({
+    required String signingPublicKey,
+    required String payload,
+    required String signature,
+  });
+}
+
+abstract interface class BitMessageProfileVerifier {
+  Future<VerifiedBitMessageProfile> verify(BitMessageProfile profile);
+}
+
+abstract interface class BitMessageCipherBackend {
+  Future<String> encrypt({required String encryptionPublicKey, required String plaintext});
+  Future<String> decrypt({required String encryptionPublicKey, required String ciphertext});
+}
+
+class VerifiedBitIntroductionEnvelope {
+  const VerifiedBitIntroductionEnvelope({
+    required this.envelope,
+    required this.senderProfile,
+    this.replyProfile,
+  });
+
+  final SignedBitIntroductionEnvelope envelope;
+  final VerifiedBitMessageProfile senderProfile;
+  final VerifiedBitMessageProfile? replyProfile;
+}
+
+class BitIntroductionEnvelopeCodec {
+  const BitIntroductionEnvelopeCodec({
+    this.signer,
+    this.signatureBackend,
+    this.profileVerifier,
+    this.cipherBackend,
+  });
+
+  final BitIntroductionSigningBackend? signer;
+  final BitIntroductionSignatureBackend? signatureBackend;
+  final BitMessageProfileVerifier? profileVerifier;
+  final BitMessageCipherBackend? cipherBackend;
+
+  Future<SignedBitIntroductionEnvelope> createSigned({
+    required String id,
+    required BitIntroductionKind kind,
+    required VerifiedBitMessageProfile senderProfile,
+    required String recipientBitNameHash,
+    required DateTime timestamp,
+    required String body,
+    String? inReplyTo,
+    VerifiedBitMessageProfile? replyProfile,
+  }) async {
+    final backend = signer ?? (throw StateError('A BitIntroductionSigningBackend is required to sign envelopes'));
+    if (replyProfile != null && replyProfile.bitNameHash != senderProfile.bitNameHash) {
+      throw ArgumentError('A reply profile must belong to the sending BitName');
+    }
+    final payload = BitIntroductionPayload(
+      id: id,
+      kind: kind,
+      senderBitNameHash: senderProfile.bitNameHash,
+      recipientBitNameHash: recipientBitNameHash,
+      timestamp: timestamp,
+      body: body,
+      inReplyTo: inReplyTo,
+      replyProfile: replyProfile?.profile,
+    );
+    final signature = await backend.sign(
+      signingPublicKey: senderProfile.signingPublicKey,
+      payload: canonicalJsonEncode(payload.toJson()),
+    );
+    return SignedBitIntroductionEnvelope(payload: payload, signature: signature);
+  }
+
+  String encode(SignedBitIntroductionEnvelope envelope) => canonicalJsonEncode(envelope.toJson());
+
+  SignedBitIntroductionEnvelope parse(String encoded) {
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(encoded);
+    } on FormatException catch (error) {
+      throw FormatException('Invalid BitIntroduction envelope JSON: ${error.message}');
+    }
+    if (decoded is! Map) throw const FormatException('BitIntroduction envelope must be an object');
+    return SignedBitIntroductionEnvelope.fromJson(Map<String, dynamic>.from(decoded));
+  }
+
+  Future<VerifiedBitIntroductionEnvelope> parseAndVerify(
+    String encoded, {
+    required VerifiedBitMessageProfile senderProfile,
+  }) => verify(parse(encoded), senderProfile: senderProfile);
+
+  Future<VerifiedBitIntroductionEnvelope> verify(
+    SignedBitIntroductionEnvelope envelope, {
+    required VerifiedBitMessageProfile senderProfile,
+    VerifiedBitMessageProfile? verifiedReplyProfile,
+  }) async {
+    final backend =
+        signatureBackend ?? (throw StateError('A BitIntroductionSignatureBackend is required to verify envelopes'));
+    if (envelope.payload.senderBitNameHash != senderProfile.bitNameHash) {
+      throw const FormatException('Envelope sender does not match the verified sender profile');
+    }
+    final valid = await backend.verify(
+      signingPublicKey: senderProfile.signingPublicKey,
+      payload: envelope.signedPayload,
+      signature: envelope.signature,
+    );
+    if (!valid) throw const FormatException('Invalid BitIntroduction signature');
+
+    VerifiedBitMessageProfile? verifiedReply;
+    final reply = envelope.payload.replyProfile;
+    if (reply != null) {
+      if (reply.bitNameHash != senderProfile.bitNameHash) {
+        throw const FormatException('Reply profile does not belong to the sender');
+      }
+      verifiedReply =
+          verifiedReplyProfile ??
+          await (profileVerifier ??
+                  (throw StateError(
+                    'A BitMessageProfileVerifier is required when an envelope carries a reply profile',
+                  )))
+              .verify(reply);
+      if (verifiedReply.bitNameHash != senderProfile.bitNameHash) {
+        throw const FormatException('Verified reply profile does not belong to the sender');
+      }
+      if (canonicalJsonEncode(verifiedReply.profile.toJson()) != canonicalJsonEncode(reply.toJson())) {
+        throw const FormatException('Verified reply profile differs from the signed profile');
+      }
+    }
+    return VerifiedBitIntroductionEnvelope(
+      envelope: envelope,
+      senderProfile: senderProfile,
+      replyProfile: verifiedReply,
+    );
+  }
+
+  Future<BitMessageWire> createWire({
+    required SignedBitIntroductionEnvelope envelope,
+    required VerifiedBitMessageProfile recipientProfile,
+  }) async {
+    final backend = cipherBackend ?? (throw StateError('A BitMessageCipherBackend is required to create a wire frame'));
+    if (envelope.payload.recipientBitNameHash != recipientProfile.bitNameHash) {
+      throw ArgumentError('Envelope recipient does not match recipientProfile');
+    }
+    return BitMessageWire(
+      recipientBitNameHash: recipientProfile.bitNameHash,
+      ciphertext: await backend.encrypt(
+        encryptionPublicKey: recipientProfile.encryptionPublicKey,
+        plaintext: encode(envelope),
+      ),
+    );
+  }
+
+  Future<SignedBitIntroductionEnvelope> openWire({
+    required BitMessageWire wire,
+    required VerifiedBitMessageProfile recipientProfile,
+  }) async {
+    final backend = cipherBackend ?? (throw StateError('A BitMessageCipherBackend is required to open a wire frame'));
+    if (wire.recipientBitNameHash != recipientProfile.bitNameHash) {
+      throw const FormatException('Wire recipient does not match the local BitName');
+    }
+    final envelope = parse(
+      await backend.decrypt(
+        encryptionPublicKey: recipientProfile.encryptionPublicKey,
+        ciphertext: wire.ciphertext,
+      ),
+    );
+    if (envelope.payload.recipientBitNameHash != wire.recipientBitNameHash) {
+      throw const FormatException('Encrypted envelope recipient does not match its outer wire');
+    }
+    return envelope;
+  }
+}

--- a/bitwindow/lib/services/bitmessage_server.dart
+++ b/bitwindow/lib/services/bitmessage_server.dart
@@ -1,0 +1,143 @@
+// dart format off
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:bitwindow/models/bitintroduction_protocol.dart';
+import 'package:bitwindow/models/bitnames_commitment.dart';
+typedef BitMessageProfileProvider = FutureOr<BitMessageProfile?> Function(String? bitNameHash);
+typedef IncomingBitMessageCallback = FutureOr<void> Function(BitMessageWire wire);
+class BitMessageServer {
+  BitMessageServer({
+    required this.profileProvider,
+    required this.onIncomingWire,
+    this.allowRemoteClients,
+    InternetAddress? bindAddress,
+    this.port = 0,
+    this.maxBodyBytes = 64 * 1024,
+    this.requestBodyTimeout = const Duration(seconds: 5),
+    this.callbackTimeout = const Duration(seconds: 10),
+    this.idleTimeout = const Duration(seconds: 15),
+    this.maxConcurrentRequests = 16,
+  }) : bindAddress = bindAddress ?? InternetAddress.loopbackIPv4 {
+    if (maxBodyBytes <= 0) throw ArgumentError.value(maxBodyBytes, 'maxBodyBytes', 'must be positive'); if (port < 0 || port > 65535) throw ArgumentError.value(port, 'port', 'must be between 0 and 65535'); if (maxConcurrentRequests < 1) throw ArgumentError.value(maxConcurrentRequests, 'maxConcurrentRequests');
+  }
+  final BitMessageProfileProvider profileProvider; final IncomingBitMessageCallback onIncomingWire;
+  final bool Function()? allowRemoteClients; final InternetAddress bindAddress;
+  final int port, maxBodyBytes; final Duration requestBodyTimeout, callbackTimeout, idleTimeout;
+  final int maxConcurrentRequests; HttpServer? _server; int _activeRequests = 0;
+  bool get isRunning => _server != null; Uri get localEndpoint {
+    final server = _server ?? (throw StateError('BitMessageServer has not been started'));
+    final address = server.address.address;
+    return Uri.parse(
+      'http://${server.address.type == InternetAddressType.IPv6 ? '[$address]' : address}:${server.port}',
+    );
+  }
+  Future<Uri> start() async {
+    if (isRunning) throw StateError('BitMessageServer is already running');
+    final server = await HttpServer.bind(bindAddress, port, shared: false);
+    server
+      ..idleTimeout = idleTimeout
+      ..autoCompress = false;
+    _server = server; server.listen((request) => unawaited(_handle(request)));
+    return localEndpoint;
+  }
+  Future<void> stop() async {
+    final server = _server; _server = null;
+    await server?.close(force: true);
+  }
+  Future<void> _handle(HttpRequest request) async {
+    if (_activeRequests >= maxConcurrentRequests) {
+      await _json(request.response, HttpStatus.serviceUnavailable, {'error': 'busy'});
+      return;
+    }
+    _activeRequests++;
+    try {
+      if (!(allowRemoteClients?.call() ?? true) && !(request.connectionInfo?.remoteAddress.isLoopback ?? false)) {
+        await _json(request.response, HttpStatus.forbidden, {'error': 'tor_only'});
+        return;
+      }
+      final commit = RegExp(r'^/bitname/([0-9a-fA-F]{64})/bitname_commit$').firstMatch(request.uri.path);
+      final submit = RegExp(r'^/bitname/([0-9a-fA-F]{64})/bitmessage_submit$').firstMatch(request.uri.path);
+      if (commit != null) {
+        if (!await _requireMethod(request, 'GET')) return;
+        await _serveProfile(request.response, commit[1]!.toLowerCase());
+      } else if (submit != null) {
+        if (!await _requireMethod(request, 'POST')) return;
+        await _accept(request, submit[1]!.toLowerCase());
+      } else if (request.uri.path == '/bitname_commit') {
+        if (!await _requireMethod(request, 'GET')) return;
+        await _serveProfile(request.response, null);
+      } else if (request.uri.path == '/bitmessage_submit') {
+        if (!await _requireMethod(request, 'POST')) return;
+        await _accept(request, null);
+      } else {
+        await _json(request.response, HttpStatus.notFound, {'error': 'not_found'});
+      }
+    } on _BodyTooLarge {
+      await _json(request.response, HttpStatus.requestEntityTooLarge, {'error': 'body_too_large'});
+    } on TimeoutException {
+      await _json(request.response, HttpStatus.requestTimeout, {'error': 'request_timeout'});
+    } on FormatException catch (error) {
+      await _json(request.response, HttpStatus.badRequest, {'error': 'invalid_request', 'detail': error.message});
+    } catch (_) {
+      await _json(request.response, HttpStatus.internalServerError, {'error': 'internal_error'});
+    } finally {
+      _activeRequests--;
+    }
+  }
+  Future<bool> _requireMethod(HttpRequest request, String method) async {
+    if (request.method == method) return true;
+    request.response.headers.set(HttpHeaders.allowHeader, method);
+    await _json(request.response, HttpStatus.methodNotAllowed, {'error': 'method_not_allowed'});
+    return false;
+  }
+  Future<void> _serveProfile(HttpResponse response, String? hash) async {
+    final profile = await Future<BitMessageProfile?>.sync(() => profileProvider(hash)).timeout(callbackTimeout);
+    if (profile == null) return _json(response, HttpStatus.notFound, {'error': 'identity_not_found'});
+    if (hash != null && profile.bitNameHash != hash) {
+      throw const FormatException('profile provider returned the wrong identity');
+    }
+    await _json(response, HttpStatus.ok, bitNamesCommitResponse(profile));
+  }
+  Future<void> _accept(HttpRequest request, String? expectedHash) async {
+    if (request.headers.contentType?.mimeType != ContentType.json.mimeType) {
+      return _json(request.response, HttpStatus.unsupportedMediaType, {'error': 'content_type_must_be_json'});
+    }
+    dynamic decoded;
+    try {
+      decoded = jsonDecode(utf8.decode(await _read(request)));
+    } on FormatException catch (error) {
+      throw FormatException('body is not valid UTF-8 JSON: $error');
+    }
+    if (decoded is! Map) throw const FormatException('body must be an object');
+    final wire = BitMessageWire.fromJson(Map<String, dynamic>.from(decoded));
+    if (expectedHash != null && wire.recipientBitNameHash != expectedHash) {
+      throw const FormatException('wire recipient does not match endpoint identity');
+    }
+    try {
+      await Future<void>.sync(() => onIncomingWire(wire)).timeout(callbackTimeout);
+    } on TimeoutException {
+      return _json(request.response, HttpStatus.gatewayTimeout, {'error': 'callback_timeout'});
+    }
+    await _json(request.response, HttpStatus.accepted, {'accepted': true});
+  }
+  Future<List<int>> _read(HttpRequest request) async {
+    if (request.contentLength > maxBodyBytes) throw const _BodyTooLarge();
+    final bytes = <int>[];
+    await (() async {
+      await for (final chunk in request) {
+        if (bytes.length + chunk.length > maxBodyBytes) throw const _BodyTooLarge();
+        bytes.addAll(chunk);
+      }
+    })().timeout(requestBodyTimeout);
+    return bytes;
+  }
+  Future<void> _json(HttpResponse response, int status, Map<String, dynamic> body) async {
+    response
+      ..statusCode = status
+      ..headers.contentType = ContentType.json;
+    response.headers.set(HttpHeaders.cacheControlHeader, 'no-store');
+    response.write(jsonEncode(body)); await response.close();
+  }
+}
+class _BodyTooLarge implements Exception { const _BodyTooLarge(); }

--- a/bitwindow/lib/services/bitmessage_transport.dart
+++ b/bitwindow/lib/services/bitmessage_transport.dart
@@ -1,0 +1,161 @@
+import 'dart:convert';
+
+import 'package:bitwindow/models/bitintroduction_protocol.dart';
+import 'package:bitwindow/models/bitnames_commitment.dart';
+import 'package:http/http.dart' as http;
+
+// dart format off
+enum BitMessageTransportType { direct, tor }
+class BitMessageHttpResponse {
+  const BitMessageHttpResponse({required this.statusCode, required this.body});
+  final int statusCode;
+  final String body;
+}
+abstract interface class BitMessageHttpDialer {
+  Future<BitMessageHttpResponse> get(Uri uri, {required Duration timeout});
+  Future<BitMessageHttpResponse> postJson(Uri uri, {required String body, required Duration timeout});
+  void close();
+}
+class DirectBitMessageHttpDialer implements BitMessageHttpDialer {
+  DirectBitMessageHttpDialer({http.Client? client}) : _client = client ?? http.Client();
+  final http.Client _client;
+
+  @override
+  Future<BitMessageHttpResponse> get(Uri uri, {required Duration timeout}) =>
+      _send(http.Request('GET', uri)..headers['accept'] = 'application/json', timeout);
+
+  @override
+  Future<BitMessageHttpResponse> postJson(
+    Uri uri, {
+    required String body,
+    required Duration timeout,
+  }) => _send(http.Request('POST', uri)
+    ..headers.addAll(const {'accept': 'application/json', 'content-type': 'application/json'})
+    ..body = body, timeout);
+
+  Future<BitMessageHttpResponse> _send(http.Request request, Duration timeout) async {
+    request.followRedirects = false;
+    final response = await _client.send(request).timeout(timeout), bytes = <int>[];
+    await response.stream.fold<void>(null, (_, chunk) {
+      if (bytes.length + chunk.length > 64 * 1024) throw StateError('HTTP response is too large');
+      bytes.addAll(chunk);
+    }).timeout(timeout);
+    return BitMessageHttpResponse(statusCode: response.statusCode, body: utf8.decode(bytes));
+  }
+
+  @override
+  void close() => _client.close();
+}
+class BitMessageSendResult {
+  const BitMessageSendResult({required this.transport, this.endpoint, this.failedAttempts = const []});
+  final BitMessageTransportType transport;
+  final Uri? endpoint;
+  final List<String> failedAttempts;
+}
+class BitMessageTransportException implements Exception {
+  const BitMessageTransportException(this.message, this.attempts);
+  final String message;
+  final List<String> attempts;
+
+  @override
+  String toString() => '$message (${attempts.join('; ')})';
+}
+
+class BitMessageTransport {
+  BitMessageTransport({
+    required this.directDialer,
+    this.torDialer,
+    this.requestTimeout = const Duration(seconds: 10),
+    this.maxProfileResponseBytes = 16 * 1024,
+  }) {
+    if (maxProfileResponseBytes <= 0) {
+      throw ArgumentError.value(maxProfileResponseBytes, 'maxProfileResponseBytes', 'must be positive');
+    }
+  }
+
+  final BitMessageHttpDialer directDialer;
+  final BitMessageHttpDialer? torDialer;
+  final Duration requestTimeout;
+  final int maxProfileResponseBytes;
+
+  Future<BitMessageSendResult> send(BitMessageWire wire, VerifiedBitMessageProfile profile,
+    {bool torOnly = false}) async {
+    if (wire.recipientBitNameHash != profile.bitNameHash) {
+      throw ArgumentError('Wire recipient does not match the verified profile');
+    }
+    final routes = _routes(profile.profile, torOnly);
+    if (torOnly && routes.isEmpty) {
+      throw const BitMessageTransportException('Tor mode is enabled but no Tor route is available', []);
+    }
+
+    final failures = <String>[];
+    for (final route in routes) {
+      try {
+        await _verifyProfile(route, profile);
+        final response = await route.dialer.postJson(route.endpoint.resolve('bitmessage_submit'),
+          body: canonicalJsonEncode(wire.toJson()), timeout: requestTimeout);
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          throw StateError('submit returned HTTP ${response.statusCode}');
+        }
+        return BitMessageSendResult(transport: route.type, endpoint: route.endpoint,
+          failedAttempts: List.unmodifiable(failures));
+      } catch (error) {
+        failures.add('${route.type.name}:${route.endpoint}: $error');
+      }
+    }
+    throw BitMessageTransportException('No BitMessage route accepted the message', List.unmodifiable(failures));
+  }
+
+  Future<BitMessageProfile?> discoverProfile(BitMessageProfile previous, {bool torOnly = false}) async {
+    for (final route in _routes(previous, torOnly)) {
+      try {
+        final profile = await _readProfile(route);
+        if (profile.bitNameHash == previous.bitNameHash) return profile;
+      } catch (_) {}
+    }
+    return null;
+  }
+
+  List<_HttpRoute> _routes(BitMessageProfile profile, bool torOnly) => [
+    if (!torOnly) ...profile.directEndpoints.map((uri) => _HttpRoute(BitMessageTransportType.direct, uri, directDialer)),
+    if (torDialer != null) ...profile.torEndpoints.map((uri) => _HttpRoute(BitMessageTransportType.tor, uri, torDialer!)),
+  ];
+
+  Future<void> _verifyProfile(_HttpRoute route, VerifiedBitMessageProfile expected) async {
+    final served = await _readProfile(route);
+    if (bitNamesAuthoritativeProfileCommitment(served) != expected.onChainCommitment) {
+      throw StateError('served profile does not match the authoritative BitName commitment');
+    }
+    if (canonicalJsonEncode(served.toJson()) != canonicalJsonEncode(expected.profile.toJson())) {
+      throw StateError('served profile differs from the verified profile');
+    }
+  }
+
+  Future<BitMessageProfile> _readProfile(_HttpRoute route) async {
+    final response = await route.dialer.get(route.endpoint.resolve('bitname_commit'), timeout: requestTimeout);
+    if (response.statusCode != 200) throw StateError('commit returned HTTP ${response.statusCode}');
+    if (utf8.encode(response.body).length > maxProfileResponseBytes) {
+      throw StateError('committed profile response is too large');
+    }
+    dynamic decoded;
+    try {
+      decoded = jsonDecode(response.body);
+    } on FormatException {
+      throw StateError('committed profile response is not valid JSON');
+    }
+    if (decoded is! Map) throw StateError('committed profile response must be an object');
+    return bitNamesProfileFromCommitResponse(Map<String, dynamic>.from(decoded));
+  }
+
+  void close() {
+    directDialer.close();
+    if (!identical(torDialer, directDialer)) torDialer?.close();
+  }
+}
+
+class _HttpRoute {
+  const _HttpRoute(this.type, this.endpoint, this.dialer);
+  final BitMessageTransportType type;
+  final Uri endpoint;
+  final BitMessageHttpDialer dialer;
+}

--- a/bitwindow/lib/services/bitnames_bitintroduction_backend.dart
+++ b/bitwindow/lib/services/bitnames_bitintroduction_backend.dart
@@ -1,0 +1,65 @@
+import 'package:bitwindow/models/bitintroduction_protocol.dart';
+import 'package:bitwindow/models/bitnames_commitment.dart';
+import 'package:bitwindow/services/bitintroduction_codec.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+// dart format off
+class BitnamesBitIntroductionSigner implements BitIntroductionSigningBackend {
+  const BitnamesBitIntroductionSigner(this.rpc);
+  final BitnamesRPC rpc;
+  @override
+  Future<String> sign({required String signingPublicKey, required String payload}) => rpc.signArbitraryMsg(msg: payload, verifyingKey: signingPublicKey);
+}
+class BitnamesBitIntroductionSignatureVerifier implements BitIntroductionSignatureBackend {
+  const BitnamesBitIntroductionSignatureVerifier(this.rpc);
+  final BitnamesRPC rpc;
+  @override
+  Future<bool> verify({required String signingPublicKey, required String payload, required String signature}) =>
+      rpc.verifySignature(signature: signature, verifyingKey: signingPublicKey, msg: payload);
+}
+class BitnamesBitMessageCipher implements BitMessageCipherBackend {
+  const BitnamesBitMessageCipher(this.rpc);
+  final BitnamesRPC rpc;
+  @override
+  Future<String> encrypt({required String encryptionPublicKey, required String plaintext}) => rpc.encryptMsg(msg: plaintext, encryptionPubkey: encryptionPublicKey);
+  @override
+  Future<String> decrypt({required String encryptionPublicKey, required String ciphertext}) => rpc.decryptMsg(ciphertext: ciphertext, encryptionPubkey: encryptionPublicKey);
+}
+class BitnamesBitMessageProfileVerifier implements BitMessageProfileVerifier {
+  const BitnamesBitMessageProfileVerifier(this.rpc, {required this.commitmentNetwork});
+  final BitnamesRPC rpc;
+  final String commitmentNetwork;
+  @override
+  Future<VerifiedBitMessageProfile> verify(BitMessageProfile profile) async {
+    final resolution = await rpc.resolveBitName(profile.bitNameHash);
+    if (resolution == null) throw StateError('BitName is no longer registered');
+    return verifyAt(profile, resolution.data, canonicalJsonEncode(resolution.outpoint));
+  }
+  VerifiedBitMessageProfile verifyAt(BitMessageProfile profile, BitNameData data, String reference) {
+    final commitment = data.commitment;
+    if (commitment == null) throw StateError('BitName has not committed to a reply profile');
+    final assessment = assessBitMessageProfileCommitment(
+      profile: profile,
+      onChainCommitment: commitment,
+      network: commitmentNetwork,
+    );
+    if (!assessment.verified) {
+      throw StateError('${assessment.summary}. ${assessment.details}');
+    }
+    if (!_sameKey(data.signingPubkey, profile.signingPublicKey)) throw StateError('Reply profile signing key does not match BitNames');
+    if (!_sameKey(data.encryptionPubkey, profile.encryptionPublicKey)) throw StateError('Reply profile encryption key does not match BitNames');
+    if (data.paymailFeeSats != profile.paymailFeeSats) throw StateError('Reply profile introduction fee does not match BitNames');
+    return VerifiedBitMessageProfile.verified(
+      profile: profile,
+      onChainCommitment: commitment,
+      verificationReference: reference,
+      commitmentVerifier: (candidate, onChain) => assessBitMessageProfileCommitment(
+        profile: candidate,
+        onChainCommitment: onChain,
+        network: commitmentNetwork,
+      ).verified,
+    );
+  }
+  bool _sameKey(String? onChain, String claimed) => onChain?.toLowerCase() == claimed.toLowerCase();
+}
+// dart format on

--- a/bitwindow/lib/services/bitnames_secure_store.dart
+++ b/bitwindow/lib/services/bitnames_secure_store.dart
@@ -1,0 +1,701 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:flutter/foundation.dart';
+import 'package:pointycastle/export.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:synchronized/synchronized.dart';
+
+enum BitnamesStorageState {
+  locked,
+  empty,
+  ready,
+  migrated,
+  recovered,
+  corrupt,
+}
+
+class BitnamesStorageStatus {
+  const BitnamesStorageStatus(
+    this.state, {
+    this.generation,
+    this.details,
+  });
+
+  final BitnamesStorageState state;
+  final int? generation;
+  final String? details;
+
+  bool get writable => {
+    BitnamesStorageState.empty,
+    BitnamesStorageState.ready,
+    BitnamesStorageState.migrated,
+    BitnamesStorageState.recovered,
+  }.contains(state);
+
+  String get summary => switch (state) {
+    BitnamesStorageState.locked => 'Private chat storage is locked',
+    BitnamesStorageState.empty => 'Private chat storage is ready',
+    BitnamesStorageState.ready => 'Chats and reply routes are encrypted',
+    BitnamesStorageState.migrated => 'Existing chats were encrypted',
+    BitnamesStorageState.recovered => 'Encrypted chat storage recovered safely',
+    BitnamesStorageState.corrupt => 'Private chat storage needs recovery',
+  };
+}
+
+class BitnamesStorageException implements Exception {
+  const BitnamesStorageException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+class BitnamesStorageIdentity {
+  BitnamesStorageIdentity({
+    required this.scope,
+    required Uint8List secret,
+  }) : secret = Uint8List.fromList(secret);
+
+  final String scope;
+  final Uint8List secret;
+}
+
+abstract class BitnamesStorageKeySource implements Listenable {
+  Future<BitnamesStorageIdentity?> current();
+}
+
+class WalletBitnamesStorageKeySource implements BitnamesStorageKeySource {
+  WalletBitnamesStorageKeySource(this.walletReader);
+
+  final WalletReaderProvider walletReader;
+
+  @visibleForTesting
+  static BitnamesStorageIdentity derive({
+    required String masterMnemonic,
+    String walletBinding = '',
+  }) {
+    final mnemonic = _normalizeWords(masterMnemonic);
+    final binding = _normalizeWords(walletBinding);
+    if (mnemonic.isEmpty) {
+      throw const BitnamesStorageException('The unlocked wallet has no encryption key material');
+    }
+    final root = crypto.sha256.convert(
+      utf8.encode(
+        'bitnames-storage-root-v2\u0000$mnemonic\u0000$binding',
+      ),
+    );
+    return BitnamesStorageIdentity(
+      scope: crypto.Hmac(
+        crypto.sha256,
+        root.bytes,
+      ).convert(utf8.encode('scope')).toString(),
+      secret: Uint8List.fromList(
+        crypto.Hmac(
+          crypto.sha256,
+          root.bytes,
+        ).convert(utf8.encode('encryption')).bytes,
+      ),
+    );
+  }
+
+  @override
+  Future<BitnamesStorageIdentity?> current() async {
+    final wallet = walletReader.activeWallet;
+    if (!walletReader.isWalletUnlocked || wallet == null) {
+      return null;
+    }
+    try {
+      return derive(
+        masterMnemonic: wallet.master.mnemonic,
+        walletBinding: wallet.l1.mnemonic,
+      );
+    } on BitnamesStorageException {
+      return null;
+    }
+  }
+
+  @override
+  void addListener(VoidCallback listener) => walletReader.addListener(listener);
+
+  @override
+  void removeListener(VoidCallback listener) => walletReader.removeListener(listener);
+}
+
+class BitnamesSecureStore {
+  BitnamesSecureStore({
+    required this.store,
+    required this.keySource,
+    DateTime Function()? now,
+    Uint8List Function(int)? randomBytes,
+  }) : _now = now ?? DateTime.now,
+       _randomBytes = randomBytes ?? _secureRandomBytes;
+
+  static const format = 'bitnames-private-store';
+  static const schema = 2;
+  static const legacyStateKey = 'bitintroduction_state_v1';
+  static const legacyContactsKey = 'chat_contacts';
+  static const legacyOwnedKey = 'owned_bitname_hashes';
+
+  final KeyValueStore store;
+  final BitnamesStorageKeySource keySource;
+  final DateTime Function() _now;
+  final Uint8List Function(int) _randomBytes;
+  final Lock _lock = Lock();
+
+  BitnamesStorageStatus status = const BitnamesStorageStatus(
+    BitnamesStorageState.locked,
+  );
+  String? _activeScope;
+  String? _activeSlot;
+  int _generation = 0;
+  bool _migratedThisSession = false;
+  bool _recoveredThisSession = false;
+
+  Future<Map<String, dynamic>> load() => _lock.synchronized(
+    () => _translate(
+      _load,
+      'Private BitNames storage could not be read safely',
+    ),
+  );
+
+  Future<void> save(Map<String, dynamic> state) => _lock.synchronized(
+    () => _translate(
+      () => _save(state),
+      'The encrypted write did not complete; reload to recover an authenticated generation',
+    ),
+  );
+
+  Future<String> exportEncrypted() => _lock.synchronized(
+    () => _translate(() async {
+      final identity = await _identity();
+      await _loadSecure(identity, allowEmpty: false);
+      final prefix = _prefix(identity.scope);
+      final head = await store.getString('${prefix}head');
+      final a = await store.getString('${prefix}a');
+      final b = await store.getString('${prefix}b');
+      if (head == null || (a == null && b == null)) {
+        throw const BitnamesStorageException('No encrypted BitNames data is available to export');
+      }
+      return jsonEncode({
+        'format': '$format-backup',
+        'schema': schema,
+        'scope': identity.scope,
+        'exported_at': _now().toUtc().toIso8601String(),
+        'head': head,
+        if (a != null) 'a': a,
+        if (b != null) 'b': b,
+      });
+    }, 'The encrypted BitNames backup could not be created'),
+  );
+
+  Future<void> restoreEncrypted(
+    String encoded, {
+    bool allowRollback = false,
+  }) => _lock.synchronized(
+    () => _translate(() async {
+      final identity = await _identity();
+      late Map<String, dynamic> backup;
+      try {
+        backup = Map<String, dynamic>.from(jsonDecode(encoded) as Map);
+      } catch (_) {
+        throw const BitnamesStorageException('The BitNames backup is malformed');
+      }
+      if (backup['format'] != '$format-backup' || backup['schema'] != schema || backup['scope'] != identity.scope) {
+        throw const BitnamesStorageException(
+          'The BitNames backup belongs to another wallet or storage version',
+        );
+      }
+      final candidates = <_DecodedSlot>[];
+      for (final slot in const ['a', 'b']) {
+        final raw = backup[slot];
+        if (raw is String) {
+          try {
+            candidates.add(_decryptSlot(raw, slot, identity));
+          } on BitnamesStorageException {
+            // A backup retains two generations. One valid authenticated slot
+            // is sufficient; a corrupt companion is never loaded.
+          }
+        }
+      }
+      if (candidates.isEmpty) {
+        throw const BitnamesStorageException('The BitNames backup contains no valid encrypted state');
+      }
+      candidates.sort((a, b) => b.generation.compareTo(a.generation));
+      final restored = candidates.first;
+      final current = await _loadSecure(identity, allowEmpty: true);
+      if (!allowRollback && current != null && restored.generation < current.generation) {
+        throw const BitnamesStorageException(
+          'The BitNames backup is older than the current encrypted history',
+        );
+      }
+      await _save(
+        restored.state,
+        minimumGeneration: restored.generation,
+      );
+    }, 'The encrypted BitNames backup could not be restored'),
+  );
+
+  Future<void> clear() => _lock.synchronized(
+    () => _translate(() async {
+      final identity = await _identity();
+      final prefix = _prefix(identity.scope);
+      for (final key in [
+        '${prefix}head',
+        '${prefix}a',
+        '${prefix}b',
+        legacyStateKey,
+        legacyContactsKey,
+        legacyOwnedKey,
+      ]) {
+        await store.delete(key);
+      }
+      await _scrubRecoveryCopy('${prefix}cleared');
+      _activeSlot = null;
+      _activeScope = identity.scope;
+      _generation = 0;
+      _migratedThisSession = false;
+      _recoveredThisSession = false;
+      status = const BitnamesStorageStatus(BitnamesStorageState.empty);
+    }, 'Private BitNames data could not be cleared safely'),
+  );
+
+  Future<Map<String, dynamic>> _load() async {
+    final identity = await keySource.current();
+    if (identity == null) {
+      status = const BitnamesStorageStatus(
+        BitnamesStorageState.locked,
+        details: 'Unlock the active BitWindow wallet to decrypt chat data',
+      );
+      _forgetActive();
+      return {};
+    }
+    try {
+      final secure = await _loadSecure(identity, allowEmpty: true);
+      if (secure != null) {
+        await _deleteLegacy();
+        return secure.state;
+      }
+      final legacy = await _readLegacy();
+      if (legacy == null) {
+        status = const BitnamesStorageStatus(BitnamesStorageState.empty);
+        return {};
+      }
+      await _save(legacy);
+      await _deleteLegacy();
+      _migratedThisSession = true;
+      status = BitnamesStorageStatus(
+        BitnamesStorageState.migrated,
+        generation: _generation,
+        details: 'Plaintext BitNames settings were moved into authenticated encryption',
+      );
+      return legacy;
+    } on BitnamesStorageException catch (error) {
+      status = BitnamesStorageStatus(
+        BitnamesStorageState.corrupt,
+        generation: _generation == 0 ? null : _generation,
+        details: error.message,
+      );
+      _forgetActive();
+      rethrow;
+    }
+  }
+
+  Future<T> _translate<T>(
+    Future<T> Function() action,
+    String safeFailure,
+  ) async {
+    try {
+      return await action();
+    } on BitnamesStorageException {
+      rethrow;
+    } catch (_) {
+      status = BitnamesStorageStatus(
+        BitnamesStorageState.corrupt,
+        generation: _generation == 0 ? null : _generation,
+        details: safeFailure,
+      );
+      throw BitnamesStorageException(safeFailure);
+    }
+  }
+
+  Future<void> _save(
+    Map<String, dynamic> state, {
+    int? minimumGeneration,
+  }) async {
+    final identity = await _identity();
+    if (_activeScope != null && _activeScope != identity.scope) {
+      throw const BitnamesStorageException(
+        'The active wallet changed before the encrypted transaction committed',
+      );
+    }
+    final current = await _loadSecure(identity, allowEmpty: true);
+    final normalized = _normalizeState(state);
+    final generation = max(
+      (current?.generation ?? 0) + 1,
+      minimumGeneration ?? 1,
+    );
+    final slot = (current?.slot ?? _activeSlot) == 'a' ? 'b' : 'a';
+    final raw = _encryptSlot(normalized, slot, generation, identity);
+    final prefix = _prefix(identity.scope);
+    await store.setString('$prefix$slot', raw);
+    final verified = _decryptSlot(
+      (await store.getString('$prefix$slot')) ??
+          (throw const BitnamesStorageException('Encrypted write was not persisted')),
+      slot,
+      identity,
+    );
+    if (verified.generation != generation) {
+      throw const BitnamesStorageException('Encrypted write verification failed');
+    }
+    await store.setString('${prefix}head', jsonEncode(_header(slot, generation, identity.scope)));
+    _activeSlot = slot;
+    _activeScope = identity.scope;
+    _generation = generation;
+    status = BitnamesStorageStatus(
+      _recoveredThisSession
+          ? BitnamesStorageState.recovered
+          : _migratedThisSession
+          ? BitnamesStorageState.migrated
+          : BitnamesStorageState.ready,
+      generation: generation,
+      details: _recoveredThisSession
+          ? 'A complete authenticated generation was selected; incomplete or corrupt data was not loaded'
+          : _migratedThisSession
+          ? 'Plaintext BitNames settings were moved into authenticated encryption'
+          : null,
+    );
+  }
+
+  Future<_DecodedSlot?> _loadSecure(
+    BitnamesStorageIdentity identity, {
+    required bool allowEmpty,
+  }) async {
+    if (_activeScope != null && _activeScope != identity.scope) {
+      _migratedThisSession = false;
+      _recoveredThisSession = false;
+    }
+    final prefix = _prefix(identity.scope);
+    final rawHead = await store.getString('${prefix}head');
+    final rawA = await store.getString('${prefix}a');
+    final rawB = await store.getString('${prefix}b');
+    if (rawHead == null && rawA == null && rawB == null) {
+      if (!allowEmpty) {
+        throw const BitnamesStorageException('No encrypted BitNames state exists');
+      }
+      _activeSlot = null;
+      _activeScope = identity.scope;
+      _generation = 0;
+      return null;
+    }
+
+    final valid = <_DecodedSlot>[];
+    final failures = <String>[];
+    for (final candidate in [('a', rawA), ('b', rawB)]) {
+      if (candidate.$2 == null) continue;
+      try {
+        valid.add(_decryptSlot(candidate.$2!, candidate.$1, identity));
+      } on BitnamesStorageException catch (error) {
+        failures.add('${candidate.$1}: ${error.message}');
+      }
+    }
+    if (valid.isEmpty) {
+      throw BitnamesStorageException(
+        'Encrypted BitNames state could not be authenticated'
+        '${failures.isEmpty ? '' : ' (${failures.join('; ')})'}',
+      );
+    }
+    valid.sort((a, b) => b.generation.compareTo(a.generation));
+    final selected = valid.first;
+    var recovered = failures.isNotEmpty;
+    try {
+      final head = Map<String, dynamic>.from(jsonDecode(rawHead!) as Map);
+      recovered =
+          recovered ||
+          head['format'] != format ||
+          head['schema'] != schema ||
+          head['scope'] != identity.scope ||
+          head['slot'] != selected.slot ||
+          head['generation'] != selected.generation;
+    } catch (_) {
+      recovered = true;
+    }
+    if (recovered) {
+      _recoveredThisSession = true;
+      await store.setString(
+        '${prefix}head',
+        jsonEncode(_header(selected.slot, selected.generation, identity.scope)),
+      );
+    }
+    _activeSlot = selected.slot;
+    _activeScope = identity.scope;
+    _generation = selected.generation;
+    status = BitnamesStorageStatus(
+      _recoveredThisSession ? BitnamesStorageState.recovered : BitnamesStorageState.ready,
+      generation: selected.generation,
+      details: _recoveredThisSession
+          ? 'A complete authenticated generation was selected; incomplete or corrupt data was not loaded'
+          : null,
+    );
+    return selected;
+  }
+
+  String _encryptSlot(
+    Map<String, dynamic> state,
+    String slot,
+    int generation,
+    BitnamesStorageIdentity identity,
+  ) {
+    final nonce = _randomBytes(12);
+    final header = _header(slot, generation, identity.scope);
+    final plaintext = utf8.encode(
+      jsonEncode({
+        ...header,
+        'saved_at': _now().toUtc().toIso8601String(),
+        'state': state,
+      }),
+    );
+    final cipher = GCMBlockCipher(AESEngine())
+      ..init(
+        true,
+        AEADParameters(
+          KeyParameter(_deriveKey(identity)),
+          128,
+          nonce,
+          Uint8List.fromList(utf8.encode(jsonEncode(header))),
+        ),
+      );
+    final encrypted = cipher.process(Uint8List.fromList(plaintext));
+    return jsonEncode({
+      ...header,
+      'nonce': base64Encode(nonce),
+      'ciphertext': base64Encode(encrypted),
+    });
+  }
+
+  _DecodedSlot _decryptSlot(
+    String raw,
+    String expectedSlot,
+    BitnamesStorageIdentity identity,
+  ) {
+    try {
+      final envelope = Map<String, dynamic>.from(jsonDecode(raw) as Map);
+      final generation = envelope['generation'];
+      final slot = envelope['slot'];
+      if (envelope['format'] != format ||
+          envelope['schema'] != schema ||
+          envelope['scope'] != identity.scope ||
+          slot != expectedSlot ||
+          generation is! int ||
+          generation < 1 ||
+          envelope['nonce'] is! String ||
+          envelope['ciphertext'] is! String) {
+        throw const BitnamesStorageException('Encrypted slot metadata is invalid');
+      }
+      final nonce = base64Decode(envelope['nonce'] as String);
+      if (nonce.length != 12) {
+        throw const BitnamesStorageException('Encrypted slot nonce is invalid');
+      }
+      final header = _header(slot as String, generation, identity.scope);
+      final cipher = GCMBlockCipher(AESEngine())
+        ..init(
+          false,
+          AEADParameters(
+            KeyParameter(_deriveKey(identity)),
+            128,
+            nonce,
+            Uint8List.fromList(utf8.encode(jsonEncode(header))),
+          ),
+        );
+      final plaintext = cipher.process(
+        Uint8List.fromList(base64Decode(envelope['ciphertext'] as String)),
+      );
+      final decoded = Map<String, dynamic>.from(
+        jsonDecode(utf8.decode(plaintext)) as Map,
+      );
+      if (decoded['format'] != format ||
+          decoded['schema'] != schema ||
+          decoded['scope'] != identity.scope ||
+          decoded['slot'] != slot ||
+          decoded['generation'] != generation ||
+          decoded['state'] is! Map) {
+        throw const BitnamesStorageException('Encrypted slot contents are inconsistent');
+      }
+      return _DecodedSlot(
+        slot,
+        generation,
+        _normalizeState(Map<String, dynamic>.from(decoded['state'] as Map)),
+      );
+    } on BitnamesStorageException {
+      rethrow;
+    } catch (_) {
+      throw const BitnamesStorageException(
+        'Encrypted slot is corrupt or the wallet key does not match',
+      );
+    }
+  }
+
+  Map<String, dynamic> _header(String slot, int generation, String scope) => {
+    'format': format,
+    'schema': schema,
+    'scope': scope,
+    'slot': slot,
+    'generation': generation,
+  };
+
+  Uint8List _deriveKey(BitnamesStorageIdentity identity) {
+    final salt = utf8.encode('BitWindow BitNames private storage v2');
+    final extracted = crypto.Hmac(crypto.sha256, salt).convert(identity.secret).bytes;
+    final info = utf8.encode('wallet:${identity.scope}\u0000aes-256-gcm\u0001');
+    return Uint8List.fromList(
+      crypto.Hmac(crypto.sha256, extracted).convert(info).bytes,
+    );
+  }
+
+  Future<BitnamesStorageIdentity> _identity() async {
+    final identity = await keySource.current();
+    if (identity == null) {
+      status = const BitnamesStorageStatus(
+        BitnamesStorageState.locked,
+        details: 'Unlock the active BitWindow wallet to decrypt chat data',
+      );
+      _forgetActive();
+      throw const BitnamesStorageException(
+        'Unlock the active BitWindow wallet before using BitNames chat',
+      );
+    }
+    return identity;
+  }
+
+  Future<Map<String, dynamic>?> _readLegacy() async {
+    final rawState = await store.getString(legacyStateKey);
+    final rawContacts = await store.getString(legacyContactsKey);
+    final rawOwned = await store.getString(legacyOwnedKey);
+    if (rawState == null && rawContacts == null && rawOwned == null) return null;
+    try {
+      final state = rawState == null ? <String, dynamic>{} : Map<String, dynamic>.from(jsonDecode(rawState) as Map);
+      if ((state['contacts'] as List?)?.isNotEmpty != true && rawContacts != null) {
+        state['contacts'] = List<dynamic>.from(jsonDecode(rawContacts) as List);
+      }
+      if ((state['owned'] as List?)?.isNotEmpty != true && rawOwned != null) {
+        state['owned'] = List<dynamic>.from(jsonDecode(rawOwned) as List);
+      }
+      return _normalizeState(state);
+    } catch (_) {
+      throw const BitnamesStorageException(
+        'Existing plaintext BitNames data is malformed; it was left untouched',
+      );
+    }
+  }
+
+  Future<void> _deleteLegacy() async {
+    await store.delete(legacyStateKey);
+    await store.delete(legacyContactsKey);
+    await store.delete(legacyOwnedKey);
+    await _scrubRecoveryCopy('bitintroduction_legacy_scrub_v2');
+  }
+
+  Future<void> _scrubRecoveryCopy(String marker) async {
+    // FileStorage keeps one complete prior generation for crash recovery.
+    // Rotate a non-secret tombstone through it so deleted plaintext/ciphertext
+    // is not left in that logical recovery copy.
+    await store.setString(marker, 'cleared');
+    await store.delete(marker);
+  }
+
+  Map<String, dynamic> _normalizeState(Map<String, dynamic> input) {
+    late Map<String, dynamic> state;
+    try {
+      state = Map<String, dynamic>.from(
+        jsonDecode(jsonEncode(input)) as Map,
+      );
+    } catch (_) {
+      throw const BitnamesStorageException('BitNames state is not valid JSON data');
+    }
+    _deduplicate(state, 'contacts', (entry) => '${entry['local_bitname'] ?? ''}:${entry['id'] ?? ''}');
+    _deduplicate(state, 'messages', (entry) {
+      return _messageKey(entry);
+    });
+    _deduplicate(state, 'operations', (entry) => '${entry['id'] ?? ''}');
+    state.remove('_indexes');
+    return state;
+  }
+
+  void _deduplicate(
+    Map<String, dynamic> state,
+    String field,
+    String Function(Map<String, dynamic>) keyOf,
+  ) {
+    final raw = state[field];
+    if (raw == null) return;
+    if (raw is! List) {
+      throw BitnamesStorageException('BitNames $field index is malformed');
+    }
+    final seen = <String, String>{};
+    final clean = <Map<String, dynamic>>[];
+    for (final value in raw) {
+      if (value is! Map) {
+        throw BitnamesStorageException('BitNames $field record is malformed');
+      }
+      final record = Map<String, dynamic>.from(value);
+      final key = keyOf(record);
+      if (key.isEmpty || key.endsWith(':')) {
+        throw BitnamesStorageException('BitNames $field record has no stable identity');
+      }
+      final canonical = _canonicalJson(record);
+      final prior = seen[key];
+      if (prior != null && prior != canonical) {
+        throw BitnamesStorageException(
+          'BitNames $field contains conflicting record $key',
+        );
+      }
+      if (prior == null) {
+        seen[key] = canonical;
+        clean.add(record);
+      }
+    }
+    state[field] = clean;
+  }
+
+  String _prefix(String scope) => 'bitintroduction_secure_v2_${scope}_';
+
+  void _forgetActive() {
+    _activeScope = null;
+    _activeSlot = null;
+    _generation = 0;
+    _migratedThisSession = false;
+    _recoveredThisSession = false;
+  }
+
+  static Uint8List _secureRandomBytes(int length) {
+    final random = Random.secure();
+    return Uint8List.fromList(
+      List<int>.generate(length, (_) => random.nextInt(256)),
+    );
+  }
+}
+
+class _DecodedSlot {
+  const _DecodedSlot(this.slot, this.generation, this.state);
+  final String slot;
+  final int generation;
+  final Map<String, dynamic> state;
+}
+
+String _messageKey(Map<String, dynamic> message) {
+  final local = message['is_outgoing'] == true ? message['sender_bitname'] : message['recipient_bitname'];
+  return '$local:${message['id'] ?? ''}';
+}
+
+String _normalizeWords(String value) => value.trim().toLowerCase().split(RegExp(r'\s+')).join(' ');
+
+String _canonicalJson(Object? value) {
+  if (value is Map) {
+    final keys = value.keys.cast<String>().toList()..sort();
+    return '{${keys.map((key) => '${jsonEncode(key)}:${_canonicalJson(value[key])}').join(',')}}';
+  }
+  if (value is List) {
+    return '[${value.map(_canonicalJson).join(',')}]';
+  }
+  return jsonEncode(value);
+}

--- a/sail_ui/lib/rpcs/bitnames_rpc.dart
+++ b/sail_ui/lib/rpcs/bitnames_rpc.dart
@@ -20,6 +20,8 @@ import 'package:sail_ui/settings/client_settings.dart';
 import 'package:sail_ui/settings/hash_plaintext_settings.dart';
 import 'package:sail_ui/widgets/components/core_transaction.dart';
 
+enum BitnamesTransactionStatus { absent, pending, confirmed }
+
 /// API to the bitnames server.
 abstract class BitnamesRPC extends SidechainRPC {
   BitnamesRPC({required super.binaryType});
@@ -29,6 +31,20 @@ abstract class BitnamesRPC extends SidechainRPC {
 
   /// Get BitName data
   Future<BitNameData?> getBitNameData(String name);
+
+  /// Get BitName data at an exact block/transaction position.
+  Future<BitNameData> bitNameDataAtPosition(String bitname, String blockHash, int txIndex) async {
+    final data = await callRAW('bitname_data_at_position', [bitname, blockHash, txIndex]);
+    if (data is! Map) throw const FormatException('Invalid historical BitName data');
+    return BitNameData.fromJson(Map<String, dynamic>.from(data));
+  }
+
+  /// Return whether a transaction is included in the current canonical chain.
+  Future<bool> isTransactionConfirmed(String txid) async =>
+      await transactionStatus(txid) == BitnamesTransactionStatus.confirmed;
+
+  Future<BitnamesTransactionStatus> transactionStatus(String txid) async =>
+      transactionInfoStatus(await callRAW('get_transaction_info', [txid]));
 
   /// List all BitNames
   Future<List<BitnameEntry>> listBitNames();
@@ -101,6 +117,33 @@ abstract class BitnamesRPC extends SidechainRPC {
   /// Get all paymail
   Future<Map<String, dynamic>> getPaymail();
 
+  /// Get JSON-safe, ordered paymail entries with recipient attribution.
+  Future<List<PaymailEntry>> getPaymailEntries() async {
+    final entries = await callRAW('get_paymail_entries');
+    if (entries == null) return [];
+    if (entries is! List) throw const FormatException('Invalid paymail entries');
+    return entries.map((entry) => PaymailEntry.fromJson(Map<String, dynamic>.from(entry as Map))).toList();
+  }
+
+  /// Resolve a BitName to its current ownership output and data.
+  Future<BitNameResolution?> resolveBitName(String bitname) async {
+    final resolution = await callRAW('resolve_bitname', [bitname]);
+    if (resolution == null) return null;
+    if (resolution is! Map) throw const FormatException('Invalid BitName resolution');
+    return BitNameResolution.fromJson(Map<String, dynamic>.from(resolution));
+  }
+
+  /// Update mutable data for an owned BitName.
+  Future<String> updateBitName({
+    required String bitname,
+    required BitNameDataUpdates updates,
+    required int feeSats,
+  }) async {
+    final txid = await callRAW('update_bitname', [bitname, updates.toJson(), feeSats]);
+    if (txid is! String) throw const FormatException('Invalid BitName update transaction');
+    return txid;
+  }
+
   /// Get wallet addresses, sorted by base58 encoding
   Future<List<String>> getWalletAddresses();
 
@@ -132,6 +175,18 @@ abstract class BitnamesRPC extends SidechainRPC {
     required String address,
   });
 
+  /// Verify a signature against the specified key and domain separation tag.
+  Future<bool> verifySignature({
+    required String signature,
+    required String verifyingKey,
+    String domain = 'arbitrary',
+    required String msg,
+  }) async {
+    final valid = await callRAW('verify_signature', [signature, verifyingKey, domain, msg]);
+    if (valid is! bool) throw const FormatException('Invalid signature verification response');
+    return valid;
+  }
+
   /// Transfer funds to the specified address
   Future<String> transfer({
     required String dest,
@@ -139,6 +194,18 @@ abstract class BitnamesRPC extends SidechainRPC {
     required int fee,
     String? memo,
   });
+
+  Future<String> transferIdempotent({
+    required String idempotencyKey,
+    required String dest,
+    required int value,
+    required int fee,
+    String? memo,
+  }) async {
+    final txid = await callRAW('transfer', [dest, value, fee, memo, idempotencyKey]);
+    if (txid is! String) throw const FormatException('Invalid transfer transaction');
+    return txid;
+  }
 }
 
 class BitnamesLive extends BitnamesRPC {
@@ -162,7 +229,9 @@ class BitnamesLive extends BitnamesRPC {
 
   @override
   Future<(double, double)> balance() async {
-    final resp = await GetIt.I.get<OrchestratorRPC>().getSidechainBalance(binaryType);
+    final resp = await GetIt.I.get<OrchestratorRPC>().getSidechainBalance(
+      binaryType,
+    );
     final confirmed = satoshiToBTC(resp.confirmedSats.toInt());
     final unconfirmed = satoshiToBTC(resp.pendingSats.toInt());
     return (confirmed, unconfirmed);
@@ -209,7 +278,9 @@ class BitnamesLive extends BitnamesRPC {
   @override
   Future<dynamic> callRAW(String method, [dynamic params]) async {
     final paramsJson = params != null ? jsonEncode(params) : '';
-    final resp = await _client.callRaw(pb.CallRawRequest(method: method, paramsJson: paramsJson));
+    final resp = await _client.callRaw(
+      pb.CallRawRequest(method: method, paramsJson: paramsJson),
+    );
     if (resp.resultJson.isEmpty) return null;
     return jsonDecode(resp.resultJson);
   }
@@ -235,7 +306,11 @@ class BitnamesLive extends BitnamesRPC {
   Future<double> sideEstimateFee() async => 0.00001;
 
   @override
-  Future<String> sideSend(String address, double amount, bool subtractFeeFromAmount) async {
+  Future<String> sideSend(
+    String address,
+    double amount,
+    bool subtractFeeFromAmount,
+  ) async {
     final resp = await _client.transfer(
       pb.TransferRequest(
         address: address,
@@ -257,7 +332,9 @@ class BitnamesLive extends BitnamesRPC {
 
   @override
   Future<BitNameData?> getBitNameData(String name) async {
-    final resp = await _client.getBitNameData(pb.GetBitNameDataRequest(name: name));
+    final resp = await _client.getBitNameData(
+      pb.GetBitNameDataRequest(name: name),
+    );
     if (resp.dataJson.isEmpty) return null;
     final decoded = jsonDecode(resp.dataJson) as Map<String, dynamic>;
     return BitNameData.fromJson(decoded);
@@ -330,17 +407,16 @@ class BitnamesLive extends BitnamesRPC {
   Future<String> registerBitName(String plainName, BitNameData? data) async {
     final dataJson = data != null ? jsonEncode(data.toJson()) : '';
     final resp = await _client.registerBitName(
-      pb.RegisterBitNameRequest(
-        plainName: plainName,
-        dataJson: dataJson,
-      ),
+      pb.RegisterBitNameRequest(plainName: plainName, dataJson: dataJson),
     );
     return resp.txid;
   }
 
   @override
   Future<String> reserveBitName(String name) async {
-    final resp = await _client.reserveBitName(pb.ReserveBitNameRequest(name: name));
+    final resp = await _client.reserveBitName(
+      pb.ReserveBitNameRequest(name: name),
+    );
     return resp.txid;
   }
 
@@ -353,19 +429,25 @@ class BitnamesLive extends BitnamesRPC {
 
   @override
   Future<String> getBMMInclusions(String blockHash) async {
-    final resp = await _client.getBmmInclusions(pb.GetBmmInclusionsRequest(blockHash: blockHash));
+    final resp = await _client.getBmmInclusions(
+      pb.GetBmmInclusionsRequest(blockHash: blockHash),
+    );
     return resp.inclusions;
   }
 
   @override
   Future<String?> getBestMainchainBlockHash() async {
-    final resp = await _client.getBestMainchainBlockHash(pb.GetBestMainchainBlockHashRequest());
+    final resp = await _client.getBestMainchainBlockHash(
+      pb.GetBestMainchainBlockHashRequest(),
+    );
     return resp.hash.isEmpty ? null : resp.hash;
   }
 
   @override
   Future<String?> getBestSidechainBlockHash() async {
-    final resp = await _client.getBestSidechainBlockHash(pb.GetBestSidechainBlockHashRequest());
+    final resp = await _client.getBestSidechainBlockHash(
+      pb.GetBestSidechainBlockHashRequest(),
+    );
     return resp.hash.isEmpty ? null : resp.hash;
   }
 
@@ -379,7 +461,9 @@ class BitnamesLive extends BitnamesRPC {
 
   @override
   Future<PendingWithdrawalBundle?> getPendingWithdrawalBundle() async {
-    final resp = await _client.getPendingWithdrawalBundle(pb.GetPendingWithdrawalBundleRequest());
+    final resp = await _client.getPendingWithdrawalBundle(
+      pb.GetPendingWithdrawalBundleRequest(),
+    );
     if (resp.bundleJson.isEmpty) return null;
     final decoded = jsonDecode(resp.bundleJson);
     return PendingWithdrawalBundle.fromJson(decoded as Map<String, dynamic>);
@@ -393,24 +477,32 @@ class BitnamesLive extends BitnamesRPC {
 
   @override
   Future<void> setSeedFromMnemonic(String mnemonic) async {
-    await _client.setSeedFromMnemonic(pb.SetSeedFromMnemonicRequest(mnemonic: mnemonic));
+    await _client.setSeedFromMnemonic(
+      pb.SetSeedFromMnemonicRequest(mnemonic: mnemonic),
+    );
   }
 
   @override
   Future<int> getSidechainWealth() async {
-    final resp = await _client.getSidechainWealth(pb.GetSidechainWealthRequest());
+    final resp = await _client.getSidechainWealth(
+      pb.GetSidechainWealthRequest(),
+    );
     return resp.sats.toInt();
   }
 
   @override
   Future<String> getNewEncryptionKey() async {
-    final resp = await _client.getNewEncryptionKey(pb.GetNewEncryptionKeyRequest());
+    final resp = await _client.getNewEncryptionKey(
+      pb.GetNewEncryptionKeyRequest(),
+    );
     return resp.key;
   }
 
   @override
   Future<String> getNewVerifyingKey() async {
-    final resp = await _client.getNewVerifyingKey(pb.GetNewVerifyingKeyRequest());
+    final resp = await _client.getNewVerifyingKey(
+      pb.GetNewVerifyingKeyRequest(),
+    );
     return resp.key;
   }
 
@@ -453,10 +545,7 @@ class BitnamesLive extends BitnamesRPC {
     required String encryptionPubkey,
   }) async {
     final resp = await _client.encryptMsg(
-      pb.EncryptMsgRequest(
-        msg: msg,
-        encryptionPubkey: encryptionPubkey,
-      ),
+      pb.EncryptMsgRequest(msg: msg, encryptionPubkey: encryptionPubkey),
     );
     return resp.ciphertext;
   }
@@ -476,7 +565,9 @@ class BitnamesLive extends BitnamesRPC {
 
   @override
   Future<String> resolveCommit(String bitname) async {
-    final resp = await _client.resolveCommit(pb.ResolveCommitRequest(bitname: bitname));
+    final resp = await _client.resolveCommit(
+      pb.ResolveCommitRequest(bitname: bitname),
+    );
     return resp.commitment;
   }
 
@@ -486,10 +577,7 @@ class BitnamesLive extends BitnamesRPC {
     required String verifyingKey,
   }) async {
     final resp = await _client.signArbitraryMsg(
-      pb.SignArbitraryMsgRequest(
-        msg: msg,
-        verifyingKey: verifyingKey,
-      ),
+      pb.SignArbitraryMsgRequest(msg: msg, verifyingKey: verifyingKey),
     );
     return resp.signature;
   }
@@ -500,20 +588,16 @@ class BitnamesLive extends BitnamesRPC {
     required String address,
   }) async {
     final resp = await _client.signArbitraryMsgAsAddr(
-      pb.SignArbitraryMsgAsAddrRequest(
-        msg: msg,
-        address: address,
-      ),
+      pb.SignArbitraryMsgAsAddrRequest(msg: msg, address: address),
     );
-    return {
-      'verifying_key': resp.verifyingKey,
-      'signature': resp.signature,
-    };
+    return {'verifying_key': resp.verifyingKey, 'signature': resp.signature};
   }
 
   @override
   Future<List<String>> getWalletAddresses() async {
-    final resp = await _client.getWalletAddresses(pb.GetWalletAddressesRequest());
+    final resp = await _client.getWalletAddresses(
+      pb.GetWalletAddressesRequest(),
+    );
     return resp.addresses.toList();
   }
 
@@ -605,6 +689,7 @@ class BitnamesLive extends BitnamesRPC {
 final bitnamesRPCMethods = [
   'balance',
   'bitname_data',
+  'bitname_data_at_position',
   'bitnames',
   'connect_peer',
   'create_deposit',
@@ -621,6 +706,8 @@ final bitnamesRPCMethods = [
   'get_new_verifying_key',
   'getblockcount',
   'get_paymail',
+  'get_paymail_entries',
+  'get_transaction_info',
   'get_wallet_addresses',
   'get_wallet_utxos',
   'latest_failed_withdrawal_bundle_height',
@@ -632,6 +719,7 @@ final bitnamesRPCMethods = [
   'pending_withdrawal_bundle',
   'register_bitname',
   'reserve_bitname',
+  'resolve_bitname',
   'resolve_commit',
   'set_seed_from_mnemonic',
   'sidechain_wealth',
@@ -639,12 +727,27 @@ final bitnamesRPCMethods = [
   'sign_arbitrary_msg_as_addr',
   'stop',
   'transfer',
+  'update_bitname',
   'verify_signature',
   'withdraw',
 ];
 
+/// Decode the backend's nullable transaction information without treating a
+/// malformed response as confirmation.
+BitnamesTransactionStatus transactionInfoStatus(Object? info) {
+  if (info == null) return BitnamesTransactionStatus.absent;
+  if (info is! Map<String, dynamic>) throw const FormatException('Invalid transaction info');
+  final txin = info['txin'];
+  if (txin == null) return BitnamesTransactionStatus.pending;
+  if (txin is! Map<String, dynamic> || txin['block_hash'] is! String || txin['idx'] is! int) {
+    throw const FormatException('Invalid transaction inclusion');
+  }
+  return BitnamesTransactionStatus.confirmed;
+}
+
 // Models for Bitnames RPC responses
 class BitNameData {
+  final String? seqId;
   final String? commitment;
   final String? encryptionPubkey;
   final int? paymailFeeSats;
@@ -653,6 +756,7 @@ class BitNameData {
   final String? socketAddrV6;
 
   BitNameData({
+    this.seqId,
     this.commitment,
     this.encryptionPubkey,
     this.paymailFeeSats,
@@ -662,6 +766,7 @@ class BitNameData {
   });
 
   Map<String, dynamic> toJson() => {
+    if (seqId != null) 'seq_id': seqId,
     if (commitment != null) 'commitment': commitment,
     if (encryptionPubkey != null) 'encryption_pubkey': encryptionPubkey,
     if (paymailFeeSats != null) 'paymail_fee_sats': paymailFeeSats,
@@ -671,12 +776,175 @@ class BitNameData {
   };
 
   factory BitNameData.fromJson(Map<String, dynamic> json) => BitNameData(
-    commitment: json['commitment'] as String?,
+    seqId: json['seq_id'] as String?,
+    commitment: switch (json['commitment']) {
+      final String value => value,
+      final List<dynamic> value => hex.encode(value.cast<int>()),
+      _ => null,
+    },
     encryptionPubkey: json['encryption_pubkey'] as String?,
-    paymailFeeSats: json['paymail_fee_sats'] as int?,
+    paymailFeeSats: switch (json['paymail_fee_sats']) {
+      final int value when value >= 0 => value,
+      _ => null,
+    },
     signingPubkey: json['signing_pubkey'] as String?,
     socketAddrV4: json['socket_addr_v4'] as String?,
     socketAddrV6: json['socket_addr_v6'] as String?,
+  );
+}
+
+enum BitNameUpdateAction { retain, delete, set }
+
+/// A single mutable BitName field update.
+///
+/// The JSON encoding matches the backend's `Retain`, `Delete`, and
+/// `{ "Set": value }` representation.
+class BitNameUpdate<T extends Object> {
+  final BitNameUpdateAction action;
+  final T? value;
+
+  const BitNameUpdate.retain() : action = BitNameUpdateAction.retain, value = null;
+
+  const BitNameUpdate.delete() : action = BitNameUpdateAction.delete, value = null;
+
+  const BitNameUpdate.set(T this.value) : action = BitNameUpdateAction.set;
+
+  Object toJson() => switch (action) {
+    BitNameUpdateAction.retain => 'Retain',
+    BitNameUpdateAction.delete => 'Delete',
+    BitNameUpdateAction.set => {'Set': value},
+  };
+}
+
+/// Mutable updates for a BitName. Unspecified fields are retained.
+class BitNameDataUpdates {
+  final BitNameUpdate<String> commitment;
+  final BitNameUpdate<String> socketAddrV4;
+  final BitNameUpdate<String> socketAddrV6;
+  final BitNameUpdate<String> encryptionPubkey;
+  final BitNameUpdate<String> signingPubkey;
+  final BitNameUpdate<int> paymailFeeSats;
+
+  const BitNameDataUpdates({
+    this.commitment = const BitNameUpdate<String>.retain(),
+    this.socketAddrV4 = const BitNameUpdate<String>.retain(),
+    this.socketAddrV6 = const BitNameUpdate<String>.retain(),
+    this.encryptionPubkey = const BitNameUpdate<String>.retain(),
+    this.signingPubkey = const BitNameUpdate<String>.retain(),
+    this.paymailFeeSats = const BitNameUpdate<int>.retain(),
+  });
+
+  Map<String, dynamic> toJson() => {
+    'commitment': commitment.action == BitNameUpdateAction.set
+        ? {'Set': hex.decode(commitment.value!)}
+        : commitment.toJson(),
+    'socket_addr_v4': socketAddrV4.toJson(),
+    'socket_addr_v6': socketAddrV6.toJson(),
+    'encryption_pubkey': encryptionPubkey.toJson(),
+    'signing_pubkey': signingPubkey.toJson(),
+    'paymail_fee_sats': paymailFeeSats.toJson(),
+  };
+}
+
+class BitNameResolution {
+  final String bitname;
+  final Map<String, dynamic> outpoint;
+  final String address;
+  final BitNameData data;
+
+  const BitNameResolution({
+    required this.bitname,
+    required this.outpoint,
+    required this.address,
+    required this.data,
+  });
+
+  factory BitNameResolution.fromJson(Map<String, dynamic> json) => BitNameResolution(
+    bitname: json['bitname'] as String,
+    outpoint: Map<String, dynamic>.from(json['outpoint'] as Map),
+    address: json['address'] as String,
+    data: BitNameData.fromJson(json['data'] as Map<String, dynamic>),
+  );
+}
+
+class PaymailRecipient {
+  final String bitname;
+  final BitNameData data;
+  final int? requiredFeeSats;
+
+  const PaymailRecipient({
+    required this.bitname,
+    required this.data,
+    this.requiredFeeSats,
+  });
+
+  factory PaymailRecipient.fromJson(Map<String, dynamic> json) => PaymailRecipient(
+    bitname: json['bitname'] as String,
+    data: BitNameData.fromJson(json['data'] as Map<String, dynamic>),
+    requiredFeeSats: switch (json['required_fee_sats']) {
+      final int value when value >= 0 => value,
+      _ => null,
+    },
+  );
+}
+
+class PaymailOutput {
+  final String address;
+  final Map<String, dynamic> content;
+  final String memoHex;
+
+  const PaymailOutput({
+    required this.address,
+    required this.content,
+    required this.memoHex,
+  });
+
+  factory PaymailOutput.fromJson(Map<String, dynamic> json) {
+    final memo = json['memo'];
+    final memoHex = switch (memo) {
+      String value => value,
+      List<dynamic> bytes => bytes.cast<int>().map((byte) => byte.toRadixString(16).padLeft(2, '0')).join(),
+      _ => throw FormatException('Invalid paymail memo: $memo'),
+    };
+    return PaymailOutput(
+      address: json['address'] as String,
+      content: Map<String, dynamic>.from(json['content'] as Map),
+      memoHex: memoHex,
+    );
+  }
+}
+
+class PaymailEntry {
+  final Map<String, dynamic> outpoint;
+  final PaymailOutput output;
+  final int valueSats;
+  final String blockHash;
+  final int blockHeight;
+  final int txIndex;
+  final List<PaymailRecipient> recipients;
+
+  const PaymailEntry({
+    required this.outpoint,
+    required this.output,
+    required this.valueSats,
+    required this.blockHash,
+    required this.blockHeight,
+    required this.txIndex,
+    required this.recipients,
+  });
+
+  factory PaymailEntry.fromJson(Map<String, dynamic> json) => PaymailEntry(
+    outpoint: Map<String, dynamic>.from(json['outpoint'] as Map),
+    output: PaymailOutput.fromJson(json['output'] as Map<String, dynamic>),
+    valueSats: json['value_sats'] as int,
+    blockHash: json['block_hash'] as String,
+    blockHeight: json['block_height'] as int,
+    txIndex: json['tx_index'] as int,
+    recipients: (json['recipients'] as List<dynamic>)
+        .map(
+          (recipient) => PaymailRecipient.fromJson(recipient as Map<String, dynamic>),
+        )
+        .toList(),
   );
 }
 
@@ -738,6 +1006,9 @@ class BitnameDetails {
     socketAddrV6: json['socket_addr_v6'] as String?,
     encryptionPubkey: json['encryption_pubkey'] as String?,
     signingPubkey: json['signing_pubkey'] as String?,
-    paymailFeeSats: json['paymail_fee_sats'] as int?,
+    paymailFeeSats: switch (json['paymail_fee_sats']) {
+      final int value when value >= 0 => value,
+      _ => null,
+    },
   );
 }

--- a/sail_ui/lib/rpcs/thunder_utxo.dart
+++ b/sail_ui/lib/rpcs/thunder_utxo.dart
@@ -36,9 +36,13 @@ class SidechainUTXO {
       final regular = outpoint['Regular'] as Map<String, dynamic>;
       outpointStr = '${regular['txid']}:${regular['vout']}';
       type = OutpointType.regular;
-    } else {
+    } else if (outpoint.containsKey('Deposit')) {
       outpointStr = outpoint['Deposit'] as String;
       type = OutpointType.deposit;
+    } else {
+      final coinbase = outpoint['Coinbase'] as Map<String, dynamic>;
+      outpointStr = '${coinbase['merkle_root']}:${coinbase['vout']}';
+      type = OutpointType.regular;
     }
 
     return SidechainUTXO(
@@ -77,9 +81,13 @@ class BitnamesUTXO extends SidechainUTXO {
       final regular = outpoint['Regular'] as Map<String, dynamic>;
       outpointStr = '${regular['txid']}:${regular['vout']}';
       type = OutpointType.regular;
-    } else {
+    } else if (outpoint.containsKey('Deposit')) {
       outpointStr = outpoint['Deposit'] as String;
       type = OutpointType.deposit;
+    } else {
+      final coinbase = outpoint['Coinbase'] as Map<String, dynamic>;
+      outpointStr = '${coinbase['merkle_root']}:${coinbase['vout']}';
+      type = OutpointType.regular;
     }
 
     // Get value from content

--- a/sail_ui/lib/settings/secure_store.dart
+++ b/sail_ui/lib/settings/secure_store.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:sail_ui/utils/file_utils.dart';
+import 'package:synchronized/synchronized.dart';
 
 abstract class KeyValueStore {
   Future<String?> getString(String key);
@@ -17,6 +18,8 @@ abstract class KeyValueStore {
 
 // Native implementation using file system
 class FileStorage implements KeyValueStore {
+  static final Map<String, Lock> _processLocks = {};
+
   static FileStorage fromDirectory(Directory dir) {
     final file = File('${dir.path}${Platform.pathSeparator}settings.json');
     return FileStorage._(file);
@@ -25,45 +28,145 @@ class FileStorage implements KeyValueStore {
   final File file;
   Map<String, String> _cache = {};
   bool _loaded = false;
+  bool _loadedFromBackup = false;
+  final Lock _processLock;
 
-  FileStorage._(this.file);
+  FileStorage._(this.file)
+    : _processLock = _processLocks.putIfAbsent(
+        file.absolute.path,
+        Lock.new,
+      );
 
-  Future<void> _ensureLoaded() async {
-    if (_loaded) return;
-
+  Future<void> _ensureLoaded({bool refresh = false}) async {
+    if (_loaded && !refresh) return;
+    if (refresh) {
+      _loaded = false;
+      _loadedFromBackup = false;
+      _cache = {};
+    }
+    final backup = File('${file.path}.bak');
+    Object? primaryError;
     if (await file.exists()) {
       try {
-        final contents = await file.readAsString();
-        _cache = Map<String, String>.from(jsonDecode(contents));
-      } catch (e) {
-        // If file is corrupted, start fresh
-        _cache = {};
+        _cache = await _read(file);
+        _loaded = true;
+        return;
+      } catch (error) {
+        primaryError = error;
       }
+    }
+    if (await backup.exists()) {
+      try {
+        _cache = await _read(backup);
+        _loaded = true;
+        _loadedFromBackup = true;
+        return;
+      } catch (backupError) {
+        throw FileSystemException(
+          'Settings and its recovery copy are corrupt '
+          '(primary: $primaryError, recovery: $backupError)',
+          file.path,
+        );
+      }
+    }
+    if (primaryError != null) {
+      throw FileSystemException(
+        'Settings are corrupt and no recovery copy exists: $primaryError',
+        file.path,
+      );
     }
     _loaded = true;
   }
 
+  Future<T> _withFileLock<T>(Future<T> Function() action) async {
+    await file.parent.create(recursive: true);
+    final lockFile = await File('${file.path}.lock').open(mode: FileMode.append);
+    var locked = false;
+    try {
+      await lockFile.lock(FileLock.exclusive);
+      locked = true;
+      return await action();
+    } finally {
+      if (locked) await lockFile.unlock();
+      await lockFile.close();
+    }
+  }
+
+  Future<Map<String, String>> _read(File source) async {
+    final decoded = jsonDecode(await source.readAsString());
+    if (decoded is! Map) throw const FormatException('settings root is not an object');
+    final result = <String, String>{};
+    for (final entry in decoded.entries) {
+      if (entry.key is! String || entry.value is! String) {
+        throw const FormatException('settings entry is not a string pair');
+      }
+      result[entry.key as String] = entry.value as String;
+    }
+    return result;
+  }
+
   Future<void> _save() async {
-    await file.writeAsString(jsonEncode(_cache));
+    await file.parent.create(recursive: true);
+    final temporary = File('${file.path}.next');
+    final backup = File('${file.path}.bak');
+    await temporary.writeAsString(jsonEncode(_cache), flush: true);
+    try {
+      if (await file.exists()) {
+        if (_loadedFromBackup) {
+          await file.delete();
+        } else {
+          if (await backup.exists()) await backup.delete();
+          await file.rename(backup.path);
+        }
+      }
+      await temporary.rename(file.path);
+      _loadedFromBackup = false;
+    } catch (_) {
+      if (!await file.exists() && await backup.exists()) {
+        await backup.rename(file.path);
+      }
+      rethrow;
+    } finally {
+      if (await temporary.exists()) await temporary.delete();
+    }
   }
 
   @override
-  Future<String?> getString(String key) async {
-    await _ensureLoaded();
-    return _cache[key];
-  }
+  Future<String?> getString(String key) => _processLock.synchronized(
+    () => _withFileLock(() async {
+      await _ensureLoaded(refresh: true);
+      return _cache[key];
+    }),
+  );
 
   @override
-  Future<void> setString(String key, String value) async {
-    await _ensureLoaded();
-    _cache[key] = value;
-    await _save();
-  }
+  Future<void> setString(String key, String value) => _processLock.synchronized(
+    () => _withFileLock(() async {
+      await _ensureLoaded(refresh: true);
+      final existed = _cache.containsKey(key);
+      final previous = _cache[key];
+      _cache[key] = value;
+      try {
+        await _save();
+      } catch (_) {
+        existed ? _cache[key] = previous! : _cache.remove(key);
+        rethrow;
+      }
+    }),
+  );
 
   @override
-  Future<void> delete(String key) async {
-    await _ensureLoaded();
-    _cache.remove(key);
-    await _save();
-  }
+  Future<void> delete(String key) => _processLock.synchronized(
+    () => _withFileLock(() async {
+      await _ensureLoaded(refresh: true);
+      if (!_cache.containsKey(key)) return;
+      final previous = _cache.remove(key)!;
+      try {
+        await _save();
+      } catch (_) {
+        _cache[key] = previous;
+        rethrow;
+      }
+    }),
+  );
 }

--- a/sidechain-orchestrator/sidechain/bitnames/client.go
+++ b/sidechain-orchestrator/sidechain/bitnames/client.go
@@ -284,7 +284,7 @@ func (c *Client) PendingWithdrawalBundle(ctx context.Context) (json.RawMessage, 
 
 // ConnectPeer connects to a peer at the given address.
 func (c *Client) ConnectPeer(ctx context.Context, address string) error {
-	_, err := c.call(ctx, "connect_peer", address)
+	_, err := c.call(ctx, "connect_peer", []any{address})
 	return err
 }
 
@@ -330,17 +330,17 @@ func (c *Client) EncryptMsg(ctx context.Context, encryptionPubkey, msg string) (
 // DecryptMsg decrypts a ciphertext with the given encryption public key.
 // Returns the hex-encoded plaintext (caller must decode if needed).
 func (c *Client) DecryptMsg(ctx context.Context, encryptionPubkey, ciphertext string) (string, error) {
-	return unmarshal[string](c, ctx, "decrypt_msg", []interface{}{encryptionPubkey, ciphertext, true})
+	return unmarshal[string](c, ctx, "decrypt_msg", []interface{}{encryptionPubkey, ciphertext})
 }
 
 // SignArbitraryMsg signs a message with the specified verifying key.
 func (c *Client) SignArbitraryMsg(ctx context.Context, msg, verifyingKey string) (string, error) {
-	return unmarshal[string](c, ctx, "sign_arbitrary_msg", []interface{}{msg, verifyingKey})
+	return unmarshal[string](c, ctx, "sign_arbitrary_msg", []interface{}{verifyingKey, msg})
 }
 
 // SignArbitraryMsgAsAddr signs a message with the secret key for the given address.
 func (c *Client) SignArbitraryMsgAsAddr(ctx context.Context, msg, address string) (*SignatureResponse, error) {
-	r, err := unmarshal[SignatureResponse](c, ctx, "sign_arbitrary_msg_as_addr", []interface{}{msg, address})
+	r, err := unmarshal[SignatureResponse](c, ctx, "sign_arbitrary_msg_as_addr", []interface{}{address, msg})
 	if err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/bitnames/handler.go
+++ b/sidechain-orchestrator/sidechain/bitnames/handler.go
@@ -158,7 +158,7 @@ func (h *Handler) CreateDeposit(ctx context.Context, req *connect.Request[pb.Cre
 }
 
 func (h *Handler) ConnectPeer(ctx context.Context, req *connect.Request[pb.ConnectPeerRequest]) (*connect.Response[pb.ConnectPeerResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "connect_peer", req.Msg.Address, nil); err != nil {
+	if _, err := h.proxy.Client.CallRaw(ctx, "connect_peer", []any{req.Msg.Address}); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ConnectPeerResponse{}), nil
@@ -276,7 +276,7 @@ func (h *Handler) GetNewVerifyingKey(ctx context.Context, req *connect.Request[p
 
 func (h *Handler) DecryptMsg(ctx context.Context, req *connect.Request[pb.DecryptMsgRequest]) (*connect.Response[pb.DecryptMsgResponse], error) {
 	var plaintext string
-	params := []any{req.Msg.EncryptionPubkey, req.Msg.Ciphertext, true}
+	params := []any{req.Msg.EncryptionPubkey, req.Msg.Ciphertext}
 	if err := h.proxy.Client.Call(ctx, "decrypt_msg", params, &plaintext); err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (h *Handler) ResolveCommit(ctx context.Context, req *connect.Request[pb.Res
 
 func (h *Handler) SignArbitraryMsg(ctx context.Context, req *connect.Request[pb.SignArbitraryMsgRequest]) (*connect.Response[pb.SignArbitraryMsgResponse], error) {
 	var signature string
-	params := []any{req.Msg.Msg, req.Msg.VerifyingKey}
+	params := []any{req.Msg.VerifyingKey, req.Msg.Msg}
 	if err := h.proxy.Client.Call(ctx, "sign_arbitrary_msg", params, &signature); err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (h *Handler) SignArbitraryMsgAsAddr(ctx context.Context, req *connect.Reque
 		VerifyingKey string `json:"verifying_key"`
 		Signature    string `json:"signature"`
 	}
-	params := []any{req.Msg.Msg, req.Msg.Address}
+	params := []any{req.Msg.Address, req.Msg.Msg}
 	if err := h.proxy.Client.Call(ctx, "sign_arbitrary_msg_as_addr", params, &result); err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/bitnames/types.go
+++ b/sidechain-orchestrator/sidechain/bitnames/types.go
@@ -11,12 +11,13 @@ type BalanceResponse struct {
 
 // BitNameData holds optional metadata fields attached to a BitName.
 type BitNameData struct {
-	Commitment      *string `json:"commitment,omitempty"`
+	SeqID            string  `json:"seq_id,omitempty"`
+	Commitment       *string `json:"commitment,omitempty"`
 	EncryptionPubkey *string `json:"encryption_pubkey,omitempty"`
-	PaymailFeeSats  *int64  `json:"paymail_fee_sats,omitempty"`
+	PaymailFeeSats   *uint64 `json:"paymail_fee_sats,omitempty"`
 	SigningPubkey    *string `json:"signing_pubkey,omitempty"`
-	SocketAddrV4    *string `json:"socket_addr_v4,omitempty"`
-	SocketAddrV6    *string `json:"socket_addr_v6,omitempty"`
+	SocketAddrV4     *string `json:"socket_addr_v4,omitempty"`
+	SocketAddrV6     *string `json:"socket_addr_v6,omitempty"`
 }
 
 // BitnameDetails describes the on-chain state of a registered BitName.
@@ -67,12 +68,12 @@ type SignatureResponse struct {
 
 // BmmResult is the response from the "mine" RPC.
 type BmmResult struct {
-	HashLastMainBlock     string  `json:"hash_last_main_block"`
-	BmmBlockCreated       *string `json:"bmm_block_created,omitempty"`
-	BmmBlockSubmitted     *string `json:"bmm_block_submitted,omitempty"`
+	HashLastMainBlock      string  `json:"hash_last_main_block"`
+	BmmBlockCreated        *string `json:"bmm_block_created,omitempty"`
+	BmmBlockSubmitted      *string `json:"bmm_block_submitted,omitempty"`
 	BmmBlockSubmittedBlind *string `json:"bmm_block_submitted_blind,omitempty"`
-	Ntxn                  int     `json:"ntxn"`
-	Nfees                 int     `json:"nfees"`
-	Txid                  string  `json:"txid"`
-	Error                 *string `json:"error,omitempty"`
+	Ntxn                   int     `json:"ntxn"`
+	Nfees                  int     `json:"nfees"`
+	Txid                   string  `json:"txid"`
+	Error                  *string `json:"error,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Add canonical signed and encrypted BitIntroduction envelopes with verified direct-transport profiles.
- Add namespaced reply-profile commitments while preserving recognized legacy commitments and unknown application data.
- Add wallet-scoped authenticated storage for private state, pending operations, migration, rollback protection, and corruption recovery.
- Add durable BitNames chain operation tracking across restarts and reorganizations.
- Extend the Dart and Go BitNames bridges with historical profile lookup, transaction confirmation, and raw RPC support.
- Improve BitName registration and reply-profile progress reporting.
- Make shared local-settings writes atomic.

## Protocol and compatibility

- Uses canonical signed JSON envelopes shared by direct delivery and eventual chain fallback.
- Supports historical profile verification using block hash and transaction position.
- Recognizes existing legacy reply-profile commitments.
- Preserves unknown application commitments and refuses unsafe replacement or downgrade.
- Introduces no Tor dependency and does not expose the full BitWindow chat interface yet.

## Validation

- BitWindow analyzer: clean.
- BitNames analyzer: clean.
- Sail UI analyzer: clean.
- BitNames Flutter suite: 11/11 passed.
- Go BitNames bridge tests: passed.
- Diff check: clean.

## Review order

This is PR 1 of 2. It establishes the protocol, persistence, recovery, and RPC interfaces used by the BitWindow chat and Tor integration in PR 2.
