### PR TITLE
Add BitNames chat with optional Tor

### DIFF
--- a/bitnames/lib/pages/tabs/messaging_page.dart
+++ b/bitnames/lib/pages/tabs/messaging_page.dart
@@ -53,123 +53,142 @@ class _MessagingTabPageState extends State<MessagingTabPage> {
   @override
   Widget build(BuildContext context) {
     return QtPage(
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Encrypt Card
-          Expanded(
-            child: SailCard(
-              title: 'Encrypt',
-              subtitle: 'Encrypt a message for a BitName or pubkey',
-              error: encryptError,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  SailTextField(
-                    label: "Receiver's BitName or Encryption Pubkey (Bech32m)",
-                    hintText: 'Enter a BitName or a pubkey',
-                    controller: encryptPubkeyController,
-                    suffixWidget: _hasBitnamesEncryptMatch ? SailSVG.icon(SailSVGAsset.iconSuccess, height: 20) : null,
-                  ),
-                  const SizedBox(height: 16),
-                  SailTextField(
-                    label: 'Plaintext message:',
-                    hintText: 'Enter a message to encrypt',
-                    controller: encryptMessageController,
-                    minLines: 3,
-                    maxLines: 6,
-                  ),
-                  const SizedBox(height: 16),
-                  SailButton(
-                    label: 'Encrypt',
-                    onPressed: handleEncrypt,
-                    loading: encryptLoading,
-                  ),
-                  if (encryptResult != null)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 12),
-                      child: SailText.secondary13(
-                        encryptResult!,
-                        monospace: true,
-                      ),
-                    ),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(width: 24),
-          // Decrypt Card
-          Expanded(
-            child: SailCard(
-              title: 'Decrypt',
-              subtitle: 'Decrypt a message using your pubkey',
-              error: decryptError,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  SailTextField(
-                    label: "Receiver's BitName or Encryption Pubkey (Bech32m)",
-                    hintText: 'Enter a BitName or a pubkey',
-                    controller: decryptPubkeyController,
-                    suffixWidget: _hasBitnamesDecryptMatch ? SailSVG.icon(SailSVGAsset.iconSuccess, height: 20) : null,
-                  ),
-                  const SizedBox(height: 16),
-                  SailTextField(
-                    label: 'Ciphertext message (hex):',
-                    hintText: 'Enter a ciphertext message',
-                    controller: decryptMessageController,
-                    minLines: 3,
-                    maxLines: 6,
-                  ),
-                  const SizedBox(height: 16),
-                  SailButton(
-                    label: 'Decrypt',
-                    onPressed: handleDecrypt,
-                    loading: decryptLoading,
-                  ),
-                  if (decryptResult != null)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 12),
-                      child: SailText.secondary13(
-                        decryptResult!,
-                        monospace: true,
-                      ),
-                    ),
-                ],
-              ),
-            ),
-          ),
-        ],
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final encrypt = _encryptCard(), decrypt = _decryptCard();
+          if (constraints.maxWidth < 800) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [encrypt, const SizedBox(height: 24), decrypt],
+            );
+          }
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(child: encrypt),
+              const SizedBox(width: 24),
+              Expanded(child: decrypt),
+            ],
+          );
+        },
       ),
     );
   }
 
-  /// Resolves the input to an encryption pubkey
-  /// Input can be: username, blake3 hash, or direct encryption key
-  String? _resolveEncryptionKey(String input) {
-    if (input.isEmpty) {
-      return null;
-    }
+  Widget _encryptCard() => SailCard(
+    title: 'Encrypt',
+    subtitle: 'Encrypt a message for a BitName or pubkey',
+    error: encryptError,
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SailTextField(
+          label: "Recipient's BitName or encryption pubkey (Bech32m)",
+          hintText: 'Enter a BitName or pubkey',
+          controller: encryptPubkeyController,
+          suffixWidget: _hasBitnamesEncryptMatch ? SailSVG.icon(SailSVGAsset.iconSuccess, height: 20) : null,
+        ),
+        const SizedBox(height: 16),
+        SailTextField(
+          label: 'Plaintext message',
+          hintText: 'Enter a message to encrypt',
+          controller: encryptMessageController,
+          minLines: 3,
+          maxLines: 6,
+        ),
+        const SizedBox(height: 16),
+        SailButton(
+          label: 'Encrypt',
+          onPressed: handleEncrypt,
+          loading: encryptLoading,
+        ),
+        if (encryptResult != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 12),
+            child: ResultRow(
+              label: 'Ciphertext',
+              value: encryptResult!,
+              monospace: true,
+              copyable: true,
+            ),
+          ),
+      ],
+    ),
+  );
 
+  Widget _decryptCard() => SailCard(
+    title: 'Decrypt',
+    subtitle: 'Decrypt a message sent to one of your BitNames',
+    error: decryptError,
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SailTextField(
+          label: 'Your BitName or encryption pubkey (Bech32m)',
+          hintText: 'Enter your receiving BitName or pubkey',
+          controller: decryptPubkeyController,
+          suffixWidget: _hasBitnamesDecryptMatch ? SailSVG.icon(SailSVGAsset.iconSuccess, height: 20) : null,
+        ),
+        const SizedBox(height: 16),
+        SailTextField(
+          label: 'Ciphertext message (hex)',
+          hintText: 'Enter a ciphertext message',
+          controller: decryptMessageController,
+          minLines: 3,
+          maxLines: 6,
+        ),
+        const SizedBox(height: 16),
+        SailButton(
+          label: 'Decrypt',
+          onPressed: handleDecrypt,
+          loading: decryptLoading,
+        ),
+        if (decryptResult != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 12),
+            child: ResultRow(
+              label: 'Plaintext',
+              value: decryptResult!,
+              copyable: true,
+            ),
+          ),
+      ],
+    ),
+  );
+
+  BitnameEntry? _resolveBitName(String input) {
     final trimmedInput = input.trim();
+    if (trimmedInput.isEmpty) return null;
 
-    // then check if input is a blake3 hash match
     var existingEntryMatch = bitnamesProvider.entries
-        .where((entry) => entry.hash == blake3Hex(utf8.encode(trimmedInput)).toLowerCase())
+        .where(
+          (entry) => entry.hash == blake3Hex(utf8.encode(trimmedInput)).toLowerCase(),
+        )
         .firstOrNull;
-
-    if (existingEntryMatch != null) {
-      // we found a plaintext match! save it to disk for easy access later
-      unawaited(bitnamesProvider.saveHashNameMapping(trimmedInput));
-    }
-
-    // First, check if input is already a direct hash match in bitnames
     existingEntryMatch ??= bitnamesProvider.entries
-        .where((entry) => entry.hash.toLowerCase() == trimmedInput.toLowerCase())
+        .where(
+          (entry) => entry.hash.toLowerCase() == trimmedInput.toLowerCase(),
+        )
         .firstOrNull;
+    return existingEntryMatch;
+  }
 
-    // If no bitname match found, assume input is a direct encryption key
-    return existingEntryMatch?.details.encryptionPubkey;
+  String? _resolveEncryptionKey(String input) => _resolveBitName(input)?.details.encryptionPubkey;
+
+  String _requireEncryptionKey(String input) {
+    final trimmed = input.trim(), entry = _resolveBitName(input);
+    if (entry != null) {
+      final key = entry.details.encryptionPubkey;
+      if (key == null) {
+        throw const FormatException(
+          'This BitName has no encryption key. Its owner must add one before messaging.',
+        );
+      }
+      if (!RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(trimmed)) unawaited(bitnamesProvider.saveHashNameMapping(trimmed));
+      return key;
+    }
+    if (trimmed.isEmpty) throw const FormatException('Enter a BitName or encryption pubkey.');
+    return trimmed;
   }
 
   Future<void> handleEncrypt() async {
@@ -180,21 +199,17 @@ class _MessagingTabPageState extends State<MessagingTabPage> {
     });
 
     try {
-      final resolvedKey = _resolveEncryptionKey(encryptPubkeyController.text) ?? encryptPubkeyController.text.trim();
-      if (resolvedKey.isEmpty) {
-        setState(() => encryptError = 'Must enter a valid pubkey');
-        return;
-      }
-
+      final resolvedKey = _requireEncryptionKey(encryptPubkeyController.text);
       final ciphertext = await rpc.encryptMsg(
-        msg: encryptMessageController.text.trim(),
+        msg: encryptMessageController.text,
         encryptionPubkey: resolvedKey,
       );
+      if (!mounted) return;
       setState(() => encryptResult = ciphertext);
     } catch (e) {
-      setState(() => encryptError = e.toString());
+      if (mounted) setState(() => encryptError = _friendlyError(e));
     } finally {
-      setState(() => encryptLoading = false);
+      if (mounted) setState(() => encryptLoading = false);
     }
   }
 
@@ -206,26 +221,26 @@ class _MessagingTabPageState extends State<MessagingTabPage> {
     });
 
     try {
-      final resolvedKey = _resolveEncryptionKey(decryptPubkeyController.text) ?? decryptPubkeyController.text.trim();
-      if (resolvedKey.isEmpty) {
-        setState(() => decryptError = 'Must enter a valid pubkey');
-        return;
-      }
-
+      final resolvedKey = _requireEncryptionKey(decryptPubkeyController.text);
       final plaintext = await rpc.decryptMsg(
         ciphertext: decryptMessageController.text.trim(),
         encryptionPubkey: resolvedKey,
       );
+      if (!mounted) return;
       setState(() => decryptResult = plaintext);
     } catch (e) {
-      setState(() => decryptError = e.toString());
+      if (mounted) setState(() => decryptError = _friendlyError(e));
     } finally {
-      setState(() => decryptLoading = false);
+      if (mounted) setState(() => decryptLoading = false);
     }
   }
 
+  String _friendlyError(Object error) => error is FormatException
+      ? error.message.toString()
+      : 'Request failed. Check the BitNames connection and try again.';
+
   void _onChange() {
-    setState(() {});
+    if (mounted) setState(() {});
   }
 
   @override

--- a/bitnames/lib/pages/tabs/reserve_register_page.dart
+++ b/bitnames/lib/pages/tabs/reserve_register_page.dart
@@ -174,6 +174,12 @@ class BitnamesTabPage extends StatelessWidget {
                                   hintText: 'Enter IPv6 address',
                                   controller: model.ipv6Controller,
                                 ),
+                                SailTextField(
+                                  label: 'Introduction fee (sats)',
+                                  hintText: '1000',
+                                  controller: model.paymailFeeController,
+                                  textFieldType: TextFieldType.number,
+                                ),
                                 SailCheckbox(
                                   label: 'Set Encryption Pubkey',
                                   value: model.useEncryptionKey,
@@ -208,6 +214,9 @@ class BitnamesTabPage extends StatelessWidget {
                                   label: 'Register',
                                   onPressed: () => model.registerBitname(context),
                                   loading: model.registerLoading,
+                                  disabled:
+                                      (model.useEncryptionKey && model.encryptionKey == null) ||
+                                      (model.useSigningKey && model.signingKey == null),
                                 ),
                               ],
                             ),
@@ -426,6 +435,7 @@ class BitnamesViewModel extends BaseViewModel {
   // Register state
   bool registerLoading = false;
   String? registerError;
+  bool _disposed = false;
 
   // New state variables
   bool useEncryptionKey = false;
@@ -447,20 +457,20 @@ class BitnamesViewModel extends BaseViewModel {
     encryptionKey = null;
     signingKey = null;
 
-    while (encryptionKey == null || signingKey == null) {
+    while (!_disposed && (encryptionKey == null || signingKey == null)) {
       try {
         if (encryptionKey == null) {
           encryptionKey = await bitnamesRPC.getNewEncryptionKey();
-          notifyListeners();
+          if (!_disposed) notifyListeners();
         }
 
         if (signingKey == null) {
           signingKey = await bitnamesRPC.getNewVerifyingKey();
-          notifyListeners();
+          if (!_disposed) notifyListeners();
         }
       } catch (e) {
         // If there's an error, wait a bit before retrying
-        await Future.delayed(const Duration(milliseconds: 500));
+        if (!_disposed) await Future.delayed(const Duration(milliseconds: 500));
       }
     }
   }
@@ -568,13 +578,21 @@ class BitnamesViewModel extends BaseViewModel {
       return;
     }
 
-    final name = registerNameController.text.trim();
+    final name = registerNameController.text.trim().toLowerCase();
     final commitment = commitmentController.text.trim().isEmpty ? null : commitmentController.text.trim();
     final ipv4 = ipv4Controller.text.trim().isEmpty ? null : ipv4Controller.text.trim();
     final ipv6 = ipv6Controller.text.trim().isEmpty ? null : ipv6Controller.text.trim();
+    final paymailFee = int.tryParse(
+      paymailFeeController.text.trim().isEmpty ? '1000' : paymailFeeController.text.trim(),
+    );
 
     if (name.isEmpty) {
       registerError = 'Name cannot be empty';
+      notifyListeners();
+      return;
+    }
+    if (paymailFee == null || paymailFee < 0) {
+      registerError = 'Introduction fee must be zero or greater';
       notifyListeners();
       return;
     }
@@ -605,7 +623,7 @@ class BitnamesViewModel extends BaseViewModel {
         BitNameData(
           commitment: commitment,
           encryptionPubkey: useEncryptionKey ? encryptionKey : null,
-          paymailFeeSats: 1000,
+          paymailFeeSats: paymailFee,
           signingPubkey: useSigningKey ? signingKey : null,
           socketAddrV4: ipv4,
           socketAddrV6: ipv6,
@@ -626,6 +644,7 @@ class BitnamesViewModel extends BaseViewModel {
       commitmentController.clear();
       ipv4Controller.clear();
       ipv6Controller.clear();
+      paymailFeeController.clear();
       useEncryptionKey = false;
       useSigningKey = false;
 
@@ -639,6 +658,7 @@ class BitnamesViewModel extends BaseViewModel {
 
   @override
   void dispose() {
+    _disposed = true;
     searchController.dispose();
     reserveNameController.dispose();
     registerNameController.dispose();

--- a/bitnames/lib/providers/bitnames_provider.dart
+++ b/bitnames/lib/providers/bitnames_provider.dart
@@ -22,14 +22,21 @@ class BitnamesProvider extends ChangeNotifier {
 
   BitnamesProvider() {
     rpc.addListener(fetch);
-    fetch();
+    _initialize();
     _startRetryTimer();
+  }
+
+  Future<void> _initialize() async {
+    hashNameMapping = await clientSettings.getValue(HashNameMappingSetting()) as HashNameMappingSetting;
+    notifyListeners();
+    await fetch();
   }
 
   /// Save a new hash-name mapping
   Future<void> saveHashNameMapping(String name, {bool isMine = false}) async {
     final hash = blake3Hex(utf8.encode(name));
-    final newMappings = Map<String, HashMapping>.from(hashNameMapping.value);
+    final stored = await clientSettings.getValue(HashNameMappingSetting());
+    final newMappings = Map<String, HashMapping>.from(stored.value);
     newMappings[hash] = HashMapping(name: name, isMine: isMine);
     hashNameMapping = HashNameMappingSetting(newValue: newMappings);
     await clientSettings.setValue(hashNameMapping);
@@ -47,7 +54,7 @@ class BitnamesProvider extends ChangeNotifier {
 
     _retryTimer?.cancel();
     _retryTimer = Timer.periodic(const Duration(milliseconds: 500), (timer) {
-      if (entries.isNotEmpty && initialized) {
+      if (initialized) {
         timer.cancel();
         _retryTimer = null;
         return;
@@ -77,7 +84,18 @@ class BitnamesProvider extends ChangeNotifier {
   bool _listEquals(List<BitnameEntry> a, List<BitnameEntry> b) {
     if (a.length != b.length) return false;
     for (int i = 0; i < a.length; i++) {
-      if (a[i].hash != b[i].hash || a[i].plaintextName != b[i].plaintextName) return false;
+      final x = a[i], y = b[i], xd = x.details, yd = y.details;
+      if (x.hash != y.hash ||
+          x.plaintextName != y.plaintextName ||
+          xd.seqId != yd.seqId ||
+          xd.commitment != yd.commitment ||
+          xd.socketAddrV4 != yd.socketAddrV4 ||
+          xd.socketAddrV6 != yd.socketAddrV6 ||
+          xd.encryptionPubkey != yd.encryptionPubkey ||
+          xd.signingPubkey != yd.signingPubkey ||
+          xd.paymailFeeSats != yd.paymailFeeSats) {
+        return false;
+      }
     }
     return true;
   }

--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -291,7 +291,9 @@ Future<(Directory, File, Logger)> init(String arguments) async {
   GetIt.I.registerLazySingleton<MempoolProvider>(() => MempoolProvider());
   GetIt.I.registerSingleton<NotificationStreamProvider>(NotificationStreamProvider());
   GetIt.I.registerSingleton<ForkProvider>(ForkProvider()..init());
-  GetIt.I.registerSingleton<ChatProvider>(ChatProvider());
+  if (!isSubWindow) {
+    GetIt.I.registerSingleton<ChatProvider>(ChatProvider());
+  }
   GetIt.I.registerSingleton<FastWithdrawalProvider>(FastWithdrawalProvider());
   GetIt.I.registerSingleton<UpdateProvider>(
     UpdateProvider(

--- a/bitwindow/lib/models/bitintroduction_protocol.dart
+++ b/bitwindow/lib/models/bitintroduction_protocol.dart
@@ -1,0 +1,333 @@
+import 'dart:convert';
+import 'package:thirds/blake3.dart';
+
+const bitIntroductionProtocol = 'bitintroduction';
+const bitIntroductionProtocolVersion = 1;
+
+enum BitIntroductionKind {
+  introduction('introduction'),
+  acceptance('acceptance'),
+  message('message');
+
+  const BitIntroductionKind(this.wireName);
+  final String wireName;
+  static BitIntroductionKind fromWireName(String value) {
+    for (final kind in values) {
+      if (kind.wireName == value) return kind;
+    }
+    throw FormatException('Unsupported BitIntroduction kind: $value');
+  }
+}
+
+class BitMessageProfile {
+  BitMessageProfile({
+    required String bitNameHash,
+    required this.signingPublicKey,
+    required this.encryptionPublicKey,
+    Iterable<Uri> directEndpoints = const [],
+    Iterable<Uri> torEndpoints = const [],
+    this.paymailFeeSats,
+    Map<String, dynamic>? commitmentManifest,
+  }) : bitNameHash = _bitNameHash(bitNameHash),
+       directEndpoints = List.unmodifiable(_endpoints(directEndpoints, false)),
+       torEndpoints = List.unmodifiable(_endpoints(torEndpoints, true)),
+       commitmentManifest = commitmentManifest == null ? null : _immutableJsonObject(commitmentManifest) {
+    _notEmpty(signingPublicKey, 'signingPublicKey');
+    _notEmpty(encryptionPublicKey, 'encryptionPublicKey');
+    if (paymailFeeSats != null && paymailFeeSats! < 0) {
+      throw ArgumentError.value(paymailFeeSats, 'paymailFeeSats', 'must be non-negative');
+    }
+  }
+
+  final String bitNameHash, signingPublicKey, encryptionPublicKey;
+  final List<Uri> directEndpoints, torEndpoints;
+  final int? paymailFeeSats;
+  final Map<String, dynamic>? commitmentManifest;
+
+  factory BitMessageProfile.fromJson(Map<String, dynamic> json) => BitMessageProfile(
+    bitNameHash: _string(json, 'bitname_hash'),
+    signingPublicKey: _string(json, 'signing_public_key'),
+    encryptionPublicKey: _string(json, 'encryption_public_key'),
+    directEndpoints: _uriList(json['direct_endpoints'], 'direct_endpoints'),
+    torEndpoints: _uriList(json['tor_endpoints'], 'tor_endpoints'),
+    paymailFeeSats: _optionalInt(json, 'paymail_fee_sats'),
+    commitmentManifest: switch (json['commitment_manifest']) {
+      final Map value => Map<String, dynamic>.from(value),
+      null => null,
+      _ => throw const FormatException('commitment_manifest must be an object'),
+    },
+  );
+
+  Map<String, dynamic> toCommitmentPayloadJson() => {
+    'bitname_hash': bitNameHash,
+    'signing_public_key': signingPublicKey,
+    'encryption_public_key': encryptionPublicKey,
+    'direct_endpoints': directEndpoints.map((uri) => '$uri').toList(),
+    'tor_endpoints': torEndpoints.map((uri) => '$uri').toList(),
+    if (paymailFeeSats != null) 'paymail_fee_sats': paymailFeeSats,
+  };
+
+  Map<String, dynamic> toJson() => {
+    ...toCommitmentPayloadJson(),
+    if (commitmentManifest != null) 'commitment_manifest': _cloneJsonObject(commitmentManifest!),
+  };
+
+  BitMessageProfile withCommitmentManifest(
+    Map<String, dynamic>? manifest,
+  ) => BitMessageProfile(
+    bitNameHash: bitNameHash,
+    signingPublicKey: signingPublicKey,
+    encryptionPublicKey: encryptionPublicKey,
+    directEndpoints: directEndpoints,
+    torEndpoints: torEndpoints,
+    paymailFeeSats: paymailFeeSats,
+    commitmentManifest: manifest,
+  );
+}
+
+class VerifiedBitMessageProfile {
+  VerifiedBitMessageProfile.verified({
+    required this.profile,
+    required String onChainCommitment,
+    required this.verificationReference,
+    bool Function(BitMessageProfile profile, String commitment)? commitmentVerifier,
+  }) : onChainCommitment = onChainCommitment.trim().toLowerCase() {
+    if (!_hashPattern.hasMatch(this.onChainCommitment)) {
+      throw ArgumentError.value(onChainCommitment, 'onChainCommitment', 'must be a 32-byte hexadecimal hash');
+    }
+    if (!(commitmentVerifier?.call(profile, this.onChainCommitment) ??
+        bitMessageProfileCommitment(profile) == this.onChainCommitment)) {
+      throw ArgumentError.value(onChainCommitment, 'onChainCommitment', 'does not commit to the canonical profile');
+    }
+    _notEmpty(verificationReference, 'verificationReference');
+  }
+
+  final BitMessageProfile profile;
+  final String onChainCommitment, verificationReference;
+  String get bitNameHash => profile.bitNameHash;
+  String get bitNameCommit => onChainCommitment;
+  String get signingPublicKey => profile.signingPublicKey;
+  String get encryptionPublicKey => profile.encryptionPublicKey;
+  List<Uri> get directEndpoints => profile.directEndpoints;
+  List<Uri> get torEndpoints => profile.torEndpoints;
+  int? get paymailFeeSats => profile.paymailFeeSats;
+}
+
+String bitMessageProfileCommitment(BitMessageProfile profile) => blake3Hex(
+  utf8.encode(
+    canonicalJsonEncode(profile.toCommitmentPayloadJson()),
+  ),
+);
+
+class BitIntroductionPayload {
+  BitIntroductionPayload({
+    this.version = bitIntroductionProtocolVersion,
+    required this.id,
+    required this.kind,
+    required String senderBitNameHash,
+    required String recipientBitNameHash,
+    required DateTime timestamp,
+    required this.body,
+    this.inReplyTo,
+    this.replyProfile,
+  }) : senderBitNameHash = _bitNameHash(senderBitNameHash),
+       recipientBitNameHash = _bitNameHash(recipientBitNameHash),
+       timestamp = timestamp.toUtc() {
+    if (version != bitIntroductionProtocolVersion) {
+      throw ArgumentError.value(version, 'version', 'unsupported protocol version');
+    }
+    _boundedId(id, 'id');
+    if (inReplyTo != null) _boundedId(inReplyTo!, 'inReplyTo');
+    if (kind == BitIntroductionKind.acceptance && inReplyTo == null) {
+      throw ArgumentError('Acceptance messages must reference the introduction ID');
+    }
+    if (replyProfile != null && replyProfile!.bitNameHash != this.senderBitNameHash) {
+      throw ArgumentError('replyProfile must belong to senderBitNameHash');
+    }
+  }
+
+  final int version;
+  final String id, senderBitNameHash, recipientBitNameHash, body;
+  final BitIntroductionKind kind;
+  final DateTime timestamp;
+  final String? inReplyTo;
+  final BitMessageProfile? replyProfile;
+
+  factory BitIntroductionPayload.fromJson(Map<String, dynamic> json) {
+    final protocol = _string(json, 'protocol');
+    if (protocol != bitIntroductionProtocol) throw FormatException('Unsupported protocol: $protocol');
+    final reply = json['reply_profile'];
+    if (reply != null && reply is! Map) throw const FormatException('reply_profile must be an object');
+    final parent = json['in_reply_to'];
+    if (parent != null && parent is! String) throw const FormatException('in_reply_to must be a string');
+    return BitIntroductionPayload(
+      version: _integer(json, 'version'),
+      id: _string(json, 'id'),
+      kind: BitIntroductionKind.fromWireName(_string(json, 'kind')),
+      senderBitNameHash: _string(json, 'sender_bitname_hash'),
+      recipientBitNameHash: _string(json, 'recipient_bitname_hash'),
+      timestamp: DateTime.fromMillisecondsSinceEpoch(_integer(json, 'timestamp_ms'), isUtc: true),
+      body: _string(json, 'body', empty: true),
+      inReplyTo: parent as String?,
+      replyProfile: reply == null ? null : BitMessageProfile.fromJson(Map<String, dynamic>.from(reply)),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'protocol': bitIntroductionProtocol,
+    'version': version,
+    'id': id,
+    'kind': kind.wireName,
+    'sender_bitname_hash': senderBitNameHash,
+    'recipient_bitname_hash': recipientBitNameHash,
+    'timestamp_ms': timestamp.millisecondsSinceEpoch,
+    'body': body,
+    if (inReplyTo != null) 'in_reply_to': inReplyTo,
+    if (replyProfile != null) 'reply_profile': replyProfile!.toJson(),
+  };
+}
+
+class SignedBitIntroductionEnvelope {
+  SignedBitIntroductionEnvelope({required this.payload, required this.signature}) {
+    _notEmpty(signature, 'signature');
+  }
+
+  final BitIntroductionPayload payload;
+  final String signature;
+  String get signedPayload => canonicalJsonEncode(payload.toJson());
+
+  factory SignedBitIntroductionEnvelope.fromJson(Map<String, dynamic> json) {
+    final payload = json['payload'];
+    if (payload is! Map) throw const FormatException('payload must be an object');
+    return SignedBitIntroductionEnvelope(
+      payload: BitIntroductionPayload.fromJson(Map<String, dynamic>.from(payload)),
+      signature: _string(json, 'signature'),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {'payload': payload.toJson(), 'signature': signature};
+}
+
+class BitMessageWire {
+  BitMessageWire({required String recipientBitNameHash, required this.ciphertext})
+    : recipientBitNameHash = _bitNameHash(recipientBitNameHash) {
+    _notEmpty(ciphertext, 'ciphertext');
+  }
+
+  final String recipientBitNameHash, ciphertext;
+
+  factory BitMessageWire.fromJson(Map<String, dynamic> json) => BitMessageWire(
+    recipientBitNameHash: _string(json, 'recipient_bitname_hash'),
+    ciphertext: _string(json, 'ciphertext'),
+  );
+
+  Map<String, dynamic> toJson() => {'recipient_bitname_hash': recipientBitNameHash, 'ciphertext': ciphertext};
+}
+
+String canonicalJsonEncode(Object? value) {
+  if (value == null) return 'null';
+  if (value is String) return jsonEncode(value);
+  if (value is bool) return '$value';
+  if (value is int) return '$value';
+  if (value is num) throw ArgumentError.value(value, 'value', 'canonical signed JSON only permits integer numbers');
+  if (value is List) return '[${value.map(canonicalJsonEncode).join(',')}]';
+  if (value is Map) {
+    final entries = value.entries.map((entry) {
+      if (entry.key is! String) {
+        throw ArgumentError.value(entry.key, 'key', 'canonical JSON object keys must be strings');
+      }
+      return MapEntry(entry.key as String, entry.value);
+    }).toList()..sort((a, b) => a.key.compareTo(b.key));
+    return '{${entries.map((e) => '${jsonEncode(e.key)}:${canonicalJsonEncode(e.value)}').join(',')}}';
+  }
+  throw ArgumentError.value(value, 'value', 'not a JSON value');
+}
+
+final _hashPattern = RegExp(r'^[0-9a-f]{64}$');
+
+Map<String, dynamic> _cloneJsonObject(Map<String, dynamic> value) {
+  try {
+    return Map<String, dynamic>.from(
+      jsonDecode(jsonEncode(value)) as Map,
+    );
+  } catch (_) {
+    throw const FormatException('commitment_manifest must contain JSON data');
+  }
+}
+
+Map<String, dynamic> _immutableJsonObject(Map<String, dynamic> value) {
+  Object? freeze(Object? item) => switch (item) {
+    final Map map => Map<String, dynamic>.unmodifiable(
+      map.map((key, value) => MapEntry('$key', freeze(value))),
+    ),
+    final List list => List<Object?>.unmodifiable(list.map(freeze)),
+    _ => item,
+  };
+  return freeze(_cloneJsonObject(value))! as Map<String, dynamic>;
+}
+
+String _bitNameHash(String value) {
+  final hash = value.trim().toLowerCase();
+  if (!_hashPattern.hasMatch(hash)) {
+    throw ArgumentError.value(value, 'bitNameHash', 'must be a 32-byte hexadecimal hash');
+  }
+  return hash;
+}
+
+void _notEmpty(String value, String name) {
+  if (value.trim().isEmpty) throw ArgumentError.value(value, name, 'must not be empty');
+}
+
+void _boundedId(String value, String name) {
+  if (value.trim().isEmpty || value.length > 256) {
+    throw ArgumentError.value(value, name, 'must contain 1-256 characters');
+  }
+}
+
+List<Uri> _endpoints(Iterable<Uri> input, bool tor) {
+  final unique = <String, Uri>{};
+  for (final endpoint in input) {
+    final scheme = endpoint.scheme.toLowerCase();
+    final host = endpoint.host.toLowerCase();
+    final basicInvalid = !endpoint.hasScheme || host.isEmpty || endpoint.hasFragment || endpoint.userInfo.isNotEmpty;
+    final routeInvalid = tor
+        ? scheme != 'http' || !host.endsWith('.onion')
+        : !{'http', 'https'}.contains(scheme) || host.endsWith('.onion');
+    if (basicInvalid || routeInvalid) {
+      throw ArgumentError.value(endpoint, tor ? 'torEndpoints' : 'directEndpoints', 'invalid endpoint');
+    }
+    var path = endpoint.path.isEmpty ? '/' : endpoint.path;
+    if (!path.endsWith('/')) path += '/';
+    final normalized = endpoint.replace(scheme: scheme, host: host, path: path);
+    unique['$normalized'] = normalized;
+  }
+  final keys = unique.keys.toList()..sort();
+  return keys.map((key) => unique[key]!).toList();
+}
+
+List<Uri> _uriList(dynamic value, String field) {
+  if (value == null) return const [];
+  if (value is! List) throw FormatException('$field must be an array');
+  return value.map((item) {
+    if (item is! String) throw FormatException('$field entries must be strings');
+    final uri = Uri.tryParse(item);
+    if (uri == null) throw FormatException('$field contains an invalid URI');
+    return uri;
+  }).toList();
+}
+
+String _string(Map<String, dynamic> json, String field, {bool empty = false}) {
+  final value = json[field];
+  if (value is! String || (!empty && value.trim().isEmpty)) {
+    throw FormatException('$field must be ${empty ? 'a string' : 'a non-empty string'}');
+  }
+  return value;
+}
+
+int _integer(Map<String, dynamic> json, String field) {
+  final value = json[field];
+  if (value is! int) throw FormatException('$field must be an integer');
+  return value;
+}
+
+int? _optionalInt(Map<String, dynamic> json, String field) => json[field] == null ? null : _integer(json, field);

--- a/bitwindow/lib/models/bitnames_commitment.dart
+++ b/bitwindow/lib/models/bitnames_commitment.dart
@@ -1,0 +1,580 @@
+import 'dart:convert';
+
+import 'package:bitwindow/models/bitintroduction_protocol.dart';
+import 'package:thirds/blake3.dart';
+
+const bitNamesCommitmentManifestProtocol = 'bitnames-commitment-manifest';
+const bitNamesCommitmentManifestVersion = 1;
+const bitNamesApplicationCommitmentProtocol = 'bitnames-application-commitment';
+const bitIntroductionCommitmentNamespace = 'org.layertwolabs.bitintroduction';
+const bitIntroductionCommitmentPurpose = 'reply-profile';
+const bitIntroductionCommitmentVersion = 1;
+const bitNamesCommitmentChain = 'bip300:2:bitnames';
+const bitNamesCommitmentMaxBytes = 16 * 1024;
+
+enum BitNamesCommitmentActivation {
+  legacyCompatible,
+  namespacedV1,
+}
+
+enum BitNamesProfileCommitmentKind {
+  empty,
+  legacy,
+  namespaced,
+  unknown,
+  malformed,
+  wrongNetwork,
+  conflict,
+}
+
+class BitNamesCommitmentAssessment {
+  const BitNamesCommitmentAssessment(
+    this.kind,
+    this.summary,
+    this.details, {
+    this.manifest,
+  });
+
+  final BitNamesProfileCommitmentKind kind;
+  final String summary;
+  final String details;
+  final BitNamesCommitmentManifest? manifest;
+
+  bool get verified => kind == BitNamesProfileCommitmentKind.legacy || kind == BitNamesProfileCommitmentKind.namespaced;
+  bool get writable => kind == BitNamesProfileCommitmentKind.empty || verified;
+}
+
+class BitNamesCommitmentConflict implements Exception {
+  const BitNamesCommitmentConflict(this.message);
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class BitNamesCommitmentManifest {
+  BitNamesCommitmentManifest._(this._json);
+
+  final Map<String, dynamic> _json;
+
+  String get network => _json['network'] as String;
+  String get bitNameHash => _json['bitname_hash'] as String;
+  Map<String, dynamic> get applications => _cloneObject(_json['applications'] as Map);
+  Map<String, dynamic> toJson() => _cloneObject(_json);
+  String get commitment => blake3Hex(utf8.encode(canonicalJsonEncode(_json)));
+
+  factory BitNamesCommitmentManifest.parse(
+    Map<String, dynamic> source,
+  ) {
+    final json = _cloneObject(source);
+    _boundedCanonical(json);
+    if (json['protocol'] != bitNamesCommitmentManifestProtocol) {
+      throw const FormatException(
+        'unsupported BitNames commitment protocol',
+      );
+    }
+    if (json['version'] != bitNamesCommitmentManifestVersion) {
+      throw const FormatException(
+        'unsupported BitNames commitment manifest version',
+      );
+    }
+    if (!_hasExactKeys(json, const {
+      'protocol',
+      'version',
+      'network',
+      'bitname_hash',
+      'applications',
+    })) {
+      throw const FormatException(
+        'BitNames commitment manifest v1 has unknown or missing fields',
+      );
+    }
+    final network = json['network'];
+    if (network is! String || bitNamesCommitmentNetwork(network) != network) {
+      throw const FormatException(
+        'invalid BitNames commitment network',
+      );
+    }
+    final bitNameHash = json['bitname_hash'];
+    if (bitNameHash is! String || !_hashPattern.hasMatch(bitNameHash)) {
+      throw const FormatException(
+        'invalid BitName commitment identity',
+      );
+    }
+    final applications = json['applications'];
+    if (applications is! Map || applications.isEmpty || applications.length > 32) {
+      throw const FormatException(
+        'BitNames commitment applications must contain 1 to 32 entries',
+      );
+    }
+    for (final entry in applications.entries) {
+      if (entry.key is! String || !_namespacePattern.hasMatch(entry.key as String)) {
+        throw const FormatException(
+          'invalid BitNames application namespace',
+        );
+      }
+      if (entry.value is! Map) {
+        throw const FormatException(
+          'BitNames application commitment must be an object',
+        );
+      }
+      final application = Map<String, dynamic>.from(
+        entry.value as Map,
+      );
+      if (application['version'] is! int ||
+          (application['version'] as int) < 1 ||
+          (application['version'] as int) > 0x7fffffff ||
+          application['purpose'] is! String ||
+          !_purposePattern.hasMatch(application['purpose'] as String) ||
+          application['commitment'] is! String ||
+          !_hashPattern.hasMatch(
+            application['commitment'] as String,
+          ) ||
+          application['data'] is! Map) {
+        throw const FormatException(
+          'invalid BitNames application commitment entry',
+        );
+      }
+    }
+    return BitNamesCommitmentManifest._(json);
+  }
+
+  factory BitNamesCommitmentManifest.forReplyProfile(
+    BitMessageProfile profile, {
+    required String network,
+    BitNamesCommitmentManifest? base,
+  }) {
+    final scope = bitNamesCommitmentNetwork(network);
+    if (base != null) {
+      if (base.network != scope || base.bitNameHash != profile.bitNameHash) {
+        throw const BitNamesCommitmentConflict(
+          'The existing commitment manifest belongs to another network or BitName',
+        );
+      }
+      final existing = base.applications[bitIntroductionCommitmentNamespace];
+      if (existing is Map &&
+          (existing['version'] != bitIntroductionCommitmentVersion ||
+              existing['purpose'] != bitIntroductionCommitmentPurpose)) {
+        throw const BitNamesCommitmentConflict(
+          'The BitIntroduction namespace uses an unknown version and was preserved',
+        );
+      }
+    }
+    final payload = profile.toCommitmentPayloadJson();
+    final applications = base?.applications ?? <String, dynamic>{};
+    applications[bitIntroductionCommitmentNamespace] = {
+      'version': bitIntroductionCommitmentVersion,
+      'purpose': bitIntroductionCommitmentPurpose,
+      'commitment': bitNamesApplicationCommitment(
+        namespace: bitIntroductionCommitmentNamespace,
+        purpose: bitIntroductionCommitmentPurpose,
+        network: scope,
+        bitNameHash: profile.bitNameHash,
+        payload: payload,
+      ),
+      'data': payload,
+    };
+    return BitNamesCommitmentManifest.parse({
+      'protocol': bitNamesCommitmentManifestProtocol,
+      'version': bitNamesCommitmentManifestVersion,
+      'network': scope,
+      'bitname_hash': profile.bitNameHash,
+      'applications': applications,
+    });
+  }
+
+  BitMessageProfile replyProfile() {
+    final raw = applications[bitIntroductionCommitmentNamespace];
+    if (raw is! Map) {
+      throw const FormatException(
+        'manifest has no BitIntroduction commitment',
+      );
+    }
+    final entry = Map<String, dynamic>.from(raw);
+    if (entry['version'] != bitIntroductionCommitmentVersion || entry['purpose'] != bitIntroductionCommitmentPurpose) {
+      throw const FormatException(
+        'unsupported BitIntroduction commitment version or purpose',
+      );
+    }
+    if (!_hasExactKeys(entry, const {
+      'version',
+      'purpose',
+      'commitment',
+      'data',
+    })) {
+      throw const FormatException(
+        'BitIntroduction commitment v1 has unknown or missing fields',
+      );
+    }
+    final data = entry['data'];
+    if (data is! Map) {
+      throw const FormatException(
+        'BitIntroduction commitment data is malformed',
+      );
+    }
+    final profile = BitMessageProfile.fromJson(
+      Map<String, dynamic>.from(data),
+    );
+    if (profile.bitNameHash != bitNameHash) {
+      throw const FormatException(
+        'BitIntroduction profile belongs to another BitName',
+      );
+    }
+    final expected = bitNamesApplicationCommitment(
+      namespace: bitIntroductionCommitmentNamespace,
+      purpose: bitIntroductionCommitmentPurpose,
+      network: network,
+      bitNameHash: bitNameHash,
+      payload: profile.toCommitmentPayloadJson(),
+    );
+    if (entry['commitment'] != expected ||
+        canonicalJsonEncode(data) !=
+            canonicalJsonEncode(
+              profile.toCommitmentPayloadJson(),
+            )) {
+      throw const FormatException(
+        'BitIntroduction commitment data does not match its leaf',
+      );
+    }
+    return profile.withCommitmentManifest(toJson());
+  }
+}
+
+class BitNamesCommitmentWritePlan {
+  const BitNamesCommitmentWritePlan({
+    required this.profile,
+    required this.commitment,
+    required this.kind,
+    required this.migratesLegacy,
+    required this.preservedApplications,
+  });
+
+  final BitMessageProfile profile;
+  final String commitment;
+  final BitNamesProfileCommitmentKind kind;
+  final bool migratesLegacy;
+  final int preservedApplications;
+
+  String get summary => switch (kind) {
+    BitNamesProfileCommitmentKind.namespaced =>
+      migratesLegacy
+          ? 'Migrating the legacy reply profile into the namespaced v1 manifest'
+          : 'Publishing a namespaced v1 reply-profile commitment',
+    _ => 'Publishing a legacy-compatible reply-profile commitment',
+  };
+}
+
+class BitNamesCommitmentPlanner {
+  const BitNamesCommitmentPlanner({
+    required this.network,
+    required this.activation,
+  });
+
+  final String network;
+  final BitNamesCommitmentActivation activation;
+
+  BitNamesCommitmentAssessment assess({
+    required String? onChainCommitment,
+    BitMessageProfile? knownProfile,
+  }) => assessBitMessageProfileCommitment(
+    profile: knownProfile,
+    onChainCommitment: onChainCommitment,
+    network: network,
+  );
+
+  BitNamesCommitmentWritePlan plan({
+    required BitMessageProfile profile,
+    required String? currentCommitment,
+    BitMessageProfile? knownProfile,
+  }) {
+    final baseProfile = profile.withCommitmentManifest(null);
+    final assessment = assess(
+      onChainCommitment: currentCommitment,
+      knownProfile: knownProfile ?? baseProfile,
+    );
+    if (!assessment.writable) {
+      throw BitNamesCommitmentConflict(assessment.details);
+    }
+    final existingNamespaced = assessment.kind == BitNamesProfileCommitmentKind.namespaced;
+    final useNamespaced =
+        existingNamespaced ||
+        _isSelfConsistentNamespacedProfile(knownProfile, network) ||
+        activation == BitNamesCommitmentActivation.namespacedV1;
+    if (!useNamespaced) {
+      return BitNamesCommitmentWritePlan(
+        profile: baseProfile,
+        commitment: bitMessageProfileCommitment(baseProfile),
+        kind: BitNamesProfileCommitmentKind.legacy,
+        migratesLegacy: false,
+        preservedApplications: 0,
+      );
+    }
+    final manifest = BitNamesCommitmentManifest.forReplyProfile(
+      baseProfile,
+      network: network,
+      base: assessment.manifest,
+    );
+    final committedProfile = baseProfile.withCommitmentManifest(manifest.toJson());
+    return BitNamesCommitmentWritePlan(
+      profile: committedProfile,
+      commitment: manifest.commitment,
+      kind: BitNamesProfileCommitmentKind.namespaced,
+      migratesLegacy: assessment.kind == BitNamesProfileCommitmentKind.legacy,
+      preservedApplications: manifest.applications.length - 1,
+    );
+  }
+}
+
+bool _isSelfConsistentNamespacedProfile(
+  BitMessageProfile? profile,
+  String network,
+) {
+  if (profile?.commitmentManifest == null) return false;
+  try {
+    final manifest = BitNamesCommitmentManifest.parse(
+      profile!.commitmentManifest!,
+    );
+    return assessBitMessageProfileCommitment(
+          profile: profile,
+          onChainCommitment: manifest.commitment,
+          network: network,
+        ).kind ==
+        BitNamesProfileCommitmentKind.namespaced;
+  } catch (_) {
+    return false;
+  }
+}
+
+BitNamesCommitmentAssessment assessBitMessageProfileCommitment({
+  required BitMessageProfile? profile,
+  required String? onChainCommitment,
+  required String network,
+}) {
+  if (onChainCommitment == null) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.empty,
+      'No application commitment is set',
+      'BitWindow can publish without replacing another application.',
+    );
+  }
+  final commitment = onChainCommitment.trim().toLowerCase();
+  if (!_hashPattern.hasMatch(commitment)) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.malformed,
+      'The on-chain commitment is malformed',
+      'BitWindow will not replace a malformed or ambiguous commitment.',
+    );
+  }
+  if (profile == null) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.unknown,
+      'Another or unknown application commitment is present',
+      'BitWindow cannot authenticate its contents, so publishing is blocked to preserve it.',
+    );
+  }
+  final manifestJson = profile.commitmentManifest;
+  if (manifestJson == null) {
+    if (bitMessageProfileCommitment(profile) == commitment) {
+      return const BitNamesCommitmentAssessment(
+        BitNamesProfileCommitmentKind.legacy,
+        'Legacy BitIntroduction reply profile',
+        'This commitment is recognized and remains verifiable.',
+      );
+    }
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.conflict,
+      'The commitment was replaced',
+      'The saved reply profile no longer matches on-chain state; BitWindow will not overwrite it.',
+    );
+  }
+
+  String manifestCommitment;
+  try {
+    _boundedCanonical(manifestJson);
+    manifestCommitment = blake3Hex(
+      utf8.encode(canonicalJsonEncode(manifestJson)),
+    );
+  } catch (_) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.malformed,
+      'The saved commitment proof is malformed',
+      'BitWindow cannot authenticate this manifest and will not replace the on-chain commitment.',
+    );
+  }
+  if (manifestCommitment != commitment) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.conflict,
+      'The commitment was replaced',
+      'The saved manifest no longer matches on-chain state; BitWindow will not overwrite it.',
+    );
+  }
+  if (manifestJson['protocol'] != bitNamesCommitmentManifestProtocol ||
+      manifestJson['version'] != bitNamesCommitmentManifestVersion) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.unknown,
+      'Unknown commitment manifest version',
+      'The authenticated bytes are preserved, but this BitWindow version will not interpret or overwrite them.',
+    );
+  }
+  try {
+    final manifest = BitNamesCommitmentManifest.parse(manifestJson);
+    if (manifest.network != bitNamesCommitmentNetwork(network)) {
+      return const BitNamesCommitmentAssessment(
+        BitNamesProfileCommitmentKind.wrongNetwork,
+        'Reply profile belongs to another network',
+        'Cross-network commitment replay was rejected.',
+      );
+    }
+    final committed = manifest.replyProfile();
+    if (canonicalJsonEncode(
+          committed.toCommitmentPayloadJson(),
+        ) !=
+        canonicalJsonEncode(
+          profile.toCommitmentPayloadJson(),
+        )) {
+      return const BitNamesCommitmentAssessment(
+        BitNamesProfileCommitmentKind.conflict,
+        'Reply-profile commitment data differs',
+        'The manifest is authenticated but does not describe the supplied reply profile.',
+      );
+    }
+    return BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.namespaced,
+      'Namespaced BitIntroduction v1 commitment',
+      'The manifest is authenticated for ${manifest.network} and preserves ${manifest.applications.length - 1} other application namespace(s).',
+      manifest: manifest,
+    );
+  } catch (_) {
+    return const BitNamesCommitmentAssessment(
+      BitNamesProfileCommitmentKind.malformed,
+      'The commitment manifest is invalid',
+      'BitWindow will not interpret or replace invalid authenticated application data.',
+    );
+  }
+}
+
+String bitNamesApplicationCommitment({
+  required String namespace,
+  required String purpose,
+  required String network,
+  required String bitNameHash,
+  required Map<String, dynamic> payload,
+  int version = bitIntroductionCommitmentVersion,
+}) {
+  if (!_namespacePattern.hasMatch(namespace) ||
+      !_purposePattern.hasMatch(purpose) ||
+      !_hashPattern.hasMatch(bitNameHash) ||
+      version < 1 ||
+      version > 0x7fffffff) {
+    throw const FormatException(
+      'invalid application commitment domain',
+    );
+  }
+  final preimage = {
+    'protocol': bitNamesApplicationCommitmentProtocol,
+    'version': version,
+    'network': bitNamesCommitmentNetwork(network),
+    'bitname_hash': bitNameHash,
+    'namespace': namespace,
+    'purpose': purpose,
+    'payload': _cloneObject(payload),
+  };
+  _boundedCanonical(preimage);
+  return blake3Hex(
+    utf8.encode(canonicalJsonEncode(preimage)),
+  );
+}
+
+String bitNamesCommitmentNetwork(String network) {
+  final normalized = network.trim().toLowerCase();
+  final full = normalized.startsWith('$bitNamesCommitmentChain:') ? normalized : '$bitNamesCommitmentChain:$normalized';
+  final suffix = full.substring(
+    bitNamesCommitmentChain.length + 1,
+  );
+  if (!_networkPattern.hasMatch(suffix)) {
+    throw const FormatException(
+      'invalid BitNames commitment network',
+    );
+  }
+  return full;
+}
+
+String bitNamesAuthoritativeProfileCommitment(
+  BitMessageProfile profile,
+) {
+  final manifest = profile.commitmentManifest;
+  return manifest == null
+      ? bitMessageProfileCommitment(profile)
+      : BitNamesCommitmentManifest.parse(
+          manifest,
+        ).commitment;
+}
+
+Map<String, dynamic> bitNamesCommitResponse(
+  BitMessageProfile profile,
+) {
+  final manifest = profile.commitmentManifest;
+  return manifest == null
+      ? profile.toCommitmentPayloadJson()
+      : BitNamesCommitmentManifest.parse(
+          manifest,
+        ).toJson();
+}
+
+BitMessageProfile bitNamesProfileFromCommitResponse(
+  Map<String, dynamic> response,
+) {
+  if (response['protocol'] == bitNamesCommitmentManifestProtocol) {
+    return BitNamesCommitmentManifest.parse(
+      response,
+    ).replyProfile();
+  }
+  final profile = BitMessageProfile.fromJson(response);
+  if (profile.commitmentManifest != null) {
+    throw const FormatException(
+      'legacy profile response cannot carry a manifest wrapper',
+    );
+  }
+  return profile;
+}
+
+final _hashPattern = RegExp(r'^[0-9a-f]{64}$');
+final _namespacePattern = RegExp(
+  r'^(?=.{3,127}$)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$',
+);
+final _purposePattern = RegExp(
+  r'^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$',
+);
+final _networkPattern = RegExp(
+  r'^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$',
+);
+
+bool _hasExactKeys(Map value, Set<String> keys) => value.length == keys.length && value.keys.every(keys.contains);
+
+Map<String, dynamic> _cloneObject(Map source) {
+  try {
+    return Map<String, dynamic>.from(
+      jsonDecode(jsonEncode(source)) as Map,
+    );
+  } catch (_) {
+    throw const FormatException(
+      'commitment data must be a JSON object',
+    );
+  }
+}
+
+void _boundedCanonical(Map<String, dynamic> value) {
+  late final List<int> encoded;
+  try {
+    encoded = utf8.encode(canonicalJsonEncode(value));
+  } on ArgumentError {
+    throw const FormatException(
+      'commitment data must use canonical JSON values',
+    );
+  }
+  if (encoded.length > bitNamesCommitmentMaxBytes) {
+    throw const FormatException(
+      'BitNames commitment manifest exceeds 16 KiB',
+    );
+  }
+}

--- a/bitwindow/lib/models/bitnames_recovery.dart
+++ b/bitwindow/lib/models/bitnames_recovery.dart
@@ -1,0 +1,426 @@
+enum BitnamesChainHealthState {
+  unknown,
+  disconnected,
+  synced,
+  waitingForBlock,
+  recovering,
+  stalled,
+  error,
+}
+
+class BitnamesChainSnapshot {
+  const BitnamesChainSnapshot({
+    this.state = BitnamesChainHealthState.unknown,
+    this.enforcerHeight,
+    this.enforcerHash,
+    this.bitnamesMainchainHash,
+    this.sidechainHeight,
+    this.sidechainHash,
+    this.peerCount,
+    this.observedAt,
+    this.lastProgressAt,
+    this.lastReconciledAt,
+    this.recoveryAttempts = 0,
+    this.recoveryTip,
+    this.error,
+  });
+
+  final BitnamesChainHealthState state;
+  final int? enforcerHeight;
+  final String? enforcerHash;
+  final String? bitnamesMainchainHash;
+  final int? sidechainHeight;
+  final String? sidechainHash;
+  final int? peerCount;
+  final DateTime? observedAt;
+  final DateTime? lastProgressAt;
+  final DateTime? lastReconciledAt;
+  final int recoveryAttempts;
+  final String? recoveryTip;
+  final String? error;
+
+  bool get mutationSafe =>
+      state == BitnamesChainHealthState.synced || state == BitnamesChainHealthState.waitingForBlock;
+  bool get needsAttention =>
+      state == BitnamesChainHealthState.stalled ||
+      state == BitnamesChainHealthState.error ||
+      state == BitnamesChainHealthState.disconnected;
+
+  String get summary => switch (state) {
+    BitnamesChainHealthState.unknown => 'Checking BitNames chain progress…',
+    BitnamesChainHealthState.disconnected => 'BitNames or its enforcer is disconnected',
+    BitnamesChainHealthState.synced => 'BitNames is operational • sidechain block ${sidechainHeight ?? 'unknown'}',
+    BitnamesChainHealthState.waitingForBlock => 'Transaction submitted • waiting for a BitNames miner and BMM block',
+    BitnamesChainHealthState.recovering => 'BitNames RPC failed • restarting it once and reconciling',
+    BitnamesChainHealthState.stalled =>
+      'BitNames has not produced a sidechain block • submitted transactions remain pending',
+    BitnamesChainHealthState.error => 'Could not verify BitNames chain progress',
+  };
+
+  String get details {
+    final enforcer = '${enforcerHeight ?? '?'} • ${_short(enforcerHash)}';
+    final observed = _short(bitnamesMainchainHash);
+    final sidechain = '${sidechainHeight ?? '?'} • ${_short(sidechainHash)}';
+    final parts = [
+      'Enforcer tip $enforcer',
+      'Sidechain tip BMM-verified in mainchain block $observed',
+      'BitNames sidechain $sidechain',
+      if (peerCount != null) '$peerCount peer${peerCount == 1 ? '' : 's'}',
+      if (lastProgressAt != null) 'last progress ${lastProgressAt!.toIso8601String()}',
+      if (error != null) error!,
+    ];
+    return parts.join(' • ');
+  }
+
+  BitnamesChainSnapshot copyWith({
+    BitnamesChainHealthState? state,
+    int? enforcerHeight,
+    String? enforcerHash,
+    String? bitnamesMainchainHash,
+    int? sidechainHeight,
+    String? sidechainHash,
+    int? peerCount,
+    DateTime? observedAt,
+    DateTime? lastProgressAt,
+    DateTime? lastReconciledAt,
+    int? recoveryAttempts,
+    String? recoveryTip,
+    String? error,
+    bool clearRecoveryTip = false,
+    bool clearError = false,
+  }) {
+    return BitnamesChainSnapshot(
+      state: state ?? this.state,
+      enforcerHeight: enforcerHeight ?? this.enforcerHeight,
+      enforcerHash: enforcerHash ?? this.enforcerHash,
+      bitnamesMainchainHash: bitnamesMainchainHash ?? this.bitnamesMainchainHash,
+      sidechainHeight: sidechainHeight ?? this.sidechainHeight,
+      sidechainHash: sidechainHash ?? this.sidechainHash,
+      peerCount: peerCount ?? this.peerCount,
+      observedAt: observedAt ?? this.observedAt,
+      lastProgressAt: lastProgressAt ?? this.lastProgressAt,
+      lastReconciledAt: lastReconciledAt ?? this.lastReconciledAt,
+      recoveryAttempts: recoveryAttempts ?? this.recoveryAttempts,
+      recoveryTip: clearRecoveryTip ? null : recoveryTip ?? this.recoveryTip,
+      error: clearError ? null : error ?? this.error,
+    );
+  }
+
+  factory BitnamesChainSnapshot.fromJson(Map<String, dynamic> json) {
+    return BitnamesChainSnapshot(
+      state: BitnamesChainHealthState.values.firstWhere(
+        (value) => value.name == json['state'],
+        orElse: () => BitnamesChainHealthState.unknown,
+      ),
+      enforcerHeight: json['enforcer_height'] as int?,
+      enforcerHash: json['enforcer_hash'] as String?,
+      bitnamesMainchainHash: json['bitnames_mainchain_hash'] as String?,
+      sidechainHeight: json['sidechain_height'] as int?,
+      sidechainHash: json['sidechain_hash'] as String?,
+      peerCount: json['peer_count'] as int?,
+      observedAt: _date(json['observed_at']),
+      lastProgressAt: _date(json['last_progress_at']),
+      lastReconciledAt: _date(json['last_reconciled_at']),
+      recoveryAttempts: json['recovery_attempts'] as int? ?? 0,
+      recoveryTip: json['recovery_tip'] as String?,
+      error: json['error'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'state': state.name,
+    if (enforcerHeight != null) 'enforcer_height': enforcerHeight,
+    if (enforcerHash != null) 'enforcer_hash': enforcerHash,
+    if (bitnamesMainchainHash != null) 'bitnames_mainchain_hash': bitnamesMainchainHash,
+    if (sidechainHeight != null) 'sidechain_height': sidechainHeight,
+    if (sidechainHash != null) 'sidechain_hash': sidechainHash,
+    if (peerCount != null) 'peer_count': peerCount,
+    if (observedAt != null) 'observed_at': observedAt!.millisecondsSinceEpoch,
+    if (lastProgressAt != null) 'last_progress_at': lastProgressAt!.millisecondsSinceEpoch,
+    if (lastReconciledAt != null) 'last_reconciled_at': lastReconciledAt!.millisecondsSinceEpoch,
+    'recovery_attempts': recoveryAttempts,
+    if (recoveryTip != null) 'recovery_tip': recoveryTip,
+    if (error != null) 'error': error,
+  };
+}
+
+class BitnamesChainObservation {
+  const BitnamesChainObservation({
+    required this.enforcerHeight,
+    required this.enforcerHash,
+    required this.bitnamesMainchainHash,
+    required this.sidechainHeight,
+    required this.sidechainHash,
+    required this.peerCount,
+    this.waitingForBlock = false,
+  });
+
+  final int enforcerHeight;
+  final String enforcerHash;
+  final String bitnamesMainchainHash;
+  final int sidechainHeight;
+  final String sidechainHash;
+  final int peerCount;
+  final bool waitingForBlock;
+}
+
+class BitnamesChainRecoveryDecision {
+  const BitnamesChainRecoveryDecision({
+    required this.snapshot,
+    this.restartBitnames = false,
+    this.reconcile = false,
+  });
+
+  final BitnamesChainSnapshot snapshot;
+  final bool restartBitnames;
+  final bool reconcile;
+}
+
+class BitnamesChainRecovery {
+  const BitnamesChainRecovery({
+    this.stallAfter = const Duration(seconds: 90),
+    this.maxAutomaticRestarts = 1,
+  });
+
+  final Duration stallAfter;
+  final int maxAutomaticRestarts;
+
+  BitnamesChainRecoveryDecision disconnected(
+    BitnamesChainSnapshot previous,
+    DateTime now,
+  ) {
+    return BitnamesChainRecoveryDecision(
+      snapshot: previous.copyWith(
+        state: BitnamesChainHealthState.disconnected,
+        observedAt: now,
+      ),
+    );
+  }
+
+  BitnamesChainRecoveryDecision failed(
+    BitnamesChainSnapshot previous,
+    DateTime now,
+    Object error,
+  ) {
+    final canRestart = previous.recoveryAttempts < maxAutomaticRestarts;
+    return BitnamesChainRecoveryDecision(
+      snapshot: previous.copyWith(
+        state: canRestart ? BitnamesChainHealthState.recovering : BitnamesChainHealthState.error,
+        observedAt: now,
+        recoveryAttempts: canRestart ? previous.recoveryAttempts + 1 : previous.recoveryAttempts,
+        error: '$error',
+      ),
+      restartBitnames: canRestart,
+    );
+  }
+
+  BitnamesChainRecoveryDecision observe(
+    BitnamesChainSnapshot previous,
+    BitnamesChainObservation observation,
+    DateTime now,
+  ) {
+    final bitnamesProgressed =
+        previous.bitnamesMainchainHash != observation.bitnamesMainchainHash ||
+        previous.sidechainHeight != observation.sidechainHeight ||
+        previous.sidechainHash != observation.sidechainHash;
+    final firstObservation = previous.observedAt == null;
+    final lastProgress = firstObservation || bitnamesProgressed
+        ? now
+        : previous.lastProgressAt ?? previous.observedAt ?? now;
+    final state = !observation.waitingForBlock
+        ? BitnamesChainHealthState.synced
+        : now.difference(lastProgress) < stallAfter
+        ? BitnamesChainHealthState.waitingForBlock
+        : BitnamesChainHealthState.stalled;
+    return BitnamesChainRecoveryDecision(
+      snapshot: _snapshot(
+        observation,
+        now,
+        lastProgress,
+        state,
+        recoveryAttempts: 0,
+      ),
+      reconcile: true,
+    );
+  }
+
+  BitnamesChainSnapshot _snapshot(
+    BitnamesChainObservation observation,
+    DateTime now,
+    DateTime lastProgress,
+    BitnamesChainHealthState state, {
+    required int recoveryAttempts,
+    String? recoveryTip,
+  }) {
+    return BitnamesChainSnapshot(
+      state: state,
+      enforcerHeight: observation.enforcerHeight,
+      enforcerHash: observation.enforcerHash,
+      bitnamesMainchainHash: observation.bitnamesMainchainHash,
+      sidechainHeight: observation.sidechainHeight,
+      sidechainHash: observation.sidechainHash,
+      peerCount: observation.peerCount,
+      observedAt: now,
+      lastProgressAt: lastProgress,
+      recoveryAttempts: recoveryAttempts,
+      recoveryTip: recoveryTip,
+    );
+  }
+}
+
+enum BitnamesOperationType {
+  registration,
+  profilePublication,
+}
+
+enum BitnamesOperationPhase {
+  prepared,
+  reservationSubmitting,
+  reservationSubmitted,
+  registrationSubmitting,
+  registrationSubmitted,
+  profileSubmitting,
+  profileSubmitted,
+  confirmed,
+  paused,
+  failed,
+  cancelled,
+}
+
+class BitnamesOperation {
+  const BitnamesOperation({
+    required this.id,
+    required this.type,
+    required this.phase,
+    required this.bitnameHash,
+    required this.createdAt,
+    required this.updatedAt,
+    this.plaintextName,
+    this.reservationTxid,
+    this.txid,
+    this.introductionFeeSats,
+    this.encryptionPubkey,
+    this.signingPubkey,
+    this.profile,
+    this.lastObservedSidechainHeight,
+    this.attempts = 0,
+    this.maySpend = false,
+    this.lastError,
+  });
+
+  final String id;
+  final BitnamesOperationType type;
+  final BitnamesOperationPhase phase;
+  final String bitnameHash;
+  final String? plaintextName;
+  final String? reservationTxid;
+  final String? txid;
+  final int? introductionFeeSats;
+  final String? encryptionPubkey;
+  final String? signingPubkey;
+  final Map<String, dynamic>? profile;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final int? lastObservedSidechainHeight;
+  final int attempts;
+  final bool maySpend;
+  final String? lastError;
+
+  bool get terminal =>
+      phase == BitnamesOperationPhase.confirmed ||
+      phase == BitnamesOperationPhase.failed ||
+      phase == BitnamesOperationPhase.cancelled;
+  bool get uncertain =>
+      phase == BitnamesOperationPhase.reservationSubmitting ||
+      phase == BitnamesOperationPhase.registrationSubmitting ||
+      phase == BitnamesOperationPhase.profileSubmitting;
+
+  BitnamesOperation copyWith({
+    BitnamesOperationPhase? phase,
+    String? reservationTxid,
+    String? txid,
+    int? introductionFeeSats,
+    String? encryptionPubkey,
+    String? signingPubkey,
+    Map<String, dynamic>? profile,
+    DateTime? updatedAt,
+    int? lastObservedSidechainHeight,
+    int? attempts,
+    bool? maySpend,
+    String? lastError,
+    bool clearError = false,
+  }) {
+    return BitnamesOperation(
+      id: id,
+      type: type,
+      phase: phase ?? this.phase,
+      bitnameHash: bitnameHash,
+      plaintextName: plaintextName,
+      reservationTxid: reservationTxid ?? this.reservationTxid,
+      txid: txid ?? this.txid,
+      introductionFeeSats: introductionFeeSats ?? this.introductionFeeSats,
+      encryptionPubkey: encryptionPubkey ?? this.encryptionPubkey,
+      signingPubkey: signingPubkey ?? this.signingPubkey,
+      profile: profile ?? this.profile,
+      createdAt: createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      lastObservedSidechainHeight: lastObservedSidechainHeight ?? this.lastObservedSidechainHeight,
+      attempts: attempts ?? this.attempts,
+      maySpend: maySpend ?? this.maySpend,
+      lastError: clearError ? null : lastError ?? this.lastError,
+    );
+  }
+
+  factory BitnamesOperation.fromJson(Map<String, dynamic> json) {
+    return BitnamesOperation(
+      id: json['id'] as String,
+      type: BitnamesOperationType.values.firstWhere(
+        (value) => value.name == json['type'],
+      ),
+      phase: BitnamesOperationPhase.values.firstWhere(
+        (value) => value.name == json['phase'],
+      ),
+      bitnameHash: json['bitname_hash'] as String,
+      plaintextName: json['plaintext_name'] as String?,
+      reservationTxid: json['reservation_txid'] as String?,
+      txid: json['txid'] as String?,
+      introductionFeeSats: json['introduction_fee_sats'] as int?,
+      encryptionPubkey: json['encryption_pubkey'] as String?,
+      signingPubkey: json['signing_pubkey'] as String?,
+      profile: json['profile'] is Map ? Map<String, dynamic>.from(json['profile'] as Map) : null,
+      createdAt: _date(json['created_at'])!,
+      updatedAt: _date(json['updated_at'])!,
+      lastObservedSidechainHeight: json['last_observed_sidechain_height'] as int?,
+      attempts: json['attempts'] as int? ?? 0,
+      maySpend: json['may_spend'] == true,
+      lastError: json['last_error'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'type': type.name,
+    'phase': phase.name,
+    'bitname_hash': bitnameHash,
+    if (plaintextName != null) 'plaintext_name': plaintextName,
+    if (reservationTxid != null) 'reservation_txid': reservationTxid,
+    if (txid != null) 'txid': txid,
+    if (introductionFeeSats != null) 'introduction_fee_sats': introductionFeeSats,
+    if (encryptionPubkey != null) 'encryption_pubkey': encryptionPubkey,
+    if (signingPubkey != null) 'signing_pubkey': signingPubkey,
+    if (profile != null) 'profile': profile,
+    'created_at': createdAt.millisecondsSinceEpoch,
+    'updated_at': updatedAt.millisecondsSinceEpoch,
+    if (lastObservedSidechainHeight != null) 'last_observed_sidechain_height': lastObservedSidechainHeight,
+    'attempts': attempts,
+    'may_spend': maySpend,
+    if (lastError != null) 'last_error': lastError,
+  };
+}
+
+DateTime? _date(Object? value) => value is int ? DateTime.fromMillisecondsSinceEpoch(value) : null;
+
+String _short(String? value) {
+  if (value == null || value.isEmpty) return 'unknown';
+  return value.length <= 12 ? value : '${value.substring(0, 12)}…';
+}

--- a/bitwindow/lib/models/chat_models.dart
+++ b/bitwindow/lib/models/chat_models.dart
@@ -1,38 +1,54 @@
-class StatusMessage {
-  final String id;
-  final String message;
+// dart format off
+enum ChatRelationshipState { none, outgoingIntroduction, incomingIntroduction, acceptancePending, accepted, rejected, blocked }
+enum ChatMessageKind { introduction, acceptance, message }
+enum ChatDeliveryState { pending, delivered, confirmed, failed }
+enum ChatTransport { bitnamesChain, direct, tor }
 
-  StatusMessage({required this.id, required this.message});
+class StatusMessage {
+  final String id; final String message; final bool completed;
+
+  StatusMessage({required this.id, required this.message, this.completed = false});
 }
 
 class ChatMessage {
   final String id;
   final String content;
-  final String senderPubkey;
-  final String recipientPubkey;
+  final String senderBitname;
+  final String recipientBitname;
   final DateTime timestamp;
   final bool isOutgoing;
+  final ChatMessageKind kind; final ChatDeliveryState deliveryState; final ChatTransport transport;
+  final String? introductionId;
   final String? txid;
   final int? valueSats;
+  final String? error;
+  String get localBitname => isOutgoing ? senderBitname : recipientBitname;
 
   ChatMessage({
     required this.id,
     required this.content,
-    required this.senderPubkey,
-    required this.recipientPubkey,
+    required this.senderBitname,
+    required this.recipientBitname,
     required this.timestamp,
     required this.isOutgoing,
+    this.kind = ChatMessageKind.message, this.deliveryState = ChatDeliveryState.pending,
+    this.transport = ChatTransport.bitnamesChain, this.introductionId,
     this.txid,
     this.valueSats,
+    this.error,
   });
 
   factory ChatMessage.fromJson(Map<String, dynamic> json) => ChatMessage(
     id: json['id'] ?? '',
     content: json['content'] ?? '',
-    senderPubkey: json['sender_pubkey'] ?? '',
-    recipientPubkey: json['recipient_pubkey'] ?? '',
+    senderBitname: json['sender_bitname'] ?? json['sender_pubkey'] ?? '',
+    recipientBitname: json['recipient_bitname'] ?? json['recipient_pubkey'] ?? '',
     timestamp: json['timestamp'] != null ? DateTime.fromMillisecondsSinceEpoch(json['timestamp']) : DateTime.now(),
     isOutgoing: json['is_outgoing'] ?? false,
+    kind: _enum(ChatMessageKind.values, json['kind'], ChatMessageKind.message),
+    deliveryState: _enum(ChatDeliveryState.values, json['delivery_state'], ChatDeliveryState.confirmed),
+    transport: _enum(ChatTransport.values, json['transport'], ChatTransport.bitnamesChain),
+    introductionId: json['introduction_id'], error: json['error'],
     txid: json['txid'],
     valueSats: json['value_sats'],
   );
@@ -40,109 +56,151 @@ class ChatMessage {
   Map<String, dynamic> toJson() => {
     'id': id,
     'content': content,
-    'sender_pubkey': senderPubkey,
-    'recipient_pubkey': recipientPubkey,
+    'sender_bitname': senderBitname,
+    'recipient_bitname': recipientBitname,
     'timestamp': timestamp.millisecondsSinceEpoch,
     'is_outgoing': isOutgoing,
-    'txid': txid,
-    'value_sats': valueSats,
+    'kind': kind.name, 'delivery_state': deliveryState.name, 'transport': transport.name,
+    if (introductionId != null) 'introduction_id': introductionId,
+    if (txid != null) 'txid': txid,
+    if (valueSats != null) 'value_sats': valueSats,
+    if (error != null) 'error': error,
   };
 
   ChatMessage copyWith({
     String? id,
     String? content,
-    String? senderPubkey,
-    String? recipientPubkey,
+    String? senderBitname,
+    String? recipientBitname,
     DateTime? timestamp,
     bool? isOutgoing,
+    ChatMessageKind? kind, ChatDeliveryState? deliveryState, ChatTransport? transport,
+    String? introductionId, String? error,
     String? txid,
     int? valueSats,
   }) {
     return ChatMessage(
       id: id ?? this.id,
       content: content ?? this.content,
-      senderPubkey: senderPubkey ?? this.senderPubkey,
-      recipientPubkey: recipientPubkey ?? this.recipientPubkey,
+      senderBitname: senderBitname ?? this.senderBitname,
+      recipientBitname: recipientBitname ?? this.recipientBitname,
       timestamp: timestamp ?? this.timestamp,
       isOutgoing: isOutgoing ?? this.isOutgoing,
+      kind: kind ?? this.kind, deliveryState: deliveryState ?? this.deliveryState,
+      transport: transport ?? this.transport, introductionId: introductionId ?? this.introductionId,
       txid: txid ?? this.txid,
       valueSats: valueSats ?? this.valueSats,
+      error: error ?? this.error,
     );
   }
 }
 
 class ChatContact {
   final String id;
+  final String localBitname;
   final String name;
   final String? plaintextName;
   final String encryptionPubkey;
-  final String address;
+  final String? signingPubkey; final String? address;
   final int? paymailFeeSats;
+  final ChatRelationshipState relationshipState; final String? introductionId;
+  final Map<String, dynamic>? replyProfile;
   final String? lastMessage;
   final DateTime? lastMessageTime;
+  final int unreadCount;
   final bool isManual;
 
   ChatContact({
     required this.id,
+    this.localBitname = '',
     required this.name,
     this.plaintextName,
     required this.encryptionPubkey,
-    required this.address,
+    this.signingPubkey, this.address,
     this.paymailFeeSats,
+    this.relationshipState = ChatRelationshipState.none, this.introductionId, this.replyProfile,
     this.lastMessage,
     this.lastMessageTime,
+    this.unreadCount = 0,
     this.isManual = false,
   });
 
-  String get displayName => plaintextName ?? name;
+  String get displayName => plaintextName ?? (name == id && id.length > 8 ? 'BitName ${id.substring(0, 8)}…' : name);
+  String get relationshipId => '$localBitname:$id';
+  bool get isAccepted => relationshipState == ChatRelationshipState.accepted;
 
   factory ChatContact.fromJson(Map<String, dynamic> json) => ChatContact(
     id: json['id'] ?? '',
+    localBitname: json['local_bitname'] ?? '',
     name: json['name'] ?? '',
     plaintextName: json['plaintext_name'],
     encryptionPubkey: json['encryption_pubkey'] ?? '',
-    address: json['address'] ?? '',
+    signingPubkey: json['signing_pubkey'], address: json['address'],
     paymailFeeSats: json['paymail_fee_sats'],
+    relationshipState: _enum(ChatRelationshipState.values, json['relationship_state'], ChatRelationshipState.none),
+    introductionId: json['introduction_id'],
+    replyProfile: json['reply_profile'] is Map ? Map<String, dynamic>.from(json['reply_profile']) : null,
     lastMessage: json['last_message'],
     lastMessageTime: json['last_message_time'] != null
         ? DateTime.fromMillisecondsSinceEpoch(json['last_message_time'])
         : null,
+    unreadCount: json['unread_count'] ?? 0,
     isManual: json['is_manual'] ?? false,
   );
 
   Map<String, dynamic> toJson() => {
     'id': id,
+    'local_bitname': localBitname,
     'name': name,
-    'plaintext_name': plaintextName,
+    if (plaintextName != null) 'plaintext_name': plaintextName,
     'encryption_pubkey': encryptionPubkey,
-    'address': address,
-    'paymail_fee_sats': paymailFeeSats,
-    'last_message': lastMessage,
-    'last_message_time': lastMessageTime?.millisecondsSinceEpoch,
+    if (signingPubkey != null) 'signing_pubkey': signingPubkey,
+    if (address != null) 'address': address,
+    if (paymailFeeSats != null) 'paymail_fee_sats': paymailFeeSats,
+    'relationship_state': relationshipState.name,
+    if (introductionId != null) 'introduction_id': introductionId,
+    if (replyProfile != null) 'reply_profile': replyProfile,
+    if (lastMessage != null) 'last_message': lastMessage,
+    if (lastMessageTime != null) 'last_message_time': lastMessageTime!.millisecondsSinceEpoch,
+    'unread_count': unreadCount,
     'is_manual': isManual,
   };
 
   ChatContact copyWith({
     String? id,
+    String? localBitname,
     String? name,
     String? plaintextName,
     String? encryptionPubkey,
-    String? address,
+    String? signingPubkey, String? address,
     int? paymailFeeSats,
+    ChatRelationshipState? relationshipState, String? introductionId,
+    bool clearIntroductionId = false,
+    Map<String, dynamic>? replyProfile,
     String? lastMessage,
     DateTime? lastMessageTime,
+    int? unreadCount,
     bool? isManual,
   }) {
     return ChatContact(
       id: id ?? this.id,
+      localBitname: localBitname ?? this.localBitname,
       name: name ?? this.name,
       plaintextName: plaintextName ?? this.plaintextName,
       encryptionPubkey: encryptionPubkey ?? this.encryptionPubkey,
-      address: address ?? this.address,
+      signingPubkey: signingPubkey ?? this.signingPubkey, address: address ?? this.address,
       paymailFeeSats: paymailFeeSats ?? this.paymailFeeSats,
+      relationshipState: relationshipState ?? this.relationshipState,
+      introductionId: clearIntroductionId ? null : introductionId ?? this.introductionId,
+      replyProfile: replyProfile ?? this.replyProfile,
       lastMessage: lastMessage ?? this.lastMessage,
       lastMessageTime: lastMessageTime ?? this.lastMessageTime,
+      unreadCount: unreadCount ?? this.unreadCount,
       isManual: isManual ?? this.isManual,
     );
   }
 }
+
+T _enum<T extends Enum>(List<T> values, Object? name, T fallback) =>
+    values.firstWhere((value) => value.name == name, orElse: () => fallback);
+// dart format on

--- a/bitwindow/lib/pages/chat_page.dart
+++ b/bitwindow/lib/pages/chat_page.dart
@@ -1,10 +1,15 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:auto_route/auto_route.dart';
+import 'package:bitwindow/models/bitintroduction_protocol.dart';
+import 'package:bitwindow/models/bitnames_recovery.dart';
 import 'package:bitwindow/models/chat_models.dart';
 import 'package:bitwindow/pages/sidechains_page.dart';
 import 'package:bitwindow/providers/chat_provider.dart';
+import 'package:bitwindow/services/bitnames_secure_store.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
 import 'package:sail_ui/sail_ui.dart';
@@ -73,9 +78,19 @@ class ChatPage extends StatelessWidget {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
+                      _ChainHealthBar(
+                        health: model.chainHealth,
+                        onRetry: model.retryChainRecovery,
+                      ),
+                      _PrivateStorageBar(
+                        status: model.storageStatus,
+                        onBackup: () => model.backupPrivateData(context),
+                        onRestore: () => model.restorePrivateData(context),
+                        onClear: () => model.clearPrivateData(context),
+                      ),
                       // Status bars - stack all status messages
                       ...model.statusMessages.map(
-                        (status) => _ClaimingStatusBar(status: status.message),
+                        (status) => _ClaimingStatusBar(status: status),
                       ),
                       // Main action bar
                       Row(
@@ -85,12 +100,41 @@ class ChatPage extends StatelessWidget {
                           if (model.myIdentities.isNotEmpty)
                             _SearchableIdentityDropdown(
                               identities: model.myIdentities,
-                              allBitNames: model.allBitNames,
                               selectedIdentity: model.selectedIdentity,
                               onIdentitySelected: model.selectIdentity,
                             )
                           else
-                            SailText.secondary13('No BitNames owned'),
+                            SailText.secondary13(model.chatError ?? 'No BitNames owned'),
+                          if (model.selectedIdentity != null) ...[
+                            const SizedBox(width: SailStyleValues.padding08),
+                            if (model.messagingProfilePending)
+                              SizedBox(
+                                width: 14,
+                                height: 14,
+                                child: LoadingIndicator(color: theme.colors.primary),
+                              )
+                            else
+                              SailSVG.fromAsset(
+                                model.messagingReady ? SailSVGAsset.check : SailSVGAsset.iconWarning,
+                                color: model.messagingReady ? theme.colors.success : theme.colors.warning,
+                                height: 14,
+                              ),
+                            const SizedBox(width: SailStyleValues.padding04),
+                            SailText.secondary12(
+                              model.messagingProfilePending
+                                  ? 'Registered • reply profile waiting for a BitNames block'
+                                  : model.messagingReady
+                                  ? 'Registered • ready to message'
+                                  : model.commitmentBlocked
+                                  ? 'Registered • existing application commitment protected'
+                                  : 'Registered • reply profile not published',
+                              color: model.messagingProfilePending
+                                  ? theme.colors.primary
+                                  : model.messagingReady
+                                  ? theme.colors.success
+                                  : theme.colors.warning,
+                            ),
+                          ],
                           const SizedBox(width: SailStyleValues.padding12),
                           if (model.hasSufficientBalance)
                             SailTooltip(
@@ -98,7 +142,7 @@ class ChatPage extends StatelessWidget {
                               child: SailButton(
                                 label: 'Register BitName',
                                 variant: ButtonVariant.secondary,
-                                disabled: model.isClaiming,
+                                disabled: model.isClaiming || !model.chainWritesReady,
                                 onPressed: () async => _showRegisterBitNameDialog(context, model),
                                 skipLoading: true,
                               ),
@@ -114,8 +158,16 @@ class ChatPage extends StatelessWidget {
                             ),
                           const Spacer(),
                           SailButton(
+                            label: model.messagingProfilePending ? 'Reply profile pending' : 'Messaging setup',
+                            variant: ButtonVariant.secondary,
+                            disabled: model.selectedIdentity == null || model.messagingProfilePending,
+                            onPressed: () async => _showMessagingSetupDialog(context, model),
+                          ),
+                          const SizedBox(width: SailStyleValues.padding08),
+                          SailButton(
                             label: 'Add Contact',
                             variant: ButtonVariant.secondary,
+                            disabled: model.selectedIdentity == null,
                             onPressed: () async => _showAddContactDialog(context, model),
                           ),
                         ],
@@ -142,11 +194,11 @@ class ChatPage extends StatelessWidget {
                                   child: Column(
                                     mainAxisSize: MainAxisSize.min,
                                     children: [
-                                      SailText.secondary13('No contacts yet'),
+                                      SailText.secondary13('No conversations yet'),
                                       const SizedBox(height: SailStyleValues.padding08),
                                       SailText.secondary12(
-                                        'Add a contact to start chatting',
-                                        color: theme.colors.textTertiary,
+                                        'Find a BitName to start a conversation',
+                                        color: theme.colors.textSecondary,
                                       ),
                                     ],
                                   ),
@@ -201,6 +253,11 @@ class ChatPage extends StatelessWidget {
                                                   contact.displayName,
                                                   bold: true,
                                                 ),
+                                                SailText.secondary12(
+                                                  contact.id,
+                                                  color: theme.colors.textSecondary,
+                                                  overflow: TextOverflow.ellipsis,
+                                                ),
                                                 if (contact.lastMessage != null)
                                                   SailText.secondary12(
                                                     contact.lastMessage!,
@@ -246,11 +303,39 @@ class ChatPage extends StatelessWidget {
                             )
                           : SailCard(
                               title: model.selectedContact!.displayName,
-                              subtitle:
-                                  'Paymail fee: ${model.selectedContact!.paymailFeeSats ?? 1000} sats per message',
+                              subtitle: model.relationshipStatus,
                               bottomPadding: false,
                               child: Column(
                                 children: [
+                                  if (model.selectedContact!.relationshipState ==
+                                      ChatRelationshipState.incomingIntroduction)
+                                    Row(
+                                      children: [
+                                        SailButton(label: 'Accept', onPressed: () async => model.accept(context)),
+                                        const SizedBox(width: SailStyleValues.padding08),
+                                        SailButton(
+                                          label: 'Reject',
+                                          variant: ButtonVariant.secondary,
+                                          onPressed: model.reject,
+                                        ),
+                                        const SizedBox(width: SailStyleValues.padding08),
+                                        SailButton(
+                                          label: 'Block',
+                                          variant: ButtonVariant.destructive,
+                                          onPressed: model.block,
+                                        ),
+                                      ],
+                                    ),
+                                  if (model.selectedContact!.relationshipState ==
+                                      ChatRelationshipState.outgoingIntroduction)
+                                    Align(
+                                      alignment: Alignment.centerLeft,
+                                      child: SailButton(
+                                        label: 'Stop waiting',
+                                        variant: ButtonVariant.secondary,
+                                        onPressed: model.cancelIntroduction,
+                                      ),
+                                    ),
                                   Expanded(
                                     // Message list (inlined)
                                     child: Builder(
@@ -269,8 +354,17 @@ class ChatPage extends StatelessWidget {
                                         return ListView.builder(
                                           reverse: true,
                                           padding: const EdgeInsets.all(SailStyleValues.padding08),
-                                          itemCount: messages.length,
+                                          itemCount: messages.length + (model.hasOlderMessages ? 1 : 0),
                                           itemBuilder: (context, index) {
+                                            if (index == messages.length) {
+                                              return Center(
+                                                child: SailButton(
+                                                  label: 'Load earlier messages',
+                                                  variant: ButtonVariant.secondary,
+                                                  onPressed: model.loadOlderMessages,
+                                                ),
+                                              );
+                                            }
                                             final message = messages[messages.length - 1 - index];
                                             // Message bubble (inlined)
                                             final isOwn = message.isOutgoing;
@@ -311,6 +405,26 @@ class ChatPage extends StatelessWidget {
                                                             color: theme.colors.textTertiary,
                                                           ),
                                                         ],
+                                                        const SizedBox(width: SailStyleValues.padding08),
+                                                        SailText.secondary12(
+                                                          _messageDelivery(message),
+                                                          color: message.deliveryState == ChatDeliveryState.failed
+                                                              ? theme.colors.error
+                                                              : theme.colors.textTertiary,
+                                                        ),
+                                                        if (message.error != null &&
+                                                            message.kind != ChatMessageKind.introduction &&
+                                                            (message.kind != ChatMessageKind.acceptance ||
+                                                                model.selectedContact!.relationshipState ==
+                                                                    ChatRelationshipState.incomingIntroduction)) ...[
+                                                          const SizedBox(width: SailStyleValues.padding08),
+                                                          SailButton(
+                                                            label: 'Send on chain',
+                                                            variant: ButtonVariant.secondary,
+                                                            onPressed: () async =>
+                                                                model.sendViaChain(context, message.id),
+                                                          ),
+                                                        ],
                                                       ],
                                                     ),
                                                   ],
@@ -329,18 +443,19 @@ class ChatPage extends StatelessWidget {
                                       Expanded(
                                         child: SailTextField(
                                           controller: model.messageController,
-                                          hintText: 'Type a message...',
+                                          hintText: model.sendHint,
+                                          enabled: model.canSend,
                                           maxLines: 3,
                                           minLines: 1,
-                                          onSubmitted: (_) => model.sendMessage(),
+                                          onSubmitted: (_) => model.sendMessage(context),
                                         ),
                                       ),
                                       const SizedBox(width: SailStyleValues.padding08),
                                       SailButton(
                                         label: 'Send',
                                         loading: model.isSending,
-                                        disabled: model.messageController.text.isEmpty,
-                                        onPressed: model.sendMessage,
+                                        disabled: !model.canSend || model.messageController.text.isEmpty,
+                                        onPressed: () async => model.sendMessage(context),
                                       ),
                                     ],
                                   ),
@@ -378,9 +493,24 @@ class ChatPage extends StatelessWidget {
     return '$hour:$minute';
   }
 
+  String _messageDelivery(ChatMessage message) {
+    if (message.deliveryState == ChatDeliveryState.failed) {
+      return '${message.transport == ChatTransport.tor ? 'Tor' : 'Direct'} delivery failed';
+    }
+    if (message.deliveryState == ChatDeliveryState.pending) {
+      return message.transport == ChatTransport.bitnamesChain ? 'Waiting for BitNames block' : 'Sending';
+    }
+    return switch (message.transport) {
+      ChatTransport.bitnamesChain => 'Confirmed on BitNames',
+      ChatTransport.tor => message.isOutgoing ? 'Delivered through Tor' : 'Received through Tor',
+      ChatTransport.direct => message.isOutgoing ? 'Delivered directly' : 'Received directly',
+    };
+  }
+
   Future<void> _showAddContactDialog(BuildContext context, ChatViewModel model) async {
     await showThemedDialog<void>(
       context: context,
+      barrierDismissible: false,
       builder: (context) => _AddContactDialog(model: model),
     );
   }
@@ -392,39 +522,261 @@ class ChatPage extends StatelessWidget {
       builder: (context) => _RegisterBitNameDialog(model: model),
     );
   }
+
+  Future<void> _showMessagingSetupDialog(BuildContext context, ChatViewModel model) async {
+    final fee = TextEditingController(text: '${model.selectedIdentity?.details.paymailFeeSats ?? 1000}');
+    var busy = false;
+    Future<void> run(StateSetter setState, Future<bool> Function() action, String success) async {
+      setState(() => busy = true);
+      final ok = await action();
+      if (context.mounted) {
+        showSailToast(context, ok ? success : model.chatError ?? 'Messaging setup failed');
+        setState(() => busy = false);
+      }
+    }
+
+    await showThemedDialog<void>(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (context, setState) => SailDialog(
+          title: 'Messaging setup',
+          subtitle: model.torOnly
+              ? 'Tor-only: messages and BitNames chain writes use Tor'
+              : 'Direct messaging shares your detected IP address with contacts',
+          actions: [
+            SailButton(
+              label: 'Close',
+              variant: ButtonVariant.secondary,
+              disabled: busy,
+              onPressed: () async => Navigator.pop(context),
+            ),
+          ],
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SailTextField(
+                controller: fee,
+                label: 'Introduction fee (sats)',
+                hintText: '1000',
+                helperText: 'Leave blank to stop accepting introductions',
+                textFieldType: TextFieldType.number,
+              ),
+              const SizedBox(height: SailStyleValues.padding12),
+              SailText.secondary12(
+                model.torOnly
+                    ? 'Your IP address is hidden. BitNames chain writes also use the connected Tor tunnel.'
+                    : 'Your reply address is detected automatically. Use Tor-only mode to hide your IP address.',
+              ),
+              const SizedBox(height: SailStyleValues.padding12),
+              SailText.primary13(model.commitmentSummary),
+              const SizedBox(height: SailStyleValues.padding04),
+              SailText.secondary12(
+                '${model.commitmentDetails}\n${model.commitmentMode} • ${model.commitmentNetwork}',
+                color: model.commitmentBlocked
+                    ? SailTheme.of(context).colors.warning
+                    : SailTheme.of(context).colors.textSecondary,
+              ),
+              const SizedBox(height: SailStyleValues.padding12),
+              Row(
+                children: [
+                  SailButton(
+                    label: model.torReady ? 'Tor ready' : 'Download / start Tor',
+                    disabled: busy || model.torReady,
+                    onPressed: () async => run(setState, model.startTor, 'BitNames Tor is ready'),
+                  ),
+                  const SizedBox(width: SailStyleValues.padding08),
+                  SailButton(
+                    label: model.torOnly ? 'Use direct mode' : 'Use Tor-only mode',
+                    disabled: busy || (!model.torOnly && !model.hasTorChainPeer),
+                    onPressed: () async => run(
+                      setState,
+                      () => model.setTorOnly(!model.torOnly),
+                      model.torOnly ? 'Direct mode enabled' : 'Tor-only mode enabled',
+                    ),
+                  ),
+                  const SizedBox(width: SailStyleValues.padding08),
+                  SailButton(
+                    label: 'Save & publish reply profile',
+                    disabled: busy,
+                    onPressed: () async => run(
+                      setState,
+                      () => model.publishProfile(fee.text),
+                      'Reply profile submitted • waiting for a BitNames block',
+                    ),
+                  ),
+                ],
+              ),
+              if (!model.torOnly && !model.hasTorChainPeer) ...[
+                const SizedBox(height: SailStyleValues.padding08),
+                SailText.secondary12(
+                  'Tor-only chain routing needs a Tor-capable contact or LayerTwo relay. None is configured yet.',
+                  color: SailTheme.of(context).colors.warning,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class _ClaimingStatusBar extends StatelessWidget {
-  final String status;
-
   const _ClaimingStatusBar({required this.status});
+  final StatusMessage status;
 
   @override
   Widget build(BuildContext context) {
     final theme = SailTheme.of(context);
+    return _StatusBar(
+      color: status.completed ? theme.colors.success : theme.colors.primary,
+      title: status.message,
+      loading: !status.completed,
+      fillAlpha: 0.1,
+      borderAlpha: 0.3,
+    );
+  }
+}
 
+class _PrivateStorageBar extends StatelessWidget {
+  const _PrivateStorageBar({
+    required this.status,
+    required this.onBackup,
+    required this.onRestore,
+    required this.onClear,
+  });
+
+  final BitnamesStorageStatus status;
+  final Future<void> Function() onBackup;
+  final Future<void> Function() onRestore;
+  final Future<void> Function() onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+    final problem = {BitnamesStorageState.locked, BitnamesStorageState.corrupt}.contains(status.state);
+    final color = problem ? theme.colors.warning : theme.colors.success;
+    final details = [
+      if (status.details != null) status.details!,
+      if (status.generation != null) 'Authenticated generation ${status.generation}',
+    ].join(' • ');
+    return _StatusBar(
+      color: color,
+      icon: problem ? SailSVGAsset.iconWarning : SailSVGAsset.check,
+      title: status.summary,
+      details: details.isEmpty ? null : details,
+      actions: status.writable
+          ? [
+              SailButton(label: 'Encrypted backup', variant: ButtonVariant.secondary, onPressed: onBackup),
+              SailButton(label: 'Restore', variant: ButtonVariant.secondary, onPressed: onRestore),
+              SailButton(label: 'Clear chats', variant: ButtonVariant.secondary, onPressed: onClear),
+            ]
+          : const [],
+    );
+  }
+}
+
+class _ChainHealthBar extends StatelessWidget {
+  const _ChainHealthBar({required this.health, required this.onRetry});
+
+  final BitnamesChainSnapshot health;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+    final attention = health.needsAttention;
+    final waiting =
+        health.state == BitnamesChainHealthState.waitingForBlock ||
+        health.state == BitnamesChainHealthState.recovering ||
+        health.state == BitnamesChainHealthState.unknown;
+    final color = health.state == BitnamesChainHealthState.synced
+        ? theme.colors.success
+        : attention
+        ? theme.colors.warning
+        : theme.colors.primary;
+    final retry = health.state == BitnamesChainHealthState.stalled || health.state == BitnamesChainHealthState.error;
+    return _StatusBar(
+      color: color,
+      icon: health.state == BitnamesChainHealthState.synced ? SailSVGAsset.check : SailSVGAsset.iconWarning,
+      loading: waiting,
+      title: health.summary,
+      details: health.details,
+      actions: retry
+          ? [
+              SailButton(
+                label: health.state == BitnamesChainHealthState.stalled ? 'Check again' : 'Retry recovery',
+                variant: ButtonVariant.secondary,
+                onPressed: onRetry,
+              ),
+            ]
+          : const [],
+    );
+  }
+}
+
+class _StatusBar extends StatelessWidget {
+  const _StatusBar({
+    required this.color,
+    required this.title,
+    this.details,
+    this.icon = SailSVGAsset.check,
+    this.loading = false,
+    this.actions = const [],
+    this.fillAlpha = 0.08,
+    this.borderAlpha = 0.25,
+  });
+
+  final Color color;
+  final String title;
+  final String? details;
+  final SailSVGAsset icon;
+  final bool loading;
+  final List<Widget> actions;
+  final double fillAlpha;
+  final double borderAlpha;
+
+  @override
+  Widget build(BuildContext context) {
     return Container(
+      width: double.infinity,
       padding: const EdgeInsets.symmetric(
         horizontal: SailStyleValues.padding12,
         vertical: SailStyleValues.padding08,
       ),
       margin: const EdgeInsets.only(bottom: SailStyleValues.padding08),
       decoration: BoxDecoration(
-        color: theme.colors.primary.withValues(alpha: 0.1),
+        color: color.withValues(alpha: fillAlpha),
         borderRadius: SailStyleValues.borderRadius,
-        border: Border.all(color: theme.colors.primary.withValues(alpha: 0.3)),
+        border: Border.all(color: color.withValues(alpha: borderAlpha)),
       ),
       child: Row(
         children: [
-          SizedBox(
-            width: 16,
-            height: 16,
-            child: LoadingIndicator(color: theme.colors.primary),
-          ),
+          if (loading)
+            SizedBox(
+              width: 16,
+              height: 16,
+              child: LoadingIndicator(color: color),
+            )
+          else
+            SailSVG.fromAsset(icon, color: color, height: 16),
           const SizedBox(width: SailStyleValues.padding12),
           Expanded(
-            child: SailText.primary13(status),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SailText.primary13(title, color: color),
+                if (details != null) ...[
+                  const SizedBox(height: SailStyleValues.padding04),
+                  SailText.secondary12(details!),
+                ],
+              ],
+            ),
           ),
+          for (final action in actions) ...[
+            const SizedBox(width: SailStyleValues.padding12),
+            action,
+          ],
         ],
       ),
     );
@@ -479,7 +831,7 @@ class _AddContactDialogState extends State<_AddContactDialog> {
 
     // Find BitName with matching hash
     return widget.model.allBitNames.where((entry) {
-      return entry.hash.toLowerCase() == searchHash.toLowerCase();
+      return entry.hash.toLowerCase() == query.toLowerCase() || entry.hash.toLowerCase() == searchHash.toLowerCase();
     }).firstOrNull;
   }
 
@@ -523,9 +875,11 @@ class _AddContactDialogState extends State<_AddContactDialog> {
 
     try {
       // Create contact directly from entry data (no need to lookup again)
-      await widget.model.addContactFromEntry(entry);
-      if (mounted) {
+      final added = await widget.model.addContactFromEntry(entry);
+      if (mounted && added) {
         Navigator.of(context).pop();
+      } else if (mounted) {
+        showSailToast(context, widget.model.chatError ?? 'Could not add this contact');
       }
     } finally {
       if (mounted) setState(() => isLoading = false);
@@ -656,17 +1010,26 @@ class _RegisterBitNameDialog extends StatefulWidget {
 
 class _RegisterBitNameDialogState extends State<_RegisterBitNameDialog> {
   final controller = TextEditingController();
+  final feeController = TextEditingController(text: '1000');
+  late bool useTor;
+  bool busy = false;
+  bool registered = false;
+  String? resultMessage;
 
   @override
   void initState() {
     super.initState();
+    useTor = widget.model.torOnly;
     controller.addListener(_onTextChanged);
+    feeController.addListener(_onTextChanged);
   }
 
   @override
   void dispose() {
     controller.removeListener(_onTextChanged);
+    feeController.removeListener(_onTextChanged);
     controller.dispose();
+    feeController.dispose();
     super.dispose();
   }
 
@@ -682,22 +1045,51 @@ class _RegisterBitNameDialogState extends State<_RegisterBitNameDialog> {
       title: 'Register BitName',
       actions: [
         SailButton(
-          label: 'Cancel',
+          label: busy || registered ? 'Close' : 'Cancel',
           variant: ButtonVariant.secondary,
           onPressed: () async => Navigator.of(context).pop(),
         ),
         SailButton(
-          label: 'Register',
-          disabled: controller.text.isEmpty,
-          onPressed: () async {
-            if (controller.text.isNotEmpty) {
-              final name = controller.text;
-              // Close dialog immediately - progress shows in main status bar
-              Navigator.of(context).pop();
-              // Start claiming in background (fire and forget)
-              unawaited(widget.model.claimIdentity(name));
-            }
-          },
+          label: registered
+              ? 'Done'
+              : busy
+              ? 'Waiting for block...'
+              : 'Register',
+          disabled: controller.text.trim().isEmpty || (int.tryParse(feeController.text.trim()) ?? -1) < 0 || busy,
+          skipLoading: true,
+          onPressed: registered
+              ? () async => Navigator.of(context).pop()
+              : () async {
+                  setState(() {
+                    busy = true;
+                    resultMessage = null;
+                  });
+                  final ready = await widget.model.prepareRegistration(useTor);
+                  if (!ready || !mounted) {
+                    if (mounted) {
+                      setState(() {
+                        busy = false;
+                        resultMessage = widget.model.chatError ?? 'Messaging setup failed';
+                      });
+                    }
+                    return;
+                  }
+                  final name = controller.text.trim();
+                  final fee = int.parse(feeController.text.trim());
+                  final txid = await widget.model.registerIdentity(name, fee);
+                  if (!mounted) return;
+                  setState(() {
+                    busy = false;
+                    registered = txid != null;
+                    resultMessage = registered
+                        ? widget.model.messagingProfilePending
+                              ? '"$name" is registered • its reply profile is waiting for one more BitNames block'
+                              : widget.model.messagingReady
+                              ? '"$name" is registered and ready to message'
+                              : '"$name" is registered • publish its reply profile before chatting'
+                        : widget.model.chatError ?? 'Registration failed';
+                  });
+                },
         ),
       ],
       child: SizedBox(
@@ -708,16 +1100,55 @@ class _RegisterBitNameDialogState extends State<_RegisterBitNameDialog> {
           children: [
             SailText.secondary13('Enter a name to register as your identity'),
             const SizedBox(height: SailStyleValues.padding12),
+            SailText.secondary12(
+              'BitWindow handles registration automatically. It normally needs three BitNames blocks: '
+              'reservation, registered name, then the reply profile used for paid introductions and replies.',
+            ),
+            const SizedBox(height: SailStyleValues.padding12),
             SailTextField(
               controller: controller,
               hintText: 'e.g., alice',
               label: 'BitName',
             ),
+            const SizedBox(height: SailStyleValues.padding12),
+            SailTextField(
+              controller: feeController,
+              hintText: '1000',
+              label: 'Introduction fee (sats)',
+              textFieldType: TextFieldType.number,
+            ),
+            const SizedBox(height: SailStyleValues.padding04),
+            SailText.secondary12(
+              'People pay this amount to you, plus the 100-sat BitNames chain fee.',
+              color: theme.colors.textSecondary,
+            ),
+            const SizedBox(height: SailStyleValues.padding12),
+            SailCheckbox(
+              value: useTor,
+              onChanged: busy || !widget.model.hasTorChainPeer ? null : (value) => setState(() => useTor = value),
+              label: 'Continue through Tor',
+            ),
             const SizedBox(height: SailStyleValues.padding08),
             SailText.secondary12(
-              'This will reserve and register the name on the BitNames sidechain.',
-              color: theme.colors.textTertiary,
+              !widget.model.hasTorChainPeer
+                  ? 'Tor registration needs a Tor-capable BitNames peer or LayerTwo relay; none is configured yet.'
+                  : useTor
+                  ? 'Requires a reachable BitNames Tor peer; setup fails safely if none is available.'
+                  : 'Direct setup shares your detected IP address with contacts.',
+              color: theme.colors.textSecondary,
             ),
+            if (busy || resultMessage != null) ...[
+              const SizedBox(height: SailStyleValues.padding12),
+              AnimatedBuilder(
+                animation: widget.model,
+                builder: (context, _) => SailText.primary13(
+                  resultMessage ??
+                      widget.model.claimingStatus ??
+                      'Registration submitted • waiting for a BitNames block',
+                  color: registered ? theme.colors.success : theme.colors.primary,
+                ),
+              ),
+            ],
           ],
         ),
       ),
@@ -741,9 +1172,69 @@ class ChatViewModel extends BaseViewModel {
   ChatContact? get selectedContact => _chatProvider.selectedContact;
 
   List<ChatMessage> get currentConversation => _chatProvider.currentConversation;
+  bool get hasOlderMessages => _chatProvider.hasOlderMessages;
 
   bool get isSending => _chatProvider.isSending;
   String? get chatError => _chatProvider.error;
+  bool get torOnly => _chatProvider.torOnly;
+  bool get torReady => _chatProvider.torStatus.ready;
+  String? get ownOnion => _chatProvider.torStatus.onionHost;
+  bool get messagingReady => _chatProvider.selectedProfileReady;
+  bool get messagingProfilePending => _chatProvider.selectedProfilePending;
+  bool get commitmentBlocked => _chatProvider.selectedCommitmentBlocked;
+  String get commitmentSummary =>
+      _chatProvider.selectedCommitmentAssessment?.summary ?? 'Select a BitName to inspect its application commitment';
+  String get commitmentDetails =>
+      _chatProvider.selectedCommitmentAssessment?.details ?? 'No commitment state is available.';
+  String get commitmentMode => _chatProvider.commitmentMode;
+  String get commitmentNetwork => _chatProvider.commitmentNetwork;
+  BitnamesChainSnapshot get chainHealth => _chatProvider.chainHealth;
+  BitnamesStorageStatus get storageStatus => _chatProvider.storageStatus;
+  bool get chainWritesReady => chainHealth.mutationSafe && storageStatus.writable;
+  bool get hasTorChainPeer {
+    if (torOnly || _chatProvider.hasConfiguredTorPeer) return true;
+    try {
+      final profile = selectedContact?.replyProfile;
+      return profile != null && BitMessageProfile.fromJson(profile).torEndpoints.isNotEmpty;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  bool get canSend => switch (selectedContact?.relationshipState) {
+    ChatRelationshipState.accepted => true,
+    ChatRelationshipState.none => selectedContact?.paymailFeeSats != null,
+    _ => false,
+  };
+  bool get introductionAwaitingBlock => currentConversation.any(
+    (message) =>
+        message.id == selectedContact?.introductionId &&
+        message.isOutgoing &&
+        message.kind == ChatMessageKind.introduction &&
+        message.deliveryState == ChatDeliveryState.pending,
+  );
+  String get relationshipStatus => switch (selectedContact!.relationshipState) {
+    ChatRelationshipState.accepted => 'Accepted • direct/Tor chat unlocked',
+    ChatRelationshipState.incomingIntroduction => 'Introduction received • accept to unlock chat',
+    ChatRelationshipState.acceptancePending => 'Acceptance sent • waiting for chain confirmation',
+    ChatRelationshipState.outgoingIntroduction when introductionAwaitingBlock =>
+      'Introduction submitted • waiting for a BitNames block',
+    ChatRelationshipState.outgoingIntroduction => 'Introduction sent • waiting for acceptance',
+    ChatRelationshipState.rejected => 'Introduction closed • no further payment will be sent',
+    ChatRelationshipState.blocked => 'Blocked',
+    _ when selectedContact!.paymailFeeSats != null =>
+      'Introduction: ${selectedContact!.paymailFeeSats} sats + 100 sats chain fee',
+    _ => 'This BitName is not accepting introductions',
+  };
+  String get sendHint => switch (selectedContact?.relationshipState) {
+    ChatRelationshipState.incomingIntroduction => 'Accept or reject this introduction',
+    ChatRelationshipState.acceptancePending => 'Waiting for acceptance confirmation',
+    ChatRelationshipState.outgoingIntroduction when introductionAwaitingBlock => 'Waiting for a BitNames block',
+    ChatRelationshipState.outgoingIntroduction => 'Waiting for acceptance',
+    ChatRelationshipState.rejected => 'Introduction closed',
+    ChatRelationshipState.blocked => 'Contact blocked',
+    _ => 'Type a message...',
+  };
 
   bool get isClaiming => _chatProvider.isClaiming;
   String? get claimingStatus => _chatProvider.claimingStatus;
@@ -758,6 +1249,7 @@ class ChatViewModel extends BaseViewModel {
   void init() {
     if (isConnected) {
       _chatProvider.startPolling();
+      unawaited(_chatProvider.refresh());
     }
   }
 
@@ -768,8 +1260,6 @@ class ChatViewModel extends BaseViewModel {
   void _onConnectionChanged() {
     if (isConnected) {
       _chatProvider.startPolling();
-    } else {
-      _chatProvider.stopPolling();
     }
     notifyListeners();
   }
@@ -778,45 +1268,186 @@ class ChatViewModel extends BaseViewModel {
     _chatProvider.selectIdentity(identity);
   }
 
-  Future<String?> claimIdentity(String name) async {
-    return await _chatProvider.claimIdentity(name);
+  Future<bool> prepareRegistration(bool useTor) async {
+    if (useTor && !torReady && !await startTor()) return false;
+    return setTorOnly(useTor);
+  }
+
+  Future<String?> registerIdentity(String name, int fee) async {
+    final txid = await _chatProvider.claimIdentity(name, introductionFeeSats: fee);
+    if (txid != null) await publishProfile('$fee');
+    return txid;
   }
 
   Future<void> saveNameMapping(String plaintextName) async {
     await _chatProvider.saveNameMapping(plaintextName);
   }
 
-  Future<void> addContactFromEntry(BitnameEntry entry) async {
-    await _chatProvider.addContactFromEntry(entry);
-  }
+  Future<bool> addContactFromEntry(BitnameEntry entry) => _chatProvider.addContactFromEntry(entry);
 
   void selectContact(ChatContact contact) {
     _chatProvider.selectContact(contact);
   }
 
-  Future<ChatContact?> lookupAndAddContact(String nameOrHash) async {
-    setBusy(true);
-    try {
-      final contact = await _chatProvider.lookupBitName(nameOrHash);
-      if (contact != null) {
-        await _chatProvider.addContact(contact);
-      }
-      return contact;
-    } finally {
-      setBusy(false);
+  Future<void> loadOlderMessages() async => _chatProvider.loadOlderMessages();
+
+  Future<void> sendMessage(BuildContext context) async {
+    if (messageController.text.isEmpty) return;
+    final contact = selectedContact!;
+    if (contact.relationshipState == ChatRelationshipState.none &&
+        !await _confirmSpend(
+          context,
+          'Send introduction?',
+          '${contact.paymailFeeSats} sats to the recipient + ${ChatProvider.minerFeeSats} sats chain fee',
+        )) {
+      return;
+    }
+    final content = messageController.text;
+    messageController.clear();
+    final result = await _chatProvider.send(content);
+    if (!result.sent && !result.needsChainConfirmation) {
+      messageController.text = content;
+    }
+    if (context.mounted) await _handleFallback(context, result);
+  }
+
+  Future<void> accept(BuildContext context) async {
+    final result = await _chatProvider.acceptIntroduction();
+    if (context.mounted) await _handleFallback(context, result);
+  }
+
+  Future<void> reject() => _chatProvider.rejectIntroduction();
+  Future<void> cancelIntroduction() => _chatProvider.cancelIntroduction();
+  Future<void> block() => _chatProvider.blockContact();
+  Future<void> retryChainRecovery() => _chatProvider.retryChainRecovery();
+  Future<void> sendViaChain(BuildContext context, String id) => _sendFallback(context, id);
+  Future<void> _handleFallback(BuildContext context, ChatSendResult result) async {
+    if (result.needsChainConfirmation && result.id != null) {
+      await _sendFallback(context, result.id!);
+    } else if (!result.sent && context.mounted) {
+      showSailToast(context, result.error ?? 'Message failed');
     }
   }
 
-  Future<void> sendMessage() async {
-    if (messageController.text.isEmpty) return;
+  Future<void> _sendFallback(BuildContext context, String id) async {
+    if (!await _confirmSpend(
+      context,
+      'Send through BitNames?',
+      '${ChatProvider.fallbackValueSats} sat + ${ChatProvider.minerFeeSats} sats chain fee',
+    )) {
+      return;
+    }
+    final result = await _chatProvider.sendViaChain(id);
+    if (!result.sent && context.mounted) showSailToast(context, result.error ?? 'Chain send failed');
+  }
 
-    final content = messageController.text;
-    messageController.clear();
+  Future<bool> startTor() async => (await _chatProvider.downloadAndStartTor()).ready;
+  Future<bool> setTorOnly(bool enabled) {
+    final profile = selectedContact?.replyProfile;
+    final onion = profile == null ? null : BitMessageProfile.fromJson(profile).torEndpoints.firstOrNull?.host;
+    final peer = onion == null || onion.contains(':') ? onion : '$onion:6002';
+    return _chatProvider.setTorOnly(enabled, peerOnion: peer);
+  }
 
-    final txid = await _chatProvider.sendMessage(content);
-    if (txid == null && _chatProvider.error != null) {
-      // Message failed, restore text
-      messageController.text = content;
+  Future<bool> publishProfile(String fee) async {
+    try {
+      final onion = ownOnion;
+      final parsedFee = int.tryParse(fee.trim());
+      if (fee.trim().isNotEmpty && parsedFee == null) return false;
+      final interfaces = await NetworkInterface.list(type: InternetAddressType.IPv4);
+      final address = interfaces.expand((interface) => interface.addresses).where((ip) => !ip.isLoopback).firstOrNull;
+      return await _chatProvider.publishProfile(
+            direct: [if (!torOnly && address != null) Uri.parse('http://${address.address}:37999')],
+            tor: [if (onion != null) Uri.parse('http://$onion')],
+            paymailFeeSats: parsedFee,
+          ) !=
+          null;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<void> backupPrivateData(BuildContext context) async {
+    await _runPrivateAction(
+      context,
+      success: 'Encrypted chats, reply routes, and pending operations backed up',
+      failure: 'Private backup failed',
+      action: () async {
+        final path = await FilePicker.saveFile(
+          dialogTitle: 'Save encrypted BitNames backup',
+          fileName: 'bitnames-private-${DateTime.now().toUtc().toIso8601String().replaceAll(':', '-')}.json',
+          type: FileType.custom,
+          allowedExtensions: ['json'],
+        );
+        if (path == null) return false;
+        await File(path).writeAsString(
+          await _chatProvider.exportPrivateData(),
+          flush: true,
+        );
+        return true;
+      },
+    );
+  }
+
+  Future<void> restorePrivateData(BuildContext context) async {
+    await _runPrivateAction(
+      context,
+      success: 'Encrypted BitNames data authenticated and restored',
+      failure: 'Private restore rejected',
+      action: () async {
+        final result = await FilePicker.pickFiles(
+          dialogTitle: 'Restore encrypted BitNames backup',
+          type: FileType.custom,
+          allowedExtensions: ['json'],
+        );
+        final path = result?.files.single.path;
+        if (path == null) return false;
+        final file = File(path);
+        if (await file.length() > 64 * 1024 * 1024) {
+          throw const BitnamesStorageException('Backup is larger than the 64 MiB safety limit');
+        }
+        await _chatProvider.restorePrivateData(await file.readAsString());
+        return true;
+      },
+    );
+  }
+
+  Future<void> clearPrivateData(BuildContext context) async {
+    final confirmed = await showThemedDialog<bool>(
+      context: context,
+      builder: (dialogContext) => SailAlertCard(
+        title: 'Clear private chat history?',
+        subtitle:
+            'Contacts, messages, and queued encrypted deliveries will be removed. '
+            'Registered BitNames and confirmed reply profiles stay available.',
+        confirmText: 'Clear chats',
+        onConfirm: () async => Navigator.pop(dialogContext, true),
+        onCancel: () async => Navigator.pop(dialogContext, false),
+      ),
+    );
+    if (confirmed != true || !context.mounted) return;
+    await _runPrivateAction(
+      context,
+      success: 'Private BitNames chat history cleared',
+      failure: 'Could not clear chats',
+      action: () async {
+        await _chatProvider.clearChatHistory();
+        return true;
+      },
+    );
+  }
+
+  Future<void> _runPrivateAction(
+    BuildContext context, {
+    required Future<bool> Function() action,
+    required String success,
+    required String failure,
+  }) async {
+    try {
+      final completed = await action();
+      if (completed && context.mounted) showSailToast(context, success, variant: SailToastVariant.success);
+    } catch (e) {
+      if (context.mounted) showSailToast(context, '$failure: $e');
     }
   }
 
@@ -824,33 +1455,38 @@ class ChatViewModel extends BaseViewModel {
   void dispose() {
     _chatProvider.removeListener(_onProviderChanged);
     _bitnamesRPC.removeListener(_onConnectionChanged);
-    _chatProvider.stopPolling();
     messageController.dispose();
     super.dispose();
   }
 }
 
+Future<bool> _confirmSpend(BuildContext context, String title, String subtitle) async =>
+    await showThemedDialog<bool>(
+      context: context,
+      builder: (dialogContext) => SailAlertCard(
+        title: title,
+        subtitle: subtitle,
+        confirmText: 'Confirm spend',
+        onConfirm: () async => Navigator.pop(dialogContext, true),
+        onCancel: () async => Navigator.pop(dialogContext, false),
+      ),
+    ) ==
+    true;
+
 /// Searchable dropdown for selecting a BitName identity.
 /// Supports searching by plaintext name (uses Blake3 hash matching)
 /// or by hash prefix.
-class _SearchableIdentityDropdown extends StatefulWidget {
+class _SearchableIdentityDropdown extends StatelessWidget {
   final List<BitnameEntry> identities;
-  final List<BitnameEntry> allBitNames;
   final BitnameEntry? selectedIdentity;
   final ValueChanged<BitnameEntry> onIdentitySelected;
 
   const _SearchableIdentityDropdown({
     required this.identities,
-    required this.allBitNames,
     required this.selectedIdentity,
     required this.onIdentitySelected,
   });
 
-  @override
-  State<_SearchableIdentityDropdown> createState() => _SearchableIdentityDropdownState();
-}
-
-class _SearchableIdentityDropdownState extends State<_SearchableIdentityDropdown> {
   String _displayName(BitnameEntry entry) {
     return entry.plaintextName ?? '${entry.hash.substring(0, 8)}...';
   }
@@ -859,14 +1495,14 @@ class _SearchableIdentityDropdownState extends State<_SearchableIdentityDropdown
   Widget build(BuildContext context) {
     return SailCombobox<BitnameEntry>(
       items: [
-        for (final entry in widget.identities)
+        for (final entry in identities)
           SailComboboxItem(
             value: entry,
             label: _displayName(entry),
             subtitle: '${entry.hash.substring(0, 16)}...',
           ),
       ],
-      value: widget.selectedIdentity,
+      value: selectedIdentity,
       placeholder: 'Select identity',
       searchPlaceholder: 'Search by name or hash...',
       noResultsText: 'No matching identities found',
@@ -887,7 +1523,7 @@ class _SearchableIdentityDropdownState extends State<_SearchableIdentityDropdown
         }
         return entry.hash.toLowerCase().contains(query);
       },
-      onChanged: widget.onIdentitySelected,
+      onChanged: onIdentitySelected,
     );
   }
 }

--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -1637,7 +1637,13 @@ class _DepositModalState extends State<DepositModal> {
                     ),
                   ),
                   UnitDropdown(value: Unit.BTC, onChanged: (_) {}, enabled: false),
-                  Expanded(child: Container()),
+                  Expanded(
+                    child: NumericField(
+                      label: 'Bitcoin network fee',
+                      controller: feeController,
+                      hintText: '0.0001',
+                    ),
+                  ),
                 ],
               ),
               const SailSpacing(SailStyleValues.padding08),

--- a/bitwindow/lib/providers/chat_provider.dart
+++ b/bitwindow/lib/providers/chat_provider.dart
@@ -1,80 +1,518 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
+import 'package:bitwindow/models/bitintroduction_protocol.dart';
+import 'package:bitwindow/models/bitnames_commitment.dart';
+import 'package:bitwindow/models/bitnames_recovery.dart';
 import 'package:bitwindow/models/chat_models.dart';
+import 'package:bitwindow/services/bitintroduction_codec.dart';
+import 'package:bitwindow/services/bitmessage_server.dart';
+import 'package:bitwindow/services/bitmessage_transport.dart';
+import 'package:bitwindow/services/bitnames_bitintroduction_backend.dart';
+import 'package:bitwindow/services/bitnames_secure_store.dart';
+import 'package:bitwindow/services/bitnames_tor_controller.dart';
+import 'package:bitwindow/services/tor_bitmessage_dialer.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:sail_ui/sail_ui.dart';
+import 'package:synchronized/synchronized.dart';
 import 'package:thirds/blake3.dart';
+import 'package:uuid/uuid.dart';
+
+// dart format off
+enum ChatSendDisposition { sent, needsChainConfirmation, failed }
+class ChatSendResult {
+  const ChatSendResult(this.disposition, {this.id, this.reference, this.error}); final ChatSendDisposition disposition; final String? id, reference, error;
+  bool get sent => disposition == ChatSendDisposition.sent; bool get needsChainConfirmation => disposition == ChatSendDisposition.needsChainConfirmation;
+}
+typedef TorMutationGuard = Future<String?> Function();
 
 class ChatProvider extends ChangeNotifier {
-  BitnamesRPC get bitnamesRPC => GetIt.I.get<BitnamesRPC>();
-  BalanceProvider get balanceProvider => GetIt.I.get<BalanceProvider>();
-  final ClientSettings _clientSettings = GetIt.I.get<ClientSettings>();
+  ChatProvider({
+    BitnamesRPC? rpc, ClientSettings? settings, BalanceProvider? balances,
+    EnforcerRPC? enforcer, Future<void> Function()? restartBitnames,
+    BitMessageTransport? transport, BitnamesTorController? tor, TorMutationGuard? torMutationGuard,
+    BitnamesSecureStore? secureStore, BitnamesStorageKeySource? storageKeySource,
+    DateTime Function()? now, String Function()? id, this.autoStart = true,
+    this.pollInterval = const Duration(seconds: 30), int serverPort = 37999,
+    BitnamesChainRecovery chainRecovery = const BitnamesChainRecovery(),
+    String? commitmentNetwork,
+    BitNamesCommitmentActivation? commitmentActivation,
+  }) : bitnamesRPC = rpc ?? GetIt.I.get<BitnamesRPC>(),
+       _settings = settings ?? GetIt.I.get<ClientSettings>(),
+       _balances = balances ?? _get<BalanceProvider>(),
+       _enforcer = enforcer ?? _get<EnforcerRPC>(),
+       _restartBitnames = restartBitnames ?? _defaultRestartBitnames,
+       // ignore: prefer_initializing_formals
+       _chainRecovery = chainRecovery,
+       _tor = tor ?? _defaultTor(),
+       // ignore: prefer_initializing_formals
+       _torMutationGuard = torMutationGuard,
+       _now = now ?? DateTime.now,
+       _newId = id ?? const Uuid().v4,
+       _commitmentNetwork = bitNamesCommitmentNetwork(
+         commitmentNetwork ?? _defaultCommitmentNetwork(),
+       ),
+       _commitmentActivation = commitmentActivation ??
+           (_namespacedCommitmentsActivated
+               ? BitNamesCommitmentActivation.namespacedV1
+               : BitNamesCommitmentActivation.legacyCompatible) {
+    _storageKeys = secureStore?.keySource ?? storageKeySource ?? _defaultStorageKeys();
+    _secureStore = secureStore ?? BitnamesSecureStore(store: _settings.store, keySource: _storageKeys);
+    _verifier = BitnamesBitMessageProfileVerifier(
+      bitnamesRPC,
+      commitmentNetwork: _commitmentNetwork,
+    );
+    _codec = BitIntroductionEnvelopeCodec(signer: BitnamesBitIntroductionSigner(bitnamesRPC), signatureBackend: BitnamesBitIntroductionSignatureVerifier(bitnamesRPC), profileVerifier: _verifier, cipherBackend: BitnamesBitMessageCipher(bitnamesRPC));
+    _ownsTransport = transport == null;
+    _transport = transport ?? BitMessageTransport(directDialer: DirectBitMessageHttpDialer(), torDialer: createTorBitMessageDialer());
+    _server = BitMessageServer(port: serverPort, bindAddress: InternetAddress.anyIPv4, allowRemoteClients: () => !_torOnly, profileProvider: (hash) => hash == null ? null : _profiles[hash], onIncomingWire: (wire) async {
+      if (!await receiveWire(wire, ChatTransport.direct)) throw const FormatException('BitMessage was rejected');
+    });
+    bitnamesRPC.addListener(_onConnectionChanged);
+    _balances?.addListener(_onBalanceChanged);
+    _storageKeys.addListener(_onStorageKeyChanged);
+    if (autoStart) unawaited(initialize());
+  }
+
+  static const minerFeeSats = 100, fallbackValueSats = 1, maxMessageBytes = 4096;
+  static const _namespacedCommitmentsActivated =
+      bool.fromEnvironment('BITNAMES_NAMESPACED_COMMITMENTS');
+  final BitnamesRPC bitnamesRPC; final ClientSettings _settings; final BalanceProvider? _balances;
+  final EnforcerRPC? _enforcer; final Future<void> Function()? _restartBitnames;
+  final BitnamesChainRecovery _chainRecovery;
+  final BitnamesTorController? _tor; final TorMutationGuard? _torMutationGuard;
+  final DateTime Function() _now; final String Function() _newId;
+  final String _commitmentNetwork;
+  final BitNamesCommitmentActivation _commitmentActivation;
+  final bool autoStart; final Duration pollInterval;
+  late final BitnamesBitMessageProfileVerifier _verifier; late final BitIntroductionEnvelopeCodec _codec;
+  late final BitMessageTransport _transport; late final BitMessageServer _server; late final bool _ownsTransport;
+  late final BitnamesStorageKeySource _storageKeys;
+  late final BitnamesSecureStore _secureStore;
 
   List<BitnameEntry> _allBitNames = [];
-  List<BitnameEntry> get allBitNames => _allBitNames;
-
-  // BitNames owned by this wallet (from UTXOs)
   List<BitnameEntry> _myIdentities = [];
-  List<BitnameEntry> get myIdentities => _myIdentities;
-
-  // Cached owned hashes for quick startup
   Set<String> _ownedHashes = {};
+  BitnameEntry? _selectedIdentity;
+  String? _preferredIdentityHash;
+  ClientSettings get _clientSettings => _settings;
+  HashNameMappingSetting _hashNameMapping = HashNameMappingSetting();
+  List<ChatContact> _contacts = [];
+  final List<ChatMessage> _messages = [];
+  final Map<String, BitMessageProfile> _profiles = {}; final Set<String> _pendingProfiles = {}; final Map<String, BitMessageWire> _pendingWires = {};
+  final Map<String, BitnamesOperation> _operations = {};
+  ChatContact? _selectedContact;
+  int _conversationPageSize = 50;
+  Timer? _pollTimer;
+  Future<void>? _ready; String? _torPeerOnion;
+  bool _polling = false, _refreshing = false, _isSending = false, _torOnly = false, _disposed = false;
+  String? _error;
+  final Lock _saveLock = Lock();
+  final Lock _operationLock = Lock();
+  final Lock _storageReloadLock = Lock();
+  BitnamesChainSnapshot _chainHealth = const BitnamesChainSnapshot();
+  BitnamesTorStatus _torStatus = const BitnamesTorStatus(state: BitnamesTorState.unavailable);
 
-  // BitNames sidechain balance from BalanceProvider
+  List<BitnameEntry> get allBitNames => _allBitNames;
+  List<BitnameEntry> get myIdentities => _myIdentities;
+  BitnameEntry? get selectedIdentity => _selectedIdentity;
+  ChatContact? get selectedContact => _selectedContact;
+  List<ChatContact> get contacts => _contacts.where((c) => c.localBitname == (_selectedIdentity?.hash ?? '')).toList();
+  List<ChatMessage> get messages => List.unmodifiable(_messages);
+  List<ChatMessage> get _allCurrentConversation {
+    final me = _selectedIdentity?.hash, them = _selectedContact?.id;
+    return me == null || them == null ? [] : _conversation(me, them).toList();
+  }
+  List<ChatMessage> get currentConversation {
+    final local = _selectedIdentity?.hash, remote = _selectedContact?.id;
+    if (local == null || remote == null) return [];
+    return conversationPage(
+      localBitname: local,
+      remoteBitname: remote,
+      limit: _conversationPageSize,
+    );
+  }
+  bool get hasOlderMessages =>
+      _allCurrentConversation.length > currentConversation.length;
+  bool get isSending => _isSending;
+  bool get isLoading => _ready != null && _myIdentities.isEmpty; String? get error => _error;
+  bool get torOnly => _torOnly; BitnamesTorStatus get torStatus => _torStatus;
+  bool get hasConfiguredTorPeer => _torPeerOnion != null;
+  BalanceProvider get balanceProvider => _balances ?? GetIt.I.get<BalanceProvider>();
   double get balanceBTC => balanceProvider.balanceFor(bitnamesRPC).$1;
   int get balanceSats => (balanceBTC * 100000000).round();
   bool get hasSufficientBalance => balanceSats >= 10000;
+  Map<String, BitMessageProfile> get profiles => Map.unmodifiable(_profiles);
+  bool profileReady(String hash) {
+    final identity = _myIdentities.where((entry) => entry.hash == hash).firstOrNull;
+    final profile = _profiles[hash];
+    return identity != null &&
+        profile != null &&
+        !_pendingProfiles.contains(hash) &&
+        _profileMatchesCommitment(identity, profile);
+  }
+  bool get selectedProfileReady => _selectedIdentity != null && profileReady(_selectedIdentity!.hash);
+  bool get selectedProfilePending => _selectedIdentity != null && _pendingProfiles.contains(_selectedIdentity!.hash);
+  String get commitmentNetwork => _commitmentNetwork;
+  String get commitmentMode => _commitmentActivation == BitNamesCommitmentActivation.namespacedV1
+      ? 'Namespaced v1 writes enabled'
+      : 'Legacy-compatible writes; existing namespaced commitments remain namespaced';
+  BitNamesCommitmentAssessment? get selectedCommitmentAssessment {
+    final identity = _selectedIdentity;
+    if (identity == null) return null;
+    return assessBitMessageProfileCommitment(
+      profile: _profiles[identity.hash],
+      onChainCommitment: identity.details.commitment,
+      network: _commitmentNetwork,
+    );
+  }
+  bool get selectedCommitmentBlocked {
+    final assessment = selectedCommitmentAssessment;
+    return assessment != null && !assessment.writable;
+  }
+  BitnamesChainSnapshot get chainHealth => _chainHealth;
+  List<BitnamesOperation> get operations => List.unmodifiable(_operations.values);
+  BitnamesStorageStatus get storageStatus => _secureStore.status;
+  bool get privateStorageReady => storageStatus.writable;
 
-  HashNameMappingSetting _hashNameMapping = HashNameMappingSetting();
-
-  BitnameEntry? _selectedIdentity;
-  BitnameEntry? get selectedIdentity => _selectedIdentity;
-
-  List<ChatContact> _contacts = [];
-  List<ChatContact> get contacts => _contacts;
-
-  ChatContact? _selectedContact;
-  ChatContact? get selectedContact => _selectedContact;
-
-  final List<ChatMessage> _messages = [];
-  List<ChatMessage> get messages => _messages;
-
-  List<ChatMessage> get currentConversation {
-    if (_selectedContact == null || _selectedIdentity == null) return [];
-    return _messages.where((m) {
-      final isWithContact =
-          m.senderPubkey == _selectedContact!.encryptionPubkey ||
-          m.recipientPubkey == _selectedContact!.encryptionPubkey;
-      final isFromMyIdentity =
-          m.senderPubkey == _selectedIdentity!.details.encryptionPubkey ||
-          m.recipientPubkey == _selectedIdentity!.details.encryptionPubkey;
-      return isWithContact && isFromMyIdentity;
-    }).toList()..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+  Future<void> initialize() => _ready ??= _init();
+  Future<void> _init() async {
+    final opened = await _saveLock.synchronized(_openPrivateState);
+    if (!opened) {
+      _changed();
+      return;
+    }
+    if (_tor != null) _torStatus = await _tor.refresh();
+    if (autoStart) await _startRuntime();
+    if (_torOnly && _torPeerOnion != null) {
+      unawaited(_restoreTor());
+    }
+    if (bitnamesRPC.connected) await refresh();
+    _changed();
   }
 
-  final bool _isLoading = false;
-  bool get isLoading => _isLoading;
+  Future<bool> _openPrivateState() async {
+    _clearPrivateMemory();
+    try {
+      final state = await _secureStore.load();
+      if (!storageStatus.writable) {
+        _error = null;
+        return false;
+      }
+      _hydrate(state);
+      _restoreOperationStatuses();
+      _error = null;
+      return true;
+    } on BitnamesStorageException catch (e) {
+      _error = 'Private BitNames storage was not opened: $e';
+      return false;
+    }
+  }
 
-  String? _error;
-  String? get error => _error;
+  void _hydrate(Map<String, dynamic> state) {
+    _contacts = _list(state['contacts'], ChatContact.fromJson);
+    _messages.addAll(_list(state['messages'], ChatMessage.fromJson));
+    for (final json in _maps(state['profiles'])) { final profile = BitMessageProfile.fromJson(json); _profiles[profile.bitNameHash] = profile; }
+    _pendingProfiles.addAll((state['pending_profiles'] as List? ?? []).whereType<String>());
+    for (final entry in (state['pending_wires'] is Map ? state['pending_wires'] as Map : const {}).entries) {
+      try {
+        if (entry.key is String && entry.value is Map) {
+          _pendingWires[entry.key as String] = BitMessageWire.fromJson(Map<String, dynamic>.from(entry.value as Map));
+        }
+      } catch (_) {}
+    }
+    for (final json in _maps(state['operations'])) {
+      try {
+        final operation = BitnamesOperation.fromJson(json);
+        _operations[operation.id] = operation;
+      } catch (_) {}
+    }
+    if (state['chain_health'] is Map) {
+      try {
+        _chainHealth = BitnamesChainSnapshot.fromJson(
+          Map<String, dynamic>.from(state['chain_health'] as Map),
+        );
+      } catch (_) {}
+    }
+    _ownedHashes = (state['owned'] as List? ?? []).whereType<String>().toSet();
+    _preferredIdentityHash = state['selected_identity'] is String ? state['selected_identity'] as String : null;
+    _torOnly = state['tor_only'] == true;
+    _torPeerOnion = state['tor_peer'] is String ? state['tor_peer'] as String : null;
+  }
 
-  bool _isSending = false;
-  bool get isSending => _isSending;
+  void _clearPrivateMemory() {
+    _contacts = [];
+    _messages.clear();
+    _profiles.clear();
+    _pendingProfiles.clear();
+    _pendingWires.clear();
+    _operations.clear();
+    _ownedHashes.clear();
+    _myIdentities = [];
+    _selectedIdentity = null;
+    _selectedContact = null;
+    _conversationPageSize = 50;
+    _preferredIdentityHash = null;
+    _torPeerOnion = null;
+    _torOnly = false;
+    _statusMessages.clear();
+  }
 
-  Timer? _pollTimer;
-  static const _pollInterval = Duration(seconds: 30);
+  Future<void> _startRuntime() async {
+    if (!_server.isRunning) {
+      try { await _server.start(); }
+      catch (e) { _error = 'BitMessage listener unavailable: $e'; }
+    }
+    startPolling();
+  }
 
-  ChatProvider() {
-    bitnamesRPC.addListener(_onConnectionChanged);
-    balanceProvider.addListener(_onBalanceChanged);
-    _init();
+  void _onStorageKeyChanged() {
+    unawaited(_storageReloadLock.synchronized(() async {
+      if (_disposed) return;
+      var ready = false;
+      await _saveLock.synchronized(() async {
+        stopPolling();
+        if (_server.isRunning) await _server.stop();
+        ready = await _openPrivateState();
+      });
+      if (ready) {
+        if (autoStart) await _startRuntime();
+        if (_torOnly && _torPeerOnion != null) unawaited(_restoreTor());
+        if (bitnamesRPC.connected) await refresh();
+      }
+      _changed();
+    }));
+  }
+
+  Future<void> _restoreTor() async {
+    try { await _tor?.enableChainTor(bitnamesRPC, _torPeerOnion!); }
+    catch (e) { _error = 'Tor-only BitNames is not ready: $e'; }
+    _changed();
+  }
+
+  Future<void> refresh() async {
+    if (_refreshing || !privateStorageReady) return;
+    _refreshing = true;
+    try {
+      if (_tor != null) _torStatus = await _tor.refresh();
+      if (!await _refreshChainHealth()) return;
+      await fetchIdentities();
+      await _reconcileOperations();
+      await fetchPaymail();
+      _chainHealth = _chainHealth.copyWith(lastReconciledAt: _now());
+      await _save();
+    } finally {
+      _refreshing = false;
+      _changed();
+    }
+  }
+
+  Future<bool> _refreshChainHealth() async {
+    final enforcer = _enforcer;
+    if (enforcer == null) return bitnamesRPC.connected;
+    final now = _now();
+    if (!bitnamesRPC.connected || !enforcer.connected) {
+      _chainHealth = _chainRecovery.disconnected(_chainHealth, now).snapshot;
+      await _save();
+      return false;
+    }
+    try {
+      final enforcerInfo = await enforcer.getBlockchainInfo();
+      final bitnamesMainchainHash =
+          await bitnamesRPC.getBestMainchainBlockHash();
+      final sidechainHeight = await bitnamesRPC.getBlockCount();
+      final sidechainHash = await bitnamesRPC.getBestSidechainBlockHash();
+      final peers = await bitnamesRPC.listPeers();
+      if (bitnamesMainchainHash == null || sidechainHash == null) {
+        throw StateError('BitNames did not report complete chain tips');
+      }
+      final decision = _chainRecovery.observe(
+        _chainHealth,
+        BitnamesChainObservation(
+          enforcerHeight: enforcerInfo.blocks,
+          enforcerHash: enforcerInfo.bestBlockHash,
+          bitnamesMainchainHash: bitnamesMainchainHash,
+          sidechainHeight: sidechainHeight,
+          sidechainHash: sidechainHash,
+          peerCount: peers.length,
+          waitingForBlock: _hasPendingChainWork,
+        ),
+        now,
+      );
+      _chainHealth = decision.snapshot;
+      await _save();
+      if (decision.restartBitnames) {
+        final restart = _restartBitnames;
+        if (restart == null) {
+          _chainHealth = _chainHealth.copyWith(
+            state: BitnamesChainHealthState.stalled,
+            error: 'Automatic BitNames restart is unavailable',
+          );
+          await _save();
+          return false;
+        }
+        try {
+          await restart();
+        } catch (e) {
+          _chainHealth = _chainHealth.copyWith(
+            state: BitnamesChainHealthState.error,
+            error: 'Automatic BitNames restart failed: $e',
+          );
+          await _save();
+        }
+        return false;
+      }
+      return _chainHealth.mutationSafe;
+    } catch (e) {
+      final decision = _chainRecovery.failed(_chainHealth, now, e);
+      _chainHealth = decision.snapshot;
+      await _save();
+      if (decision.restartBitnames && _restartBitnames != null) {
+        try {
+          await _restartBitnames();
+        } catch (restartError) {
+          _chainHealth = _chainHealth.copyWith(
+            state: BitnamesChainHealthState.error,
+            error: 'Automatic BitNames restart failed: $restartError',
+          );
+          await _save();
+        }
+      }
+      return false;
+    }
+  }
+
+  bool get _hasPendingChainWork =>
+      _operations.values.any(
+        (operation) =>
+            !operation.terminal &&
+            operation.phase != BitnamesOperationPhase.prepared &&
+            operation.phase != BitnamesOperationPhase.paused,
+      ) ||
+      _messages.any(
+        (message) =>
+            message.transport == ChatTransport.bitnamesChain &&
+            message.deliveryState == ChatDeliveryState.pending,
+      );
+
+  Future<void> retryChainRecovery() async {
+    if (_chainHealth.state == BitnamesChainHealthState.stalled) {
+      _chainHealth = _chainHealth.copyWith(
+        state: BitnamesChainHealthState.waitingForBlock,
+        observedAt: _now(),
+        lastProgressAt: _now(),
+        clearError: true,
+      );
+      await _save();
+      await refresh();
+      return;
+    }
+    final restart = _restartBitnames;
+    if (restart == null) {
+      _fail('BitNames restart is unavailable');
+      return;
+    }
+    _chainHealth = _chainHealth.copyWith(
+      state: BitnamesChainHealthState.recovering,
+      observedAt: _now(),
+      lastProgressAt: _now(),
+      recoveryAttempts: _chainHealth.recoveryAttempts + 1,
+      recoveryTip: _chainHealth.enforcerHash,
+      clearError: true,
+    );
+    await _save();
+    _changed();
+    try {
+      await restart();
+    } catch (e) {
+      _chainHealth = _chainHealth.copyWith(
+        state: BitnamesChainHealthState.error,
+        error: 'Could not restart BitNames: $e',
+      );
+      await _save();
+      _changed();
+    }
+  }
+
+  void _restoreOperationStatuses() {
+    for (final operation in _operations.values.where((op) => !op.terminal)) {
+      _addStatus(operation.id, _operationStatus(operation));
+    }
+  }
+
+  String _operationStatus(BitnamesOperation operation) {
+    final name =
+        operation.plaintextName ??
+        (operation.bitnameHash.length > 8
+            ? '${operation.bitnameHash.substring(0, 8)}…'
+            : operation.bitnameHash);
+    return switch (operation.phase) {
+      BitnamesOperationPhase.prepared =>
+        'Preparing BitName operation for "$name"',
+      BitnamesOperationPhase.reservationSubmitting =>
+        'Reservation submission for "$name" was interrupted • checking chain state before any retry',
+      BitnamesOperationPhase.reservationSubmitted =>
+        'Reservation for "$name" submitted • waiting for a BitNames block'
+            '${operation.reservationTxid == null ? '' : ' • transaction ${_short(operation.reservationTxid!)}'}',
+      BitnamesOperationPhase.registrationSubmitting =>
+        'Registration submission for "$name" was interrupted • checking chain state before any retry',
+      BitnamesOperationPhase.registrationSubmitted =>
+        '"$name" registration submitted • waiting for a BitNames block'
+            '${operation.txid == null ? '' : ' • transaction ${_short(operation.txid!)}'}',
+      BitnamesOperationPhase.profileSubmitting =>
+        'Reply-profile submission for "$name" was interrupted • checking chain state before any retry',
+      BitnamesOperationPhase.profileSubmitted =>
+        'Reply profile for "$name" submitted • waiting for a BitNames block'
+            '${operation.txid == null ? '' : ' • transaction ${_short(operation.txid!)}'}',
+      BitnamesOperationPhase.paused =>
+        '$name operation paused safely • ${operation.lastError ?? 'review required'}',
+      BitnamesOperationPhase.failed =>
+        '$name operation failed • ${operation.lastError ?? 'unknown error'}',
+      BitnamesOperationPhase.cancelled => '$name operation cancelled',
+      BitnamesOperationPhase.confirmed => '$name operation confirmed',
+    };
+  }
+
+  Future<void> _putOperation(BitnamesOperation operation) async {
+    _operations[operation.id] = operation;
+    if (operation.phase == BitnamesOperationPhase.confirmed) {
+      _addStatus(operation.id, _operationStatus(operation), completed: true);
+    } else if (!operation.terminal) {
+      _addStatus(operation.id, _operationStatus(operation));
+    }
+    await _save();
+  }
+
+  Future<BitnamesOperation> _transitionOperation(
+    BitnamesOperation operation,
+    BitnamesOperationPhase phase, {
+    String? reservationTxid,
+    String? txid,
+    String? error,
+    bool observeHeight = false,
+    bool incrementAttempts = false,
+    bool maySpend = false,
+  }) async {
+    final updated = operation.copyWith(
+      phase: phase,
+      reservationTxid: reservationTxid,
+      txid: txid,
+      updatedAt: _now(),
+      lastObservedSidechainHeight: observeHeight ? _chainHealth.sidechainHeight : null,
+      attempts: incrementAttempts ? operation.attempts + 1 : null,
+      maySpend: maySpend,
+      lastError: error,
+      clearError: error == null,
+    );
+    await _putOperation(updated);
+    return updated;
   }
 
   void _onConnectionChanged() {
-    if (bitnamesRPC.connected) {
-      _init();
+    if (bitnamesRPC.connected && privateStorageReady) {
+      unawaited(refresh());
     }
   }
 
@@ -83,18 +521,7 @@ class ChatProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> _init() async {
-    if (!bitnamesRPC.connected) return;
-    await Future.wait([
-      fetchIdentities(),
-      _loadContacts(),
-    ]);
-  }
-
   Future<void> fetchIdentities() async {
-    // Load cached data first for quick startup
-    await _loadCachedData();
-
     if (!bitnamesRPC.connected) return;
 
     try {
@@ -104,6 +531,12 @@ class ChatProvider extends ChangeNotifier {
 
       // Fetch all BitNames (for lookup and search)
       _allBitNames = await bitnamesRPC.listBitNames();
+      final namesByHash = {for (final entry in _allBitNames) entry.hash: entry.plaintextName};
+      _contacts = _contacts
+          .map((contact) => namesByHash[contact.id] == null
+              ? contact
+              : contact.copyWith(plaintextName: namesByHash[contact.id]))
+          .toList();
 
       // Get wallet UTXOs and find owned BitNames
       final utxos = await bitnamesRPC.listUTXOs();
@@ -126,15 +559,37 @@ class ChatProvider extends ChangeNotifier {
 
       // Save owned hashes for quick startup next time
       _ownedHashes = ownedHashes;
-      await _saveOwnedHashes();
+      await _save();
 
       // Match owned hashes to full BitName entries
       _myIdentities = _allBitNames.where((entry) => _ownedHashes.contains(entry.hash)).toList();
 
-      // Select first owned identity if none selected
-      if (_selectedIdentity == null && _myIdentities.isNotEmpty) {
-        _selectedIdentity = _myIdentities.first;
+      final preferredHash = _selectedIdentity?.hash ?? _preferredIdentityHash;
+      final refreshed = _myIdentities.where((entry) => entry.hash == preferredHash).firstOrNull;
+      if (refreshed == null) _selectedContact = null;
+      _selectedIdentity = refreshed ?? _myIdentities.firstOrNull;
+      _preferredIdentityHash = _selectedIdentity?.hash;
+      for (final identity in _myIdentities) {
+        final profile = _profiles[identity.hash];
+        final statusId = 'profile_${identity.hash}';
+        if (profile != null && _profileMatchesCommitment(identity, profile)) {
+          if (_pendingProfiles.remove(identity.hash)) {
+            _addStatus(
+              statusId,
+              'Reply profile confirmed in a BitNames block • "${_identityLabel(identity)}" is ready to message',
+              completed: true,
+            );
+            Timer(const Duration(seconds: 15), () => _removeStatus(statusId));
+          }
+        } else if (_pendingProfiles.contains(identity.hash) &&
+            !_statusMessages.any((status) => status.id == statusId)) {
+          _addStatus(
+            statusId,
+            'Reply profile for "${_identityLabel(identity)}" submitted • waiting for a BitNames block',
+          );
+        }
       }
+      await _save();
       notifyListeners();
     } catch (e) {
       _error = 'Failed to fetch identities: $e';
@@ -142,76 +597,287 @@ class ChatProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> _loadCachedData() async {
+  Future<String?> publishProfile({
+    required Iterable<Uri> direct,
+    required Iterable<Uri> tor,
+    required int? paymailFeeSats,
+  }) async {
+    final me = _selectedIdentity;
+    if (me == null) { _fail('Select a registered BitName first'); return null; }
+    final statusId = 'profile_${me.hash}';
+    final existing = _operations[statusId];
+    if (existing?.phase == BitnamesOperationPhase.paused) {
+      _fail(
+        'The previous reply-profile transaction is paused safely: ${existing!.lastError ?? 'review required'}',
+      );
+      return null;
+    }
+    if (existing != null && !existing.terminal) {
+      await _reconcileOperations();
+      if (!(_operations[statusId]?.terminal ?? true)) {
+        _fail('A reply-profile operation for this BitName is already being reconciled');
+        return null;
+      }
+    }
+    if (paymailFeeSats != null && paymailFeeSats < 0) { _fail('Introduction fee cannot be negative'); return null; }
+    _addStatus(statusId, 'Creating signing and encryption keys for the reply profile...');
+    if (!await _mutationAllowed()) { _removeStatus(statusId); return null; }
+    BitnamesOperation? operation;
     try {
-      // Load hash-name mappings
-      final loadedMapping = await _clientSettings.getValue(HashNameMappingSetting());
-      _hashNameMapping = loadedMapping as HashNameMappingSetting;
-
-      // Load cached owned hashes
-      final ownedSetting = await _clientSettings.getValue(OwnedBitNamesSetting());
-      _ownedHashes = ownedSetting.value.toSet();
-
-      notifyListeners();
+      final identity = me;
+      if (!await _ownsBitNameNow(identity.hash)) {
+        throw StateError('The selected BitName is no longer owned by this wallet');
+      }
+      final resolution = await _resolveOrNull(identity.hash);
+      if (resolution == null) {
+        throw StateError('The selected BitName is no longer registered');
+      }
+      final currentCommitment = resolution.data.commitment;
+      final signing = resolution.data.signingPubkey ?? await bitnamesRPC.getNewVerifyingKey();
+      final encryption = resolution.data.encryptionPubkey ?? await bitnamesRPC.getNewEncryptionKey();
+      final proposedProfile = BitMessageProfile(bitNameHash: identity.hash, signingPublicKey: signing,
+        encryptionPublicKey: encryption, directEndpoints: direct.map((u) => _path(u, identity.hash)),
+        torEndpoints: tor.map((u) => _path(u, identity.hash)), paymailFeeSats: paymailFeeSats);
+      if (proposedProfile.directEndpoints.isEmpty && proposedProfile.torEndpoints.isEmpty) {
+        _removeStatus(statusId); _fail('Add a direct or Tor endpoint'); return null;
+      }
+      final planner = BitNamesCommitmentPlanner(
+        network: _commitmentNetwork,
+        activation: _commitmentActivation,
+      );
+      var knownProfile = _profiles[identity.hash];
+      var assessment = planner.assess(
+        onChainCommitment: currentCommitment,
+        knownProfile: knownProfile,
+      );
+      if (!assessment.writable && knownProfile != null) {
+        final discovered = await _transport.discoverProfile(knownProfile, torOnly: _torOnly);
+        final discoveredAssessment = planner.assess(
+          onChainCommitment: currentCommitment,
+          knownProfile: discovered,
+        );
+        if (discoveredAssessment.writable) {
+          knownProfile = discovered;
+          assessment = discoveredAssessment;
+        }
+      }
+      if (!assessment.writable) {
+        throw BitNamesCommitmentConflict('${assessment.summary}. ${assessment.details}');
+      }
+      final plan = planner.plan(
+        profile: proposedProfile,
+        currentCommitment: currentCommitment,
+        knownProfile: knownProfile,
+      );
+      final profile = plan.profile;
+      _addStatus(
+        statusId,
+        '${plan.summary} • ${plan.commitment.substring(0, 12)}… on $_commitmentNetwork'
+        '${plan.preservedApplications == 0 ? '' : ' • preserving ${plan.preservedApplications} other application namespace(s)'}',
+      );
+      final preflight = await _resolveOrNull(identity.hash);
+      if (preflight == null || !await _ownsBitNameNow(identity.hash)) {
+        throw StateError('BitName ownership changed while the reply profile was being prepared');
+      }
+      if (preflight.data.commitment != currentCommitment) {
+        throw const BitNamesCommitmentConflict(
+          'The application commitment changed while the reply profile was being prepared; nothing was submitted',
+        );
+      }
+      if (preflight.data.seqId != resolution.data.seqId ||
+          preflight.data.signingPubkey != resolution.data.signingPubkey ||
+          preflight.data.encryptionPubkey != resolution.data.encryptionPubkey ||
+          preflight.data.paymailFeeSats != resolution.data.paymailFeeSats) {
+        throw const BitNamesCommitmentConflict(
+          'BitName data changed while the reply profile was being prepared; nothing was submitted',
+        );
+      }
+      final now = _now();
+      operation = BitnamesOperation(
+        id: statusId,
+        type: BitnamesOperationType.profilePublication,
+        phase: BitnamesOperationPhase.profileSubmitting,
+        bitnameHash: identity.hash,
+        plaintextName: identity.plaintextName,
+        introductionFeeSats: paymailFeeSats,
+        encryptionPubkey: encryption,
+        signingPubkey: signing,
+        profile: profile.toJson(),
+        createdAt: now,
+        updatedAt: now,
+        lastObservedSidechainHeight: _chainHealth.sidechainHeight,
+        attempts: 1,
+        maySpend: true,
+      );
+      await _putOperation(operation);
+      final txid = await bitnamesRPC.updateBitName(bitname: identity.hash,
+        updates: BitNameDataUpdates(commitment: BitNameUpdate.set(plan.commitment),
+          signingPubkey: BitNameUpdate.set(signing), encryptionPubkey: BitNameUpdate.set(encryption),
+          paymailFeeSats: paymailFeeSats == null ? const BitNameUpdate<int>.delete() : BitNameUpdate.set(paymailFeeSats)),
+        feeSats: minerFeeSats);
+      _profiles[identity.hash] = profile; _pendingProfiles.add(identity.hash);
+      operation = await _transitionOperation(
+        operation,
+        BitnamesOperationPhase.profileSubmitted,
+        txid: txid,
+      );
+      _changed();
+      return txid;
     } catch (e) {
-      // Ignore errors on cache load
+      if (operation != null) {
+        await _transitionOperation(
+          operation,
+          operation.phase,
+          error: 'Submission outcome is unknown: $e',
+        );
+      } else {
+        _removeStatus(statusId);
+      }
+      _fail('Could not publish reply profile: $e'); return null;
     }
   }
 
-  Future<void> _saveOwnedHashes() async {
-    final setting = OwnedBitNamesSetting(newValue: _ownedHashes.toList());
-    await _clientSettings.setValue(setting);
+  Future<bool> setTorOnly(bool enabled, {String? peerOnion}) async {
+    if (!privateStorageReady) {
+      _fail('${storageStatus.summary}. Unlock the wallet before changing Tor routing');
+      return false;
+    }
+    if (!enabled && !_torOnly) return true;
+    if (enabled && _torOnly && _tor != null && await _tor.chainTorReady(bitnamesRPC)) return true;
+    try {
+      if (enabled) {
+        final controller = _tor;
+        final onion = peerOnion;
+        if (controller == null || onion == null) {
+          throw StateError('No BitNames Tor peer is configured. Use direct mode or connect a Tor-capable contact first');
+        }
+        await controller.enableChainTor(bitnamesRPC, onion);
+        _torPeerOnion = onion;
+      } else { await _tor?.disableChainTor(); }
+      _torOnly = enabled; await _save(); _changed();
+      return true;
+    } catch (e) {
+      _fail('Could not ${enabled ? 'enable' : 'disable'} Tor mode: $e'); return false;
+    }
   }
 
-  /// Search for a BitName by plaintext name using Blake3 hash
-  BitnameEntry? searchBitNameByPlaintext(String searchText) {
-    if (searchText.isEmpty) return null;
+  Future<BitnamesTorStatus> downloadAndStartTor() async {
+    try { _torStatus = await _tor!.downloadAndStart(); }
+    catch (e) { _torStatus = BitnamesTorStatus(state: BitnamesTorState.error, error: '$e'); }
+    _changed(); return _torStatus;
+  }
+
+  Future<bool> addContactFromEntry(BitnameEntry entry) async {
+    if (entry.hash == _selectedIdentity?.hash) {
+      _fail('Choose a different BitName; you cannot add your current identity'); return false;
+    }
+    if (entry.details.encryptionPubkey == null) {
+      _error = 'BitName has no encryption key';
+      notifyListeners();
+      return false;
+    }
+
+    final resolution = await bitnamesRPC.resolveBitName(entry.hash);
+    if (resolution == null) { _fail('Could not resolve this BitName'); return false; }
+    final address = resolution.address;
+
+    final contact = ChatContact(
+      id: entry.hash,
+      localBitname: _selectedIdentity?.hash ?? '',
+      name: entry.hash,
+      plaintextName: entry.plaintextName,
+      encryptionPubkey: entry.details.encryptionPubkey!,
+      signingPubkey: entry.details.signingPubkey,
+      address: address,
+      paymailFeeSats: entry.details.paymailFeeSats,
+      isManual: true,
+    );
+
+    await addContact(contact);
+    return true;
+  }
+
+  Future<ChatContact?> lookupBitName(String nameOrHash) async {
+    if (!bitnamesRPC.connected) return null;
 
     try {
-      final searchHash = blake3Hex(utf8.encode(searchText.toLowerCase()));
-      return _allBitNames.firstWhere(
-        (entry) => entry.hash.toLowerCase() == searchHash.toLowerCase(),
-        orElse: () => throw StateError('Not found'),
+      final hash = RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(nameOrHash)
+          ? nameOrHash.toLowerCase()
+          : blake3Hex(utf8.encode(nameOrHash.trim().toLowerCase()));
+      final resolution = await bitnamesRPC.resolveBitName(hash);
+      final data = resolution?.data;
+      if (data == null || data.encryptionPubkey == null || _selectedIdentity == null) return null;
+
+      return ChatContact(
+        id: hash,
+        localBitname: _selectedIdentity!.hash,
+        name: hash,
+        plaintextName: nameOrHash,
+        encryptionPubkey: data.encryptionPubkey!,
+        signingPubkey: data.signingPubkey,
+        address: resolution!.address,
+        paymailFeeSats: data.paymailFeeSats,
+        isManual: true,
       );
     } catch (e) {
+      _error = 'Failed to lookup BitName: $e';
+      notifyListeners();
       return null;
     }
   }
 
-  /// Get filtered BitNames based on search text
-  List<BitnameEntry> getFilteredBitNames(String searchText) {
-    if (searchText.isEmpty) return myIdentities;
-
-    final searchLower = searchText.toLowerCase();
-
-    // First try to find by Blake3 hash match
-    String? searchHash;
-    try {
-      searchHash = blake3Hex(utf8.encode(searchLower));
-    } catch (e) {
-      searchHash = null;
+  Future<void> addContact(ChatContact contact) async {
+    final existingIndex = _contacts.indexWhere((c) => c.relationshipId == contact.relationshipId);
+    if (existingIndex >= 0) {
+      final old = _contacts[existingIndex];
+      contact = ChatContact(id: contact.id, localBitname: contact.localBitname, name: contact.name,
+        plaintextName: contact.plaintextName, encryptionPubkey: contact.encryptionPubkey,
+        signingPubkey: contact.signingPubkey, address: contact.address,
+        paymailFeeSats: contact.paymailFeeSats, relationshipState: old.relationshipState,
+        introductionId: old.introductionId, replyProfile: old.replyProfile,
+        lastMessage: old.lastMessage, lastMessageTime: old.lastMessageTime,
+        unreadCount: old.unreadCount, isManual: contact.isManual);
+    } else {
+      _contacts.add(contact);
     }
+    await _storeContact(contact);
+  }
 
-    return myIdentities.where((entry) {
-      // Check hash match
-      if (searchHash != null && entry.hash.toLowerCase() == searchHash.toLowerCase()) {
-        return true;
-      }
-      // Check plaintext name match
-      if (entry.plaintextName?.toLowerCase().contains(searchLower) ?? false) {
-        return true;
-      }
-      // Check hash prefix match
-      if (entry.hash.toLowerCase().contains(searchLower)) {
-        return true;
-      }
-      return false;
-    }).toList();
+  Future<void> _putContact(ChatContact contact) => _storeContact(contact);
+
+  Future<void> _storeContact(ChatContact contact) async {
+    _storeContactInMemory(contact);
+    await _save(); notifyListeners();
+  }
+
+  void _storeContactInMemory(ChatContact contact) {
+    final index = _contacts.indexWhere((c) => c.relationshipId == contact.relationshipId);
+    if (index >= 0) {
+      _contacts[index] = contact;
+    } else {
+      _contacts.add(contact);
+    }
+    if (_selectedContact?.relationshipId == contact.relationshipId) _selectedContact = contact;
+  }
+
+  void selectContact(ChatContact contact) {
+    _selectedContact = contact;
+    _conversationPageSize = 50;
+    notifyListeners();
+  }
+
+  void loadOlderMessages() {
+    _conversationPageSize += 50;
+    notifyListeners();
   }
 
   void selectIdentity(BitnameEntry identity) {
     _selectedIdentity = identity;
+    _preferredIdentityHash = identity.hash;
+    _selectedContact = null;
+    _conversationPageSize = 50;
     notifyListeners();
+    unawaited(_save());
     fetchPaymail();
   }
 
@@ -226,15 +892,15 @@ class ChatProvider extends ChangeNotifier {
   final List<StatusMessage> _statusMessages = [];
   List<StatusMessage> get statusMessages => List.unmodifiable(_statusMessages);
 
-  void _addStatus(String id, String message) {
+  void _addStatus(String id, String message, {bool completed = false}) {
     _statusMessages.removeWhere((s) => s.id == id);
-    _statusMessages.add(StatusMessage(id: id, message: message));
-    notifyListeners();
+    _statusMessages.add(StatusMessage(id: id, message: message, completed: completed));
+    _changed();
   }
 
   void _removeStatus(String id) {
     _statusMessages.removeWhere((s) => s.id == id);
-    notifyListeners();
+    _changed();
   }
 
   // Legacy getters for compatibility - check for any claiming_ status
@@ -243,76 +909,105 @@ class ChatProvider extends ChangeNotifier {
 
   /// Reserve and register a BitName automatically
   /// Handles the reserve-wait-register dance internally
-  Future<String?> claimIdentity(String plaintextName) async {
+  Future<String?> claimIdentity(String plaintextName, {int introductionFeeSats = 1000}) async {
+    plaintextName = plaintextName.trim().toLowerCase();
+    // Add progress before connection/privacy guards so Register never appears to do nothing.
+    final statusId = 'claiming_$plaintextName';
+    _addStatus(statusId, 'Preparing registration for "$plaintextName"...');
+    if (plaintextName.isEmpty || introductionFeeSats < 0 || introductionFeeSats > 2100000000000000) {
+      _fail('Enter a name and an introduction fee from 0 to 2,100,000,000,000,000 sats');
+      _removeStatus(statusId); return null;
+    }
     if (!bitnamesRPC.connected) {
       _error = 'BitNames not connected';
-      notifyListeners();
+      _addStatus(statusId, 'Registration paused • BitNames is not connected');
+      await Future.delayed(const Duration(seconds: 5));
+      _removeStatus(statusId);
       return null;
     }
-
-    // Use a unique status ID per claim so back-to-back claims work
-    final statusId = 'claiming_$plaintextName';
-    _addStatus(statusId, 'Checking balance...');
-
+    if (!await _mutationAllowed()) {
+      _addStatus(statusId, 'Registration paused • start BitNames Tor, then try again');
+      await Future.delayed(const Duration(seconds: 5));
+      _removeStatus(statusId);
+      return null;
+    }
+    _addStatus(statusId, 'Checking balance and existing chain state...');
     try {
-      // Check balance first
-      final balance = await bitnamesRPC.getBalance();
-      if (balance.availableSats < 10000) {
-        _error = 'Insufficient BitNames balance. Deposit funds to BitNames sidechain first.';
-        notifyListeners();
+      final hash = blake3Hex(utf8.encode(plaintextName));
+      final operationId = 'registration_$hash';
+      var operation = _operations[operationId];
+      if (operation?.phase == BitnamesOperationPhase.paused ||
+          operation?.phase == BitnamesOperationPhase.failed ||
+          operation?.phase == BitnamesOperationPhase.cancelled) {
+        _fail(
+          'The previous registration is ${operation!.phase.name}: '
+          '${operation.lastError ?? 'review is required before another spend'}',
+        );
         return null;
       }
-
-      // Step 1: Reserve (wait for tx to be mined)
-      _addStatus(statusId, 'Reserving "$plaintextName"...');
-      await bitnamesRPC.reserveBitName(plaintextName);
-
-      // Get encryption key for paymail
-      final encryptionPubkey = await bitnamesRPC.getNewEncryptionKey();
-
-      // Retry register until reservation is mined (stay in "Reserving" state)
-      String? txid;
-      const retryDelay = Duration(seconds: 10);
-
-      while (txid == null) {
+      if (operation != null && !operation.terminal) {
+        _addStatus(operation.id, _operationStatus(operation));
+      }
+      var alreadyRegistered = _allBitNames.any((entry) => entry.hash == hash);
+      if (!alreadyRegistered) {
         try {
-          txid = await bitnamesRPC.registerBitName(
-            plaintextName,
-            BitNameData(
-              encryptionPubkey: encryptionPubkey,
-              paymailFeeSats: 1000,
-            ),
-          );
+          alreadyRegistered = await bitnamesRPC.resolveBitName(hash) != null;
         } catch (e) {
-          final errorStr = e.toString().toLowerCase();
-          if (errorStr.contains('reservation') || errorStr.contains('not found')) {
-            // Reservation not mined yet, wait and retry
-            await Future.delayed(retryDelay);
-          } else {
-            // Different error, rethrow
-            rethrow;
-          }
+          if (!e.toString().toLowerCase().contains('missing bitname')) rethrow;
         }
       }
-
-      // Step 2: Register tx submitted, wait for it to be mined
-      _addStatus(statusId, 'Registering "$plaintextName"...');
-      await _hashNameMapping.saveMapping(plaintextName, isMine: true);
-
-      // Poll until BitName appears in identity list (register tx mined)
+      if (alreadyRegistered && operation == null) {
+        _fail('That BitName is already registered'); return null;
+      }
+      if (operation == null) {
+        final balance = await bitnamesRPC.getBalance();
+        if (balance.availableSats < 10000) {
+          _error = 'Insufficient BitNames balance. Deposit funds to BitNames sidechain first.';
+          notifyListeners();
+          return null;
+        }
+        final now = _now();
+        operation = BitnamesOperation(
+          id: operationId,
+          type: BitnamesOperationType.registration,
+          phase: BitnamesOperationPhase.prepared,
+          bitnameHash: hash,
+          plaintextName: plaintextName,
+          introductionFeeSats: introductionFeeSats,
+          createdAt: now,
+          updatedAt: now,
+          lastObservedSidechainHeight: _chainHealth.sidechainHeight,
+        );
+        await _putOperation(operation);
+      }
+      const retryDelay = Duration(seconds: 10);
       while (true) {
-        await fetchIdentities();
-        if (_myIdentities.any((entry) => entry.plaintextName == plaintextName)) {
-          break;
+        await _reconcileOperations();
+        operation = _operations[operationId]!;
+        if (operation.phase == BitnamesOperationPhase.confirmed) {
+          final registered = _myIdentities.where((entry) => entry.hash == hash).firstOrNull;
+          if (registered != null) {
+            _selectedIdentity = registered;
+            _preferredIdentityHash = registered.hash;
+            _selectedContact = null;
+            await _save();
+            _changed();
+          }
+          Timer(const Duration(seconds: 15), () => _removeStatus(operationId));
+          _removeStatus(statusId);
+          return operation.txid;
+        }
+        if (operation.uncertain && operation.lastError != null) {
+          _fail(operation.lastError);
+          return null;
+        }
+        if (!_chainHealth.mutationSafe) {
+          _fail('${_chainHealth.summary}. Registration will resume automatically after reconciliation.');
+          return null;
         }
         await Future.delayed(retryDelay);
+        await refresh();
       }
-
-      // Step 3: Registered successfully
-      _addStatus(statusId, 'Registered "$plaintextName" successfully!');
-      await Future.delayed(const Duration(seconds: 5));
-
-      return txid;
     } catch (e) {
       _error = 'Failed to claim BitName: $e';
       notifyListeners();
@@ -322,324 +1017,869 @@ class ChatProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> _loadContacts() async {
-    try {
-      final setting = ChatContactsSetting();
-      final loaded = await _clientSettings.getValue(setting);
-      _contacts = loaded.value;
-      notifyListeners();
-    } catch (e) {
-      _contacts = [];
+  Future<void> _reconcileOperations() =>
+      _operationLock.synchronized(_reconcileOperationsUnlocked);
+
+  Future<void> _reconcileOperationsUnlocked() async {
+    if (!bitnamesRPC.connected || !_chainHealth.mutationSafe) return;
+    for (final operation in _operations.values.toList()) {
+      if (operation.phase == BitnamesOperationPhase.failed ||
+          operation.phase == BitnamesOperationPhase.cancelled) {
+        continue;
+      }
+      if (operation.type == BitnamesOperationType.registration) {
+        await _reconcileRegistration(operation);
+      } else {
+        await _reconcileProfile(operation);
+      }
     }
   }
 
-  Future<void> _saveContacts() async {
-    final setting = ChatContactsSetting(newValue: _contacts);
-    await _clientSettings.setValue(setting);
-  }
-
-  Future<void> addContact(ChatContact contact) async {
-    final existingIndex = _contacts.indexWhere((c) => c.id == contact.id);
-    if (existingIndex >= 0) {
-      _contacts[existingIndex] = contact;
-    } else {
-      _contacts.add(contact);
-    }
-    await _saveContacts();
-    notifyListeners();
-  }
-
-  Future<void> removeContact(String contactId) async {
-    _contacts.removeWhere((c) => c.id == contactId);
-    if (_selectedContact?.id == contactId) {
-      _selectedContact = null;
-    }
-    await _saveContacts();
-    notifyListeners();
-  }
-
-  /// Add contact directly from a BitnameEntry (no lookup needed)
-  Future<void> addContactFromEntry(BitnameEntry entry) async {
-    if (entry.details.encryptionPubkey == null) {
-      _error = 'BitName has no encryption key';
-      notifyListeners();
+  Future<void> _reconcileRegistration(BitnamesOperation operation) async {
+    final resolution = await _resolveOrNull(operation.bitnameHash);
+    final owned = resolution != null && await _ownsBitNameNow(operation.bitnameHash);
+    if (owned) {
+      if (operation.plaintextName != null) {
+        await _hashNameMapping.saveMapping(operation.plaintextName!, isMine: true);
+      }
+      if (operation.phase != BitnamesOperationPhase.confirmed) {
+        await _transitionOperation(
+          operation,
+          BitnamesOperationPhase.confirmed,
+          observeHeight: true,
+        );
+        await fetchIdentities();
+      }
       return;
     }
 
-    // Get an address for sending to this contact
-    final address = await bitnamesRPC.getNewAddress();
+    if (operation.phase == BitnamesOperationPhase.confirmed) {
+      await _transitionOperation(
+        operation,
+        BitnamesOperationPhase.registrationSubmitted,
+        error: 'Registration was removed by a reorg or ownership changed; no transaction was resent',
+      );
+      return;
+    }
 
-    final contact = ChatContact(
-      id: entry.hash,
-      name: entry.hash,
-      plaintextName: entry.plaintextName,
-      encryptionPubkey: entry.details.encryptionPubkey!,
-      address: address,
-      paymailFeeSats: entry.details.paymailFeeSats,
-      isManual: true,
-    );
-
-    await addContact(contact);
+    switch (operation.phase) {
+      case BitnamesOperationPhase.prepared:
+        final submitting = await _transitionOperation(
+          operation,
+          BitnamesOperationPhase.reservationSubmitting,
+          incrementAttempts: true,
+          maySpend: true,
+        );
+        try {
+          final txid = await bitnamesRPC.reserveBitName(operation.plaintextName!);
+          await _transitionOperation(
+            submitting,
+            BitnamesOperationPhase.reservationSubmitted,
+            reservationTxid: txid,
+            observeHeight: true,
+          );
+        } catch (e) {
+          await _transitionOperation(
+            submitting,
+            submitting.phase,
+            error: 'Reservation submission outcome is unknown; BitWindow will not spend again automatically: $e',
+          );
+        }
+        return;
+      case BitnamesOperationPhase.reservationSubmitting:
+        if (operation.lastError == null) {
+          await _transitionOperation(
+            operation,
+            operation.phase,
+            error: 'BitWindow restarted during reservation submission; checking ownership without resubmitting',
+          );
+        } else if (operation.lastObservedSidechainHeight != null &&
+            (_chainHealth.sidechainHeight ?? 0) >
+                operation.lastObservedSidechainHeight!) {
+          await _submitRegistration(
+            operation,
+            probingUncertainReservation: true,
+          );
+        }
+        return;
+      case BitnamesOperationPhase.reservationSubmitted:
+        final txid = operation.reservationTxid;
+        if (txid == null) {
+          await _pauseOperation(operation, 'Reservation transaction ID is missing');
+          return;
+        }
+        final status = await bitnamesRPC.transactionStatus(txid);
+        if (status == BitnamesTransactionStatus.absent) {
+          await _pauseOperation(
+            operation,
+            'Reservation is no longer in the canonical chain or mempool; retry requires fresh approval',
+          );
+          return;
+        }
+        if (status == BitnamesTransactionStatus.pending) return;
+        await _submitRegistration(operation);
+        return;
+      case BitnamesOperationPhase.registrationSubmitting:
+        if (operation.lastError == null) {
+          await _transitionOperation(
+            operation,
+            operation.phase,
+            error: 'BitWindow restarted during registration submission; checking ownership without resubmitting',
+          );
+        }
+        return;
+      case BitnamesOperationPhase.registrationSubmitted:
+        final txid = operation.txid;
+        if (txid == null) {
+          await _pauseOperation(operation, 'Registration transaction ID is missing');
+          return;
+        }
+        final status = await bitnamesRPC.transactionStatus(txid);
+        if (status == BitnamesTransactionStatus.absent) {
+          await _pauseOperation(
+            operation,
+            'Registration is no longer in the canonical chain or mempool; no transaction was resent',
+          );
+        } else if (status == BitnamesTransactionStatus.confirmed) {
+          await _pauseOperation(
+            operation,
+            'Registration transaction is confirmed but ownership is not visible; wallet reconciliation is required',
+          );
+        }
+        return;
+      case BitnamesOperationPhase.profileSubmitting:
+      case BitnamesOperationPhase.profileSubmitted:
+      case BitnamesOperationPhase.paused:
+      case BitnamesOperationPhase.failed:
+      case BitnamesOperationPhase.cancelled:
+      case BitnamesOperationPhase.confirmed:
+        return;
+    }
   }
 
-  void selectContact(ChatContact contact) {
-    _selectedContact = contact;
-    notifyListeners();
+  Future<void> _submitRegistration(
+    BitnamesOperation operation, {
+    bool probingUncertainReservation = false,
+  }) async {
+    var current = operation;
+    if (current.encryptionPubkey == null || current.signingPubkey == null) {
+      current = current.copyWith(
+        encryptionPubkey:
+            current.encryptionPubkey ??
+            await bitnamesRPC.getNewEncryptionKey(),
+        signingPubkey:
+            current.signingPubkey ?? await bitnamesRPC.getNewVerifyingKey(),
+        updatedAt: _now(),
+      );
+      await _putOperation(current);
+    }
+    final submitting = await _transitionOperation(
+      current,
+      BitnamesOperationPhase.registrationSubmitting,
+      incrementAttempts: true,
+      maySpend: true,
+    );
+    try {
+      final txid = await bitnamesRPC.registerBitName(
+        current.plaintextName!,
+        BitNameData(
+          encryptionPubkey: current.encryptionPubkey,
+          signingPubkey: current.signingPubkey,
+          paymailFeeSats: current.introductionFeeSats,
+        ),
+      );
+      await _transitionOperation(
+        submitting,
+        BitnamesOperationPhase.registrationSubmitted,
+        txid: txid,
+        observeHeight: true,
+      );
+    } catch (e) {
+      final missingReservation =
+          probingUncertainReservation &&
+          RegExp(
+            'reservation|missing bitname|not found',
+            caseSensitive: false,
+          ).hasMatch('$e');
+      await _transitionOperation(
+        submitting,
+        missingReservation
+            ? BitnamesOperationPhase.reservationSubmitting
+            : BitnamesOperationPhase.registrationSubmitting,
+        observeHeight: true,
+        error: missingReservation
+            ? 'No confirmed reservation was found at sidechain block '
+                  '${_chainHealth.sidechainHeight ?? 'unknown'}; waiting without resubmitting'
+            : 'Registration submission outcome is unknown; BitWindow will not spend again automatically: $e',
+      );
+    }
+  }
+
+  Future<void> _reconcileProfile(BitnamesOperation operation) async {
+    BitMessageProfile? profile;
+    try {
+      profile =
+          operation.profile == null
+              ? _profiles[operation.bitnameHash]
+              : BitMessageProfile.fromJson(operation.profile!);
+    } catch (_) {}
+    if (profile == null) {
+      await _pauseOperation(operation, 'Saved reply profile is missing or invalid');
+      return;
+    }
+    final identity =
+        _allBitNames
+            .where((entry) => entry.hash == operation.bitnameHash)
+            .firstOrNull;
+    final canonical =
+        identity != null && _profileMatchesCommitment(identity, profile);
+    if (canonical) {
+      _profiles[operation.bitnameHash] = profile;
+      _pendingProfiles.remove(operation.bitnameHash);
+      if (operation.phase != BitnamesOperationPhase.confirmed) {
+        await _transitionOperation(
+          operation,
+          BitnamesOperationPhase.confirmed,
+          observeHeight: true,
+        );
+      }
+      return;
+    }
+
+    _pendingProfiles.add(operation.bitnameHash);
+    if (operation.phase == BitnamesOperationPhase.confirmed) {
+      await _transitionOperation(
+        operation,
+        BitnamesOperationPhase.profileSubmitted,
+        error: 'Reply-profile confirmation was removed by a reorg or replaced; messaging remains locked',
+      );
+      return;
+    }
+    if (operation.phase == BitnamesOperationPhase.profileSubmitting) {
+      if (operation.lastError == null) {
+        await _transitionOperation(
+          operation,
+          operation.phase,
+          error: 'BitWindow restarted during reply-profile submission; checking the chain without resubmitting',
+        );
+      }
+      return;
+    }
+    if (operation.phase != BitnamesOperationPhase.profileSubmitted) return;
+    final txid = operation.txid;
+    if (txid == null) {
+      await _pauseOperation(operation, 'Reply-profile transaction ID is missing');
+      return;
+    }
+    final status = await bitnamesRPC.transactionStatus(txid);
+    if (status == BitnamesTransactionStatus.absent) {
+      await _pauseOperation(
+        operation,
+        'Reply-profile transaction is no longer canonical; no transaction was resent',
+      );
+    } else if (status == BitnamesTransactionStatus.confirmed) {
+      await _pauseOperation(
+        operation,
+        'Reply-profile transaction confirmed but its commitment is not current; another update may have replaced it',
+      );
+    }
+  }
+
+  Future<void> _pauseOperation(
+    BitnamesOperation operation,
+    String reason,
+  ) =>
+      _transitionOperation(operation, BitnamesOperationPhase.paused, error: reason);
+
+  Future<BitNameResolution?> _resolveOrNull(String bitname) async {
+    try {
+      return await bitnamesRPC.resolveBitName(bitname);
+    } catch (e) {
+      if (e.toString().toLowerCase().contains('missing bitname')) return null;
+      rethrow;
+    }
+  }
+
+  Future<ChatSendResult> send(String body) async {
+    if (_selectedContact?.relationshipState == ChatRelationshipState.accepted) {
+      return _sendDirect(body, BitIntroductionKind.message, _selectedContact!.introductionId);
+    }
+    return sendIntroduction(body);
+  }
+
+  Future<ChatSendResult> sendIntroduction(String body) async {
+    final contact = _selectedContact;
+    if (_isSending) return _failed('A message is already being sent');
+    if (contact == null || contact.relationshipState != ChatRelationshipState.none) {
+      return _failed('A new introduction is not allowed for this contact'); }
+    _isSending = true; _changed();
+    try {
+      final ctx = await _context();
+      final fee = ctx?.remote.data.paymailFeeSats;
+      if (ctx == null) {
+        return _failed(_error ?? 'Publish the reply profile in Messaging setup and wait for its BitNames block');
+      }
+      if (fee != ctx.contact.paymailFeeSats) {
+        await addContact(ChatContact(id: ctx.contact.id, localBitname: ctx.contact.localBitname,
+          name: ctx.contact.name, plaintextName: ctx.contact.plaintextName,
+          encryptionPubkey: ctx.remote.data.encryptionPubkey!, signingPubkey: ctx.remote.data.signingPubkey,
+          address: ctx.remote.address, paymailFeeSats: fee, isManual: ctx.contact.isManual));
+        if (fee == null) return _failed('Recipient is not accepting introductions');
+        return _failed('The introduction fee changed to $fee sats; review and confirm it again');
+      }
+      if (fee == null) return _failed('Recipient is not accepting introductions');
+      if (!await _mutationAllowed()) return _failed(_error!);
+      final prepared = await _prepare(ctx, body, BitIntroductionKind.introduction, null, true);
+      final id = prepared.$1.payload.id, pending = _message(prepared.$1, true, ChatTransport.bitnamesChain, null, fee)
+        .copyWith(deliveryState: ChatDeliveryState.pending);
+      _pendingWires[id] = prepared.$2;
+      final contact = ctx.contact.copyWith(address: ctx.remote.address,
+        relationshipState: ChatRelationshipState.outgoingIntroduction, introductionId: prepared.$1.payload.id);
+      _storeContactInMemory(contact); _storeMessageInMemory(pending); await _save(); _changed();
+      try { final txid = await bitnamesRPC.transferIdempotent(idempotencyKey: id, dest: ctx.remote.address,
+        value: fee, fee: minerFeeSats, memo: prepared.$2.ciphertext);
+        await _putMessage(pending.copyWith(txid: txid));
+        return ChatSendResult(ChatSendDisposition.sent, id: id, reference: txid);
+      } catch (e) { return ChatSendResult(ChatSendDisposition.failed, id: id,
+        error: 'Introduction is queued and will retry when BitNames reconnects: $e'); }
+    } catch (e) { return _failed('Could not send introduction: $e'); }
+    finally { _isSending = false; _changed(); }
+  }
+
+  Future<ChatSendResult> _sendDirect(String body, BitIntroductionKind kind, String? reply) async {
+    if (!privateStorageReady) {
+      return _failed('${storageStatus.summary}. ${storageStatus.details ?? 'Unlock the wallet before messaging'}');
+    }
+    final ctx = await _context();
+    final accepting = kind == BitIntroductionKind.acceptance &&
+        ctx?.contact.relationshipState == ChatRelationshipState.incomingIntroduction;
+    if (ctx == null) {
+      return _failed(_error ?? 'Publish the reply profile in Messaging setup and wait for its BitNames block');
+    }
+    if (!ctx.contact.isAccepted && !accepting) return _failed('Chat is not accepted');
+    final remoteProfile = _profile(ctx.contact);
+    if (remoteProfile == null) return _failed('This contact has not published a verified reply profile');
+    late (SignedBitIntroductionEnvelope, BitMessageWire) prepared;
+    try { prepared = await _prepare(ctx, body, kind, reply, true); }
+    catch (e) { return _failed('Could not prepare message: $e'); }
+    final transport = _torOnly ? ChatTransport.tor : ChatTransport.direct;
+    final pending = _message(prepared.$1, true, transport)
+        .copyWith(deliveryState: ChatDeliveryState.pending);
+    _pendingWires[prepared.$1.payload.id] = prepared.$2;
+    _storeMessageInMemory(pending);
+    await _save();
+    try {
+      VerifiedBitMessageProfile verified;
+      try { verified = await _verifier.verify(remoteProfile); }
+      catch (_) { final current = await _transport.discoverProfile(remoteProfile, torOnly: _torOnly);
+        if (current == null) rethrow; verified = await _verifier.verify(current);
+        await _putContact(ctx.contact.copyWith(encryptionPubkey: current.encryptionPublicKey,
+          signingPubkey: current.signingPublicKey, replyProfile: current.toJson())); }
+      await _transport.send(prepared.$2, verified, torOnly: _torOnly);
+      _pendingWires.remove(prepared.$1.payload.id);
+      _storeMessageInMemory(_message(prepared.$1, true, transport));
+      if (accepting) {
+        _storeContactInMemory(
+          ctx.contact.copyWith(relationshipState: ChatRelationshipState.accepted),
+        );
+      }
+      await _save(); _changed();
+      return ChatSendResult(ChatSendDisposition.sent, id: prepared.$1.payload.id);
+    } catch (e) {
+      _storeMessageInMemory(_message(prepared.$1, true, transport, null, null, '$e'));
+      await _save(); _changed();
+      return ChatSendResult(ChatSendDisposition.needsChainConfirmation, id: prepared.$1.payload.id, error: '$e');
+    }
+  }
+
+  Future<ChatSendResult> acceptIntroduction() async {
+    if (_isSending) return _failed('A message is already being sent');
+    final contact = _selectedContact;
+    if (contact?.relationshipState != ChatRelationshipState.incomingIntroduction) return _failed('No introduction to accept');
+    if (_messages.any((m) => m.kind == ChatMessageKind.acceptance && m.senderBitname == contact!.localBitname &&
+        m.recipientBitname == contact.id && _pendingWires.containsKey(m.id))) {
+      return _failed('Retry or reject the pending acceptance first'); }
+    _isSending = true; _changed();
+    try { return await _sendDirect('accepted', BitIntroductionKind.acceptance, contact!.introductionId);
+    } finally { _isSending = false; _changed(); }
+  }
+
+  Future<void> rejectIntroduction() => _setRelationship(ChatRelationshipState.rejected);
+  Future<void> cancelIntroduction() async {
+    final contact = _selectedContact;
+    if (_isSending || contact?.relationshipState != ChatRelationshipState.outgoingIntroduction) return;
+    final id = contact!.introductionId;
+    _pendingWires.remove(id);
+    _messages.removeWhere((m) => m.id == id && m.localBitname == contact.localBitname);
+    await _putContact(contact.copyWith(
+      relationshipState: ChatRelationshipState.rejected, clearIntroductionId: true));
+    await _save();
+  }
+  Future<void> blockContact() => _setRelationship(ChatRelationshipState.blocked);
+  Future<void> _setRelationship(ChatRelationshipState state) async {
+    if (!_isSending && _selectedContact != null) await _putContact(_selectedContact!.copyWith(relationshipState: state));
+  }
+
+  Future<ChatSendResult> sendViaChain(String id) async {
+    if (_isSending) return _failed('A message is already being sent');
+    final wire = _pendingWires[id];
+    final message = _messages.where((m) => m.id == id && m.localBitname == _selectedIdentity?.hash).firstOrNull;
+    final contact = message == null ? null : _find(message.senderBitname, message.recipientBitname);
+    final accepting = message?.kind == ChatMessageKind.acceptance &&
+        contact?.relationshipState == ChatRelationshipState.incomingIntroduction;
+    final allowed = message?.kind == ChatMessageKind.acceptance ? accepting : contact?.isAccepted == true;
+    if (wire == null || message == null || !allowed ||
+        message.kind == ChatMessageKind.introduction) { return _failed('Chain fallback is only available after acceptance'); }
+    _isSending = true; _changed();
+    try {
+      if (!await _mutationAllowed()) return _failed(_error!);
+      if (!await _ownsBitNameNow(message.senderBitname)) throw StateError('The sending BitName is no longer owned');
+      final remote = await bitnamesRPC.resolveBitName(message.recipientBitname);
+      if (remote == null) throw StateError('Recipient is not registered');
+      final pending = ChatMessage(id: message.id, content: message.content, senderBitname: message.senderBitname,
+          recipientBitname: message.recipientBitname, timestamp: message.timestamp, isOutgoing: true,
+          kind: message.kind, deliveryState: ChatDeliveryState.pending, transport: ChatTransport.bitnamesChain,
+          introductionId: message.introductionId, valueSats: fallbackValueSats);
+      _storeMessageInMemory(pending);
+      if (accepting) {
+        _storeContactInMemory(
+          contact!.copyWith(relationshipState: ChatRelationshipState.acceptancePending),
+        );
+      }
+      await _save(); _changed();
+      final txid = await bitnamesRPC.transferIdempotent(idempotencyKey: id, dest: remote.address,
+        value: fallbackValueSats, fee: minerFeeSats, memo: wire.ciphertext);
+      await _putMessage(pending.copyWith(txid: txid));
+      return ChatSendResult(ChatSendDisposition.sent, id: id, reference: txid);
+    } catch (e) { return ChatSendResult(ChatSendDisposition.needsChainConfirmation, id: id, error: '$e'); }
+    finally { _isSending = false; _changed(); }
   }
 
   Future<void> fetchPaymail() async {
-    if (!bitnamesRPC.connected || _selectedIdentity == null) return;
-
+    if (_polling || !bitnamesRPC.connected) return;
+    _polling = true;
     try {
-      final paymail = await bitnamesRPC.getPaymail();
-      await _processPaymail(paymail);
-    } catch (e) {
-      _error = 'Failed to fetch paymail: $e';
-      notifyListeners();
-    }
-  }
-
-  Future<void> _processPaymail(Map<String, dynamic> paymail) async {
-    if (paymail.isEmpty || _selectedIdentity == null) return;
-
-    final myEncryptionPubkey = _selectedIdentity!.details.encryptionPubkey;
-    if (myEncryptionPubkey == null) return;
-
-    for (final entry in paymail.entries) {
-      final outpointKey = entry.key;
-      final data = entry.value as Map<String, dynamic>;
-
-      // Skip if we already have this message
-      if (_messages.any((m) => m.id == outpointKey)) continue;
-
-      final senderAddress = data['address'] as String;
-      final content = data['content'] as Map<String, dynamic>;
-      final memoBytes = data['memo'] as List<dynamic>;
-
-      // Skip if no memo (no message content)
-      if (memoBytes.isEmpty) continue;
-
-      // Extract value from content (BitcoinSats format)
-      int? valueSats;
-      if (content.containsKey('BitcoinSats')) {
-        valueSats = content['BitcoinSats'] as int?;
-      }
-
-      // Convert memo bytes to hex string (ciphertext)
-      final ciphertext = memoBytes.map((b) => (b as int).toRadixString(16).padLeft(2, '0')).join();
-
-      try {
-        // Decrypt the message using our encryption key
-        final plaintext = await bitnamesRPC.decryptMsg(
-          ciphertext: ciphertext,
-          encryptionPubkey: myEncryptionPubkey,
-        );
-
-        // Create ChatMessage
-        final message = ChatMessage(
-          id: outpointKey,
-          content: plaintext,
-          senderPubkey: senderAddress,
-          recipientPubkey: myEncryptionPubkey,
-          timestamp: DateTime.now(),
-          isOutgoing: false,
-          txid: outpointKey,
-          valueSats: valueSats,
-        );
-        _messages.add(message);
-
-        // Update contact's last message if we have them as a contact
-        final contactIndex = _contacts.indexWhere((c) => c.address == senderAddress);
-        if (contactIndex >= 0) {
-          _contacts[contactIndex] = _contacts[contactIndex].copyWith(
-            lastMessage: plaintext,
-            lastMessageTime: DateTime.now(),
-          );
-          await _saveContacts();
+      await _recoverDirectSubmissions();
+      await _recoverChainSubmissions();
+      await _confirmAcceptances();
+      final mailbox = await bitnamesRPC.getPaymailEntries(), validatedChainIds = <String>{};
+      for (final mail in mailbox) {
+        for (final recipient in mail.recipients.where((r) => _ownedHashes.contains(r.bitname))) {
+          try { if (await receiveWire(
+            BitMessageWire(recipientBitNameHash: recipient.bitname, ciphertext: mail.output.memoHex), ChatTransport.bitnamesChain,
+            value: mail.valueSats, requiredFee: recipient.requiredFeeSats, recipientData: recipient.data,
+            reference: canonicalJsonEncode(mail.outpoint), blockHash: mail.blockHash, txIndex: mail.txIndex, validatedChainIds: validatedChainIds,
+          )) { break; } } catch (e) { _fail('Could not receive chain message: $e'); }
         }
-      } catch (e) {
-        // Failed to decrypt - may not be intended for us or invalid
       }
+      await _reconcileChain(validatedChainIds);
+    } catch (e) { _fail('Could not poll BitIntroduction messages: $e');
+    } finally {
+      _polling = false;
     }
-
-    notifyListeners();
   }
 
-  Future<String?> sendMessage(String content) async {
-    if (_selectedContact == null || _selectedIdentity == null) {
-      _error = 'No contact or identity selected';
-      notifyListeners();
-      return null;
-    }
-
-    if (_selectedIdentity!.details.encryptionPubkey == null) {
-      _error = 'Selected identity has no encryption key';
-      notifyListeners();
-      return null;
-    }
-
-    _isSending = true;
-    _error = null;
-    notifyListeners();
-
-    try {
-      // 1. Encrypt the message with recipient's pubkey
-      final ciphertext = await bitnamesRPC.encryptMsg(
-        msg: content,
-        encryptionPubkey: _selectedContact!.encryptionPubkey,
-      );
-
-      // 2. Send as transfer with memo
-      final txid = await bitnamesRPC.transfer(
-        dest: _selectedContact!.address,
-        value: _selectedContact!.paymailFeeSats ?? 1000,
-        fee: 100,
-        memo: ciphertext,
-      );
-
-      // 3. Add to local message list
-      final message = ChatMessage(
-        id: txid,
-        content: content,
-        senderPubkey: _selectedIdentity!.details.encryptionPubkey!,
-        recipientPubkey: _selectedContact!.encryptionPubkey,
-        timestamp: DateTime.now(),
-        isOutgoing: true,
-        txid: txid,
-        valueSats: _selectedContact!.paymailFeeSats ?? 1000,
-      );
-      _messages.add(message);
-
-      // 4. Update contact's last message
-      final contactIndex = _contacts.indexWhere((c) => c.id == _selectedContact!.id);
-      if (contactIndex >= 0) {
-        _contacts[contactIndex] = _contacts[contactIndex].copyWith(
-          lastMessage: content,
-          lastMessageTime: DateTime.now(),
+  Future<void> _recoverDirectSubmissions() async {
+    final pending = _messages.where(
+      (message) =>
+          message.isOutgoing &&
+          message.transport != ChatTransport.bitnamesChain &&
+          message.deliveryState == ChatDeliveryState.pending &&
+          _pendingWires.containsKey(message.id),
+    ).toList();
+    for (final message in pending) {
+      final contact = _find(message.senderBitname, message.recipientBitname);
+      final profile = _profile(contact);
+      try {
+        if (message.transport == ChatTransport.direct && _torOnly) {
+          throw StateError('Direct retry blocked because Tor-only mode is enabled');
+        }
+        if (contact == null || profile == null) {
+          throw StateError('The saved contact reply profile is unavailable');
+        }
+        final verified = await _verifier.verify(profile);
+        await _transport.send(
+          _pendingWires[message.id]!,
+          verified,
+          torOnly: message.transport == ChatTransport.tor,
         );
-        await _saveContacts();
+        _pendingWires.remove(message.id);
+        _storeMessageInMemory(
+          message.copyWith(deliveryState: ChatDeliveryState.confirmed),
+        );
+        if (message.kind == ChatMessageKind.acceptance &&
+            contact.relationshipState ==
+                ChatRelationshipState.incomingIntroduction) {
+          _storeContactInMemory(
+            contact.copyWith(relationshipState: ChatRelationshipState.accepted),
+          );
+        }
+        await _save();
+      } catch (e) {
+        _storeMessageInMemory(
+          message.copyWith(
+            deliveryState: ChatDeliveryState.failed,
+            error: 'Interrupted delivery was not retried successfully: $e',
+          ),
+        );
+        await _save();
       }
-
-      notifyListeners();
-      return txid;
-    } catch (e) {
-      _error = 'Failed to send message: $e';
-      notifyListeners();
-      return null;
-    } finally {
-      _isSending = false;
-      notifyListeners();
     }
+    if (pending.isNotEmpty) _changed();
+  }
+
+  Future<void> _confirmAcceptances() async {
+    for (final message in _messages.where((m) => m.kind == ChatMessageKind.acceptance && m.txid != null)) {
+      final contact = _find(message.senderBitname, message.recipientBitname);
+      if (!{ChatRelationshipState.incomingIntroduction, ChatRelationshipState.acceptancePending}.contains(contact?.relationshipState)) continue;
+      try { if (await bitnamesRPC.isTransactionConfirmed(message.txid!)) {
+        await _putContact(contact!.copyWith(relationshipState: ChatRelationshipState.accepted)); } } catch (_) {}
+    }
+  }
+
+  Future<void> _recoverChainSubmissions() async {
+    for (final message in _messages.where((m) => m.isOutgoing && m.transport == ChatTransport.bitnamesChain && _pendingWires.containsKey(m.id)).toList()) {
+      try {
+        final status = message.txid == null ? BitnamesTransactionStatus.absent : await bitnamesRPC.transactionStatus(message.txid!);
+        if (status == BitnamesTransactionStatus.confirmed) {
+          await _putMessage(message.copyWith(deliveryState: ChatDeliveryState.confirmed)); continue; }
+        if (status == BitnamesTransactionStatus.pending || !await _mutationAllowed() || !await _ownsBitNameNow(message.senderBitname)) continue;
+        final remote = await bitnamesRPC.resolveBitName(message.recipientBitname); if (remote == null) continue;
+        if (message.kind == ChatMessageKind.introduction && remote.data.paymailFeeSats != message.valueSats) continue;
+        final txid = await bitnamesRPC.transferIdempotent(idempotencyKey: message.id, dest: remote.address,
+          value: message.valueSats!, fee: minerFeeSats, memo: _pendingWires[message.id]!.ciphertext);
+        await _putMessage(message.copyWith(txid: txid, deliveryState: ChatDeliveryState.pending));
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _reconcileChain(Set<String> validatedChainIds) async {
+    final valid = <String>{}, auth = _messages.where((m) => m.transport == ChatTransport.bitnamesChain).toList();
+    for (final message in auth) { try { if (message.txid != null &&
+      (message.isOutgoing ? await bitnamesRPC.isTransactionConfirmed(message.txid!) : validatedChainIds.contains(message.id))) { valid.add(message.id); } } catch (_) {} }
+    for (final message in auth.where((message) => message.isOutgoing)) {
+      final state = valid.contains(message.id)
+          ? ChatDeliveryState.confirmed
+          : ChatDeliveryState.pending;
+      if (message.deliveryState != state) {
+        await _putMessage(message.copyWith(deliveryState: state));
+      }
+    }
+    for (final contact in _contacts) {
+      if ({ChatRelationshipState.blocked, ChatRelationshipState.rejected}.contains(contact.relationshipState)) continue;
+      final intro = _messages.where((m) => m.id == contact.introductionId && m.localBitname == contact.localBitname && m.kind == ChatMessageKind.introduction).firstOrNull;
+      if (intro == null) continue;
+      final canonical = valid.contains(intro.id), acceptances = _messages.where((m) => m.localBitname == contact.localBitname && m.kind == ChatMessageKind.acceptance && m.introductionId == intro.id);
+      final accepted = canonical && acceptances.any((m) => m.deliveryState == ChatDeliveryState.confirmed && (m.transport != ChatTransport.bitnamesChain || valid.contains(m.id)));
+      final pending = canonical && acceptances.any((m) => m.isOutgoing && m.transport == ChatTransport.bitnamesChain && !valid.contains(m.id));
+      final state = accepted ? ChatRelationshipState.accepted : !canonical ? (intro.isOutgoing ? ChatRelationshipState.outgoingIntroduction : ChatRelationshipState.none) : intro.isOutgoing ? ChatRelationshipState.outgoingIntroduction : pending ? ChatRelationshipState.acceptancePending : ChatRelationshipState.incomingIntroduction;
+      if (state != contact.relationshipState) await _putContact(contact.copyWith(relationshipState: state));
+    }
+    _messages.removeWhere((m) => auth.contains(m) && !m.isOutgoing && !valid.contains(m.id)); await _save();
+  }
+
+  Future<bool> receiveWire(
+    BitMessageWire wire,
+    ChatTransport transport, {
+    int? value,
+    int? requiredFee,
+    BitNameData? recipientData,
+    String? reference,
+    String? blockHash,
+    int? txIndex, Set<String>? validatedChainIds,
+  }) async {
+    bool reject(String reason) { if (transport == ChatTransport.bitnamesChain) throw FormatException(reason); return false; }
+    if (!privateStorageReady) return reject('private chat storage is locked or unavailable');
+    if (!_ownedHashes.contains(wire.recipientBitNameHash)) return reject('recipient BitName is not owned');
+    final data = recipientData ?? (await bitnamesRPC.resolveBitName(wire.recipientBitNameHash))?.data;
+    if (data?.encryptionPubkey == null || data?.signingPubkey == null) return reject('recipient profile has no messaging keys');
+    final recipient = _synthetic(wire.recipientBitNameHash, data!);
+    final envelope = await _codec.openWire(wire: wire, recipientProfile: recipient);
+    final payload = envelope.payload;
+    if (utf8.encode(payload.body).length > maxMessageBytes) return reject('message is oversized');
+    final existing = _find(payload.recipientBitNameHash, payload.senderBitNameHash);
+    if (existing?.relationshipState == ChatRelationshipState.blocked) return reject('sender is blocked');
+    if (payload.kind == BitIntroductionKind.introduction &&
+        (transport != ChatTransport.bitnamesChain || requiredFee == null || value != requiredFee)) { return reject('introduction payment does not match the advertised fee'); }
+    if (payload.kind != BitIntroductionKind.introduction &&
+        transport == ChatTransport.bitnamesChain && value != fallbackValueSats) { return reject('fallback payment is not 1 sat'); }
+    final claimed = payload.replyProfile ?? _profile(existing);
+    if (claimed == null) return reject('sender supplied no reply profile');
+    final historical = blockHash == null || txIndex == null ? null :
+        await bitnamesRPC.bitNameDataAtPosition(payload.senderBitNameHash, blockHash, txIndex);
+    final sender = historical == null ? await _verifier.verify(claimed) :
+        _verifier.verifyAt(claimed, historical, '$blockHash:$txIndex');
+    await _codec.verify(envelope, senderProfile: sender, verifiedReplyProfile: historical == null ? null : sender);
+    final duplicate = _messages.where((m) => m.id == payload.id && m.localBitname == wire.recipientBitNameHash).firstOrNull;
+    if (duplicate != null) { final same = duplicate.senderBitname == payload.senderBitNameHash &&
+        duplicate.recipientBitname == payload.recipientBitNameHash && duplicate.content == payload.body &&
+        duplicate.kind.index == payload.kind.index && duplicate.timestamp.millisecondsSinceEpoch == payload.timestamp.millisecondsSinceEpoch;
+      if (same) validatedChainIds?.add(payload.id); return same; }
+    final state = switch (payload.kind) {
+      BitIntroductionKind.introduction when existing == null || existing.relationshipState == ChatRelationshipState.none ||
+              existing.relationshipState == ChatRelationshipState.rejected =>
+        ChatRelationshipState.incomingIntroduction,
+      BitIntroductionKind.acceptance when existing?.relationshipState == ChatRelationshipState.outgoingIntroduction &&
+              existing?.introductionId == payload.inReplyTo =>
+        ChatRelationshipState.accepted,
+      BitIntroductionKind.message when existing?.isAccepted == true && existing?.introductionId == payload.inReplyTo =>
+        ChatRelationshipState.accepted,
+      _ => null,
+    };
+    if (state == null) return reject('message is invalid for the current relationship state');
+    final senderResolution = await bitnamesRPC.resolveBitName(payload.senderBitNameHash);
+    if (senderResolution == null) return reject('sender BitName is not registered');
+    final base = existing ?? ChatContact(id: payload.senderBitNameHash, localBitname: payload.recipientBitNameHash,
+      name: payload.senderBitNameHash,
+      plaintextName: _allBitNames.where((entry) => entry.hash == payload.senderBitNameHash).firstOrNull?.plaintextName,
+      encryptionPubkey: sender.encryptionPublicKey);
+    _storeContactInMemory(base.copyWith(address: senderResolution.address, signingPubkey: sender.signingPublicKey,
+      relationshipState: state, introductionId: payload.kind == BitIntroductionKind.introduction ? payload.id : existing?.introductionId,
+      replyProfile: sender.profile.toJson(), lastMessage: payload.body, lastMessageTime: payload.timestamp));
+    _storeMessageInMemory(_message(envelope, false, transport, reference, value));
+    await _save(); _changed();
+    validatedChainIds?.add(payload.id); return true;
+  }
+
+  Future<_Context?> _context() async {
+    final me = _selectedIdentity, contact = _selectedContact;
+    if (me == null || contact == null || !_ownedHashes.contains(me.hash) || contact.localBitname != me.hash) return null;
+    final profile = _profiles[me.hash];
+    if (profile == null || _pendingProfiles.contains(me.hash)) {
+      _fail('Publish the reply profile in Messaging setup and wait for its BitNames block'); return null;
+    }
+    try {
+      if (!await _ownsBitNameNow(me.hash)) throw StateError('The selected BitName is no longer owned');
+      final self = await _verifier.verify(profile);
+      final remote = await bitnamesRPC.resolveBitName(contact.id);
+      if (remote?.data.encryptionPubkey == null || remote?.data.signingPubkey == null) return null;
+      return _Context(contact, self, remote!, _synthetic(contact.id, remote.data));
+    } catch (e) {
+      _fail('Could not verify messaging profiles: $e'); return null;
+    }
+  }
+
+  Future<(SignedBitIntroductionEnvelope, BitMessageWire)> _prepare(
+    _Context ctx,
+    String body,
+    BitIntroductionKind kind,
+    String? reply,
+    bool includeProfile,
+  ) async {
+    if (utf8.encode(body).length > maxMessageBytes) throw ArgumentError('Messages are limited to $maxMessageBytes UTF-8 bytes');
+    final envelope = await _codec.createSigned(id: _newId(), kind: kind, senderProfile: ctx.self,
+      recipientBitNameHash: ctx.contact.id, timestamp: _now(), body: body, inReplyTo: reply,
+      replyProfile: includeProfile ? ctx.self : null);
+    return (envelope, await _codec.createWire(envelope: envelope, recipientProfile: ctx.remoteCipher));
+  }
+
+  VerifiedBitMessageProfile _synthetic(String hash, BitNameData data) {
+    final profile = BitMessageProfile(bitNameHash: hash, signingPublicKey: data.signingPubkey!,
+      encryptionPublicKey: data.encryptionPubkey!, paymailFeeSats: data.paymailFeeSats);
+    return VerifiedBitMessageProfile.verified(profile: profile,
+      onChainCommitment: bitMessageProfileCommitment(profile), verificationReference: 'encryption-only');
+  }
+
+  BitMessageProfile? _profile(ChatContact? contact) {
+    try {
+      return contact?.replyProfile == null ? null : BitMessageProfile.fromJson(contact!.replyProfile!);
+    } catch (_) { return null; }
+  }
+
+  Future<bool> _ownsBitNameNow(String hash) async => (await bitnamesRPC.listUTXOs()).any((utxo) {
+    if (utxo is! BitnamesUTXO || utxo.type != OutpointType.bitname) return false;
+    try { return (jsonDecode(utxo.content) as Map<String, dynamic>)['BitName'] == hash; } catch (_) { return false; }
+  });
+  ChatContact? _find(String local, String remote) =>
+      _contacts.where((c) => c.localBitname == local && c.id == remote).firstOrNull;
+  Iterable<ChatMessage> _conversation(String local, String remote) =>
+      _messages.where((message) => message.localBitname == local &&
+          ((message.senderBitname == local && message.recipientBitname == remote) ||
+           (message.senderBitname == remote && message.recipientBitname == local)));
+  String _identityLabel(BitnameEntry identity) => identity.plaintextName ?? '${identity.hash.substring(0, 8)}…';
+  String _short(String value) => value.length <= 12 ? value : '${value.substring(0, 12)}…';
+  bool _profileMatchesCommitment(BitnameEntry identity, BitMessageProfile profile) =>
+      assessBitMessageProfileCommitment(
+        profile: profile,
+        onChainCommitment: identity.details.commitment,
+        network: _commitmentNetwork,
+      ).verified;
+
+  ChatMessage _message(
+    SignedBitIntroductionEnvelope envelope,
+    bool outgoing,
+    ChatTransport transport, [
+    String? reference,
+    int? value,
+    String? error,
+  ]) {
+    final p = envelope.payload;
+    return ChatMessage(id: p.id, content: p.body, senderBitname: p.senderBitNameHash,
+      recipientBitname: p.recipientBitNameHash, timestamp: p.timestamp, isOutgoing: outgoing,
+      kind: ChatMessageKind.values[BitIntroductionKind.values.indexOf(p.kind)],
+      deliveryState: error == null ? ChatDeliveryState.confirmed : ChatDeliveryState.failed,
+      transport: transport, introductionId: p.kind == BitIntroductionKind.introduction ? p.id : p.inReplyTo,
+      txid: reference, valueSats: value, error: error);
+  }
+
+  Future<void> _putMessage(ChatMessage message) async {
+    _storeMessageInMemory(message);
+    await _save(); _changed();
+  }
+
+  void _storeMessageInMemory(ChatMessage message) {
+    final index = _messages.indexWhere((m) => m.id == message.id && m.localBitname == message.localBitname);
+    index < 0 ? _messages.add(message) : _messages[index] = message;
+  }
+
+  Future<bool> _mutationAllowed() async {
+    if (!privateStorageReady) {
+      _fail('${storageStatus.summary}. ${storageStatus.details ?? 'Unlock the wallet before continuing'}');
+      return false;
+    }
+    if (_enforcer != null) {
+      final observedAt = _chainHealth.observedAt;
+      final stale =
+          observedAt == null ||
+          _now().difference(observedAt) > pollInterval;
+      if ((stale || !_chainHealth.mutationSafe) &&
+          !await _refreshChainHealth()) {
+        _fail('${_chainHealth.summary}. ${_chainHealth.details}');
+        return false;
+      }
+    }
+    if (!_torOnly) return true;
+    final guard = _torMutationGuard;
+    if (guard != null) {
+      final reason = await guard();
+      if (reason == null) return true;
+      _fail(reason); return false;
+    }
+    if (await _tor?.chainTorReady(bitnamesRPC) ?? false) return true;
+    _fail('Tor-only BitNames writes require --tor-proxy-mode and a connected loopback UDP tunnel peer'); return false;
+  }
+
+  Map<String, dynamic> _snapshot() => {
+      'contacts': _contacts.map((e) => e.toJson()).toList(),
+      'messages': _messages.map((e) => e.toJson()).toList(),
+      'profiles': _profiles.values.map((e) => e.toJson()).toList(),
+      'pending_profiles': _pendingProfiles.toList(),
+      'pending_wires': _pendingWires.map((k, v) => MapEntry(k, v.toJson())),
+      'operations': _operations.values.map((e) => e.toJson()).toList(),
+      'chain_health': _chainHealth.toJson(),
+      'owned': _ownedHashes.toList(),
+      'tor_only': _torOnly,
+      if (_selectedIdentity != null) 'selected_identity': _selectedIdentity!.hash,
+      if (_torPeerOnion != null) 'tor_peer': _torPeerOnion,
+    };
+
+  Future<void> _save() {
+    if (!privateStorageReady) {
+      throw BitnamesStorageException(
+        '${storageStatus.summary}. ${storageStatus.details ?? 'Unlock the wallet before changing private BitNames data'}',
+      );
+    }
+    return _saveLock.synchronized(
+      () => _secureStore.save(_snapshot()),
+    );
+  }
+
+  Future<String> exportPrivateData() => _secureStore.exportEncrypted();
+
+  Future<void> restorePrivateData(String encoded) async {
+    await _saveLock.synchronized(() async {
+      await _secureStore.restoreEncrypted(encoded);
+      final state = await _secureStore.load();
+      _clearPrivateMemory();
+      _hydrate(state);
+      _restoreOperationStatuses();
+    });
+    _changed();
+  }
+
+  Future<void> clearChatHistory() async {
+    if (!privateStorageReady) {
+      throw BitnamesStorageException(storageStatus.summary);
+    }
+    await _saveLock.synchronized(() async {
+      _contacts.clear();
+      _messages.clear();
+      _pendingWires.clear();
+      _selectedContact = null;
+      await _secureStore.clear();
+      await _secureStore.save(_snapshot());
+    });
+    _changed();
+  }
+
+  List<ChatMessage> conversationPage({
+    required String localBitname,
+    required String remoteBitname,
+    int limit = 50,
+    DateTime? before,
+  }) {
+    if (limit < 1 || limit > 500) throw ArgumentError.value(limit, 'limit', 'must be between 1 and 500');
+    final messages = _conversation(localBitname, remoteBitname)
+        .where((message) => before == null || message.timestamp.isBefore(before))
+        .toList()..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    return messages.length <= limit ? messages : messages.sublist(messages.length - limit);
   }
 
   void startPolling() {
-    _pollTimer?.cancel();
-    _pollTimer = Timer.periodic(_pollInterval, (_) {
-      fetchPaymail();
-    });
+    if (!privateStorageReady) return;
+    _pollTimer ??= Timer.periodic(pollInterval, (_) => unawaited(refresh()));
   }
-
-  void stopPolling() {
-    _pollTimer?.cancel();
-    _pollTimer = null;
-  }
-
-  Future<ChatContact?> lookupBitName(String nameOrHash) async {
-    if (!bitnamesRPC.connected) return null;
-
-    try {
-      final data = await bitnamesRPC.getBitNameData(nameOrHash);
-      if (data == null || data.encryptionPubkey == null) return null;
-
-      // Get an address for this identity
-      final address = await bitnamesRPC.getNewAddress();
-
-      return ChatContact(
-        id: nameOrHash,
-        name: nameOrHash,
-        plaintextName: nameOrHash,
-        encryptionPubkey: data.encryptionPubkey!,
-        address: address,
-        paymailFeeSats: data.paymailFeeSats,
-        isManual: true,
-      );
-    } catch (e) {
-      _error = 'Failed to lookup BitName: $e';
-      notifyListeners();
-      return null;
-    }
-  }
-
-  void clearError() {
-    _error = null;
-    notifyListeners();
-  }
+  void stopPolling() { _pollTimer?.cancel(); _pollTimer = null; }
+  ChatSendResult _failed(String message) { _fail(message); return ChatSendResult(ChatSendDisposition.failed, error: message); }
+  void _fail(String? value) { _error = value; _changed(); }
+  void _changed() { if (!_disposed) notifyListeners(); }
 
   @override
   void dispose() {
-    bitnamesRPC.removeListener(_onConnectionChanged);
-    balanceProvider.removeListener(_onBalanceChanged);
+    _disposed = true;
     _pollTimer?.cancel();
+    bitnamesRPC.removeListener(_onConnectionChanged);
+    _balances?.removeListener(_onBalanceChanged);
+    _storageKeys.removeListener(_onStorageKeyChanged);
+    unawaited(_server.stop());
+    if (_ownsTransport) _transport.close();
+    _tor?.close();
     super.dispose();
   }
 }
 
-class ChatContactsSetting extends SettingValue<List<ChatContact>> {
-  ChatContactsSetting({super.newValue});
-
-  @override
-  String get key => 'chat_contacts';
-
-  @override
-  List<ChatContact> defaultValue() => [];
-
-  @override
-  String toJson() {
-    return jsonEncode(value.map((e) => e.toJson()).toList());
-  }
-
-  @override
-  List<ChatContact>? fromJson(String jsonString) {
-    try {
-      final List<dynamic> decoded = jsonDecode(jsonString);
-      return decoded.map((e) => ChatContact.fromJson(e as Map<String, dynamic>)).toList();
-    } catch (e) {
-      return null;
-    }
-  }
-
-  @override
-  SettingValue<List<ChatContact>> withValue([List<ChatContact>? value]) {
-    return ChatContactsSetting(newValue: value);
-  }
+class _Context {
+  const _Context(this.contact, this.self, this.remote, this.remoteCipher);
+  final ChatContact contact; final VerifiedBitMessageProfile self, remoteCipher; final BitNameResolution remote;
 }
 
-class OwnedBitNamesSetting extends SettingValue<List<String>> {
-  OwnedBitNamesSetting({super.newValue});
-
-  @override
-  String get key => 'owned_bitname_hashes';
-
-  @override
-  List<String> defaultValue() => [];
-
-  @override
-  String toJson() {
-    return jsonEncode(value);
-  }
-
-  @override
-  List<String>? fromJson(String jsonString) {
-    try {
-      final List<dynamic> decoded = jsonDecode(jsonString);
-      return decoded.cast<String>();
-    } catch (e) {
-      return null;
-    }
-  }
-
-  @override
-  SettingValue<List<String>> withValue([List<String>? value]) {
-    return OwnedBitNamesSetting(newValue: value);
-  }
+List<Map<String, dynamic>> _maps(Object? value) => (value as List? ?? []).map((e) => Map<String, dynamic>.from(e as Map)).toList();
+List<T> _list<T>(Object? value, T Function(Map<String, dynamic>) decode) => _maps(value).map(decode).toList();
+Uri _path(Uri uri, String hash) {
+  final base = uri.path.endsWith('/') ? uri : uri.replace(path: '${uri.path}/');
+  return base.path.endsWith('/bitname/$hash/') ? base : base.resolve('bitname/$hash/');
 }
+T? _get<T extends Object>() => GetIt.I.isRegistered<T>() ? GetIt.I.get<T>() : null;
+String _defaultCommitmentNetwork() =>
+    _get<BitcoinConfProvider>()?.network.toReadableNet() ?? 'signet';
+Future<void> _defaultRestartBitnames() async {
+  final binaries = _get<BinaryProvider>();
+  final bitnames = binaries?.binaries.whereType<BitNames>().firstOrNull;
+  if (binaries == null || bitnames == null) {
+    throw StateError('BitNames is not managed by the local orchestrator');
+  }
+  await binaries.restart(bitnames);
+}
+BitnamesTorController? _defaultTor() {
+  final orchestrator = _get<OrchestratorRPC>();
+  return orchestrator == null ? null : BitnamesTorController(orchestrator: orchestrator);
+}
+BitnamesStorageKeySource _defaultStorageKeys() {
+  final walletReader = _get<WalletReaderProvider>();
+  if (walletReader == null) {
+    throw StateError('WalletReaderProvider is required for encrypted BitNames storage');
+  }
+  return WalletBitnamesStorageKeySource(walletReader);
+}
+extension _First<T> on Iterable<T> { T? get firstOrNull => isEmpty ? null : first; }
+// dart format on

--- a/bitwindow/lib/services/bitintroduction_codec.dart
+++ b/bitwindow/lib/services/bitintroduction_codec.dart
@@ -1,0 +1,180 @@
+import 'dart:convert';
+
+import 'package:bitwindow/models/bitintroduction_protocol.dart';
+
+abstract interface class BitIntroductionSigningBackend {
+  Future<String> sign({required String signingPublicKey, required String payload});
+}
+
+abstract interface class BitIntroductionSignatureBackend {
+  Future<bool> verify({
+    required String signingPublicKey,
+    required String payload,
+    required String signature,
+  });
+}
+
+abstract interface class BitMessageProfileVerifier {
+  Future<VerifiedBitMessageProfile> verify(BitMessageProfile profile);
+}
+
+abstract interface class BitMessageCipherBackend {
+  Future<String> encrypt({required String encryptionPublicKey, required String plaintext});
+  Future<String> decrypt({required String encryptionPublicKey, required String ciphertext});
+}
+
+class VerifiedBitIntroductionEnvelope {
+  const VerifiedBitIntroductionEnvelope({
+    required this.envelope,
+    required this.senderProfile,
+    this.replyProfile,
+  });
+
+  final SignedBitIntroductionEnvelope envelope;
+  final VerifiedBitMessageProfile senderProfile;
+  final VerifiedBitMessageProfile? replyProfile;
+}
+
+class BitIntroductionEnvelopeCodec {
+  const BitIntroductionEnvelopeCodec({
+    this.signer,
+    this.signatureBackend,
+    this.profileVerifier,
+    this.cipherBackend,
+  });
+
+  final BitIntroductionSigningBackend? signer;
+  final BitIntroductionSignatureBackend? signatureBackend;
+  final BitMessageProfileVerifier? profileVerifier;
+  final BitMessageCipherBackend? cipherBackend;
+
+  Future<SignedBitIntroductionEnvelope> createSigned({
+    required String id,
+    required BitIntroductionKind kind,
+    required VerifiedBitMessageProfile senderProfile,
+    required String recipientBitNameHash,
+    required DateTime timestamp,
+    required String body,
+    String? inReplyTo,
+    VerifiedBitMessageProfile? replyProfile,
+  }) async {
+    final backend = signer ?? (throw StateError('A BitIntroductionSigningBackend is required to sign envelopes'));
+    if (replyProfile != null && replyProfile.bitNameHash != senderProfile.bitNameHash) {
+      throw ArgumentError('A reply profile must belong to the sending BitName');
+    }
+    final payload = BitIntroductionPayload(
+      id: id,
+      kind: kind,
+      senderBitNameHash: senderProfile.bitNameHash,
+      recipientBitNameHash: recipientBitNameHash,
+      timestamp: timestamp,
+      body: body,
+      inReplyTo: inReplyTo,
+      replyProfile: replyProfile?.profile,
+    );
+    final signature = await backend.sign(
+      signingPublicKey: senderProfile.signingPublicKey,
+      payload: canonicalJsonEncode(payload.toJson()),
+    );
+    return SignedBitIntroductionEnvelope(payload: payload, signature: signature);
+  }
+
+  String encode(SignedBitIntroductionEnvelope envelope) => canonicalJsonEncode(envelope.toJson());
+
+  SignedBitIntroductionEnvelope parse(String encoded) {
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(encoded);
+    } on FormatException catch (error) {
+      throw FormatException('Invalid BitIntroduction envelope JSON: ${error.message}');
+    }
+    if (decoded is! Map) throw const FormatException('BitIntroduction envelope must be an object');
+    return SignedBitIntroductionEnvelope.fromJson(Map<String, dynamic>.from(decoded));
+  }
+
+  Future<VerifiedBitIntroductionEnvelope> parseAndVerify(
+    String encoded, {
+    required VerifiedBitMessageProfile senderProfile,
+  }) => verify(parse(encoded), senderProfile: senderProfile);
+
+  Future<VerifiedBitIntroductionEnvelope> verify(
+    SignedBitIntroductionEnvelope envelope, {
+    required VerifiedBitMessageProfile senderProfile,
+    VerifiedBitMessageProfile? verifiedReplyProfile,
+  }) async {
+    final backend =
+        signatureBackend ?? (throw StateError('A BitIntroductionSignatureBackend is required to verify envelopes'));
+    if (envelope.payload.senderBitNameHash != senderProfile.bitNameHash) {
+      throw const FormatException('Envelope sender does not match the verified sender profile');
+    }
+    final valid = await backend.verify(
+      signingPublicKey: senderProfile.signingPublicKey,
+      payload: envelope.signedPayload,
+      signature: envelope.signature,
+    );
+    if (!valid) throw const FormatException('Invalid BitIntroduction signature');
+
+    VerifiedBitMessageProfile? verifiedReply;
+    final reply = envelope.payload.replyProfile;
+    if (reply != null) {
+      if (reply.bitNameHash != senderProfile.bitNameHash) {
+        throw const FormatException('Reply profile does not belong to the sender');
+      }
+      verifiedReply =
+          verifiedReplyProfile ??
+          await (profileVerifier ??
+                  (throw StateError(
+                    'A BitMessageProfileVerifier is required when an envelope carries a reply profile',
+                  )))
+              .verify(reply);
+      if (verifiedReply.bitNameHash != senderProfile.bitNameHash) {
+        throw const FormatException('Verified reply profile does not belong to the sender');
+      }
+      if (canonicalJsonEncode(verifiedReply.profile.toJson()) != canonicalJsonEncode(reply.toJson())) {
+        throw const FormatException('Verified reply profile differs from the signed profile');
+      }
+    }
+    return VerifiedBitIntroductionEnvelope(
+      envelope: envelope,
+      senderProfile: senderProfile,
+      replyProfile: verifiedReply,
+    );
+  }
+
+  Future<BitMessageWire> createWire({
+    required SignedBitIntroductionEnvelope envelope,
+    required VerifiedBitMessageProfile recipientProfile,
+  }) async {
+    final backend = cipherBackend ?? (throw StateError('A BitMessageCipherBackend is required to create a wire frame'));
+    if (envelope.payload.recipientBitNameHash != recipientProfile.bitNameHash) {
+      throw ArgumentError('Envelope recipient does not match recipientProfile');
+    }
+    return BitMessageWire(
+      recipientBitNameHash: recipientProfile.bitNameHash,
+      ciphertext: await backend.encrypt(
+        encryptionPublicKey: recipientProfile.encryptionPublicKey,
+        plaintext: encode(envelope),
+      ),
+    );
+  }
+
+  Future<SignedBitIntroductionEnvelope> openWire({
+    required BitMessageWire wire,
+    required VerifiedBitMessageProfile recipientProfile,
+  }) async {
+    final backend = cipherBackend ?? (throw StateError('A BitMessageCipherBackend is required to open a wire frame'));
+    if (wire.recipientBitNameHash != recipientProfile.bitNameHash) {
+      throw const FormatException('Wire recipient does not match the local BitName');
+    }
+    final envelope = parse(
+      await backend.decrypt(
+        encryptionPublicKey: recipientProfile.encryptionPublicKey,
+        ciphertext: wire.ciphertext,
+      ),
+    );
+    if (envelope.payload.recipientBitNameHash != wire.recipientBitNameHash) {
+      throw const FormatException('Encrypted envelope recipient does not match its outer wire');
+    }
+    return envelope;
+  }
+}

--- a/bitwindow/lib/services/bitmessage_server.dart
+++ b/bitwindow/lib/services/bitmessage_server.dart
@@ -1,0 +1,143 @@
+// dart format off
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:bitwindow/models/bitintroduction_protocol.dart';
+import 'package:bitwindow/models/bitnames_commitment.dart';
+typedef BitMessageProfileProvider = FutureOr<BitMessageProfile?> Function(String? bitNameHash);
+typedef IncomingBitMessageCallback = FutureOr<void> Function(BitMessageWire wire);
+class BitMessageServer {
+  BitMessageServer({
+    required this.profileProvider,
+    required this.onIncomingWire,
+    this.allowRemoteClients,
+    InternetAddress? bindAddress,
+    this.port = 0,
+    this.maxBodyBytes = 64 * 1024,
+    this.requestBodyTimeout = const Duration(seconds: 5),
+    this.callbackTimeout = const Duration(seconds: 10),
+    this.idleTimeout = const Duration(seconds: 15),
+    this.maxConcurrentRequests = 16,
+  }) : bindAddress = bindAddress ?? InternetAddress.loopbackIPv4 {
+    if (maxBodyBytes <= 0) throw ArgumentError.value(maxBodyBytes, 'maxBodyBytes', 'must be positive'); if (port < 0 || port > 65535) throw ArgumentError.value(port, 'port', 'must be between 0 and 65535'); if (maxConcurrentRequests < 1) throw ArgumentError.value(maxConcurrentRequests, 'maxConcurrentRequests');
+  }
+  final BitMessageProfileProvider profileProvider; final IncomingBitMessageCallback onIncomingWire;
+  final bool Function()? allowRemoteClients; final InternetAddress bindAddress;
+  final int port, maxBodyBytes; final Duration requestBodyTimeout, callbackTimeout, idleTimeout;
+  final int maxConcurrentRequests; HttpServer? _server; int _activeRequests = 0;
+  bool get isRunning => _server != null; Uri get localEndpoint {
+    final server = _server ?? (throw StateError('BitMessageServer has not been started'));
+    final address = server.address.address;
+    return Uri.parse(
+      'http://${server.address.type == InternetAddressType.IPv6 ? '[$address]' : address}:${server.port}',
+    );
+  }
+  Future<Uri> start() async {
+    if (isRunning) throw StateError('BitMessageServer is already running');
+    final server = await HttpServer.bind(bindAddress, port, shared: false);
+    server
+      ..idleTimeout = idleTimeout
+      ..autoCompress = false;
+    _server = server; server.listen((request) => unawaited(_handle(request)));
+    return localEndpoint;
+  }
+  Future<void> stop() async {
+    final server = _server; _server = null;
+    await server?.close(force: true);
+  }
+  Future<void> _handle(HttpRequest request) async {
+    if (_activeRequests >= maxConcurrentRequests) {
+      await _json(request.response, HttpStatus.serviceUnavailable, {'error': 'busy'});
+      return;
+    }
+    _activeRequests++;
+    try {
+      if (!(allowRemoteClients?.call() ?? true) && !(request.connectionInfo?.remoteAddress.isLoopback ?? false)) {
+        await _json(request.response, HttpStatus.forbidden, {'error': 'tor_only'});
+        return;
+      }
+      final commit = RegExp(r'^/bitname/([0-9a-fA-F]{64})/bitname_commit$').firstMatch(request.uri.path);
+      final submit = RegExp(r'^/bitname/([0-9a-fA-F]{64})/bitmessage_submit$').firstMatch(request.uri.path);
+      if (commit != null) {
+        if (!await _requireMethod(request, 'GET')) return;
+        await _serveProfile(request.response, commit[1]!.toLowerCase());
+      } else if (submit != null) {
+        if (!await _requireMethod(request, 'POST')) return;
+        await _accept(request, submit[1]!.toLowerCase());
+      } else if (request.uri.path == '/bitname_commit') {
+        if (!await _requireMethod(request, 'GET')) return;
+        await _serveProfile(request.response, null);
+      } else if (request.uri.path == '/bitmessage_submit') {
+        if (!await _requireMethod(request, 'POST')) return;
+        await _accept(request, null);
+      } else {
+        await _json(request.response, HttpStatus.notFound, {'error': 'not_found'});
+      }
+    } on _BodyTooLarge {
+      await _json(request.response, HttpStatus.requestEntityTooLarge, {'error': 'body_too_large'});
+    } on TimeoutException {
+      await _json(request.response, HttpStatus.requestTimeout, {'error': 'request_timeout'});
+    } on FormatException catch (error) {
+      await _json(request.response, HttpStatus.badRequest, {'error': 'invalid_request', 'detail': error.message});
+    } catch (_) {
+      await _json(request.response, HttpStatus.internalServerError, {'error': 'internal_error'});
+    } finally {
+      _activeRequests--;
+    }
+  }
+  Future<bool> _requireMethod(HttpRequest request, String method) async {
+    if (request.method == method) return true;
+    request.response.headers.set(HttpHeaders.allowHeader, method);
+    await _json(request.response, HttpStatus.methodNotAllowed, {'error': 'method_not_allowed'});
+    return false;
+  }
+  Future<void> _serveProfile(HttpResponse response, String? hash) async {
+    final profile = await Future<BitMessageProfile?>.sync(() => profileProvider(hash)).timeout(callbackTimeout);
+    if (profile == null) return _json(response, HttpStatus.notFound, {'error': 'identity_not_found'});
+    if (hash != null && profile.bitNameHash != hash) {
+      throw const FormatException('profile provider returned the wrong identity');
+    }
+    await _json(response, HttpStatus.ok, bitNamesCommitResponse(profile));
+  }
+  Future<void> _accept(HttpRequest request, String? expectedHash) async {
+    if (request.headers.contentType?.mimeType != ContentType.json.mimeType) {
+      return _json(request.response, HttpStatus.unsupportedMediaType, {'error': 'content_type_must_be_json'});
+    }
+    dynamic decoded;
+    try {
+      decoded = jsonDecode(utf8.decode(await _read(request)));
+    } on FormatException catch (error) {
+      throw FormatException('body is not valid UTF-8 JSON: $error');
+    }
+    if (decoded is! Map) throw const FormatException('body must be an object');
+    final wire = BitMessageWire.fromJson(Map<String, dynamic>.from(decoded));
+    if (expectedHash != null && wire.recipientBitNameHash != expectedHash) {
+      throw const FormatException('wire recipient does not match endpoint identity');
+    }
+    try {
+      await Future<void>.sync(() => onIncomingWire(wire)).timeout(callbackTimeout);
+    } on TimeoutException {
+      return _json(request.response, HttpStatus.gatewayTimeout, {'error': 'callback_timeout'});
+    }
+    await _json(request.response, HttpStatus.accepted, {'accepted': true});
+  }
+  Future<List<int>> _read(HttpRequest request) async {
+    if (request.contentLength > maxBodyBytes) throw const _BodyTooLarge();
+    final bytes = <int>[];
+    await (() async {
+      await for (final chunk in request) {
+        if (bytes.length + chunk.length > maxBodyBytes) throw const _BodyTooLarge();
+        bytes.addAll(chunk);
+      }
+    })().timeout(requestBodyTimeout);
+    return bytes;
+  }
+  Future<void> _json(HttpResponse response, int status, Map<String, dynamic> body) async {
+    response
+      ..statusCode = status
+      ..headers.contentType = ContentType.json;
+    response.headers.set(HttpHeaders.cacheControlHeader, 'no-store');
+    response.write(jsonEncode(body)); await response.close();
+  }
+}
+class _BodyTooLarge implements Exception { const _BodyTooLarge(); }

--- a/bitwindow/lib/services/bitmessage_transport.dart
+++ b/bitwindow/lib/services/bitmessage_transport.dart
@@ -1,0 +1,161 @@
+import 'dart:convert';
+
+import 'package:bitwindow/models/bitintroduction_protocol.dart';
+import 'package:bitwindow/models/bitnames_commitment.dart';
+import 'package:http/http.dart' as http;
+
+// dart format off
+enum BitMessageTransportType { direct, tor }
+class BitMessageHttpResponse {
+  const BitMessageHttpResponse({required this.statusCode, required this.body});
+  final int statusCode;
+  final String body;
+}
+abstract interface class BitMessageHttpDialer {
+  Future<BitMessageHttpResponse> get(Uri uri, {required Duration timeout});
+  Future<BitMessageHttpResponse> postJson(Uri uri, {required String body, required Duration timeout});
+  void close();
+}
+class DirectBitMessageHttpDialer implements BitMessageHttpDialer {
+  DirectBitMessageHttpDialer({http.Client? client}) : _client = client ?? http.Client();
+  final http.Client _client;
+
+  @override
+  Future<BitMessageHttpResponse> get(Uri uri, {required Duration timeout}) =>
+      _send(http.Request('GET', uri)..headers['accept'] = 'application/json', timeout);
+
+  @override
+  Future<BitMessageHttpResponse> postJson(
+    Uri uri, {
+    required String body,
+    required Duration timeout,
+  }) => _send(http.Request('POST', uri)
+    ..headers.addAll(const {'accept': 'application/json', 'content-type': 'application/json'})
+    ..body = body, timeout);
+
+  Future<BitMessageHttpResponse> _send(http.Request request, Duration timeout) async {
+    request.followRedirects = false;
+    final response = await _client.send(request).timeout(timeout), bytes = <int>[];
+    await response.stream.fold<void>(null, (_, chunk) {
+      if (bytes.length + chunk.length > 64 * 1024) throw StateError('HTTP response is too large');
+      bytes.addAll(chunk);
+    }).timeout(timeout);
+    return BitMessageHttpResponse(statusCode: response.statusCode, body: utf8.decode(bytes));
+  }
+
+  @override
+  void close() => _client.close();
+}
+class BitMessageSendResult {
+  const BitMessageSendResult({required this.transport, this.endpoint, this.failedAttempts = const []});
+  final BitMessageTransportType transport;
+  final Uri? endpoint;
+  final List<String> failedAttempts;
+}
+class BitMessageTransportException implements Exception {
+  const BitMessageTransportException(this.message, this.attempts);
+  final String message;
+  final List<String> attempts;
+
+  @override
+  String toString() => '$message (${attempts.join('; ')})';
+}
+
+class BitMessageTransport {
+  BitMessageTransport({
+    required this.directDialer,
+    this.torDialer,
+    this.requestTimeout = const Duration(seconds: 10),
+    this.maxProfileResponseBytes = 16 * 1024,
+  }) {
+    if (maxProfileResponseBytes <= 0) {
+      throw ArgumentError.value(maxProfileResponseBytes, 'maxProfileResponseBytes', 'must be positive');
+    }
+  }
+
+  final BitMessageHttpDialer directDialer;
+  final BitMessageHttpDialer? torDialer;
+  final Duration requestTimeout;
+  final int maxProfileResponseBytes;
+
+  Future<BitMessageSendResult> send(BitMessageWire wire, VerifiedBitMessageProfile profile,
+    {bool torOnly = false}) async {
+    if (wire.recipientBitNameHash != profile.bitNameHash) {
+      throw ArgumentError('Wire recipient does not match the verified profile');
+    }
+    final routes = _routes(profile.profile, torOnly);
+    if (torOnly && routes.isEmpty) {
+      throw const BitMessageTransportException('Tor mode is enabled but no Tor route is available', []);
+    }
+
+    final failures = <String>[];
+    for (final route in routes) {
+      try {
+        await _verifyProfile(route, profile);
+        final response = await route.dialer.postJson(route.endpoint.resolve('bitmessage_submit'),
+          body: canonicalJsonEncode(wire.toJson()), timeout: requestTimeout);
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          throw StateError('submit returned HTTP ${response.statusCode}');
+        }
+        return BitMessageSendResult(transport: route.type, endpoint: route.endpoint,
+          failedAttempts: List.unmodifiable(failures));
+      } catch (error) {
+        failures.add('${route.type.name}:${route.endpoint}: $error');
+      }
+    }
+    throw BitMessageTransportException('No BitMessage route accepted the message', List.unmodifiable(failures));
+  }
+
+  Future<BitMessageProfile?> discoverProfile(BitMessageProfile previous, {bool torOnly = false}) async {
+    for (final route in _routes(previous, torOnly)) {
+      try {
+        final profile = await _readProfile(route);
+        if (profile.bitNameHash == previous.bitNameHash) return profile;
+      } catch (_) {}
+    }
+    return null;
+  }
+
+  List<_HttpRoute> _routes(BitMessageProfile profile, bool torOnly) => [
+    if (!torOnly) ...profile.directEndpoints.map((uri) => _HttpRoute(BitMessageTransportType.direct, uri, directDialer)),
+    if (torDialer != null) ...profile.torEndpoints.map((uri) => _HttpRoute(BitMessageTransportType.tor, uri, torDialer!)),
+  ];
+
+  Future<void> _verifyProfile(_HttpRoute route, VerifiedBitMessageProfile expected) async {
+    final served = await _readProfile(route);
+    if (bitNamesAuthoritativeProfileCommitment(served) != expected.onChainCommitment) {
+      throw StateError('served profile does not match the authoritative BitName commitment');
+    }
+    if (canonicalJsonEncode(served.toJson()) != canonicalJsonEncode(expected.profile.toJson())) {
+      throw StateError('served profile differs from the verified profile');
+    }
+  }
+
+  Future<BitMessageProfile> _readProfile(_HttpRoute route) async {
+    final response = await route.dialer.get(route.endpoint.resolve('bitname_commit'), timeout: requestTimeout);
+    if (response.statusCode != 200) throw StateError('commit returned HTTP ${response.statusCode}');
+    if (utf8.encode(response.body).length > maxProfileResponseBytes) {
+      throw StateError('committed profile response is too large');
+    }
+    dynamic decoded;
+    try {
+      decoded = jsonDecode(response.body);
+    } on FormatException {
+      throw StateError('committed profile response is not valid JSON');
+    }
+    if (decoded is! Map) throw StateError('committed profile response must be an object');
+    return bitNamesProfileFromCommitResponse(Map<String, dynamic>.from(decoded));
+  }
+
+  void close() {
+    directDialer.close();
+    if (!identical(torDialer, directDialer)) torDialer?.close();
+  }
+}
+
+class _HttpRoute {
+  const _HttpRoute(this.type, this.endpoint, this.dialer);
+  final BitMessageTransportType type;
+  final Uri endpoint;
+  final BitMessageHttpDialer dialer;
+}

--- a/bitwindow/lib/services/bitnames_bitintroduction_backend.dart
+++ b/bitwindow/lib/services/bitnames_bitintroduction_backend.dart
@@ -1,0 +1,65 @@
+import 'package:bitwindow/models/bitintroduction_protocol.dart';
+import 'package:bitwindow/models/bitnames_commitment.dart';
+import 'package:bitwindow/services/bitintroduction_codec.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+// dart format off
+class BitnamesBitIntroductionSigner implements BitIntroductionSigningBackend {
+  const BitnamesBitIntroductionSigner(this.rpc);
+  final BitnamesRPC rpc;
+  @override
+  Future<String> sign({required String signingPublicKey, required String payload}) => rpc.signArbitraryMsg(msg: payload, verifyingKey: signingPublicKey);
+}
+class BitnamesBitIntroductionSignatureVerifier implements BitIntroductionSignatureBackend {
+  const BitnamesBitIntroductionSignatureVerifier(this.rpc);
+  final BitnamesRPC rpc;
+  @override
+  Future<bool> verify({required String signingPublicKey, required String payload, required String signature}) =>
+      rpc.verifySignature(signature: signature, verifyingKey: signingPublicKey, msg: payload);
+}
+class BitnamesBitMessageCipher implements BitMessageCipherBackend {
+  const BitnamesBitMessageCipher(this.rpc);
+  final BitnamesRPC rpc;
+  @override
+  Future<String> encrypt({required String encryptionPublicKey, required String plaintext}) => rpc.encryptMsg(msg: plaintext, encryptionPubkey: encryptionPublicKey);
+  @override
+  Future<String> decrypt({required String encryptionPublicKey, required String ciphertext}) => rpc.decryptMsg(ciphertext: ciphertext, encryptionPubkey: encryptionPublicKey);
+}
+class BitnamesBitMessageProfileVerifier implements BitMessageProfileVerifier {
+  const BitnamesBitMessageProfileVerifier(this.rpc, {required this.commitmentNetwork});
+  final BitnamesRPC rpc;
+  final String commitmentNetwork;
+  @override
+  Future<VerifiedBitMessageProfile> verify(BitMessageProfile profile) async {
+    final resolution = await rpc.resolveBitName(profile.bitNameHash);
+    if (resolution == null) throw StateError('BitName is no longer registered');
+    return verifyAt(profile, resolution.data, canonicalJsonEncode(resolution.outpoint));
+  }
+  VerifiedBitMessageProfile verifyAt(BitMessageProfile profile, BitNameData data, String reference) {
+    final commitment = data.commitment;
+    if (commitment == null) throw StateError('BitName has not committed to a reply profile');
+    final assessment = assessBitMessageProfileCommitment(
+      profile: profile,
+      onChainCommitment: commitment,
+      network: commitmentNetwork,
+    );
+    if (!assessment.verified) {
+      throw StateError('${assessment.summary}. ${assessment.details}');
+    }
+    if (!_sameKey(data.signingPubkey, profile.signingPublicKey)) throw StateError('Reply profile signing key does not match BitNames');
+    if (!_sameKey(data.encryptionPubkey, profile.encryptionPublicKey)) throw StateError('Reply profile encryption key does not match BitNames');
+    if (data.paymailFeeSats != profile.paymailFeeSats) throw StateError('Reply profile introduction fee does not match BitNames');
+    return VerifiedBitMessageProfile.verified(
+      profile: profile,
+      onChainCommitment: commitment,
+      verificationReference: reference,
+      commitmentVerifier: (candidate, onChain) => assessBitMessageProfileCommitment(
+        profile: candidate,
+        onChainCommitment: onChain,
+        network: commitmentNetwork,
+      ).verified,
+    );
+  }
+  bool _sameKey(String? onChain, String claimed) => onChain?.toLowerCase() == claimed.toLowerCase();
+}
+// dart format on

--- a/bitwindow/lib/services/bitnames_secure_store.dart
+++ b/bitwindow/lib/services/bitnames_secure_store.dart
@@ -1,0 +1,701 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:flutter/foundation.dart';
+import 'package:pointycastle/export.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:synchronized/synchronized.dart';
+
+enum BitnamesStorageState {
+  locked,
+  empty,
+  ready,
+  migrated,
+  recovered,
+  corrupt,
+}
+
+class BitnamesStorageStatus {
+  const BitnamesStorageStatus(
+    this.state, {
+    this.generation,
+    this.details,
+  });
+
+  final BitnamesStorageState state;
+  final int? generation;
+  final String? details;
+
+  bool get writable => {
+    BitnamesStorageState.empty,
+    BitnamesStorageState.ready,
+    BitnamesStorageState.migrated,
+    BitnamesStorageState.recovered,
+  }.contains(state);
+
+  String get summary => switch (state) {
+    BitnamesStorageState.locked => 'Private chat storage is locked',
+    BitnamesStorageState.empty => 'Private chat storage is ready',
+    BitnamesStorageState.ready => 'Chats and reply routes are encrypted',
+    BitnamesStorageState.migrated => 'Existing chats were encrypted',
+    BitnamesStorageState.recovered => 'Encrypted chat storage recovered safely',
+    BitnamesStorageState.corrupt => 'Private chat storage needs recovery',
+  };
+}
+
+class BitnamesStorageException implements Exception {
+  const BitnamesStorageException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+class BitnamesStorageIdentity {
+  BitnamesStorageIdentity({
+    required this.scope,
+    required Uint8List secret,
+  }) : secret = Uint8List.fromList(secret);
+
+  final String scope;
+  final Uint8List secret;
+}
+
+abstract class BitnamesStorageKeySource implements Listenable {
+  Future<BitnamesStorageIdentity?> current();
+}
+
+class WalletBitnamesStorageKeySource implements BitnamesStorageKeySource {
+  WalletBitnamesStorageKeySource(this.walletReader);
+
+  final WalletReaderProvider walletReader;
+
+  @visibleForTesting
+  static BitnamesStorageIdentity derive({
+    required String masterMnemonic,
+    String walletBinding = '',
+  }) {
+    final mnemonic = _normalizeWords(masterMnemonic);
+    final binding = _normalizeWords(walletBinding);
+    if (mnemonic.isEmpty) {
+      throw const BitnamesStorageException('The unlocked wallet has no encryption key material');
+    }
+    final root = crypto.sha256.convert(
+      utf8.encode(
+        'bitnames-storage-root-v2\u0000$mnemonic\u0000$binding',
+      ),
+    );
+    return BitnamesStorageIdentity(
+      scope: crypto.Hmac(
+        crypto.sha256,
+        root.bytes,
+      ).convert(utf8.encode('scope')).toString(),
+      secret: Uint8List.fromList(
+        crypto.Hmac(
+          crypto.sha256,
+          root.bytes,
+        ).convert(utf8.encode('encryption')).bytes,
+      ),
+    );
+  }
+
+  @override
+  Future<BitnamesStorageIdentity?> current() async {
+    final wallet = walletReader.activeWallet;
+    if (!walletReader.isWalletUnlocked || wallet == null) {
+      return null;
+    }
+    try {
+      return derive(
+        masterMnemonic: wallet.master.mnemonic,
+        walletBinding: wallet.l1.mnemonic,
+      );
+    } on BitnamesStorageException {
+      return null;
+    }
+  }
+
+  @override
+  void addListener(VoidCallback listener) => walletReader.addListener(listener);
+
+  @override
+  void removeListener(VoidCallback listener) => walletReader.removeListener(listener);
+}
+
+class BitnamesSecureStore {
+  BitnamesSecureStore({
+    required this.store,
+    required this.keySource,
+    DateTime Function()? now,
+    Uint8List Function(int)? randomBytes,
+  }) : _now = now ?? DateTime.now,
+       _randomBytes = randomBytes ?? _secureRandomBytes;
+
+  static const format = 'bitnames-private-store';
+  static const schema = 2;
+  static const legacyStateKey = 'bitintroduction_state_v1';
+  static const legacyContactsKey = 'chat_contacts';
+  static const legacyOwnedKey = 'owned_bitname_hashes';
+
+  final KeyValueStore store;
+  final BitnamesStorageKeySource keySource;
+  final DateTime Function() _now;
+  final Uint8List Function(int) _randomBytes;
+  final Lock _lock = Lock();
+
+  BitnamesStorageStatus status = const BitnamesStorageStatus(
+    BitnamesStorageState.locked,
+  );
+  String? _activeScope;
+  String? _activeSlot;
+  int _generation = 0;
+  bool _migratedThisSession = false;
+  bool _recoveredThisSession = false;
+
+  Future<Map<String, dynamic>> load() => _lock.synchronized(
+    () => _translate(
+      _load,
+      'Private BitNames storage could not be read safely',
+    ),
+  );
+
+  Future<void> save(Map<String, dynamic> state) => _lock.synchronized(
+    () => _translate(
+      () => _save(state),
+      'The encrypted write did not complete; reload to recover an authenticated generation',
+    ),
+  );
+
+  Future<String> exportEncrypted() => _lock.synchronized(
+    () => _translate(() async {
+      final identity = await _identity();
+      await _loadSecure(identity, allowEmpty: false);
+      final prefix = _prefix(identity.scope);
+      final head = await store.getString('${prefix}head');
+      final a = await store.getString('${prefix}a');
+      final b = await store.getString('${prefix}b');
+      if (head == null || (a == null && b == null)) {
+        throw const BitnamesStorageException('No encrypted BitNames data is available to export');
+      }
+      return jsonEncode({
+        'format': '$format-backup',
+        'schema': schema,
+        'scope': identity.scope,
+        'exported_at': _now().toUtc().toIso8601String(),
+        'head': head,
+        if (a != null) 'a': a,
+        if (b != null) 'b': b,
+      });
+    }, 'The encrypted BitNames backup could not be created'),
+  );
+
+  Future<void> restoreEncrypted(
+    String encoded, {
+    bool allowRollback = false,
+  }) => _lock.synchronized(
+    () => _translate(() async {
+      final identity = await _identity();
+      late Map<String, dynamic> backup;
+      try {
+        backup = Map<String, dynamic>.from(jsonDecode(encoded) as Map);
+      } catch (_) {
+        throw const BitnamesStorageException('The BitNames backup is malformed');
+      }
+      if (backup['format'] != '$format-backup' || backup['schema'] != schema || backup['scope'] != identity.scope) {
+        throw const BitnamesStorageException(
+          'The BitNames backup belongs to another wallet or storage version',
+        );
+      }
+      final candidates = <_DecodedSlot>[];
+      for (final slot in const ['a', 'b']) {
+        final raw = backup[slot];
+        if (raw is String) {
+          try {
+            candidates.add(_decryptSlot(raw, slot, identity));
+          } on BitnamesStorageException {
+            // A backup retains two generations. One valid authenticated slot
+            // is sufficient; a corrupt companion is never loaded.
+          }
+        }
+      }
+      if (candidates.isEmpty) {
+        throw const BitnamesStorageException('The BitNames backup contains no valid encrypted state');
+      }
+      candidates.sort((a, b) => b.generation.compareTo(a.generation));
+      final restored = candidates.first;
+      final current = await _loadSecure(identity, allowEmpty: true);
+      if (!allowRollback && current != null && restored.generation < current.generation) {
+        throw const BitnamesStorageException(
+          'The BitNames backup is older than the current encrypted history',
+        );
+      }
+      await _save(
+        restored.state,
+        minimumGeneration: restored.generation,
+      );
+    }, 'The encrypted BitNames backup could not be restored'),
+  );
+
+  Future<void> clear() => _lock.synchronized(
+    () => _translate(() async {
+      final identity = await _identity();
+      final prefix = _prefix(identity.scope);
+      for (final key in [
+        '${prefix}head',
+        '${prefix}a',
+        '${prefix}b',
+        legacyStateKey,
+        legacyContactsKey,
+        legacyOwnedKey,
+      ]) {
+        await store.delete(key);
+      }
+      await _scrubRecoveryCopy('${prefix}cleared');
+      _activeSlot = null;
+      _activeScope = identity.scope;
+      _generation = 0;
+      _migratedThisSession = false;
+      _recoveredThisSession = false;
+      status = const BitnamesStorageStatus(BitnamesStorageState.empty);
+    }, 'Private BitNames data could not be cleared safely'),
+  );
+
+  Future<Map<String, dynamic>> _load() async {
+    final identity = await keySource.current();
+    if (identity == null) {
+      status = const BitnamesStorageStatus(
+        BitnamesStorageState.locked,
+        details: 'Unlock the active BitWindow wallet to decrypt chat data',
+      );
+      _forgetActive();
+      return {};
+    }
+    try {
+      final secure = await _loadSecure(identity, allowEmpty: true);
+      if (secure != null) {
+        await _deleteLegacy();
+        return secure.state;
+      }
+      final legacy = await _readLegacy();
+      if (legacy == null) {
+        status = const BitnamesStorageStatus(BitnamesStorageState.empty);
+        return {};
+      }
+      await _save(legacy);
+      await _deleteLegacy();
+      _migratedThisSession = true;
+      status = BitnamesStorageStatus(
+        BitnamesStorageState.migrated,
+        generation: _generation,
+        details: 'Plaintext BitNames settings were moved into authenticated encryption',
+      );
+      return legacy;
+    } on BitnamesStorageException catch (error) {
+      status = BitnamesStorageStatus(
+        BitnamesStorageState.corrupt,
+        generation: _generation == 0 ? null : _generation,
+        details: error.message,
+      );
+      _forgetActive();
+      rethrow;
+    }
+  }
+
+  Future<T> _translate<T>(
+    Future<T> Function() action,
+    String safeFailure,
+  ) async {
+    try {
+      return await action();
+    } on BitnamesStorageException {
+      rethrow;
+    } catch (_) {
+      status = BitnamesStorageStatus(
+        BitnamesStorageState.corrupt,
+        generation: _generation == 0 ? null : _generation,
+        details: safeFailure,
+      );
+      throw BitnamesStorageException(safeFailure);
+    }
+  }
+
+  Future<void> _save(
+    Map<String, dynamic> state, {
+    int? minimumGeneration,
+  }) async {
+    final identity = await _identity();
+    if (_activeScope != null && _activeScope != identity.scope) {
+      throw const BitnamesStorageException(
+        'The active wallet changed before the encrypted transaction committed',
+      );
+    }
+    final current = await _loadSecure(identity, allowEmpty: true);
+    final normalized = _normalizeState(state);
+    final generation = max(
+      (current?.generation ?? 0) + 1,
+      minimumGeneration ?? 1,
+    );
+    final slot = (current?.slot ?? _activeSlot) == 'a' ? 'b' : 'a';
+    final raw = _encryptSlot(normalized, slot, generation, identity);
+    final prefix = _prefix(identity.scope);
+    await store.setString('$prefix$slot', raw);
+    final verified = _decryptSlot(
+      (await store.getString('$prefix$slot')) ??
+          (throw const BitnamesStorageException('Encrypted write was not persisted')),
+      slot,
+      identity,
+    );
+    if (verified.generation != generation) {
+      throw const BitnamesStorageException('Encrypted write verification failed');
+    }
+    await store.setString('${prefix}head', jsonEncode(_header(slot, generation, identity.scope)));
+    _activeSlot = slot;
+    _activeScope = identity.scope;
+    _generation = generation;
+    status = BitnamesStorageStatus(
+      _recoveredThisSession
+          ? BitnamesStorageState.recovered
+          : _migratedThisSession
+          ? BitnamesStorageState.migrated
+          : BitnamesStorageState.ready,
+      generation: generation,
+      details: _recoveredThisSession
+          ? 'A complete authenticated generation was selected; incomplete or corrupt data was not loaded'
+          : _migratedThisSession
+          ? 'Plaintext BitNames settings were moved into authenticated encryption'
+          : null,
+    );
+  }
+
+  Future<_DecodedSlot?> _loadSecure(
+    BitnamesStorageIdentity identity, {
+    required bool allowEmpty,
+  }) async {
+    if (_activeScope != null && _activeScope != identity.scope) {
+      _migratedThisSession = false;
+      _recoveredThisSession = false;
+    }
+    final prefix = _prefix(identity.scope);
+    final rawHead = await store.getString('${prefix}head');
+    final rawA = await store.getString('${prefix}a');
+    final rawB = await store.getString('${prefix}b');
+    if (rawHead == null && rawA == null && rawB == null) {
+      if (!allowEmpty) {
+        throw const BitnamesStorageException('No encrypted BitNames state exists');
+      }
+      _activeSlot = null;
+      _activeScope = identity.scope;
+      _generation = 0;
+      return null;
+    }
+
+    final valid = <_DecodedSlot>[];
+    final failures = <String>[];
+    for (final candidate in [('a', rawA), ('b', rawB)]) {
+      if (candidate.$2 == null) continue;
+      try {
+        valid.add(_decryptSlot(candidate.$2!, candidate.$1, identity));
+      } on BitnamesStorageException catch (error) {
+        failures.add('${candidate.$1}: ${error.message}');
+      }
+    }
+    if (valid.isEmpty) {
+      throw BitnamesStorageException(
+        'Encrypted BitNames state could not be authenticated'
+        '${failures.isEmpty ? '' : ' (${failures.join('; ')})'}',
+      );
+    }
+    valid.sort((a, b) => b.generation.compareTo(a.generation));
+    final selected = valid.first;
+    var recovered = failures.isNotEmpty;
+    try {
+      final head = Map<String, dynamic>.from(jsonDecode(rawHead!) as Map);
+      recovered =
+          recovered ||
+          head['format'] != format ||
+          head['schema'] != schema ||
+          head['scope'] != identity.scope ||
+          head['slot'] != selected.slot ||
+          head['generation'] != selected.generation;
+    } catch (_) {
+      recovered = true;
+    }
+    if (recovered) {
+      _recoveredThisSession = true;
+      await store.setString(
+        '${prefix}head',
+        jsonEncode(_header(selected.slot, selected.generation, identity.scope)),
+      );
+    }
+    _activeSlot = selected.slot;
+    _activeScope = identity.scope;
+    _generation = selected.generation;
+    status = BitnamesStorageStatus(
+      _recoveredThisSession ? BitnamesStorageState.recovered : BitnamesStorageState.ready,
+      generation: selected.generation,
+      details: _recoveredThisSession
+          ? 'A complete authenticated generation was selected; incomplete or corrupt data was not loaded'
+          : null,
+    );
+    return selected;
+  }
+
+  String _encryptSlot(
+    Map<String, dynamic> state,
+    String slot,
+    int generation,
+    BitnamesStorageIdentity identity,
+  ) {
+    final nonce = _randomBytes(12);
+    final header = _header(slot, generation, identity.scope);
+    final plaintext = utf8.encode(
+      jsonEncode({
+        ...header,
+        'saved_at': _now().toUtc().toIso8601String(),
+        'state': state,
+      }),
+    );
+    final cipher = GCMBlockCipher(AESEngine())
+      ..init(
+        true,
+        AEADParameters(
+          KeyParameter(_deriveKey(identity)),
+          128,
+          nonce,
+          Uint8List.fromList(utf8.encode(jsonEncode(header))),
+        ),
+      );
+    final encrypted = cipher.process(Uint8List.fromList(plaintext));
+    return jsonEncode({
+      ...header,
+      'nonce': base64Encode(nonce),
+      'ciphertext': base64Encode(encrypted),
+    });
+  }
+
+  _DecodedSlot _decryptSlot(
+    String raw,
+    String expectedSlot,
+    BitnamesStorageIdentity identity,
+  ) {
+    try {
+      final envelope = Map<String, dynamic>.from(jsonDecode(raw) as Map);
+      final generation = envelope['generation'];
+      final slot = envelope['slot'];
+      if (envelope['format'] != format ||
+          envelope['schema'] != schema ||
+          envelope['scope'] != identity.scope ||
+          slot != expectedSlot ||
+          generation is! int ||
+          generation < 1 ||
+          envelope['nonce'] is! String ||
+          envelope['ciphertext'] is! String) {
+        throw const BitnamesStorageException('Encrypted slot metadata is invalid');
+      }
+      final nonce = base64Decode(envelope['nonce'] as String);
+      if (nonce.length != 12) {
+        throw const BitnamesStorageException('Encrypted slot nonce is invalid');
+      }
+      final header = _header(slot as String, generation, identity.scope);
+      final cipher = GCMBlockCipher(AESEngine())
+        ..init(
+          false,
+          AEADParameters(
+            KeyParameter(_deriveKey(identity)),
+            128,
+            nonce,
+            Uint8List.fromList(utf8.encode(jsonEncode(header))),
+          ),
+        );
+      final plaintext = cipher.process(
+        Uint8List.fromList(base64Decode(envelope['ciphertext'] as String)),
+      );
+      final decoded = Map<String, dynamic>.from(
+        jsonDecode(utf8.decode(plaintext)) as Map,
+      );
+      if (decoded['format'] != format ||
+          decoded['schema'] != schema ||
+          decoded['scope'] != identity.scope ||
+          decoded['slot'] != slot ||
+          decoded['generation'] != generation ||
+          decoded['state'] is! Map) {
+        throw const BitnamesStorageException('Encrypted slot contents are inconsistent');
+      }
+      return _DecodedSlot(
+        slot,
+        generation,
+        _normalizeState(Map<String, dynamic>.from(decoded['state'] as Map)),
+      );
+    } on BitnamesStorageException {
+      rethrow;
+    } catch (_) {
+      throw const BitnamesStorageException(
+        'Encrypted slot is corrupt or the wallet key does not match',
+      );
+    }
+  }
+
+  Map<String, dynamic> _header(String slot, int generation, String scope) => {
+    'format': format,
+    'schema': schema,
+    'scope': scope,
+    'slot': slot,
+    'generation': generation,
+  };
+
+  Uint8List _deriveKey(BitnamesStorageIdentity identity) {
+    final salt = utf8.encode('BitWindow BitNames private storage v2');
+    final extracted = crypto.Hmac(crypto.sha256, salt).convert(identity.secret).bytes;
+    final info = utf8.encode('wallet:${identity.scope}\u0000aes-256-gcm\u0001');
+    return Uint8List.fromList(
+      crypto.Hmac(crypto.sha256, extracted).convert(info).bytes,
+    );
+  }
+
+  Future<BitnamesStorageIdentity> _identity() async {
+    final identity = await keySource.current();
+    if (identity == null) {
+      status = const BitnamesStorageStatus(
+        BitnamesStorageState.locked,
+        details: 'Unlock the active BitWindow wallet to decrypt chat data',
+      );
+      _forgetActive();
+      throw const BitnamesStorageException(
+        'Unlock the active BitWindow wallet before using BitNames chat',
+      );
+    }
+    return identity;
+  }
+
+  Future<Map<String, dynamic>?> _readLegacy() async {
+    final rawState = await store.getString(legacyStateKey);
+    final rawContacts = await store.getString(legacyContactsKey);
+    final rawOwned = await store.getString(legacyOwnedKey);
+    if (rawState == null && rawContacts == null && rawOwned == null) return null;
+    try {
+      final state = rawState == null ? <String, dynamic>{} : Map<String, dynamic>.from(jsonDecode(rawState) as Map);
+      if ((state['contacts'] as List?)?.isNotEmpty != true && rawContacts != null) {
+        state['contacts'] = List<dynamic>.from(jsonDecode(rawContacts) as List);
+      }
+      if ((state['owned'] as List?)?.isNotEmpty != true && rawOwned != null) {
+        state['owned'] = List<dynamic>.from(jsonDecode(rawOwned) as List);
+      }
+      return _normalizeState(state);
+    } catch (_) {
+      throw const BitnamesStorageException(
+        'Existing plaintext BitNames data is malformed; it was left untouched',
+      );
+    }
+  }
+
+  Future<void> _deleteLegacy() async {
+    await store.delete(legacyStateKey);
+    await store.delete(legacyContactsKey);
+    await store.delete(legacyOwnedKey);
+    await _scrubRecoveryCopy('bitintroduction_legacy_scrub_v2');
+  }
+
+  Future<void> _scrubRecoveryCopy(String marker) async {
+    // FileStorage keeps one complete prior generation for crash recovery.
+    // Rotate a non-secret tombstone through it so deleted plaintext/ciphertext
+    // is not left in that logical recovery copy.
+    await store.setString(marker, 'cleared');
+    await store.delete(marker);
+  }
+
+  Map<String, dynamic> _normalizeState(Map<String, dynamic> input) {
+    late Map<String, dynamic> state;
+    try {
+      state = Map<String, dynamic>.from(
+        jsonDecode(jsonEncode(input)) as Map,
+      );
+    } catch (_) {
+      throw const BitnamesStorageException('BitNames state is not valid JSON data');
+    }
+    _deduplicate(state, 'contacts', (entry) => '${entry['local_bitname'] ?? ''}:${entry['id'] ?? ''}');
+    _deduplicate(state, 'messages', (entry) {
+      return _messageKey(entry);
+    });
+    _deduplicate(state, 'operations', (entry) => '${entry['id'] ?? ''}');
+    state.remove('_indexes');
+    return state;
+  }
+
+  void _deduplicate(
+    Map<String, dynamic> state,
+    String field,
+    String Function(Map<String, dynamic>) keyOf,
+  ) {
+    final raw = state[field];
+    if (raw == null) return;
+    if (raw is! List) {
+      throw BitnamesStorageException('BitNames $field index is malformed');
+    }
+    final seen = <String, String>{};
+    final clean = <Map<String, dynamic>>[];
+    for (final value in raw) {
+      if (value is! Map) {
+        throw BitnamesStorageException('BitNames $field record is malformed');
+      }
+      final record = Map<String, dynamic>.from(value);
+      final key = keyOf(record);
+      if (key.isEmpty || key.endsWith(':')) {
+        throw BitnamesStorageException('BitNames $field record has no stable identity');
+      }
+      final canonical = _canonicalJson(record);
+      final prior = seen[key];
+      if (prior != null && prior != canonical) {
+        throw BitnamesStorageException(
+          'BitNames $field contains conflicting record $key',
+        );
+      }
+      if (prior == null) {
+        seen[key] = canonical;
+        clean.add(record);
+      }
+    }
+    state[field] = clean;
+  }
+
+  String _prefix(String scope) => 'bitintroduction_secure_v2_${scope}_';
+
+  void _forgetActive() {
+    _activeScope = null;
+    _activeSlot = null;
+    _generation = 0;
+    _migratedThisSession = false;
+    _recoveredThisSession = false;
+  }
+
+  static Uint8List _secureRandomBytes(int length) {
+    final random = Random.secure();
+    return Uint8List.fromList(
+      List<int>.generate(length, (_) => random.nextInt(256)),
+    );
+  }
+}
+
+class _DecodedSlot {
+  const _DecodedSlot(this.slot, this.generation, this.state);
+  final String slot;
+  final int generation;
+  final Map<String, dynamic> state;
+}
+
+String _messageKey(Map<String, dynamic> message) {
+  final local = message['is_outgoing'] == true ? message['sender_bitname'] : message['recipient_bitname'];
+  return '$local:${message['id'] ?? ''}';
+}
+
+String _normalizeWords(String value) => value.trim().toLowerCase().split(RegExp(r'\s+')).join(' ');
+
+String _canonicalJson(Object? value) {
+  if (value is Map) {
+    final keys = value.keys.cast<String>().toList()..sort();
+    return '{${keys.map((key) => '${jsonEncode(key)}:${_canonicalJson(value[key])}').join(',')}}';
+  }
+  if (value is List) {
+    return '[${value.map(_canonicalJson).join(',')}]';
+  }
+  return jsonEncode(value);
+}

--- a/bitwindow/lib/services/bitnames_tor_controller.dart
+++ b/bitwindow/lib/services/bitnames_tor_controller.dart
@@ -1,0 +1,160 @@
+// dart format off
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:sail_ui/sail_ui.dart';
+enum BitnamesTorState { unavailable, notDownloaded, stopped, downloading, starting, ready, error }
+class BitnamesTorStatus {
+  const BitnamesTorStatus({required this.state, this.onionHost, this.p2pOnion, this.p2pReady = false,
+    this.socksAddress = '127.0.0.1:19050', this.error});
+  final BitnamesTorState state; final String? onionHost, p2pOnion, error;
+  final bool p2pReady; final String socksAddress;
+  bool get ready => state == BitnamesTorState.ready;
+}
+class BitnamesTorController {
+  BitnamesTorController({required this.orchestrator, http.Client? httpClient, Uri? statusEndpoint, this._controlToken})
+    : statusEndpoint = statusEndpoint ?? Uri.parse('http://127.0.0.1:37998/status'),
+       _httpClient = httpClient ?? http.Client();
+  static const binaryName = 'bitnames-tor'; final OrchestratorRPC orchestrator;
+  final Uri statusEndpoint; final http.Client _httpClient; String? _controlToken;
+  final Set<String> _tunnelAddresses = {}; bool _chainTorPrepared = false;
+  bool get chainTorPrepared => _chainTorPrepared;
+  Future<BitnamesTorStatus> refresh() async {
+    final runtime = await _runtimeStatus();
+    if (runtime?.ready ?? false) return runtime!;
+    try {
+      final binary = (await orchestrator.getBinaryStatus(binaryName)).status;
+      if (!binary.downloaded) {
+        return const BitnamesTorStatus(state: BitnamesTorState.notDownloaded);
+      }
+      if (binary.running || binary.initializing) {
+        return BitnamesTorStatus(state: BitnamesTorState.starting, error: runtime?.error);
+      }
+      final error = binary.error.isNotEmpty
+          ? binary.error
+          : binary.connectionError.isNotEmpty
+          ? binary.connectionError
+          : runtime?.error;
+      final state = error == null ? BitnamesTorState.stopped : BitnamesTorState.error;
+      return BitnamesTorStatus(state: state, error: error);
+    } catch (error) {
+      return BitnamesTorStatus(state: BitnamesTorState.unavailable, error: '$error');
+    }
+  }
+  Future<BitnamesTorStatus> downloadAndStart({Duration timeout = const Duration(minutes: 15)}) async {
+    if ((await orchestrator.getBinaryStatus(binaryName)).status.downloaded) return start();
+    await orchestrator.downloadBinary(binaryName);
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      final status = (await orchestrator.getBinaryStatus(binaryName)).status;
+      if (status.downloaded) return start(timeout: const Duration(minutes: 2));
+      if (status.error.isNotEmpty) throw StateError(status.error);
+      await _pause();
+    }
+    throw TimeoutException('Timed out downloading BitNames Tor');
+  }
+  Future<BitnamesTorStatus> start({Duration timeout = const Duration(minutes: 2)}) async { final existing = await refresh(); if (existing.ready) return existing;
+    await orchestrator.startBinary(binaryName);
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      final status = await _runtimeStatus();
+      if (status?.ready ?? false) return status!;
+      if (status?.state == BitnamesTorState.error) throw StateError(status?.error ?? 'BitNames Tor failed to start');
+      await _pause();
+    }
+    throw TimeoutException('Timed out starting BitNames Tor');
+  }
+  Future<void> stop() async { _chainTorPrepared = false; _tunnelAddresses.clear(); await orchestrator.stopBinary(binaryName); }
+  Future<String> connectP2P(String onion) async {
+    final endpoint = statusEndpoint.replace(path: '/p2p/connect');
+    final request = _httpClient.post(endpoint, headers: await _headers(contentType: true), body: jsonEncode({'onion': onion}));
+    final response = await request.timeout(const Duration(seconds: 20));
+    if (response.statusCode != 200) {
+      throw StateError('BitNames Tor peer failed: ${response.body.trim()}');
+    }
+    final body = jsonDecode(response.body);
+    final address = body is Map ? body['udp_address'] as String? : null;
+    if (address == null || !_isLoopbackSocket(address)) {
+      throw StateError('BitNames Tor returned an unsafe peer address');
+    }
+    _tunnelAddresses.add(address);
+    return address;
+  }
+  Future<void> enableChainTor(BitnamesRPC rpc, String peerOnion,
+    {Duration timeout = const Duration(minutes: 2)}) async {
+    _chainTorPrepared = false;
+    final status = await refresh();
+    if (!status.ready || !status.p2pReady) throw StateError('Start BitNames Tor before enabling Tor mode');
+    final tunnel = await connectP2P(peerOnion);
+    await _restartBitNames(['--tor-proxy-mode', '--tor-proxy-peer', tunnel], timeout);
+    _chainTorPrepared = true;
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      if (await chainTorReady(rpc)) return;
+      try { await rpc.connectPeer(tunnel); } catch (_) {}
+      await _pause();
+    }
+    _chainTorPrepared = false;
+    throw StateError('BitNames did not establish a Tor-only peer');
+  }
+  Future<void> disableChainTor({Duration timeout = const Duration(minutes: 2)}) async {
+    _chainTorPrepared = false; _tunnelAddresses.clear(); await _restartBitNames(const [], timeout); }
+  Future<bool> chainTorReady(BitnamesRPC rpc) async {
+    if (!_chainTorPrepared) return false;
+    final status = await _runtimeStatus();
+    if (!(status?.ready ?? false) || !(status?.p2pReady ?? false)) return false;
+    try {
+      final peers = await rpc.listPeers();
+      return peers.isNotEmpty &&
+          peers.every((peer) => _isLoopbackSocket(peer.address)) &&
+          peers.any((peer) => peer.status.toLowerCase() == 'connected' && _tunnelAddresses.contains(peer.address));
+    } catch (_) {
+      return false;
+    }
+  }
+  Future<void> _restartBitNames(List<String> args, Duration timeout) async {
+    await orchestrator.stopBinary('bitnames', force: true); final deadline = DateTime.now().add(timeout); while ((await orchestrator.getBinaryStatus('bitnames')).status.connected && DateTime.now().isBefore(deadline)) { await _pause(); } await _pause();
+    await orchestrator.startWithL1('bitnames', targetArgs: args, forceBackend: true);
+    while (DateTime.now().isBefore(deadline)) {
+      final status = (await orchestrator.getBinaryStatus('bitnames')).status;
+      if (status.connected) return;
+      final errors = [status.startupError];
+      final error = errors.firstWhere((value) => value.isNotEmpty, orElse: () => '');
+      if (error.isNotEmpty) throw StateError(error);
+      await _pause();
+    }
+    throw TimeoutException('Timed out restarting BitNames');
+  }
+  Future<BitnamesTorStatus?> _runtimeStatus() async {
+    try {
+      final request = _httpClient.get(statusEndpoint, headers: await _headers());
+      final body = jsonDecode((await request.timeout(const Duration(seconds: 1))).body);
+      if (body is! Map) return null;
+      final json = Map<String, dynamic>.from(body);
+      final rawError = json['error'] as String?;
+      final error = (rawError?.trim().isEmpty ?? true) ? null : rawError;
+      var state = error == null ? BitnamesTorState.starting : BitnamesTorState.error;
+      if (json['ready'] == true) state = BitnamesTorState.ready;
+      return BitnamesTorStatus(state: state, onionHost: _withoutScheme(json['onion'] as String?),
+        p2pOnion: json['p2p_onion'] as String?, p2pReady: json['p2p_ready'] == true,
+        socksAddress: json['socks_address'] as String? ?? '127.0.0.1:19050', error: error);
+    } catch (_) { return null; }
+  }
+  Future<Map<String, String>> _headers({bool contentType = false}) async => {
+    'accept': 'application/json', 'authorization': 'Bearer ${await _token()}',
+    if (contentType) 'content-type': 'application/json',
+  }; Future<String> _token() async {
+    if (_controlToken != null) return _controlToken!;
+    final env = Platform.environment, home = env['HOME'] ?? env['USERPROFILE'];
+    final base = Platform.isWindows ? env['APPDATA'] : Platform.isMacOS ? '$home/Library/Application Support' : env['XDG_CONFIG_HOME'] ?? '$home/.config';
+    return _controlToken = (await File('$base/bitnames-tor/control-token').readAsString()).trim();
+  }
+  Future<void> _pause() => Future<void>.delayed(const Duration(milliseconds: 500));
+  void close() => _httpClient.close();
+}
+String? _withoutScheme(String? value) => value?.replaceFirst(RegExp(r'^https?://'), '');
+bool _isLoopbackSocket(String value) {
+  final host = Uri.tryParse('udp://$value')?.host;
+  return host != null && (InternetAddress.tryParse(host)?.isLoopback ?? false);
+}

--- a/bitwindow/lib/services/tor_bitmessage_dialer.dart
+++ b/bitwindow/lib/services/tor_bitmessage_dialer.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:bitwindow/services/bitmessage_transport.dart';
+import 'package:http/io_client.dart';
+import 'package:socks5_proxy/socks_client.dart';
+
+BitMessageHttpDialer createTorBitMessageDialer({
+  String proxyHost = '127.0.0.1',
+  int proxyPort = 19050,
+}) {
+  final address = InternetAddress.tryParse(proxyHost);
+  if (address == null || !address.isLoopback) {
+    throw ArgumentError.value(
+      proxyHost,
+      'proxyHost',
+      'the BitNames Tor proxy must be a loopback address',
+    );
+  }
+  if (proxyPort < 1 || proxyPort > 65535) {
+    throw ArgumentError.value(proxyPort, 'proxyPort', 'must be a valid port');
+  }
+
+  final nativeClient = HttpClient();
+  SocksTCPClient.assignToHttpClient(nativeClient, [
+    ProxySettings(address, proxyPort),
+  ]);
+  return DirectBitMessageHttpDialer(client: IOClient(nativeClient));
+}

--- a/bitwindow/pubspec.lock
+++ b/bitwindow/pubspec.lock
@@ -1188,6 +1188,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  socks5_proxy:
+    dependency: "direct main"
+    description:
+      name: socks5_proxy
+      sha256: "80fa31a9ebfc0dc8de7b0e568c8d8927b65558ef2c7591cbee5afac814fb8f74"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   source_gen:
     dependency: transitive
     description:

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   stacked: ^3.5.0
   qr_flutter: ^4.1.0
   http: ^1.6.0
+  socks5_proxy: 2.1.1
   intl: ^0.20.2
   cupertino_icons: ^1.0.8
   collection: ^1.19.1

--- a/sail_ui/lib/rpcs/bitnames_rpc.dart
+++ b/sail_ui/lib/rpcs/bitnames_rpc.dart
@@ -20,6 +20,8 @@ import 'package:sail_ui/settings/client_settings.dart';
 import 'package:sail_ui/settings/hash_plaintext_settings.dart';
 import 'package:sail_ui/widgets/components/core_transaction.dart';
 
+enum BitnamesTransactionStatus { absent, pending, confirmed }
+
 /// API to the bitnames server.
 abstract class BitnamesRPC extends SidechainRPC {
   BitnamesRPC({required super.binaryType});
@@ -29,6 +31,20 @@ abstract class BitnamesRPC extends SidechainRPC {
 
   /// Get BitName data
   Future<BitNameData?> getBitNameData(String name);
+
+  /// Get BitName data at an exact block/transaction position.
+  Future<BitNameData> bitNameDataAtPosition(String bitname, String blockHash, int txIndex) async {
+    final data = await callRAW('bitname_data_at_position', [bitname, blockHash, txIndex]);
+    if (data is! Map) throw const FormatException('Invalid historical BitName data');
+    return BitNameData.fromJson(Map<String, dynamic>.from(data));
+  }
+
+  /// Return whether a transaction is included in the current canonical chain.
+  Future<bool> isTransactionConfirmed(String txid) async =>
+      await transactionStatus(txid) == BitnamesTransactionStatus.confirmed;
+
+  Future<BitnamesTransactionStatus> transactionStatus(String txid) async =>
+      transactionInfoStatus(await callRAW('get_transaction_info', [txid]));
 
   /// List all BitNames
   Future<List<BitnameEntry>> listBitNames();
@@ -101,6 +117,33 @@ abstract class BitnamesRPC extends SidechainRPC {
   /// Get all paymail
   Future<Map<String, dynamic>> getPaymail();
 
+  /// Get JSON-safe, ordered paymail entries with recipient attribution.
+  Future<List<PaymailEntry>> getPaymailEntries() async {
+    final entries = await callRAW('get_paymail_entries');
+    if (entries == null) return [];
+    if (entries is! List) throw const FormatException('Invalid paymail entries');
+    return entries.map((entry) => PaymailEntry.fromJson(Map<String, dynamic>.from(entry as Map))).toList();
+  }
+
+  /// Resolve a BitName to its current ownership output and data.
+  Future<BitNameResolution?> resolveBitName(String bitname) async {
+    final resolution = await callRAW('resolve_bitname', [bitname]);
+    if (resolution == null) return null;
+    if (resolution is! Map) throw const FormatException('Invalid BitName resolution');
+    return BitNameResolution.fromJson(Map<String, dynamic>.from(resolution));
+  }
+
+  /// Update mutable data for an owned BitName.
+  Future<String> updateBitName({
+    required String bitname,
+    required BitNameDataUpdates updates,
+    required int feeSats,
+  }) async {
+    final txid = await callRAW('update_bitname', [bitname, updates.toJson(), feeSats]);
+    if (txid is! String) throw const FormatException('Invalid BitName update transaction');
+    return txid;
+  }
+
   /// Get wallet addresses, sorted by base58 encoding
   Future<List<String>> getWalletAddresses();
 
@@ -132,6 +175,18 @@ abstract class BitnamesRPC extends SidechainRPC {
     required String address,
   });
 
+  /// Verify a signature against the specified key and domain separation tag.
+  Future<bool> verifySignature({
+    required String signature,
+    required String verifyingKey,
+    String domain = 'arbitrary',
+    required String msg,
+  }) async {
+    final valid = await callRAW('verify_signature', [signature, verifyingKey, domain, msg]);
+    if (valid is! bool) throw const FormatException('Invalid signature verification response');
+    return valid;
+  }
+
   /// Transfer funds to the specified address
   Future<String> transfer({
     required String dest,
@@ -139,6 +194,18 @@ abstract class BitnamesRPC extends SidechainRPC {
     required int fee,
     String? memo,
   });
+
+  Future<String> transferIdempotent({
+    required String idempotencyKey,
+    required String dest,
+    required int value,
+    required int fee,
+    String? memo,
+  }) async {
+    final txid = await callRAW('transfer', [dest, value, fee, memo, idempotencyKey]);
+    if (txid is! String) throw const FormatException('Invalid transfer transaction');
+    return txid;
+  }
 }
 
 class BitnamesLive extends BitnamesRPC {
@@ -162,7 +229,9 @@ class BitnamesLive extends BitnamesRPC {
 
   @override
   Future<(double, double)> balance() async {
-    final resp = await GetIt.I.get<OrchestratorRPC>().getSidechainBalance(binaryType);
+    final resp = await GetIt.I.get<OrchestratorRPC>().getSidechainBalance(
+      binaryType,
+    );
     final confirmed = satoshiToBTC(resp.confirmedSats.toInt());
     final unconfirmed = satoshiToBTC(resp.pendingSats.toInt());
     return (confirmed, unconfirmed);
@@ -209,7 +278,9 @@ class BitnamesLive extends BitnamesRPC {
   @override
   Future<dynamic> callRAW(String method, [dynamic params]) async {
     final paramsJson = params != null ? jsonEncode(params) : '';
-    final resp = await _client.callRaw(pb.CallRawRequest(method: method, paramsJson: paramsJson));
+    final resp = await _client.callRaw(
+      pb.CallRawRequest(method: method, paramsJson: paramsJson),
+    );
     if (resp.resultJson.isEmpty) return null;
     return jsonDecode(resp.resultJson);
   }
@@ -235,7 +306,11 @@ class BitnamesLive extends BitnamesRPC {
   Future<double> sideEstimateFee() async => 0.00001;
 
   @override
-  Future<String> sideSend(String address, double amount, bool subtractFeeFromAmount) async {
+  Future<String> sideSend(
+    String address,
+    double amount,
+    bool subtractFeeFromAmount,
+  ) async {
     final resp = await _client.transfer(
       pb.TransferRequest(
         address: address,
@@ -257,7 +332,9 @@ class BitnamesLive extends BitnamesRPC {
 
   @override
   Future<BitNameData?> getBitNameData(String name) async {
-    final resp = await _client.getBitNameData(pb.GetBitNameDataRequest(name: name));
+    final resp = await _client.getBitNameData(
+      pb.GetBitNameDataRequest(name: name),
+    );
     if (resp.dataJson.isEmpty) return null;
     final decoded = jsonDecode(resp.dataJson) as Map<String, dynamic>;
     return BitNameData.fromJson(decoded);
@@ -330,17 +407,16 @@ class BitnamesLive extends BitnamesRPC {
   Future<String> registerBitName(String plainName, BitNameData? data) async {
     final dataJson = data != null ? jsonEncode(data.toJson()) : '';
     final resp = await _client.registerBitName(
-      pb.RegisterBitNameRequest(
-        plainName: plainName,
-        dataJson: dataJson,
-      ),
+      pb.RegisterBitNameRequest(plainName: plainName, dataJson: dataJson),
     );
     return resp.txid;
   }
 
   @override
   Future<String> reserveBitName(String name) async {
-    final resp = await _client.reserveBitName(pb.ReserveBitNameRequest(name: name));
+    final resp = await _client.reserveBitName(
+      pb.ReserveBitNameRequest(name: name),
+    );
     return resp.txid;
   }
 
@@ -353,19 +429,25 @@ class BitnamesLive extends BitnamesRPC {
 
   @override
   Future<String> getBMMInclusions(String blockHash) async {
-    final resp = await _client.getBmmInclusions(pb.GetBmmInclusionsRequest(blockHash: blockHash));
+    final resp = await _client.getBmmInclusions(
+      pb.GetBmmInclusionsRequest(blockHash: blockHash),
+    );
     return resp.inclusions;
   }
 
   @override
   Future<String?> getBestMainchainBlockHash() async {
-    final resp = await _client.getBestMainchainBlockHash(pb.GetBestMainchainBlockHashRequest());
+    final resp = await _client.getBestMainchainBlockHash(
+      pb.GetBestMainchainBlockHashRequest(),
+    );
     return resp.hash.isEmpty ? null : resp.hash;
   }
 
   @override
   Future<String?> getBestSidechainBlockHash() async {
-    final resp = await _client.getBestSidechainBlockHash(pb.GetBestSidechainBlockHashRequest());
+    final resp = await _client.getBestSidechainBlockHash(
+      pb.GetBestSidechainBlockHashRequest(),
+    );
     return resp.hash.isEmpty ? null : resp.hash;
   }
 
@@ -379,7 +461,9 @@ class BitnamesLive extends BitnamesRPC {
 
   @override
   Future<PendingWithdrawalBundle?> getPendingWithdrawalBundle() async {
-    final resp = await _client.getPendingWithdrawalBundle(pb.GetPendingWithdrawalBundleRequest());
+    final resp = await _client.getPendingWithdrawalBundle(
+      pb.GetPendingWithdrawalBundleRequest(),
+    );
     if (resp.bundleJson.isEmpty) return null;
     final decoded = jsonDecode(resp.bundleJson);
     return PendingWithdrawalBundle.fromJson(decoded as Map<String, dynamic>);
@@ -393,24 +477,32 @@ class BitnamesLive extends BitnamesRPC {
 
   @override
   Future<void> setSeedFromMnemonic(String mnemonic) async {
-    await _client.setSeedFromMnemonic(pb.SetSeedFromMnemonicRequest(mnemonic: mnemonic));
+    await _client.setSeedFromMnemonic(
+      pb.SetSeedFromMnemonicRequest(mnemonic: mnemonic),
+    );
   }
 
   @override
   Future<int> getSidechainWealth() async {
-    final resp = await _client.getSidechainWealth(pb.GetSidechainWealthRequest());
+    final resp = await _client.getSidechainWealth(
+      pb.GetSidechainWealthRequest(),
+    );
     return resp.sats.toInt();
   }
 
   @override
   Future<String> getNewEncryptionKey() async {
-    final resp = await _client.getNewEncryptionKey(pb.GetNewEncryptionKeyRequest());
+    final resp = await _client.getNewEncryptionKey(
+      pb.GetNewEncryptionKeyRequest(),
+    );
     return resp.key;
   }
 
   @override
   Future<String> getNewVerifyingKey() async {
-    final resp = await _client.getNewVerifyingKey(pb.GetNewVerifyingKeyRequest());
+    final resp = await _client.getNewVerifyingKey(
+      pb.GetNewVerifyingKeyRequest(),
+    );
     return resp.key;
   }
 
@@ -453,10 +545,7 @@ class BitnamesLive extends BitnamesRPC {
     required String encryptionPubkey,
   }) async {
     final resp = await _client.encryptMsg(
-      pb.EncryptMsgRequest(
-        msg: msg,
-        encryptionPubkey: encryptionPubkey,
-      ),
+      pb.EncryptMsgRequest(msg: msg, encryptionPubkey: encryptionPubkey),
     );
     return resp.ciphertext;
   }
@@ -476,7 +565,9 @@ class BitnamesLive extends BitnamesRPC {
 
   @override
   Future<String> resolveCommit(String bitname) async {
-    final resp = await _client.resolveCommit(pb.ResolveCommitRequest(bitname: bitname));
+    final resp = await _client.resolveCommit(
+      pb.ResolveCommitRequest(bitname: bitname),
+    );
     return resp.commitment;
   }
 
@@ -486,10 +577,7 @@ class BitnamesLive extends BitnamesRPC {
     required String verifyingKey,
   }) async {
     final resp = await _client.signArbitraryMsg(
-      pb.SignArbitraryMsgRequest(
-        msg: msg,
-        verifyingKey: verifyingKey,
-      ),
+      pb.SignArbitraryMsgRequest(msg: msg, verifyingKey: verifyingKey),
     );
     return resp.signature;
   }
@@ -500,20 +588,16 @@ class BitnamesLive extends BitnamesRPC {
     required String address,
   }) async {
     final resp = await _client.signArbitraryMsgAsAddr(
-      pb.SignArbitraryMsgAsAddrRequest(
-        msg: msg,
-        address: address,
-      ),
+      pb.SignArbitraryMsgAsAddrRequest(msg: msg, address: address),
     );
-    return {
-      'verifying_key': resp.verifyingKey,
-      'signature': resp.signature,
-    };
+    return {'verifying_key': resp.verifyingKey, 'signature': resp.signature};
   }
 
   @override
   Future<List<String>> getWalletAddresses() async {
-    final resp = await _client.getWalletAddresses(pb.GetWalletAddressesRequest());
+    final resp = await _client.getWalletAddresses(
+      pb.GetWalletAddressesRequest(),
+    );
     return resp.addresses.toList();
   }
 
@@ -605,6 +689,7 @@ class BitnamesLive extends BitnamesRPC {
 final bitnamesRPCMethods = [
   'balance',
   'bitname_data',
+  'bitname_data_at_position',
   'bitnames',
   'connect_peer',
   'create_deposit',
@@ -621,6 +706,8 @@ final bitnamesRPCMethods = [
   'get_new_verifying_key',
   'getblockcount',
   'get_paymail',
+  'get_paymail_entries',
+  'get_transaction_info',
   'get_wallet_addresses',
   'get_wallet_utxos',
   'latest_failed_withdrawal_bundle_height',
@@ -632,6 +719,7 @@ final bitnamesRPCMethods = [
   'pending_withdrawal_bundle',
   'register_bitname',
   'reserve_bitname',
+  'resolve_bitname',
   'resolve_commit',
   'set_seed_from_mnemonic',
   'sidechain_wealth',
@@ -639,12 +727,27 @@ final bitnamesRPCMethods = [
   'sign_arbitrary_msg_as_addr',
   'stop',
   'transfer',
+  'update_bitname',
   'verify_signature',
   'withdraw',
 ];
 
+/// Decode the backend's nullable transaction information without treating a
+/// malformed response as confirmation.
+BitnamesTransactionStatus transactionInfoStatus(Object? info) {
+  if (info == null) return BitnamesTransactionStatus.absent;
+  if (info is! Map<String, dynamic>) throw const FormatException('Invalid transaction info');
+  final txin = info['txin'];
+  if (txin == null) return BitnamesTransactionStatus.pending;
+  if (txin is! Map<String, dynamic> || txin['block_hash'] is! String || txin['idx'] is! int) {
+    throw const FormatException('Invalid transaction inclusion');
+  }
+  return BitnamesTransactionStatus.confirmed;
+}
+
 // Models for Bitnames RPC responses
 class BitNameData {
+  final String? seqId;
   final String? commitment;
   final String? encryptionPubkey;
   final int? paymailFeeSats;
@@ -653,6 +756,7 @@ class BitNameData {
   final String? socketAddrV6;
 
   BitNameData({
+    this.seqId,
     this.commitment,
     this.encryptionPubkey,
     this.paymailFeeSats,
@@ -662,6 +766,7 @@ class BitNameData {
   });
 
   Map<String, dynamic> toJson() => {
+    if (seqId != null) 'seq_id': seqId,
     if (commitment != null) 'commitment': commitment,
     if (encryptionPubkey != null) 'encryption_pubkey': encryptionPubkey,
     if (paymailFeeSats != null) 'paymail_fee_sats': paymailFeeSats,
@@ -671,12 +776,175 @@ class BitNameData {
   };
 
   factory BitNameData.fromJson(Map<String, dynamic> json) => BitNameData(
-    commitment: json['commitment'] as String?,
+    seqId: json['seq_id'] as String?,
+    commitment: switch (json['commitment']) {
+      final String value => value,
+      final List<dynamic> value => hex.encode(value.cast<int>()),
+      _ => null,
+    },
     encryptionPubkey: json['encryption_pubkey'] as String?,
-    paymailFeeSats: json['paymail_fee_sats'] as int?,
+    paymailFeeSats: switch (json['paymail_fee_sats']) {
+      final int value when value >= 0 => value,
+      _ => null,
+    },
     signingPubkey: json['signing_pubkey'] as String?,
     socketAddrV4: json['socket_addr_v4'] as String?,
     socketAddrV6: json['socket_addr_v6'] as String?,
+  );
+}
+
+enum BitNameUpdateAction { retain, delete, set }
+
+/// A single mutable BitName field update.
+///
+/// The JSON encoding matches the backend's `Retain`, `Delete`, and
+/// `{ "Set": value }` representation.
+class BitNameUpdate<T extends Object> {
+  final BitNameUpdateAction action;
+  final T? value;
+
+  const BitNameUpdate.retain() : action = BitNameUpdateAction.retain, value = null;
+
+  const BitNameUpdate.delete() : action = BitNameUpdateAction.delete, value = null;
+
+  const BitNameUpdate.set(T this.value) : action = BitNameUpdateAction.set;
+
+  Object toJson() => switch (action) {
+    BitNameUpdateAction.retain => 'Retain',
+    BitNameUpdateAction.delete => 'Delete',
+    BitNameUpdateAction.set => {'Set': value},
+  };
+}
+
+/// Mutable updates for a BitName. Unspecified fields are retained.
+class BitNameDataUpdates {
+  final BitNameUpdate<String> commitment;
+  final BitNameUpdate<String> socketAddrV4;
+  final BitNameUpdate<String> socketAddrV6;
+  final BitNameUpdate<String> encryptionPubkey;
+  final BitNameUpdate<String> signingPubkey;
+  final BitNameUpdate<int> paymailFeeSats;
+
+  const BitNameDataUpdates({
+    this.commitment = const BitNameUpdate<String>.retain(),
+    this.socketAddrV4 = const BitNameUpdate<String>.retain(),
+    this.socketAddrV6 = const BitNameUpdate<String>.retain(),
+    this.encryptionPubkey = const BitNameUpdate<String>.retain(),
+    this.signingPubkey = const BitNameUpdate<String>.retain(),
+    this.paymailFeeSats = const BitNameUpdate<int>.retain(),
+  });
+
+  Map<String, dynamic> toJson() => {
+    'commitment': commitment.action == BitNameUpdateAction.set
+        ? {'Set': hex.decode(commitment.value!)}
+        : commitment.toJson(),
+    'socket_addr_v4': socketAddrV4.toJson(),
+    'socket_addr_v6': socketAddrV6.toJson(),
+    'encryption_pubkey': encryptionPubkey.toJson(),
+    'signing_pubkey': signingPubkey.toJson(),
+    'paymail_fee_sats': paymailFeeSats.toJson(),
+  };
+}
+
+class BitNameResolution {
+  final String bitname;
+  final Map<String, dynamic> outpoint;
+  final String address;
+  final BitNameData data;
+
+  const BitNameResolution({
+    required this.bitname,
+    required this.outpoint,
+    required this.address,
+    required this.data,
+  });
+
+  factory BitNameResolution.fromJson(Map<String, dynamic> json) => BitNameResolution(
+    bitname: json['bitname'] as String,
+    outpoint: Map<String, dynamic>.from(json['outpoint'] as Map),
+    address: json['address'] as String,
+    data: BitNameData.fromJson(json['data'] as Map<String, dynamic>),
+  );
+}
+
+class PaymailRecipient {
+  final String bitname;
+  final BitNameData data;
+  final int? requiredFeeSats;
+
+  const PaymailRecipient({
+    required this.bitname,
+    required this.data,
+    this.requiredFeeSats,
+  });
+
+  factory PaymailRecipient.fromJson(Map<String, dynamic> json) => PaymailRecipient(
+    bitname: json['bitname'] as String,
+    data: BitNameData.fromJson(json['data'] as Map<String, dynamic>),
+    requiredFeeSats: switch (json['required_fee_sats']) {
+      final int value when value >= 0 => value,
+      _ => null,
+    },
+  );
+}
+
+class PaymailOutput {
+  final String address;
+  final Map<String, dynamic> content;
+  final String memoHex;
+
+  const PaymailOutput({
+    required this.address,
+    required this.content,
+    required this.memoHex,
+  });
+
+  factory PaymailOutput.fromJson(Map<String, dynamic> json) {
+    final memo = json['memo'];
+    final memoHex = switch (memo) {
+      String value => value,
+      List<dynamic> bytes => bytes.cast<int>().map((byte) => byte.toRadixString(16).padLeft(2, '0')).join(),
+      _ => throw FormatException('Invalid paymail memo: $memo'),
+    };
+    return PaymailOutput(
+      address: json['address'] as String,
+      content: Map<String, dynamic>.from(json['content'] as Map),
+      memoHex: memoHex,
+    );
+  }
+}
+
+class PaymailEntry {
+  final Map<String, dynamic> outpoint;
+  final PaymailOutput output;
+  final int valueSats;
+  final String blockHash;
+  final int blockHeight;
+  final int txIndex;
+  final List<PaymailRecipient> recipients;
+
+  const PaymailEntry({
+    required this.outpoint,
+    required this.output,
+    required this.valueSats,
+    required this.blockHash,
+    required this.blockHeight,
+    required this.txIndex,
+    required this.recipients,
+  });
+
+  factory PaymailEntry.fromJson(Map<String, dynamic> json) => PaymailEntry(
+    outpoint: Map<String, dynamic>.from(json['outpoint'] as Map),
+    output: PaymailOutput.fromJson(json['output'] as Map<String, dynamic>),
+    valueSats: json['value_sats'] as int,
+    blockHash: json['block_hash'] as String,
+    blockHeight: json['block_height'] as int,
+    txIndex: json['tx_index'] as int,
+    recipients: (json['recipients'] as List<dynamic>)
+        .map(
+          (recipient) => PaymailRecipient.fromJson(recipient as Map<String, dynamic>),
+        )
+        .toList(),
   );
 }
 
@@ -738,6 +1006,9 @@ class BitnameDetails {
     socketAddrV6: json['socket_addr_v6'] as String?,
     encryptionPubkey: json['encryption_pubkey'] as String?,
     signingPubkey: json['signing_pubkey'] as String?,
-    paymailFeeSats: json['paymail_fee_sats'] as int?,
+    paymailFeeSats: switch (json['paymail_fee_sats']) {
+      final int value when value >= 0 => value,
+      _ => null,
+    },
   );
 }

--- a/sail_ui/lib/rpcs/thunder_utxo.dart
+++ b/sail_ui/lib/rpcs/thunder_utxo.dart
@@ -36,9 +36,13 @@ class SidechainUTXO {
       final regular = outpoint['Regular'] as Map<String, dynamic>;
       outpointStr = '${regular['txid']}:${regular['vout']}';
       type = OutpointType.regular;
-    } else {
+    } else if (outpoint.containsKey('Deposit')) {
       outpointStr = outpoint['Deposit'] as String;
       type = OutpointType.deposit;
+    } else {
+      final coinbase = outpoint['Coinbase'] as Map<String, dynamic>;
+      outpointStr = '${coinbase['merkle_root']}:${coinbase['vout']}';
+      type = OutpointType.regular;
     }
 
     return SidechainUTXO(
@@ -77,9 +81,13 @@ class BitnamesUTXO extends SidechainUTXO {
       final regular = outpoint['Regular'] as Map<String, dynamic>;
       outpointStr = '${regular['txid']}:${regular['vout']}';
       type = OutpointType.regular;
-    } else {
+    } else if (outpoint.containsKey('Deposit')) {
       outpointStr = outpoint['Deposit'] as String;
       type = OutpointType.deposit;
+    } else {
+      final coinbase = outpoint['Coinbase'] as Map<String, dynamic>;
+      outpointStr = '${coinbase['merkle_root']}:${coinbase['vout']}';
+      type = OutpointType.regular;
     }
 
     // Get value from content

--- a/sail_ui/lib/settings/secure_store.dart
+++ b/sail_ui/lib/settings/secure_store.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:sail_ui/utils/file_utils.dart';
+import 'package:synchronized/synchronized.dart';
 
 abstract class KeyValueStore {
   Future<String?> getString(String key);
@@ -17,6 +18,8 @@ abstract class KeyValueStore {
 
 // Native implementation using file system
 class FileStorage implements KeyValueStore {
+  static final Map<String, Lock> _processLocks = {};
+
   static FileStorage fromDirectory(Directory dir) {
     final file = File('${dir.path}${Platform.pathSeparator}settings.json');
     return FileStorage._(file);
@@ -25,45 +28,145 @@ class FileStorage implements KeyValueStore {
   final File file;
   Map<String, String> _cache = {};
   bool _loaded = false;
+  bool _loadedFromBackup = false;
+  final Lock _processLock;
 
-  FileStorage._(this.file);
+  FileStorage._(this.file)
+    : _processLock = _processLocks.putIfAbsent(
+        file.absolute.path,
+        Lock.new,
+      );
 
-  Future<void> _ensureLoaded() async {
-    if (_loaded) return;
-
+  Future<void> _ensureLoaded({bool refresh = false}) async {
+    if (_loaded && !refresh) return;
+    if (refresh) {
+      _loaded = false;
+      _loadedFromBackup = false;
+      _cache = {};
+    }
+    final backup = File('${file.path}.bak');
+    Object? primaryError;
     if (await file.exists()) {
       try {
-        final contents = await file.readAsString();
-        _cache = Map<String, String>.from(jsonDecode(contents));
-      } catch (e) {
-        // If file is corrupted, start fresh
-        _cache = {};
+        _cache = await _read(file);
+        _loaded = true;
+        return;
+      } catch (error) {
+        primaryError = error;
       }
+    }
+    if (await backup.exists()) {
+      try {
+        _cache = await _read(backup);
+        _loaded = true;
+        _loadedFromBackup = true;
+        return;
+      } catch (backupError) {
+        throw FileSystemException(
+          'Settings and its recovery copy are corrupt '
+          '(primary: $primaryError, recovery: $backupError)',
+          file.path,
+        );
+      }
+    }
+    if (primaryError != null) {
+      throw FileSystemException(
+        'Settings are corrupt and no recovery copy exists: $primaryError',
+        file.path,
+      );
     }
     _loaded = true;
   }
 
+  Future<T> _withFileLock<T>(Future<T> Function() action) async {
+    await file.parent.create(recursive: true);
+    final lockFile = await File('${file.path}.lock').open(mode: FileMode.append);
+    var locked = false;
+    try {
+      await lockFile.lock(FileLock.exclusive);
+      locked = true;
+      return await action();
+    } finally {
+      if (locked) await lockFile.unlock();
+      await lockFile.close();
+    }
+  }
+
+  Future<Map<String, String>> _read(File source) async {
+    final decoded = jsonDecode(await source.readAsString());
+    if (decoded is! Map) throw const FormatException('settings root is not an object');
+    final result = <String, String>{};
+    for (final entry in decoded.entries) {
+      if (entry.key is! String || entry.value is! String) {
+        throw const FormatException('settings entry is not a string pair');
+      }
+      result[entry.key as String] = entry.value as String;
+    }
+    return result;
+  }
+
   Future<void> _save() async {
-    await file.writeAsString(jsonEncode(_cache));
+    await file.parent.create(recursive: true);
+    final temporary = File('${file.path}.next');
+    final backup = File('${file.path}.bak');
+    await temporary.writeAsString(jsonEncode(_cache), flush: true);
+    try {
+      if (await file.exists()) {
+        if (_loadedFromBackup) {
+          await file.delete();
+        } else {
+          if (await backup.exists()) await backup.delete();
+          await file.rename(backup.path);
+        }
+      }
+      await temporary.rename(file.path);
+      _loadedFromBackup = false;
+    } catch (_) {
+      if (!await file.exists() && await backup.exists()) {
+        await backup.rename(file.path);
+      }
+      rethrow;
+    } finally {
+      if (await temporary.exists()) await temporary.delete();
+    }
   }
 
   @override
-  Future<String?> getString(String key) async {
-    await _ensureLoaded();
-    return _cache[key];
-  }
+  Future<String?> getString(String key) => _processLock.synchronized(
+    () => _withFileLock(() async {
+      await _ensureLoaded(refresh: true);
+      return _cache[key];
+    }),
+  );
 
   @override
-  Future<void> setString(String key, String value) async {
-    await _ensureLoaded();
-    _cache[key] = value;
-    await _save();
-  }
+  Future<void> setString(String key, String value) => _processLock.synchronized(
+    () => _withFileLock(() async {
+      await _ensureLoaded(refresh: true);
+      final existed = _cache.containsKey(key);
+      final previous = _cache[key];
+      _cache[key] = value;
+      try {
+        await _save();
+      } catch (_) {
+        existed ? _cache[key] = previous! : _cache.remove(key);
+        rethrow;
+      }
+    }),
+  );
 
   @override
-  Future<void> delete(String key) async {
-    await _ensureLoaded();
-    _cache.remove(key);
-    await _save();
-  }
+  Future<void> delete(String key) => _processLock.synchronized(
+    () => _withFileLock(() async {
+      await _ensureLoaded(refresh: true);
+      if (!_cache.containsKey(key)) return;
+      final previous = _cache.remove(key)!;
+      try {
+        await _save();
+      } catch (_) {
+        _cache[key] = previous;
+        rethrow;
+      }
+    }),
+  );
 }

--- a/sail_ui/lib/widgets/inputs/sail_combobox.dart
+++ b/sail_ui/lib/widgets/inputs/sail_combobox.dart
@@ -333,7 +333,7 @@ class _ComboboxRowState extends State<_ComboboxRow> {
                         widget.subtitle!,
                         overflow: TextOverflow.ellipsis,
                         style: SailStyleValues.twelve.copyWith(
-                          color: theme.colors.textTertiary,
+                          color: theme.colors.textSecondary,
                         ),
                       ),
                   ],

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -69,14 +69,19 @@ func (h *Handler) GetBinaryVersion(ctx context.Context, req *connect.Request[pb.
 	}), nil
 }
 
-// DownloadBinary dispatches a download in a background goroutine and
-// returns immediately. Mirrors StartWithL1's fire-and-forget shape so a
-// transport blip / client disconnect can't cancel an in-flight download.
-// Progress is polled out of GetSyncStatus (DownloadManager.state-backed).
+// DownloadBinary normally dispatches a background download. The security-
+// pinned Tor bundle waits so an integrity failure reaches BitWindow before it
+// can start an older executable. Other progress remains poll-driven.
 func (h *Handler) DownloadBinary(ctx context.Context, req *connect.Request[pb.DownloadBinaryRequest]) (*connect.Response[pb.DownloadBinaryResponse], error) {
 	ch, err := h.orch.Download(context.Background(), req.Msg.Name, req.Msg.Force)
 	if err != nil {
 		return nil, err
+	}
+	if req.Msg.Name == "bitnames-tor" {
+		if err := waitForCompletedDownload(ch); err != nil {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+		}
+		return connect.NewResponse(&pb.DownloadBinaryResponse{}), nil
 	}
 
 	go func() {
@@ -86,6 +91,20 @@ func (h *Handler) DownloadBinary(ctx context.Context, req *connect.Request[pb.Do
 	}()
 
 	return connect.NewResponse(&pb.DownloadBinaryResponse{}), nil
+}
+
+func waitForCompletedDownload(ch <-chan orchestrator.DownloadProgress) error {
+	done := false
+	for progress := range ch {
+		if progress.Error != nil {
+			return progress.Error
+		}
+		done = done || progress.Done
+	}
+	if !done {
+		return fmt.Errorf("download ended without a completed artifact")
+	}
+	return nil
 }
 
 func (h *Handler) StartBinary(ctx context.Context, req *connect.Request[pb.StartBinaryRequest]) (*connect.Response[pb.StartBinaryResponse], error) {

--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -404,6 +404,74 @@
       },
       "hashes": {}
     },
+    "bitnames-tor": {
+      "type": "utility",
+      "name": "BitNames Tor",
+      "version": "latest",
+      "description": "Private BitIntroduction routing and onion service",
+      "require_hash": true,
+      "preserve_archive_tree": true,
+      "repo_url": "https://github.com/LayerTwo-Labs/bitnames-tor",
+      "port": 37998,
+      "chain_layer": 0,
+      "color": "purple",
+      "health_check": {
+        "type": "tcp"
+      },
+      "dependencies": [],
+      "startup_log_patterns": ["Bootstrapped", "onion service ready"],
+      "directories": {
+        "binary": {
+          "default": {
+            "linux": ".bitnames-tor",
+            "macos": "BitNames Tor",
+            "windows": "BitNames Tor"
+          }
+        },
+        "flutter_frontend": {
+          "linux": "",
+          "macos": "",
+          "windows": ""
+        }
+      },
+      "download": {
+        "binary": "bitnames-tor",
+        "files": {
+          "default": {
+            "base_url": "https://github.com/LayerTwo-Labs/bitnames-tor/releases/latest/download/",
+            "linux-x86_64": "bitnames-tor-latest-x86_64-unknown-linux-gnu.zip",
+            "macos-x86_64": "bitnames-tor-latest-x86_64-apple-darwin.zip",
+            "macos-arm64": "bitnames-tor-latest-aarch64-apple-darwin.zip",
+            "windows-x86_64": "bitnames-tor-latest-x86_64-pc-windows-gnu.zip"
+          }
+        },
+        "extract_subfolder": {
+          "default": {
+            "linux": "bitnames-tor",
+            "macos": "bitnames-tor",
+            "windows": "bitnames-tor"
+          }
+        }
+      },
+      "hashes": {
+        "linux-x86_64": {
+          "sha256": "58307ce3bf96a9b8d5bba87466bbc180844ecb81ead748ec4af10f1e424e0ead",
+          "size": 34707268
+        },
+        "macos-x86_64": {
+          "sha256": "fe486068b2ec0dbf29516d6a6c97c100a268bc68360d89ece296064bd7c81650",
+          "size": 21782699
+        },
+        "macos-arm64": {
+          "sha256": "7d283d41171b79ad139a44a38b544f01dc28dd0248e29dd0ffb030a356de98c9",
+          "size": 20993965
+        },
+        "windows-x86_64": {
+          "sha256": "57a3a6ca9944d5aa9ed8dfe2cb7339df67ba3e8fe21b0aa6e1c6b91a25b54269",
+          "size": 24886928
+        }
+      }
+    },
     "bitnames": {
       "type": "sidechain",
       "slot": 2,

--- a/sidechain-orchestrator/config.go
+++ b/sidechain-orchestrator/config.go
@@ -27,6 +27,11 @@ const (
 	DownloadSourceGitHub                       // GitHub releases API (regex matching)
 )
 
+type ArchiveHash struct {
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+
 // BinaryConfig is the 1:1 Go port of Dart's Binary abstract class + subclasses.
 // Every field maps to a Dart property from binaries.dart / sidechains.dart.
 type BinaryConfig struct {
@@ -52,10 +57,14 @@ type BinaryConfig struct {
 	FlutterFrontendDir map[string]string
 
 	// Primary download configuration — Dart: MetadataConfig.downloadConfig
-	DownloadSource   DownloadSource
-	DownloadURLs     map[string]string // network -> base URL ("default", etc.)
-	Files            map[string]string // os -> filename or regex pattern
-	ExtractSubfolder map[string]string // os -> subfolder to extract from zip (empty = root)
+	DownloadSource      DownloadSource
+	DownloadURLs        map[string]string // network -> base URL ("default", "forknet", etc.)
+	Files               map[string]string // os -> filename or regex pattern
+	ForknetFiles        map[string]string // os -> forknet-specific filename (BitcoinCore only)
+	ExtractSubfolder    map[string]string // os -> subfolder to extract from zip (empty = root)
+	ArchiveHashes       map[string]ArchiveHash
+	RequireHash         bool
+	PreserveArchiveTree bool
 
 	// Core variant configuration — only populated for the bitcoincore entry.
 	// Keys are variant IDs ("core", "patched", "knots").

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -404,6 +404,74 @@
       },
       "hashes": {}
     },
+    "bitnames-tor": {
+      "type": "utility",
+      "name": "BitNames Tor",
+      "version": "latest",
+      "description": "Private BitIntroduction routing and onion service",
+      "require_hash": true,
+      "preserve_archive_tree": true,
+      "repo_url": "https://github.com/LayerTwo-Labs/bitnames-tor",
+      "port": 37998,
+      "chain_layer": 0,
+      "color": "purple",
+      "health_check": {
+        "type": "tcp"
+      },
+      "dependencies": [],
+      "startup_log_patterns": ["Bootstrapped", "onion service ready"],
+      "directories": {
+        "binary": {
+          "default": {
+            "linux": ".bitnames-tor",
+            "macos": "BitNames Tor",
+            "windows": "BitNames Tor"
+          }
+        },
+        "flutter_frontend": {
+          "linux": "",
+          "macos": "",
+          "windows": ""
+        }
+      },
+      "download": {
+        "binary": "bitnames-tor",
+        "files": {
+          "default": {
+            "base_url": "https://github.com/LayerTwo-Labs/bitnames-tor/releases/latest/download/",
+            "linux-x86_64": "bitnames-tor-latest-x86_64-unknown-linux-gnu.zip",
+            "macos-x86_64": "bitnames-tor-latest-x86_64-apple-darwin.zip",
+            "macos-arm64": "bitnames-tor-latest-aarch64-apple-darwin.zip",
+            "windows-x86_64": "bitnames-tor-latest-x86_64-pc-windows-gnu.zip"
+          }
+        },
+        "extract_subfolder": {
+          "default": {
+            "linux": "bitnames-tor",
+            "macos": "bitnames-tor",
+            "windows": "bitnames-tor"
+          }
+        }
+      },
+      "hashes": {
+        "linux-x86_64": {
+          "sha256": "58307ce3bf96a9b8d5bba87466bbc180844ecb81ead748ec4af10f1e424e0ead",
+          "size": 34707268
+        },
+        "macos-x86_64": {
+          "sha256": "fe486068b2ec0dbf29516d6a6c97c100a268bc68360d89ece296064bd7c81650",
+          "size": 21782699
+        },
+        "macos-arm64": {
+          "sha256": "7d283d41171b79ad139a44a38b544f01dc28dd0248e29dd0ffb030a356de98c9",
+          "size": 20993965
+        },
+        "windows-x86_64": {
+          "sha256": "57a3a6ca9944d5aa9ed8dfe2cb7339df67ba3e8fe21b0aa6e1c6b91a25b54269",
+          "size": 24886928
+        }
+      }
+    },
     "bitnames": {
       "type": "sidechain",
       "slot": 2,

--- a/sidechain-orchestrator/config_loader.go
+++ b/sidechain-orchestrator/config_loader.go
@@ -49,9 +49,11 @@ type jsonBinaryConf struct {
 		FlutterFrontend map[string]string          `json:"flutter_frontend"`
 	} `json:"directories"`
 
-	Download    *jsonDownloadConf `json:"download"`
-	AltDownload *jsonDownloadConf `json:"alternative_download"`
-	Hashes      map[string]any    `json:"hashes"`
+	Download            *jsonDownloadConf      `json:"download"`
+	AltDownload         *jsonDownloadConf      `json:"alternative_download"`
+	Hashes              map[string]ArchiveHash `json:"hashes"`
+	RequireHash         bool                   `json:"require_hash"`
+	PreserveArchiveTree bool                   `json:"preserve_archive_tree"`
 }
 
 type jsonDownloadConf struct {
@@ -253,17 +255,20 @@ func jsonToBinaryConfig(key string, jb jsonBinaryConf) BinaryConfig {
 	}
 
 	bc := BinaryConfig{
-		Name:               name,
-		DisplayName:        jb.Name,
-		Version:            jb.Version,
-		Description:        jb.Description,
-		RepoURL:            jb.RepoURL,
-		Port:               jb.Port,
-		ChainLayer:         jb.ChainLayer,
-		Slot:               jb.Slot,
-		IsBitcoinCore:      jb.IsBitcoinCore,
-		Dependencies:       jb.Dependencies,
-		StartupLogPatterns: jb.StartupLogPatterns,
+		Name:                name,
+		DisplayName:         jb.Name,
+		Version:             jb.Version,
+		Description:         jb.Description,
+		RepoURL:             jb.RepoURL,
+		Port:                jb.Port,
+		ChainLayer:          jb.ChainLayer,
+		Slot:                jb.Slot,
+		IsBitcoinCore:       jb.IsBitcoinCore,
+		Dependencies:        jb.Dependencies,
+		StartupLogPatterns:  jb.StartupLogPatterns,
+		ArchiveHashes:       jb.Hashes,
+		RequireHash:         jb.RequireHash,
+		PreserveArchiveTree: jb.PreserveArchiveTree,
 	}
 
 	// Parse health check from JSON

--- a/sidechain-orchestrator/download.go
+++ b/sidechain-orchestrator/download.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
 )
@@ -44,6 +45,16 @@ type DownloadState struct {
 }
 
 const bytesPerMB int64 = 1024 * 1024
+
+// Archive limits are deliberately well above any supported node bundle while
+// preventing a malformed release archive from consuming unbounded disk space.
+const (
+	maxArchiveEntries       = 10_000
+	maxArchiveDownloadBytes = int64(2 << 30)    // 2 GiB
+	maxArchiveExpandedBytes = uint64(2 << 30)   // 2 GiB
+	maxArchiveEntryBytes    = uint64(512 << 20) // 512 MiB
+	maxArchiveDownloadTime  = 15 * time.Minute
+)
 
 // toMB rounds bytes down to whole megabytes. -1 (unknown total) passes through.
 func toMB(bytes int64) int64 {
@@ -137,7 +148,7 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 		binPath = TestSidechainBinaryPath(d.dataDir, binaryName)
 	}
 
-	if !force {
+	if !force && !config.RequireHash {
 		if _, err := os.Stat(binPath); err == nil {
 			ch := make(chan DownloadProgress, 1)
 			ch <- DownloadProgress{Message: binPath, Done: true}
@@ -194,6 +205,8 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 	d.state.Store(stateKey, DownloadState{Running: true})
 
 	go func() {
+		ctx, cancel := context.WithTimeout(ctx, maxArchiveDownloadTime)
+		defer cancel()
 		defer d.inFlight.Delete(inFlightKey)
 		defer d.state.Delete(stateKey)
 		defer close(ch)
@@ -259,6 +272,17 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 		case DownloadSourceDirect:
 			downloadURL = baseURL + fileName
 		}
+		expected, pinned := config.ArchiveHashes[currentPlatform()]
+		if !pinned {
+			expected, pinned = config.ArchiveHashes[currentOS()]
+		}
+		if !config.RequireHash {
+			expected, pinned = ArchiveHash{}, false
+		}
+		if config.RequireHash && (!pinned || expected.SHA256 == "") {
+			send(DownloadProgress{Error: fmt.Errorf("no trusted archive hash configured for %s on %s", config.Name, currentPlatform())})
+			return
+		}
 
 		d.log.Info().Str("url", downloadURL).Str("binary", config.Name).Msg("downloading")
 
@@ -271,7 +295,7 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 
 		savePath := filepath.Join(tmpDir, filepath.Base(downloadURL))
 
-		if err := d.downloadFile(ctx, downloadURL, savePath, send); err != nil {
+		if err := d.downloadFile(ctx, downloadURL, savePath, send, expected.Size); err != nil {
 			send(DownloadProgress{Error: err})
 			return
 		}
@@ -282,13 +306,21 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 		}
 		archiveHash, archiveSize, err := hashFile(savePath)
 		if err != nil {
-			d.log.Warn().Err(err).Msg("failed to hash archive")
-		} else {
-			d.log.Info().Str("hash", archiveHash).Int64("size", archiveSize).Str("binary", config.Name).Msg("archive hash")
-			if d.configFilePath != "" {
-				if err := writeHashToConfig(d.configFilePath, config.Name, currentPlatform(), archiveHash, archiveSize); err != nil {
-					d.log.Warn().Err(err).Msg("failed to write hash to config")
-				}
+			send(DownloadProgress{Error: fmt.Errorf("hash archive: %w", err)})
+			return
+		}
+		if pinned && expected.SHA256 != "" && !strings.EqualFold(expected.SHA256, archiveHash) {
+			send(DownloadProgress{Error: fmt.Errorf("archive hash mismatch for %s", config.Name)})
+			return
+		}
+		if pinned && expected.Size > 0 && expected.Size != archiveSize {
+			send(DownloadProgress{Error: fmt.Errorf("archive size mismatch for %s", config.Name)})
+			return
+		}
+		d.log.Info().Str("hash", archiveHash).Int64("size", archiveSize).Str("binary", config.Name).Msg("archive hash checked")
+		if d.configFilePath != "" && !pinned {
+			if err := writeHashToConfig(d.configFilePath, config.Name, currentPlatform(), archiveHash, archiveSize); err != nil {
+				d.log.Warn().Err(err).Msg("failed to write hash to config")
 			}
 		}
 
@@ -457,11 +489,18 @@ func (d *DownloadManager) probeContentLength(ctx context.Context, url string) in
 // mirror them into the DownloadManager.state map so polled status reads pick
 // them up. Returning false from send aborts the download (caller decided the
 // consumer is gone).
-func (d *DownloadManager) downloadFile(ctx context.Context, url, savePath string, send func(DownloadProgress) bool) error {
+func (d *DownloadManager) downloadFile(ctx context.Context, url, savePath string, send func(DownloadProgress) bool, expectedSizes ...int64) error {
 	// Probe the size first — final GET responses sometimes lack Content-Length
 	// (S3 redirects, transfer-encoded responses), and the UI's progress bar
 	// goes blank when total is unknown.
 	probedTotal := d.probeContentLength(ctx, url)
+	limit := maxArchiveDownloadBytes
+	if len(expectedSizes) > 0 && expectedSizes[0] > 0 && expectedSizes[0] < limit {
+		limit = expectedSizes[0]
+	}
+	if probedTotal > limit {
+		return fmt.Errorf("download exceeds %d-byte limit", limit)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -476,6 +515,9 @@ func (d *DownloadManager) downloadFile(ctx context.Context, url, savePath string
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("download returned HTTP %d", resp.StatusCode)
+	}
+	if resp.ContentLength > limit {
+		return fmt.Errorf("download exceeds %d-byte limit", limit)
 	}
 
 	f, err := os.Create(savePath)
@@ -497,6 +539,9 @@ func (d *DownloadManager) downloadFile(ctx context.Context, url, savePath string
 	for {
 		n, readErr := resp.Body.Read(buf)
 		if n > 0 {
+			if downloaded+int64(n) > limit {
+				return fmt.Errorf("download exceeds %d-byte limit", limit)
+			}
 			if _, err := f.Write(buf[:n]); err != nil {
 				return fmt.Errorf("write: %w", err)
 			}
@@ -565,6 +610,34 @@ func (d *DownloadManager) extractBinary(archivePath string, config BinaryConfig,
 	case strings.HasSuffix(lower, ".zip"):
 		// Test sidechain archives ship as Flutter app bundles — flatten-by-
 		// basename would destroy the bundle, so preserve the tree.
+		if config.PreserveArchiveTree && stripPrefix == "" {
+			stripPrefix = config.ExtractSubfolder[currentOS()]
+		}
+		if config.PreserveArchiveTree {
+			stage, err := os.MkdirTemp(destDir, ".orchestrator-verify-*")
+			if err != nil {
+				return false, fmt.Errorf("create bundle staging dir: %w", err)
+			}
+			defer os.RemoveAll(stage) //nolint:errcheck // cleanup
+			if _, err := d.extractZipPreservingTree(archivePath, stage, stripPrefix); err != nil {
+				return false, err
+			}
+			name := extractName
+			torName := "tor"
+			if runtime.GOOS == "windows" {
+				name, torName = name+".exe", torName+".exe"
+			}
+			required := []string{name}
+			if extractName == "bitnames-tor" {
+				required = append(required, filepath.Join("tor", torName))
+			}
+			for _, path := range required {
+				if info, err := os.Stat(filepath.Join(stage, path)); err != nil || info.IsDir() {
+					return false, fmt.Errorf("archive missing required executable %s", path)
+				}
+			}
+			return d.extractZipPreservingTree(archivePath, destDir, stripPrefix)
+		}
 		if hasSCVariant {
 			return d.extractZipPreservingTree(archivePath, destDir, stripPrefix)
 		}
@@ -595,6 +668,9 @@ func (d *DownloadManager) extractZipPreservingTree(archivePath, destDir, stripPr
 		return false, fmt.Errorf("open zip: %w", err)
 	}
 	defer r.Close() //nolint:errcheck // cleanup
+	if err := validateZipArchive(r.File); err != nil {
+		return false, err
+	}
 
 	if stripPrefix != "" && !strings.HasSuffix(stripPrefix, "/") {
 		stripPrefix += "/"
@@ -617,15 +693,24 @@ func (d *DownloadManager) extractZipPreservingTree(archivePath, destDir, stripPr
 			}
 		}
 
-		destPath := filepath.Join(destDir, name)
+		destPath, err := archiveDestination(destDir, name)
+		if err != nil {
+			return false, fmt.Errorf("invalid zip entry %q: %w", f.Name, err)
+		}
 
 		if f.FileInfo().IsDir() {
+			if err := rejectSymlinkParent(destDir, destPath); err != nil {
+				return false, err
+			}
 			if err := os.MkdirAll(destPath, 0o755); err != nil {
 				return false, fmt.Errorf("create dir: %w", err)
 			}
 			continue
 		}
 
+		if err := rejectSymlinkParent(destDir, destPath); err != nil {
+			return false, err
+		}
 		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 			return false, fmt.Errorf("create dir: %w", err)
 		}
@@ -639,10 +724,16 @@ func (d *DownloadManager) extractZipPreservingTree(archivePath, destDir, stripPr
 			if err != nil {
 				return false, fmt.Errorf("open symlink %s: %w", f.Name, err)
 			}
-			target, err := io.ReadAll(rc)
+			target, err := io.ReadAll(io.LimitReader(rc, int64(maxArchiveEntryBytes)+1))
 			_ = rc.Close()
 			if err != nil {
 				return false, fmt.Errorf("read symlink %s: %w", f.Name, err)
+			}
+			if uint64(len(target)) > maxArchiveEntryBytes {
+				return false, fmt.Errorf("symlink %s exceeds size limit", f.Name)
+			}
+			if err := validateSymlinkTarget(destDir, destPath, string(target)); err != nil {
+				return false, fmt.Errorf("invalid symlink %s: %w", f.Name, err)
 			}
 			_ = os.Remove(destPath)
 			if err := os.Symlink(string(target), destPath); err != nil {
@@ -678,6 +769,9 @@ func (d *DownloadManager) extractZip(archivePath, destDir, binaryName string) (b
 		return false, fmt.Errorf("open zip: %w", err)
 	}
 	defer r.Close() //nolint:errcheck // cleanup
+	if err := validateZipArchive(r.File); err != nil {
+		return false, err
+	}
 
 	tmpDir, err := os.MkdirTemp("", "orchestrator-extract-*")
 	if err != nil {
@@ -690,7 +784,10 @@ func (d *DownloadManager) extractZip(archivePath, destDir, binaryName string) (b
 			continue
 		}
 
-		destPath := filepath.Join(tmpDir, f.Name)
+		destPath, err := archiveDestination(tmpDir, f.Name)
+		if err != nil {
+			return false, fmt.Errorf("invalid zip entry %q: %w", f.Name, err)
+		}
 		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 			return false, fmt.Errorf("create dir: %w", err)
 		}
@@ -704,6 +801,9 @@ func (d *DownloadManager) extractZip(archivePath, destDir, binaryName string) (b
 }
 
 func extractZipFile(f *zip.File, dest string) error {
+	if f.UncompressedSize64 > maxArchiveEntryBytes {
+		return fmt.Errorf("zip entry %s exceeds size limit", f.Name)
+	}
 	rc, err := f.Open()
 	if err != nil {
 		return fmt.Errorf("open zip entry %s: %w", f.Name, err)
@@ -716,11 +816,121 @@ func extractZipFile(f *zip.File, dest string) error {
 	}
 	defer outFile.Close() //nolint:errcheck // cleanup
 
-	if _, err := io.Copy(outFile, rc); err != nil {
+	if _, err := io.Copy(outFile, io.LimitReader(rc, int64(maxArchiveEntryBytes)+1)); err != nil {
 		return fmt.Errorf("extract %s: %w", f.Name, err)
+	}
+	info, err := outFile.Stat()
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", f.Name, err)
+	}
+	if uint64(info.Size()) > maxArchiveEntryBytes {
+		return fmt.Errorf("zip entry %s exceeds size limit", f.Name)
 	}
 
 	return nil
+}
+
+func validateZipArchive(files []*zip.File) error {
+	if len(files) > maxArchiveEntries {
+		return fmt.Errorf("zip contains too many entries: %d", len(files))
+	}
+	var total uint64
+	for _, f := range files {
+		if _, err := archiveDestination("/archive-root", f.Name); err != nil {
+			return fmt.Errorf("invalid zip entry %q: %w", f.Name, err)
+		}
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		if f.UncompressedSize64 > maxArchiveEntryBytes || total > maxArchiveExpandedBytes-f.UncompressedSize64 {
+			return fmt.Errorf("zip expanded size exceeds limit")
+		}
+		total += f.UncompressedSize64
+	}
+	return nil
+}
+
+func archiveDestination(root, name string) (string, error) {
+	if name == "" || strings.IndexByte(name, 0) >= 0 {
+		return "", fmt.Errorf("empty or NUL-containing path")
+	}
+	// ZIP paths are slash-separated. Normalize backslashes too so an archive
+	// rejected on Unix cannot become traversal when later handled on Windows.
+	normalized := strings.ReplaceAll(name, "\\", "/")
+	if err := validatePortableArchivePath(normalized); err != nil {
+		return "", err
+	}
+	clean := filepath.Clean(filepath.FromSlash(normalized))
+	if filepath.IsAbs(clean) || hasWindowsVolumePath(normalized) || clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes extraction root")
+	}
+	dest := filepath.Join(root, clean)
+	rel, err := filepath.Rel(root, dest)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes extraction root")
+	}
+	return dest, nil
+}
+
+func validatePortableArchivePath(path string) error {
+	for _, part := range strings.Split(path, "/") {
+		trimmed := strings.TrimRight(part, " .")
+		stem := strings.ToUpper(strings.SplitN(trimmed, ".", 2)[0])
+		reserved := stem == "CON" || stem == "PRN" || stem == "AUX" || stem == "NUL" || stem == "CONIN$" || stem == "CONOUT$" ||
+			(len(stem) == 4 && (strings.HasPrefix(stem, "COM") || strings.HasPrefix(stem, "LPT")) && stem[3] >= '1' && stem[3] <= '9')
+		if strings.Contains(part, ":") || reserved {
+			return fmt.Errorf("non-portable archive path")
+		}
+	}
+	return nil
+}
+
+// rejectSymlinkParent prevents a later archive entry from traversing a link
+// placed by an earlier entry. Framework links themselves remain supported.
+func rejectSymlinkParent(root, dest string) error {
+	rel, err := filepath.Rel(root, filepath.Dir(dest))
+	if err != nil {
+		return err
+	}
+	current := root
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		if part == "." || part == "" {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write through symlink %s", current)
+		}
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSymlinkTarget(root, link, target string) error {
+	if target == "" || strings.IndexByte(target, 0) >= 0 {
+		return fmt.Errorf("empty or NUL-containing target")
+	}
+	normalizedText := strings.ReplaceAll(target, "\\", "/")
+	if err := validatePortableArchivePath(normalizedText); err != nil {
+		return err
+	}
+	normalized := filepath.FromSlash(normalizedText)
+	if filepath.IsAbs(normalized) || hasWindowsVolumePath(normalizedText) {
+		return fmt.Errorf("absolute target")
+	}
+	resolved := filepath.Clean(filepath.Join(filepath.Dir(link), normalized))
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("target escapes extraction root")
+	}
+	return nil
+}
+
+func hasWindowsVolumePath(path string) bool {
+	return len(path) >= 2 && ((path[0] >= 'a' && path[0] <= 'z') || (path[0] >= 'A' && path[0] <= 'Z')) && path[1] == ':'
 }
 
 // extractTarGz extracts a tar.gz archive.
@@ -744,6 +954,8 @@ func (d *DownloadManager) extractTarGz(archivePath, destDir, binaryName string) 
 	defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup
 
 	tr := tar.NewReader(gz)
+	entries := 0
+	var expanded uint64
 	for {
 		header, err := tr.Next()
 		if err == io.EOF {
@@ -752,10 +964,18 @@ func (d *DownloadManager) extractTarGz(archivePath, destDir, binaryName string) 
 		if err != nil {
 			return false, fmt.Errorf("read tar: %w", err)
 		}
+		entries++
+		if entries > maxArchiveEntries {
+			return false, fmt.Errorf("tar contains too many entries")
+		}
 
 		if header.Typeflag != tar.TypeReg {
 			continue
 		}
+		if header.Size < 0 || uint64(header.Size) > maxArchiveEntryBytes || expanded > maxArchiveExpandedBytes-uint64(header.Size) {
+			return false, fmt.Errorf("tar expanded size exceeds limit")
+		}
+		expanded += uint64(header.Size)
 
 		// Skip non-binary files (LICENSE, README, etc.)
 		base := filepath.Base(header.Name)
@@ -769,9 +989,14 @@ func (d *DownloadManager) extractTarGz(archivePath, destDir, binaryName string) 
 			return false, fmt.Errorf("create %s: %w", destPath, err)
 		}
 
-		if _, err := io.Copy(outFile, tr); err != nil {
+		written, err := io.Copy(outFile, io.LimitReader(tr, int64(maxArchiveEntryBytes)+1))
+		if err != nil {
 			_ = outFile.Close()
 			return false, fmt.Errorf("extract %s: %w", header.Name, err)
+		}
+		if written != header.Size {
+			_ = outFile.Close()
+			return false, fmt.Errorf("tar entry %s has invalid size", header.Name)
 		}
 		_ = outFile.Close()
 	}

--- a/sidechain-orchestrator/sidechain/bitnames/client.go
+++ b/sidechain-orchestrator/sidechain/bitnames/client.go
@@ -284,7 +284,7 @@ func (c *Client) PendingWithdrawalBundle(ctx context.Context) (json.RawMessage, 
 
 // ConnectPeer connects to a peer at the given address.
 func (c *Client) ConnectPeer(ctx context.Context, address string) error {
-	_, err := c.call(ctx, "connect_peer", address)
+	_, err := c.call(ctx, "connect_peer", []any{address})
 	return err
 }
 
@@ -330,17 +330,17 @@ func (c *Client) EncryptMsg(ctx context.Context, encryptionPubkey, msg string) (
 // DecryptMsg decrypts a ciphertext with the given encryption public key.
 // Returns the hex-encoded plaintext (caller must decode if needed).
 func (c *Client) DecryptMsg(ctx context.Context, encryptionPubkey, ciphertext string) (string, error) {
-	return unmarshal[string](c, ctx, "decrypt_msg", []interface{}{encryptionPubkey, ciphertext, true})
+	return unmarshal[string](c, ctx, "decrypt_msg", []interface{}{encryptionPubkey, ciphertext})
 }
 
 // SignArbitraryMsg signs a message with the specified verifying key.
 func (c *Client) SignArbitraryMsg(ctx context.Context, msg, verifyingKey string) (string, error) {
-	return unmarshal[string](c, ctx, "sign_arbitrary_msg", []interface{}{msg, verifyingKey})
+	return unmarshal[string](c, ctx, "sign_arbitrary_msg", []interface{}{verifyingKey, msg})
 }
 
 // SignArbitraryMsgAsAddr signs a message with the secret key for the given address.
 func (c *Client) SignArbitraryMsgAsAddr(ctx context.Context, msg, address string) (*SignatureResponse, error) {
-	r, err := unmarshal[SignatureResponse](c, ctx, "sign_arbitrary_msg_as_addr", []interface{}{msg, address})
+	r, err := unmarshal[SignatureResponse](c, ctx, "sign_arbitrary_msg_as_addr", []interface{}{address, msg})
 	if err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/bitnames/handler.go
+++ b/sidechain-orchestrator/sidechain/bitnames/handler.go
@@ -158,7 +158,7 @@ func (h *Handler) CreateDeposit(ctx context.Context, req *connect.Request[pb.Cre
 }
 
 func (h *Handler) ConnectPeer(ctx context.Context, req *connect.Request[pb.ConnectPeerRequest]) (*connect.Response[pb.ConnectPeerResponse], error) {
-	if err := h.proxy.Client.Call(ctx, "connect_peer", req.Msg.Address, nil); err != nil {
+	if _, err := h.proxy.Client.CallRaw(ctx, "connect_peer", []any{req.Msg.Address}); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ConnectPeerResponse{}), nil
@@ -276,7 +276,7 @@ func (h *Handler) GetNewVerifyingKey(ctx context.Context, req *connect.Request[p
 
 func (h *Handler) DecryptMsg(ctx context.Context, req *connect.Request[pb.DecryptMsgRequest]) (*connect.Response[pb.DecryptMsgResponse], error) {
 	var plaintext string
-	params := []any{req.Msg.EncryptionPubkey, req.Msg.Ciphertext, true}
+	params := []any{req.Msg.EncryptionPubkey, req.Msg.Ciphertext}
 	if err := h.proxy.Client.Call(ctx, "decrypt_msg", params, &plaintext); err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (h *Handler) ResolveCommit(ctx context.Context, req *connect.Request[pb.Res
 
 func (h *Handler) SignArbitraryMsg(ctx context.Context, req *connect.Request[pb.SignArbitraryMsgRequest]) (*connect.Response[pb.SignArbitraryMsgResponse], error) {
 	var signature string
-	params := []any{req.Msg.Msg, req.Msg.VerifyingKey}
+	params := []any{req.Msg.VerifyingKey, req.Msg.Msg}
 	if err := h.proxy.Client.Call(ctx, "sign_arbitrary_msg", params, &signature); err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (h *Handler) SignArbitraryMsgAsAddr(ctx context.Context, req *connect.Reque
 		VerifyingKey string `json:"verifying_key"`
 		Signature    string `json:"signature"`
 	}
-	params := []any{req.Msg.Msg, req.Msg.Address}
+	params := []any{req.Msg.Address, req.Msg.Msg}
 	if err := h.proxy.Client.Call(ctx, "sign_arbitrary_msg_as_addr", params, &result); err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/sidechain/bitnames/types.go
+++ b/sidechain-orchestrator/sidechain/bitnames/types.go
@@ -11,12 +11,13 @@ type BalanceResponse struct {
 
 // BitNameData holds optional metadata fields attached to a BitName.
 type BitNameData struct {
-	Commitment      *string `json:"commitment,omitempty"`
+	SeqID            string  `json:"seq_id,omitempty"`
+	Commitment       *string `json:"commitment,omitempty"`
 	EncryptionPubkey *string `json:"encryption_pubkey,omitempty"`
-	PaymailFeeSats  *int64  `json:"paymail_fee_sats,omitempty"`
+	PaymailFeeSats   *uint64 `json:"paymail_fee_sats,omitempty"`
 	SigningPubkey    *string `json:"signing_pubkey,omitempty"`
-	SocketAddrV4    *string `json:"socket_addr_v4,omitempty"`
-	SocketAddrV6    *string `json:"socket_addr_v6,omitempty"`
+	SocketAddrV4     *string `json:"socket_addr_v4,omitempty"`
+	SocketAddrV6     *string `json:"socket_addr_v6,omitempty"`
 }
 
 // BitnameDetails describes the on-chain state of a registered BitName.
@@ -67,12 +68,12 @@ type SignatureResponse struct {
 
 // BmmResult is the response from the "mine" RPC.
 type BmmResult struct {
-	HashLastMainBlock     string  `json:"hash_last_main_block"`
-	BmmBlockCreated       *string `json:"bmm_block_created,omitempty"`
-	BmmBlockSubmitted     *string `json:"bmm_block_submitted,omitempty"`
+	HashLastMainBlock      string  `json:"hash_last_main_block"`
+	BmmBlockCreated        *string `json:"bmm_block_created,omitempty"`
+	BmmBlockSubmitted      *string `json:"bmm_block_submitted,omitempty"`
 	BmmBlockSubmittedBlind *string `json:"bmm_block_submitted_blind,omitempty"`
-	Ntxn                  int     `json:"ntxn"`
-	Nfees                 int     `json:"nfees"`
-	Txid                  string  `json:"txid"`
-	Error                 *string `json:"error,omitempty"`
+	Ntxn                   int     `json:"ntxn"`
+	Nfees                  int     `json:"nfees"`
+	Txid                   string  `json:"txid"`
+	Error                  *string `json:"error,omitempty"`
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #1930. Review and merge the foundation PR first. Until #1930 is merged, GitHub will also show its foundation commit in this stacked PR.

## Summary

- Add paid BitName introductions followed by acceptance-gated ongoing chat.
- Charge the recipient’s advertised introduction amount plus the 100-sat chain fee.
- Use 1 sat plus the 100-sat chain fee for acceptance or message fallback.
- Reuse the same signed, encrypted envelope and message ID across direct, Tor, retry, and chain-fallback delivery.
- Unlock chat only after direct acceptance delivery or confirmed on-chain acceptance.
- Add duplicate-delivery protection, identity ownership checks, restart recovery, and reorg reconciliation.
- Add guided registration, reply-profile publication, contacts, readable BitName labels, block waits, transaction status, routes, and costs to BitWindow.
- Support automatically detected direct reply endpoints and onion reply endpoints.
- Ensure Tor-only mode blocks direct delivery and rejects BitNames chain writes without an authenticated connected tunnel.
- Download only pinned BitNames Tor bundles with hash, size, timeout, and safe-extraction verification.
- Add encrypted private-state backup, restore, and clearing controls.

## User experience

BitWindow guides the user through:

1. Starting BitNames and its enforcer.
2. Registering a BitName.
3. Waiting for reservation and registration blocks.
4. Publishing a reply profile.
5. Selecting direct or Tor-only communication.
6. Finding another BitName and confirming its advertised introduction fee.
7. Sending and accepting an introduction.
8. Waiting for delivery or chain confirmation.
9. Continuing the unlocked conversation directly, through Tor, or by chain fallback.

The interface exposes the real protocol steps, waits, routes, costs, block state, and recoverable errors without requiring users to manually coordinate separate pages.

## Validation

- Final source tree is byte-for-byte identical to the previously validated full implementation.
- BitWindow, BitNames, and Sail UI analyzers: clean.
- BitWindow suite: 76/76 passed.
- BitNames suite: 11/11 passed.
- Sail UI suite: 260/260 passed.
- Focused recovery, encrypted-storage, restart, reorg, and payment-state tests: 31/31 passed.
- Diff and formatting checks: clean.

## Dependency

This is PR 2 of 2 and depends on #1930. After the foundation PR merges, this commit will be rebased onto the updated upstream branch if the merge strategy does not preserve the foundation commit.
