### PR TITLE
bitwindow: add CPU mining to drynet

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.276
+version: 1.0.277
 
 environment:
   sdk: 3.12.0

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.276
+version: 1.0.277
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/lib/pages/cpu_mining_page.dart
+++ b/bitwindow/lib/pages/cpu_mining_page.dart
@@ -26,6 +26,7 @@ class _CpuMiningPageState extends State<CpuMiningPage> {
   void initState() {
     super.initState();
     _loadCoinbaseAddress();
+    _miningProvider.refreshStatus();
     _miningProvider.addListener(_onMiningStateChanged);
   }
 

--- a/bitwindow/lib/pages/root_page.dart
+++ b/bitwindow/lib/pages/root_page.dart
@@ -19,6 +19,7 @@ import 'package:bitwindow/pages/overview_page.dart';
 import 'package:bitwindow/pages/wallet/bitcoin_uri_dialog.dart';
 import 'package:bitwindow/providers/transactions_provider.dart';
 import 'package:bitwindow/widgets/fork_countdown_timer.dart';
+import 'package:bitwindow/widgets/mining_banner.dart';
 import 'package:bitwindow/widgets/proof_of_funds_modal.dart';
 import 'package:bitwindow/providers/bitwindow_settings_provider.dart';
 import 'package:bitwindow/providers/blockchain_provider.dart';
@@ -1091,7 +1092,9 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
                     body: Column(
                       children: [
                         Expanded(
-                          child: ForkCountdownHeader(child: child),
+                          child: ForkCountdownHeader(
+                            child: MiningBannerHeader(child: child),
+                          ),
                         ),
                         const StatusBar(),
                       ],

--- a/bitwindow/lib/pages/welcome/multisig_config_step.dart
+++ b/bitwindow/lib/pages/welcome/multisig_config_step.dart
@@ -581,6 +581,9 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> {
     try {
       final resp = await GetIt.I.get<OrchestratorRPC>().wallet.parseMultisigConfig(content);
       setState(() {
+        // An imported config is inherently multisig; switch mode so Next builds
+        // the multisig wallet instead of a single-sig one from the first leg.
+        _policy = 'multi';
         _threshold = resp.m;
         _total = resp.n;
         if (resp.scriptType.isNotEmpty) _scriptType = resp.scriptType;

--- a/bitwindow/lib/providers/mining_provider.dart
+++ b/bitwindow/lib/providers/mining_provider.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
-import 'package:sail_ui/gen/bitwindowd/v1/bitwindowd.pb.dart';
 import 'package:sail_ui/rpcs/bitwindow_api.dart';
 
 class MiningProvider extends ChangeNotifier {
@@ -16,69 +15,28 @@ class MiningProvider extends ChangeNotifier {
   String? error;
   List<String> foundBlockHashes = [];
 
-  StreamSubscription<MineBlocksResponse>? _miningSubscription;
+  Timer? _pollTimer;
 
   Future<void> startMining() async {
-    if (isMining) {
-      _log.w('Mining already started');
-      return;
-    }
-
     try {
       _log.i('Starting CPU mining');
       error = null;
-      isMining = true;
-      notifyListeners();
-
-      final stream = _bitwindowd.bitwindowd.mineBlocks();
-      _miningSubscription = stream.listen(
-        (response) {
-          if (response.hasHashRate()) {
-            hashRate = response.hashRate.hashRate;
-            _log.d('Hash rate: ${hashRate.toStringAsFixed(2)} H/s');
-          } else if (response.hasBlockFound()) {
-            final blockHash = response.blockFound.blockHash;
-            blocksFound++;
-            foundBlockHashes.insert(0, blockHash);
-            _log.i('Block found: $blockHash (total: $blocksFound)');
-          }
-          notifyListeners();
-        },
-        onError: (e) {
-          _log.e('Mining stream error: $e');
-          error = e.toString();
-          isMining = false;
-          notifyListeners();
-        },
-        onDone: () {
-          _log.i('Mining stream completed');
-          isMining = false;
-          hashRate = 0.0;
-          notifyListeners();
-        },
-        cancelOnError: false,
-      );
+      await _bitwindowd.bitwindowd.startMining();
+      _startPolling();
+      await refreshStatus();
     } catch (e) {
       _log.e('Failed to start mining: $e');
       error = e.toString();
-      isMining = false;
       notifyListeners();
     }
   }
 
   Future<void> stopMining() async {
-    if (!isMining) {
-      _log.w('Mining not running');
-      return;
-    }
-
     try {
       _log.i('Stopping CPU mining');
-      await _miningSubscription?.cancel();
-      _miningSubscription = null;
-      isMining = false;
-      hashRate = 0.0;
-      notifyListeners();
+      await _bitwindowd.bitwindowd.stopMining();
+      _stopPolling();
+      await refreshStatus();
     } catch (e) {
       _log.e('Failed to stop mining: $e');
       error = e.toString();
@@ -86,9 +44,37 @@ class MiningProvider extends ChangeNotifier {
     }
   }
 
+  Future<void> refreshStatus() async {
+    try {
+      final status = await _bitwindowd.bitwindowd.getMiningStatus();
+      isMining = status.mining;
+      hashRate = status.hashRate;
+      blocksFound = status.blocksFound;
+      foundBlockHashes = status.recentBlockHashes;
+      error = status.error.isNotEmpty ? status.error : null;
+      if (isMining) {
+        _startPolling();
+      } else {
+        _stopPolling();
+      }
+      notifyListeners();
+    } catch (e) {
+      _log.w('Failed to fetch mining status: $e');
+    }
+  }
+
+  void _startPolling() {
+    _pollTimer ??= Timer.periodic(const Duration(seconds: 3), (_) => refreshStatus());
+  }
+
+  void _stopPolling() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
   @override
   void dispose() {
-    _miningSubscription?.cancel();
+    _stopPolling();
     super.dispose();
   }
 }

--- a/bitwindow/lib/widgets/mining_banner.dart
+++ b/bitwindow/lib/widgets/mining_banner.dart
@@ -1,0 +1,112 @@
+import 'package:bitwindow/providers/mining_provider.dart';
+import 'package:bitwindow/routing/router.dart';
+import 'package:flutter/widgets.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+/// Pins the [MiningBanner] strip above [child]; the strip hides itself when
+/// mining is unavailable or dismissed.
+class MiningBannerHeader extends StatelessWidget {
+  const MiningBannerHeader({super.key, required this.child});
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const MiningBanner(),
+        Expanded(child: child),
+      ],
+    );
+  }
+}
+
+/// Drynet-only prompt to start mining. Shown while mining is stopped and not
+/// dismissed; tapping opens the miner page, the trailing x dismisses it.
+class MiningBanner extends StatefulWidget {
+  const MiningBanner({super.key});
+
+  @override
+  State<MiningBanner> createState() => _MiningBannerState();
+}
+
+class _MiningBannerState extends State<MiningBanner> {
+  BitcoinConfProvider get _conf => GetIt.I.get<BitcoinConfProvider>();
+  MiningProvider get _mining => GetIt.I.get<MiningProvider>();
+  ClientSettings get _settings => GetIt.I.get<ClientSettings>();
+
+  bool _dismissed = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _conf.addListener(_onChange);
+    _mining.addListener(_onChange);
+    _loadDismissed();
+    _mining.refreshStatus();
+  }
+
+  @override
+  void dispose() {
+    _conf.removeListener(_onChange);
+    _mining.removeListener(_onChange);
+    super.dispose();
+  }
+
+  void _onChange() {
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _loadDismissed() async {
+    final setting = await _settings.getValue(MiningBannerDismissedSetting());
+    if (mounted) setState(() => _dismissed = setting.value);
+  }
+
+  Future<void> _dismiss() async {
+    await _settings.setValue(MiningBannerDismissedSetting().withValue(true));
+    if (mounted) setState(() => _dismissed = true);
+  }
+
+  bool get _onDrynet => _conf.network == BitcoinNetwork.BITCOIN_NETWORK_DRYNET;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_onDrynet || _dismissed || _mining.isMining) return const SizedBox.shrink();
+
+    final theme = SailTheme.of(context);
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => GetIt.I.get<AppRouter>().push(CpuMiningRoute()),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+        decoration: BoxDecoration(
+          color: theme.colors.orange.withValues(alpha: 0.08),
+          border: Border(bottom: BorderSide(color: theme.colors.divider)),
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 6,
+              height: 6,
+              decoration: BoxDecoration(color: theme.colors.orange, shape: BoxShape.circle),
+            ),
+            const SizedBox(width: 8),
+            SailText.secondary12('You can mine blocks on drynet', bold: true, color: theme.colors.text),
+            const SizedBox(width: 10),
+            SailText.secondary12('Start mining now →', color: theme.colors.orange),
+            const Spacer(),
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: _dismiss,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4),
+                child: SailText.secondary13('✕', color: theme.colors.textSecondary),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.135
+version: 0.2.136
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"os/exec"
@@ -93,6 +94,20 @@ type Server struct {
 	// hash too, so same-height reorgs invalidate.
 	listBlocksCache sync.Map // listBlocksCacheKey -> *listBlocksCacheEntry
 	listBlocksTip   atomic.Pointer[blocksTip]
+
+	mining miningController
+}
+
+// miningController owns the backend CPU miner so mining survives independent of
+// any client. Guarded by mu; a nil miner means stopped.
+type miningController struct {
+	mu      sync.Mutex
+	miner   *cpuminer.Miner
+	cancel  context.CancelFunc
+	done    chan struct{} // closed when the miner goroutine has fully exited
+	started time.Time
+	blocks  []string
+	lastErr string // why the miner last stopped on its own, "" if cleanly
 }
 
 type listBlocksCacheKey struct {
@@ -154,6 +169,10 @@ func (s *Server) UpdateNetwork(ctx context.Context, req *connect.Request[pb.Upda
 	if !isKnownNetwork(network) {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unknown network: %q", req.Msg.Network))
 	}
+
+	// Stop the drynet miner before switching away: the recycle builds a fresh
+	// server that would otherwise have no handle to stop it.
+	s.stopMiner()
 
 	confClient := orchrpc.NewBitcoinConfServiceClient(
 		http.DefaultClient,
@@ -1111,30 +1130,33 @@ func (s *Server) getCoinbaseAddress(ctx context.Context) (string, error) {
 	}
 }
 
-func (s *Server) MineBlocks(ctx context.Context, req *connect.Request[emptypb.Empty], stream *connect.ServerStream[pb.MineBlocksResponse]) error {
-	// Verify we're actually able to connect to Bitcoin Core
-	if _, err := s.data.BlockchainInfo(ctx, &corepb.GetBlockchainInfoRequest{}); err != nil {
-		return err
-	}
-
-	// Gate on the configured network rather than Core's reported chain: forknet
-	// and drynet both report "main" and so are indistinguishable from real
-	// mainnet there, which is why they could never be allowlisted by chain name.
+// StartMining spins up the backend CPU miner on drynet, idempotently. The miner
+// runs on a detached context and keeps going after this call returns.
+func (s *Server) StartMining(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+	// Gate on the configured network rather than Core's reported chain: drynet
+	// reports "main" and so is indistinguishable from real mainnet there.
 	network := s.config.BitcoinCoreNetwork
 	if !config.IsMineableNetwork(network) {
-		return connect.NewError(
+		return nil, connect.NewError(
 			connect.CodeFailedPrecondition,
-			fmt.Errorf(
-				"generating blocks on %s is not supported",
-				cmp.Or(string(network), "unknown network"),
-			),
+			fmt.Errorf("mining is only available on drynet, not %s", cmp.Or(string(network), "unknown network")),
 		)
 	}
 
-	// Get a payout address from the active wallet for mining rewards
+	s.mining.mu.Lock()
+	defer s.mining.mu.Unlock()
+	if s.mining.miner != nil {
+		return connect.NewResponse(&emptypb.Empty{}), nil
+	}
+
+	if _, err := s.data.BlockchainInfo(ctx, &corepb.GetBlockchainInfoRequest{}); err != nil {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("bitcoin core unreachable: %w", err))
+	}
+
+	// Get a payout address from the active wallet for mining rewards.
 	address, err := s.getCoinbaseAddress(ctx)
 	if err != nil {
-		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("get mining address: %w", err))
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("get mining address: %w", err))
 	}
 
 	// cpuminer talks raw bitcoind JSON-RPC; pull the live creds from
@@ -1147,62 +1169,107 @@ func (s *Server) MineBlocks(ctx context.Context, req *connect.Request[emptypb.Em
 	)
 	confResp, err := confClient.GetBitcoinConfig(ctx, connect.NewRequest(&orchpb.GetBitcoinConfigRequest{}))
 	if err != nil {
-		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("read bitcoin config from orchestrator: %w", err))
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("read bitcoin config from orchestrator: %w", err))
 	}
 	miner, err := cpuminer.New(cpuminer.Config{
 		RpcURL:          fmt.Sprintf("http://localhost:%d", confResp.Msg.RpcPort),
 		RpcUser:         confResp.Msg.RpcUser,
 		RpcPass:         confResp.Msg.RpcPassword,
-		Routines:        1, // Single routine sufficient for regtest/testnet mining
+		Routines:        1,
 		CoinbaseAddress: address,
 	})
 	if err != nil {
-		return fmt.Errorf("create miner: %w", err)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create miner: %w", err))
 	}
 
-	errs := make(chan error)
+	logger := zerolog.Ctx(ctx)
+	minerCtx, cancel := context.WithCancel(logger.WithContext(context.Background()))
+	done := make(chan struct{})
+	s.mining.miner = miner
+	s.mining.cancel = cancel
+	s.mining.done = done
+	s.mining.started = time.Now()
+	s.mining.blocks = nil
+	s.mining.lastErr = ""
 
-	start := time.Now()
-
+	go s.consumeMinedBlocks(minerCtx, miner)
 	go func() {
-		for block := range miner.AcceptedBlocks() {
-			if err := stream.Send(&pb.MineBlocksResponse{
-				Event: &pb.MineBlocksResponse_BlockFound_{
-					BlockFound: &pb.MineBlocksResponse_BlockFound{
-						BlockHash: block.String(),
-					},
-				},
-			}); err != nil {
-				errs <- fmt.Errorf("send block found update: %w", err)
+		err := miner.Start(minerCtx)
+		// Also fires the block consumer's exit when Start returns on its own
+		// (an internal error), not just when StopMining cancels.
+		cancel()
+		fatal := err != nil && !errors.Is(err, context.Canceled)
+		s.mining.mu.Lock()
+		if s.mining.miner == miner {
+			s.mining.miner = nil
+			s.mining.cancel = nil
+			s.mining.done = nil
+			if fatal {
+				s.mining.lastErr = err.Error()
 			}
 		}
-	}()
-
-	go func() {
-		if err := miner.Start(ctx); err != nil {
-			errs <- err
+		s.mining.mu.Unlock()
+		close(done)
+		if fatal {
+			logger.Error().Err(err).Msg("cpu miner stopped with error")
 		}
 	}()
 
-	hashRateTicker := time.NewTicker(time.Second * 5)
-	defer hashRateTicker.Stop()
+	return connect.NewResponse(&emptypb.Empty{}), nil
+}
 
-	go func() {
-		for range hashRateTicker.C {
-			hashRate := miner.GetHashes()
-			if err := stream.Send(&pb.MineBlocksResponse{
-				Event: &pb.MineBlocksResponse_HashRate_{
-					HashRate: &pb.MineBlocksResponse_HashRate{
-						HashRate: float64(hashRate) / time.Since(start).Seconds(),
-					},
-				},
-			}); err != nil {
-				errs <- fmt.Errorf("send hash rate update: %w", err)
+// consumeMinedBlocks records accepted block hashes until the miner is cancelled.
+func (s *Server) consumeMinedBlocks(ctx context.Context, miner *cpuminer.Miner) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case block := <-miner.AcceptedBlocks():
+			s.mining.mu.Lock()
+			if s.mining.miner == miner {
+				s.mining.blocks = append([]string{block.String()}, s.mining.blocks...)
 			}
+			s.mining.mu.Unlock()
 		}
-	}()
+	}
+}
 
-	return <-errs
+// StopMining cancels the backend miner. Idempotent.
+func (s *Server) StopMining(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+	s.stopMiner()
+	return connect.NewResponse(&emptypb.Empty{}), nil
+}
+
+// stopMiner cancels the miner and waits for its goroutine to exit, so a
+// following Start never overlaps a miner that is still hashing.
+func (s *Server) stopMiner() {
+	s.mining.mu.Lock()
+	cancel, done := s.mining.cancel, s.mining.done
+	s.mining.mu.Unlock()
+	if cancel == nil {
+		return
+	}
+	cancel()
+	<-done
+}
+
+// GetMiningStatus reports whether the miner is running plus its hash rate and
+// the blocks found this session, which survive a stop until mining restarts.
+func (s *Server) GetMiningStatus(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[pb.GetMiningStatusResponse], error) {
+	s.mining.mu.Lock()
+	defer s.mining.mu.Unlock()
+	resp := &pb.GetMiningStatusResponse{
+		BlocksFound:       int32(len(s.mining.blocks)),
+		RecentBlockHashes: append([]string(nil), s.mining.blocks...),
+		Error:             s.mining.lastErr,
+	}
+	if s.mining.miner != nil {
+		resp.Mining = true
+		if elapsed := time.Since(s.mining.started).Seconds(); elapsed > 0 {
+			resp.HashRate = float64(s.mining.miner.GetHashes()) / elapsed
+		}
+	}
+	return connect.NewResponse(resp), nil
 }
 
 func (s *Server) GetNetworkStats(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[pb.GetNetworkStatsResponse], error) {

--- a/bitwindow/server/config/config.go
+++ b/bitwindow/server/config/config.go
@@ -131,18 +131,8 @@ func IsFullChainNetwork(n Network) bool {
 	return n == NetworkMainnet || n == NetworkForknet || n == NetworkDrynet
 }
 
-// IsMineableNetwork reports whether blocks can usefully be generated locally.
-// Forknet and drynet are drivechain testnets that restart difficulty at 1 from
-// their fork block, so they are CPU-mineable at home even though they run on
-// mainnet params; regtest and testnet are trivially mineable. Real mainnet and
-// signet are not — signet blocks are produced by its challenge signers.
+// IsMineableNetwork reports whether users may CPU-mine blocks locally. Only
+// drynet is enabled, where difficulty restarts at 1 from the fork block.
 func IsMineableNetwork(n Network) bool {
-	switch n {
-	case NetworkRegtest, NetworkTestnet, NetworkForknet, NetworkDrynet:
-		return true
-	case NetworkMainnet, NetworkSignet:
-		return false
-	default:
-		return false
-	}
+	return n == NetworkDrynet
 }

--- a/bitwindow/server/cpuminer/miner.go
+++ b/bitwindow/server/cpuminer/miner.go
@@ -461,9 +461,8 @@ func New(cfg Config) (*Miner, error) {
 
 	return &Miner{
 		client: http.DefaultClient,
-		// Buffered: consumers (e.g. the bitwindowd MineBlocks stream) read
-		// asynchronously, and in CLI mode there is no consumer at all. The
-		// send side never blocks and coalesces latest-wins on overflow.
+		// Buffered: consumers read asynchronously, and in CLI mode there is no
+		// consumer at all. The send side never blocks on overflow.
 		acceptedBlocks:    make(chan chainhash.Hash, 64),
 		routines:          cfg.Routines,
 		scanTime:          cfg.ScanTime,
@@ -557,17 +556,25 @@ func (m *Miner) Start(ctx context.Context) error {
 	if m.routines == 0 {
 		panic("PROGRAMMER ERROR: zero routines")
 	}
-	errs := make(chan error)
+	// A fatal error in one routine cancels the rest; parent cancellation stops
+	// them all. Start returns only once every routine has actually exited.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	errs := make(chan error, m.routines)
+	var wg sync.WaitGroup
 	for i := 0; i < m.routines; i++ {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			log := zerolog.Ctx(ctx).With().Int("routine", i).Logger()
-			ctx := log.WithContext(ctx)
-
-			if err := m.runRoutine(ctx, i); err != nil && !errors.Is(err, context.Canceled) {
+			if err := m.runRoutine(log.WithContext(ctx), i); err != nil && !errors.Is(err, context.Canceled) {
 				errs <- fmt.Errorf("miner routine no. %d: %w", i, err)
+				cancel()
 			}
 		}()
 	}
+	wg.Wait()
+	close(errs)
 	return <-errs
 }
 
@@ -690,6 +697,14 @@ func (m *Miner) scanhashSha256d(
 	hash := make([]byte, 32)
 
 	for header.Nonce < maxNonce && time.Since(start) < m.scanTime {
+		// Stop promptly when cancelled instead of scanning out the whole
+		// scanTime; checked in bulk so it costs nothing per hash.
+		if header.Nonce&0xffff == 0 {
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
+		}
+
 		// Update nonce
 		header.Nonce++
 		binary.LittleEndian.PutUint32(data[76:], header.Nonce)

--- a/bitwindow/server/gen/bitwindowd/v1/bitwindowd.pb.go
+++ b/bitwindow/server/gen/bitwindowd/v1/bitwindowd.pb.go
@@ -1822,31 +1822,36 @@ func (x *ListBlocksResponse) GetHasMore() bool {
 	return false
 }
 
-type MineBlocksResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Types that are valid to be assigned to Event:
-	//
-	//	*MineBlocksResponse_BlockFound_
-	//	*MineBlocksResponse_HashRate_
-	Event         isMineBlocksResponse_Event `protobuf_oneof:"event"`
+type GetMiningStatusResponse struct {
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Mining bool                   `protobuf:"varint,1,opt,name=mining,proto3" json:"mining,omitempty"`
+	// Hashes per second, averaged since the miner started.
+	HashRate    float64 `protobuf:"fixed64,2,opt,name=hash_rate,json=hashRate,proto3" json:"hash_rate,omitempty"`
+	BlocksFound int32   `protobuf:"varint,3,opt,name=blocks_found,json=blocksFound,proto3" json:"blocks_found,omitempty"`
+	// Block hashes found this session, newest first.
+	RecentBlockHashes []string `protobuf:"bytes,4,rep,name=recent_block_hashes,json=recentBlockHashes,proto3" json:"recent_block_hashes,omitempty"`
+	// Why the miner last stopped on its own (e.g. the node is still syncing),
+	// empty when it stopped cleanly. StartMining returns before work is fetched,
+	// so this is where a startup failure surfaces.
+	Error         string `protobuf:"bytes,5,opt,name=error,proto3" json:"error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *MineBlocksResponse) Reset() {
-	*x = MineBlocksResponse{}
+func (x *GetMiningStatusResponse) Reset() {
+	*x = GetMiningStatusResponse{}
 	mi := &file_bitwindowd_v1_bitwindowd_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *MineBlocksResponse) String() string {
+func (x *GetMiningStatusResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*MineBlocksResponse) ProtoMessage() {}
+func (*GetMiningStatusResponse) ProtoMessage() {}
 
-func (x *MineBlocksResponse) ProtoReflect() protoreflect.Message {
+func (x *GetMiningStatusResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_bitwindowd_v1_bitwindowd_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1858,51 +1863,45 @@ func (x *MineBlocksResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use MineBlocksResponse.ProtoReflect.Descriptor instead.
-func (*MineBlocksResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use GetMiningStatusResponse.ProtoReflect.Descriptor instead.
+func (*GetMiningStatusResponse) Descriptor() ([]byte, []int) {
 	return file_bitwindowd_v1_bitwindowd_proto_rawDescGZIP(), []int{25}
 }
 
-func (x *MineBlocksResponse) GetEvent() isMineBlocksResponse_Event {
+func (x *GetMiningStatusResponse) GetMining() bool {
 	if x != nil {
-		return x.Event
+		return x.Mining
+	}
+	return false
+}
+
+func (x *GetMiningStatusResponse) GetHashRate() float64 {
+	if x != nil {
+		return x.HashRate
+	}
+	return 0
+}
+
+func (x *GetMiningStatusResponse) GetBlocksFound() int32 {
+	if x != nil {
+		return x.BlocksFound
+	}
+	return 0
+}
+
+func (x *GetMiningStatusResponse) GetRecentBlockHashes() []string {
+	if x != nil {
+		return x.RecentBlockHashes
 	}
 	return nil
 }
 
-func (x *MineBlocksResponse) GetBlockFound() *MineBlocksResponse_BlockFound {
+func (x *GetMiningStatusResponse) GetError() string {
 	if x != nil {
-		if x, ok := x.Event.(*MineBlocksResponse_BlockFound_); ok {
-			return x.BlockFound
-		}
+		return x.Error
 	}
-	return nil
+	return ""
 }
-
-func (x *MineBlocksResponse) GetHashRate() *MineBlocksResponse_HashRate {
-	if x != nil {
-		if x, ok := x.Event.(*MineBlocksResponse_HashRate_); ok {
-			return x.HashRate
-		}
-	}
-	return nil
-}
-
-type isMineBlocksResponse_Event interface {
-	isMineBlocksResponse_Event()
-}
-
-type MineBlocksResponse_BlockFound_ struct {
-	BlockFound *MineBlocksResponse_BlockFound `protobuf:"bytes,1,opt,name=block_found,json=blockFound,proto3,oneof"`
-}
-
-type MineBlocksResponse_HashRate_ struct {
-	HashRate *MineBlocksResponse_HashRate `protobuf:"bytes,2,opt,name=hash_rate,json=hashRate,proto3,oneof"`
-}
-
-func (*MineBlocksResponse_BlockFound_) isMineBlocksResponse_Event() {}
-
-func (*MineBlocksResponse_HashRate_) isMineBlocksResponse_Event() {}
 
 type GetNetworkStatsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -2235,95 +2234,6 @@ func (*UpdateNetworkResponse) Descriptor() ([]byte, []int) {
 	return file_bitwindowd_v1_bitwindowd_proto_rawDescGZIP(), []int{29}
 }
 
-type MineBlocksResponse_HashRate struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Hashes per second
-	HashRate      float64 `protobuf:"fixed64,1,opt,name=hash_rate,json=hashRate,proto3" json:"hash_rate,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *MineBlocksResponse_HashRate) Reset() {
-	*x = MineBlocksResponse_HashRate{}
-	mi := &file_bitwindowd_v1_bitwindowd_proto_msgTypes[30]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *MineBlocksResponse_HashRate) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*MineBlocksResponse_HashRate) ProtoMessage() {}
-
-func (x *MineBlocksResponse_HashRate) ProtoReflect() protoreflect.Message {
-	mi := &file_bitwindowd_v1_bitwindowd_proto_msgTypes[30]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use MineBlocksResponse_HashRate.ProtoReflect.Descriptor instead.
-func (*MineBlocksResponse_HashRate) Descriptor() ([]byte, []int) {
-	return file_bitwindowd_v1_bitwindowd_proto_rawDescGZIP(), []int{25, 0}
-}
-
-func (x *MineBlocksResponse_HashRate) GetHashRate() float64 {
-	if x != nil {
-		return x.HashRate
-	}
-	return 0
-}
-
-type MineBlocksResponse_BlockFound struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	BlockHash     string                 `protobuf:"bytes,1,opt,name=block_hash,json=blockHash,proto3" json:"block_hash,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *MineBlocksResponse_BlockFound) Reset() {
-	*x = MineBlocksResponse_BlockFound{}
-	mi := &file_bitwindowd_v1_bitwindowd_proto_msgTypes[31]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *MineBlocksResponse_BlockFound) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*MineBlocksResponse_BlockFound) ProtoMessage() {}
-
-func (x *MineBlocksResponse_BlockFound) ProtoReflect() protoreflect.Message {
-	mi := &file_bitwindowd_v1_bitwindowd_proto_msgTypes[31]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use MineBlocksResponse_BlockFound.ProtoReflect.Descriptor instead.
-func (*MineBlocksResponse_BlockFound) Descriptor() ([]byte, []int) {
-	return file_bitwindowd_v1_bitwindowd_proto_rawDescGZIP(), []int{25, 1}
-}
-
-func (x *MineBlocksResponse_BlockFound) GetBlockHash() string {
-	if x != nil {
-		return x.BlockHash
-	}
-	return ""
-}
-
 var File_bitwindowd_v1_bitwindowd_proto protoreflect.FileDescriptor
 
 const file_bitwindowd_v1_bitwindowd_proto_rawDesc = "" +
@@ -2462,18 +2372,13 @@ const file_bitwindowd_v1_bitwindowd_proto_rawDesc = "" +
 	"\x05txids\x18\x10 \x03(\tR\x05txids\"j\n" +
 	"\x12ListBlocksResponse\x129\n" +
 	"\rrecent_blocks\x18\x04 \x03(\v2\x14.bitwindowd.v1.BlockR\frecentBlocks\x12\x19\n" +
-	"\bhas_more\x18\x05 \x01(\bR\ahasMore\"\x8f\x02\n" +
-	"\x12MineBlocksResponse\x12O\n" +
-	"\vblock_found\x18\x01 \x01(\v2,.bitwindowd.v1.MineBlocksResponse.BlockFoundH\x00R\n" +
-	"blockFound\x12I\n" +
-	"\thash_rate\x18\x02 \x01(\v2*.bitwindowd.v1.MineBlocksResponse.HashRateH\x00R\bhashRate\x1a'\n" +
-	"\bHashRate\x12\x1b\n" +
-	"\thash_rate\x18\x01 \x01(\x01R\bhashRate\x1a+\n" +
-	"\n" +
-	"BlockFound\x12\x1d\n" +
-	"\n" +
-	"block_hash\x18\x01 \x01(\tR\tblockHashB\a\n" +
-	"\x05event\"\xe1\x04\n" +
+	"\bhas_more\x18\x05 \x01(\bR\ahasMore\"\xb7\x01\n" +
+	"\x17GetMiningStatusResponse\x12\x16\n" +
+	"\x06mining\x18\x01 \x01(\bR\x06mining\x12\x1b\n" +
+	"\thash_rate\x18\x02 \x01(\x01R\bhashRate\x12!\n" +
+	"\fblocks_found\x18\x03 \x01(\x05R\vblocksFound\x12.\n" +
+	"\x13recent_block_hashes\x18\x04 \x03(\tR\x11recentBlockHashes\x12\x14\n" +
+	"\x05error\x18\x05 \x01(\tR\x05error\"\xe1\x04\n" +
 	"\x17GetNetworkStatsResponse\x12)\n" +
 	"\x10network_hashrate\x18\x01 \x01(\x01R\x0fnetworkHashrate\x12\x1e\n" +
 	"\n" +
@@ -2523,11 +2428,13 @@ const file_bitwindowd_v1_bitwindowd_proto_rawDesc = "" +
 	"\x14ADDRESS_TYPE_UNKNOWN\x10\x01\x12\x1b\n" +
 	"\x17ADDRESS_TYPE_BITCOIN_L1\x10\x02\x12#\n" +
 	"\x1fADDRESS_TYPE_DRIVECHAIN_DEPOSIT\x10\x03\x12#\n" +
-	"\x1fADDRESS_TYPE_BIP47_PAYMENT_CODE\x10\x042\xfc\f\n" +
+	"\x1fADDRESS_TYPE_BIP47_PAYMENT_CODE\x10\x042\x81\x0e\n" +
 	"\x11BitwindowdService\x12K\n" +
-	"\x04Stop\x12+.bitwindowd.v1.BitwindowdServiceStopRequest\x1a\x16.google.protobuf.Empty\x12I\n" +
+	"\x04Stop\x12+.bitwindowd.v1.BitwindowdServiceStopRequest\x1a\x16.google.protobuf.Empty\x12=\n" +
+	"\vStartMining\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\x12<\n" +
 	"\n" +
-	"MineBlocks\x12\x16.google.protobuf.Empty\x1a!.bitwindowd.v1.MineBlocksResponse0\x01\x12J\n" +
+	"StopMining\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\x12Q\n" +
+	"\x0fGetMiningStatus\x12\x16.google.protobuf.Empty\x1a&.bitwindowd.v1.GetMiningStatusResponse\x12J\n" +
 	"\fCreateDenial\x12\".bitwindowd.v1.CreateDenialRequest\x1a\x16.google.protobuf.Empty\x12J\n" +
 	"\fCancelDenial\x12\".bitwindowd.v1.CancelDenialRequest\x1a\x16.google.protobuf.Empty\x12H\n" +
 	"\vPauseDenial\x12!.bitwindowd.v1.PauseDenialRequest\x1a\x16.google.protobuf.Empty\x12J\n" +
@@ -2561,7 +2468,7 @@ func file_bitwindowd_v1_bitwindowd_proto_rawDescGZIP() []byte {
 }
 
 var file_bitwindowd_v1_bitwindowd_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_bitwindowd_v1_bitwindowd_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+var file_bitwindowd_v1_bitwindowd_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_bitwindowd_v1_bitwindowd_proto_goTypes = []any{
 	(Direction)(0),                         // 0: bitwindowd.v1.Direction
 	(BitcoinNetwork)(0),                    // 1: bitwindowd.v1.BitcoinNetwork
@@ -2591,81 +2498,81 @@ var file_bitwindowd_v1_bitwindowd_proto_goTypes = []any{
 	(*ListBlocksRequest)(nil),              // 25: bitwindowd.v1.ListBlocksRequest
 	(*Block)(nil),                          // 26: bitwindowd.v1.Block
 	(*ListBlocksResponse)(nil),             // 27: bitwindowd.v1.ListBlocksResponse
-	(*MineBlocksResponse)(nil),             // 28: bitwindowd.v1.MineBlocksResponse
+	(*GetMiningStatusResponse)(nil),        // 28: bitwindowd.v1.GetMiningStatusResponse
 	(*GetNetworkStatsResponse)(nil),        // 29: bitwindowd.v1.GetNetworkStatsResponse
 	(*ProcessBandwidth)(nil),               // 30: bitwindowd.v1.ProcessBandwidth
 	(*UpdateNetworkRequest)(nil),           // 31: bitwindowd.v1.UpdateNetworkRequest
 	(*UpdateNetworkResponse)(nil),          // 32: bitwindowd.v1.UpdateNetworkResponse
-	(*MineBlocksResponse_HashRate)(nil),    // 33: bitwindowd.v1.MineBlocksResponse.HashRate
-	(*MineBlocksResponse_BlockFound)(nil),  // 34: bitwindowd.v1.MineBlocksResponse.BlockFound
-	(*timestamppb.Timestamp)(nil),          // 35: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                  // 36: google.protobuf.Empty
+	(*timestamppb.Timestamp)(nil),          // 33: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                  // 34: google.protobuf.Empty
 }
 var file_bitwindowd_v1_bitwindowd_proto_depIdxs = []int32{
-	35, // 0: bitwindowd.v1.DenialInfo.create_time:type_name -> google.protobuf.Timestamp
-	35, // 1: bitwindowd.v1.DenialInfo.cancel_time:type_name -> google.protobuf.Timestamp
-	35, // 2: bitwindowd.v1.DenialInfo.next_execution_time:type_name -> google.protobuf.Timestamp
+	33, // 0: bitwindowd.v1.DenialInfo.create_time:type_name -> google.protobuf.Timestamp
+	33, // 1: bitwindowd.v1.DenialInfo.cancel_time:type_name -> google.protobuf.Timestamp
+	33, // 2: bitwindowd.v1.DenialInfo.next_execution_time:type_name -> google.protobuf.Timestamp
 	6,  // 3: bitwindowd.v1.DenialInfo.executions:type_name -> bitwindowd.v1.ExecutedDenial
-	35, // 4: bitwindowd.v1.DenialInfo.paused_at:type_name -> google.protobuf.Timestamp
-	35, // 5: bitwindowd.v1.ExecutedDenial.create_time:type_name -> google.protobuf.Timestamp
+	33, // 4: bitwindowd.v1.DenialInfo.paused_at:type_name -> google.protobuf.Timestamp
+	33, // 5: bitwindowd.v1.ExecutedDenial.create_time:type_name -> google.protobuf.Timestamp
 	0,  // 6: bitwindowd.v1.CreateAddressBookEntryRequest.direction:type_name -> bitwindowd.v1.Direction
 	12, // 7: bitwindowd.v1.CreateAddressBookEntryResponse.entry:type_name -> bitwindowd.v1.AddressBookEntry
 	0,  // 8: bitwindowd.v1.AddressBookEntry.direction:type_name -> bitwindowd.v1.Direction
-	35, // 9: bitwindowd.v1.AddressBookEntry.create_time:type_name -> google.protobuf.Timestamp
+	33, // 9: bitwindowd.v1.AddressBookEntry.create_time:type_name -> google.protobuf.Timestamp
 	2,  // 10: bitwindowd.v1.AddressBookEntry.type:type_name -> bitwindowd.v1.AddressType
 	12, // 11: bitwindowd.v1.ListAddressBookResponse.entries:type_name -> bitwindowd.v1.AddressBookEntry
-	35, // 12: bitwindowd.v1.GetSyncInfoResponse.tip_block_processed_at:type_name -> google.protobuf.Timestamp
+	33, // 12: bitwindowd.v1.GetSyncInfoResponse.tip_block_processed_at:type_name -> google.protobuf.Timestamp
 	24, // 13: bitwindowd.v1.ListRecentTransactionsResponse.transactions:type_name -> bitwindowd.v1.RecentTransaction
-	35, // 14: bitwindowd.v1.RecentTransaction.time:type_name -> google.protobuf.Timestamp
-	35, // 15: bitwindowd.v1.Block.block_time:type_name -> google.protobuf.Timestamp
+	33, // 14: bitwindowd.v1.RecentTransaction.time:type_name -> google.protobuf.Timestamp
+	33, // 15: bitwindowd.v1.Block.block_time:type_name -> google.protobuf.Timestamp
 	26, // 16: bitwindowd.v1.ListBlocksResponse.recent_blocks:type_name -> bitwindowd.v1.Block
-	34, // 17: bitwindowd.v1.MineBlocksResponse.block_found:type_name -> bitwindowd.v1.MineBlocksResponse.BlockFound
-	33, // 18: bitwindowd.v1.MineBlocksResponse.hash_rate:type_name -> bitwindowd.v1.MineBlocksResponse.HashRate
-	30, // 19: bitwindowd.v1.GetNetworkStatsResponse.bitcoind_bandwidth:type_name -> bitwindowd.v1.ProcessBandwidth
-	30, // 20: bitwindowd.v1.GetNetworkStatsResponse.enforcer_bandwidth:type_name -> bitwindowd.v1.ProcessBandwidth
-	3,  // 21: bitwindowd.v1.BitwindowdService.Stop:input_type -> bitwindowd.v1.BitwindowdServiceStopRequest
-	36, // 22: bitwindowd.v1.BitwindowdService.MineBlocks:input_type -> google.protobuf.Empty
+	30, // 17: bitwindowd.v1.GetNetworkStatsResponse.bitcoind_bandwidth:type_name -> bitwindowd.v1.ProcessBandwidth
+	30, // 18: bitwindowd.v1.GetNetworkStatsResponse.enforcer_bandwidth:type_name -> bitwindowd.v1.ProcessBandwidth
+	3,  // 19: bitwindowd.v1.BitwindowdService.Stop:input_type -> bitwindowd.v1.BitwindowdServiceStopRequest
+	34, // 20: bitwindowd.v1.BitwindowdService.StartMining:input_type -> google.protobuf.Empty
+	34, // 21: bitwindowd.v1.BitwindowdService.StopMining:input_type -> google.protobuf.Empty
+	34, // 22: bitwindowd.v1.BitwindowdService.GetMiningStatus:input_type -> google.protobuf.Empty
 	4,  // 23: bitwindowd.v1.BitwindowdService.CreateDenial:input_type -> bitwindowd.v1.CreateDenialRequest
 	7,  // 24: bitwindowd.v1.BitwindowdService.CancelDenial:input_type -> bitwindowd.v1.CancelDenialRequest
 	8,  // 25: bitwindowd.v1.BitwindowdService.PauseDenial:input_type -> bitwindowd.v1.PauseDenialRequest
 	9,  // 26: bitwindowd.v1.BitwindowdService.ResumeDenial:input_type -> bitwindowd.v1.ResumeDenialRequest
 	10, // 27: bitwindowd.v1.BitwindowdService.CreateAddressBookEntry:input_type -> bitwindowd.v1.CreateAddressBookEntryRequest
-	36, // 28: bitwindowd.v1.BitwindowdService.ListAddressBook:input_type -> google.protobuf.Empty
+	34, // 28: bitwindowd.v1.BitwindowdService.ListAddressBook:input_type -> google.protobuf.Empty
 	14, // 29: bitwindowd.v1.BitwindowdService.UpdateAddressBookEntry:input_type -> bitwindowd.v1.UpdateAddressBookEntryRequest
 	15, // 30: bitwindowd.v1.BitwindowdService.DeleteAddressBookEntry:input_type -> bitwindowd.v1.DeleteAddressBookEntryRequest
-	36, // 31: bitwindowd.v1.BitwindowdService.GetSyncInfo:input_type -> google.protobuf.Empty
+	34, // 31: bitwindowd.v1.BitwindowdService.GetSyncInfo:input_type -> google.protobuf.Empty
 	17, // 32: bitwindowd.v1.BitwindowdService.SetTransactionNote:input_type -> bitwindowd.v1.SetTransactionNoteRequest
-	36, // 33: bitwindowd.v1.BitwindowdService.ExportLabels:input_type -> google.protobuf.Empty
+	34, // 33: bitwindowd.v1.BitwindowdService.ExportLabels:input_type -> google.protobuf.Empty
 	19, // 34: bitwindowd.v1.BitwindowdService.ImportLabels:input_type -> bitwindowd.v1.ImportLabelsRequest
-	36, // 35: bitwindowd.v1.BitwindowdService.GetFireplaceStats:input_type -> google.protobuf.Empty
+	34, // 35: bitwindowd.v1.BitwindowdService.GetFireplaceStats:input_type -> google.protobuf.Empty
 	22, // 36: bitwindowd.v1.BitwindowdService.ListRecentTransactions:input_type -> bitwindowd.v1.ListRecentTransactionsRequest
 	25, // 37: bitwindowd.v1.BitwindowdService.ListBlocks:input_type -> bitwindowd.v1.ListBlocksRequest
-	36, // 38: bitwindowd.v1.BitwindowdService.GetNetworkStats:input_type -> google.protobuf.Empty
+	34, // 38: bitwindowd.v1.BitwindowdService.GetNetworkStats:input_type -> google.protobuf.Empty
 	31, // 39: bitwindowd.v1.BitwindowdService.UpdateNetwork:input_type -> bitwindowd.v1.UpdateNetworkRequest
-	36, // 40: bitwindowd.v1.BitwindowdService.Stop:output_type -> google.protobuf.Empty
-	28, // 41: bitwindowd.v1.BitwindowdService.MineBlocks:output_type -> bitwindowd.v1.MineBlocksResponse
-	36, // 42: bitwindowd.v1.BitwindowdService.CreateDenial:output_type -> google.protobuf.Empty
-	36, // 43: bitwindowd.v1.BitwindowdService.CancelDenial:output_type -> google.protobuf.Empty
-	36, // 44: bitwindowd.v1.BitwindowdService.PauseDenial:output_type -> google.protobuf.Empty
-	36, // 45: bitwindowd.v1.BitwindowdService.ResumeDenial:output_type -> google.protobuf.Empty
-	11, // 46: bitwindowd.v1.BitwindowdService.CreateAddressBookEntry:output_type -> bitwindowd.v1.CreateAddressBookEntryResponse
-	13, // 47: bitwindowd.v1.BitwindowdService.ListAddressBook:output_type -> bitwindowd.v1.ListAddressBookResponse
-	36, // 48: bitwindowd.v1.BitwindowdService.UpdateAddressBookEntry:output_type -> google.protobuf.Empty
-	36, // 49: bitwindowd.v1.BitwindowdService.DeleteAddressBookEntry:output_type -> google.protobuf.Empty
-	16, // 50: bitwindowd.v1.BitwindowdService.GetSyncInfo:output_type -> bitwindowd.v1.GetSyncInfoResponse
-	36, // 51: bitwindowd.v1.BitwindowdService.SetTransactionNote:output_type -> google.protobuf.Empty
-	18, // 52: bitwindowd.v1.BitwindowdService.ExportLabels:output_type -> bitwindowd.v1.ExportLabelsResponse
-	20, // 53: bitwindowd.v1.BitwindowdService.ImportLabels:output_type -> bitwindowd.v1.ImportLabelsResponse
-	21, // 54: bitwindowd.v1.BitwindowdService.GetFireplaceStats:output_type -> bitwindowd.v1.GetFireplaceStatsResponse
-	23, // 55: bitwindowd.v1.BitwindowdService.ListRecentTransactions:output_type -> bitwindowd.v1.ListRecentTransactionsResponse
-	27, // 56: bitwindowd.v1.BitwindowdService.ListBlocks:output_type -> bitwindowd.v1.ListBlocksResponse
-	29, // 57: bitwindowd.v1.BitwindowdService.GetNetworkStats:output_type -> bitwindowd.v1.GetNetworkStatsResponse
-	32, // 58: bitwindowd.v1.BitwindowdService.UpdateNetwork:output_type -> bitwindowd.v1.UpdateNetworkResponse
-	40, // [40:59] is the sub-list for method output_type
-	21, // [21:40] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	34, // 40: bitwindowd.v1.BitwindowdService.Stop:output_type -> google.protobuf.Empty
+	34, // 41: bitwindowd.v1.BitwindowdService.StartMining:output_type -> google.protobuf.Empty
+	34, // 42: bitwindowd.v1.BitwindowdService.StopMining:output_type -> google.protobuf.Empty
+	28, // 43: bitwindowd.v1.BitwindowdService.GetMiningStatus:output_type -> bitwindowd.v1.GetMiningStatusResponse
+	34, // 44: bitwindowd.v1.BitwindowdService.CreateDenial:output_type -> google.protobuf.Empty
+	34, // 45: bitwindowd.v1.BitwindowdService.CancelDenial:output_type -> google.protobuf.Empty
+	34, // 46: bitwindowd.v1.BitwindowdService.PauseDenial:output_type -> google.protobuf.Empty
+	34, // 47: bitwindowd.v1.BitwindowdService.ResumeDenial:output_type -> google.protobuf.Empty
+	11, // 48: bitwindowd.v1.BitwindowdService.CreateAddressBookEntry:output_type -> bitwindowd.v1.CreateAddressBookEntryResponse
+	13, // 49: bitwindowd.v1.BitwindowdService.ListAddressBook:output_type -> bitwindowd.v1.ListAddressBookResponse
+	34, // 50: bitwindowd.v1.BitwindowdService.UpdateAddressBookEntry:output_type -> google.protobuf.Empty
+	34, // 51: bitwindowd.v1.BitwindowdService.DeleteAddressBookEntry:output_type -> google.protobuf.Empty
+	16, // 52: bitwindowd.v1.BitwindowdService.GetSyncInfo:output_type -> bitwindowd.v1.GetSyncInfoResponse
+	34, // 53: bitwindowd.v1.BitwindowdService.SetTransactionNote:output_type -> google.protobuf.Empty
+	18, // 54: bitwindowd.v1.BitwindowdService.ExportLabels:output_type -> bitwindowd.v1.ExportLabelsResponse
+	20, // 55: bitwindowd.v1.BitwindowdService.ImportLabels:output_type -> bitwindowd.v1.ImportLabelsResponse
+	21, // 56: bitwindowd.v1.BitwindowdService.GetFireplaceStats:output_type -> bitwindowd.v1.GetFireplaceStatsResponse
+	23, // 57: bitwindowd.v1.BitwindowdService.ListRecentTransactions:output_type -> bitwindowd.v1.ListRecentTransactionsResponse
+	27, // 58: bitwindowd.v1.BitwindowdService.ListBlocks:output_type -> bitwindowd.v1.ListBlocksResponse
+	29, // 59: bitwindowd.v1.BitwindowdService.GetNetworkStats:output_type -> bitwindowd.v1.GetNetworkStatsResponse
+	32, // 60: bitwindowd.v1.BitwindowdService.UpdateNetwork:output_type -> bitwindowd.v1.UpdateNetworkResponse
+	40, // [40:61] is the sub-list for method output_type
+	19, // [19:40] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_bitwindowd_v1_bitwindowd_proto_init() }
@@ -2675,17 +2582,13 @@ func file_bitwindowd_v1_bitwindowd_proto_init() {
 	}
 	file_bitwindowd_v1_bitwindowd_proto_msgTypes[2].OneofWrappers = []any{}
 	file_bitwindowd_v1_bitwindowd_proto_msgTypes[21].OneofWrappers = []any{}
-	file_bitwindowd_v1_bitwindowd_proto_msgTypes[25].OneofWrappers = []any{
-		(*MineBlocksResponse_BlockFound_)(nil),
-		(*MineBlocksResponse_HashRate_)(nil),
-	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_bitwindowd_v1_bitwindowd_proto_rawDesc), len(file_bitwindowd_v1_bitwindowd_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   32,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/bitwindow/server/gen/bitwindowd/v1/bitwindowdv1connect/bitwindowd.connect.go
+++ b/bitwindow/server/gen/bitwindowd/v1/bitwindowdv1connect/bitwindowd.connect.go
@@ -36,9 +36,15 @@ const (
 const (
 	// BitwindowdServiceStopProcedure is the fully-qualified name of the BitwindowdService's Stop RPC.
 	BitwindowdServiceStopProcedure = "/bitwindowd.v1.BitwindowdService/Stop"
-	// BitwindowdServiceMineBlocksProcedure is the fully-qualified name of the BitwindowdService's
-	// MineBlocks RPC.
-	BitwindowdServiceMineBlocksProcedure = "/bitwindowd.v1.BitwindowdService/MineBlocks"
+	// BitwindowdServiceStartMiningProcedure is the fully-qualified name of the BitwindowdService's
+	// StartMining RPC.
+	BitwindowdServiceStartMiningProcedure = "/bitwindowd.v1.BitwindowdService/StartMining"
+	// BitwindowdServiceStopMiningProcedure is the fully-qualified name of the BitwindowdService's
+	// StopMining RPC.
+	BitwindowdServiceStopMiningProcedure = "/bitwindowd.v1.BitwindowdService/StopMining"
+	// BitwindowdServiceGetMiningStatusProcedure is the fully-qualified name of the BitwindowdService's
+	// GetMiningStatus RPC.
+	BitwindowdServiceGetMiningStatusProcedure = "/bitwindowd.v1.BitwindowdService/GetMiningStatus"
 	// BitwindowdServiceCreateDenialProcedure is the fully-qualified name of the BitwindowdService's
 	// CreateDenial RPC.
 	BitwindowdServiceCreateDenialProcedure = "/bitwindowd.v1.BitwindowdService/CreateDenial"
@@ -100,7 +106,11 @@ type BitwindowdServiceClient interface {
 	// immediately. Pass skip_downstream=true to leave the orchestratord stack
 	// running (only bitwindowd dies).
 	Stop(context.Context, *connect.Request[v1.BitwindowdServiceStopRequest]) (*connect.Response[emptypb.Empty], error)
-	MineBlocks(context.Context, *connect.Request[emptypb.Empty]) (*connect.ServerStreamForClient[v1.MineBlocksResponse], error)
+	// CPU mining, drynet only. Start/Stop control a backend-owned miner that
+	// keeps running independent of any client; GetMiningStatus polls its stats.
+	StartMining(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error)
+	StopMining(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error)
+	GetMiningStatus(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[v1.GetMiningStatusResponse], error)
 	// Deniability operations
 	CreateDenial(context.Context, *connect.Request[v1.CreateDenialRequest]) (*connect.Response[emptypb.Empty], error)
 	CancelDenial(context.Context, *connect.Request[v1.CancelDenialRequest]) (*connect.Response[emptypb.Empty], error)
@@ -153,10 +163,22 @@ func NewBitwindowdServiceClient(httpClient connect.HTTPClient, baseURL string, o
 			connect.WithSchema(bitwindowdServiceMethods.ByName("Stop")),
 			connect.WithClientOptions(opts...),
 		),
-		mineBlocks: connect.NewClient[emptypb.Empty, v1.MineBlocksResponse](
+		startMining: connect.NewClient[emptypb.Empty, emptypb.Empty](
 			httpClient,
-			baseURL+BitwindowdServiceMineBlocksProcedure,
-			connect.WithSchema(bitwindowdServiceMethods.ByName("MineBlocks")),
+			baseURL+BitwindowdServiceStartMiningProcedure,
+			connect.WithSchema(bitwindowdServiceMethods.ByName("StartMining")),
+			connect.WithClientOptions(opts...),
+		),
+		stopMining: connect.NewClient[emptypb.Empty, emptypb.Empty](
+			httpClient,
+			baseURL+BitwindowdServiceStopMiningProcedure,
+			connect.WithSchema(bitwindowdServiceMethods.ByName("StopMining")),
+			connect.WithClientOptions(opts...),
+		),
+		getMiningStatus: connect.NewClient[emptypb.Empty, v1.GetMiningStatusResponse](
+			httpClient,
+			baseURL+BitwindowdServiceGetMiningStatusProcedure,
+			connect.WithSchema(bitwindowdServiceMethods.ByName("GetMiningStatus")),
 			connect.WithClientOptions(opts...),
 		),
 		createDenial: connect.NewClient[v1.CreateDenialRequest, emptypb.Empty](
@@ -267,7 +289,9 @@ func NewBitwindowdServiceClient(httpClient connect.HTTPClient, baseURL string, o
 // bitwindowdServiceClient implements BitwindowdServiceClient.
 type bitwindowdServiceClient struct {
 	stop                   *connect.Client[v1.BitwindowdServiceStopRequest, emptypb.Empty]
-	mineBlocks             *connect.Client[emptypb.Empty, v1.MineBlocksResponse]
+	startMining            *connect.Client[emptypb.Empty, emptypb.Empty]
+	stopMining             *connect.Client[emptypb.Empty, emptypb.Empty]
+	getMiningStatus        *connect.Client[emptypb.Empty, v1.GetMiningStatusResponse]
 	createDenial           *connect.Client[v1.CreateDenialRequest, emptypb.Empty]
 	cancelDenial           *connect.Client[v1.CancelDenialRequest, emptypb.Empty]
 	pauseDenial            *connect.Client[v1.PauseDenialRequest, emptypb.Empty]
@@ -292,9 +316,19 @@ func (c *bitwindowdServiceClient) Stop(ctx context.Context, req *connect.Request
 	return c.stop.CallUnary(ctx, req)
 }
 
-// MineBlocks calls bitwindowd.v1.BitwindowdService.MineBlocks.
-func (c *bitwindowdServiceClient) MineBlocks(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.ServerStreamForClient[v1.MineBlocksResponse], error) {
-	return c.mineBlocks.CallServerStream(ctx, req)
+// StartMining calls bitwindowd.v1.BitwindowdService.StartMining.
+func (c *bitwindowdServiceClient) StartMining(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+	return c.startMining.CallUnary(ctx, req)
+}
+
+// StopMining calls bitwindowd.v1.BitwindowdService.StopMining.
+func (c *bitwindowdServiceClient) StopMining(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+	return c.stopMining.CallUnary(ctx, req)
+}
+
+// GetMiningStatus calls bitwindowd.v1.BitwindowdService.GetMiningStatus.
+func (c *bitwindowdServiceClient) GetMiningStatus(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[v1.GetMiningStatusResponse], error) {
+	return c.getMiningStatus.CallUnary(ctx, req)
 }
 
 // CreateDenial calls bitwindowd.v1.BitwindowdService.CreateDenial.
@@ -390,7 +424,11 @@ type BitwindowdServiceHandler interface {
 	// immediately. Pass skip_downstream=true to leave the orchestratord stack
 	// running (only bitwindowd dies).
 	Stop(context.Context, *connect.Request[v1.BitwindowdServiceStopRequest]) (*connect.Response[emptypb.Empty], error)
-	MineBlocks(context.Context, *connect.Request[emptypb.Empty], *connect.ServerStream[v1.MineBlocksResponse]) error
+	// CPU mining, drynet only. Start/Stop control a backend-owned miner that
+	// keeps running independent of any client; GetMiningStatus polls its stats.
+	StartMining(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error)
+	StopMining(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error)
+	GetMiningStatus(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[v1.GetMiningStatusResponse], error)
 	// Deniability operations
 	CreateDenial(context.Context, *connect.Request[v1.CreateDenialRequest]) (*connect.Response[emptypb.Empty], error)
 	CancelDenial(context.Context, *connect.Request[v1.CancelDenialRequest]) (*connect.Response[emptypb.Empty], error)
@@ -439,10 +477,22 @@ func NewBitwindowdServiceHandler(svc BitwindowdServiceHandler, opts ...connect.H
 		connect.WithSchema(bitwindowdServiceMethods.ByName("Stop")),
 		connect.WithHandlerOptions(opts...),
 	)
-	bitwindowdServiceMineBlocksHandler := connect.NewServerStreamHandler(
-		BitwindowdServiceMineBlocksProcedure,
-		svc.MineBlocks,
-		connect.WithSchema(bitwindowdServiceMethods.ByName("MineBlocks")),
+	bitwindowdServiceStartMiningHandler := connect.NewUnaryHandler(
+		BitwindowdServiceStartMiningProcedure,
+		svc.StartMining,
+		connect.WithSchema(bitwindowdServiceMethods.ByName("StartMining")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bitwindowdServiceStopMiningHandler := connect.NewUnaryHandler(
+		BitwindowdServiceStopMiningProcedure,
+		svc.StopMining,
+		connect.WithSchema(bitwindowdServiceMethods.ByName("StopMining")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bitwindowdServiceGetMiningStatusHandler := connect.NewUnaryHandler(
+		BitwindowdServiceGetMiningStatusProcedure,
+		svc.GetMiningStatus,
+		connect.WithSchema(bitwindowdServiceMethods.ByName("GetMiningStatus")),
 		connect.WithHandlerOptions(opts...),
 	)
 	bitwindowdServiceCreateDenialHandler := connect.NewUnaryHandler(
@@ -551,8 +601,12 @@ func NewBitwindowdServiceHandler(svc BitwindowdServiceHandler, opts ...connect.H
 		switch r.URL.Path {
 		case BitwindowdServiceStopProcedure:
 			bitwindowdServiceStopHandler.ServeHTTP(w, r)
-		case BitwindowdServiceMineBlocksProcedure:
-			bitwindowdServiceMineBlocksHandler.ServeHTTP(w, r)
+		case BitwindowdServiceStartMiningProcedure:
+			bitwindowdServiceStartMiningHandler.ServeHTTP(w, r)
+		case BitwindowdServiceStopMiningProcedure:
+			bitwindowdServiceStopMiningHandler.ServeHTTP(w, r)
+		case BitwindowdServiceGetMiningStatusProcedure:
+			bitwindowdServiceGetMiningStatusHandler.ServeHTTP(w, r)
 		case BitwindowdServiceCreateDenialProcedure:
 			bitwindowdServiceCreateDenialHandler.ServeHTTP(w, r)
 		case BitwindowdServiceCancelDenialProcedure:
@@ -600,8 +654,16 @@ func (UnimplementedBitwindowdServiceHandler) Stop(context.Context, *connect.Requ
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bitwindowd.v1.BitwindowdService.Stop is not implemented"))
 }
 
-func (UnimplementedBitwindowdServiceHandler) MineBlocks(context.Context, *connect.Request[emptypb.Empty], *connect.ServerStream[v1.MineBlocksResponse]) error {
-	return connect.NewError(connect.CodeUnimplemented, errors.New("bitwindowd.v1.BitwindowdService.MineBlocks is not implemented"))
+func (UnimplementedBitwindowdServiceHandler) StartMining(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bitwindowd.v1.BitwindowdService.StartMining is not implemented"))
+}
+
+func (UnimplementedBitwindowdServiceHandler) StopMining(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bitwindowd.v1.BitwindowdService.StopMining is not implemented"))
+}
+
+func (UnimplementedBitwindowdServiceHandler) GetMiningStatus(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[v1.GetMiningStatusResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bitwindowd.v1.BitwindowdService.GetMiningStatus is not implemented"))
 }
 
 func (UnimplementedBitwindowdServiceHandler) CreateDenial(context.Context, *connect.Request[v1.CreateDenialRequest]) (*connect.Response[emptypb.Empty], error) {

--- a/bitwindow/server/proto/bitwindowd/v1/bitwindowd.proto
+++ b/bitwindow/server/proto/bitwindowd/v1/bitwindowd.proto
@@ -13,7 +13,11 @@ service BitwindowdService {
   // running (only bitwindowd dies).
   rpc Stop(BitwindowdServiceStopRequest) returns (google.protobuf.Empty);
 
-  rpc MineBlocks(google.protobuf.Empty) returns (stream MineBlocksResponse);
+  // CPU mining, drynet only. Start/Stop control a backend-owned miner that
+  // keeps running independent of any client; GetMiningStatus polls its stats.
+  rpc StartMining(google.protobuf.Empty) returns (google.protobuf.Empty);
+  rpc StopMining(google.protobuf.Empty) returns (google.protobuf.Empty);
+  rpc GetMiningStatus(google.protobuf.Empty) returns (GetMiningStatusResponse);
 
   // Deniability operations
   rpc CreateDenial(CreateDenialRequest) returns (google.protobuf.Empty);
@@ -270,20 +274,17 @@ message ListBlocksResponse {
   bool has_more = 5; // Whether there are more blocks available
 }
 
-message MineBlocksResponse {
-  message HashRate {
-    // Hashes per second
-    double hash_rate = 1;
-  }
-
-  message BlockFound {
-    string block_hash = 1;
-  }
-
-  oneof event {
-    BlockFound block_found = 1;
-    HashRate hash_rate = 2;
-  }
+message GetMiningStatusResponse {
+  bool mining = 1;
+  // Hashes per second, averaged since the miner started.
+  double hash_rate = 2;
+  int32 blocks_found = 3;
+  // Block hashes found this session, newest first.
+  repeated string recent_block_hashes = 4;
+  // Why the miner last stopped on its own (e.g. the node is still syncing),
+  // empty when it stopped cleanly. StartMining returns before work is fetched,
+  // so this is where a startup failure surfaces.
+  string error = 5;
 }
 
 message GetNetworkStatsResponse {

--- a/bitwindow/test/mocks/api_mock.dart
+++ b/bitwindow/test/mocks/api_mock.dart
@@ -164,9 +164,13 @@ class MockBitwindowdAPI implements BitwindowAPI {
   Future<void> updateNetwork(String network) async {}
 
   @override
-  Stream<MineBlocksResponse> mineBlocks() {
-    return Stream.periodic(const Duration(seconds: 1)).map((_) => MineBlocksResponse());
-  }
+  Future<void> startMining() async {}
+
+  @override
+  Future<void> stopMining() async {}
+
+  @override
+  Future<GetMiningStatusResponse> getMiningStatus() async => GetMiningStatusResponse();
 
   @override
   Future<void> pauseDenial(Int64 id) {

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.149
+version: 1.0.150
 
 environment:
   sdk: 3.12.0

--- a/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.connect.client.dart
+++ b/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.connect.client.dart
@@ -31,15 +31,51 @@ extension type BitwindowdServiceClient (connect.Transport _transport) {
     );
   }
 
-  Stream<bitwindowdv1bitwindowd.MineBlocksResponse> mineBlocks(
+  /// CPU mining, drynet only. Start/Stop control a backend-owned miner that
+  /// keeps running independent of any client; GetMiningStatus polls its stats.
+  Future<googleprotobufempty.Empty> startMining(
     googleprotobufempty.Empty input, {
     connect.Headers? headers,
     connect.AbortSignal? signal,
     Function(connect.Headers)? onHeader,
     Function(connect.Headers)? onTrailer,
   }) {
-    return connect.Client(_transport).server(
-      specs.BitwindowdService.mineBlocks,
+    return connect.Client(_transport).unary(
+      specs.BitwindowdService.startMining,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
+  Future<googleprotobufempty.Empty> stopMining(
+    googleprotobufempty.Empty input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.BitwindowdService.stopMining,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
+  Future<bitwindowdv1bitwindowd.GetMiningStatusResponse> getMiningStatus(
+    googleprotobufempty.Empty input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.BitwindowdService.getMiningStatus,
       input,
       signal: signal,
       headers: headers,

--- a/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.connect.spec.dart
+++ b/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.connect.spec.dart
@@ -23,11 +23,27 @@ abstract final class BitwindowdService {
     googleprotobufempty.Empty.new,
   );
 
-  static const mineBlocks = connect.Spec(
-    '/$name/MineBlocks',
-    connect.StreamType.server,
+  /// CPU mining, drynet only. Start/Stop control a backend-owned miner that
+  /// keeps running independent of any client; GetMiningStatus polls its stats.
+  static const startMining = connect.Spec(
+    '/$name/StartMining',
+    connect.StreamType.unary,
     googleprotobufempty.Empty.new,
-    bitwindowdv1bitwindowd.MineBlocksResponse.new,
+    googleprotobufempty.Empty.new,
+  );
+
+  static const stopMining = connect.Spec(
+    '/$name/StopMining',
+    connect.StreamType.unary,
+    googleprotobufempty.Empty.new,
+    googleprotobufempty.Empty.new,
+  );
+
+  static const getMiningStatus = connect.Spec(
+    '/$name/GetMiningStatus',
+    connect.StreamType.unary,
+    googleprotobufempty.Empty.new,
+    bitwindowdv1bitwindowd.GetMiningStatusResponse.new,
   );
 
   /// Deniability operations

--- a/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.pb.dart
+++ b/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.pb.dart
@@ -2164,140 +2164,42 @@ class ListBlocksResponse extends $pb.GeneratedMessage {
   void clearHasMore() => clearField(5);
 }
 
-class MineBlocksResponse_HashRate extends $pb.GeneratedMessage {
-  factory MineBlocksResponse_HashRate({
+class GetMiningStatusResponse extends $pb.GeneratedMessage {
+  factory GetMiningStatusResponse({
+    $core.bool? mining,
     $core.double? hashRate,
+    $core.int? blocksFound,
+    $core.Iterable<$core.String>? recentBlockHashes,
+    $core.String? error,
   }) {
     final $result = create();
-    if (hashRate != null) {
-      $result.hashRate = hashRate;
-    }
-    return $result;
-  }
-  MineBlocksResponse_HashRate._() : super();
-  factory MineBlocksResponse_HashRate.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory MineBlocksResponse_HashRate.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineBlocksResponse.HashRate', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitwindowd.v1'), createEmptyInstance: create)
-    ..a<$core.double>(1, _omitFieldNames ? '' : 'hashRate', $pb.PbFieldType.OD)
-    ..hasRequiredFields = false
-  ;
-
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  MineBlocksResponse_HashRate clone() => MineBlocksResponse_HashRate()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  MineBlocksResponse_HashRate copyWith(void Function(MineBlocksResponse_HashRate) updates) => super.copyWith((message) => updates(message as MineBlocksResponse_HashRate)) as MineBlocksResponse_HashRate;
-
-  $pb.BuilderInfo get info_ => _i;
-
-  @$core.pragma('dart2js:noInline')
-  static MineBlocksResponse_HashRate create() => MineBlocksResponse_HashRate._();
-  MineBlocksResponse_HashRate createEmptyInstance() => create();
-  static $pb.PbList<MineBlocksResponse_HashRate> createRepeated() => $pb.PbList<MineBlocksResponse_HashRate>();
-  @$core.pragma('dart2js:noInline')
-  static MineBlocksResponse_HashRate getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MineBlocksResponse_HashRate>(create);
-  static MineBlocksResponse_HashRate? _defaultInstance;
-
-  /// Hashes per second
-  @$pb.TagNumber(1)
-  $core.double get hashRate => $_getN(0);
-  @$pb.TagNumber(1)
-  set hashRate($core.double v) { $_setDouble(0, v); }
-  @$pb.TagNumber(1)
-  $core.bool hasHashRate() => $_has(0);
-  @$pb.TagNumber(1)
-  void clearHashRate() => clearField(1);
-}
-
-class MineBlocksResponse_BlockFound extends $pb.GeneratedMessage {
-  factory MineBlocksResponse_BlockFound({
-    $core.String? blockHash,
-  }) {
-    final $result = create();
-    if (blockHash != null) {
-      $result.blockHash = blockHash;
-    }
-    return $result;
-  }
-  MineBlocksResponse_BlockFound._() : super();
-  factory MineBlocksResponse_BlockFound.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory MineBlocksResponse_BlockFound.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineBlocksResponse.BlockFound', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitwindowd.v1'), createEmptyInstance: create)
-    ..aOS(1, _omitFieldNames ? '' : 'blockHash')
-    ..hasRequiredFields = false
-  ;
-
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  MineBlocksResponse_BlockFound clone() => MineBlocksResponse_BlockFound()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  MineBlocksResponse_BlockFound copyWith(void Function(MineBlocksResponse_BlockFound) updates) => super.copyWith((message) => updates(message as MineBlocksResponse_BlockFound)) as MineBlocksResponse_BlockFound;
-
-  $pb.BuilderInfo get info_ => _i;
-
-  @$core.pragma('dart2js:noInline')
-  static MineBlocksResponse_BlockFound create() => MineBlocksResponse_BlockFound._();
-  MineBlocksResponse_BlockFound createEmptyInstance() => create();
-  static $pb.PbList<MineBlocksResponse_BlockFound> createRepeated() => $pb.PbList<MineBlocksResponse_BlockFound>();
-  @$core.pragma('dart2js:noInline')
-  static MineBlocksResponse_BlockFound getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MineBlocksResponse_BlockFound>(create);
-  static MineBlocksResponse_BlockFound? _defaultInstance;
-
-  @$pb.TagNumber(1)
-  $core.String get blockHash => $_getSZ(0);
-  @$pb.TagNumber(1)
-  set blockHash($core.String v) { $_setString(0, v); }
-  @$pb.TagNumber(1)
-  $core.bool hasBlockHash() => $_has(0);
-  @$pb.TagNumber(1)
-  void clearBlockHash() => clearField(1);
-}
-
-enum MineBlocksResponse_Event {
-  blockFound, 
-  hashRate, 
-  notSet
-}
-
-class MineBlocksResponse extends $pb.GeneratedMessage {
-  factory MineBlocksResponse({
-    MineBlocksResponse_BlockFound? blockFound,
-    MineBlocksResponse_HashRate? hashRate,
-  }) {
-    final $result = create();
-    if (blockFound != null) {
-      $result.blockFound = blockFound;
+    if (mining != null) {
+      $result.mining = mining;
     }
     if (hashRate != null) {
       $result.hashRate = hashRate;
     }
+    if (blocksFound != null) {
+      $result.blocksFound = blocksFound;
+    }
+    if (recentBlockHashes != null) {
+      $result.recentBlockHashes.addAll(recentBlockHashes);
+    }
+    if (error != null) {
+      $result.error = error;
+    }
     return $result;
   }
-  MineBlocksResponse._() : super();
-  factory MineBlocksResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory MineBlocksResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  GetMiningStatusResponse._() : super();
+  factory GetMiningStatusResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetMiningStatusResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static const $core.Map<$core.int, MineBlocksResponse_Event> _MineBlocksResponse_EventByTag = {
-    1 : MineBlocksResponse_Event.blockFound,
-    2 : MineBlocksResponse_Event.hashRate,
-    0 : MineBlocksResponse_Event.notSet
-  };
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MineBlocksResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitwindowd.v1'), createEmptyInstance: create)
-    ..oo(0, [1, 2])
-    ..aOM<MineBlocksResponse_BlockFound>(1, _omitFieldNames ? '' : 'blockFound', subBuilder: MineBlocksResponse_BlockFound.create)
-    ..aOM<MineBlocksResponse_HashRate>(2, _omitFieldNames ? '' : 'hashRate', subBuilder: MineBlocksResponse_HashRate.create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetMiningStatusResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitwindowd.v1'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'mining')
+    ..a<$core.double>(2, _omitFieldNames ? '' : 'hashRate', $pb.PbFieldType.OD)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'blocksFound', $pb.PbFieldType.O3)
+    ..pPS(4, _omitFieldNames ? '' : 'recentBlockHashes')
+    ..aOS(5, _omitFieldNames ? '' : 'error')
     ..hasRequiredFields = false
   ;
 
@@ -2305,47 +2207,66 @@ class MineBlocksResponse extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
   'Will be removed in next major version')
-  MineBlocksResponse clone() => MineBlocksResponse()..mergeFromMessage(this);
+  GetMiningStatusResponse clone() => GetMiningStatusResponse()..mergeFromMessage(this);
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  MineBlocksResponse copyWith(void Function(MineBlocksResponse) updates) => super.copyWith((message) => updates(message as MineBlocksResponse)) as MineBlocksResponse;
+  GetMiningStatusResponse copyWith(void Function(GetMiningStatusResponse) updates) => super.copyWith((message) => updates(message as GetMiningStatusResponse)) as GetMiningStatusResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
-  static MineBlocksResponse create() => MineBlocksResponse._();
-  MineBlocksResponse createEmptyInstance() => create();
-  static $pb.PbList<MineBlocksResponse> createRepeated() => $pb.PbList<MineBlocksResponse>();
+  static GetMiningStatusResponse create() => GetMiningStatusResponse._();
+  GetMiningStatusResponse createEmptyInstance() => create();
+  static $pb.PbList<GetMiningStatusResponse> createRepeated() => $pb.PbList<GetMiningStatusResponse>();
   @$core.pragma('dart2js:noInline')
-  static MineBlocksResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MineBlocksResponse>(create);
-  static MineBlocksResponse? _defaultInstance;
-
-  MineBlocksResponse_Event whichEvent() => _MineBlocksResponse_EventByTag[$_whichOneof(0)]!;
-  void clearEvent() => clearField($_whichOneof(0));
+  static GetMiningStatusResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetMiningStatusResponse>(create);
+  static GetMiningStatusResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
-  MineBlocksResponse_BlockFound get blockFound => $_getN(0);
+  $core.bool get mining => $_getBF(0);
   @$pb.TagNumber(1)
-  set blockFound(MineBlocksResponse_BlockFound v) { setField(1, v); }
+  set mining($core.bool v) { $_setBool(0, v); }
   @$pb.TagNumber(1)
-  $core.bool hasBlockFound() => $_has(0);
+  $core.bool hasMining() => $_has(0);
   @$pb.TagNumber(1)
-  void clearBlockFound() => clearField(1);
-  @$pb.TagNumber(1)
-  MineBlocksResponse_BlockFound ensureBlockFound() => $_ensure(0);
+  void clearMining() => clearField(1);
 
+  /// Hashes per second, averaged since the miner started.
   @$pb.TagNumber(2)
-  MineBlocksResponse_HashRate get hashRate => $_getN(1);
+  $core.double get hashRate => $_getN(1);
   @$pb.TagNumber(2)
-  set hashRate(MineBlocksResponse_HashRate v) { setField(2, v); }
+  set hashRate($core.double v) { $_setDouble(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasHashRate() => $_has(1);
   @$pb.TagNumber(2)
   void clearHashRate() => clearField(2);
-  @$pb.TagNumber(2)
-  MineBlocksResponse_HashRate ensureHashRate() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  $core.int get blocksFound => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set blocksFound($core.int v) { $_setSignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasBlocksFound() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearBlocksFound() => clearField(3);
+
+  /// Block hashes found this session, newest first.
+  @$pb.TagNumber(4)
+  $core.List<$core.String> get recentBlockHashes => $_getList(3);
+
+  /// Why the miner last stopped on its own (e.g. the node is still syncing),
+  /// empty when it stopped cleanly. StartMining returns before work is fetched,
+  /// so this is where a startup failure surfaces.
+  @$pb.TagNumber(5)
+  $core.String get error => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set error($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasError() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearError() => clearField(5);
 }
 
 class GetNetworkStatsResponse extends $pb.GeneratedMessage {
@@ -2812,8 +2733,14 @@ class BitwindowdServiceApi {
   $async.Future<$1.Empty> stop($pb.ClientContext? ctx, BitwindowdServiceStopRequest request) =>
     _client.invoke<$1.Empty>(ctx, 'BitwindowdService', 'Stop', request, $1.Empty())
   ;
-  $async.Future<MineBlocksResponse> mineBlocks($pb.ClientContext? ctx, $1.Empty request) =>
-    _client.invoke<MineBlocksResponse>(ctx, 'BitwindowdService', 'MineBlocks', request, MineBlocksResponse())
+  $async.Future<$1.Empty> startMining($pb.ClientContext? ctx, $1.Empty request) =>
+    _client.invoke<$1.Empty>(ctx, 'BitwindowdService', 'StartMining', request, $1.Empty())
+  ;
+  $async.Future<$1.Empty> stopMining($pb.ClientContext? ctx, $1.Empty request) =>
+    _client.invoke<$1.Empty>(ctx, 'BitwindowdService', 'StopMining', request, $1.Empty())
+  ;
+  $async.Future<GetMiningStatusResponse> getMiningStatus($pb.ClientContext? ctx, $1.Empty request) =>
+    _client.invoke<GetMiningStatusResponse>(ctx, 'BitwindowdService', 'GetMiningStatus', request, GetMiningStatusResponse())
   ;
   $async.Future<$1.Empty> createDenial($pb.ClientContext? ctx, CreateDenialRequest request) =>
     _client.invoke<$1.Empty>(ctx, 'BitwindowdService', 'CreateDenial', request, $1.Empty())

--- a/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.pbjson.dart
+++ b/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.pbjson.dart
@@ -501,42 +501,24 @@ final $typed_data.Uint8List listBlocksResponseDescriptor = $convert.base64Decode
     'ChJMaXN0QmxvY2tzUmVzcG9uc2USOQoNcmVjZW50X2Jsb2NrcxgEIAMoCzIULmJpdHdpbmRvd2'
     'QudjEuQmxvY2tSDHJlY2VudEJsb2NrcxIZCghoYXNfbW9yZRgFIAEoCFIHaGFzTW9yZQ==');
 
-@$core.Deprecated('Use mineBlocksResponseDescriptor instead')
-const MineBlocksResponse$json = {
-  '1': 'MineBlocksResponse',
+@$core.Deprecated('Use getMiningStatusResponseDescriptor instead')
+const GetMiningStatusResponse$json = {
+  '1': 'GetMiningStatusResponse',
   '2': [
-    {'1': 'block_found', '3': 1, '4': 1, '5': 11, '6': '.bitwindowd.v1.MineBlocksResponse.BlockFound', '9': 0, '10': 'blockFound'},
-    {'1': 'hash_rate', '3': 2, '4': 1, '5': 11, '6': '.bitwindowd.v1.MineBlocksResponse.HashRate', '9': 0, '10': 'hashRate'},
-  ],
-  '3': [MineBlocksResponse_HashRate$json, MineBlocksResponse_BlockFound$json],
-  '8': [
-    {'1': 'event'},
+    {'1': 'mining', '3': 1, '4': 1, '5': 8, '10': 'mining'},
+    {'1': 'hash_rate', '3': 2, '4': 1, '5': 1, '10': 'hashRate'},
+    {'1': 'blocks_found', '3': 3, '4': 1, '5': 5, '10': 'blocksFound'},
+    {'1': 'recent_block_hashes', '3': 4, '4': 3, '5': 9, '10': 'recentBlockHashes'},
+    {'1': 'error', '3': 5, '4': 1, '5': 9, '10': 'error'},
   ],
 };
 
-@$core.Deprecated('Use mineBlocksResponseDescriptor instead')
-const MineBlocksResponse_HashRate$json = {
-  '1': 'HashRate',
-  '2': [
-    {'1': 'hash_rate', '3': 1, '4': 1, '5': 1, '10': 'hashRate'},
-  ],
-};
-
-@$core.Deprecated('Use mineBlocksResponseDescriptor instead')
-const MineBlocksResponse_BlockFound$json = {
-  '1': 'BlockFound',
-  '2': [
-    {'1': 'block_hash', '3': 1, '4': 1, '5': 9, '10': 'blockHash'},
-  ],
-};
-
-/// Descriptor for `MineBlocksResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List mineBlocksResponseDescriptor = $convert.base64Decode(
-    'ChJNaW5lQmxvY2tzUmVzcG9uc2USTwoLYmxvY2tfZm91bmQYASABKAsyLC5iaXR3aW5kb3dkLn'
-    'YxLk1pbmVCbG9ja3NSZXNwb25zZS5CbG9ja0ZvdW5kSABSCmJsb2NrRm91bmQSSQoJaGFzaF9y'
-    'YXRlGAIgASgLMiouYml0d2luZG93ZC52MS5NaW5lQmxvY2tzUmVzcG9uc2UuSGFzaFJhdGVIAF'
-    'IIaGFzaFJhdGUaJwoISGFzaFJhdGUSGwoJaGFzaF9yYXRlGAEgASgBUghoYXNoUmF0ZRorCgpC'
-    'bG9ja0ZvdW5kEh0KCmJsb2NrX2hhc2gYASABKAlSCWJsb2NrSGFzaEIHCgVldmVudA==');
+/// Descriptor for `GetMiningStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getMiningStatusResponseDescriptor = $convert.base64Decode(
+    'ChdHZXRNaW5pbmdTdGF0dXNSZXNwb25zZRIWCgZtaW5pbmcYASABKAhSBm1pbmluZxIbCgloYX'
+    'NoX3JhdGUYAiABKAFSCGhhc2hSYXRlEiEKDGJsb2Nrc19mb3VuZBgDIAEoBVILYmxvY2tzRm91'
+    'bmQSLgoTcmVjZW50X2Jsb2NrX2hhc2hlcxgEIAMoCVIRcmVjZW50QmxvY2tIYXNoZXMSFAoFZX'
+    'Jyb3IYBSABKAlSBWVycm9y');
 
 @$core.Deprecated('Use getNetworkStatsResponseDescriptor instead')
 const GetNetworkStatsResponse$json = {
@@ -619,7 +601,9 @@ const $core.Map<$core.String, $core.dynamic> BitwindowdServiceBase$json = {
   '1': 'BitwindowdService',
   '2': [
     {'1': 'Stop', '2': '.bitwindowd.v1.BitwindowdServiceStopRequest', '3': '.google.protobuf.Empty'},
-    {'1': 'MineBlocks', '2': '.google.protobuf.Empty', '3': '.bitwindowd.v1.MineBlocksResponse', '6': true},
+    {'1': 'StartMining', '2': '.google.protobuf.Empty', '3': '.google.protobuf.Empty'},
+    {'1': 'StopMining', '2': '.google.protobuf.Empty', '3': '.google.protobuf.Empty'},
+    {'1': 'GetMiningStatus', '2': '.google.protobuf.Empty', '3': '.bitwindowd.v1.GetMiningStatusResponse'},
     {'1': 'CreateDenial', '2': '.bitwindowd.v1.CreateDenialRequest', '3': '.google.protobuf.Empty'},
     {'1': 'CancelDenial', '2': '.bitwindowd.v1.CancelDenialRequest', '3': '.google.protobuf.Empty'},
     {'1': 'PauseDenial', '2': '.bitwindowd.v1.PauseDenialRequest', '3': '.google.protobuf.Empty'},
@@ -644,9 +628,7 @@ const $core.Map<$core.String, $core.dynamic> BitwindowdServiceBase$json = {
 const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> BitwindowdServiceBase$messageJson = {
   '.bitwindowd.v1.BitwindowdServiceStopRequest': BitwindowdServiceStopRequest$json,
   '.google.protobuf.Empty': $1.Empty$json,
-  '.bitwindowd.v1.MineBlocksResponse': MineBlocksResponse$json,
-  '.bitwindowd.v1.MineBlocksResponse.BlockFound': MineBlocksResponse_BlockFound$json,
-  '.bitwindowd.v1.MineBlocksResponse.HashRate': MineBlocksResponse_HashRate$json,
+  '.bitwindowd.v1.GetMiningStatusResponse': GetMiningStatusResponse$json,
   '.bitwindowd.v1.CreateDenialRequest': CreateDenialRequest$json,
   '.bitwindowd.v1.CancelDenialRequest': CancelDenialRequest$json,
   '.bitwindowd.v1.PauseDenialRequest': PauseDenialRequest$json,
@@ -679,33 +661,36 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> Bitwindowd
 /// Descriptor for `BitwindowdService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
 final $typed_data.Uint8List bitwindowdServiceDescriptor = $convert.base64Decode(
     'ChFCaXR3aW5kb3dkU2VydmljZRJLCgRTdG9wEisuYml0d2luZG93ZC52MS5CaXR3aW5kb3dkU2'
-    'VydmljZVN0b3BSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EkkKCk1pbmVCbG9ja3MS'
-    'Fi5nb29nbGUucHJvdG9idWYuRW1wdHkaIS5iaXR3aW5kb3dkLnYxLk1pbmVCbG9ja3NSZXNwb2'
-    '5zZTABEkoKDENyZWF0ZURlbmlhbBIiLmJpdHdpbmRvd2QudjEuQ3JlYXRlRGVuaWFsUmVxdWVz'
-    'dBoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRJKCgxDYW5jZWxEZW5pYWwSIi5iaXR3aW5kb3dkLn'
-    'YxLkNhbmNlbERlbmlhbFJlcXVlc3QaFi5nb29nbGUucHJvdG9idWYuRW1wdHkSSAoLUGF1c2VE'
-    'ZW5pYWwSIS5iaXR3aW5kb3dkLnYxLlBhdXNlRGVuaWFsUmVxdWVzdBoWLmdvb2dsZS5wcm90b2'
-    'J1Zi5FbXB0eRJKCgxSZXN1bWVEZW5pYWwSIi5iaXR3aW5kb3dkLnYxLlJlc3VtZURlbmlhbFJl'
-    'cXVlc3QaFi5nb29nbGUucHJvdG9idWYuRW1wdHkSdQoWQ3JlYXRlQWRkcmVzc0Jvb2tFbnRyeR'
-    'IsLmJpdHdpbmRvd2QudjEuQ3JlYXRlQWRkcmVzc0Jvb2tFbnRyeVJlcXVlc3QaLS5iaXR3aW5k'
-    'b3dkLnYxLkNyZWF0ZUFkZHJlc3NCb29rRW50cnlSZXNwb25zZRJRCg9MaXN0QWRkcmVzc0Jvb2'
-    'sSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaJi5iaXR3aW5kb3dkLnYxLkxpc3RBZGRyZXNzQm9v'
-    'a1Jlc3BvbnNlEl4KFlVwZGF0ZUFkZHJlc3NCb29rRW50cnkSLC5iaXR3aW5kb3dkLnYxLlVwZG'
-    'F0ZUFkZHJlc3NCb29rRW50cnlSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5El4KFkRl'
-    'bGV0ZUFkZHJlc3NCb29rRW50cnkSLC5iaXR3aW5kb3dkLnYxLkRlbGV0ZUFkZHJlc3NCb29rRW'
-    '50cnlSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EkkKC0dldFN5bmNJbmZvEhYuZ29v'
-    'Z2xlLnByb3RvYnVmLkVtcHR5GiIuYml0d2luZG93ZC52MS5HZXRTeW5jSW5mb1Jlc3BvbnNlEl'
-    'YKElNldFRyYW5zYWN0aW9uTm90ZRIoLmJpdHdpbmRvd2QudjEuU2V0VHJhbnNhY3Rpb25Ob3Rl'
-    'UmVxdWVzdBoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRJLCgxFeHBvcnRMYWJlbHMSFi5nb29nbG'
-    'UucHJvdG9idWYuRW1wdHkaIy5iaXR3aW5kb3dkLnYxLkV4cG9ydExhYmVsc1Jlc3BvbnNlElcK'
-    'DEltcG9ydExhYmVscxIiLmJpdHdpbmRvd2QudjEuSW1wb3J0TGFiZWxzUmVxdWVzdBojLmJpdH'
-    'dpbmRvd2QudjEuSW1wb3J0TGFiZWxzUmVzcG9uc2USVQoRR2V0RmlyZXBsYWNlU3RhdHMSFi5n'
-    'b29nbGUucHJvdG9idWYuRW1wdHkaKC5iaXR3aW5kb3dkLnYxLkdldEZpcmVwbGFjZVN0YXRzUm'
-    'VzcG9uc2USdQoWTGlzdFJlY2VudFRyYW5zYWN0aW9ucxIsLmJpdHdpbmRvd2QudjEuTGlzdFJl'
-    'Y2VudFRyYW5zYWN0aW9uc1JlcXVlc3QaLS5iaXR3aW5kb3dkLnYxLkxpc3RSZWNlbnRUcmFuc2'
-    'FjdGlvbnNSZXNwb25zZRJRCgpMaXN0QmxvY2tzEiAuYml0d2luZG93ZC52MS5MaXN0QmxvY2tz'
-    'UmVxdWVzdBohLmJpdHdpbmRvd2QudjEuTGlzdEJsb2Nrc1Jlc3BvbnNlElEKD0dldE5ldHdvcm'
-    'tTdGF0cxIWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRomLmJpdHdpbmRvd2QudjEuR2V0TmV0d29y'
-    'a1N0YXRzUmVzcG9uc2USWgoNVXBkYXRlTmV0d29yaxIjLmJpdHdpbmRvd2QudjEuVXBkYXRlTm'
-    'V0d29ya1JlcXVlc3QaJC5iaXR3aW5kb3dkLnYxLlVwZGF0ZU5ldHdvcmtSZXNwb25zZQ==');
+    'VydmljZVN0b3BSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5Ej0KC1N0YXJ0TWluaW5n'
+    'EhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EjwKClN0b3'
+    'BNaW5pbmcSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaFi5nb29nbGUucHJvdG9idWYuRW1wdHkS'
+    'UQoPR2V0TWluaW5nU3RhdHVzEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GiYuYml0d2luZG93ZC'
+    '52MS5HZXRNaW5pbmdTdGF0dXNSZXNwb25zZRJKCgxDcmVhdGVEZW5pYWwSIi5iaXR3aW5kb3dk'
+    'LnYxLkNyZWF0ZURlbmlhbFJlcXVlc3QaFi5nb29nbGUucHJvdG9idWYuRW1wdHkSSgoMQ2FuY2'
+    'VsRGVuaWFsEiIuYml0d2luZG93ZC52MS5DYW5jZWxEZW5pYWxSZXF1ZXN0GhYuZ29vZ2xlLnBy'
+    'b3RvYnVmLkVtcHR5EkgKC1BhdXNlRGVuaWFsEiEuYml0d2luZG93ZC52MS5QYXVzZURlbmlhbF'
+    'JlcXVlc3QaFi5nb29nbGUucHJvdG9idWYuRW1wdHkSSgoMUmVzdW1lRGVuaWFsEiIuYml0d2lu'
+    'ZG93ZC52MS5SZXN1bWVEZW5pYWxSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EnUKFk'
+    'NyZWF0ZUFkZHJlc3NCb29rRW50cnkSLC5iaXR3aW5kb3dkLnYxLkNyZWF0ZUFkZHJlc3NCb29r'
+    'RW50cnlSZXF1ZXN0Gi0uYml0d2luZG93ZC52MS5DcmVhdGVBZGRyZXNzQm9va0VudHJ5UmVzcG'
+    '9uc2USUQoPTGlzdEFkZHJlc3NCb29rEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GiYuYml0d2lu'
+    'ZG93ZC52MS5MaXN0QWRkcmVzc0Jvb2tSZXNwb25zZRJeChZVcGRhdGVBZGRyZXNzQm9va0VudH'
+    'J5EiwuYml0d2luZG93ZC52MS5VcGRhdGVBZGRyZXNzQm9va0VudHJ5UmVxdWVzdBoWLmdvb2ds'
+    'ZS5wcm90b2J1Zi5FbXB0eRJeChZEZWxldGVBZGRyZXNzQm9va0VudHJ5EiwuYml0d2luZG93ZC'
+    '52MS5EZWxldGVBZGRyZXNzQm9va0VudHJ5UmVxdWVzdBoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0'
+    'eRJJCgtHZXRTeW5jSW5mbxIWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRoiLmJpdHdpbmRvd2Qudj'
+    'EuR2V0U3luY0luZm9SZXNwb25zZRJWChJTZXRUcmFuc2FjdGlvbk5vdGUSKC5iaXR3aW5kb3dk'
+    'LnYxLlNldFRyYW5zYWN0aW9uTm90ZVJlcXVlc3QaFi5nb29nbGUucHJvdG9idWYuRW1wdHkSSw'
+    'oMRXhwb3J0TGFiZWxzEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GiMuYml0d2luZG93ZC52MS5F'
+    'eHBvcnRMYWJlbHNSZXNwb25zZRJXCgxJbXBvcnRMYWJlbHMSIi5iaXR3aW5kb3dkLnYxLkltcG'
+    '9ydExhYmVsc1JlcXVlc3QaIy5iaXR3aW5kb3dkLnYxLkltcG9ydExhYmVsc1Jlc3BvbnNlElUK'
+    'EUdldEZpcmVwbGFjZVN0YXRzEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GiguYml0d2luZG93ZC'
+    '52MS5HZXRGaXJlcGxhY2VTdGF0c1Jlc3BvbnNlEnUKFkxpc3RSZWNlbnRUcmFuc2FjdGlvbnMS'
+    'LC5iaXR3aW5kb3dkLnYxLkxpc3RSZWNlbnRUcmFuc2FjdGlvbnNSZXF1ZXN0Gi0uYml0d2luZG'
+    '93ZC52MS5MaXN0UmVjZW50VHJhbnNhY3Rpb25zUmVzcG9uc2USUQoKTGlzdEJsb2NrcxIgLmJp'
+    'dHdpbmRvd2QudjEuTGlzdEJsb2Nrc1JlcXVlc3QaIS5iaXR3aW5kb3dkLnYxLkxpc3RCbG9ja3'
+    'NSZXNwb25zZRJRCg9HZXROZXR3b3JrU3RhdHMSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaJi5i'
+    'aXR3aW5kb3dkLnYxLkdldE5ldHdvcmtTdGF0c1Jlc3BvbnNlEloKDVVwZGF0ZU5ldHdvcmsSIy'
+    '5iaXR3aW5kb3dkLnYxLlVwZGF0ZU5ldHdvcmtSZXF1ZXN0GiQuYml0d2luZG93ZC52MS5VcGRh'
+    'dGVOZXR3b3JrUmVzcG9uc2U=');
 

--- a/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.pbserver.dart
+++ b/sail_ui/lib/gen/bitwindowd/v1/bitwindowd.pbserver.dart
@@ -23,7 +23,9 @@ export 'bitwindowd.pb.dart';
 
 abstract class BitwindowdServiceBase extends $pb.GeneratedService {
   $async.Future<$1.Empty> stop($pb.ServerContext ctx, $3.BitwindowdServiceStopRequest request);
-  $async.Future<$3.MineBlocksResponse> mineBlocks($pb.ServerContext ctx, $1.Empty request);
+  $async.Future<$1.Empty> startMining($pb.ServerContext ctx, $1.Empty request);
+  $async.Future<$1.Empty> stopMining($pb.ServerContext ctx, $1.Empty request);
+  $async.Future<$3.GetMiningStatusResponse> getMiningStatus($pb.ServerContext ctx, $1.Empty request);
   $async.Future<$1.Empty> createDenial($pb.ServerContext ctx, $3.CreateDenialRequest request);
   $async.Future<$1.Empty> cancelDenial($pb.ServerContext ctx, $3.CancelDenialRequest request);
   $async.Future<$1.Empty> pauseDenial($pb.ServerContext ctx, $3.PauseDenialRequest request);
@@ -45,7 +47,9 @@ abstract class BitwindowdServiceBase extends $pb.GeneratedService {
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
       case 'Stop': return $3.BitwindowdServiceStopRequest();
-      case 'MineBlocks': return $1.Empty();
+      case 'StartMining': return $1.Empty();
+      case 'StopMining': return $1.Empty();
+      case 'GetMiningStatus': return $1.Empty();
       case 'CreateDenial': return $3.CreateDenialRequest();
       case 'CancelDenial': return $3.CancelDenialRequest();
       case 'PauseDenial': return $3.PauseDenialRequest();
@@ -70,7 +74,9 @@ abstract class BitwindowdServiceBase extends $pb.GeneratedService {
   $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
       case 'Stop': return this.stop(ctx, request as $3.BitwindowdServiceStopRequest);
-      case 'MineBlocks': return this.mineBlocks(ctx, request as $1.Empty);
+      case 'StartMining': return this.startMining(ctx, request as $1.Empty);
+      case 'StopMining': return this.stopMining(ctx, request as $1.Empty);
+      case 'GetMiningStatus': return this.getMiningStatus(ctx, request as $1.Empty);
       case 'CreateDenial': return this.createDenial(ctx, request as $3.CreateDenialRequest);
       case 'CancelDenial': return this.cancelDenial(ctx, request as $3.CancelDenialRequest);
       case 'PauseDenial': return this.pauseDenial(ctx, request as $3.PauseDenialRequest);

--- a/sail_ui/lib/rpcs/bitwindow_api.dart
+++ b/sail_ui/lib/rpcs/bitwindow_api.dart
@@ -358,8 +358,10 @@ class BitwindowRPCLive extends BitwindowRPC {
 abstract class BitwindowAPI {
   Future<void> stop({bool skipDownstream = false});
 
-  // CPU mining
-  Stream<MineBlocksResponse> mineBlocks();
+  // CPU mining (drynet only)
+  Future<void> startMining();
+  Future<void> stopMining();
+  Future<GetMiningStatusResponse> getMiningStatus();
 
   // Denial methods here
   Future<void> createDenial({
@@ -420,13 +422,29 @@ class _BitwindowAPILive implements BitwindowAPI {
   }
 
   @override
-  Stream<MineBlocksResponse> mineBlocks() {
+  Future<void> startMining() async {
     try {
-      final response = _client.mineBlocks(Empty());
-      return response;
+      await _client.startMining(Empty());
     } catch (e) {
-      final error = 'could not start mining: ${extractConnectException(e)}';
-      throw BitwindowException(error);
+      throw BitwindowException('could not start mining: ${extractConnectException(e)}');
+    }
+  }
+
+  @override
+  Future<void> stopMining() async {
+    try {
+      await _client.stopMining(Empty());
+    } catch (e) {
+      throw BitwindowException('could not stop mining: ${extractConnectException(e)}');
+    }
+  }
+
+  @override
+  Future<GetMiningStatusResponse> getMiningStatus() async {
+    try {
+      return await _client.getMiningStatus(Empty());
+    } catch (e) {
+      throw BitwindowException('could not get mining status: ${extractConnectException(e)}');
     }
   }
 

--- a/sail_ui/lib/sail_ui.dart
+++ b/sail_ui/lib/sail_ui.dart
@@ -219,6 +219,7 @@ export 'settings/debug_settings.dart';
 export 'settings/font_settings.dart';
 export 'settings/hash_plaintext_settings.dart';
 export 'settings/secure_store.dart';
+export 'settings/mining_banner_setting.dart';
 export 'settings/test_sidechains_settings.dart';
 export 'settings/bitwindow_settings.dart';
 export 'settings/notification_history_setting.dart';

--- a/sail_ui/lib/settings/mining_banner_setting.dart
+++ b/sail_ui/lib/settings/mining_banner_setting.dart
@@ -1,0 +1,20 @@
+import 'package:sail_ui/sail_ui.dart';
+
+class MiningBannerDismissedSetting extends SettingValue<bool> {
+  MiningBannerDismissedSetting({super.newValue});
+
+  @override
+  String get key => 'mining_banner_dismissed';
+
+  @override
+  bool defaultValue() => false;
+
+  @override
+  String toJson() => value.toString();
+
+  @override
+  bool? fromJson(String jsonString) => jsonString == 'true';
+
+  @override
+  SettingValue<bool> withValue([bool? value]) => MiningBannerDismissedSetting(newValue: value);
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.278
+version: 1.0.279
 
 environment:
   sdk: 3.12.0

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.149
+version: 1.0.150
 
 environment:
   sdk: 3.12.0

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.276
+version: 1.0.277
 
 environment:
   sdk: 3.12.0


### PR DESCRIPTION
Reworks CPU mining so the backend owns the miner and the app drives it with Start, Stop and GetMiningStatus calls that the UI polls, instead of holding a stream open. Mining is limited to drynet. Adds a dismissible banner on drynet that opens the mining page.