### PR TITLE
fix build isues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,23 +253,6 @@ jobs:
           brew install gnu-sed
           echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
 
-        # hwi-daemon freezes libusb into its bundle
-      - name: Install libusb on macOS
-        if: runner.os == 'macOS'
-        run: brew install libusb
-
-      - name: Fetch libusb on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $ver = "1.0.27"
-          Invoke-WebRequest "https://github.com/libusb/libusb/releases/download/v$ver/libusb-$ver.7z" -OutFile libusb.7z
-          7z x libusb.7z -olibusb-dist
-          $dll = Get-ChildItem libusb-dist -Recurse -Filter libusb-1.0.dll |
-                 Where-Object { $_.FullName -like '*\VS2022\MS64\dll\*' } | Select-Object -First 1
-          if (-not $dll) { throw "no VS2022/MS64 libusb-1.0.dll in libusb-$ver.7z" }
-          "LIBUSB_DLL=$($dll.FullName)" >> $env:GITHUB_ENV
-
         # https://docs.flutter.dev/platform-integration/linux/building
       # prettier-ignore
       - run:  sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get install -y curl git unzip xz-utils zip libglu1-mesa && sudo apt-get install clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev libcurl4-openssl-dev libusb-1.0-0-dev

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -134,6 +134,57 @@ jobs:
         working-directory: bitwindow/server
         run: go test -v -tags integration -timeout 10m ./integrationtest/
 
+  hwi-daemon:
+    name: hwi daemon (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft == false
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-2022, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install libusb (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -y && sudo apt-get install -y libusb-1.0-0-dev
+
+      - name: Install libusb (macOS)
+        if: runner.os == 'macOS'
+        run: brew install libusb
+
+      - name: Fetch libusb (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ver = "1.0.27"
+          Invoke-WebRequest "https://github.com/libusb/libusb/releases/download/v$ver/libusb-$ver.7z" -OutFile libusb.7z
+          7z x libusb.7z -olibusb-dist
+          $dll = Get-ChildItem libusb-dist -Recurse -Filter libusb-1.0.dll |
+                 Where-Object { $_.FullName -like '*\VS2022\MS64\dll\*' } | Select-Object -First 1
+          if (-not $dll) { throw "no VS2022/MS64 libusb-1.0.dll in libusb-$ver.7z" }
+          "LIBUSB_DLL=$($dll.FullName)" >> $env:GITHUB_ENV
+
+      - name: Freeze the hwi daemon
+        shell: bash
+        run: |
+          out="$PWD/hwi-out/hwi-daemon"
+          [[ "$RUNNER_OS" == "Windows" ]] && out="$out.exe"
+          sidechain-orchestrator/hwi-daemon/build.sh "$out"
+          # Go execs the daemon, so hand it a path the host understands.
+          [[ "$RUNNER_OS" == "Windows" ]] && out="$(cygpath -w "$out")"
+          echo "ORCHESTRATOR_HWI_DAEMON=$out" >> "$GITHUB_ENV"
+
+      - name: Run the daemon smoke test
+        working-directory: sidechain-orchestrator
+        run: go test -v -run TestHWIDaemonSmoke -timeout 10m ./wallet/
+
   replay-protection:
     name: replay protection (macOS)
     runs-on: macos-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -151,26 +151,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Install libusb (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update -y && sudo apt-get install -y libusb-1.0-0-dev
-
-      - name: Install libusb (macOS)
-        if: runner.os == 'macOS'
-        run: brew install libusb
-
-      - name: Fetch libusb (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $ver = "1.0.27"
-          Invoke-WebRequest "https://github.com/libusb/libusb/releases/download/v$ver/libusb-$ver.7z" -OutFile libusb.7z
-          7z x libusb.7z -olibusb-dist
-          $dll = Get-ChildItem libusb-dist -Recurse -Filter libusb-1.0.dll |
-                 Where-Object { $_.FullName -like '*\VS2022\MS64\dll\*' } | Select-Object -First 1
-          if (-not $dll) { throw "no VS2022/MS64 libusb-1.0.dll in libusb-$ver.7z" }
-          "LIBUSB_DLL=$($dll.FullName)" >> $env:GITHUB_ENV
-
       - name: Freeze the hwi daemon
         shell: bash
         run: |

--- a/bitassets/macos/Podfile.lock
+++ b/bitassets/macos/Podfile.lock
@@ -5,15 +5,12 @@ PODS:
   - desktop_multi_window (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - screen_retriever_macos (0.0.1):
-    - FlutterMacOS
   - Sparkle (2.9.1)
 
 DEPENDENCIES:
   - auto_updater_macos (from `Flutter/ephemeral/.symlinks/plugins/auto_updater_macos/macos`)
   - desktop_multi_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
 
 SPEC REPOS:
   trunk:
@@ -26,14 +23,11 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  screen_retriever_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
 
 SPEC CHECKSUMS:
   auto_updater_macos: 3a42f1a06be6981f1a18be37e6e7bf86aa732118
   desktop_multi_window: 93667594ccc4b88d91a97972fd3b1b89667fa80a
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   Sparkle: a4115cd9a339b297a61163256e6954d9e35297ce
 
 PODFILE CHECKSUM: 9e8d6c0fdb46e19301c6444943a68374392cb446

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.280
+version: 1.0.281
 
 environment:
   sdk: 3.12.0

--- a/bitassets/scripts/download-binaries.sh
+++ b/bitassets/scripts/download-binaries.sh
@@ -12,6 +12,7 @@ echo "Building orchestratord in $(pwd)"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Forcing amd64 GOARCH"
     export GOARCH=amd64
+    export CGO_ENABLED=1
 fi
 
 go build -o ./bin/orchestratord ./cmd/orchestratord/

--- a/bitnames/macos/Podfile.lock
+++ b/bitnames/macos/Podfile.lock
@@ -5,15 +5,12 @@ PODS:
   - desktop_multi_window (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - screen_retriever_macos (0.0.1):
-    - FlutterMacOS
   - Sparkle (2.9.1)
 
 DEPENDENCIES:
   - auto_updater_macos (from `Flutter/ephemeral/.symlinks/plugins/auto_updater_macos/macos`)
   - desktop_multi_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
 
 SPEC REPOS:
   trunk:
@@ -26,14 +23,11 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  screen_retriever_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
 
 SPEC CHECKSUMS:
   auto_updater_macos: 3a42f1a06be6981f1a18be37e6e7bf86aa732118
   desktop_multi_window: 93667594ccc4b88d91a97972fd3b1b89667fa80a
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   Sparkle: a4115cd9a339b297a61163256e6954d9e35297ce
 
 PODFILE CHECKSUM: 9e8d6c0fdb46e19301c6444943a68374392cb446

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.280
+version: 1.0.281
 
 environment:
   sdk: 3.12.0

--- a/bitnames/scripts/download-binaries.sh
+++ b/bitnames/scripts/download-binaries.sh
@@ -12,6 +12,7 @@ echo "Building orchestratord in $(pwd)"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Forcing amd64 GOARCH"
     export GOARCH=amd64
+    export CGO_ENABLED=1
 fi
 
 go build -o ./bin/orchestratord ./cmd/orchestratord/

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.139
+version: 0.2.140
 
 environment:
   sdk: 3.12.0

--- a/bitwindow/scripts/download-binaries.sh
+++ b/bitwindow/scripts/download-binaries.sh
@@ -111,13 +111,15 @@ build_hwi_daemon() {
     esac
     cp "$libusb" "$tmp/$wanted"
     # PyInstaller splits --add-binary on the host os.pathsep.
-    local sep=":"; [[ "$os" == "windows" ]] && sep=";"
+    local sep=":" staged="$tmp/$wanted"
+    # MSYS mangles the ";"-joined argument instead of translating the path.
+    [[ "$os" == "windows" ]] && { sep=";"; staged="$(cygpath -w "$staged")"; }
     echo "Building hwi-daemon (${goarch:-host}) — installs hwi + pyinstaller into a temp venv"
     "$py" -m venv "$tmp/venv"
     local vpy="$tmp/venv/$bindir/python"
     "$vpy" -m pip install --quiet --upgrade pip
     "$vpy" -m pip install --quiet "hwi==2.1.1" pyinstaller
-    "$vpy" -m PyInstaller --onefile --name "$name" --collect-all hwilib --add-binary "$tmp/$wanted$sep." \
+    "$vpy" -m PyInstaller --onefile --name "$name" --collect-all hwilib --add-binary "$staged$sep." \
         --distpath "$(dirname "$out")" --workpath "$tmp/build" --specpath "$tmp" "$script"
     chmod +x "$out" 2>/dev/null || true
     rm -rf "$tmp"

--- a/bitwindow/scripts/download-binaries.sh
+++ b/bitwindow/scripts/download-binaries.sh
@@ -72,57 +72,7 @@ build_hwi_daemon() {
         echo "skipping hwi-daemon for $goarch (not host arch)"
         return
     fi
-    local py
-    py="$(command -v python3 || command -v python)" || {
-        echo "python not found; cannot build hwi-daemon" >&2
-        return 1
-    }
-    local bindir=bin
-    [[ "$os" == "windows" ]] && bindir=Scripts
-    local script="$original_cwd/../sidechain-orchestrator/hwi-daemon/hwi_daemon.py"
-    local name; name="$(basename "$out")"; name="${name%"$exe"}"
-    local tmp; tmp="$(mktemp -d)"
-    # hwi dlopens libusb by name, which PyInstaller's import analysis never sees.
-    # Unfrozen it resolves to whatever the build machine happens to have installed.
-    local libusb="" d
-    case "$os" in
-        darwin)  libusb="$(brew --prefix libusb 2>/dev/null)/lib/libusb-1.0.dylib" ;;
-        windows) libusb="${LIBUSB_DLL:-}" ;;
-        linux)
-            for d in /lib/x86_64-linux-gnu /lib/aarch64-linux-gnu /usr/lib64 /lib64 /usr/lib /lib; do
-                [[ -f "$d/libusb-1.0.so.0" ]] && { libusb="$d/libusb-1.0.so.0"; break; }
-            done
-            ;;
-    esac
-    [[ -n "$libusb" && -f "$libusb" ]] || {
-        echo "libusb not found${libusb:+ at $libusb}; hwi cannot reach devices without it" >&2
-        echo "  macOS:   brew install libusb" >&2
-        echo "  Linux:   apt-get install libusb-1.0-0-dev" >&2
-        echo "  Windows: set LIBUSB_DLL to a libusb-1.0.dll" >&2
-        return 1
-    }
-    # PyInstaller keeps the source basename, and hwi asks for the unversioned
-    # name, so stage a copy under exactly the name it will look for.
-    local wanted
-    case "$os" in
-        darwin)  wanted=libusb-1.0.dylib ;;
-        windows) wanted=libusb-1.0.dll ;;
-        linux)   wanted=libusb-1.0.so ;;
-    esac
-    cp "$libusb" "$tmp/$wanted"
-    # PyInstaller splits --add-binary on the host os.pathsep.
-    local sep=":" staged="$tmp/$wanted"
-    # MSYS mangles the ";"-joined argument instead of translating the path.
-    [[ "$os" == "windows" ]] && { sep=";"; staged="$(cygpath -w "$staged")"; }
-    echo "Building hwi-daemon (${goarch:-host}) — installs hwi + pyinstaller into a temp venv"
-    "$py" -m venv "$tmp/venv"
-    local vpy="$tmp/venv/$bindir/python"
-    "$vpy" -m pip install --quiet --upgrade pip
-    "$vpy" -m pip install --quiet "hwi==2.1.1" pyinstaller
-    "$vpy" -m PyInstaller --onefile --name "$name" --collect-all hwilib --add-binary "$staged$sep." \
-        --distpath "$(dirname "$out")" --workpath "$tmp/build" --specpath "$tmp" "$script"
-    chmod +x "$out" 2>/dev/null || true
-    rm -rf "$tmp"
+    "$original_cwd/../sidechain-orchestrator/hwi-daemon/build.sh" "$out"
 }
 
 for target in "${targets[@]}"; do

--- a/coinshift/macos/Podfile.lock
+++ b/coinshift/macos/Podfile.lock
@@ -5,15 +5,12 @@ PODS:
   - desktop_multi_window (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - screen_retriever_macos (0.0.1):
-    - FlutterMacOS
   - Sparkle (2.7.1)
 
 DEPENDENCIES:
   - auto_updater_macos (from `Flutter/ephemeral/.symlinks/plugins/auto_updater_macos/macos`)
   - desktop_multi_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
 
 SPEC REPOS:
   trunk:
@@ -26,14 +23,11 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  screen_retriever_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
 
 SPEC CHECKSUMS:
   auto_updater_macos: 3a42f1a06be6981f1a18be37e6e7bf86aa732118
   desktop_multi_window: 93667594ccc4b88d91a97972fd3b1b89667fa80a
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   Sparkle: 5f93557176b762f712e8cd80680778bf23c7348c
 
 PODFILE CHECKSUM: 9e8d6c0fdb46e19301c6444943a68374392cb446

--- a/coinshift/scripts/download-binaries.sh
+++ b/coinshift/scripts/download-binaries.sh
@@ -12,6 +12,7 @@ echo "Building orchestratord in $(pwd)"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Forcing amd64 GOARCH"
     export GOARCH=amd64
+    export CGO_ENABLED=1
 fi
 
 go build -o ./bin/orchestratord ./cmd/orchestratord/

--- a/photon/macos/Podfile.lock
+++ b/photon/macos/Podfile.lock
@@ -5,15 +5,12 @@ PODS:
   - desktop_multi_window (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - screen_retriever_macos (0.0.1):
-    - FlutterMacOS
   - Sparkle (2.9.1)
 
 DEPENDENCIES:
   - auto_updater_macos (from `Flutter/ephemeral/.symlinks/plugins/auto_updater_macos/macos`)
   - desktop_multi_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
 
 SPEC REPOS:
   trunk:
@@ -26,14 +23,11 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  screen_retriever_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
 
 SPEC CHECKSUMS:
   auto_updater_macos: 3a42f1a06be6981f1a18be37e6e7bf86aa732118
   desktop_multi_window: 93667594ccc4b88d91a97972fd3b1b89667fa80a
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   Sparkle: a4115cd9a339b297a61163256e6954d9e35297ce
 
 PODFILE CHECKSUM: 9e8d6c0fdb46e19301c6444943a68374392cb446

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.153
+version: 1.0.154
 
 environment:
   sdk: 3.12.0

--- a/photon/scripts/download-binaries.sh
+++ b/photon/scripts/download-binaries.sh
@@ -12,6 +12,7 @@ echo "Building orchestratord in $(pwd)"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Forcing amd64 GOARCH"
     export GOARCH=amd64
+    export CGO_ENABLED=1
 fi
 
 go build -o ./bin/orchestratord ./cmd/orchestratord/

--- a/sidechain-orchestrator/hwi-daemon/build.sh
+++ b/sidechain-orchestrator/hwi-daemon/build.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Freezes hwi_daemon.py into a standalone binary at $1.
+set -e
+set -o pipefail
+
+out="${1:?usage: build.sh <output-path>}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "$(uname -s)" in
+    Darwin*)              os=darwin ;;
+    MINGW*|MSYS*|CYGWIN*) os=windows ;;
+    *)                    os=linux ;;
+esac
+
+py="$(command -v python3 || command -v python)" || {
+    echo "python not found; cannot build hwi-daemon" >&2
+    exit 1
+}
+
+bindir=bin
+[[ "$os" == "windows" ]] && bindir=Scripts
+
+name="$(basename "$out")"; name="${name%.exe}"
+tmp="$(mktemp -d)"
+
+# hwi dlopens libusb by name, which PyInstaller's import analysis never sees.
+# Unfrozen it resolves to whatever the build machine happens to have installed.
+libusb="" d=""
+case "$os" in
+    darwin)  libusb="$(brew --prefix libusb 2>/dev/null)/lib/libusb-1.0.dylib" ;;
+    windows) libusb="${LIBUSB_DLL:-}" ;;
+    linux)
+        for d in /lib/x86_64-linux-gnu /lib/aarch64-linux-gnu /usr/lib64 /lib64 /usr/lib /lib; do
+            [[ -f "$d/libusb-1.0.so.0" ]] && { libusb="$d/libusb-1.0.so.0"; break; }
+        done
+        ;;
+esac
+[[ -n "$libusb" && -f "$libusb" ]] || {
+    echo "libusb not found${libusb:+ at $libusb}; hwi cannot reach devices without it" >&2
+    echo "  macOS:   brew install libusb" >&2
+    echo "  Linux:   apt-get install libusb-1.0-0-dev" >&2
+    echo "  Windows: set LIBUSB_DLL to a libusb-1.0.dll" >&2
+    exit 1
+}
+
+# PyInstaller keeps the source basename, and hwi asks for the unversioned name,
+# so stage a copy under exactly the name it will look for.
+case "$os" in
+    darwin)  wanted=libusb-1.0.dylib ;;
+    windows) wanted=libusb-1.0.dll ;;
+    linux)   wanted=libusb-1.0.so ;;
+esac
+cp "$libusb" "$tmp/$wanted"
+
+# PyInstaller splits --add-binary on the host os.pathsep.
+sep=":" staged="$tmp/$wanted"
+# MSYS mangles the ";"-joined argument instead of translating the path.
+[[ "$os" == "windows" ]] && { sep=";"; staged="$(cygpath -w "$staged")"; }
+
+echo "Building hwi-daemon — installs hwi + pyinstaller into a temp venv"
+"$py" -m venv "$tmp/venv"
+vpy="$tmp/venv/$bindir/python"
+"$vpy" -m pip install --quiet --upgrade pip
+"$vpy" -m pip install --quiet "hwi==2.1.1" pyinstaller
+"$vpy" -m PyInstaller --onefile --name "$name" --collect-all hwilib --add-binary "$staged$sep." \
+    --distpath "$(dirname "$out")" --workpath "$tmp/build" --specpath "$tmp" "$here/hwi_daemon.py"
+chmod +x "$out" 2>/dev/null || true
+rm -rf "$tmp"

--- a/sidechain-orchestrator/hwi-daemon/build.sh
+++ b/sidechain-orchestrator/hwi-daemon/build.sh
@@ -23,46 +23,24 @@ bindir=bin
 name="$(basename "$out")"; name="${name%.exe}"
 tmp="$(mktemp -d)"
 
-# hwi dlopens libusb by name, which PyInstaller's import analysis never sees.
-# Unfrozen it resolves to whatever the build machine happens to have installed.
-libusb="" d=""
-case "$os" in
-    darwin)  libusb="$(brew --prefix libusb 2>/dev/null)/lib/libusb-1.0.dylib" ;;
-    windows) libusb="${LIBUSB_DLL:-}" ;;
-    linux)
-        for d in /lib/x86_64-linux-gnu /lib/aarch64-linux-gnu /usr/lib64 /lib64 /usr/lib /lib; do
-            [[ -f "$d/libusb-1.0.so.0" ]] && { libusb="$d/libusb-1.0.so.0"; break; }
-        done
-        ;;
-esac
-[[ -n "$libusb" && -f "$libusb" ]] || {
-    echo "libusb not found${libusb:+ at $libusb}; hwi cannot reach devices without it" >&2
-    echo "  macOS:   brew install libusb" >&2
-    echo "  Linux:   apt-get install libusb-1.0-0-dev" >&2
-    echo "  Windows: set LIBUSB_DLL to a libusb-1.0.dll" >&2
-    exit 1
-}
-
-# PyInstaller keeps the source basename, and hwi asks for the unversioned name,
-# so stage a copy under exactly the name it will look for.
-case "$os" in
-    darwin)  wanted=libusb-1.0.dylib ;;
-    windows) wanted=libusb-1.0.dll ;;
-    linux)   wanted=libusb-1.0.so ;;
-esac
-cp "$libusb" "$tmp/$wanted"
-
-# PyInstaller splits --add-binary on the host os.pathsep.
-sep=":" staged="$tmp/$wanted"
-# MSYS mangles the ";"-joined argument instead of translating the path.
-[[ "$os" == "windows" ]] && { sep=";"; staged="$(cygpath -w "$staged")"; }
-
 echo "Building hwi-daemon — installs hwi + pyinstaller into a temp venv"
 "$py" -m venv "$tmp/venv"
 vpy="$tmp/venv/$bindir/python"
 "$vpy" -m pip install --quiet --upgrade pip
-"$vpy" -m pip install --quiet "hwi==2.1.1" pyinstaller
-"$vpy" -m PyInstaller --onefile --name "$name" --collect-all hwilib --add-binary "$staged$sep." \
+"$vpy" -m pip install --quiet "hwi==2.1.1" pyinstaller libusb-package
+
+# hwi dlopens libusb by name, which PyInstaller's import analysis never sees.
+# libusb-package ships it prebuilt, already under the name hwi asks for.
+libusb="$("$vpy" -c 'import libusb_package; print(libusb_package.get_library_path() or "")')"
+[[ -n "$libusb" ]] || {
+    echo "libusb-package shipped no library for this platform" >&2
+    exit 1
+}
+
+# PyInstaller splits --add-binary on the host os.pathsep.
+sep=":"; [[ "$os" == "windows" ]] && sep=";"
+
+"$vpy" -m PyInstaller --onefile --name "$name" --collect-all hwilib --add-binary "$libusb$sep." \
     --distpath "$(dirname "$out")" --workpath "$tmp/build" --specpath "$tmp" "$here/hwi_daemon.py"
 chmod +x "$out" 2>/dev/null || true
 rm -rf "$tmp"

--- a/sidechain-orchestrator/wallet/hwi_daemon_test.go
+++ b/sidechain-orchestrator/wallet/hwi_daemon_test.go
@@ -1,0 +1,46 @@
+package wallet
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHWIDaemonSmoke drives a real daemon over the pipe protocol. Against the
+// frozen binary, enumerate is what proves libusb loads out of the bundle.
+func TestHWIDaemonSmoke(t *testing.T) {
+	if os.Getenv("ORCHESTRATOR_HWI_DAEMON") == "" {
+		t.Skip("set ORCHESTRATOR_HWI_DAEMON to the daemon to run this")
+	}
+	t.Cleanup(func() {
+		daemonMu.Lock()
+		defer daemonMu.Unlock()
+		if daemon != nil {
+			daemon.close()
+			daemon = nil
+		}
+	})
+
+	// A onefile bundle unpacks itself on first start.
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	runner := NewHWIRunner(&chaincfg.SigNetParams)
+
+	devices, err := runner.Enumerate(ctx, "")
+	require.NoError(t, err)
+	t.Logf("enumerate found %d devices", len(devices))
+
+	_, err = hwiCall(ctx, map[string]any{"cmd": "nonsense"})
+	require.ErrorContains(t, err, "unknown command")
+
+	_, err = runner.GetXpub(ctx, HardwareSelector{Fingerprint: "deadbeef"}, "m/84'/1'/0'")
+	require.Error(t, err)
+
+	_, err = runner.Enumerate(ctx, "")
+	require.NoError(t, err, "daemon did not survive the failed commands")
+}

--- a/thunder/macos/Podfile.lock
+++ b/thunder/macos/Podfile.lock
@@ -5,15 +5,12 @@ PODS:
   - desktop_multi_window (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - screen_retriever_macos (0.0.1):
-    - FlutterMacOS
   - Sparkle (2.9.1)
 
 DEPENDENCIES:
   - auto_updater_macos (from `Flutter/ephemeral/.symlinks/plugins/auto_updater_macos/macos`)
   - desktop_multi_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
 
 SPEC REPOS:
   trunk:
@@ -26,14 +23,11 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  screen_retriever_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
 
 SPEC CHECKSUMS:
   auto_updater_macos: 3a42f1a06be6981f1a18be37e6e7bf86aa732118
   desktop_multi_window: 93667594ccc4b88d91a97972fd3b1b89667fa80a
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   Sparkle: a4115cd9a339b297a61163256e6954d9e35297ce
 
 PODFILE CHECKSUM: 9e8d6c0fdb46e19301c6444943a68374392cb446

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.282
+version: 1.0.283
 
 environment:
   sdk: 3.12.0

--- a/thunder/scripts/download-binaries.sh
+++ b/thunder/scripts/download-binaries.sh
@@ -17,6 +17,7 @@ echo "Building orchestratord in $server_cwd"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Forcing amd64 GOARCH"
     export GOARCH=amd64
+    export CGO_ENABLED=1
 fi
 
 go build -o ./bin/orchestratord ./cmd/orchestratord/

--- a/truthcoin/macos/Podfile.lock
+++ b/truthcoin/macos/Podfile.lock
@@ -5,15 +5,12 @@ PODS:
   - desktop_multi_window (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - screen_retriever_macos (0.0.1):
-    - FlutterMacOS
   - Sparkle (2.9.1)
 
 DEPENDENCIES:
   - auto_updater_macos (from `Flutter/ephemeral/.symlinks/plugins/auto_updater_macos/macos`)
   - desktop_multi_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
 
 SPEC REPOS:
   trunk:
@@ -26,14 +23,11 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  screen_retriever_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
 
 SPEC CHECKSUMS:
   auto_updater_macos: 3a42f1a06be6981f1a18be37e6e7bf86aa732118
   desktop_multi_window: 93667594ccc4b88d91a97972fd3b1b89667fa80a
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   Sparkle: a4115cd9a339b297a61163256e6954d9e35297ce
 
 PODFILE CHECKSUM: 9e8d6c0fdb46e19301c6444943a68374392cb446

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.153
+version: 1.0.154
 
 environment:
   sdk: 3.12.0

--- a/truthcoin/scripts/download-binaries.sh
+++ b/truthcoin/scripts/download-binaries.sh
@@ -12,6 +12,7 @@ echo "Building orchestratord in $(pwd)"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Forcing amd64 GOARCH"
     export GOARCH=amd64
+    export CGO_ENABLED=1
 fi
 
 go build -o ./bin/orchestratord ./cmd/orchestratord/

--- a/zside/macos/Podfile.lock
+++ b/zside/macos/Podfile.lock
@@ -5,15 +5,12 @@ PODS:
   - desktop_multi_window (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - screen_retriever_macos (0.0.1):
-    - FlutterMacOS
   - Sparkle (2.9.1)
 
 DEPENDENCIES:
   - auto_updater_macos (from `Flutter/ephemeral/.symlinks/plugins/auto_updater_macos/macos`)
   - desktop_multi_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
 
 SPEC REPOS:
   trunk:
@@ -26,14 +23,11 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  screen_retriever_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
 
 SPEC CHECKSUMS:
   auto_updater_macos: 3a42f1a06be6981f1a18be37e6e7bf86aa732118
   desktop_multi_window: 93667594ccc4b88d91a97972fd3b1b89667fa80a
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   Sparkle: a4115cd9a339b297a61163256e6954d9e35297ce
 
 PODFILE CHECKSUM: 9e8d6c0fdb46e19301c6444943a68374392cb446

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.280
+version: 1.0.281
 
 environment:
   sdk: 3.12.0

--- a/zside/scripts/download-binaries.sh
+++ b/zside/scripts/download-binaries.sh
@@ -12,6 +12,7 @@ echo "Building orchestratord in $(pwd)"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Forcing amd64 GOARCH"
     export GOARCH=amd64
+    export CGO_ENABLED=1
 fi
 
 go build -o ./bin/orchestratord ./cmd/orchestratord/


### PR DESCRIPTION
The macOS sidechain builds cross-compile to amd64, which turns cgo off, and go-sqlite3 needs it — sqliteguard was the first code to touch a cgo-only symbol and turned that into a compile error. On Windows, MSYS mangled the POSIX temp path inside PyInstaller's semicolon-joined --add-binary argument instead of translating it, so it never found libusb.

Also freezes the hwi daemon in its own script and adds a smoke test that enumerates devices through the frozen binary on Linux, macOS and Windows, so a bundle that cannot load libusb fails CI.