### PR TITLE
fix: Back off and expire /paid retries for pending fast withdrawals

### DIFF
--- a/bitwindow/server/engines/sidechain_monitor_engine.go
+++ b/bitwindow/server/engines/sidechain_monitor_engine.go
@@ -69,6 +69,32 @@ type PendingFastWithdrawal struct {
 	ExpectedAmount int64     `json:"expected_amount"` // Amount expected (sats)
 	ServerURL      string    `json:"server_url"`      // Fast withdrawal server URL
 	CreatedAt      time.Time `json:"created_at"`
+	Attempts       int       `json:"attempts"`     // Failed /paid completion attempts so far
+	LastAttempt    time.Time `json:"last_attempt"` // When the last /paid attempt was made
+}
+
+const (
+	// completionBackoffBase is the delay before the first /paid retry. Each
+	// subsequent failure doubles it, up to completionBackoffMaxShift.
+	completionBackoffBase = 30 * time.Second
+
+	// completionBackoffMaxShift caps the exponential backoff at
+	// completionBackoffBase << completionBackoffMaxShift (16 minutes).
+	completionBackoffMaxShift = 5
+)
+
+// completionBackoff returns how long to wait before re-POSTing /paid after the
+// given number of failed attempts
+func completionBackoff(attempts int) time.Duration {
+	shift := attempts - 1
+	if shift < 0 {
+		shift = 0
+	}
+	if shift > completionBackoffMaxShift {
+		shift = completionBackoffMaxShift
+	}
+
+	return completionBackoffBase << shift
 }
 
 // NewSidechainMonitorEngine creates a new sidechain monitoring engine
@@ -135,7 +161,7 @@ func (e *SidechainMonitorEngine) Run(ctx context.Context) error {
 					pollCount++
 					// Cleanup old withdrawals every 60 polls for ALL sidechains (fix memory leak)
 					if pollCount%60 == 0 {
-						e.cleanupOldWithdrawals()
+						e.cleanupOldWithdrawals(ctx)
 					}
 
 					// Dynamic polling interval based on pending withdrawals
@@ -209,9 +235,15 @@ func (e *SidechainMonitorEngine) checkFastWithdrawalPayments(ctx context.Context
 	e.mu.RLock()
 	var pendingForSidechain []PendingFastWithdrawal
 	for _, pending := range e.pendingFastWithdrawals {
-		if pending.Sidechain == sidechain {
-			pendingForSidechain = append(pendingForSidechain, pending)
+		if pending.Sidechain != sidechain {
+			continue
 		}
+		// Skip rows still backing off from a failed /paid POST, so a server that
+		// is down doesn't get the same completion re-posted on every poll
+		if !pending.LastAttempt.IsZero() && time.Since(pending.LastAttempt) < completionBackoff(pending.Attempts) {
+			continue
+		}
+		pendingForSidechain = append(pendingForSidechain, pending)
 	}
 	e.mu.RUnlock()
 
@@ -262,11 +294,28 @@ func (e *SidechainMonitorEngine) checkFastWithdrawalPayments(ctx context.Context
 			// Auto-complete the withdrawal
 			if err := e.completeWithdrawal(ctx, pending, txid); err != nil {
 				log.Error().Err(err).Str("hash", pending.Hash).Msg("failed to auto-complete withdrawal")
+				e.recordFailedCompletion(pending.Hash)
 			}
 		}
 	}
 
 	return nil
+}
+
+// recordFailedCompletion notes a failed /paid POST so the next attempt for the
+// same withdrawal is delayed by completionBackoff instead of firing next poll
+func (e *SidechainMonitorEngine) recordFailedCompletion(hash string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	pending, exists := e.pendingFastWithdrawals[hash]
+	if !exists {
+		return // Already completed or cleaned up
+	}
+
+	pending.Attempts++
+	pending.LastAttempt = time.Now()
+	e.pendingFastWithdrawals[hash] = pending
 }
 
 // getPollInterval returns the polling interval based on pending withdrawals
@@ -288,7 +337,9 @@ func (e *SidechainMonitorEngine) getPollInterval() time.Duration {
 }
 
 // cleanupOldWithdrawals removes withdrawals older than 1 hour to prevent memory bloat
-func (e *SidechainMonitorEngine) cleanupOldWithdrawals() {
+func (e *SidechainMonitorEngine) cleanupOldWithdrawals(ctx context.Context) {
+	log := zerolog.Ctx(ctx)
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -296,6 +347,20 @@ func (e *SidechainMonitorEngine) cleanupOldWithdrawals() {
 	for txid, withdrawal := range e.detectedWithdrawals {
 		if withdrawal.DetectedAt.Before(cutoff) {
 			delete(e.detectedWithdrawals, txid)
+		}
+	}
+
+	// Pending fast withdrawals are retried until the server accepts the /paid
+	// POST, so they need the same retention or they accumulate forever
+	for hash, pending := range e.pendingFastWithdrawals {
+		if pending.CreatedAt.Before(cutoff) {
+			delete(e.pendingFastWithdrawals, hash)
+
+			log.Warn().
+				Str("hash", hash).
+				Str("sidechain", pending.Sidechain).
+				Int("attempts", pending.Attempts).
+				Msg("giving up on auto-completing fast withdrawal, retention expired")
 		}
 	}
 }

--- a/bitwindow/server/engines/sidechain_monitor_engine_test.go
+++ b/bitwindow/server/engines/sidechain_monitor_engine_test.go
@@ -189,10 +189,77 @@ func TestSidechainMonitorEngine_CleanupOldWithdrawals(t *testing.T) {
 		DetectedAt: newTime,
 	}
 
+	// Add old and new pending fast withdrawals
+	engine.pendingFastWithdrawals["old-hash"] = PendingFastWithdrawal{
+		Hash:      "old-hash",
+		Sidechain: "thunder",
+		Attempts:  12,
+		CreatedAt: oldTime,
+	}
+	engine.pendingFastWithdrawals["new-hash"] = PendingFastWithdrawal{
+		Hash:      "new-hash",
+		Sidechain: "thunder",
+		CreatedAt: newTime,
+	}
+
 	// Run cleanup
-	engine.cleanupOldWithdrawals()
+	engine.cleanupOldWithdrawals(context.Background())
 
 	// Old withdrawal should be removed, new one should remain
 	assert.NotContains(t, engine.detectedWithdrawals, "old-txid")
 	assert.Contains(t, engine.detectedWithdrawals, "new-txid")
+
+	// Same for pending fast withdrawals - otherwise a withdrawal the server
+	// never accepts is retried forever
+	assert.NotContains(t, engine.pendingFastWithdrawals, "old-hash")
+	assert.Contains(t, engine.pendingFastWithdrawals, "new-hash")
+}
+
+func TestSidechainMonitorEngine_FailedCompletionBacksOff(t *testing.T) {
+	ctx := zerolog.New(zerolog.NewTestWriter(t)).WithContext(context.Background())
+
+	// Mock server that always fails the /paid POST
+	var paidRequests int
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paidRequests++
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{"status": "error"}); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	engine := NewSidechainMonitorEngine(
+		nil, nil, nil, nil, nil, nil,
+		nil,
+	)
+
+	pending := PendingFastWithdrawal{
+		Hash:           "test-hash-123456789abcdef",
+		Sidechain:      "thunder",
+		ServerAddress:  "thunder1test456",
+		ExpectedAmount: 105000,
+		ServerURL:      mockServer.URL,
+		CreatedAt:      time.Now(),
+	}
+
+	err := engine.RegisterPendingFastWithdrawal(ctx, pending)
+	require.NoError(t, err)
+
+	// A failing completion must not drop the withdrawal, but must record the attempt
+	err = engine.completeWithdrawal(ctx, pending, "test-txid-456789abcdef123")
+	require.Error(t, err)
+	engine.recordFailedCompletion(pending.Hash)
+	assert.Equal(t, 1, paidRequests)
+
+	stored := engine.pendingFastWithdrawals[pending.Hash]
+	assert.Equal(t, 1, stored.Attempts)
+	assert.False(t, stored.LastAttempt.IsZero())
+
+	// Backoff grows with the attempt count, and is capped
+	assert.Equal(t, 30*time.Second, completionBackoff(0))
+	assert.Equal(t, 30*time.Second, completionBackoff(1))
+	assert.Equal(t, 60*time.Second, completionBackoff(2))
+	assert.Equal(t, 16*time.Minute, completionBackoff(6))
+	assert.Equal(t, 16*time.Minute, completionBackoff(100))
 }

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -342,8 +342,12 @@ func (p *CoreBackend) NextChangeAddress(ctx context.Context, walletID string) (s
 	return p.rpc.GetRawChangeAddress(ctx, name)
 }
 
-// WatchKeys imports each key as a pkh() descriptor. Per-key import failures
-// are logged, not fatal — matching how Core treats already-known descriptors.
+// WatchKeys imports each key as a pkh() descriptor. Re-importing a descriptor
+// Core already knows still reports success, so a success:false result means
+// that key is genuinely not being watched: log every failure and return an
+// error. Callers persist an import watermark once this returns nil (the BIP47
+// per-sender window), and swallowing a partial failure would move that
+// watermark past addresses the wallet never actually watches.
 func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []WatchKey) error {
 	name, err := p.walletName(ctx, walletID)
 	if err != nil {
@@ -360,6 +364,7 @@ func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []Wat
 	if err != nil {
 		return err
 	}
+	var failed []string
 	for i, r := range results {
 		if r.Success {
 			continue
@@ -369,6 +374,10 @@ func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []Wat
 			msg = r.Error.Message
 		}
 		p.log.Warn().Int("descriptor_index", i).Str("error", msg).Msg("watch key import failed")
+		failed = append(failed, fmt.Sprintf("%d: %s", i, msg))
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("%d of %d watch key imports failed [%s]", len(failed), len(results), strings.Join(failed, "; "))
 	}
 	return nil
 }

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -698,6 +698,45 @@ func TestCoreBackendWatchKeys(t *testing.T) {
 	assert.Equal(t, float64(1_700_000_000), asFloat(t, descs[0].Timestamp))
 }
 
+// A per-descriptor success:false means that key is not watched. WatchKeys must
+// surface it, otherwise the BIP47 engine bumps its import watermark past
+// addresses Core never got.
+func TestCoreBackendWatchKeysPartialImportFailure(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	ctx := context.Background()
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+
+	// Core accepts the first descriptor and rejects the second.
+	fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			if i == 1 {
+				results[i] = map[string]any{"success": false, "error": map[string]any{"code": -1, "message": "Rescan failed"}}
+				continue
+			}
+			results[i] = map[string]any{"success": true}
+		}
+		return results, ""
+	})
+
+	first, err := btcutil.NewWIF(fixedKey(0x11), &chaincfg.RegressionNetParams, true)
+	require.NoError(t, err)
+	second, err := btcutil.NewWIF(fixedKey(0x12), &chaincfg.RegressionNetParams, true)
+	require.NoError(t, err)
+
+	err = backend.WatchKeys(ctx, coreID, []WatchKey{
+		{WIF: first.String(), RescanFrom: 1_700_000_000},
+		{WIF: second.String(), RescanFrom: 1_700_000_000},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Rescan failed")
+}
+
 func TestCoreBackendNextReceiveAddress(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
 	fake.stubEnsureFlow()


### PR DESCRIPTION
**What's wrong**

In `SidechainMonitorEngine`, when `completeWithdrawal` fails (the fast-withdrawal server errors on `/paid`) the pending row is left untouched in `pendingFastWithdrawals`, so the next poll re-POSTs `/paid` for the same withdrawal — and the one after that, for as long as the server keeps failing. `cleanupOldWithdrawals` only pruned `detectedWithdrawals`, so those pending rows also never expire: a withdrawal the server never accepts is retried indefinitely and its entry stays in the map.

**The fix**

Track `Attempts`/`LastAttempt` per pending withdrawal. `checkFastWithdrawalPayments` skips rows still inside their backoff window (30s, doubling to a 16 minute cap), `recordFailedCompletion` records each failure, and `cleanupOldWithdrawals` now applies the same one-hour retention to pending rows, logging the hash and attempt count when it gives up.

This bounds the retry loop client-side; it does not make `/paid` idempotent on the server. Happy to adjust scope if you would rather key completion server-side.

**Tests**

The cleanup test now covers pending rows, and `TestSidechainMonitorEngine_FailedCompletionBacksOff` asserts a failing POST is recorded once and that the backoff grows and clamps.

Finding report (access-controlled): https://giaki3003.tech/#/findings/20260629-2116-kimiclaw-confirm-glmclaw-drivechain-frontends-bitwindow-sidechainmonitor-paid-retry-nonidempotent

---
Part of a short series for this repo (fix 2 of 17); builds on https://github.com/LayerTwo-Labs/drivechain-frontends/pull/1943, so it reads best merged after that one. Happy to rebase or split if you'd prefer them independent.