### PR TITLE
fix: Use a real TLS transport for https:// orchestrator dials

### DIFF
--- a/bitwindow/server/dial/dial.go
+++ b/bitwindow/server/dial/dial.go
@@ -39,9 +39,10 @@ func Bitcoind(ctx context.Context, orchestratorAddr string) (corerpc.BitcoinServ
 	if orchestratorAddr == "" {
 		return nil, errors.New("empty orchestrator addr")
 	}
+	addr := ensureHTTPScheme(orchestratorAddr)
 	return corerpc.NewBitcoinServiceClient(
-		getSharedClient(ctx),
-		ensureHTTPScheme(orchestratorAddr),
+		clientForScheme(ctx, addr),
+		addr,
 		connect.WithGRPC(),
 		// Bitcoind is the one dial target on the orchestrator (its hosted core
 		// proxy); enforcer/sidechain dials go to other daemons and stay
@@ -60,6 +61,17 @@ func ensureHTTPScheme(addr string) string {
 		return addr
 	}
 	return "http://" + addr
+}
+
+// clientForScheme picks the client matching addr's scheme (addr must already
+// have been through ensureHTTPScheme). The shared client is h2c: it dials
+// cleartext no matter what scheme the URL carries, so handing it an https://
+// orchestrator URL would put the local-auth cookie on the wire in the clear.
+func clientForScheme(ctx context.Context, addr string) *http.Client {
+	if strings.HasPrefix(strings.ToLower(addr), "https://") {
+		return getSharedTLSClient(ctx)
+	}
+	return getSharedClient(ctx)
 }
 
 func EnforcerValidator(ctx context.Context, url string) (
@@ -234,9 +246,13 @@ func CoinShift(ctx context.Context, host string, port int) (*coinshift.Client, e
 }
 
 var (
-	// Shared HTTP client for all connections
+	// Shared HTTP client for all cleartext (http://) connections
 	sharedClient *http.Client
 	clientOnce   sync.Once
+
+	// Shared HTTP client for https:// targets. Same settings, but real TLS.
+	sharedTLSClient *http.Client
+	tlsClientOnce   sync.Once
 
 	// cookieDir is the bitwindow data dir holding .auth.cookie, used by the
 	// orchestrator-targeting Bitcoind client. Set once at startup via
@@ -248,27 +264,47 @@ var (
 // (Bitcoind proxy) client. Call once at startup before the first dial.
 func SetCookieDir(dir string) { cookieDir = dir }
 
-// getSharedClient returns a singleton HTTP client for all connections
+// getSharedClient returns a singleton HTTP client for cleartext connections
 func getSharedClient(ctx context.Context) *http.Client {
 	clientOnce.Do(func() {
-		sharedClient = &http.Client{
-			Transport: &http2.Transport{
-				AllowHTTP: true,
-				DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
-					return net.Dial(network, addr)
-				},
-				// Without explicit timeouts here, clients linger indefinitely
-				IdleConnTimeout:  15 * time.Second,
-				ReadIdleTimeout:  30 * time.Second, // Close if no data received for 30s
-				PingTimeout:      15 * time.Second,
-				WriteByteTimeout: 10 * time.Second,
-
-				CountError: func(errType string) {
-					zerolog.Ctx(ctx).Error().Msgf("HTTP/2 transport error: %s", errType)
-				},
-			},
-			Timeout: 30 * time.Second, // Overall request timeout
-		}
+		sharedClient = newHTTP2Client(ctx, true)
 	})
 	return sharedClient
+}
+
+// getSharedTLSClient returns a singleton HTTP client for https:// connections.
+func getSharedTLSClient(ctx context.Context) *http.Client {
+	tlsClientOnce.Do(func() {
+		sharedTLSClient = newHTTP2Client(ctx, false)
+	})
+	return sharedTLSClient
+}
+
+// newHTTP2Client builds an HTTP/2 client with our standard timeouts. With
+// cleartext set it speaks h2c (prior knowledge, no TLS handshake); otherwise
+// http2.Transport's own TLS dialer handles the connection. The h2c dialer must
+// never be used for https:// targets — it ignores the *tls.Config it is handed
+// and would send the request, headers and all, unencrypted.
+func newHTTP2Client(ctx context.Context, cleartext bool) *http.Client {
+	transport := &http2.Transport{
+		// Without explicit timeouts here, clients linger indefinitely
+		IdleConnTimeout:  15 * time.Second,
+		ReadIdleTimeout:  30 * time.Second, // Close if no data received for 30s
+		PingTimeout:      15 * time.Second,
+		WriteByteTimeout: 10 * time.Second,
+
+		CountError: func(errType string) {
+			zerolog.Ctx(ctx).Error().Msgf("HTTP/2 transport error: %s", errType)
+		},
+	}
+	if cleartext {
+		transport.AllowHTTP = true
+		transport.DialTLS = func(network, addr string, _ *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		}
+	}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   30 * time.Second, // Overall request timeout
+	}
 }

--- a/bitwindow/server/dial/dial_test.go
+++ b/bitwindow/server/dial/dial_test.go
@@ -1,6 +1,10 @@
 package dial
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/net/http2"
+)
 
 // TestEnsureHTTPScheme guards the double-prefix regression. config.OrchestratorAddr
 // defaults to a full URL ("http://localhost:30400"); dial.Bitcoind used to wrap
@@ -37,5 +41,44 @@ func TestEnsureHTTPScheme(t *testing.T) {
 func TestBitcoind_RejectsEmptyAddr(t *testing.T) {
 	if _, err := Bitcoind(t.Context(), ""); err == nil {
 		t.Fatal("Bitcoind(\"\") returned nil error")
+	}
+}
+
+// TestClientForScheme guards the cookie-leak regression. Every dial used the
+// h2c client, whose DialTLS hook discards the *tls.Config it is handed and
+// plain net.Dials instead — x/net/http2 routes https:// connections through
+// that same hook, so an https:// orchestrator.addr dialed cleartext and the
+// local-auth bearer cookie went out unencrypted. https:// must get a transport
+// that actually does TLS.
+func TestClientForScheme(t *testing.T) {
+	cleartext := clientForScheme(t.Context(), "http://localhost:30400")
+	encrypted := clientForScheme(t.Context(), "https://orch.example.com")
+
+	if cleartext == encrypted {
+		t.Fatal("http:// and https:// got the same client")
+	}
+
+	h2c, ok := cleartext.Transport.(*http2.Transport)
+	if !ok {
+		t.Fatalf("http:// transport = %T, want *http2.Transport", cleartext.Transport)
+	}
+	if !h2c.AllowHTTP || h2c.DialTLS == nil {
+		t.Error("http:// client is not the h2c transport")
+	}
+
+	tlsTransport, ok := encrypted.Transport.(*http2.Transport)
+	if !ok {
+		t.Fatalf("https:// transport = %T, want *http2.Transport", encrypted.Transport)
+	}
+	if tlsTransport.AllowHTTP {
+		t.Error("https:// client allows cleartext HTTP/2")
+	}
+	if tlsTransport.DialTLS != nil || tlsTransport.DialTLSContext != nil {
+		t.Error("https:// client overrides the TLS dialer, bypassing TLS")
+	}
+
+	// ensureHTTPScheme passes mixed-case schemes through untouched.
+	if got := clientForScheme(t.Context(), "HTTPS://orch.example.com"); got != encrypted {
+		t.Error("mixed-case https:// did not get the TLS client")
 	}
 }

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -174,19 +174,16 @@ func DetectFileType(content []byte) string {
 	// Try to detect text files
 	sampleSize := min(1024, len(content))
 
-	// Check if content looks like valid UTF-8 text
+	// Check if content is printable ASCII text. Non-ASCII bytes must classify as
+	// "bin": the "txt" path stores content raw in the OP_RETURN, and retrieval
+	// runs it through opreturns.OPReturnToReadable, which hex-encodes anything
+	// containing a byte above 0x7E and so destroys the "metadataB64|content"
+	// framing that DecodeOPReturnData needs.
 	isText := true
 	for i := range sampleSize {
 		b := content[i]
 		// Allow printable ASCII, newlines, tabs
-		if b < 0x09 || (b > 0x0D && b < 0x20) || b == 0x7F {
-			// Check for UTF-8 multi-byte sequences
-			if b >= 0x80 && b <= 0xBF {
-				continue // continuation byte
-			}
-			if b >= 0xC0 && b <= 0xF7 {
-				continue // start of multi-byte
-			}
+		if b < 0x09 || (b > 0x0D && b < 0x20) || b >= 0x7F {
 			isText = false
 			break
 		}

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/bitdrive"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/opreturns"
 	"github.com/btcsuite/btcd/chaincfg"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -225,5 +226,69 @@ func TestSaveFile_SameSecondNoCollision(t *testing.T) {
 	}
 	if string(secondContent) != "second file" {
 		t.Fatalf("second file content wrong: got %q", secondContent)
+	}
+}
+
+// TestDetectFileType_NonASCIIIsBinary verifies that any byte above 0x7E makes
+// content classify as "bin" rather than "txt". Classifying it as text sends it
+// down the raw-storage path, which cannot survive retrieval.
+func TestDetectFileType_NonASCIIIsBinary(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		want    string
+	}{
+		{"plain ascii", []byte("hello world\n\tand tabs"), "txt"},
+		{"utf-8 multi-byte", []byte("café"), "bin"},
+		{"high byte", []byte("prefix\xFFsuffix"), "bin"},
+		{"continuation byte only", []byte("prefix\xBFsuffix"), "bin"},
+		{"delete char", []byte("prefix\x7Fsuffix"), "bin"},
+		{"nul byte", []byte("prefix\x00suffix"), "bin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectFileType(tt.content); got != tt.want {
+				t.Fatalf("DetectFileType(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEncodeOPReturnData_NonASCIIRoundTrip walks a payload containing a byte
+// above 0x7F through the full store/retrieve chain:
+// EncodeOPReturnData -> FormatOPReturnData -> OPReturnToReadable ->
+// DecodeOPReturnData. Storing such content as "txt" put raw high bytes on
+// chain, which OPReturnToReadable then hex-encoded, hiding the "|" separator
+// and making DecodeOPReturnData fail with "invalid OP_RETURN format".
+func TestEncodeOPReturnData_NonASCIIRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	engine := &BitDriveEngine{}
+
+	contents := [][]byte{
+		[]byte("café ☕ unicode text"),
+		[]byte("ascii with one high byte: \xFE"),
+		{0x00, 0x01, 0x80, 0xFF, 0x7C, 0x41},
+	}
+
+	for _, content := range contents {
+		metadataB64, contentStr, _, err := engine.EncodeOPReturnData(ctx, content, false)
+		if err != nil {
+			t.Fatalf("encode %q: %v", content, err)
+		}
+
+		opReturnData := FormatOPReturnData(metadataB64, contentStr)
+		readable := opreturns.OPReturnToReadable([]byte(opReturnData))
+
+		decoded, metadata, err := engine.DecodeOPReturnData(ctx, readable)
+		if err != nil {
+			t.Fatalf("decode %q: %v", content, err)
+		}
+		if metadata.FileType != "bin" {
+			t.Fatalf("expected file type bin for %q, got %q", content, metadata.FileType)
+		}
+		if !bytes.Equal(decoded, content) {
+			t.Fatalf("round trip mismatch: got %q, want %q", decoded, content)
+		}
 	}
 }

--- a/bitwindow/server/engines/sidechain_monitor_engine.go
+++ b/bitwindow/server/engines/sidechain_monitor_engine.go
@@ -69,6 +69,32 @@ type PendingFastWithdrawal struct {
 	ExpectedAmount int64     `json:"expected_amount"` // Amount expected (sats)
 	ServerURL      string    `json:"server_url"`      // Fast withdrawal server URL
 	CreatedAt      time.Time `json:"created_at"`
+	Attempts       int       `json:"attempts"`     // Failed /paid completion attempts so far
+	LastAttempt    time.Time `json:"last_attempt"` // When the last /paid attempt was made
+}
+
+const (
+	// completionBackoffBase is the delay before the first /paid retry. Each
+	// subsequent failure doubles it, up to completionBackoffMaxShift.
+	completionBackoffBase = 30 * time.Second
+
+	// completionBackoffMaxShift caps the exponential backoff at
+	// completionBackoffBase << completionBackoffMaxShift (16 minutes).
+	completionBackoffMaxShift = 5
+)
+
+// completionBackoff returns how long to wait before re-POSTing /paid after the
+// given number of failed attempts
+func completionBackoff(attempts int) time.Duration {
+	shift := attempts - 1
+	if shift < 0 {
+		shift = 0
+	}
+	if shift > completionBackoffMaxShift {
+		shift = completionBackoffMaxShift
+	}
+
+	return completionBackoffBase << shift
 }
 
 // NewSidechainMonitorEngine creates a new sidechain monitoring engine
@@ -135,7 +161,7 @@ func (e *SidechainMonitorEngine) Run(ctx context.Context) error {
 					pollCount++
 					// Cleanup old withdrawals every 60 polls for ALL sidechains (fix memory leak)
 					if pollCount%60 == 0 {
-						e.cleanupOldWithdrawals()
+						e.cleanupOldWithdrawals(ctx)
 					}
 
 					// Dynamic polling interval based on pending withdrawals
@@ -209,9 +235,15 @@ func (e *SidechainMonitorEngine) checkFastWithdrawalPayments(ctx context.Context
 	e.mu.RLock()
 	var pendingForSidechain []PendingFastWithdrawal
 	for _, pending := range e.pendingFastWithdrawals {
-		if pending.Sidechain == sidechain {
-			pendingForSidechain = append(pendingForSidechain, pending)
+		if pending.Sidechain != sidechain {
+			continue
 		}
+		// Skip rows still backing off from a failed /paid POST, so a server that
+		// is down doesn't get the same completion re-posted on every poll
+		if !pending.LastAttempt.IsZero() && time.Since(pending.LastAttempt) < completionBackoff(pending.Attempts) {
+			continue
+		}
+		pendingForSidechain = append(pendingForSidechain, pending)
 	}
 	e.mu.RUnlock()
 
@@ -262,11 +294,28 @@ func (e *SidechainMonitorEngine) checkFastWithdrawalPayments(ctx context.Context
 			// Auto-complete the withdrawal
 			if err := e.completeWithdrawal(ctx, pending, txid); err != nil {
 				log.Error().Err(err).Str("hash", pending.Hash).Msg("failed to auto-complete withdrawal")
+				e.recordFailedCompletion(pending.Hash)
 			}
 		}
 	}
 
 	return nil
+}
+
+// recordFailedCompletion notes a failed /paid POST so the next attempt for the
+// same withdrawal is delayed by completionBackoff instead of firing next poll
+func (e *SidechainMonitorEngine) recordFailedCompletion(hash string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	pending, exists := e.pendingFastWithdrawals[hash]
+	if !exists {
+		return // Already completed or cleaned up
+	}
+
+	pending.Attempts++
+	pending.LastAttempt = time.Now()
+	e.pendingFastWithdrawals[hash] = pending
 }
 
 // getPollInterval returns the polling interval based on pending withdrawals
@@ -288,7 +337,9 @@ func (e *SidechainMonitorEngine) getPollInterval() time.Duration {
 }
 
 // cleanupOldWithdrawals removes withdrawals older than 1 hour to prevent memory bloat
-func (e *SidechainMonitorEngine) cleanupOldWithdrawals() {
+func (e *SidechainMonitorEngine) cleanupOldWithdrawals(ctx context.Context) {
+	log := zerolog.Ctx(ctx)
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -296,6 +347,20 @@ func (e *SidechainMonitorEngine) cleanupOldWithdrawals() {
 	for txid, withdrawal := range e.detectedWithdrawals {
 		if withdrawal.DetectedAt.Before(cutoff) {
 			delete(e.detectedWithdrawals, txid)
+		}
+	}
+
+	// Pending fast withdrawals are retried until the server accepts the /paid
+	// POST, so they need the same retention or they accumulate forever
+	for hash, pending := range e.pendingFastWithdrawals {
+		if pending.CreatedAt.Before(cutoff) {
+			delete(e.pendingFastWithdrawals, hash)
+
+			log.Warn().
+				Str("hash", hash).
+				Str("sidechain", pending.Sidechain).
+				Int("attempts", pending.Attempts).
+				Msg("giving up on auto-completing fast withdrawal, retention expired")
 		}
 	}
 }

--- a/bitwindow/server/engines/sidechain_monitor_engine_test.go
+++ b/bitwindow/server/engines/sidechain_monitor_engine_test.go
@@ -189,10 +189,77 @@ func TestSidechainMonitorEngine_CleanupOldWithdrawals(t *testing.T) {
 		DetectedAt: newTime,
 	}
 
+	// Add old and new pending fast withdrawals
+	engine.pendingFastWithdrawals["old-hash"] = PendingFastWithdrawal{
+		Hash:      "old-hash",
+		Sidechain: "thunder",
+		Attempts:  12,
+		CreatedAt: oldTime,
+	}
+	engine.pendingFastWithdrawals["new-hash"] = PendingFastWithdrawal{
+		Hash:      "new-hash",
+		Sidechain: "thunder",
+		CreatedAt: newTime,
+	}
+
 	// Run cleanup
-	engine.cleanupOldWithdrawals()
+	engine.cleanupOldWithdrawals(context.Background())
 
 	// Old withdrawal should be removed, new one should remain
 	assert.NotContains(t, engine.detectedWithdrawals, "old-txid")
 	assert.Contains(t, engine.detectedWithdrawals, "new-txid")
+
+	// Same for pending fast withdrawals - otherwise a withdrawal the server
+	// never accepts is retried forever
+	assert.NotContains(t, engine.pendingFastWithdrawals, "old-hash")
+	assert.Contains(t, engine.pendingFastWithdrawals, "new-hash")
+}
+
+func TestSidechainMonitorEngine_FailedCompletionBacksOff(t *testing.T) {
+	ctx := zerolog.New(zerolog.NewTestWriter(t)).WithContext(context.Background())
+
+	// Mock server that always fails the /paid POST
+	var paidRequests int
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paidRequests++
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{"status": "error"}); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	engine := NewSidechainMonitorEngine(
+		nil, nil, nil, nil, nil, nil,
+		nil,
+	)
+
+	pending := PendingFastWithdrawal{
+		Hash:           "test-hash-123456789abcdef",
+		Sidechain:      "thunder",
+		ServerAddress:  "thunder1test456",
+		ExpectedAmount: 105000,
+		ServerURL:      mockServer.URL,
+		CreatedAt:      time.Now(),
+	}
+
+	err := engine.RegisterPendingFastWithdrawal(ctx, pending)
+	require.NoError(t, err)
+
+	// A failing completion must not drop the withdrawal, but must record the attempt
+	err = engine.completeWithdrawal(ctx, pending, "test-txid-456789abcdef123")
+	require.Error(t, err)
+	engine.recordFailedCompletion(pending.Hash)
+	assert.Equal(t, 1, paidRequests)
+
+	stored := engine.pendingFastWithdrawals[pending.Hash]
+	assert.Equal(t, 1, stored.Attempts)
+	assert.False(t, stored.LastAttempt.IsZero())
+
+	// Backoff grows with the attempt count, and is capped
+	assert.Equal(t, 30*time.Second, completionBackoff(0))
+	assert.Equal(t, 30*time.Second, completionBackoff(1))
+	assert.Equal(t, 60*time.Second, completionBackoff(2))
+	assert.Equal(t, 16*time.Minute, completionBackoff(6))
+	assert.Equal(t, 16*time.Minute, completionBackoff(100))
 }

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -342,8 +342,12 @@ func (p *CoreBackend) NextChangeAddress(ctx context.Context, walletID string) (s
 	return p.rpc.GetRawChangeAddress(ctx, name)
 }
 
-// WatchKeys imports each key as a pkh() descriptor. Per-key import failures
-// are logged, not fatal — matching how Core treats already-known descriptors.
+// WatchKeys imports each key as a pkh() descriptor. Re-importing a descriptor
+// Core already knows still reports success, so a success:false result means
+// that key is genuinely not being watched: log every failure and return an
+// error. Callers persist an import watermark once this returns nil (the BIP47
+// per-sender window), and swallowing a partial failure would move that
+// watermark past addresses the wallet never actually watches.
 func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []WatchKey) error {
 	name, err := p.walletName(ctx, walletID)
 	if err != nil {
@@ -360,6 +364,7 @@ func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []Wat
 	if err != nil {
 		return err
 	}
+	var failed []string
 	for i, r := range results {
 		if r.Success {
 			continue
@@ -369,6 +374,10 @@ func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []Wat
 			msg = r.Error.Message
 		}
 		p.log.Warn().Int("descriptor_index", i).Str("error", msg).Msg("watch key import failed")
+		failed = append(failed, fmt.Sprintf("%d: %s", i, msg))
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("%d of %d watch key imports failed [%s]", len(failed), len(results), strings.Join(failed, "; "))
 	}
 	return nil
 }

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -698,6 +698,45 @@ func TestCoreBackendWatchKeys(t *testing.T) {
 	assert.Equal(t, float64(1_700_000_000), asFloat(t, descs[0].Timestamp))
 }
 
+// A per-descriptor success:false means that key is not watched. WatchKeys must
+// surface it, otherwise the BIP47 engine bumps its import watermark past
+// addresses Core never got.
+func TestCoreBackendWatchKeysPartialImportFailure(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	ctx := context.Background()
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+
+	// Core accepts the first descriptor and rejects the second.
+	fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			if i == 1 {
+				results[i] = map[string]any{"success": false, "error": map[string]any{"code": -1, "message": "Rescan failed"}}
+				continue
+			}
+			results[i] = map[string]any{"success": true}
+		}
+		return results, ""
+	})
+
+	first, err := btcutil.NewWIF(fixedKey(0x11), &chaincfg.RegressionNetParams, true)
+	require.NoError(t, err)
+	second, err := btcutil.NewWIF(fixedKey(0x12), &chaincfg.RegressionNetParams, true)
+	require.NoError(t, err)
+
+	err = backend.WatchKeys(ctx, coreID, []WatchKey{
+		{WIF: first.String(), RescanFrom: 1_700_000_000},
+		{WIF: second.String(), RescanFrom: 1_700_000_000},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Rescan failed")
+}
+
 func TestCoreBackendNextReceiveAddress(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
 	fake.stubEnsureFlow()


### PR DESCRIPTION
**What's wrong**

`dial.Bitcoind` used `getSharedClient`, whose `http2.Transport` sets `AllowHTTP` and installs a `DialTLS` hook that discards the `*tls.Config` it is handed and calls `net.Dial`. x/net/http2 routes `https://` connections through that same hook, so an `https://` orchestrator address was dialed in cleartext. This is also the one dial target that attaches the local-auth cookie as a bearer header (`SetCookieDir`/localauth), so the cookie and the request body went out unencrypted for an operator who pointed `orchestrator.addr` at an https URL.

**The fix**

Split the singleton in two. `newHTTP2Client` builds the transport with the existing timeouts either in h2c mode or with http2's own TLS dialer; `getSharedClient` keeps h2c for `http://`, `getSharedTLSClient` serves `https://`, and `clientForScheme` picks between them from the scheme `ensureHTTPScheme` already normalised.

**Tests**

`TestClientForScheme` asserts the two schemes get different clients, that the `https://` client neither allows cleartext HTTP/2 nor overrides the TLS dialer, and that a mixed-case `HTTPS://` still lands on the TLS client.

Finding report (access-controlled): https://giaki3003.tech/#/findings/20260620-0043-kimiclaw-confirm-glmclaw-drivechain-frontends-bitwindow-dial-tls-bypass-cookie-leak

---
Part of a short series for this repo (fix 4 of 17); builds on https://github.com/LayerTwo-Labs/drivechain-frontends/pull/1945, so it reads best merged after that one. Happy to rebase or split if you'd prefer them independent.