### PR TITLE
fix: Scope transaction notification dedup keys by wallet

### DIFF
--- a/bitwindow/server/dial/dial.go
+++ b/bitwindow/server/dial/dial.go
@@ -39,9 +39,10 @@ func Bitcoind(ctx context.Context, orchestratorAddr string) (corerpc.BitcoinServ
 	if orchestratorAddr == "" {
 		return nil, errors.New("empty orchestrator addr")
 	}
+	addr := ensureHTTPScheme(orchestratorAddr)
 	return corerpc.NewBitcoinServiceClient(
-		getSharedClient(ctx),
-		ensureHTTPScheme(orchestratorAddr),
+		clientForScheme(ctx, addr),
+		addr,
 		connect.WithGRPC(),
 		// Bitcoind is the one dial target on the orchestrator (its hosted core
 		// proxy); enforcer/sidechain dials go to other daemons and stay
@@ -60,6 +61,17 @@ func ensureHTTPScheme(addr string) string {
 		return addr
 	}
 	return "http://" + addr
+}
+
+// clientForScheme picks the client matching addr's scheme (addr must already
+// have been through ensureHTTPScheme). The shared client is h2c: it dials
+// cleartext no matter what scheme the URL carries, so handing it an https://
+// orchestrator URL would put the local-auth cookie on the wire in the clear.
+func clientForScheme(ctx context.Context, addr string) *http.Client {
+	if strings.HasPrefix(strings.ToLower(addr), "https://") {
+		return getSharedTLSClient(ctx)
+	}
+	return getSharedClient(ctx)
 }
 
 func EnforcerValidator(ctx context.Context, url string) (
@@ -234,9 +246,13 @@ func CoinShift(ctx context.Context, host string, port int) (*coinshift.Client, e
 }
 
 var (
-	// Shared HTTP client for all connections
+	// Shared HTTP client for all cleartext (http://) connections
 	sharedClient *http.Client
 	clientOnce   sync.Once
+
+	// Shared HTTP client for https:// targets. Same settings, but real TLS.
+	sharedTLSClient *http.Client
+	tlsClientOnce   sync.Once
 
 	// cookieDir is the bitwindow data dir holding .auth.cookie, used by the
 	// orchestrator-targeting Bitcoind client. Set once at startup via
@@ -248,27 +264,47 @@ var (
 // (Bitcoind proxy) client. Call once at startup before the first dial.
 func SetCookieDir(dir string) { cookieDir = dir }
 
-// getSharedClient returns a singleton HTTP client for all connections
+// getSharedClient returns a singleton HTTP client for cleartext connections
 func getSharedClient(ctx context.Context) *http.Client {
 	clientOnce.Do(func() {
-		sharedClient = &http.Client{
-			Transport: &http2.Transport{
-				AllowHTTP: true,
-				DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
-					return net.Dial(network, addr)
-				},
-				// Without explicit timeouts here, clients linger indefinitely
-				IdleConnTimeout:  15 * time.Second,
-				ReadIdleTimeout:  30 * time.Second, // Close if no data received for 30s
-				PingTimeout:      15 * time.Second,
-				WriteByteTimeout: 10 * time.Second,
-
-				CountError: func(errType string) {
-					zerolog.Ctx(ctx).Error().Msgf("HTTP/2 transport error: %s", errType)
-				},
-			},
-			Timeout: 30 * time.Second, // Overall request timeout
-		}
+		sharedClient = newHTTP2Client(ctx, true)
 	})
 	return sharedClient
+}
+
+// getSharedTLSClient returns a singleton HTTP client for https:// connections.
+func getSharedTLSClient(ctx context.Context) *http.Client {
+	tlsClientOnce.Do(func() {
+		sharedTLSClient = newHTTP2Client(ctx, false)
+	})
+	return sharedTLSClient
+}
+
+// newHTTP2Client builds an HTTP/2 client with our standard timeouts. With
+// cleartext set it speaks h2c (prior knowledge, no TLS handshake); otherwise
+// http2.Transport's own TLS dialer handles the connection. The h2c dialer must
+// never be used for https:// targets — it ignores the *tls.Config it is handed
+// and would send the request, headers and all, unencrypted.
+func newHTTP2Client(ctx context.Context, cleartext bool) *http.Client {
+	transport := &http2.Transport{
+		// Without explicit timeouts here, clients linger indefinitely
+		IdleConnTimeout:  15 * time.Second,
+		ReadIdleTimeout:  30 * time.Second, // Close if no data received for 30s
+		PingTimeout:      15 * time.Second,
+		WriteByteTimeout: 10 * time.Second,
+
+		CountError: func(errType string) {
+			zerolog.Ctx(ctx).Error().Msgf("HTTP/2 transport error: %s", errType)
+		},
+	}
+	if cleartext {
+		transport.AllowHTTP = true
+		transport.DialTLS = func(network, addr string, _ *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		}
+	}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   30 * time.Second, // Overall request timeout
+	}
 }

--- a/bitwindow/server/dial/dial_test.go
+++ b/bitwindow/server/dial/dial_test.go
@@ -1,6 +1,10 @@
 package dial
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/net/http2"
+)
 
 // TestEnsureHTTPScheme guards the double-prefix regression. config.OrchestratorAddr
 // defaults to a full URL ("http://localhost:30400"); dial.Bitcoind used to wrap
@@ -37,5 +41,44 @@ func TestEnsureHTTPScheme(t *testing.T) {
 func TestBitcoind_RejectsEmptyAddr(t *testing.T) {
 	if _, err := Bitcoind(t.Context(), ""); err == nil {
 		t.Fatal("Bitcoind(\"\") returned nil error")
+	}
+}
+
+// TestClientForScheme guards the cookie-leak regression. Every dial used the
+// h2c client, whose DialTLS hook discards the *tls.Config it is handed and
+// plain net.Dials instead — x/net/http2 routes https:// connections through
+// that same hook, so an https:// orchestrator.addr dialed cleartext and the
+// local-auth bearer cookie went out unencrypted. https:// must get a transport
+// that actually does TLS.
+func TestClientForScheme(t *testing.T) {
+	cleartext := clientForScheme(t.Context(), "http://localhost:30400")
+	encrypted := clientForScheme(t.Context(), "https://orch.example.com")
+
+	if cleartext == encrypted {
+		t.Fatal("http:// and https:// got the same client")
+	}
+
+	h2c, ok := cleartext.Transport.(*http2.Transport)
+	if !ok {
+		t.Fatalf("http:// transport = %T, want *http2.Transport", cleartext.Transport)
+	}
+	if !h2c.AllowHTTP || h2c.DialTLS == nil {
+		t.Error("http:// client is not the h2c transport")
+	}
+
+	tlsTransport, ok := encrypted.Transport.(*http2.Transport)
+	if !ok {
+		t.Fatalf("https:// transport = %T, want *http2.Transport", encrypted.Transport)
+	}
+	if tlsTransport.AllowHTTP {
+		t.Error("https:// client allows cleartext HTTP/2")
+	}
+	if tlsTransport.DialTLS != nil || tlsTransport.DialTLSContext != nil {
+		t.Error("https:// client overrides the TLS dialer, bypassing TLS")
+	}
+
+	// ensureHTTPScheme passes mixed-case schemes through untouched.
+	if got := clientForScheme(t.Context(), "HTTPS://orch.example.com"); got != encrypted {
+		t.Error("mixed-case https:// did not get the TLS client")
 	}
 }

--- a/bitwindow/server/engines/backup_engine.go
+++ b/bitwindow/server/engines/backup_engine.go
@@ -155,10 +155,6 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 	switch ext {
 	case ".json":
 		walletJSON = data
-		// Validate it's valid wallet JSON
-		if err := validateWalletJSON(data); err != nil {
-			return fmt.Errorf("invalid wallet.json: %w", err)
-		}
 	case ".zip":
 		walletJSON, metadataJSON, multisigJSON, txJSON, err = extractZIP(data)
 		if err != nil {
@@ -172,20 +168,10 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 		return fmt.Errorf("backup does not contain wallet.json")
 	}
 
-	// Import into the DB before touching the wallet files, so a backup that
-	// fails to import leaves the current wallet in place.
-	if multisigJSON != nil {
-		if err := e.multisigStore.ImportFromJSON(ctx, multisigJSON); err != nil {
-			return fmt.Errorf("import multisig data: %w", err)
-		}
-		log.Info().Msg("restore: imported multisig data")
-	}
-
-	if txJSON != nil {
-		if err := e.multisigStore.ImportTransactionsFromJSON(ctx, txJSON); err != nil {
-			return fmt.Errorf("import transactions: %w", err)
-		}
-		log.Info().Msg("restore: imported transactions")
+	// Validate it's valid wallet JSON. This gates both file types, so a restore
+	// never writes bytes that ValidateBackup (validateJSON/validateZIP) rejects.
+	if err := validateWalletJSON(walletJSON); err != nil {
+		return fmt.Errorf("invalid wallet.json: %w", err)
 	}
 
 	// Restore wallet.json

--- a/bitwindow/server/engines/backup_engine_test.go
+++ b/bitwindow/server/engines/backup_engine_test.go
@@ -145,6 +145,25 @@ func TestRestoreBackup_JSON(t *testing.T) {
 	}
 }
 
+// a zipped wallet.json that ValidateBackup rejects must also be rejected by
+// RestoreBackup, instead of being written over the live wallet
+func TestRestoreBackup_ZIP_InvalidWalletJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	e := &BackupEngine{walletDir: tmpDir}
+
+	bad := zipWith(t, "wallet.json", []byte(`{"foo":"bar"}`))
+
+	if _, err := e.ValidateBackup(context.TODO(), bad, "backup.zip"); err == nil {
+		t.Fatal("expected ValidateBackup to reject invalid wallet.json")
+	}
+	if err := e.RestoreBackup(testCtx(), bad, "backup.zip"); err == nil {
+		t.Fatal("expected RestoreBackup to reject invalid wallet.json")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "wallet.json")); !os.IsNotExist(err) {
+		t.Fatal("RestoreBackup wrote wallet.json despite invalid contents")
+	}
+}
+
 func TestHasCurrentWallet(t *testing.T) {
 	tmpDir := t.TempDir()
 	e := &BackupEngine{walletDir: tmpDir}

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -174,19 +174,16 @@ func DetectFileType(content []byte) string {
 	// Try to detect text files
 	sampleSize := min(1024, len(content))
 
-	// Check if content looks like valid UTF-8 text
+	// Check if content is printable ASCII text. Non-ASCII bytes must classify as
+	// "bin": the "txt" path stores content raw in the OP_RETURN, and retrieval
+	// runs it through opreturns.OPReturnToReadable, which hex-encodes anything
+	// containing a byte above 0x7E and so destroys the "metadataB64|content"
+	// framing that DecodeOPReturnData needs.
 	isText := true
 	for i := range sampleSize {
 		b := content[i]
 		// Allow printable ASCII, newlines, tabs
-		if b < 0x09 || (b > 0x0D && b < 0x20) || b == 0x7F {
-			// Check for UTF-8 multi-byte sequences
-			if b >= 0x80 && b <= 0xBF {
-				continue // continuation byte
-			}
-			if b >= 0xC0 && b <= 0xF7 {
-				continue // start of multi-byte
-			}
+		if b < 0x09 || (b > 0x0D && b < 0x20) || b >= 0x7F {
 			isText = false
 			break
 		}

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -88,6 +88,11 @@ type ParsedMetadata struct {
 	IsMultisig bool
 	Timestamp  uint32
 	FileType   string
+
+	// Raw is the exact 9-byte metadata this was parsed from. Encrypt/Decrypt
+	// authenticate these bytes, so tampering with the flags, timestamp or file
+	// type fails the auth tag instead of silently decrypting to garbage.
+	Raw []byte
 }
 
 // ParseMetadata parses the 9-byte metadata from base64
@@ -110,11 +115,17 @@ func ParseMetadata(metadataB64 string) (*ParsedMetadata, error) {
 		IsMultisig: (flags & FlagMultisig) != 0,
 		Timestamp:  timestamp,
 		FileType:   fileType,
+		Raw:        metadataBytes,
 	}, nil
 }
 
 // EncodeMetadata encodes metadata into 9 bytes and returns base64
 func EncodeMetadata(encrypted, isMultisig bool, timestamp uint32, fileType string) string {
+	return base64.StdEncoding.EncodeToString(EncodeMetadataBytes(encrypted, isMultisig, timestamp, fileType))
+}
+
+// EncodeMetadataBytes encodes metadata into its 9-byte on-chain representation
+func EncodeMetadataBytes(encrypted, isMultisig bool, timestamp uint32, fileType string) []byte {
 	metadata := make([]byte, MetadataSize)
 
 	// Flags byte
@@ -140,7 +151,7 @@ func EncodeMetadata(encrypted, isMultisig bool, timestamp uint32, fileType strin
 	}
 	copy(metadata[5:9], fileTypeBytes)
 
-	return base64.StdEncoding.EncodeToString(metadata)
+	return metadata
 }
 
 // DetectFileType detects file type from magic bytes
@@ -359,8 +370,10 @@ func (e *BitDriveEngine) getAuthKey(_ context.Context) ([]byte, error) {
 // Encrypt encrypts content using XOR with derived keystream and appends HMAC auth tag.
 // The output layout is: nonce (NonceSize) || ciphertext || tag (AuthTagSize). The
 // random per-file nonce is mixed into the keystream so repeated (timestamp, fileType)
-// tuples never reuse the keystream.
-func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp uint32, fileType string) ([]byte, error) {
+// tuples never reuse the keystream. metadata is the 9-byte metadata prefix that
+// travels alongside the ciphertext; it is authenticated as associated data because
+// the keystream is derived from the timestamp and file type it carries.
+func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp uint32, fileType string, metadata []byte) ([]byte, error) {
 	// Generate a random per-file nonce
 	nonce := make([]byte, NonceSize)
 	if _, err := rand.Read(nonce); err != nil {
@@ -379,14 +392,17 @@ func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp 
 		encrypted[i] = content[i] ^ keyStream[i]
 	}
 
-	// Generate truncated authentication tag (first 8 bytes of HMAC-SHA256)
-	// over the nonce and ciphertext so nonce tampering is also detected.
+	// Generate truncated authentication tag (first 8 bytes of HMAC-SHA256) over
+	// the metadata, nonce and ciphertext so metadata and nonce tampering is also
+	// detected. All three inputs are fixed-length or trailing, so the
+	// concatenation is unambiguous.
 	authKey, err := e.getAuthKey(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get auth key: %w", err)
 	}
 
 	mac := hmac.New(sha256.New, authKey)
+	mac.Write(metadata)
 	mac.Write(nonce)
 	mac.Write(encrypted)
 	fullTag := mac.Sum(nil)
@@ -401,8 +417,11 @@ func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp 
 	return result, nil
 }
 
-// Decrypt verifies the HMAC auth tag and decrypts content
-func (e *BitDriveEngine) Decrypt(ctx context.Context, encryptedData []byte, timestamp uint32, fileType string) ([]byte, error) {
+// Decrypt verifies the HMAC auth tag and decrypts content. metadata must be the
+// 9-byte metadata prefix the ciphertext arrived with: it is authenticated as
+// associated data, so a tampered timestamp or file type is rejected rather than
+// feeding a wrong keystream seed into DeriveKeyStream.
+func (e *BitDriveEngine) Decrypt(ctx context.Context, encryptedData []byte, timestamp uint32, fileType string, metadata []byte) ([]byte, error) {
 	if len(encryptedData) <= NonceSize+AuthTagSize {
 		return nil, fmt.Errorf("encrypted data too short")
 	}
@@ -413,13 +432,14 @@ func (e *BitDriveEngine) Decrypt(ctx context.Context, encryptedData []byte, time
 	encryptedContent := encryptedData[NonceSize : NonceSize+contentLen]
 	receivedTag := encryptedData[NonceSize+contentLen:]
 
-	// Verify authentication tag over the nonce and ciphertext
+	// Verify authentication tag over the metadata, nonce and ciphertext
 	authKey, err := e.getAuthKey(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get auth key: %w", err)
 	}
 
 	mac := hmac.New(sha256.New, authKey)
+	mac.Write(metadata)
 	mac.Write(nonce)
 	mac.Write(encryptedContent)
 	fullTag := mac.Sum(nil)
@@ -450,11 +470,14 @@ func (e *BitDriveEngine) EncodeOPReturnData(ctx context.Context, content []byte,
 	timestamp := uint32(time.Now().Unix())
 	fileType := DetectFileType(content)
 
+	// Encode metadata up front so it can be authenticated with the ciphertext
+	metadataBytes := EncodeMetadataBytes(encrypt, false, timestamp, fileType)
+
 	var processedContent []byte
 	var err error
 
 	if encrypt {
-		processedContent, err = e.Encrypt(ctx, content, timestamp, fileType)
+		processedContent, err = e.Encrypt(ctx, content, timestamp, fileType, metadataBytes)
 		if err != nil {
 			return "", "", 0, fmt.Errorf("encrypt content: %w", err)
 		}
@@ -462,8 +485,7 @@ func (e *BitDriveEngine) EncodeOPReturnData(ctx context.Context, content []byte,
 		processedContent = content
 	}
 
-	// Encode metadata
-	metadataB64 := EncodeMetadata(encrypt, false, timestamp, fileType)
+	metadataB64 := base64.StdEncoding.EncodeToString(metadataBytes)
 
 	// Encode content
 	var contentStr string
@@ -501,7 +523,7 @@ func (e *BitDriveEngine) DecodeOPReturnData(ctx context.Context, opReturnMessage
 	}
 
 	if metadata.Encrypted {
-		content, err = e.Decrypt(ctx, content, metadata.Timestamp, metadata.FileType)
+		content, err = e.Decrypt(ctx, content, metadata.Timestamp, metadata.FileType, metadata.Raw)
 		if err != nil {
 			return nil, nil, fmt.Errorf("decrypt content: %w", err)
 		}
@@ -666,28 +688,21 @@ func (e *BitDriveEngine) EncodeMultisigData(ctx context.Context, jsonData []byte
 	timestamp := uint32(time.Now().Unix())
 	fileType := "json"
 
+	// Encode metadata with multisig flag up front so it can be authenticated
+	// with the ciphertext
+	metadata := EncodeMetadataBytes(encrypt, true, timestamp, fileType)
+
 	var processedContent []byte
 	var err error
 
 	if encrypt {
-		processedContent, err = e.Encrypt(ctx, jsonData, timestamp, fileType)
+		processedContent, err = e.Encrypt(ctx, jsonData, timestamp, fileType, metadata)
 		if err != nil {
 			return "", fmt.Errorf("encrypt multisig data: %w", err)
 		}
 	} else {
 		processedContent = jsonData
 	}
-
-	// Encode metadata with multisig flag
-	metadata := make([]byte, MetadataSize)
-	var flags byte
-	if encrypt {
-		flags |= FlagEncrypted
-	}
-	flags |= FlagMultisig
-	metadata[0] = flags
-	binary.BigEndian.PutUint32(metadata[1:5], timestamp)
-	copy(metadata[5:9], []byte("json"))
 
 	metadataB64 := base64.StdEncoding.EncodeToString(metadata)
 	contentB64 := base64.StdEncoding.EncodeToString(processedContent)

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/base64"
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"testing"
@@ -96,15 +98,16 @@ func TestEncrypt_SameTimestampSameFileType_NoKeystreamReuse(t *testing.T) {
 
 	const timestamp = uint32(1800000000)
 	const fileType = "txt"
+	metadata := EncodeMetadataBytes(true, false, timestamp, fileType)
 
 	plainA := []byte("BitDrive keystream reuse probe payload block AAAA")
 	plainB := []byte("BitDrive keystream reuse probe payload block BBBB")
 
-	cipherA, err := engine.Encrypt(ctx, plainA, timestamp, fileType)
+	cipherA, err := engine.Encrypt(ctx, plainA, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("encrypt A: %v", err)
 	}
-	cipherB, err := engine.Encrypt(ctx, plainB, timestamp, fileType)
+	cipherB, err := engine.Encrypt(ctx, plainB, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("encrypt B: %v", err)
 	}
@@ -132,7 +135,7 @@ func TestEncrypt_SameTimestampSameFileType_NoKeystreamReuse(t *testing.T) {
 	// Encrypting the SAME plaintext twice must also yield distinct ciphertext
 	// bodies, proving the keystream is randomized per file rather than derived
 	// solely from (timestamp, fileType).
-	cipherA2, err := engine.Encrypt(ctx, plainA, timestamp, fileType)
+	cipherA2, err := engine.Encrypt(ctx, plainA, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("encrypt A again: %v", err)
 	}
@@ -142,19 +145,73 @@ func TestEncrypt_SameTimestampSameFileType_NoKeystreamReuse(t *testing.T) {
 	}
 
 	// Both ciphertexts must still round-trip through Decrypt.
-	gotA, err := engine.Decrypt(ctx, cipherA, timestamp, fileType)
+	gotA, err := engine.Decrypt(ctx, cipherA, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("decrypt A: %v", err)
 	}
 	if !bytes.Equal(gotA, plainA) {
 		t.Fatalf("decrypt A mismatch: got %q want %q", gotA, plainA)
 	}
-	gotB, err := engine.Decrypt(ctx, cipherB, timestamp, fileType)
+	gotB, err := engine.Decrypt(ctx, cipherB, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("decrypt B: %v", err)
 	}
 	if !bytes.Equal(gotB, plainB) {
 		t.Fatalf("decrypt B mismatch: got %q want %q", gotB, plainB)
+	}
+}
+
+// TestDecodeOPReturnData_MetadataTamperRejected verifies that the auth tag covers
+// the 9-byte metadata prefix. The keystream seed mixes in the timestamp and file
+// type carried by that prefix, so a tag over nonce||ciphertext alone let an
+// attacker flip a metadata byte and have Decrypt return garbage with a nil error.
+func TestDecodeOPReturnData_MetadataTamperRejected(t *testing.T) {
+	ctx := context.Background()
+	engine := newEncryptTestEngine(t)
+
+	plain := []byte("BitDrive metadata binding probe payload")
+
+	metadataB64, contentStr, timestamp, err := engine.EncodeOPReturnData(ctx, plain, true)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	// The untampered message must still round-trip.
+	decoded, _, err := engine.DecodeOPReturnData(ctx, FormatOPReturnData(metadataB64, contentStr))
+	if err != nil {
+		t.Fatalf("decode untampered: %v", err)
+	}
+	if !bytes.Equal(decoded, plain) {
+		t.Fatalf("round trip mismatch: got %q want %q", decoded, plain)
+	}
+
+	metadataBytes, err := base64.StdEncoding.DecodeString(metadataB64)
+	if err != nil {
+		t.Fatalf("decode metadata base64: %v", err)
+	}
+
+	tampers := []struct {
+		name   string
+		mutate func(metadata []byte)
+	}{
+		{"timestamp", func(m []byte) { binary.BigEndian.PutUint32(m[1:5], timestamp+1) }},
+		{"file type", func(m []byte) { copy(m[5:9], []byte("bin ")) }},
+		{"multisig flag", func(m []byte) { m[0] |= FlagMultisig }},
+	}
+
+	for _, tt := range tampers {
+		t.Run(tt.name, func(t *testing.T) {
+			tampered := append([]byte(nil), metadataBytes...)
+			tt.mutate(tampered)
+			if bytes.Equal(tampered, metadataBytes) {
+				t.Fatal("tamper did not change the metadata")
+			}
+
+			opReturnData := FormatOPReturnData(base64.StdEncoding.EncodeToString(tampered), contentStr)
+			if _, _, err := engine.DecodeOPReturnData(ctx, opReturnData); err == nil {
+				t.Fatal("tampered metadata decrypted without error")
+			}
+		})
 	}
 }
 

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/bitdrive"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/opreturns"
 	"github.com/btcsuite/btcd/chaincfg"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -225,5 +226,69 @@ func TestSaveFile_SameSecondNoCollision(t *testing.T) {
 	}
 	if string(secondContent) != "second file" {
 		t.Fatalf("second file content wrong: got %q", secondContent)
+	}
+}
+
+// TestDetectFileType_NonASCIIIsBinary verifies that any byte above 0x7E makes
+// content classify as "bin" rather than "txt". Classifying it as text sends it
+// down the raw-storage path, which cannot survive retrieval.
+func TestDetectFileType_NonASCIIIsBinary(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		want    string
+	}{
+		{"plain ascii", []byte("hello world\n\tand tabs"), "txt"},
+		{"utf-8 multi-byte", []byte("café"), "bin"},
+		{"high byte", []byte("prefix\xFFsuffix"), "bin"},
+		{"continuation byte only", []byte("prefix\xBFsuffix"), "bin"},
+		{"delete char", []byte("prefix\x7Fsuffix"), "bin"},
+		{"nul byte", []byte("prefix\x00suffix"), "bin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectFileType(tt.content); got != tt.want {
+				t.Fatalf("DetectFileType(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEncodeOPReturnData_NonASCIIRoundTrip walks a payload containing a byte
+// above 0x7F through the full store/retrieve chain:
+// EncodeOPReturnData -> FormatOPReturnData -> OPReturnToReadable ->
+// DecodeOPReturnData. Storing such content as "txt" put raw high bytes on
+// chain, which OPReturnToReadable then hex-encoded, hiding the "|" separator
+// and making DecodeOPReturnData fail with "invalid OP_RETURN format".
+func TestEncodeOPReturnData_NonASCIIRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	engine := &BitDriveEngine{}
+
+	contents := [][]byte{
+		[]byte("café ☕ unicode text"),
+		[]byte("ascii with one high byte: \xFE"),
+		{0x00, 0x01, 0x80, 0xFF, 0x7C, 0x41},
+	}
+
+	for _, content := range contents {
+		metadataB64, contentStr, _, err := engine.EncodeOPReturnData(ctx, content, false)
+		if err != nil {
+			t.Fatalf("encode %q: %v", content, err)
+		}
+
+		opReturnData := FormatOPReturnData(metadataB64, contentStr)
+		readable := opreturns.OPReturnToReadable([]byte(opReturnData))
+
+		decoded, metadata, err := engine.DecodeOPReturnData(ctx, readable)
+		if err != nil {
+			t.Fatalf("decode %q: %v", content, err)
+		}
+		if metadata.FileType != "bin" {
+			t.Fatalf("expected file type bin for %q, got %q", content, metadata.FileType)
+		}
+		if !bytes.Equal(decoded, content) {
+			t.Fatalf("round trip mismatch: got %q, want %q", decoded, content)
+		}
 	}
 }

--- a/bitwindow/server/engines/notification_engine.go
+++ b/bitwindow/server/engines/notification_engine.go
@@ -210,27 +210,32 @@ func (e *NotificationEngine) checkWalletTransactions(ctx context.Context) error 
 			continue
 		}
 
-		e.processWalletTransactions(ctx, resp.Msg.Transactions)
+		e.processWalletTransactions(ctx, walletName, resp.Msg.Transactions)
 	}
 
 	return nil
 }
 
-func (e *NotificationEngine) processWalletTransactions(ctx context.Context, transactions []*corepb.GetTransactionResponse) {
+func (e *NotificationEngine) processWalletTransactions(ctx context.Context, walletName string, transactions []*corepb.GetTransactionResponse) {
 	log := zerolog.Ctx(ctx)
 	for _, tx := range transactions {
 		txid := tx.Txid
 		confirmations := uint32(tx.Confirmations)
 
+		// The same txid can show up in several loaded wallets, so scope the
+		// dedup key by wallet. Otherwise the first wallet we process swallows
+		// the notification for all the others.
+		eventID := walletName + ":" + txid
+
 		// Check if we've already notified about this transaction
-		notified, err := notifications.HasBeenNotified(ctx, e.db, notifications.EventTypeTransaction, txid)
+		notified, err := notifications.HasBeenNotified(ctx, e.db, notifications.EventTypeTransaction, eventID)
 		if err != nil {
 			log.Warn().Err(err).Str("txid", txid).Msg("check transaction notification status")
 			continue
 		}
 
 		// For confirmation notifications, use a separate event type
-		confEventID := txid + ":confirmed"
+		confEventID := eventID + ":confirmed"
 		confNotified, err := notifications.HasBeenNotified(ctx, e.db, notifications.EventTypeTransactionConf, confEventID)
 		if err != nil {
 			log.Warn().Err(err).Str("txid", txid).Msg("check transaction confirmation notification status")
@@ -256,7 +261,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, tran
 				},
 			}
 			e.broadcast(ctx, event)
-			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, txid); err != nil {
+			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, eventID); err != nil {
 				log.Warn().Err(err).Str("txid", txid).Msg("mark transaction notified")
 			}
 			log.Info().
@@ -278,7 +283,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, tran
 				},
 			}
 			e.broadcast(ctx, event)
-			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, txid); err != nil {
+			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, eventID); err != nil {
 				log.Warn().Err(err).Str("txid", txid).Msg("mark transaction notified")
 			}
 			log.Info().
@@ -288,7 +293,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, tran
 
 		case !notified:
 			// New transaction with zero amount - just mark as seen
-			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, txid); err != nil {
+			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, eventID); err != nil {
 				log.Warn().Err(err).Str("txid", txid).Msg("mark transaction notified")
 			}
 

--- a/bitwindow/server/engines/notification_engine_internal_test.go
+++ b/bitwindow/server/engines/notification_engine_internal_test.go
@@ -1,0 +1,50 @@
+package engines
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	notificationv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/notification/v1"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	"github.com/stretchr/testify/require"
+)
+
+// The same txid shows up in every wallet that takes part in it, so dedup has to
+// be per-wallet. Otherwise the first wallet we process swallows the
+// notification for all the others.
+func TestProcessWalletTransactions_DedupIsPerWallet(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	engine := NewNotificationEngine(db, nil)
+	events := engine.Subscribe(ctx)
+
+	const txid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	txs := []*corepb.GetTransactionResponse{{
+		Txid:          txid,
+		Amount:        1,
+		Confirmations: 0,
+	}}
+
+	engine.processWalletTransactions(ctx, "wallet-a", txs)
+	engine.processWalletTransactions(ctx, "wallet-b", txs)
+
+	// A second pass must not notify again for either wallet.
+	engine.processWalletTransactions(ctx, "wallet-a", txs)
+	engine.processWalletTransactions(ctx, "wallet-b", txs)
+
+	var received int
+	for done := false; !done; {
+		select {
+		case event := <-events:
+			require.Equal(t, notificationv1.TransactionEvent_TYPE_RECEIVED, event.GetTransaction().GetType())
+			require.Equal(t, txid, event.GetTransaction().GetTxid())
+			received++
+		default:
+			done = true
+		}
+	}
+
+	require.Equal(t, 2, received)
+}

--- a/bitwindow/server/engines/sidechain_monitor_engine.go
+++ b/bitwindow/server/engines/sidechain_monitor_engine.go
@@ -69,6 +69,32 @@ type PendingFastWithdrawal struct {
 	ExpectedAmount int64     `json:"expected_amount"` // Amount expected (sats)
 	ServerURL      string    `json:"server_url"`      // Fast withdrawal server URL
 	CreatedAt      time.Time `json:"created_at"`
+	Attempts       int       `json:"attempts"`     // Failed /paid completion attempts so far
+	LastAttempt    time.Time `json:"last_attempt"` // When the last /paid attempt was made
+}
+
+const (
+	// completionBackoffBase is the delay before the first /paid retry. Each
+	// subsequent failure doubles it, up to completionBackoffMaxShift.
+	completionBackoffBase = 30 * time.Second
+
+	// completionBackoffMaxShift caps the exponential backoff at
+	// completionBackoffBase << completionBackoffMaxShift (16 minutes).
+	completionBackoffMaxShift = 5
+)
+
+// completionBackoff returns how long to wait before re-POSTing /paid after the
+// given number of failed attempts
+func completionBackoff(attempts int) time.Duration {
+	shift := attempts - 1
+	if shift < 0 {
+		shift = 0
+	}
+	if shift > completionBackoffMaxShift {
+		shift = completionBackoffMaxShift
+	}
+
+	return completionBackoffBase << shift
 }
 
 // NewSidechainMonitorEngine creates a new sidechain monitoring engine
@@ -135,7 +161,7 @@ func (e *SidechainMonitorEngine) Run(ctx context.Context) error {
 					pollCount++
 					// Cleanup old withdrawals every 60 polls for ALL sidechains (fix memory leak)
 					if pollCount%60 == 0 {
-						e.cleanupOldWithdrawals()
+						e.cleanupOldWithdrawals(ctx)
 					}
 
 					// Dynamic polling interval based on pending withdrawals
@@ -209,9 +235,15 @@ func (e *SidechainMonitorEngine) checkFastWithdrawalPayments(ctx context.Context
 	e.mu.RLock()
 	var pendingForSidechain []PendingFastWithdrawal
 	for _, pending := range e.pendingFastWithdrawals {
-		if pending.Sidechain == sidechain {
-			pendingForSidechain = append(pendingForSidechain, pending)
+		if pending.Sidechain != sidechain {
+			continue
 		}
+		// Skip rows still backing off from a failed /paid POST, so a server that
+		// is down doesn't get the same completion re-posted on every poll
+		if !pending.LastAttempt.IsZero() && time.Since(pending.LastAttempt) < completionBackoff(pending.Attempts) {
+			continue
+		}
+		pendingForSidechain = append(pendingForSidechain, pending)
 	}
 	e.mu.RUnlock()
 
@@ -262,11 +294,28 @@ func (e *SidechainMonitorEngine) checkFastWithdrawalPayments(ctx context.Context
 			// Auto-complete the withdrawal
 			if err := e.completeWithdrawal(ctx, pending, txid); err != nil {
 				log.Error().Err(err).Str("hash", pending.Hash).Msg("failed to auto-complete withdrawal")
+				e.recordFailedCompletion(pending.Hash)
 			}
 		}
 	}
 
 	return nil
+}
+
+// recordFailedCompletion notes a failed /paid POST so the next attempt for the
+// same withdrawal is delayed by completionBackoff instead of firing next poll
+func (e *SidechainMonitorEngine) recordFailedCompletion(hash string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	pending, exists := e.pendingFastWithdrawals[hash]
+	if !exists {
+		return // Already completed or cleaned up
+	}
+
+	pending.Attempts++
+	pending.LastAttempt = time.Now()
+	e.pendingFastWithdrawals[hash] = pending
 }
 
 // getPollInterval returns the polling interval based on pending withdrawals
@@ -288,7 +337,9 @@ func (e *SidechainMonitorEngine) getPollInterval() time.Duration {
 }
 
 // cleanupOldWithdrawals removes withdrawals older than 1 hour to prevent memory bloat
-func (e *SidechainMonitorEngine) cleanupOldWithdrawals() {
+func (e *SidechainMonitorEngine) cleanupOldWithdrawals(ctx context.Context) {
+	log := zerolog.Ctx(ctx)
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -296,6 +347,20 @@ func (e *SidechainMonitorEngine) cleanupOldWithdrawals() {
 	for txid, withdrawal := range e.detectedWithdrawals {
 		if withdrawal.DetectedAt.Before(cutoff) {
 			delete(e.detectedWithdrawals, txid)
+		}
+	}
+
+	// Pending fast withdrawals are retried until the server accepts the /paid
+	// POST, so they need the same retention or they accumulate forever
+	for hash, pending := range e.pendingFastWithdrawals {
+		if pending.CreatedAt.Before(cutoff) {
+			delete(e.pendingFastWithdrawals, hash)
+
+			log.Warn().
+				Str("hash", hash).
+				Str("sidechain", pending.Sidechain).
+				Int("attempts", pending.Attempts).
+				Msg("giving up on auto-completing fast withdrawal, retention expired")
 		}
 	}
 }

--- a/bitwindow/server/engines/sidechain_monitor_engine_test.go
+++ b/bitwindow/server/engines/sidechain_monitor_engine_test.go
@@ -189,10 +189,77 @@ func TestSidechainMonitorEngine_CleanupOldWithdrawals(t *testing.T) {
 		DetectedAt: newTime,
 	}
 
+	// Add old and new pending fast withdrawals
+	engine.pendingFastWithdrawals["old-hash"] = PendingFastWithdrawal{
+		Hash:      "old-hash",
+		Sidechain: "thunder",
+		Attempts:  12,
+		CreatedAt: oldTime,
+	}
+	engine.pendingFastWithdrawals["new-hash"] = PendingFastWithdrawal{
+		Hash:      "new-hash",
+		Sidechain: "thunder",
+		CreatedAt: newTime,
+	}
+
 	// Run cleanup
-	engine.cleanupOldWithdrawals()
+	engine.cleanupOldWithdrawals(context.Background())
 
 	// Old withdrawal should be removed, new one should remain
 	assert.NotContains(t, engine.detectedWithdrawals, "old-txid")
 	assert.Contains(t, engine.detectedWithdrawals, "new-txid")
+
+	// Same for pending fast withdrawals - otherwise a withdrawal the server
+	// never accepts is retried forever
+	assert.NotContains(t, engine.pendingFastWithdrawals, "old-hash")
+	assert.Contains(t, engine.pendingFastWithdrawals, "new-hash")
+}
+
+func TestSidechainMonitorEngine_FailedCompletionBacksOff(t *testing.T) {
+	ctx := zerolog.New(zerolog.NewTestWriter(t)).WithContext(context.Background())
+
+	// Mock server that always fails the /paid POST
+	var paidRequests int
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paidRequests++
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{"status": "error"}); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	engine := NewSidechainMonitorEngine(
+		nil, nil, nil, nil, nil, nil,
+		nil,
+	)
+
+	pending := PendingFastWithdrawal{
+		Hash:           "test-hash-123456789abcdef",
+		Sidechain:      "thunder",
+		ServerAddress:  "thunder1test456",
+		ExpectedAmount: 105000,
+		ServerURL:      mockServer.URL,
+		CreatedAt:      time.Now(),
+	}
+
+	err := engine.RegisterPendingFastWithdrawal(ctx, pending)
+	require.NoError(t, err)
+
+	// A failing completion must not drop the withdrawal, but must record the attempt
+	err = engine.completeWithdrawal(ctx, pending, "test-txid-456789abcdef123")
+	require.Error(t, err)
+	engine.recordFailedCompletion(pending.Hash)
+	assert.Equal(t, 1, paidRequests)
+
+	stored := engine.pendingFastWithdrawals[pending.Hash]
+	assert.Equal(t, 1, stored.Attempts)
+	assert.False(t, stored.LastAttempt.IsZero())
+
+	// Backoff grows with the attempt count, and is capped
+	assert.Equal(t, 30*time.Second, completionBackoff(0))
+	assert.Equal(t, 30*time.Second, completionBackoff(1))
+	assert.Equal(t, 60*time.Second, completionBackoff(2))
+	assert.Equal(t, 16*time.Minute, completionBackoff(6))
+	assert.Equal(t, 16*time.Minute, completionBackoff(100))
 }

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -342,8 +342,12 @@ func (p *CoreBackend) NextChangeAddress(ctx context.Context, walletID string) (s
 	return p.rpc.GetRawChangeAddress(ctx, name)
 }
 
-// WatchKeys imports each key as a pkh() descriptor. Per-key import failures
-// are logged, not fatal — matching how Core treats already-known descriptors.
+// WatchKeys imports each key as a pkh() descriptor. Re-importing a descriptor
+// Core already knows still reports success, so a success:false result means
+// that key is genuinely not being watched: log every failure and return an
+// error. Callers persist an import watermark once this returns nil (the BIP47
+// per-sender window), and swallowing a partial failure would move that
+// watermark past addresses the wallet never actually watches.
 func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []WatchKey) error {
 	name, err := p.walletName(ctx, walletID)
 	if err != nil {
@@ -360,6 +364,7 @@ func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []Wat
 	if err != nil {
 		return err
 	}
+	var failed []string
 	for i, r := range results {
 		if r.Success {
 			continue
@@ -369,6 +374,10 @@ func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []Wat
 			msg = r.Error.Message
 		}
 		p.log.Warn().Int("descriptor_index", i).Str("error", msg).Msg("watch key import failed")
+		failed = append(failed, fmt.Sprintf("%d: %s", i, msg))
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("%d of %d watch key imports failed [%s]", len(failed), len(results), strings.Join(failed, "; "))
 	}
 	return nil
 }

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -698,6 +698,45 @@ func TestCoreBackendWatchKeys(t *testing.T) {
 	assert.Equal(t, float64(1_700_000_000), asFloat(t, descs[0].Timestamp))
 }
 
+// A per-descriptor success:false means that key is not watched. WatchKeys must
+// surface it, otherwise the BIP47 engine bumps its import watermark past
+// addresses Core never got.
+func TestCoreBackendWatchKeysPartialImportFailure(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	ctx := context.Background()
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+
+	// Core accepts the first descriptor and rejects the second.
+	fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			if i == 1 {
+				results[i] = map[string]any{"success": false, "error": map[string]any{"code": -1, "message": "Rescan failed"}}
+				continue
+			}
+			results[i] = map[string]any{"success": true}
+		}
+		return results, ""
+	})
+
+	first, err := btcutil.NewWIF(fixedKey(0x11), &chaincfg.RegressionNetParams, true)
+	require.NoError(t, err)
+	second, err := btcutil.NewWIF(fixedKey(0x12), &chaincfg.RegressionNetParams, true)
+	require.NoError(t, err)
+
+	err = backend.WatchKeys(ctx, coreID, []WatchKey{
+		{WIF: first.String(), RescanFrom: 1_700_000_000},
+		{WIF: second.String(), RescanFrom: 1_700_000_000},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Rescan failed")
+}
+
 func TestCoreBackendNextReceiveAddress(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
 	fake.stubEnsureFlow()


### PR DESCRIPTION
**What's wrong**

`processWalletTransactions` deduped on the bare txid through `notifications.HasBeenNotified`/`MarkNotified`. `checkWalletTransactions` loops over every loaded wallet, and the same txid shows up in each wallet that takes part in it, so whichever wallet is processed first marks the txid notified and every other wallet's copy is swallowed. The user sees one notification for what are, from their side, separate wallets — and the same applies to the `:confirmed` event.

**The fix**

Pass the wallet name into `processWalletTransactions` and key both the received/sent and the confirmation dedup entries on `walletName + ":" + txid`. Rows written by earlier builds are keyed on the bare txid and simply stop matching, so the upgrade may re-notify in-flight transactions once.

**Tests**

`TestProcessWalletTransactions_DedupIsPerWallet` feeds the same transaction to two wallets and asserts two notifications, then repeats both passes and asserts nothing further is emitted.

Finding report (access-controlled): https://giaki3003.tech/#/findings/20260620-1221-glmclaw-confirm-kimiclaw-drivechain-frontends-bitwindow-notification-cross-wallet-suppression

---
Part of a short series for this repo (fix 7 of 17); builds on https://github.com/LayerTwo-Labs/drivechain-frontends/pull/1948, so it reads best merged after that one. Happy to rebase or split if you'd prefer them independent.