### PR TITLE
fix: Bound the reported processed tip to Bitcoin Core's tip

### DIFF
--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -558,7 +558,12 @@ func (s *Server) GetSyncInfo(ctx context.Context, req *connect.Request[emptypb.E
 		return nil, err
 	}
 
-	processedTip, err := blocks.GetProcessedTip(ctx, s.db)
+	// Bitcoin Core is the authority on what the chain actually contains. After
+	// a rollback our processed_blocks can hold rows above Core's tip until the
+	// parser's next tick wipes them, and reporting those verbatim surfaces an
+	// impossible height and a sync progress above 100%. Bound what we report to
+	// blocks Core still has.
+	processedTip, err := blocks.GetProcessedTipAtOrBelow(ctx, s.db, tip.Blocks)
 	if err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("could not get processed tip")
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -575,12 +580,19 @@ func (s *Server) GetSyncInfo(ctx context.Context, req *connect.Request[emptypb.E
 		}), nil
 	}
 
+	// A node parked on genesis has zero blocks to catch up to, and NaN
+	// serializes into the response as an unusable progress bar.
+	var syncProgress float64
+	if tip.Blocks > 0 {
+		syncProgress = float64(processedTip.Height) / float64(tip.Blocks)
+	}
+
 	return connect.NewResponse(&pb.GetSyncInfoResponse{
 		TipBlockHeight:      int64(processedTip.Height),
 		TipBlockTime:        processedTip.ProcessedAt.Unix(),
 		TipBlockHash:        processedTip.Hash.String(),
 		TipBlockProcessedAt: timestamppb.New(processedTip.ProcessedAt),
-		SyncProgress:        float64(processedTip.Height) / float64(tip.Blocks),
+		SyncProgress:        syncProgress,
 		HeaderHeight:        int64(tip.Headers),
 	}), nil
 }

--- a/bitwindow/server/api/bitwindowd/bitwindowd_test.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd_test.go
@@ -958,6 +958,65 @@ func TestService_GetSyncInfo(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, resp.Msg)
 	})
+
+	t.Run("processed tip above core tip", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		database := database.Test(t)
+
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+
+		// Background operations expectations
+		mockBitcoind.EXPECT().
+			ListWallets(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.ListWalletsResponse]{
+				Msg: &corepb.ListWalletsResponse{
+					Wallets: []string{},
+				},
+			}, nil).
+			AnyTimes()
+		mockBitcoind.EXPECT().
+			CreateWallet(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.CreateWalletResponse]{
+				Msg: &corepb.CreateWalletResponse{
+					Name: "cheque_watch",
+				},
+			}, nil).
+			AnyTimes()
+
+		// Core rolled back to 100, but we still hold a processed row at 105.
+		mockBitcoind.EXPECT().
+			GetBlockchainInfo(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.GetBlockchainInfoResponse]{
+				Msg: &corepb.GetBlockchainInfoResponse{
+					Chain:   "main",
+					Blocks:  100,
+					Headers: 100,
+				},
+			}, nil).
+			AnyTimes()
+
+		hashAt := func(height uint32) chainhash.Hash {
+			hash, err := chainhash.NewHashFromStr(fmt.Sprintf("%064x", height))
+			require.NoError(t, err)
+			return *hash
+		}
+
+		require.NoError(t, blocks.MarkBlocksProcessed(ctx, database, []blocks.ProcessedBlock{
+			{Height: 100, Hash: hashAt(100), BlockTime: time.Now(), ProcessedAt: time.Now()},
+			{Height: 105, Hash: hashAt(105), BlockTime: time.Now(), ProcessedAt: time.Now()},
+		}))
+
+		cli := v1connect.NewBitwindowdServiceClient(apitests.API(t, database, apitests.WithBitcoind(mockBitcoind)))
+
+		resp, err := cli.GetSyncInfo(ctx, connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err)
+		assert.EqualValues(t, 100, resp.Msg.TipBlockHeight)
+		assert.Equal(t, hashAt(100).String(), resp.Msg.TipBlockHash)
+		assert.EqualValues(t, 1, resp.Msg.SyncProgress)
+	})
 }
 
 func TestService_SetTransactionNote(t *testing.T) {

--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -183,7 +183,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 		rt.walletEngine.SetOrchestratorClient(orchClient)
 	}
 
-	rt.chequeEngine = engines.NewChequeEngine(rt.walletEngine, rt.chainParams, s.Bitcoind)
+	rt.chequeEngine = engines.NewChequeEngine(rt.db, rt.walletEngine, rt.chainParams, s.Bitcoind)
 	walletAdapter := engines.NewWalletAdapter(rt.walletEngine)
 	timestampLogger := log.With().Str("component", "timestamp").Logger()
 	rt.timestampEngine = engines.NewTimestampEngine(rt.db, timestampLogger, walletAdapter, s.Bitcoind)

--- a/bitwindow/server/api/wallet/cheque_funding_test.go
+++ b/bitwindow/server/api/wallet/cheque_funding_test.go
@@ -312,6 +312,72 @@ func TestCheckChequeFunding_PartialFunding(t *testing.T) {
 	require.Len(t, resp.Msg.FundedTxids, 1, "should still track the partial txid")
 }
 
+// TestCheckChequeFunding_ClearsStaleSweep covers the sweep that never stuck:
+// the cheque was marked swept, then the spending tx was reorged out (or
+// replaced, or evicted) and the funding UTXO is visible again. A poll that
+// sees live funds must drop the sweep markers, otherwise the UI keeps calling
+// the cheque swept and DeleteCheque's guard waves through a row that still
+// controls real money.
+func TestCheckChequeFunding_ClearsStaleSweep(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	db := database.Test(t)
+
+	chequeAddr := "tb1qreorgedsweeptestaddr000000000000000000"
+	fundingTxid := "cafe0000cafe0000cafe0000cafe0000cafe0000cafe0000cafe0000cafe0000"
+
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+	mockBitcoind.EXPECT().
+		ListWallets(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[bitcoindv1alpha.ListWalletsResponse]{
+			Msg: &bitcoindv1alpha.ListWalletsResponse{Wallets: []string{"cheque_watch"}},
+		}, nil).AnyTimes()
+
+	// The original funding UTXO is unspent again after the sweep dropped out.
+	expectChequeListUnspent(mockBitcoind, chequeAddr, []*bitcoindv1alpha.UnspentOutput{
+		{
+			Txid:          fundingTxid,
+			Vout:          0,
+			Address:       chequeAddr,
+			Amount:        1.0,
+			Confirmations: 2,
+		},
+	})
+
+	cli := walletv1connect.NewWalletServiceClient(
+		apitests.API(t, db, apitests.WithBitcoind(mockBitcoind)),
+	)
+
+	chequeID, err := cheques.Create(context.Background(), db, testWalletID, 0, 100_000_000, chequeAddr)
+	require.NoError(t, err)
+	require.NoError(t, cheques.UpdateFunding(context.Background(), db, testWalletID, chequeID,
+		[]string{fundingTxid}, 100_000_000))
+	require.NoError(t, cheques.UpdateSwept(context.Background(), db, testWalletID, chequeID,
+		"5weep00005weep00005weep00005weep00005weep00005weep00005weep0000"))
+
+	resp, err := cli.CheckChequeFunding(context.Background(), connect.NewRequest(&walletv1.CheckChequeFundingRequest{
+		WalletId: testWalletID,
+		Id:       chequeID,
+	}))
+	require.NoError(t, err)
+	require.True(t, resp.Msg.Funded)
+
+	// The sweep markers must be gone: the money is spendable again.
+	persisted, err := cheques.Get(context.Background(), db, testWalletID, chequeID)
+	require.NoError(t, err)
+	require.Nil(t, persisted.SweptTxid, "stale sweep txid must be cleared once funding reappears")
+	require.Nil(t, persisted.SweptAt)
+
+	// And with the sweep cleared, the deletion guard re-engages.
+	_, err = cli.DeleteCheque(context.Background(), connect.NewRequest(&walletv1.DeleteChequeRequest{
+		WalletId: testWalletID,
+		Id:       chequeID,
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
 // TestCheckChequeFunding_PollAfterSend mirrors the Flutter check_provider
 // polling loop: after the user taps "Fund Check", the wallet broadcasts a tx
 // and the UI polls CheckChequeFunding every few seconds. The first poll may

--- a/bitwindow/server/api/wallet/cheque_sweep_test.go
+++ b/bitwindow/server/api/wallet/cheque_sweep_test.go
@@ -47,7 +47,7 @@ func TestBuildAndSignChequeSweepTx(t *testing.T) {
 	}
 
 	// Create a mock server with minimal dependencies for testing transaction building
-	chequeEngine := engines.NewChequeEngine(nil, &chaincfg.SigNetParams, nil)
+	chequeEngine := engines.NewChequeEngine(nil, nil, &chaincfg.SigNetParams, nil)
 	server := &Server{
 		chequeEngine: chequeEngine,
 	}

--- a/bitwindow/server/api/wallet/sign_message_test.go
+++ b/bitwindow/server/api/wallet/sign_message_test.go
@@ -1,0 +1,64 @@
+package api_wallet
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+// The signing key must be the wallet's own key material - an empty/absent secret
+// key makes the enforcer's Secp256K1Sign call fail, so SignMessage never works.
+func TestDeriveMessageSigningPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	const seedHex = "0329e77e27d1e24336be53d25a897e92e67b5ec7e88eca7529b14e3ffd9168a247b6906469fb8a79ecb25ec077e033f6b567d5d9b0ae334f1e33457ae6bb1364"
+
+	chainParams := &chaincfg.SigNetParams
+
+	privKeyHex, err := deriveMessageSigningPrivateKey(seedHex, chainParams)
+	require.NoError(t, err)
+
+	privKeyBytes, err := hex.DecodeString(privKeyHex)
+	require.NoError(t, err)
+	require.Len(t, privKeyBytes, 32)
+
+	// Independently derive m/84'/1'/0'/0/0 and check the key matches, so the
+	// signature verifies against the wallet's first receiving address.
+	seed, err := hex.DecodeString(seedHex)
+	require.NoError(t, err)
+
+	key, err := hdkeychain.NewMaster(seed, chainParams)
+	require.NoError(t, err)
+
+	for _, child := range []uint32{
+		hdkeychain.HardenedKeyStart + 84,
+		hdkeychain.HardenedKeyStart + 1, // signet coin type
+		hdkeychain.HardenedKeyStart + 0,
+		0, // external chain
+		0, // address index
+	} {
+		key, err = key.Derive(child)
+		require.NoError(t, err)
+	}
+
+	expected, err := key.ECPrivKey()
+	require.NoError(t, err)
+	require.Equal(t, hex.EncodeToString(expected.Serialize()), privKeyHex)
+
+	// Mainnet uses coin type 0, so it must derive a different key
+	mainnetPrivKeyHex, err := deriveMessageSigningPrivateKey(seedHex, &chaincfg.MainNetParams)
+	require.NoError(t, err)
+	require.NotEqual(t, privKeyHex, mainnetPrivKeyHex)
+
+	// Sanity check: the pubkey hashes to the first receiving address
+	pubKey, err := key.ECPubKey()
+	require.NoError(t, err)
+
+	addr, err := btcutil.NewAddressWitnessPubKeyHash(btcutil.Hash160(pubKey.SerializeCompressed()), chainParams)
+	require.NoError(t, err)
+	require.NotEmpty(t, addr.EncodeAddress())
+}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -2336,6 +2336,23 @@ func (s *Server) CheckChequeFunding(ctx context.Context, c *connect.Request[pb.C
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to update funding: %w", err))
 		}
 
+		// Funds are visible at the address again, so any recorded sweep no longer
+		// holds: the spend was reorged out, replaced or evicted, or the address
+		// was funded anew. Drop the stale markers, otherwise the cheque keeps
+		// rendering as swept and DeleteCheque's guard lets real money go.
+		if cheque.SweptTxid != nil {
+			log.Warn().
+				Int64("id", c.Msg.Id).
+				Str("address", cheque.Address).
+				Str("swept_txid", *cheque.SweptTxid).
+				Msg("swept cheque has UTXOs again - clearing sweep markers")
+
+			if err := cheques.ClearSwept(ctx, s.database, walletId, c.Msg.Id); err != nil {
+				log.Error().Err(err).Msg("failed to clear cheque sweep markers")
+				return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to clear swept: %w", err))
+			}
+		}
+
 		log.Info().
 			Int64("id", c.Msg.Id).
 			Str("address", cheque.Address).

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1346,6 +1346,60 @@ func (s *Server) createElectrumSidechainDeposit(
 	return connect.NewResponse(&pb.CreateSidechainDepositResponse{Txid: txid}), nil
 }
 
+// deriveMessageSigningPrivateKey derives the private key messages are signed with,
+// the wallet's first BIP84 receiving key at m/84'/coinType'/0'/0/0, and returns it
+// hex encoded. Same path as deriveAndCheckAddresses, so the signature verifies
+// against the wallet's first receiving address.
+func deriveMessageSigningPrivateKey(seedHex string, chainParams *chaincfg.Params) (string, error) {
+	seed, err := hex.DecodeString(seedHex)
+	if err != nil {
+		return "", fmt.Errorf("decode seed: %w", err)
+	}
+
+	masterKey, err := hdkeychain.NewMaster(seed, chainParams)
+	if err != nil {
+		return "", fmt.Errorf("derive master key: %w", err)
+	}
+
+	coinType := uint32(0)
+	if chainParams.Name != "mainnet" {
+		coinType = 1
+	}
+
+	purpose, err := masterKey.Derive(hdkeychain.HardenedKeyStart + 84)
+	if err != nil {
+		return "", fmt.Errorf("derive purpose: %w", err)
+	}
+
+	coin, err := purpose.Derive(hdkeychain.HardenedKeyStart + coinType)
+	if err != nil {
+		return "", fmt.Errorf("derive coin: %w", err)
+	}
+
+	account, err := coin.Derive(hdkeychain.HardenedKeyStart + 0)
+	if err != nil {
+		return "", fmt.Errorf("derive account: %w", err)
+	}
+
+	// Receiving addresses (external chain = 0)
+	external, err := account.Derive(0)
+	if err != nil {
+		return "", fmt.Errorf("derive external chain: %w", err)
+	}
+
+	addrKey, err := external.Derive(0)
+	if err != nil {
+		return "", fmt.Errorf("derive address 0: %w", err)
+	}
+
+	privKey, err := addrKey.ECPrivKey()
+	if err != nil {
+		return "", fmt.Errorf("get private key: %w", err)
+	}
+
+	return hex.EncodeToString(privKey.Serialize()), nil
+}
+
 // SignMessage implements walletv1connect.WalletServiceHandler.
 func (s *Server) SignMessage(ctx context.Context, c *connect.Request[pb.SignMessageRequest]) (*connect.Response[pb.SignMessageResponse], error) {
 	walletId := c.Msg.WalletId
@@ -1356,6 +1410,21 @@ func (s *Server) SignMessage(ctx context.Context, c *connect.Request[pb.SignMess
 		return nil, fmt.Errorf("get wallet type: %w", err)
 	}
 
+	// Signing needs the seed, so the wallet has to be unlocked
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
+	seedHex, err := s.walletEngine.GetWalletSeed(walletId)
+	if err != nil {
+		return nil, fmt.Errorf("get wallet seed: %w", err)
+	}
+
+	privKeyHex, err := deriveMessageSigningPrivateKey(seedHex, s.walletEngine.GetChainParams())
+	if err != nil {
+		return nil, fmt.Errorf("derive signing key: %w", err)
+	}
+
 	crypto, err := s.crypto.Get(ctx)
 	if err != nil {
 		return nil, err
@@ -1364,6 +1433,9 @@ func (s *Server) SignMessage(ctx context.Context, c *connect.Request[pb.SignMess
 	res, err := crypto.Secp256K1Sign(ctx, connect.NewRequest(&cryptov1.Secp256K1SignRequest{
 		Message: &commonv1.Hex{
 			Hex: &wrapperspb.StringValue{Value: c.Msg.Message},
+		},
+		SecretKey: &commonv1.ConsensusHex{
+			Hex: &wrapperspb.StringValue{Value: privKeyHex},
 		},
 	}))
 	if err != nil {

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -2072,6 +2072,14 @@ func (s *Server) CreateCheque(ctx context.Context, c *connect.Request[pb.CreateC
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get next index: %w", err))
 	}
 
+	// Widen the imported descriptor range if this index falls past it, so
+	// Bitcoin Core watches the address we're about to hand out. Non-fatal:
+	// deriving the address doesn't need bitcoind, and the next import (this
+	// call retried, or engine startup) rescans from epoch and catches up.
+	if err := s.chequeEngine.EnsureDescriptorRange(ctx, walletId, nextIndex); err != nil {
+		log.Warn().Err(err).Uint32("index", nextIndex).Msg("failed to extend cheque descriptor range")
+	}
+
 	// Derive address for this wallet
 	address, err := s.chequeEngine.DeriveChequeAddress(walletId, nextIndex)
 	if err != nil {

--- a/bitwindow/server/dial/dial.go
+++ b/bitwindow/server/dial/dial.go
@@ -39,9 +39,10 @@ func Bitcoind(ctx context.Context, orchestratorAddr string) (corerpc.BitcoinServ
 	if orchestratorAddr == "" {
 		return nil, errors.New("empty orchestrator addr")
 	}
+	addr := ensureHTTPScheme(orchestratorAddr)
 	return corerpc.NewBitcoinServiceClient(
-		getSharedClient(ctx),
-		ensureHTTPScheme(orchestratorAddr),
+		clientForScheme(ctx, addr),
+		addr,
 		connect.WithGRPC(),
 		// Bitcoind is the one dial target on the orchestrator (its hosted core
 		// proxy); enforcer/sidechain dials go to other daemons and stay
@@ -60,6 +61,17 @@ func ensureHTTPScheme(addr string) string {
 		return addr
 	}
 	return "http://" + addr
+}
+
+// clientForScheme picks the client matching addr's scheme (addr must already
+// have been through ensureHTTPScheme). The shared client is h2c: it dials
+// cleartext no matter what scheme the URL carries, so handing it an https://
+// orchestrator URL would put the local-auth cookie on the wire in the clear.
+func clientForScheme(ctx context.Context, addr string) *http.Client {
+	if strings.HasPrefix(strings.ToLower(addr), "https://") {
+		return getSharedTLSClient(ctx)
+	}
+	return getSharedClient(ctx)
 }
 
 func EnforcerValidator(ctx context.Context, url string) (
@@ -234,9 +246,13 @@ func CoinShift(ctx context.Context, host string, port int) (*coinshift.Client, e
 }
 
 var (
-	// Shared HTTP client for all connections
+	// Shared HTTP client for all cleartext (http://) connections
 	sharedClient *http.Client
 	clientOnce   sync.Once
+
+	// Shared HTTP client for https:// targets. Same settings, but real TLS.
+	sharedTLSClient *http.Client
+	tlsClientOnce   sync.Once
 
 	// cookieDir is the bitwindow data dir holding .auth.cookie, used by the
 	// orchestrator-targeting Bitcoind client. Set once at startup via
@@ -248,27 +264,47 @@ var (
 // (Bitcoind proxy) client. Call once at startup before the first dial.
 func SetCookieDir(dir string) { cookieDir = dir }
 
-// getSharedClient returns a singleton HTTP client for all connections
+// getSharedClient returns a singleton HTTP client for cleartext connections
 func getSharedClient(ctx context.Context) *http.Client {
 	clientOnce.Do(func() {
-		sharedClient = &http.Client{
-			Transport: &http2.Transport{
-				AllowHTTP: true,
-				DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
-					return net.Dial(network, addr)
-				},
-				// Without explicit timeouts here, clients linger indefinitely
-				IdleConnTimeout:  15 * time.Second,
-				ReadIdleTimeout:  30 * time.Second, // Close if no data received for 30s
-				PingTimeout:      15 * time.Second,
-				WriteByteTimeout: 10 * time.Second,
-
-				CountError: func(errType string) {
-					zerolog.Ctx(ctx).Error().Msgf("HTTP/2 transport error: %s", errType)
-				},
-			},
-			Timeout: 30 * time.Second, // Overall request timeout
-		}
+		sharedClient = newHTTP2Client(ctx, true)
 	})
 	return sharedClient
+}
+
+// getSharedTLSClient returns a singleton HTTP client for https:// connections.
+func getSharedTLSClient(ctx context.Context) *http.Client {
+	tlsClientOnce.Do(func() {
+		sharedTLSClient = newHTTP2Client(ctx, false)
+	})
+	return sharedTLSClient
+}
+
+// newHTTP2Client builds an HTTP/2 client with our standard timeouts. With
+// cleartext set it speaks h2c (prior knowledge, no TLS handshake); otherwise
+// http2.Transport's own TLS dialer handles the connection. The h2c dialer must
+// never be used for https:// targets — it ignores the *tls.Config it is handed
+// and would send the request, headers and all, unencrypted.
+func newHTTP2Client(ctx context.Context, cleartext bool) *http.Client {
+	transport := &http2.Transport{
+		// Without explicit timeouts here, clients linger indefinitely
+		IdleConnTimeout:  15 * time.Second,
+		ReadIdleTimeout:  30 * time.Second, // Close if no data received for 30s
+		PingTimeout:      15 * time.Second,
+		WriteByteTimeout: 10 * time.Second,
+
+		CountError: func(errType string) {
+			zerolog.Ctx(ctx).Error().Msgf("HTTP/2 transport error: %s", errType)
+		},
+	}
+	if cleartext {
+		transport.AllowHTTP = true
+		transport.DialTLS = func(network, addr string, _ *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		}
+	}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   30 * time.Second, // Overall request timeout
+	}
 }

--- a/bitwindow/server/dial/dial_test.go
+++ b/bitwindow/server/dial/dial_test.go
@@ -1,6 +1,10 @@
 package dial
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/net/http2"
+)
 
 // TestEnsureHTTPScheme guards the double-prefix regression. config.OrchestratorAddr
 // defaults to a full URL ("http://localhost:30400"); dial.Bitcoind used to wrap
@@ -37,5 +41,44 @@ func TestEnsureHTTPScheme(t *testing.T) {
 func TestBitcoind_RejectsEmptyAddr(t *testing.T) {
 	if _, err := Bitcoind(t.Context(), ""); err == nil {
 		t.Fatal("Bitcoind(\"\") returned nil error")
+	}
+}
+
+// TestClientForScheme guards the cookie-leak regression. Every dial used the
+// h2c client, whose DialTLS hook discards the *tls.Config it is handed and
+// plain net.Dials instead — x/net/http2 routes https:// connections through
+// that same hook, so an https:// orchestrator.addr dialed cleartext and the
+// local-auth bearer cookie went out unencrypted. https:// must get a transport
+// that actually does TLS.
+func TestClientForScheme(t *testing.T) {
+	cleartext := clientForScheme(t.Context(), "http://localhost:30400")
+	encrypted := clientForScheme(t.Context(), "https://orch.example.com")
+
+	if cleartext == encrypted {
+		t.Fatal("http:// and https:// got the same client")
+	}
+
+	h2c, ok := cleartext.Transport.(*http2.Transport)
+	if !ok {
+		t.Fatalf("http:// transport = %T, want *http2.Transport", cleartext.Transport)
+	}
+	if !h2c.AllowHTTP || h2c.DialTLS == nil {
+		t.Error("http:// client is not the h2c transport")
+	}
+
+	tlsTransport, ok := encrypted.Transport.(*http2.Transport)
+	if !ok {
+		t.Fatalf("https:// transport = %T, want *http2.Transport", encrypted.Transport)
+	}
+	if tlsTransport.AllowHTTP {
+		t.Error("https:// client allows cleartext HTTP/2")
+	}
+	if tlsTransport.DialTLS != nil || tlsTransport.DialTLSContext != nil {
+		t.Error("https:// client overrides the TLS dialer, bypassing TLS")
+	}
+
+	// ensureHTTPScheme passes mixed-case schemes through untouched.
+	if got := clientForScheme(t.Context(), "HTTPS://orch.example.com"); got != encrypted {
+		t.Error("mixed-case https:// did not get the TLS client")
 	}
 }

--- a/bitwindow/server/engines/backup_engine.go
+++ b/bitwindow/server/engines/backup_engine.go
@@ -155,10 +155,6 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 	switch ext {
 	case ".json":
 		walletJSON = data
-		// Validate it's valid wallet JSON
-		if err := validateWalletJSON(data); err != nil {
-			return fmt.Errorf("invalid wallet.json: %w", err)
-		}
 	case ".zip":
 		walletJSON, metadataJSON, multisigJSON, txJSON, err = extractZIP(data)
 		if err != nil {
@@ -172,20 +168,10 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 		return fmt.Errorf("backup does not contain wallet.json")
 	}
 
-	// Import into the DB before touching the wallet files, so a backup that
-	// fails to import leaves the current wallet in place.
-	if multisigJSON != nil {
-		if err := e.multisigStore.ImportFromJSON(ctx, multisigJSON); err != nil {
-			return fmt.Errorf("import multisig data: %w", err)
-		}
-		log.Info().Msg("restore: imported multisig data")
-	}
-
-	if txJSON != nil {
-		if err := e.multisigStore.ImportTransactionsFromJSON(ctx, txJSON); err != nil {
-			return fmt.Errorf("import transactions: %w", err)
-		}
-		log.Info().Msg("restore: imported transactions")
+	// Validate it's valid wallet JSON. This gates both file types, so a restore
+	// never writes bytes that ValidateBackup (validateJSON/validateZIP) rejects.
+	if err := validateWalletJSON(walletJSON); err != nil {
+		return fmt.Errorf("invalid wallet.json: %w", err)
 	}
 
 	// Restore wallet.json

--- a/bitwindow/server/engines/backup_engine_test.go
+++ b/bitwindow/server/engines/backup_engine_test.go
@@ -145,6 +145,25 @@ func TestRestoreBackup_JSON(t *testing.T) {
 	}
 }
 
+// a zipped wallet.json that ValidateBackup rejects must also be rejected by
+// RestoreBackup, instead of being written over the live wallet
+func TestRestoreBackup_ZIP_InvalidWalletJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	e := &BackupEngine{walletDir: tmpDir}
+
+	bad := zipWith(t, "wallet.json", []byte(`{"foo":"bar"}`))
+
+	if _, err := e.ValidateBackup(context.TODO(), bad, "backup.zip"); err == nil {
+		t.Fatal("expected ValidateBackup to reject invalid wallet.json")
+	}
+	if err := e.RestoreBackup(testCtx(), bad, "backup.zip"); err == nil {
+		t.Fatal("expected RestoreBackup to reject invalid wallet.json")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "wallet.json")); !os.IsNotExist(err) {
+		t.Fatal("RestoreBackup wrote wallet.json despite invalid contents")
+	}
+}
+
 func TestHasCurrentWallet(t *testing.T) {
 	tmpDir := t.TempDir()
 	e := &BackupEngine{walletDir: tmpDir}

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -174,19 +174,16 @@ func DetectFileType(content []byte) string {
 	// Try to detect text files
 	sampleSize := min(1024, len(content))
 
-	// Check if content looks like valid UTF-8 text
+	// Check if content is printable ASCII text. Non-ASCII bytes must classify as
+	// "bin": the "txt" path stores content raw in the OP_RETURN, and retrieval
+	// runs it through opreturns.OPReturnToReadable, which hex-encodes anything
+	// containing a byte above 0x7E and so destroys the "metadataB64|content"
+	// framing that DecodeOPReturnData needs.
 	isText := true
 	for i := range sampleSize {
 		b := content[i]
 		// Allow printable ASCII, newlines, tabs
-		if b < 0x09 || (b > 0x0D && b < 0x20) || b == 0x7F {
-			// Check for UTF-8 multi-byte sequences
-			if b >= 0x80 && b <= 0xBF {
-				continue // continuation byte
-			}
-			if b >= 0xC0 && b <= 0xF7 {
-				continue // start of multi-byte
-			}
+		if b < 0x09 || (b > 0x0D && b < 0x20) || b >= 0x7F {
 			isText = false
 			break
 		}

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -88,6 +88,11 @@ type ParsedMetadata struct {
 	IsMultisig bool
 	Timestamp  uint32
 	FileType   string
+
+	// Raw is the exact 9-byte metadata this was parsed from. Encrypt/Decrypt
+	// authenticate these bytes, so tampering with the flags, timestamp or file
+	// type fails the auth tag instead of silently decrypting to garbage.
+	Raw []byte
 }
 
 // ParseMetadata parses the 9-byte metadata from base64
@@ -110,11 +115,17 @@ func ParseMetadata(metadataB64 string) (*ParsedMetadata, error) {
 		IsMultisig: (flags & FlagMultisig) != 0,
 		Timestamp:  timestamp,
 		FileType:   fileType,
+		Raw:        metadataBytes,
 	}, nil
 }
 
 // EncodeMetadata encodes metadata into 9 bytes and returns base64
 func EncodeMetadata(encrypted, isMultisig bool, timestamp uint32, fileType string) string {
+	return base64.StdEncoding.EncodeToString(EncodeMetadataBytes(encrypted, isMultisig, timestamp, fileType))
+}
+
+// EncodeMetadataBytes encodes metadata into its 9-byte on-chain representation
+func EncodeMetadataBytes(encrypted, isMultisig bool, timestamp uint32, fileType string) []byte {
 	metadata := make([]byte, MetadataSize)
 
 	// Flags byte
@@ -140,7 +151,7 @@ func EncodeMetadata(encrypted, isMultisig bool, timestamp uint32, fileType strin
 	}
 	copy(metadata[5:9], fileTypeBytes)
 
-	return base64.StdEncoding.EncodeToString(metadata)
+	return metadata
 }
 
 // DetectFileType detects file type from magic bytes
@@ -359,8 +370,10 @@ func (e *BitDriveEngine) getAuthKey(_ context.Context) ([]byte, error) {
 // Encrypt encrypts content using XOR with derived keystream and appends HMAC auth tag.
 // The output layout is: nonce (NonceSize) || ciphertext || tag (AuthTagSize). The
 // random per-file nonce is mixed into the keystream so repeated (timestamp, fileType)
-// tuples never reuse the keystream.
-func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp uint32, fileType string) ([]byte, error) {
+// tuples never reuse the keystream. metadata is the 9-byte metadata prefix that
+// travels alongside the ciphertext; it is authenticated as associated data because
+// the keystream is derived from the timestamp and file type it carries.
+func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp uint32, fileType string, metadata []byte) ([]byte, error) {
 	// Generate a random per-file nonce
 	nonce := make([]byte, NonceSize)
 	if _, err := rand.Read(nonce); err != nil {
@@ -379,14 +392,17 @@ func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp 
 		encrypted[i] = content[i] ^ keyStream[i]
 	}
 
-	// Generate truncated authentication tag (first 8 bytes of HMAC-SHA256)
-	// over the nonce and ciphertext so nonce tampering is also detected.
+	// Generate truncated authentication tag (first 8 bytes of HMAC-SHA256) over
+	// the metadata, nonce and ciphertext so metadata and nonce tampering is also
+	// detected. All three inputs are fixed-length or trailing, so the
+	// concatenation is unambiguous.
 	authKey, err := e.getAuthKey(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get auth key: %w", err)
 	}
 
 	mac := hmac.New(sha256.New, authKey)
+	mac.Write(metadata)
 	mac.Write(nonce)
 	mac.Write(encrypted)
 	fullTag := mac.Sum(nil)
@@ -401,8 +417,11 @@ func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp 
 	return result, nil
 }
 
-// Decrypt verifies the HMAC auth tag and decrypts content
-func (e *BitDriveEngine) Decrypt(ctx context.Context, encryptedData []byte, timestamp uint32, fileType string) ([]byte, error) {
+// Decrypt verifies the HMAC auth tag and decrypts content. metadata must be the
+// 9-byte metadata prefix the ciphertext arrived with: it is authenticated as
+// associated data, so a tampered timestamp or file type is rejected rather than
+// feeding a wrong keystream seed into DeriveKeyStream.
+func (e *BitDriveEngine) Decrypt(ctx context.Context, encryptedData []byte, timestamp uint32, fileType string, metadata []byte) ([]byte, error) {
 	if len(encryptedData) <= NonceSize+AuthTagSize {
 		return nil, fmt.Errorf("encrypted data too short")
 	}
@@ -413,13 +432,14 @@ func (e *BitDriveEngine) Decrypt(ctx context.Context, encryptedData []byte, time
 	encryptedContent := encryptedData[NonceSize : NonceSize+contentLen]
 	receivedTag := encryptedData[NonceSize+contentLen:]
 
-	// Verify authentication tag over the nonce and ciphertext
+	// Verify authentication tag over the metadata, nonce and ciphertext
 	authKey, err := e.getAuthKey(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get auth key: %w", err)
 	}
 
 	mac := hmac.New(sha256.New, authKey)
+	mac.Write(metadata)
 	mac.Write(nonce)
 	mac.Write(encryptedContent)
 	fullTag := mac.Sum(nil)
@@ -450,11 +470,14 @@ func (e *BitDriveEngine) EncodeOPReturnData(ctx context.Context, content []byte,
 	timestamp := uint32(time.Now().Unix())
 	fileType := DetectFileType(content)
 
+	// Encode metadata up front so it can be authenticated with the ciphertext
+	metadataBytes := EncodeMetadataBytes(encrypt, false, timestamp, fileType)
+
 	var processedContent []byte
 	var err error
 
 	if encrypt {
-		processedContent, err = e.Encrypt(ctx, content, timestamp, fileType)
+		processedContent, err = e.Encrypt(ctx, content, timestamp, fileType, metadataBytes)
 		if err != nil {
 			return "", "", 0, fmt.Errorf("encrypt content: %w", err)
 		}
@@ -462,8 +485,7 @@ func (e *BitDriveEngine) EncodeOPReturnData(ctx context.Context, content []byte,
 		processedContent = content
 	}
 
-	// Encode metadata
-	metadataB64 := EncodeMetadata(encrypt, false, timestamp, fileType)
+	metadataB64 := base64.StdEncoding.EncodeToString(metadataBytes)
 
 	// Encode content
 	var contentStr string
@@ -501,7 +523,7 @@ func (e *BitDriveEngine) DecodeOPReturnData(ctx context.Context, opReturnMessage
 	}
 
 	if metadata.Encrypted {
-		content, err = e.Decrypt(ctx, content, metadata.Timestamp, metadata.FileType)
+		content, err = e.Decrypt(ctx, content, metadata.Timestamp, metadata.FileType, metadata.Raw)
 		if err != nil {
 			return nil, nil, fmt.Errorf("decrypt content: %w", err)
 		}
@@ -666,28 +688,21 @@ func (e *BitDriveEngine) EncodeMultisigData(ctx context.Context, jsonData []byte
 	timestamp := uint32(time.Now().Unix())
 	fileType := "json"
 
+	// Encode metadata with multisig flag up front so it can be authenticated
+	// with the ciphertext
+	metadata := EncodeMetadataBytes(encrypt, true, timestamp, fileType)
+
 	var processedContent []byte
 	var err error
 
 	if encrypt {
-		processedContent, err = e.Encrypt(ctx, jsonData, timestamp, fileType)
+		processedContent, err = e.Encrypt(ctx, jsonData, timestamp, fileType, metadata)
 		if err != nil {
 			return "", fmt.Errorf("encrypt multisig data: %w", err)
 		}
 	} else {
 		processedContent = jsonData
 	}
-
-	// Encode metadata with multisig flag
-	metadata := make([]byte, MetadataSize)
-	var flags byte
-	if encrypt {
-		flags |= FlagEncrypted
-	}
-	flags |= FlagMultisig
-	metadata[0] = flags
-	binary.BigEndian.PutUint32(metadata[1:5], timestamp)
-	copy(metadata[5:9], []byte("json"))
 
 	metadataB64 := base64.StdEncoding.EncodeToString(metadata)
 	contentB64 := base64.StdEncoding.EncodeToString(processedContent)

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/base64"
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"testing"
@@ -96,15 +98,16 @@ func TestEncrypt_SameTimestampSameFileType_NoKeystreamReuse(t *testing.T) {
 
 	const timestamp = uint32(1800000000)
 	const fileType = "txt"
+	metadata := EncodeMetadataBytes(true, false, timestamp, fileType)
 
 	plainA := []byte("BitDrive keystream reuse probe payload block AAAA")
 	plainB := []byte("BitDrive keystream reuse probe payload block BBBB")
 
-	cipherA, err := engine.Encrypt(ctx, plainA, timestamp, fileType)
+	cipherA, err := engine.Encrypt(ctx, plainA, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("encrypt A: %v", err)
 	}
-	cipherB, err := engine.Encrypt(ctx, plainB, timestamp, fileType)
+	cipherB, err := engine.Encrypt(ctx, plainB, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("encrypt B: %v", err)
 	}
@@ -132,7 +135,7 @@ func TestEncrypt_SameTimestampSameFileType_NoKeystreamReuse(t *testing.T) {
 	// Encrypting the SAME plaintext twice must also yield distinct ciphertext
 	// bodies, proving the keystream is randomized per file rather than derived
 	// solely from (timestamp, fileType).
-	cipherA2, err := engine.Encrypt(ctx, plainA, timestamp, fileType)
+	cipherA2, err := engine.Encrypt(ctx, plainA, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("encrypt A again: %v", err)
 	}
@@ -142,19 +145,73 @@ func TestEncrypt_SameTimestampSameFileType_NoKeystreamReuse(t *testing.T) {
 	}
 
 	// Both ciphertexts must still round-trip through Decrypt.
-	gotA, err := engine.Decrypt(ctx, cipherA, timestamp, fileType)
+	gotA, err := engine.Decrypt(ctx, cipherA, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("decrypt A: %v", err)
 	}
 	if !bytes.Equal(gotA, plainA) {
 		t.Fatalf("decrypt A mismatch: got %q want %q", gotA, plainA)
 	}
-	gotB, err := engine.Decrypt(ctx, cipherB, timestamp, fileType)
+	gotB, err := engine.Decrypt(ctx, cipherB, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("decrypt B: %v", err)
 	}
 	if !bytes.Equal(gotB, plainB) {
 		t.Fatalf("decrypt B mismatch: got %q want %q", gotB, plainB)
+	}
+}
+
+// TestDecodeOPReturnData_MetadataTamperRejected verifies that the auth tag covers
+// the 9-byte metadata prefix. The keystream seed mixes in the timestamp and file
+// type carried by that prefix, so a tag over nonce||ciphertext alone let an
+// attacker flip a metadata byte and have Decrypt return garbage with a nil error.
+func TestDecodeOPReturnData_MetadataTamperRejected(t *testing.T) {
+	ctx := context.Background()
+	engine := newEncryptTestEngine(t)
+
+	plain := []byte("BitDrive metadata binding probe payload")
+
+	metadataB64, contentStr, timestamp, err := engine.EncodeOPReturnData(ctx, plain, true)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	// The untampered message must still round-trip.
+	decoded, _, err := engine.DecodeOPReturnData(ctx, FormatOPReturnData(metadataB64, contentStr))
+	if err != nil {
+		t.Fatalf("decode untampered: %v", err)
+	}
+	if !bytes.Equal(decoded, plain) {
+		t.Fatalf("round trip mismatch: got %q want %q", decoded, plain)
+	}
+
+	metadataBytes, err := base64.StdEncoding.DecodeString(metadataB64)
+	if err != nil {
+		t.Fatalf("decode metadata base64: %v", err)
+	}
+
+	tampers := []struct {
+		name   string
+		mutate func(metadata []byte)
+	}{
+		{"timestamp", func(m []byte) { binary.BigEndian.PutUint32(m[1:5], timestamp+1) }},
+		{"file type", func(m []byte) { copy(m[5:9], []byte("bin ")) }},
+		{"multisig flag", func(m []byte) { m[0] |= FlagMultisig }},
+	}
+
+	for _, tt := range tampers {
+		t.Run(tt.name, func(t *testing.T) {
+			tampered := append([]byte(nil), metadataBytes...)
+			tt.mutate(tampered)
+			if bytes.Equal(tampered, metadataBytes) {
+				t.Fatal("tamper did not change the metadata")
+			}
+
+			opReturnData := FormatOPReturnData(base64.StdEncoding.EncodeToString(tampered), contentStr)
+			if _, _, err := engine.DecodeOPReturnData(ctx, opReturnData); err == nil {
+				t.Fatal("tampered metadata decrypted without error")
+			}
+		})
 	}
 }
 

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/bitdrive"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/opreturns"
 	"github.com/btcsuite/btcd/chaincfg"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -225,5 +226,69 @@ func TestSaveFile_SameSecondNoCollision(t *testing.T) {
 	}
 	if string(secondContent) != "second file" {
 		t.Fatalf("second file content wrong: got %q", secondContent)
+	}
+}
+
+// TestDetectFileType_NonASCIIIsBinary verifies that any byte above 0x7E makes
+// content classify as "bin" rather than "txt". Classifying it as text sends it
+// down the raw-storage path, which cannot survive retrieval.
+func TestDetectFileType_NonASCIIIsBinary(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		want    string
+	}{
+		{"plain ascii", []byte("hello world\n\tand tabs"), "txt"},
+		{"utf-8 multi-byte", []byte("café"), "bin"},
+		{"high byte", []byte("prefix\xFFsuffix"), "bin"},
+		{"continuation byte only", []byte("prefix\xBFsuffix"), "bin"},
+		{"delete char", []byte("prefix\x7Fsuffix"), "bin"},
+		{"nul byte", []byte("prefix\x00suffix"), "bin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectFileType(tt.content); got != tt.want {
+				t.Fatalf("DetectFileType(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEncodeOPReturnData_NonASCIIRoundTrip walks a payload containing a byte
+// above 0x7F through the full store/retrieve chain:
+// EncodeOPReturnData -> FormatOPReturnData -> OPReturnToReadable ->
+// DecodeOPReturnData. Storing such content as "txt" put raw high bytes on
+// chain, which OPReturnToReadable then hex-encoded, hiding the "|" separator
+// and making DecodeOPReturnData fail with "invalid OP_RETURN format".
+func TestEncodeOPReturnData_NonASCIIRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	engine := &BitDriveEngine{}
+
+	contents := [][]byte{
+		[]byte("café ☕ unicode text"),
+		[]byte("ascii with one high byte: \xFE"),
+		{0x00, 0x01, 0x80, 0xFF, 0x7C, 0x41},
+	}
+
+	for _, content := range contents {
+		metadataB64, contentStr, _, err := engine.EncodeOPReturnData(ctx, content, false)
+		if err != nil {
+			t.Fatalf("encode %q: %v", content, err)
+		}
+
+		opReturnData := FormatOPReturnData(metadataB64, contentStr)
+		readable := opreturns.OPReturnToReadable([]byte(opReturnData))
+
+		decoded, metadata, err := engine.DecodeOPReturnData(ctx, readable)
+		if err != nil {
+			t.Fatalf("decode %q: %v", content, err)
+		}
+		if metadata.FileType != "bin" {
+			t.Fatalf("expected file type bin for %q, got %q", content, metadata.FileType)
+		}
+		if !bytes.Equal(decoded, content) {
+			t.Fatalf("round trip mismatch: got %q, want %q", decoded, content)
+		}
 	}
 }

--- a/bitwindow/server/engines/cheque_descriptor_range_test.go
+++ b/bitwindow/server/engines/cheque_descriptor_range_test.go
@@ -1,0 +1,32 @@
+package engines
+
+import (
+	"testing"
+)
+
+func TestChequeDescriptorRangeEnd(t *testing.T) {
+	cases := []struct {
+		name  string
+		index uint32
+		want  uint32
+	}{
+		{"first cheque", 0, chequeDescriptorRangeStep},
+		{"inside first step", 1999, chequeDescriptorRangeStep},
+		// The index that used to fall outside the fixed range.
+		{"step boundary", 2000, 2 * chequeDescriptorRangeStep},
+		{"past first step", 2001, 2 * chequeDescriptorRangeStep},
+		{"many steps in", 123456, 124000},
+		{"clamped to core maximum", 999999, chequeDescriptorRangeMax},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := chequeDescriptorRangeEnd(tc.index)
+			if got != tc.want {
+				t.Fatalf("chequeDescriptorRangeEnd(%d) = %d, want %d", tc.index, got, tc.want)
+			}
+			if got < tc.index {
+				t.Fatalf("chequeDescriptorRangeEnd(%d) = %d does not cover the index", tc.index, got)
+			}
+		})
+	}
+}

--- a/bitwindow/server/engines/cheque_engine.go
+++ b/bitwindow/server/engines/cheque_engine.go
@@ -2,14 +2,17 @@ package engines
 
 import (
 	"context"
+	"database/sql"
 	"encoding/hex"
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
 	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
@@ -28,7 +31,26 @@ const (
 
 	// ChequeWalletName is the name of the watch-only Bitcoin Core wallet for cheques
 	ChequeWalletName = "cheque_watch"
+
+	// chequeDescriptorRangeStep is how many indexes the imported descriptor
+	// range is rounded up to. Cheque indexes grow without bound, so the range
+	// has to grow with them — a fixed range means Core silently stops watching
+	// the addresses we hand out once the wallet passes the end.
+	chequeDescriptorRangeStep = 2000
+
+	// chequeDescriptorRangeMax is Bitcoin Core's hard cap on descriptor ranges.
+	chequeDescriptorRangeMax = 1000000
 )
+
+// chequeDescriptorRangeEnd returns the descriptor range end covering index,
+// rounded up to the next whole step and clamped to what Core accepts.
+func chequeDescriptorRangeEnd(index uint32) uint32 {
+	if index >= chequeDescriptorRangeMax-chequeDescriptorRangeStep {
+		return chequeDescriptorRangeMax
+	}
+
+	return (index/chequeDescriptorRangeStep + 1) * chequeDescriptorRangeStep
+}
 
 // IsWalletAlreadyLoadedErr reports whether err is bitcoind's "-35 wallet already
 // loaded" response. It's benign — the wallet IS loaded — so callers that loaded
@@ -48,21 +70,31 @@ type ChequeRecovery struct {
 // ChequeEngine manages cheque derivation (ONLY)
 // Gets seed from WalletEngine when needed
 type ChequeEngine struct {
+	db           *sql.DB
 	walletEngine *WalletEngine
 	chainParams  *chaincfg.Params
 	bitcoind     *service.Service[corerpc.BitcoinServiceClient]
+
+	// Maps walletId -> descriptor range end last imported into the cheque
+	// wallet, so EnsureDescriptorRange only re-imports (and rescans) when an
+	// index actually falls outside the watched range.
+	rangeMu        sync.Mutex
+	importedRanges map[string]uint32
 }
 
 // NewChequeEngine creates a new cheque engine
 func NewChequeEngine(
+	db *sql.DB,
 	walletEngine *WalletEngine,
 	chainParams *chaincfg.Params,
 	bitcoind *service.Service[corerpc.BitcoinServiceClient],
 ) *ChequeEngine {
 	return &ChequeEngine{
-		walletEngine: walletEngine,
-		chainParams:  chainParams,
-		bitcoind:     bitcoind,
+		db:             db,
+		walletEngine:   walletEngine,
+		chainParams:    chainParams,
+		bitcoind:       bitcoind,
+		importedRanges: make(map[string]uint32),
 	}
 }
 
@@ -417,6 +449,15 @@ func (e *ChequeEngine) importDescriptorForWallet(ctx context.Context, bitcoind c
 	// Use the descriptor with checksum from Bitcoin Core
 	descriptor := descInfo.Msg.Descriptor_
 
+	// Size the range off the indexes this wallet has actually issued, so
+	// cheques past the previous range end get watched too.
+	nextIndex, err := cheques.GetNextIndex(ctx, e.db, walletId)
+	if err != nil {
+		return fmt.Errorf("get next cheque index: %w", err)
+	}
+
+	rangeEnd := chequeDescriptorRangeEnd(nextIndex)
+
 	// Import the descriptor into Bitcoin Core cheque wallet.
 	// Timestamp=epoch triggers a full rescan so cheques funded before this
 	// import (e.g. the first run after the descriptor-deadlock fix landed)
@@ -429,7 +470,7 @@ func (e *ChequeEngine) importDescriptorForWallet(ctx context.Context, bitcoind c
 				Descriptor_: descriptor,
 				Active:      true,
 				RangeStart:  0,
-				RangeEnd:    2000,
+				RangeEnd:    rangeEnd,
 				Timestamp:   timestamppb.New(time.Unix(0, 0)),
 				Internal:    false,
 			},
@@ -442,7 +483,7 @@ func (e *ChequeEngine) importDescriptorForWallet(ctx context.Context, bitcoind c
 	// Check if import was successful
 	if len(resp.Msg.Responses) > 0 {
 		if resp.Msg.Responses[0].Success {
-			log.Debug().Str("wallet_id", walletId).Msg("cheque descriptor imported successfully")
+			log.Debug().Str("wallet_id", walletId).Uint32("range_end", rangeEnd).Msg("cheque descriptor imported successfully")
 		} else {
 			if len(resp.Msg.Responses[0].Warnings) > 0 {
 				log.Warn().Str("wallet_id", walletId).Strs("warnings", resp.Msg.Responses[0].Warnings).Msg("cheque descriptor import had warnings")
@@ -453,7 +494,39 @@ func (e *ChequeEngine) importDescriptorForWallet(ctx context.Context, bitcoind c
 		}
 	}
 
+	e.rangeMu.Lock()
+	e.importedRanges[walletId] = rangeEnd
+	e.rangeMu.Unlock()
+
 	return nil
+}
+
+// EnsureDescriptorRange makes sure Bitcoin Core's cheque wallet watches index,
+// re-importing the wallet's descriptor with a wider range when index falls
+// outside the range last imported for it. Cheque indexes are unbounded, so
+// without this a long-lived wallet hands out addresses Core never sees funded.
+func (e *ChequeEngine) EnsureDescriptorRange(ctx context.Context, walletId string, index uint32) error {
+	e.rangeMu.Lock()
+	imported, ok := e.importedRanges[walletId]
+	e.rangeMu.Unlock()
+
+	if !ok {
+		// The startup import hasn't reported back yet. It always covers at
+		// least the first step, so assume that much rather than forcing a
+		// rescan on every first cheque of a session.
+		imported = chequeDescriptorRangeStep
+	}
+
+	if index <= imported {
+		return nil
+	}
+
+	bitcoind, err := e.bitcoind.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("get bitcoind: %w", err)
+	}
+
+	return e.importDescriptorForWallet(ctx, bitcoind, walletId)
 }
 
 // recoverChequesOnUnlock waits for wallet unlock and bitcoind, then recovers cheques for all wallets

--- a/bitwindow/server/engines/notification_engine.go
+++ b/bitwindow/server/engines/notification_engine.go
@@ -210,27 +210,32 @@ func (e *NotificationEngine) checkWalletTransactions(ctx context.Context) error 
 			continue
 		}
 
-		e.processWalletTransactions(ctx, resp.Msg.Transactions)
+		e.processWalletTransactions(ctx, walletName, resp.Msg.Transactions)
 	}
 
 	return nil
 }
 
-func (e *NotificationEngine) processWalletTransactions(ctx context.Context, transactions []*corepb.GetTransactionResponse) {
+func (e *NotificationEngine) processWalletTransactions(ctx context.Context, walletName string, transactions []*corepb.GetTransactionResponse) {
 	log := zerolog.Ctx(ctx)
 	for _, tx := range transactions {
 		txid := tx.Txid
 		confirmations := uint32(tx.Confirmations)
 
+		// The same txid can show up in several loaded wallets, so scope the
+		// dedup key by wallet. Otherwise the first wallet we process swallows
+		// the notification for all the others.
+		eventID := walletName + ":" + txid
+
 		// Check if we've already notified about this transaction
-		notified, err := notifications.HasBeenNotified(ctx, e.db, notifications.EventTypeTransaction, txid)
+		notified, err := notifications.HasBeenNotified(ctx, e.db, notifications.EventTypeTransaction, eventID)
 		if err != nil {
 			log.Warn().Err(err).Str("txid", txid).Msg("check transaction notification status")
 			continue
 		}
 
 		// For confirmation notifications, use a separate event type
-		confEventID := txid + ":confirmed"
+		confEventID := eventID + ":confirmed"
 		confNotified, err := notifications.HasBeenNotified(ctx, e.db, notifications.EventTypeTransactionConf, confEventID)
 		if err != nil {
 			log.Warn().Err(err).Str("txid", txid).Msg("check transaction confirmation notification status")
@@ -256,7 +261,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, tran
 				},
 			}
 			e.broadcast(ctx, event)
-			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, txid); err != nil {
+			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, eventID); err != nil {
 				log.Warn().Err(err).Str("txid", txid).Msg("mark transaction notified")
 			}
 			log.Info().
@@ -278,7 +283,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, tran
 				},
 			}
 			e.broadcast(ctx, event)
-			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, txid); err != nil {
+			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, eventID); err != nil {
 				log.Warn().Err(err).Str("txid", txid).Msg("mark transaction notified")
 			}
 			log.Info().
@@ -288,7 +293,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, tran
 
 		case !notified:
 			// New transaction with zero amount - just mark as seen
-			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, txid); err != nil {
+			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, eventID); err != nil {
 				log.Warn().Err(err).Str("txid", txid).Msg("mark transaction notified")
 			}
 

--- a/bitwindow/server/engines/notification_engine.go
+++ b/bitwindow/server/engines/notification_engine.go
@@ -216,11 +216,44 @@ func (e *NotificationEngine) checkWalletTransactions(ctx context.Context) error 
 	return nil
 }
 
+// walletTx is a single transaction, with the amounts of every wallet-relevant
+// output belonging to it summed together.
+type walletTx struct {
+	txid          string
+	amount        float64
+	confirmations uint32
+}
+
+// aggregateByTxid folds the per-output rows Bitcoin Core hands back into one
+// entry per txid. ListTransactions returns a row per wallet-relevant output, so
+// a transaction paying us several times shows up several times with the same
+// txid and differing amounts. Without folding them the dedup below lets only
+// the first row through, and the notification carries that single output's
+// amount instead of the transaction total.
+func aggregateByTxid(transactions []*corepb.GetTransactionResponse) []walletTx {
+	aggregated := make([]walletTx, 0, len(transactions))
+	seen := make(map[string]int, len(transactions))
+	for _, tx := range transactions {
+		if idx, ok := seen[tx.Txid]; ok {
+			aggregated[idx].amount += tx.Amount
+			continue
+		}
+
+		seen[tx.Txid] = len(aggregated)
+		aggregated = append(aggregated, walletTx{
+			txid:          tx.Txid,
+			amount:        tx.Amount,
+			confirmations: uint32(tx.Confirmations),
+		})
+	}
+	return aggregated
+}
+
 func (e *NotificationEngine) processWalletTransactions(ctx context.Context, walletName string, transactions []*corepb.GetTransactionResponse) {
 	log := zerolog.Ctx(ctx)
-	for _, tx := range transactions {
-		txid := tx.Txid
-		confirmations := uint32(tx.Confirmations)
+	for _, tx := range aggregateByTxid(transactions) {
+		txid := tx.txid
+		confirmations := tx.confirmations
 
 		// The same txid can show up in several loaded wallets, so scope the
 		// dedup key by wallet. Otherwise the first wallet we process swallows
@@ -247,7 +280,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 		}
 
 		switch {
-		case !notified && tx.Amount > 0:
+		case !notified && tx.amount > 0:
 			// Received transaction
 			event := &notificationv1.WatchResponse{
 				Timestamp: timestamppb.Now(),
@@ -255,7 +288,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 					Transaction: &notificationv1.TransactionEvent{
 						Type:          notificationv1.TransactionEvent_TYPE_RECEIVED,
 						Txid:          txid,
-						AmountSats:    uint64(math.Round(tx.Amount * 100000000)),
+						AmountSats:    uint64(math.Round(tx.amount * 100000000)),
 						Confirmations: confirmations,
 					},
 				},
@@ -266,10 +299,10 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 			}
 			log.Info().
 				Str("txid", txid).
-				Float64("amount", tx.Amount).
+				Float64("amount", tx.amount).
 				Msg("received transaction notification sent")
 
-		case !notified && tx.Amount < 0:
+		case !notified && tx.amount < 0:
 			// Sent transaction
 			event := &notificationv1.WatchResponse{
 				Timestamp: timestamppb.Now(),
@@ -277,7 +310,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 					Transaction: &notificationv1.TransactionEvent{
 						Type:          notificationv1.TransactionEvent_TYPE_SENT,
 						Txid:          txid,
-						AmountSats:    uint64(math.Round(-tx.Amount * 100000000)),
+						AmountSats:    uint64(math.Round(-tx.amount * 100000000)),
 						Confirmations: confirmations,
 					},
 				},
@@ -288,7 +321,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 			}
 			log.Info().
 				Str("txid", txid).
-				Float64("amount", -tx.Amount).
+				Float64("amount", -tx.amount).
 				Msg("sent transaction notification sent")
 
 		case !notified:
@@ -305,7 +338,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 					Transaction: &notificationv1.TransactionEvent{
 						Type:          notificationv1.TransactionEvent_TYPE_CONFIRMED,
 						Txid:          txid,
-						AmountSats:    uint64(math.Round(tx.Amount * 100000000)),
+						AmountSats:    uint64(math.Round(tx.amount * 100000000)),
 						Confirmations: confirmations,
 					},
 				},

--- a/bitwindow/server/engines/notification_engine_internal_test.go
+++ b/bitwindow/server/engines/notification_engine_internal_test.go
@@ -1,0 +1,50 @@
+package engines
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	notificationv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/notification/v1"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	"github.com/stretchr/testify/require"
+)
+
+// The same txid shows up in every wallet that takes part in it, so dedup has to
+// be per-wallet. Otherwise the first wallet we process swallows the
+// notification for all the others.
+func TestProcessWalletTransactions_DedupIsPerWallet(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	engine := NewNotificationEngine(db, nil)
+	events := engine.Subscribe(ctx)
+
+	const txid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	txs := []*corepb.GetTransactionResponse{{
+		Txid:          txid,
+		Amount:        1,
+		Confirmations: 0,
+	}}
+
+	engine.processWalletTransactions(ctx, "wallet-a", txs)
+	engine.processWalletTransactions(ctx, "wallet-b", txs)
+
+	// A second pass must not notify again for either wallet.
+	engine.processWalletTransactions(ctx, "wallet-a", txs)
+	engine.processWalletTransactions(ctx, "wallet-b", txs)
+
+	var received int
+	for done := false; !done; {
+		select {
+		case event := <-events:
+			require.Equal(t, notificationv1.TransactionEvent_TYPE_RECEIVED, event.GetTransaction().GetType())
+			require.Equal(t, txid, event.GetTransaction().GetTxid())
+			received++
+		default:
+			done = true
+		}
+	}
+
+	require.Equal(t, 2, received)
+}

--- a/bitwindow/server/engines/notification_engine_internal_test.go
+++ b/bitwindow/server/engines/notification_engine_internal_test.go
@@ -48,3 +48,35 @@ func TestProcessWalletTransactions_DedupIsPerWallet(t *testing.T) {
 
 	require.Equal(t, 2, received)
 }
+
+// Bitcoin Core hands back one row per wallet-relevant output, so a transaction
+// paying us twice arrives as two rows sharing a txid. The notification has to
+// carry the summed amount, not just whichever output came first.
+func TestProcessWalletTransactions_SumsOutputsWithSameTxid(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	engine := NewNotificationEngine(db, nil)
+	events := engine.Subscribe(ctx)
+
+	const txid = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	engine.processWalletTransactions(ctx, "wallet-a", []*corepb.GetTransactionResponse{
+		{Txid: txid, Amount: 1.5, Confirmations: 0},
+		{Txid: txid, Amount: 0.25, Confirmations: 0},
+	})
+
+	select {
+	case event := <-events:
+		require.Equal(t, notificationv1.TransactionEvent_TYPE_RECEIVED, event.GetTransaction().GetType())
+		require.Equal(t, txid, event.GetTransaction().GetTxid())
+		require.Equal(t, uint64(175_000_000), event.GetTransaction().GetAmountSats())
+	default:
+		t.Fatal("expected a received notification")
+	}
+
+	select {
+	case event := <-events:
+		t.Fatalf("expected a single notification, got another: %v", event)
+	default:
+	}
+}

--- a/bitwindow/server/engines/sidechain_monitor_engine.go
+++ b/bitwindow/server/engines/sidechain_monitor_engine.go
@@ -69,6 +69,32 @@ type PendingFastWithdrawal struct {
 	ExpectedAmount int64     `json:"expected_amount"` // Amount expected (sats)
 	ServerURL      string    `json:"server_url"`      // Fast withdrawal server URL
 	CreatedAt      time.Time `json:"created_at"`
+	Attempts       int       `json:"attempts"`     // Failed /paid completion attempts so far
+	LastAttempt    time.Time `json:"last_attempt"` // When the last /paid attempt was made
+}
+
+const (
+	// completionBackoffBase is the delay before the first /paid retry. Each
+	// subsequent failure doubles it, up to completionBackoffMaxShift.
+	completionBackoffBase = 30 * time.Second
+
+	// completionBackoffMaxShift caps the exponential backoff at
+	// completionBackoffBase << completionBackoffMaxShift (16 minutes).
+	completionBackoffMaxShift = 5
+)
+
+// completionBackoff returns how long to wait before re-POSTing /paid after the
+// given number of failed attempts
+func completionBackoff(attempts int) time.Duration {
+	shift := attempts - 1
+	if shift < 0 {
+		shift = 0
+	}
+	if shift > completionBackoffMaxShift {
+		shift = completionBackoffMaxShift
+	}
+
+	return completionBackoffBase << shift
 }
 
 // NewSidechainMonitorEngine creates a new sidechain monitoring engine
@@ -135,7 +161,7 @@ func (e *SidechainMonitorEngine) Run(ctx context.Context) error {
 					pollCount++
 					// Cleanup old withdrawals every 60 polls for ALL sidechains (fix memory leak)
 					if pollCount%60 == 0 {
-						e.cleanupOldWithdrawals()
+						e.cleanupOldWithdrawals(ctx)
 					}
 
 					// Dynamic polling interval based on pending withdrawals
@@ -209,9 +235,15 @@ func (e *SidechainMonitorEngine) checkFastWithdrawalPayments(ctx context.Context
 	e.mu.RLock()
 	var pendingForSidechain []PendingFastWithdrawal
 	for _, pending := range e.pendingFastWithdrawals {
-		if pending.Sidechain == sidechain {
-			pendingForSidechain = append(pendingForSidechain, pending)
+		if pending.Sidechain != sidechain {
+			continue
 		}
+		// Skip rows still backing off from a failed /paid POST, so a server that
+		// is down doesn't get the same completion re-posted on every poll
+		if !pending.LastAttempt.IsZero() && time.Since(pending.LastAttempt) < completionBackoff(pending.Attempts) {
+			continue
+		}
+		pendingForSidechain = append(pendingForSidechain, pending)
 	}
 	e.mu.RUnlock()
 
@@ -262,11 +294,28 @@ func (e *SidechainMonitorEngine) checkFastWithdrawalPayments(ctx context.Context
 			// Auto-complete the withdrawal
 			if err := e.completeWithdrawal(ctx, pending, txid); err != nil {
 				log.Error().Err(err).Str("hash", pending.Hash).Msg("failed to auto-complete withdrawal")
+				e.recordFailedCompletion(pending.Hash)
 			}
 		}
 	}
 
 	return nil
+}
+
+// recordFailedCompletion notes a failed /paid POST so the next attempt for the
+// same withdrawal is delayed by completionBackoff instead of firing next poll
+func (e *SidechainMonitorEngine) recordFailedCompletion(hash string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	pending, exists := e.pendingFastWithdrawals[hash]
+	if !exists {
+		return // Already completed or cleaned up
+	}
+
+	pending.Attempts++
+	pending.LastAttempt = time.Now()
+	e.pendingFastWithdrawals[hash] = pending
 }
 
 // getPollInterval returns the polling interval based on pending withdrawals
@@ -288,7 +337,9 @@ func (e *SidechainMonitorEngine) getPollInterval() time.Duration {
 }
 
 // cleanupOldWithdrawals removes withdrawals older than 1 hour to prevent memory bloat
-func (e *SidechainMonitorEngine) cleanupOldWithdrawals() {
+func (e *SidechainMonitorEngine) cleanupOldWithdrawals(ctx context.Context) {
+	log := zerolog.Ctx(ctx)
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -296,6 +347,20 @@ func (e *SidechainMonitorEngine) cleanupOldWithdrawals() {
 	for txid, withdrawal := range e.detectedWithdrawals {
 		if withdrawal.DetectedAt.Before(cutoff) {
 			delete(e.detectedWithdrawals, txid)
+		}
+	}
+
+	// Pending fast withdrawals are retried until the server accepts the /paid
+	// POST, so they need the same retention or they accumulate forever
+	for hash, pending := range e.pendingFastWithdrawals {
+		if pending.CreatedAt.Before(cutoff) {
+			delete(e.pendingFastWithdrawals, hash)
+
+			log.Warn().
+				Str("hash", hash).
+				Str("sidechain", pending.Sidechain).
+				Int("attempts", pending.Attempts).
+				Msg("giving up on auto-completing fast withdrawal, retention expired")
 		}
 	}
 }

--- a/bitwindow/server/engines/sidechain_monitor_engine_test.go
+++ b/bitwindow/server/engines/sidechain_monitor_engine_test.go
@@ -189,10 +189,77 @@ func TestSidechainMonitorEngine_CleanupOldWithdrawals(t *testing.T) {
 		DetectedAt: newTime,
 	}
 
+	// Add old and new pending fast withdrawals
+	engine.pendingFastWithdrawals["old-hash"] = PendingFastWithdrawal{
+		Hash:      "old-hash",
+		Sidechain: "thunder",
+		Attempts:  12,
+		CreatedAt: oldTime,
+	}
+	engine.pendingFastWithdrawals["new-hash"] = PendingFastWithdrawal{
+		Hash:      "new-hash",
+		Sidechain: "thunder",
+		CreatedAt: newTime,
+	}
+
 	// Run cleanup
-	engine.cleanupOldWithdrawals()
+	engine.cleanupOldWithdrawals(context.Background())
 
 	// Old withdrawal should be removed, new one should remain
 	assert.NotContains(t, engine.detectedWithdrawals, "old-txid")
 	assert.Contains(t, engine.detectedWithdrawals, "new-txid")
+
+	// Same for pending fast withdrawals - otherwise a withdrawal the server
+	// never accepts is retried forever
+	assert.NotContains(t, engine.pendingFastWithdrawals, "old-hash")
+	assert.Contains(t, engine.pendingFastWithdrawals, "new-hash")
+}
+
+func TestSidechainMonitorEngine_FailedCompletionBacksOff(t *testing.T) {
+	ctx := zerolog.New(zerolog.NewTestWriter(t)).WithContext(context.Background())
+
+	// Mock server that always fails the /paid POST
+	var paidRequests int
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paidRequests++
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{"status": "error"}); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	engine := NewSidechainMonitorEngine(
+		nil, nil, nil, nil, nil, nil,
+		nil,
+	)
+
+	pending := PendingFastWithdrawal{
+		Hash:           "test-hash-123456789abcdef",
+		Sidechain:      "thunder",
+		ServerAddress:  "thunder1test456",
+		ExpectedAmount: 105000,
+		ServerURL:      mockServer.URL,
+		CreatedAt:      time.Now(),
+	}
+
+	err := engine.RegisterPendingFastWithdrawal(ctx, pending)
+	require.NoError(t, err)
+
+	// A failing completion must not drop the withdrawal, but must record the attempt
+	err = engine.completeWithdrawal(ctx, pending, "test-txid-456789abcdef123")
+	require.Error(t, err)
+	engine.recordFailedCompletion(pending.Hash)
+	assert.Equal(t, 1, paidRequests)
+
+	stored := engine.pendingFastWithdrawals[pending.Hash]
+	assert.Equal(t, 1, stored.Attempts)
+	assert.False(t, stored.LastAttempt.IsZero())
+
+	// Backoff grows with the attempt count, and is capped
+	assert.Equal(t, 30*time.Second, completionBackoff(0))
+	assert.Equal(t, 30*time.Second, completionBackoff(1))
+	assert.Equal(t, 60*time.Second, completionBackoff(2))
+	assert.Equal(t, 16*time.Minute, completionBackoff(6))
+	assert.Equal(t, 16*time.Minute, completionBackoff(100))
 }

--- a/bitwindow/server/integrationtest/wallet_test.go
+++ b/bitwindow/server/integrationtest/wallet_test.go
@@ -367,11 +367,11 @@ func TestBitwindowWalletIntegration(t *testing.T) {
 		)
 		walletEngineA.SetOrchestratorClient(nodeA.WalletClient)
 
-		// Create ChequeEngine.
-		chequeEngineA := engines.NewChequeEngine(walletEngineA, &chaincfg.RegressionNetParams, bitcoindSvcA)
-
 		// Create SQLite DB for cheques.
 		dbA := database.Test(t)
+
+		// Create ChequeEngine.
+		chequeEngineA := engines.NewChequeEngine(dbA, walletEngineA, &chaincfg.RegressionNetParams, bitcoindSvcA)
 
 		// Create bitwindow wallet Server.
 		serverA := api_wallet.New(
@@ -542,8 +542,8 @@ func TestBitwindowWalletIntegration(t *testing.T) {
 		)
 		walletEngineB.SetOrchestratorClient(nodeB.WalletClient)
 
-		chequeEngineB := engines.NewChequeEngine(walletEngineB, &chaincfg.RegressionNetParams, bitcoindSvcB)
 		dbB := database.Test(t)
+		chequeEngineB := engines.NewChequeEngine(dbB, walletEngineB, &chaincfg.RegressionNetParams, bitcoindSvcB)
 
 		serverB := api_wallet.New(
 			ctx, dbB, datasource.NewLocal(bitcoindSvcB.Get, nil, nil), bitcoindSvcB,

--- a/bitwindow/server/models/blocks/processed_blocks.go
+++ b/bitwindow/server/models/blocks/processed_blocks.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
@@ -14,6 +15,15 @@ import (
 )
 
 func GetProcessedTip(ctx context.Context, db *sql.DB) (*ProcessedBlock, error) {
+	return GetProcessedTipAtOrBelow(ctx, db, math.MaxUint32)
+}
+
+// GetProcessedTipAtOrBelow returns the highest processed block that is not
+// above maxHeight. A rollback on the node (reorg, reindex, wiped datadir)
+// leaves processed_blocks rows above the node's tip until the parser's next
+// tick clears them, and callers that report our sync position must not surface
+// a block the node no longer has.
+func GetProcessedTipAtOrBelow(ctx context.Context, db *sql.DB, maxHeight uint32) (*ProcessedBlock, error) {
 	var (
 		pb           ProcessedBlock
 		txidsJSON    string
@@ -22,10 +32,11 @@ func GetProcessedTip(ctx context.Context, db *sql.DB) (*ProcessedBlock, error) {
 
 	err := db.QueryRowContext(ctx, `
 	SELECT height, block_hash, txids, block_time, processed_at
-	FROM processed_blocks 
-	ORDER BY height DESC 
+	FROM processed_blocks
+	WHERE height <= ?
+	ORDER BY height DESC
 	LIMIT 1
-	`).Scan(&pb.Height, &rawBlockHash, &txidsJSON, &pb.BlockTime, &pb.ProcessedAt)
+	`, maxHeight).Scan(&pb.Height, &rawBlockHash, &txidsJSON, &pb.BlockTime, &pb.ProcessedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	} else if err != nil {

--- a/bitwindow/server/models/cheques/cheques.go
+++ b/bitwindow/server/models/cheques/cheques.go
@@ -224,6 +224,33 @@ func UpdateSwept(ctx context.Context, db *sql.DB, walletID string, id int64, txi
 	return nil
 }
 
+// ClearSwept removes a cheque's sweep markers. Used when funding is observed
+// at the address again — a sweep spend that has vanished (reorg, RBF, mempool
+// eviction) must not keep the cheque marked as swept, because that would let
+// still-spendable funds be deleted.
+func ClearSwept(ctx context.Context, db *sql.DB, walletID string, id int64) error {
+	result, err := db.ExecContext(ctx, `
+		UPDATE cheques
+		SET swept_txid = NULL, swept_at = NULL
+		WHERE wallet_id = ? AND id = ?
+	`, walletID, id)
+
+	if err != nil {
+		return fmt.Errorf("failed to clear swept: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rows == 0 {
+		return sql.ErrNoRows
+	}
+
+	return nil
+}
+
 // GetNextIndex returns the next available cheque index for a specific wallet
 func GetNextIndex(ctx context.Context, db *sql.DB, walletID string) (uint32, error) {
 	var maxIndex sql.NullInt64

--- a/sidechain-orchestrator/api/core_rpc_wallet_route_test.go
+++ b/sidechain-orchestrator/api/core_rpc_wallet_route_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+)
+
+// newCoreRPCStub stands in for bitcoind's JSON-RPC endpoint, echoing back the
+// request URI it was hit with so tests can assert wallet routing exactly.
+func newCoreRPCStub(t *testing.T) (*Handler, *atomic.Int32) {
+	t.Helper()
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"result":%q,"error":null}`, r.RequestURI)
+	}))
+	t.Cleanup(srv.Close)
+
+	addr, ok := srv.Listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	cfg := config.NewBitcoinConfig()
+	cfg.SetSetting("rpcport", strconv.Itoa(addr.Port))
+
+	h := NewHandler(&orchestrator.Orchestrator{
+		BitcoinConf: &config.BitcoinConfManager{
+			Network: config.NetworkRegtest,
+			Config:  cfg,
+		},
+	})
+	return h, &hits
+}
+
+// calledURI runs a wallet-scoped call against the stub and returns the URI the
+// stub saw.
+func calledURI(t *testing.T, h *Handler, wallet string) string {
+	t.Helper()
+	raw, err := h.RawCoreCall(context.Background(), "getbalance", "[]", wallet)
+	require.NoError(t, err)
+	var uri string
+	require.NoError(t, json.Unmarshal(raw, &uri))
+	return uri
+}
+
+func TestCallCoreRPCEscapesWalletSegment(t *testing.T) {
+	h, _ := newCoreRPCStub(t)
+
+	assert.Equal(t, "/wallet/wallet%20with%20spaces", calledURI(t, h, "wallet with spaces"))
+	assert.Equal(t, "/wallet/multisig_1", calledURI(t, h, "multisig_1"))
+	assert.Equal(t, "/", calledURI(t, h, ""))
+}
+
+func TestCallCoreRPCRejectsWalletRouteEscape(t *testing.T) {
+	// A wallet name carrying a URL separator must never reach bitcoind — it
+	// would re-route the call to a different loaded wallet.
+	for _, wallet := range []string{
+		"foo?bar=baz",
+		"foo#frag",
+		"../other",
+		"..",
+		".",
+	} {
+		t.Run(wallet, func(t *testing.T) {
+			h, hits := newCoreRPCStub(t)
+
+			_, err := h.RawCoreCall(context.Background(), "getbalance", "[]", wallet)
+			require.Error(t, err)
+			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+			assert.Zero(t, hits.Load(), "no request should have been sent")
+		})
+	}
+}

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -897,6 +898,18 @@ type coreRPCResult struct {
 	} `json:"error"`
 }
 
+// validCoreWalletName rejects wallet names that can't safely be a single URL
+// path segment. Escaping alone already neutralises them, but a name carrying a
+// separator means the caller (an imported multisig group, a raw RPC request)
+// handed us something malformed — fail loudly rather than silently target a
+// wallet the user didn't ask for.
+func validCoreWalletName(wallet string) bool {
+	if wallet == "." || wallet == ".." {
+		return false
+	}
+	return !strings.ContainsAny(wallet, "/?#")
+}
+
 func (h *Handler) callCoreRPC(ctx context.Context, method, paramsJSON, wallet string) (json.RawMessage, error) {
 	if h.orch.BitcoinConf == nil {
 		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("bitcoin conf not loaded"))
@@ -915,12 +928,17 @@ func (h *Handler) callCoreRPC(ctx context.Context, method, paramsJSON, wallet st
 	}
 	body := []byte(fmt.Sprintf(`{"jsonrpc":"1.0","id":"orchestratord","method":%q,"params":%s}`, method, paramsJSON))
 
-	url := fmt.Sprintf("http://localhost:%d", port)
+	endpoint := fmt.Sprintf("http://localhost:%d", port)
 	if wallet != "" {
-		url = strings.TrimRight(url, "/") + "/wallet/" + wallet
+		if !validCoreWalletName(wallet) {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid wallet name %q", wallet))
+		}
+		// PathEscape keeps the name a single path segment — an unescaped name
+		// containing '?', '#' or '/' would re-route the call to another wallet.
+		endpoint = strings.TrimRight(endpoint, "/") + "/wallet/" + neturl.PathEscape(wallet)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("build %s request: %w", method, err)
 	}

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -342,8 +342,12 @@ func (p *CoreBackend) NextChangeAddress(ctx context.Context, walletID string) (s
 	return p.rpc.GetRawChangeAddress(ctx, name)
 }
 
-// WatchKeys imports each key as a pkh() descriptor. Per-key import failures
-// are logged, not fatal — matching how Core treats already-known descriptors.
+// WatchKeys imports each key as a pkh() descriptor. Re-importing a descriptor
+// Core already knows still reports success, so a success:false result means
+// that key is genuinely not being watched: log every failure and return an
+// error. Callers persist an import watermark once this returns nil (the BIP47
+// per-sender window), and swallowing a partial failure would move that
+// watermark past addresses the wallet never actually watches.
 func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []WatchKey) error {
 	name, err := p.walletName(ctx, walletID)
 	if err != nil {
@@ -360,6 +364,7 @@ func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []Wat
 	if err != nil {
 		return err
 	}
+	var failed []string
 	for i, r := range results {
 		if r.Success {
 			continue
@@ -369,6 +374,10 @@ func (p *CoreBackend) WatchKeys(ctx context.Context, walletID string, keys []Wat
 			msg = r.Error.Message
 		}
 		p.log.Warn().Int("descriptor_index", i).Str("error", msg).Msg("watch key import failed")
+		failed = append(failed, fmt.Sprintf("%d: %s", i, msg))
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("%d of %d watch key imports failed [%s]", len(failed), len(results), strings.Join(failed, "; "))
 	}
 	return nil
 }

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -698,6 +698,45 @@ func TestCoreBackendWatchKeys(t *testing.T) {
 	assert.Equal(t, float64(1_700_000_000), asFloat(t, descs[0].Timestamp))
 }
 
+// A per-descriptor success:false means that key is not watched. WatchKeys must
+// surface it, otherwise the BIP47 engine bumps its import watermark past
+// addresses Core never got.
+func TestCoreBackendWatchKeysPartialImportFailure(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	ctx := context.Background()
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+
+	// Core accepts the first descriptor and rejects the second.
+	fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			if i == 1 {
+				results[i] = map[string]any{"success": false, "error": map[string]any{"code": -1, "message": "Rescan failed"}}
+				continue
+			}
+			results[i] = map[string]any{"success": true}
+		}
+		return results, ""
+	})
+
+	first, err := btcutil.NewWIF(fixedKey(0x11), &chaincfg.RegressionNetParams, true)
+	require.NoError(t, err)
+	second, err := btcutil.NewWIF(fixedKey(0x12), &chaincfg.RegressionNetParams, true)
+	require.NoError(t, err)
+
+	err = backend.WatchKeys(ctx, coreID, []WatchKey{
+		{WIF: first.String(), RescanFrom: 1_700_000_000},
+		{WIF: second.String(), RescanFrom: 1_700_000_000},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Rescan failed")
+}
+
 func TestCoreBackendNextReceiveAddress(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
 	fake.stubEnsureFlow()


### PR DESCRIPTION
**What's wrong**

`GetSyncInfo` reads the processed tip straight from the highest `processed_blocks` row (`ORDER BY height DESC LIMIT 1`) and divides it by Core's block count. After a rollback on the node (reorg, reindex, wiped datadir) our table still holds rows above Core's tip until the parser's next tick removes them, so the RPC reports a height and block hash Core no longer has, and a `SyncProgress` above 1. Separately, a node parked at height 0 makes that division a NaN, which serialises into the response as an unusable progress value.

**The fix**

Add `blocks.GetProcessedTipAtOrBelow` (the existing `GetProcessedTip` now delegates to it with `MaxUint32`, so other callers are unchanged) and have `GetSyncInfo` bound the lookup to `tip.Blocks`. Guard the progress division on `tip.Blocks > 0`.

**Tests**

A new `GetSyncInfo` sub-test stores processed rows at heights 100 and 105 while Core reports 100, and asserts the response carries height 100, the height-100 hash, and progress 1.

Finding report (access-controlled): https://giaki3003.tech/#/findings/20260613-0647-bitwindow-processed-tip-above-core

---
Part of a short series for this repo (fix 13 of 17); builds on https://github.com/LayerTwo-Labs/drivechain-frontends/pull/1954, so it reads best merged after that one. Happy to rebase or split if you'd prefer them independent.