### PR TITLE
orchestrator: stop chain=main networks sharing a datadir

### DIFF
--- a/.github/workflows/bitwindow-e2e.yml
+++ b/.github/workflows/bitwindow-e2e.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 env:
-  FLUTTER_VERSION: "3.44.0"
+  FLUTTER_VERSION: "3.44.8"
   GO_VERSION: "1.25"
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,9 +180,9 @@ jobs:
           path: |
             ~/.flutter
             ~/.pub-cache
-          key: flutter-build-3.44.0-${{ runner.os }}
+          key: flutter-build-3.44.8-${{ runner.os }}
           restore-keys: |
-            flutter-build-3.44.0-
+            flutter-build-3.44.8-
 
       - name: Cache Go modules
         uses: actions/cache@v5
@@ -197,7 +197,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: 3.44.0
+          flutter-version: 3.44.8
 
       - name: Install Fastforge - a tool for building and distributing apps
         run: dart pub global activate fastforge
@@ -839,9 +839,10 @@ jobs:
       - uses: actions/upload-artifact@v5
         with:
           name:
-            ${{ matrix.client }}-binaries-${{ runner.os }}${{ (matrix.variant != ''
-            && matrix.variant != 'standard') && format('-{0}', matrix.variant) || ''
-            }}${{ matrix.chain != '' && format('-{0}', matrix.chain) || '' }}
+            ${{ matrix.client }}-binaries-${{ runner.os }}${{ (matrix.variant !=
+            '' && matrix.variant != 'standard') && format('-{0}',
+            matrix.variant) || '' }}${{ matrix.chain != '' && format('-{0}',
+            matrix.chain) || '' }}
           if-no-files-found: error
           path: ${{ env.BUILD_DIR }}/${{ matrix.client }}/release/*
 

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,8 +16,8 @@ on:
       - ".github/workflows/dart.yml"
 
 env:
-  FLUTTER_VERSION: "3.44.0"
-  DART_VERSION: "3.12.0"
+  FLUTTER_VERSION: "3.44.8"
+  DART_VERSION: "3.12.2"
 
 jobs:
   format-lint-test:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -13,7 +13,7 @@ on:
       - "sail_ui/**"
 
 env:
-  FLUTTER_VERSION: "3.44.0"
+  FLUTTER_VERSION: "3.44.8"
 
 jobs:
   smoke-test:

--- a/bitassets/pubspec.lock
+++ b/bitassets/pubspec.lock
@@ -1382,5 +1382,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: "3.12.0"
-  flutter: "3.44.0"
+  dart: "3.12.2"
+  flutter: "3.44.8"

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -5,8 +5,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.281
 
 environment:
-  sdk: 3.12.0
-  flutter: 3.44.0
+  sdk: 3.12.2
+  flutter: 3.44.8
 
 dependencies:
   flutter:

--- a/bitnames/pubspec.lock
+++ b/bitnames/pubspec.lock
@@ -1382,5 +1382,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: "3.12.0"
-  flutter: "3.44.0"
+  dart: "3.12.2"
+  flutter: "3.44.8"

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -5,8 +5,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.281
 
 environment:
-  sdk: 3.12.0
-  flutter: 3.44.0
+  sdk: 3.12.2
+  flutter: 3.44.8
 
 dependencies:
   flutter:

--- a/bitwindow/pubspec.lock
+++ b/bitwindow/pubspec.lock
@@ -1565,5 +1565,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: "3.12.0"
-  flutter: "3.44.0"
+  dart: "3.12.2"
+  flutter: "3.44.8"

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -6,8 +6,8 @@ publish_to: "none"
 version: 0.2.140
 
 environment:
-  sdk: 3.12.0
-  flutter: 3.44.0
+  sdk: 3.12.2
+  flutter: 3.44.8
 
 dependencies:
   flutter:

--- a/coinshift/pubspec.lock
+++ b/coinshift/pubspec.lock
@@ -1382,5 +1382,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: "3.12.0"
-  flutter: "3.44.0"
+  dart: "3.12.2"
+  flutter: "3.44.8"

--- a/coinshift/pubspec.yaml
+++ b/coinshift/pubspec.yaml
@@ -5,8 +5,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0
 
 environment:
-  sdk: 3.12.0
-  flutter: 3.44.0
+  sdk: 3.12.2
+  flutter: 3.44.8
 
 dependencies:
   flutter:

--- a/drivechain_lints/pubspec.lock
+++ b/drivechain_lints/pubspec.lock
@@ -346,5 +346,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: "3.12.0"
-  flutter: "3.44.0"
+  dart: "3.12.2"
+  flutter: "3.44.8"

--- a/drivechain_lints/pubspec.yaml
+++ b/drivechain_lints/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: 3.12.0
-  flutter: 3.44.0
+  sdk: 3.12.2
+  flutter: 3.44.8
 
 dependencies:
   analyzer: ">=7.3.0 <11.0.0"

--- a/photon/pubspec.lock
+++ b/photon/pubspec.lock
@@ -1382,5 +1382,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: "3.12.0"
-  flutter: "3.44.0"
+  dart: "3.12.2"
+  flutter: "3.44.8"

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -5,8 +5,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.154
 
 environment:
-  sdk: 3.12.0
-  flutter: 3.44.0
+  sdk: 3.12.2
+  flutter: 3.44.8
 
 dependencies:
   flutter:

--- a/sail_ui/pubspec.lock
+++ b/sail_ui/pubspec.lock
@@ -1319,5 +1319,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: "3.12.0"
-  flutter: "3.44.0"
+  dart: "3.12.2"
+  flutter: "3.44.8"

--- a/sail_ui/pubspec.yaml
+++ b/sail_ui/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: 3.12.0
-  flutter: 3.44.0
+  sdk: 3.12.2
+  flutter: 3.44.8
 
 dependencies:
   dart_coin_rpc:

--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -409,11 +409,13 @@ func (m *BitcoinConfManager) wipeStaleChainData(config *BitcoinConfig, networks 
 // skips the wipe rather than guessing.
 func (m *BitcoinConfManager) wipeDatadirForNetwork(config *BitcoinConfig, n Network) (string, bool) {
 	group := DatadirGroupForNetwork(n)
+	if group == DatadirGroupForNetwork(m.Network) {
+		// The live line is what bitcoind is actually running on, so it wins
+		// over a slot that a manual edit may have left stale.
+		return config.GetEffectiveSetting("datadir", CoreSectionForNetwork(n)), true
+	}
 	if slot := config.GetGroupDatadir(group); slot != "" {
 		return slot, true
-	}
-	if group == DatadirGroupForNetwork(m.Network) {
-		return config.GetEffectiveSetting("datadir", CoreSectionForNetwork(n)), true
 	}
 	return "", false
 }

--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -388,10 +388,34 @@ func (m *BitcoinConfManager) wipeStaleChainData(config *BitcoinConfig, networks 
 		return
 	}
 	for _, n := range networks {
-		override := config.GetEffectiveSetting("datadir", CoreSectionForNetwork(n))
-		m.log.Info().Str("network", string(n)).Msg("migration invalidated chain data, wiping")
+		override, ok := m.wipeDatadirForNetwork(config, n)
+		if !ok {
+			m.log.Warn().Str("network", string(n)).
+				Msg("skipping chain data wipe - no datadir recorded for that network")
+			continue
+		}
+		m.log.Info().Str("network", string(n)).Str("datadir", override).
+			Msg("migration invalidated chain data, wiping")
 		WipeChainData(n, override, m.log)
 	}
+}
+
+// wipeDatadirForNetwork resolves the datadir holding n's chain data. The live
+// `datadir=` line belongs to whichever group is active right now, so reading it
+// for an inactive network points the wipe at the wrong chain — a forknet wipe
+// run while the user sits on mainnet resolved to mainnet's datadir and deleted
+// its blocks/ and chainstate/. Only the active group may fall back to the live
+// value; an inactive group with no recorded slot returns false so the caller
+// skips the wipe rather than guessing.
+func (m *BitcoinConfManager) wipeDatadirForNetwork(config *BitcoinConfig, n Network) (string, bool) {
+	group := DatadirGroupForNetwork(n)
+	if slot := config.GetGroupDatadir(group); slot != "" {
+		return slot, true
+	}
+	if group == DatadirGroupForNetwork(m.Network) {
+		return config.GetEffectiveSetting("datadir", CoreSectionForNetwork(n)), true
+	}
+	return "", false
 }
 
 type configFileInfo struct {

--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -326,7 +327,9 @@ func (m *BitcoinConfManager) loadOrCreateConfigContent() (string, error) {
 		config := ParseBitcoinConfig(content)
 
 		if migrated, wipeNetworks := RunBitcoinConfMigrations(config); migrated {
-			m.wipeStaleChainData(config, wipeNetworks)
+			if err := m.wipeStaleChainData(config, wipeNetworks); err != nil {
+				m.log.Warn().Err(err).Msg("stale chain data left in place")
+			}
 			content = config.Serialize()
 			if err := os.WriteFile(confPath, []byte(content), 0644); err != nil {
 				m.log.Error().Err(err).Msg("failed to write migrated config")
@@ -378,46 +381,33 @@ func (m *BitcoinConfManager) loadOrCreateConfigContent() (string, error) {
 // wipeStaleChainData deletes chain state invalidated by a migration. Runs
 // before the bumped config version is persisted, so a crash mid-wipe retries
 // the migration (and wipe) on the next boot.
-func (m *BitcoinConfManager) wipeStaleChainData(config *BitcoinConfig, networks []Network) {
+func (m *BitcoinConfManager) wipeStaleChainData(config *BitcoinConfig, networks []Network) error {
 	if len(networks) == 0 {
-		return
+		return nil
 	}
 	if m.getConfigFileInfo().hasPrivateConf {
 		// That user's chain data follows their own bitcoin.conf, not ours.
-		m.log.Warn().Msg("skipping chain data wipe - user bitcoin.conf takes precedence")
-		return
+		return errors.New("wipe chain data: user bitcoin.conf takes precedence")
 	}
+	// m.Network is still the CLI/build seed here, so the live network comes from
+	// the config being migrated.
+	activeGroup := DatadirGroupForNetwork(NetworkFromConfig(config))
+
 	for _, n := range networks {
-		override, ok := m.wipeDatadirForNetwork(config, n)
-		if !ok {
-			m.log.Warn().Str("network", string(n)).
-				Msg("skipping chain data wipe - no datadir recorded for that network")
-			continue
+		group := DatadirGroupForNetwork(n)
+
+		// `datadir=` holds the active group's dir, so other groups read their slot.
+		// An empty slot leaves the wipe on the platform default datadir.
+		override := config.GetGroupDatadir(group)
+		if group == activeGroup {
+			override = config.GetEffectiveSetting("datadir", CoreSectionForNetwork(n))
 		}
+
 		m.log.Info().Str("network", string(n)).Str("datadir", override).
 			Msg("migration invalidated chain data, wiping")
 		WipeChainData(n, override, m.log)
 	}
-}
-
-// wipeDatadirForNetwork resolves the datadir holding n's chain data. The live
-// `datadir=` line belongs to whichever group is active right now, so reading it
-// for an inactive network points the wipe at the wrong chain — a forknet wipe
-// run while the user sits on mainnet resolved to mainnet's datadir and deleted
-// its blocks/ and chainstate/. Only the active group may fall back to the live
-// value; an inactive group with no recorded slot returns false so the caller
-// skips the wipe rather than guessing.
-func (m *BitcoinConfManager) wipeDatadirForNetwork(config *BitcoinConfig, n Network) (string, bool) {
-	group := DatadirGroupForNetwork(n)
-	if group == DatadirGroupForNetwork(m.Network) {
-		// The live line is what bitcoind is actually running on, so it wins
-		// over a slot that a manual edit may have left stale.
-		return config.GetEffectiveSetting("datadir", CoreSectionForNetwork(n)), true
-	}
-	if slot := config.GetGroupDatadir(group); slot != "" {
-		return slot, true
-	}
-	return "", false
+	return nil
 }
 
 type configFileInfo struct {

--- a/sidechain-orchestrator/config/bitcoin_config.go
+++ b/sidechain-orchestrator/config/bitcoin_config.go
@@ -302,12 +302,10 @@ func (c *BitcoinConfig) SetGroupDatadir(g DatadirGroup, path string) {
 	c.DatadirSlots[g] = path
 }
 
-// GroupDatadirForPick maps a directory the user just chose to the datadir a
-// group should use. Forknet and drynet run on chain=main, so Core writes
-// blocks/ and chainstate/ to the root of the datadir exactly like mainnet;
-// the extra component is the only thing keeping the three chains off each
-// other. Apply this once, where the path enters the config — slots already on
-// disk are stored verbatim, so re-applying it would redirect a live datadir.
+// GroupDatadirForPick returns the datadir a group should use for a directory
+// the user just chose. Non-default groups run on chain=main and would share
+// mainnet's datadir root. Apply once, at the pick — slots on disk are already
+// resolved and re-applying would redirect a live datadir.
 func GroupDatadirForPick(g DatadirGroup, picked string) string {
 	if g == DatadirGroupDefault || picked == "" {
 		return picked

--- a/sidechain-orchestrator/config/bitcoin_config.go
+++ b/sidechain-orchestrator/config/bitcoin_config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -83,7 +84,7 @@ func ParseBitcoinConfig(content string) *BitcoinConfig {
 				group := DatadirGroup(strings.TrimSpace(rest[:eq]))
 				path := strings.TrimSpace(rest[eq+1:])
 				if group == DatadirGroupDefault || group == DatadirGroupForknet || group == DatadirGroupDrynet {
-					config.DatadirSlots[group] = path
+					config.DatadirSlots[group] = NormalizeGroupDatadir(group, path)
 				}
 			}
 			continue
@@ -298,7 +299,23 @@ func (c *BitcoinConfig) SetGroupDatadir(g DatadirGroup, path string) {
 		delete(c.DatadirSlots, g)
 		return
 	}
-	c.DatadirSlots[g] = path
+	c.DatadirSlots[g] = NormalizeGroupDatadir(g, path)
+}
+
+// NormalizeGroupDatadir appends the group's own directory component to a
+// non-default group's datadir. Forknet and drynet run on chain=main, so Core
+// writes blocks/ and chainstate/ to the root of the datadir exactly like
+// mainnet — the suffix is the only thing keeping the three chains from loading
+// each other's data. Idempotent.
+func NormalizeGroupDatadir(g DatadirGroup, path string) string {
+	if g == DatadirGroupDefault || path == "" {
+		return path
+	}
+	clean := filepath.Clean(path)
+	if filepath.Base(clean) == string(g) {
+		return clean
+	}
+	return filepath.Join(clean, string(g))
 }
 
 func removeFromOrder(order []string, key string) []string {

--- a/sidechain-orchestrator/config/bitcoin_config.go
+++ b/sidechain-orchestrator/config/bitcoin_config.go
@@ -84,7 +84,7 @@ func ParseBitcoinConfig(content string) *BitcoinConfig {
 				group := DatadirGroup(strings.TrimSpace(rest[:eq]))
 				path := strings.TrimSpace(rest[eq+1:])
 				if group == DatadirGroupDefault || group == DatadirGroupForknet || group == DatadirGroupDrynet {
-					config.DatadirSlots[group] = NormalizeGroupDatadir(group, path)
+					config.DatadirSlots[group] = path
 				}
 			}
 			continue
@@ -299,23 +299,20 @@ func (c *BitcoinConfig) SetGroupDatadir(g DatadirGroup, path string) {
 		delete(c.DatadirSlots, g)
 		return
 	}
-	c.DatadirSlots[g] = NormalizeGroupDatadir(g, path)
+	c.DatadirSlots[g] = path
 }
 
-// NormalizeGroupDatadir appends the group's own directory component to a
-// non-default group's datadir. Forknet and drynet run on chain=main, so Core
-// writes blocks/ and chainstate/ to the root of the datadir exactly like
-// mainnet — the suffix is the only thing keeping the three chains from loading
-// each other's data. Idempotent.
-func NormalizeGroupDatadir(g DatadirGroup, path string) string {
-	if g == DatadirGroupDefault || path == "" {
-		return path
+// GroupDatadirForPick maps a directory the user just chose to the datadir a
+// group should use. Forknet and drynet run on chain=main, so Core writes
+// blocks/ and chainstate/ to the root of the datadir exactly like mainnet;
+// the extra component is the only thing keeping the three chains off each
+// other. Apply this once, where the path enters the config — slots already on
+// disk are stored verbatim, so re-applying it would redirect a live datadir.
+func GroupDatadirForPick(g DatadirGroup, picked string) string {
+	if g == DatadirGroupDefault || picked == "" {
+		return picked
 	}
-	clean := filepath.Clean(path)
-	if filepath.Base(clean) == string(g) {
-		return clean
-	}
-	return filepath.Join(clean, string(g))
+	return filepath.Join(filepath.Clean(picked), string(g))
 }
 
 func removeFromOrder(order []string, key string) []string {

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -425,6 +425,14 @@ func (m *BitcoinConfManager) UpdateDataDir(dataDir string, forNetwork Network) e
 	group := DatadirGroupForNetwork(forNetwork)
 	m.Config.SetGroupDatadir(group, cleanDataDir)
 
+	// The picker validated the path the user chose; forknet's slot is stored a
+	// level deeper than that, and bitcoind refuses to boot on a missing datadir.
+	if stored := m.Config.GetGroupDatadir(group); stored != "" {
+		if err := os.MkdirAll(stored, 0755); err != nil {
+			return fmt.Errorf("create datadir %s: %w", stored, err)
+		}
+	}
+
 	if group == DatadirGroupForNetwork(m.Network) {
 		m.materializeDatadirForGroup(group)
 	}

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -423,7 +423,7 @@ func (m *BitcoinConfManager) UpdateDataDir(dataDir string, forNetwork Network) e
 	cleanDataDir := strings.ReplaceAll(strings.TrimSpace(dataDir), "\\ ", " ")
 
 	group := DatadirGroupForNetwork(forNetwork)
-	m.Config.SetGroupDatadir(group, cleanDataDir)
+	m.Config.SetGroupDatadir(group, GroupDatadirForPick(group, cleanDataDir))
 
 	// The picker validated the path the user chose; forknet's slot is stored a
 	// level deeper than that, and bitcoind refuses to boot on a missing datadir.

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -425,14 +425,6 @@ func (m *BitcoinConfManager) UpdateDataDir(dataDir string, forNetwork Network) e
 	group := DatadirGroupForNetwork(forNetwork)
 	m.Config.SetGroupDatadir(group, GroupDatadirForPick(group, cleanDataDir))
 
-	// The picker validated the path the user chose; forknet's slot is stored a
-	// level deeper than that, and bitcoind refuses to boot on a missing datadir.
-	if stored := m.Config.GetGroupDatadir(group); stored != "" {
-		if err := os.MkdirAll(stored, 0755); err != nil {
-			return fmt.Errorf("create datadir %s: %w", stored, err)
-		}
-	}
-
 	if group == DatadirGroupForNetwork(m.Network) {
 		m.materializeDatadirForGroup(group)
 	}

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -197,6 +197,37 @@ func TestWipeStaleChainDataUsesTargetNetworkSlot(t *testing.T) {
 	require.NoError(t, err, "mainnet chain data must be untouched")
 }
 
+// For the active group the live datadir= is what bitcoind is running on. A
+// hand-edited live path with a stale slot left behind must wipe the chain the
+// node actually booted, not the one the slot remembers.
+func TestWipeStaleChainDataPrefersLiveDatadirForActiveGroup(t *testing.T) {
+	tmpDir := t.TempDir()
+	staleDir := filepath.Join(tmpDir, "stale-slot")
+	liveDir := filepath.Join(tmpDir, "hand-edited")
+	seed := func(path string) {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("stub"), 0o644))
+	}
+	seed(filepath.Join(staleDir, "signet", "blocks", "blk00000.dat"))
+	seed(filepath.Join(liveDir, "signet", "blocks", "blk00000.dat"))
+
+	m := newTestManager(tmpDir)
+	m.Network = NetworkSignet
+	m.Config.SetSetting("chain", "signet")
+	m.Config.SetGroupDatadir(DatadirGroupDefault, staleDir)
+	m.Config.SetSetting("datadir", liveDir)
+
+	m.wipeStaleChainData(m.Config, []Network{NetworkSignet})
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(filepath.Join(liveDir, "signet", "blocks"))
+		return os.IsNotExist(err)
+	}, 5*time.Second, 20*time.Millisecond, "the chain bitcoind actually booted must be wiped")
+
+	_, err := os.Stat(filepath.Join(staleDir, "signet", "blocks", "blk00000.dat"))
+	require.NoError(t, err, "the stale slot's directory must be left alone")
+}
+
 // The wipe runs entirely in the background and returns immediately so a large,
 // slow, or unresponsive datadir can't block orchestrator startup — that stall
 // is what kept the RPC listener down past the frontend's readiness timeout. The
@@ -673,7 +704,7 @@ func TestSwapAdoptsManuallyEditedDatadirIntoSlot(t *testing.T) {
 	require.NoError(t, m.UpdateNetwork(NetworkDrynet))
 
 	require.Equal(t, "/manually/edited", m.Config.GetGroupDatadir(DatadirGroupDefault))
-	require.Equal(t, "/drynet/path/drynet", m.Config.GetSetting("datadir"))
+	require.Equal(t, "/drynet/path", m.Config.GetSetting("datadir"))
 }
 
 // Within-group swap (mainnet ↔ signet) leaves datadir= alone and writes no
@@ -873,7 +904,7 @@ chain=signet
 
 	out := c.Serialize()
 	require.Contains(t, out, "# bitwindow-datadir-default=/Volumes/SSD/bitcoin\n")
-	require.Contains(t, out, "# bitwindow-datadir-drynet=/new/drynet/path/drynet\n")
+	require.Contains(t, out, "# bitwindow-datadir-drynet=/new/drynet/path\n")
 
 	// Stable order: default before drynet
 	defIdx := strings.Index(out, "# bitwindow-datadir-default=")
@@ -883,13 +914,13 @@ chain=signet
 	// Re-parse, values stable
 	c2 := ParseBitcoinConfig(out)
 	require.Equal(t, "/Volumes/SSD/bitcoin", c2.GetGroupDatadir(DatadirGroupDefault))
-	require.Equal(t, "/new/drynet/path/drynet", c2.GetGroupDatadir(DatadirGroupDrynet))
+	require.Equal(t, "/new/drynet/path", c2.GetGroupDatadir(DatadirGroupDrynet))
 }
 
 func TestDatadirSlotsClearedOnEmpty(t *testing.T) {
 	c := NewBitcoinConfig()
 	c.SetGroupDatadir(DatadirGroupDrynet, "/some/path")
-	require.Equal(t, "/some/path/drynet", c.GetGroupDatadir(DatadirGroupDrynet))
+	require.Equal(t, "/some/path", c.GetGroupDatadir(DatadirGroupDrynet))
 	c.SetGroupDatadir(DatadirGroupDrynet, "")
 	require.Equal(t, "", c.GetGroupDatadir(DatadirGroupDrynet))
 
@@ -905,31 +936,62 @@ func TestDatadirGroupForNetwork(t *testing.T) {
 	require.Equal(t, DatadirGroupDrynet, DatadirGroupForNetwork(NetworkDrynet))
 }
 
-func TestNormalizeGroupDatadir(t *testing.T) {
-	require.Equal(t, "/x/forknet", NormalizeGroupDatadir(DatadirGroupForknet, "/x"))
-	require.Equal(t, "/x/forknet", NormalizeGroupDatadir(DatadirGroupForknet, "/x/forknet"), "idempotent")
-	require.Equal(t, "/x/forknet", NormalizeGroupDatadir(DatadirGroupForknet, "/x/forknet/"), "trailing slash")
-	require.Equal(t, "/x", NormalizeGroupDatadir(DatadirGroupDefault, "/x"), "default group untouched")
-	require.Equal(t, "", NormalizeGroupDatadir(DatadirGroupForknet, ""))
+func TestGroupDatadirForPick(t *testing.T) {
+	require.Equal(t, "/x/forknet", GroupDatadirForPick(DatadirGroupForknet, "/x"))
+	require.Equal(t, "/x/drynet", GroupDatadirForPick(DatadirGroupDrynet, "/x"))
+	require.Equal(t, "/x/forknet", GroupDatadirForPick(DatadirGroupForknet, "/x/"), "trailing slash")
+	require.Equal(t, "/x", GroupDatadirForPick(DatadirGroupDefault, "/x"), "default group untouched")
+	require.Equal(t, "", GroupDatadirForPick(DatadirGroupForknet, ""))
+
+	// A directory that merely looks normalized still gets its own component,
+	// so picking /data/forknet for both mainnet and forknet cannot collide.
+	require.Equal(t, "/data/forknet/forknet", GroupDatadirForPick(DatadirGroupForknet, "/data/forknet"))
+	require.NotEqual(t,
+		GroupDatadirForPick(DatadirGroupDefault, "/data/forknet"),
+		GroupDatadirForPick(DatadirGroupForknet, "/data/forknet"),
+	)
+}
+
+// Slots already on disk record the real Core datadir. Rewriting them on parse
+// would point the next swap at a new empty directory and strand the chain and
+// wallets at the old path.
+func TestParsePreservesExistingSlotPaths(t *testing.T) {
+	c := ParseBitcoinConfig(`# bitwindow-datadir-default=/mnt/main
+# bitwindow-datadir-forknet=/mnt/fork-chain
+# bitwindow-datadir-drynet=/mnt/dry-chain
+
+chain=main
+`)
+	require.Equal(t, "/mnt/main", c.GetGroupDatadir(DatadirGroupDefault))
+	require.Equal(t, "/mnt/fork-chain", c.GetGroupDatadir(DatadirGroupForknet))
+	require.Equal(t, "/mnt/dry-chain", c.GetGroupDatadir(DatadirGroupDrynet))
+
+	require.Equal(t, c.Serialize(), ParseBitcoinConfig(c.Serialize()).Serialize(), "round-trip must be stable")
 }
 
 // The whole point of the suffix: even when the user points both groups at the
 // same folder, forknet and mainnet resolve to different bitcoind datadirs.
 func TestSameSlotPathStillSeparatesForknetFromMainnet(t *testing.T) {
+	const picked = "/Volumes/BTC"
 	c := NewBitcoinConfig()
-	c.SetGroupDatadir(DatadirGroupDefault, "/Volumes/BTC")
-	c.SetGroupDatadir(DatadirGroupForknet, "/Volumes/BTC")
+	for _, g := range []DatadirGroup{DatadirGroupDefault, DatadirGroupForknet, DatadirGroupDrynet} {
+		c.SetGroupDatadir(g, GroupDatadirForPick(g, picked))
+	}
 
 	mainnet := c.GetGroupDatadir(DatadirGroupDefault)
 	forknet := c.GetGroupDatadir(DatadirGroupForknet)
+	drynet := c.GetGroupDatadir(DatadirGroupDrynet)
 
-	require.NotEqual(t, mainnet, forknet)
+	require.Equal(t, picked, mainnet)
 	require.Equal(t, "/Volumes/BTC/forknet", forknet)
+	require.Equal(t, "/Volumes/BTC/drynet", drynet)
 
-	require.NotEqual(t,
-		BitcoinCoreDirs.DatadirNetwork(NetworkMainnet, mainnet),
-		BitcoinCoreDirs.DatadirNetwork(NetworkForknet, forknet),
-	)
+	resolved := map[string]bool{
+		BitcoinCoreDirs.DatadirNetwork(NetworkMainnet, mainnet): true,
+		BitcoinCoreDirs.DatadirNetwork(NetworkForknet, forknet): true,
+		BitcoinCoreDirs.DatadirNetwork(NetworkDrynet, drynet):   true,
+	}
+	require.Len(t, resolved, 3, "no two chain=main networks may share bitcoind's datadir")
 }
 
 // ---------------------------------------------------------------------------

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -563,9 +563,10 @@ func TestUpdateDataDirInactiveGroupLeavesActiveAlone(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(masterPath), 0755))
 	require.NoError(t, os.WriteFile(masterPath, []byte(m.Config.Serialize()), 0644))
 
-	require.NoError(t, m.UpdateDataDir("/picked/for/mainnet", NetworkMainnet))
+	picked := filepath.Join(tmpDir, "picked", "for", "mainnet")
+	require.NoError(t, m.UpdateDataDir(picked, NetworkMainnet))
 
-	require.Equal(t, "/picked/for/mainnet", m.Config.GetGroupDatadir(DatadirGroupDefault))
+	require.Equal(t, picked, m.Config.GetGroupDatadir(DatadirGroupDefault))
 	require.Equal(t, "/drynet/live", m.Config.GetSetting("datadir"), "active datadir must not change when setting inactive group")
 }
 
@@ -581,10 +582,11 @@ func TestUpdateDataDirActiveGroupUpdatesLive(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(masterPath), 0755))
 	require.NoError(t, os.WriteFile(masterPath, []byte(m.Config.Serialize()), 0644))
 
-	require.NoError(t, m.UpdateDataDir("/picked/for/mainnet", NetworkMainnet))
+	picked := filepath.Join(tmpDir, "picked", "for", "mainnet")
+	require.NoError(t, m.UpdateDataDir(picked, NetworkMainnet))
 
-	require.Equal(t, "/picked/for/mainnet", m.Config.GetGroupDatadir(DatadirGroupDefault))
-	require.Equal(t, "/picked/for/mainnet", m.Config.GetSetting("datadir"))
+	require.Equal(t, picked, m.Config.GetGroupDatadir(DatadirGroupDefault))
+	require.Equal(t, picked, m.Config.GetSetting("datadir"))
 }
 
 // Manual edit: rewrite datadir= directly on disk, reload, swap to drynet —
@@ -608,7 +610,7 @@ func TestSwapAdoptsManuallyEditedDatadirIntoSlot(t *testing.T) {
 	require.NoError(t, m.UpdateNetwork(NetworkDrynet))
 
 	require.Equal(t, "/manually/edited", m.Config.GetGroupDatadir(DatadirGroupDefault))
-	require.Equal(t, "/drynet/path", m.Config.GetSetting("datadir"))
+	require.Equal(t, "/drynet/path/drynet", m.Config.GetSetting("datadir"))
 }
 
 // Within-group swap (mainnet ↔ signet) leaves datadir= alone and writes no
@@ -808,7 +810,7 @@ chain=signet
 
 	out := c.Serialize()
 	require.Contains(t, out, "# bitwindow-datadir-default=/Volumes/SSD/bitcoin\n")
-	require.Contains(t, out, "# bitwindow-datadir-drynet=/new/drynet/path\n")
+	require.Contains(t, out, "# bitwindow-datadir-drynet=/new/drynet/path/drynet\n")
 
 	// Stable order: default before drynet
 	defIdx := strings.Index(out, "# bitwindow-datadir-default=")
@@ -818,13 +820,13 @@ chain=signet
 	// Re-parse, values stable
 	c2 := ParseBitcoinConfig(out)
 	require.Equal(t, "/Volumes/SSD/bitcoin", c2.GetGroupDatadir(DatadirGroupDefault))
-	require.Equal(t, "/new/drynet/path", c2.GetGroupDatadir(DatadirGroupDrynet))
+	require.Equal(t, "/new/drynet/path/drynet", c2.GetGroupDatadir(DatadirGroupDrynet))
 }
 
 func TestDatadirSlotsClearedOnEmpty(t *testing.T) {
 	c := NewBitcoinConfig()
 	c.SetGroupDatadir(DatadirGroupDrynet, "/some/path")
-	require.Equal(t, "/some/path", c.GetGroupDatadir(DatadirGroupDrynet))
+	require.Equal(t, "/some/path/drynet", c.GetGroupDatadir(DatadirGroupDrynet))
 	c.SetGroupDatadir(DatadirGroupDrynet, "")
 	require.Equal(t, "", c.GetGroupDatadir(DatadirGroupDrynet))
 
@@ -838,6 +840,33 @@ func TestDatadirGroupForNetwork(t *testing.T) {
 	require.Equal(t, DatadirGroupDefault, DatadirGroupForNetwork(NetworkTestnet))
 	require.Equal(t, DatadirGroupDefault, DatadirGroupForNetwork(NetworkRegtest))
 	require.Equal(t, DatadirGroupDrynet, DatadirGroupForNetwork(NetworkDrynet))
+}
+
+func TestNormalizeGroupDatadir(t *testing.T) {
+	require.Equal(t, "/x/forknet", NormalizeGroupDatadir(DatadirGroupForknet, "/x"))
+	require.Equal(t, "/x/forknet", NormalizeGroupDatadir(DatadirGroupForknet, "/x/forknet"), "idempotent")
+	require.Equal(t, "/x/forknet", NormalizeGroupDatadir(DatadirGroupForknet, "/x/forknet/"), "trailing slash")
+	require.Equal(t, "/x", NormalizeGroupDatadir(DatadirGroupDefault, "/x"), "default group untouched")
+	require.Equal(t, "", NormalizeGroupDatadir(DatadirGroupForknet, ""))
+}
+
+// The whole point of the suffix: even when the user points both groups at the
+// same folder, forknet and mainnet resolve to different bitcoind datadirs.
+func TestSameSlotPathStillSeparatesForknetFromMainnet(t *testing.T) {
+	c := NewBitcoinConfig()
+	c.SetGroupDatadir(DatadirGroupDefault, "/Volumes/BTC")
+	c.SetGroupDatadir(DatadirGroupForknet, "/Volumes/BTC")
+
+	mainnet := c.GetGroupDatadir(DatadirGroupDefault)
+	forknet := c.GetGroupDatadir(DatadirGroupForknet)
+
+	require.NotEqual(t, mainnet, forknet)
+	require.Equal(t, "/Volumes/BTC/forknet", forknet)
+
+	require.NotEqual(t,
+		BitcoinCoreDirs.DatadirNetwork(NetworkMainnet, mainnet),
+		BitcoinCoreDirs.DatadirNetwork(NetworkForknet, forknet),
+	)
 }
 
 // ---------------------------------------------------------------------------

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -140,6 +140,8 @@ func TestWipeChainDataPreservesWallets(t *testing.T) {
 // wipe mainnet's directory and deleted its blocks/ and chainstate/.
 func TestWipeStaleChainDataNeverTouchesAnotherNetworksDatadir(t *testing.T) {
 	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
 	mainnetDir := filepath.Join(tmpDir, "mainnet-chain")
 	seed := func(path string) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
@@ -154,7 +156,7 @@ func TestWipeStaleChainDataNeverTouchesAnotherNetworksDatadir(t *testing.T) {
 	m.Config.SetSetting("datadir", mainnetDir)
 	m.Config.SetGroupDatadir(DatadirGroupDefault, mainnetDir)
 
-	m.wipeStaleChainData(m.Config, []Network{NetworkForknet})
+	require.NoError(t, m.wipeStaleChainData(m.Config, []Network{NetworkForknet}))
 
 	// The wipe is asynchronous; give a buggy one time to land.
 	require.Never(t, func() bool {
@@ -186,7 +188,7 @@ func TestWipeStaleChainDataUsesTargetNetworkSlot(t *testing.T) {
 	m.Config.SetGroupDatadir(DatadirGroupDefault, mainnetDir)
 	m.Config.SetGroupDatadir(DatadirGroupForknet, forknetDir)
 
-	m.wipeStaleChainData(m.Config, []Network{NetworkForknet})
+	require.NoError(t, m.wipeStaleChainData(m.Config, []Network{NetworkForknet}))
 
 	require.Eventually(t, func() bool {
 		_, err := os.Stat(filepath.Join(forknetDir, "blocks"))
@@ -195,6 +197,40 @@ func TestWipeStaleChainDataUsesTargetNetworkSlot(t *testing.T) {
 
 	_, err := os.Stat(filepath.Join(mainnetDir, "blocks", "blk00000.dat"))
 	require.NoError(t, err, "mainnet chain data must be untouched")
+}
+
+// On the boot that runs migrations m.Network is still the CLI/build seed, so
+// trusting it pointed a signet wipe at the live forknet datadir.
+func TestWipeStaleChainDataResolvesActiveGroupFromConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	forknetDir := filepath.Join(tmpDir, "forknet-chain")
+	signetDir := filepath.Join(tmpDir, "signet-slot")
+	seed := func(path string) {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("stub"), 0o644))
+	}
+	seed(filepath.Join(forknetDir, "blocks", "blk00000.dat"))
+	seed(filepath.Join(signetDir, "signet", "blocks", "blk00000.dat"))
+
+	m := newTestManager(tmpDir)
+	m.Network = NetworkSignet
+	m.Config.SetSetting("chain", "main")
+	m.Config.SetSetting("drivechain", "1", "main")
+	m.Config.SetSetting("datadir", forknetDir)
+	m.Config.SetGroupDatadir(DatadirGroupForknet, forknetDir)
+	m.Config.SetGroupDatadir(DatadirGroupDefault, signetDir)
+
+	require.NoError(t, m.wipeStaleChainData(m.Config, []Network{NetworkSignet}))
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(filepath.Join(signetDir, "signet", "blocks"))
+		return os.IsNotExist(err)
+	}, 5*time.Second, 20*time.Millisecond, "signet's recorded slot should be wiped")
+
+	_, err := os.Stat(filepath.Join(forknetDir, "blocks", "blk00000.dat"))
+	require.NoError(t, err, "the live forknet datadir must be untouched")
 }
 
 // For the active group the live datadir= is what bitcoind is running on. A
@@ -217,7 +253,7 @@ func TestWipeStaleChainDataPrefersLiveDatadirForActiveGroup(t *testing.T) {
 	m.Config.SetGroupDatadir(DatadirGroupDefault, staleDir)
 	m.Config.SetSetting("datadir", liveDir)
 
-	m.wipeStaleChainData(m.Config, []Network{NetworkSignet})
+	require.NoError(t, m.wipeStaleChainData(m.Config, []Network{NetworkSignet}))
 
 	require.Eventually(t, func() bool {
 		_, err := os.Stat(filepath.Join(liveDir, "signet", "blocks"))

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -134,6 +134,69 @@ func TestWipeChainDataPreservesWallets(t *testing.T) {
 	}
 }
 
+// Regression: a migration armed for forknet, applied while the user is sitting
+// on mainnet, must not touch mainnet's chain. CoreSectionForNetwork(forknet) is
+// "main", so resolving the datadir from the live `datadir=` line handed the
+// wipe mainnet's directory and deleted its blocks/ and chainstate/.
+func TestWipeStaleChainDataNeverTouchesAnotherNetworksDatadir(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainnetDir := filepath.Join(tmpDir, "mainnet-chain")
+	seed := func(path string) {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("stub"), 0o644))
+	}
+	seed(filepath.Join(mainnetDir, "blocks", "blk00000.dat"))
+	seed(filepath.Join(mainnetDir, "chainstate", "CURRENT"))
+
+	m := newTestManager(tmpDir)
+	m.Network = NetworkMainnet
+	m.Config.SetSetting("chain", "main")
+	m.Config.SetSetting("datadir", mainnetDir)
+	m.Config.SetGroupDatadir(DatadirGroupDefault, mainnetDir)
+
+	m.wipeStaleChainData(m.Config, []Network{NetworkForknet})
+
+	// The wipe is asynchronous; give a buggy one time to land.
+	require.Never(t, func() bool {
+		_, err := os.Stat(filepath.Join(mainnetDir, "blocks", "blk00000.dat"))
+		return os.IsNotExist(err)
+	}, 500*time.Millisecond, 50*time.Millisecond, "mainnet chain data must survive a forknet-targeted wipe")
+
+	_, err := os.Stat(filepath.Join(mainnetDir, "chainstate", "CURRENT"))
+	require.NoError(t, err, "mainnet chainstate must survive a forknet-targeted wipe")
+}
+
+// With a forknet slot recorded, the wipe resolves to that path — not the live
+// mainnet one — and does delete forknet's chain.
+func TestWipeStaleChainDataUsesTargetNetworkSlot(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainnetDir := filepath.Join(tmpDir, "mainnet-chain")
+	forknetDir := filepath.Join(tmpDir, "forknet-chain", "forknet")
+	seed := func(path string) {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("stub"), 0o644))
+	}
+	seed(filepath.Join(mainnetDir, "blocks", "blk00000.dat"))
+	seed(filepath.Join(forknetDir, "blocks", "blk00000.dat"))
+
+	m := newTestManager(tmpDir)
+	m.Network = NetworkMainnet
+	m.Config.SetSetting("chain", "main")
+	m.Config.SetSetting("datadir", mainnetDir)
+	m.Config.SetGroupDatadir(DatadirGroupDefault, mainnetDir)
+	m.Config.SetGroupDatadir(DatadirGroupForknet, forknetDir)
+
+	m.wipeStaleChainData(m.Config, []Network{NetworkForknet})
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(filepath.Join(forknetDir, "blocks"))
+		return os.IsNotExist(err)
+	}, 5*time.Second, 20*time.Millisecond, "forknet chain data should be wiped")
+
+	_, err := os.Stat(filepath.Join(mainnetDir, "blocks", "blk00000.dat"))
+	require.NoError(t, err, "mainnet chain data must be untouched")
+}
+
 // The wipe runs entirely in the background and returns immediately so a large,
 // slow, or unresponsive datadir can't block orchestrator startup — that stall
 // is what kept the RPC listener down past the frontend's readiness timeout. The

--- a/sidechain-orchestrator/orchestrator_test.go
+++ b/sidechain-orchestrator/orchestrator_test.go
@@ -39,6 +39,13 @@ func newTestProcessManager(t *testing.T) (*ProcessManager, string) {
 	dir := t.TempDir()
 	log := testLogger(t)
 	pm := NewProcessManager(dir, NewPidFileManager(dir, log), log)
+	t.Cleanup(func() {
+		running := pm.ListRunning()
+		_ = pm.StopAll(context.Background(), true)
+		for _, name := range running {
+			pm.WaitForExit(name, 5*time.Second)
+		}
+	})
 	return pm, dir
 }
 

--- a/sidechain-orchestrator/process.go
+++ b/sidechain-orchestrator/process.go
@@ -423,18 +423,16 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 	go func() {
 		err := cmd.Wait()
 
-		// Wait for stdout/stderr to drain (like Dart's Future.wait with 2s timeout)
-		drainTimeout := time.After(2 * time.Second)
-		select {
-		case <-stdoutDone:
-		case <-drainTimeout:
-			pm.log.Warn().Str("binary", processName).Msg("timed out waiting for stdout to drain")
-		}
-		select {
-		case <-stderrDone:
-		case <-drainTimeout:
-			pm.log.Warn().Str("binary", processName).Msg("timed out waiting for stderr to drain")
-		}
+		// A descendant that inherited the pipes keeps the readers blocked past the
+		// child's exit, so closing them is what bounds the drain.
+		drain := time.AfterFunc(2*time.Second, func() {
+			stdout.Close()
+			stderr.Close()
+			pm.log.Warn().Str("binary", processName).Msg("timed out waiting for output to drain")
+		})
+		<-stdoutDone
+		<-stderrDone
+		drain.Stop()
 
 		proc.mu.Lock()
 		if err != nil {

--- a/sidechain-orchestrator/process.go
+++ b/sidechain-orchestrator/process.go
@@ -289,17 +289,28 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 
 	configureProcessAttr(cmd)
 
-	stdout, err := cmd.StdoutPipe()
+	// Own the pipes rather than using cmd.StdoutPipe: cmd.Wait closes those the
+	// moment the child exits, discarding whatever the readers hadn't drained yet.
+	stdout, stdoutW, err := os.Pipe()
 	if err != nil {
 		return 0, fmt.Errorf("stdout pipe: %w", err)
 	}
-	stderr, err := cmd.StderrPipe()
+	stderr, stderrW, err := os.Pipe()
 	if err != nil {
+		stdout.Close()
+		stdoutW.Close()
 		return 0, fmt.Errorf("stderr pipe: %w", err)
 	}
+	cmd.Stdout = stdoutW
+	cmd.Stderr = stderrW
 
-	if err := cmd.Start(); err != nil {
-		return 0, fmt.Errorf("start %s: %w", processName, err)
+	startErr := cmd.Start()
+	stdoutW.Close()
+	stderrW.Close()
+	if startErr != nil {
+		stdout.Close()
+		stderr.Close()
+		return 0, fmt.Errorf("start %s: %w", processName, startErr)
 	}
 
 	runtimeConfig := config
@@ -363,6 +374,7 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 	stdoutDone := make(chan struct{})
 	go func() {
 		defer close(stdoutDone)
+		defer stdout.Close()
 		scanner := bufio.NewScanner(stdout)
 		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
 		for scanner.Scan() {
@@ -383,6 +395,7 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 	stderrDone := make(chan struct{})
 	go func() {
 		defer close(stderrDone)
+		defer stderr.Close()
 		scanner := bufio.NewScanner(stderr)
 		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
 		for scanner.Scan() {
@@ -488,8 +501,6 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 			Line:      fmt.Sprintf("=== %s exited (code %d) ===", processName, exitCode),
 		})
 
-		close(proc.exitCh)
-
 		pm.mu.Lock()
 		delete(pm.processes, processName)
 		pm.lastExited[processName] = proc
@@ -502,6 +513,9 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 			Int("pid", proc.Pid).
 			Int("exit_code", exitCode).
 			Msg("process exited")
+
+		// Closed last so a waiter sees the drained logs and the recorded exit.
+		close(proc.exitCh)
 
 		// Notify the orchestrator so it can update ConnectionMonitor
 		if pm.OnExit != nil {

--- a/sidechain-orchestrator/process_test.go
+++ b/sidechain-orchestrator/process_test.go
@@ -83,6 +83,24 @@ func TestProcessManager_LatestRunKeepsExitedLogs(t *testing.T) {
 	assert.True(t, sawReindex, "logs the process died with must survive its removal")
 }
 
+// A descendant inheriting stdout and stderr outlives the child, so the drain has
+// to be bounded or the exit is never recorded and the name can't be restarted.
+func TestProcessManager_ExitRecordedWhenDescendantHoldsPipes(t *testing.T) {
+	pm, dir := newTestProcessManager(t)
+	symlinkSystemBinary(t, dir, "sh")
+
+	_, _ = pm.Start(context.Background(), BinaryConfig{
+		Name: "sh-daemon", BinaryName: "sh",
+	}, []string{"-c", "sleep 20 & echo spawned; exit 0"}, nil)
+
+	require.Eventually(t, func() bool {
+		_, ok := pm.LastExit("sh-daemon")
+		return ok
+	}, 10*time.Second, 100*time.Millisecond, "the exit must be recorded even while a descendant holds the pipes")
+
+	assert.False(t, pm.IsRunning("sh-daemon"))
+}
+
 func TestProcessManager_StopNotRunning(t *testing.T) {
 	pm, _ := newTestProcessManager(t)
 	assert.Error(t, pm.Stop(context.Background(), "nonexistent", false))

--- a/sidechain-orchestrator/process_test.go
+++ b/sidechain-orchestrator/process_test.go
@@ -59,6 +59,7 @@ func TestProcessManager_LatestRunKeepsExitedLogs(t *testing.T) {
 	pm, dir := newTestProcessManager(t)
 	symlinkSystemBinary(t, dir, "sh")
 
+	// Start reports the immediate exit; the point here is the logs outliving it.
 	_, _ = pm.Start(context.Background(), BinaryConfig{
 		Name: "sh-test", BinaryName: "sh",
 	}, []string{"-c", "echo Please restart with -reindex; exit 1"}, nil)

--- a/sidechain-orchestrator/swap_network_test.go
+++ b/sidechain-orchestrator/swap_network_test.go
@@ -35,15 +35,51 @@ func TestSwapNetwork_CrossGroupPreservesDatadirs(t *testing.T) {
 	// Mainnet → drynet (cross-group): live datadir flips to drynet's,
 	// default slot retains the mainnet datadir.
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkDrynet))
-	require.Equal(t, "/tmp/group-drynet", o.BitcoinConf.Config.GetSetting("datadir"))
+	require.Equal(t, "/tmp/group-drynet/drynet", o.BitcoinConf.Config.GetSetting("datadir"))
 	require.Equal(t, "/tmp/group-default", o.BitcoinConf.Config.GetGroupDatadir(config.DatadirGroupDefault))
-	require.Equal(t, "/tmp/group-drynet", o.BitcoinConf.Config.GetGroupDatadir(config.DatadirGroupDrynet))
+	require.Equal(t, "/tmp/group-drynet/drynet", o.BitcoinConf.Config.GetGroupDatadir(config.DatadirGroupDrynet))
 
 	// Drynet → mainnet (cross-group back): default slot restored, drynet
 	// slot retained for the next swap.
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
 	require.Equal(t, "/tmp/group-default", o.BitcoinConf.Config.GetSetting("datadir"))
-	require.Equal(t, "/tmp/group-drynet", o.BitcoinConf.Config.GetGroupDatadir(config.DatadirGroupDrynet))
+	require.Equal(t, "/tmp/group-drynet/drynet", o.BitcoinConf.Config.GetGroupDatadir(config.DatadirGroupDrynet))
+}
+
+// Regression: mainnet, forknet and drynet all run on chain=main, so Core
+// writes blocks/ and chainstate/ to the root of the datadir for each of them.
+// A user who picks the same folder for every group used to have bitcoind boot
+// one chain on top of another's chainstate and reindex over it. The per-group
+// suffix is what keeps them apart.
+func TestSwapNetwork_SamePickedPathKeepsChainsApart(t *testing.T) {
+	o := newTestOrchestrator(t)
+	require.NotNil(t, o.BitcoinConf)
+
+	const picked = "/tmp/one-and-only-datadir"
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupDefault, picked)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupForknet, picked)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupDrynet, picked)
+	o.BitcoinConf.Config.SetSetting("datadir", picked)
+	require.NoError(t, o.BitcoinConf.SaveConfig())
+	require.NoError(t, o.BitcoinConf.LoadConfig(false))
+
+	resolve := func(n config.Network) string {
+		require.NoError(t, o.SwapNetwork(context.Background(), n))
+		return config.BitcoinCoreDirs.DatadirNetwork(n, o.BitcoinConf.Config.GetSetting("datadir"))
+	}
+
+	mainnetDir := resolve(config.NetworkMainnet)
+	forknetDir := resolve(config.NetworkForknet)
+	drynetDir := resolve(config.NetworkDrynet)
+
+	require.Equal(t, picked, mainnetDir)
+	require.Equal(t, filepath.Join(picked, "forknet"), forknetDir)
+	require.Equal(t, filepath.Join(picked, "drynet"), drynetDir)
+	require.Len(t, map[string]bool{mainnetDir: true, forknetDir: true, drynetDir: true}, 3,
+		"no two chain=main networks may share bitcoind's datadir")
+
+	// Swapping back must restore mainnet's root, not leave it under a subdir.
+	require.Equal(t, picked, resolve(config.NetworkMainnet))
 }
 
 // Within-group swap (mainnet → signet) leaves the datadir alone — Bitcoin

--- a/sidechain-orchestrator/swap_network_test.go
+++ b/sidechain-orchestrator/swap_network_test.go
@@ -35,15 +35,15 @@ func TestSwapNetwork_CrossGroupPreservesDatadirs(t *testing.T) {
 	// Mainnet → drynet (cross-group): live datadir flips to drynet's,
 	// default slot retains the mainnet datadir.
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkDrynet))
-	require.Equal(t, "/tmp/group-drynet/drynet", o.BitcoinConf.Config.GetSetting("datadir"))
+	require.Equal(t, "/tmp/group-drynet", o.BitcoinConf.Config.GetSetting("datadir"))
 	require.Equal(t, "/tmp/group-default", o.BitcoinConf.Config.GetGroupDatadir(config.DatadirGroupDefault))
-	require.Equal(t, "/tmp/group-drynet/drynet", o.BitcoinConf.Config.GetGroupDatadir(config.DatadirGroupDrynet))
+	require.Equal(t, "/tmp/group-drynet", o.BitcoinConf.Config.GetGroupDatadir(config.DatadirGroupDrynet))
 
 	// Drynet → mainnet (cross-group back): default slot restored, drynet
 	// slot retained for the next swap.
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
 	require.Equal(t, "/tmp/group-default", o.BitcoinConf.Config.GetSetting("datadir"))
-	require.Equal(t, "/tmp/group-drynet/drynet", o.BitcoinConf.Config.GetGroupDatadir(config.DatadirGroupDrynet))
+	require.Equal(t, "/tmp/group-drynet", o.BitcoinConf.Config.GetGroupDatadir(config.DatadirGroupDrynet))
 }
 
 // Regression: mainnet, forknet and drynet all run on chain=main, so Core
@@ -56,9 +56,9 @@ func TestSwapNetwork_SamePickedPathKeepsChainsApart(t *testing.T) {
 	require.NotNil(t, o.BitcoinConf)
 
 	const picked = "/tmp/one-and-only-datadir"
-	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupDefault, picked)
-	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupForknet, picked)
-	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupDrynet, picked)
+	for _, g := range []config.DatadirGroup{config.DatadirGroupDefault, config.DatadirGroupForknet, config.DatadirGroupDrynet} {
+		o.BitcoinConf.Config.SetGroupDatadir(g, config.GroupDatadirForPick(g, picked))
+	}
 	o.BitcoinConf.Config.SetSetting("datadir", picked)
 	require.NoError(t, o.BitcoinConf.SaveConfig())
 	require.NoError(t, o.BitcoinConf.LoadConfig(false))

--- a/thunder/pubspec.lock
+++ b/thunder/pubspec.lock
@@ -1382,5 +1382,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: "3.12.0"
-  flutter: "3.44.0"
+  dart: "3.12.2"
+  flutter: "3.44.8"

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -5,8 +5,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.283
 
 environment:
-  sdk: 3.12.0
-  flutter: 3.44.0
+  sdk: 3.12.2
+  flutter: 3.44.8
 
 dependencies:
   flutter:

--- a/truthcoin/pubspec.lock
+++ b/truthcoin/pubspec.lock
@@ -1382,5 +1382,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: "3.12.0"
-  flutter: "3.44.0"
+  dart: "3.12.2"
+  flutter: "3.44.8"

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -5,8 +5,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.154
 
 environment:
-  sdk: 3.12.0
-  flutter: 3.44.0
+  sdk: 3.12.2
+  flutter: 3.44.8
 
 dependencies:
   flutter:

--- a/zside/pubspec.lock
+++ b/zside/pubspec.lock
@@ -1382,5 +1382,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: "3.12.0"
-  flutter: "3.44.0"
+  dart: "3.12.2"
+  flutter: "3.44.8"

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -5,8 +5,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.281
 
 environment:
-  sdk: 3.12.0
-  flutter: 3.44.0
+  sdk: 3.12.2
+  flutter: 3.44.8
 
 dependencies:
   flutter:


### PR DESCRIPTION
mainnet, forknet and drynet all run `chain=main`, so Core writes `blocks/` and `chainstate/` to the datadir root for each. Nothing stopped a user pointing two groups at the same folder — Core then loaded the other chain's chainstate and reindexed over it. Non-default groups now get a forced `/<group>` suffix.

Separately, `wipeStaleChainData` resolved its target from the live `datadir=` line, which belongs to whichever group is active. `CoreSectionForNetwork(drynet)` is `main`, so a drynet-armed migration applied while the user sat on mainnet deleted mainnet's blocks. It now resolves from the target network's own slot, and skips rather than guessing.