### PR TITLE
cherry pick giaki bugs

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.282
+version: 1.0.283
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.282
+version: 1.0.283
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/lib/pages/message_signer.dart
+++ b/bitwindow/lib/pages/message_signer.dart
@@ -65,7 +65,7 @@ class _SignMessageTabState extends State<SignMessageTab> {
       final walletId = _walletReader.activeWalletId;
       if (walletId == null) throw Exception('No active wallet');
 
-      final signature = await _wallet.signMessage(walletId, _messageController.text);
+      final signature = await _wallet.signMessage(walletId, _messageController.text, _addressController.text);
       setState(() {
         _signatureController.text = signature;
       });

--- a/bitwindow/lib/providers/transactions_provider.dart
+++ b/bitwindow/lib/providers/transactions_provider.dart
@@ -46,6 +46,10 @@ class TransactionProvider extends ChangeNotifier implements NetworkScoped {
   bool _isFetching = false;
   Timer? _fetchTimer; // Timer to periodically fetch transactions
 
+  // A recreated transport abandons in-flight requests without ever completing
+  // their futures, which would latch _isFetching for the rest of the session.
+  static const _fetchTimeout = Duration(seconds: 30);
+
   TransactionProvider() {
     balanceProvider.addListener(fetch);
     blockchainProvider.addListener(fetch);
@@ -229,7 +233,7 @@ class TransactionProvider extends ChangeNotifier implements NetworkScoped {
           );
           return false;
         }(),
-      ]);
+      ]).timeout(_fetchTimeout);
 
       // If any update returned true, notify listeners
       if (results.any((changed) => changed) || error != null) {

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.141
+version: 0.2.142
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -576,12 +576,17 @@ func (s *Server) GetSyncInfo(ctx context.Context, req *connect.Request[emptypb.E
 		}), nil
 	}
 
+	var syncProgress float64
+	if tip.Blocks > 0 {
+		syncProgress = float64(processedTip.Height) / float64(tip.Blocks)
+	}
+
 	return connect.NewResponse(&pb.GetSyncInfoResponse{
 		TipBlockHeight:      int64(processedTip.Height),
 		TipBlockTime:        processedTip.ProcessedAt.Unix(),
 		TipBlockHash:        processedTip.Hash.String(),
 		TipBlockProcessedAt: timestamppb.New(processedTip.ProcessedAt),
-		SyncProgress:        float64(processedTip.Height) / float64(tip.Blocks),
+		SyncProgress:        syncProgress,
 		HeaderHeight:        int64(tip.Headers),
 	}), nil
 }

--- a/bitwindow/server/api/wallet/sign_message_test.go
+++ b/bitwindow/server/api/wallet/sign_message_test.go
@@ -142,15 +142,24 @@ func TestDeriveMessageSigningPrivateKeyHandlesTaproot(t *testing.T) {
 	expected, err := key.ECPrivKey()
 	require.NoError(t, err)
 
-	// Standard wallet: taproot comes alongside segwit off the same seed.
-	privKeyHex, err := deriveMessageSigningPrivateKey(signingWallet(0, ""), chainParams, taproot.EncodeAddress())
-	require.NoError(t, err)
-	require.Equal(t, hex.EncodeToString(expected.Serialize()), privKeyHex)
+	// The key must be tweaked: an untweaked internal key signs for a pubkey the
+	// address does not commit to, so the signature proves nothing about it.
+	tweaked := txscript.TweakTaprootPrivKey(*expected, []byte{})
+	require.NotEqual(t, hex.EncodeToString(expected.Serialize()), hex.EncodeToString(tweaked.Serialize()))
+	require.Equal(t,
+		taproot.ScriptAddress(),
+		schnorr.SerializePubKey(tweaked.PubKey()),
+		"tweaked key must match the address's witness program",
+	)
 
-	// Taproot-only wallet: the explicit m/86' path is its single kind.
-	privKeyHex, err = deriveMessageSigningPrivateKey(signingWallet(0, "m/86'/1'/0'"), chainParams, taproot.EncodeAddress())
-	require.NoError(t, err)
-	require.Equal(t, hex.EncodeToString(expected.Serialize()), privKeyHex)
+	for _, wallet := range []*engines.WalletInfo{
+		signingWallet(0, ""),            // taproot comes alongside segwit off one seed
+		signingWallet(0, "m/86'/1'/0'"), // explicit m/86' path is its single kind
+	} {
+		privKeyHex, err := deriveMessageSigningPrivateKey(wallet, chainParams, taproot.EncodeAddress())
+		require.NoError(t, err)
+		require.Equal(t, hex.EncodeToString(tweaked.Serialize()), privKeyHex)
+	}
 }
 
 // The enforcer's Secp256K1Sign takes a common.Hex message, so plaintext has to be

--- a/bitwindow/server/api/wallet/sign_message_test.go
+++ b/bitwindow/server/api/wallet/sign_message_test.go
@@ -17,9 +17,12 @@ import (
 	cryptov1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/crypto/v1"
 	cryptorpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/crypto/v1/cryptov1connect"
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -71,7 +74,7 @@ func TestDeriveMessageSigningPrivateKey(t *testing.T) {
 
 	chainParams := &chaincfg.SigNetParams
 
-	for _, index := range []uint32{0, 3, messageSigningGapLimit - 1} {
+	for _, index := range []uint32{0, 3, addressScanDepth - 1} {
 		expected := deriveAddressKey(t, chainParams, 1, 0, index)
 
 		privKeyHex, err := deriveMessageSigningPrivateKey(
@@ -86,7 +89,7 @@ func TestDeriveMessageSigningPrivateKey(t *testing.T) {
 
 	// An address past the gap limit, or one from another wallet entirely, has no
 	// key here - signing it would be a lie.
-	beyondGap := deriveAddressKey(t, chainParams, 1, 0, messageSigningGapLimit)
+	beyondGap := deriveAddressKey(t, chainParams, 1, 0, addressScanDepth)
 	_, err := deriveMessageSigningPrivateKey(
 		signingWallet(0, ""), chainParams, addressOf(t, beyondGap, chainParams),
 	)
@@ -124,15 +127,30 @@ func TestDeriveMessageSigningPrivateKeyHonorsAccount(t *testing.T) {
 	require.ErrorContains(t, err, "not one of the wallet")
 }
 
-// Taproot-only wallets have no P2WPKH addresses, so this must say so instead of
-// handing back a key for an address the wallet never shows.
-func TestDeriveMessageSigningPrivateKeyRejectsNonBIP84(t *testing.T) {
+// Default wallets import BIP84 and BIP86 descriptors, and the receive UI hands
+// out both, so a taproot address must be signable too.
+func TestDeriveMessageSigningPrivateKeyHandlesTaproot(t *testing.T) {
 	t.Parallel()
 
-	_, err := deriveMessageSigningPrivateKey(
-		signingWallet(0, "m/86'/1'/0'"), &chaincfg.SigNetParams, "whatever",
-	)
-	require.ErrorContains(t, err, "P2WPKH")
+	chainParams := &chaincfg.SigNetParams
+
+	key := deriveKeyAtPurpose(t, chainParams, 86, 1, 0, 0)
+	tapKey := txscript.ComputeTaprootKeyNoScript(pubKeyOf(t, key))
+	taproot, err := btcutil.NewAddressTaproot(schnorr.SerializePubKey(tapKey), chainParams)
+	require.NoError(t, err)
+
+	expected, err := key.ECPrivKey()
+	require.NoError(t, err)
+
+	// Standard wallet: taproot comes alongside segwit off the same seed.
+	privKeyHex, err := deriveMessageSigningPrivateKey(signingWallet(0, ""), chainParams, taproot.EncodeAddress())
+	require.NoError(t, err)
+	require.Equal(t, hex.EncodeToString(expected.Serialize()), privKeyHex)
+
+	// Taproot-only wallet: the explicit m/86' path is its single kind.
+	privKeyHex, err = deriveMessageSigningPrivateKey(signingWallet(0, "m/86'/1'/0'"), chainParams, taproot.EncodeAddress())
+	require.NoError(t, err)
+	require.Equal(t, hex.EncodeToString(expected.Serialize()), privKeyHex)
 }
 
 // The enforcer's Secp256K1Sign takes a common.Hex message, so plaintext has to be
@@ -214,4 +232,30 @@ func TestSignMessageHexEncodesMessage(t *testing.T) {
 	expectedKey, err := deriveMessageSigningPrivateKey(wallet, &chaincfg.SigNetParams, address)
 	require.NoError(t, err)
 	require.Equal(t, expectedKey, signed.SecretKey.Hex.Value)
+}
+
+// deriveKeyAtPurpose walks m/purpose'/coin'/account'/0/index.
+func deriveKeyAtPurpose(t *testing.T, chainParams *chaincfg.Params, purpose, coin, account, index uint32) *hdkeychain.ExtendedKey {
+	t.Helper()
+
+	seed, err := hex.DecodeString(testSeedHex)
+	require.NoError(t, err)
+
+	key, err := hdkeychain.NewMaster(seed, chainParams)
+	require.NoError(t, err)
+
+	const h = hdkeychain.HardenedKeyStart
+	for _, child := range []uint32{h + purpose, h + coin, h + account, 0, index} {
+		key, err = key.Derive(child)
+		require.NoError(t, err)
+	}
+	return key
+}
+
+func pubKeyOf(t *testing.T, key *hdkeychain.ExtendedKey) *btcec.PublicKey {
+	t.Helper()
+
+	pubKey, err := key.ECPubKey()
+	require.NoError(t, err)
+	return pubKey
 }

--- a/bitwindow/server/api/wallet/sign_message_test.go
+++ b/bitwindow/server/api/wallet/sign_message_test.go
@@ -259,3 +259,44 @@ func pubKeyOf(t *testing.T, key *hdkeychain.ExtendedKey) *btcec.PublicKey {
 	require.NoError(t, err)
 	return pubKey
 }
+
+// Electrum wallets can sit at m/44' or m/49', and the stored wallet does not say
+// which, so those addresses must resolve too.
+func TestDeriveMessageSigningPrivateKeyHandlesLegacyAndNested(t *testing.T) {
+	t.Parallel()
+
+	chainParams := &chaincfg.SigNetParams
+
+	for _, tc := range []struct {
+		purpose uint32
+		path    string
+		address func(*testing.T, *btcec.PublicKey) string
+	}{
+		{44, "m/44'/1'/0'", func(t *testing.T, pub *btcec.PublicKey) string {
+			addr, err := btcutil.NewAddressPubKeyHash(btcutil.Hash160(pub.SerializeCompressed()), chainParams)
+			require.NoError(t, err)
+			return addr.EncodeAddress()
+		}},
+		{49, "m/49'/1'/0'", func(t *testing.T, pub *btcec.PublicKey) string {
+			witness, err := btcutil.NewAddressWitnessPubKeyHash(btcutil.Hash160(pub.SerializeCompressed()), chainParams)
+			require.NoError(t, err)
+			redeem, err := txscript.PayToAddrScript(witness)
+			require.NoError(t, err)
+			addr, err := btcutil.NewAddressScriptHash(redeem, chainParams)
+			require.NoError(t, err)
+			return addr.EncodeAddress()
+		}},
+	} {
+		key := deriveKeyAtPurpose(t, chainParams, tc.purpose, 1, 0, 0)
+		address := tc.address(t, pubKeyOf(t, key))
+
+		expected, err := key.ECPrivKey()
+		require.NoError(t, err)
+
+		for _, wallet := range []*engines.WalletInfo{signingWallet(0, ""), signingWallet(0, tc.path)} {
+			privKeyHex, err := deriveMessageSigningPrivateKey(wallet, chainParams, address)
+			require.NoError(t, err)
+			require.Equal(t, hex.EncodeToString(expected.Serialize()), privKeyHex)
+		}
+	}
+}

--- a/bitwindow/server/api/wallet/sign_message_test.go
+++ b/bitwindow/server/api/wallet/sign_message_test.go
@@ -1,0 +1,64 @@
+package api_wallet
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+// The signing key must be the wallet's own key material - an empty/absent secret
+// key makes the enforcer's Secp256K1Sign call fail, so SignMessage never works.
+func TestDeriveMessageSigningPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	const seedHex = "0329e77e27d1e24336be53d25a897e92e67b5ec7e88eca7529b14e3ffd9168a247b6906469fb8a79ecb25ec077e033f6b567d5d9b0ae334f1e33457ae6bb1364"
+
+	chainParams := &chaincfg.SigNetParams
+
+	privKeyHex, err := deriveMessageSigningPrivateKey(seedHex, chainParams)
+	require.NoError(t, err)
+
+	privKeyBytes, err := hex.DecodeString(privKeyHex)
+	require.NoError(t, err)
+	require.Len(t, privKeyBytes, 32)
+
+	// Independently derive m/84'/1'/0'/0/0 and check the key matches, so the
+	// signature verifies against the wallet's first receiving address.
+	seed, err := hex.DecodeString(seedHex)
+	require.NoError(t, err)
+
+	key, err := hdkeychain.NewMaster(seed, chainParams)
+	require.NoError(t, err)
+
+	for _, child := range []uint32{
+		hdkeychain.HardenedKeyStart + 84,
+		hdkeychain.HardenedKeyStart + 1, // signet coin type
+		hdkeychain.HardenedKeyStart + 0,
+		0, // external chain
+		0, // address index
+	} {
+		key, err = key.Derive(child)
+		require.NoError(t, err)
+	}
+
+	expected, err := key.ECPrivKey()
+	require.NoError(t, err)
+	require.Equal(t, hex.EncodeToString(expected.Serialize()), privKeyHex)
+
+	// Mainnet uses coin type 0, so it must derive a different key
+	mainnetPrivKeyHex, err := deriveMessageSigningPrivateKey(seedHex, &chaincfg.MainNetParams)
+	require.NoError(t, err)
+	require.NotEqual(t, privKeyHex, mainnetPrivKeyHex)
+
+	// Sanity check: the pubkey hashes to the first receiving address
+	pubKey, err := key.ECPubKey()
+	require.NoError(t, err)
+
+	addr, err := btcutil.NewAddressWitnessPubKeyHash(btcutil.Hash160(pubKey.SerializeCompressed()), chainParams)
+	require.NoError(t, err)
+	require.NotEmpty(t, addr.EncodeAddress())
+}

--- a/bitwindow/server/api/wallet/sign_message_test.go
+++ b/bitwindow/server/api/wallet/sign_message_test.go
@@ -1,13 +1,28 @@
 package api_wallet
 
 import (
+	"context"
 	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
+	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	commonv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/common/v1"
+	cryptov1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/crypto/v1"
+	cryptorpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/crypto/v1/cryptov1connect"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // The signing key must be the wallet's own key material - an empty/absent secret
@@ -61,4 +76,81 @@ func TestDeriveMessageSigningPrivateKey(t *testing.T) {
 	addr, err := btcutil.NewAddressWitnessPubKeyHash(btcutil.Hash160(pubKey.SerializeCompressed()), chainParams)
 	require.NoError(t, err)
 	require.NotEmpty(t, addr.EncodeAddress())
+}
+
+// The enforcer's Secp256K1Sign takes a common.Hex message, so plaintext has to be
+// hex encoded on the way in or every signature request fails to decode.
+func TestSignMessageHexEncodesMessage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+
+	const (
+		walletID = "80CEBA2163224572BDEADD2D2181C51B"
+		seedHex  = "0329e77e27d1e24336be53d25a897e92e67b5ec7e88eca7529b14e3ffd9168a247b6906469fb8a79ecb25ec077e033f6b567d5d9b0ae334f1e33457ae6bb1364"
+	)
+
+	tempDir := t.TempDir()
+	walletData, err := json.Marshal(map[string]any{
+		"version":        1,
+		"activeWalletId": walletID,
+		"wallets": []map[string]any{{
+			"version":     1,
+			"master":      map[string]any{"seed_hex": seedHex},
+			"id":          walletID,
+			"name":        "test",
+			"wallet_type": "bitcoinCore",
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "wallet.json"), walletData, 0o600))
+
+	walletEngine := engines.NewWalletEngine(
+		func(ctx context.Context) (corerpc.BitcoinServiceClient, error) { return nil, nil },
+		nil,
+		tempDir,
+		&chaincfg.SigNetParams,
+	)
+	require.True(t, walletEngine.IsUnlocked(), "unencrypted wallets auto-unlock at startup")
+
+	var signed *cryptov1.Secp256K1SignRequest
+	mockCrypto := mocks.NewMockCryptoServiceClient(ctrl)
+	mockCrypto.EXPECT().
+		Secp256K1Sign(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, req *connect.Request[cryptov1.Secp256K1SignRequest]) (*connect.Response[cryptov1.Secp256K1SignResponse], error) {
+			signed = req.Msg
+			return &connect.Response[cryptov1.Secp256K1SignResponse]{
+				Msg: &cryptov1.Secp256K1SignResponse{
+					Signature: &commonv1.Hex{Hex: wrapperspb.String("3045')")},
+				},
+			}, nil
+		})
+
+	server := &Server{
+		walletEngine: walletEngine,
+		crypto: service.New("test-crypto", func(ctx context.Context) (cryptorpc.CryptoServiceClient, error) {
+			return mockCrypto, nil
+		}),
+	}
+
+	// Non-ASCII on purpose: raw plaintext would not be valid hex either way, but
+	// multi-byte input also proves the encoding is over bytes, not runes.
+	const message = "signed by Bjørn"
+
+	res, err := server.SignMessage(ctx, connect.NewRequest(&pb.SignMessageRequest{
+		WalletId: walletID,
+		Message:  message,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "3045')", res.Msg.Signature)
+
+	require.NotNil(t, signed, "enforcer was never called")
+	decoded, err := hex.DecodeString(signed.Message.Hex.Value)
+	require.NoError(t, err, "message must be hex the enforcer can decode")
+	require.Equal(t, message, string(decoded))
+
+	expectedKey, err := deriveMessageSigningPrivateKey(seedHex, &chaincfg.SigNetParams)
+	require.NoError(t, err)
+	require.Equal(t, expectedKey, signed.SecretKey.Hex.Value)
 }

--- a/bitwindow/server/api/wallet/sign_message_test.go
+++ b/bitwindow/server/api/wallet/sign_message_test.go
@@ -25,57 +25,114 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-// The signing key must be the wallet's own key material - an empty/absent secret
-// key makes the enforcer's Secp256K1Sign call fail, so SignMessage never works.
-func TestDeriveMessageSigningPrivateKey(t *testing.T) {
-	t.Parallel()
+const testSeedHex = "0329e77e27d1e24336be53d25a897e92e67b5ec7e88eca7529b14e3ffd9168a247b6906469fb8a79ecb25ec077e033f6b567d5d9b0ae334f1e33457ae6bb1364"
 
-	const seedHex = "0329e77e27d1e24336be53d25a897e92e67b5ec7e88eca7529b14e3ffd9168a247b6906469fb8a79ecb25ec077e033f6b567d5d9b0ae334f1e33457ae6bb1364"
+// signingWallet is a seed-only wallet at the given account override.
+func signingWallet(accountIndex uint32, derivationPath string) *engines.WalletInfo {
+	wallet := &engines.WalletInfo{AccountIndex: accountIndex, DerivationPath: derivationPath}
+	wallet.Master.SeedHex = testSeedHex
+	return wallet
+}
 
-	chainParams := &chaincfg.SigNetParams
+// deriveAddressKey walks m/84'/coin'/account'/0/index for the test to compare against.
+func deriveAddressKey(t *testing.T, chainParams *chaincfg.Params, coin, account, index uint32) *hdkeychain.ExtendedKey {
+	t.Helper()
 
-	privKeyHex, err := deriveMessageSigningPrivateKey(seedHex, chainParams)
-	require.NoError(t, err)
-
-	privKeyBytes, err := hex.DecodeString(privKeyHex)
-	require.NoError(t, err)
-	require.Len(t, privKeyBytes, 32)
-
-	// Independently derive m/84'/1'/0'/0/0 and check the key matches, so the
-	// signature verifies against the wallet's first receiving address.
-	seed, err := hex.DecodeString(seedHex)
+	seed, err := hex.DecodeString(testSeedHex)
 	require.NoError(t, err)
 
 	key, err := hdkeychain.NewMaster(seed, chainParams)
 	require.NoError(t, err)
 
-	for _, child := range []uint32{
-		hdkeychain.HardenedKeyStart + 84,
-		hdkeychain.HardenedKeyStart + 1, // signet coin type
-		hdkeychain.HardenedKeyStart + 0,
-		0, // external chain
-		0, // address index
-	} {
+	const h = hdkeychain.HardenedKeyStart
+	for _, child := range []uint32{h + 84, h + coin, h + account, 0, index} {
 		key, err = key.Derive(child)
 		require.NoError(t, err)
 	}
+	return key
+}
 
-	expected, err := key.ECPrivKey()
-	require.NoError(t, err)
-	require.Equal(t, hex.EncodeToString(expected.Serialize()), privKeyHex)
+func addressOf(t *testing.T, key *hdkeychain.ExtendedKey, chainParams *chaincfg.Params) string {
+	t.Helper()
 
-	// Mainnet uses coin type 0, so it must derive a different key
-	mainnetPrivKeyHex, err := deriveMessageSigningPrivateKey(seedHex, &chaincfg.MainNetParams)
-	require.NoError(t, err)
-	require.NotEqual(t, privKeyHex, mainnetPrivKeyHex)
-
-	// Sanity check: the pubkey hashes to the first receiving address
 	pubKey, err := key.ECPubKey()
 	require.NoError(t, err)
 
 	addr, err := btcutil.NewAddressWitnessPubKeyHash(btcutil.Hash160(pubKey.SerializeCompressed()), chainParams)
 	require.NoError(t, err)
-	require.NotEmpty(t, addr.EncodeAddress())
+
+	return addr.EncodeAddress()
+}
+
+// A signature only proves ownership of the address it was made with, so signing
+// has to use the key behind the requested address - not the wallet's first one.
+func TestDeriveMessageSigningPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	chainParams := &chaincfg.SigNetParams
+
+	for _, index := range []uint32{0, 3, messageSigningGapLimit - 1} {
+		expected := deriveAddressKey(t, chainParams, 1, 0, index)
+
+		privKeyHex, err := deriveMessageSigningPrivateKey(
+			signingWallet(0, ""), chainParams, addressOf(t, expected, chainParams),
+		)
+		require.NoError(t, err)
+
+		expectedKey, err := expected.ECPrivKey()
+		require.NoError(t, err)
+		require.Equal(t, hex.EncodeToString(expectedKey.Serialize()), privKeyHex)
+	}
+
+	// An address past the gap limit, or one from another wallet entirely, has no
+	// key here - signing it would be a lie.
+	beyondGap := deriveAddressKey(t, chainParams, 1, 0, messageSigningGapLimit)
+	_, err := deriveMessageSigningPrivateKey(
+		signingWallet(0, ""), chainParams, addressOf(t, beyondGap, chainParams),
+	)
+	require.ErrorContains(t, err, "not one of the wallet")
+
+	// Mainnet uses coin type 0, so the same index is a different address entirely
+	mainnetAddr := addressOf(t, deriveAddressKey(t, &chaincfg.MainNetParams, 0, 0, 0), &chaincfg.MainNetParams)
+	_, err = deriveMessageSigningPrivateKey(signingWallet(0, ""), chainParams, mainnetAddr)
+	require.ErrorContains(t, err, "not one of the wallet")
+}
+
+// Wallets imported at a non-standard account own addresses under that account,
+// so signing must derive from it too.
+func TestDeriveMessageSigningPrivateKeyHonorsAccount(t *testing.T) {
+	t.Parallel()
+
+	chainParams := &chaincfg.SigNetParams
+	account5 := deriveAddressKey(t, chainParams, 1, 5, 0)
+	address := addressOf(t, account5, chainParams)
+
+	for _, wallet := range []*engines.WalletInfo{
+		signingWallet(5, ""),
+		signingWallet(0, "m/84'/1'/5'"),
+	} {
+		privKeyHex, err := deriveMessageSigningPrivateKey(wallet, chainParams, address)
+		require.NoError(t, err)
+
+		expected, err := account5.ECPrivKey()
+		require.NoError(t, err)
+		require.Equal(t, hex.EncodeToString(expected.Serialize()), privKeyHex)
+	}
+
+	// The default-account wallet does not own that address
+	_, err := deriveMessageSigningPrivateKey(signingWallet(0, ""), chainParams, address)
+	require.ErrorContains(t, err, "not one of the wallet")
+}
+
+// Taproot-only wallets have no P2WPKH addresses, so this must say so instead of
+// handing back a key for an address the wallet never shows.
+func TestDeriveMessageSigningPrivateKeyRejectsNonBIP84(t *testing.T) {
+	t.Parallel()
+
+	_, err := deriveMessageSigningPrivateKey(
+		signingWallet(0, "m/86'/1'/0'"), &chaincfg.SigNetParams, "whatever",
+	)
+	require.ErrorContains(t, err, "P2WPKH")
 }
 
 // The enforcer's Secp256K1Sign takes a common.Hex message, so plaintext has to be
@@ -88,7 +145,7 @@ func TestSignMessageHexEncodesMessage(t *testing.T) {
 
 	const (
 		walletID = "80CEBA2163224572BDEADD2D2181C51B"
-		seedHex  = "0329e77e27d1e24336be53d25a897e92e67b5ec7e88eca7529b14e3ffd9168a247b6906469fb8a79ecb25ec077e033f6b567d5d9b0ae334f1e33457ae6bb1364"
+		seedHex  = testSeedHex
 	)
 
 	tempDir := t.TempDir()
@@ -138,9 +195,13 @@ func TestSignMessageHexEncodesMessage(t *testing.T) {
 	// multi-byte input also proves the encoding is over bytes, not runes.
 	const message = "signed by Bjørn"
 
+	wallet := signingWallet(0, "")
+	address := addressOf(t, deriveAddressKey(t, &chaincfg.SigNetParams, 1, 0, 0), &chaincfg.SigNetParams)
+
 	res, err := server.SignMessage(ctx, connect.NewRequest(&pb.SignMessageRequest{
 		WalletId: walletID,
 		Message:  message,
+		Address:  address,
 	}))
 	require.NoError(t, err)
 	require.Equal(t, "3045')", res.Msg.Signature)
@@ -150,7 +211,7 @@ func TestSignMessageHexEncodesMessage(t *testing.T) {
 	require.NoError(t, err, "message must be hex the enforcer can decode")
 	require.Equal(t, message, string(decoded))
 
-	expectedKey, err := deriveMessageSigningPrivateKey(seedHex, &chaincfg.SigNetParams)
+	expectedKey, err := deriveMessageSigningPrivateKey(wallet, &chaincfg.SigNetParams, address)
 	require.NoError(t, err)
 	require.Equal(t, expectedKey, signed.SecretKey.Hex.Value)
 }

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -569,44 +569,11 @@ func (s *Server) deriveAndCheckAddresses(ctx context.Context, walletId string) (
 		return "", nil, fmt.Errorf("wallet has no seed")
 	}
 
-	// Decode seed
-	seed, err := hex.DecodeString(seedHex)
-	if err != nil {
-		return "", nil, fmt.Errorf("decode seed: %w", err)
-	}
-
-	// Derive master key
-	masterKey, err := hdkeychain.NewMaster(seed, s.walletEngine.GetChainParams())
-	if err != nil {
-		return "", nil, fmt.Errorf("derive master key: %w", err)
-	}
-
-	// Derive to BIP84 receiving path: m/84'/coinType'/0'/0
 	chainParams := s.walletEngine.GetChainParams()
-	coinType := uint32(0)
-	if chainParams.Name != "mainnet" {
-		coinType = 1
-	}
 
-	purpose, err := masterKey.Derive(hdkeychain.HardenedKeyStart + 84)
+	external, err := deriveExternalChainKey(seedHex, chainParams)
 	if err != nil {
-		return "", nil, fmt.Errorf("derive purpose: %w", err)
-	}
-
-	coin, err := purpose.Derive(hdkeychain.HardenedKeyStart + coinType)
-	if err != nil {
-		return "", nil, fmt.Errorf("derive coin: %w", err)
-	}
-
-	account, err := coin.Derive(hdkeychain.HardenedKeyStart + 0)
-	if err != nil {
-		return "", nil, fmt.Errorf("derive account: %w", err)
-	}
-
-	// Receiving addresses (external chain = 0)
-	external, err := account.Derive(0)
-	if err != nil {
-		return "", nil, fmt.Errorf("derive external chain: %w", err)
+		return "", nil, err
 	}
 
 	walletName, err := s.walletEngine.GetBitcoinCoreWalletName(ctx, walletId)
@@ -1314,19 +1281,17 @@ func (s *Server) createElectrumSidechainDeposit(
 	return connect.NewResponse(&pb.CreateSidechainDepositResponse{Txid: txid}), nil
 }
 
-// deriveMessageSigningPrivateKey derives the private key messages are signed with,
-// the wallet's first BIP84 receiving key at m/84'/coinType'/0'/0/0, and returns it
-// hex encoded. Same path as deriveAndCheckAddresses, so the signature verifies
-// against the wallet's first receiving address.
-func deriveMessageSigningPrivateKey(seedHex string, chainParams *chaincfg.Params) (string, error) {
+// deriveExternalChainKey derives m/84'/coinType'/0'/0, the BIP84 external chain
+// every single-sig wallet address and signing key comes from.
+func deriveExternalChainKey(seedHex string, chainParams *chaincfg.Params) (*hdkeychain.ExtendedKey, error) {
 	seed, err := hex.DecodeString(seedHex)
 	if err != nil {
-		return "", fmt.Errorf("decode seed: %w", err)
+		return nil, fmt.Errorf("decode seed: %w", err)
 	}
 
 	masterKey, err := hdkeychain.NewMaster(seed, chainParams)
 	if err != nil {
-		return "", fmt.Errorf("derive master key: %w", err)
+		return nil, fmt.Errorf("derive master key: %w", err)
 	}
 
 	coinType := uint32(0)
@@ -1336,23 +1301,33 @@ func deriveMessageSigningPrivateKey(seedHex string, chainParams *chaincfg.Params
 
 	purpose, err := masterKey.Derive(hdkeychain.HardenedKeyStart + 84)
 	if err != nil {
-		return "", fmt.Errorf("derive purpose: %w", err)
+		return nil, fmt.Errorf("derive purpose: %w", err)
 	}
 
 	coin, err := purpose.Derive(hdkeychain.HardenedKeyStart + coinType)
 	if err != nil {
-		return "", fmt.Errorf("derive coin: %w", err)
+		return nil, fmt.Errorf("derive coin: %w", err)
 	}
 
 	account, err := coin.Derive(hdkeychain.HardenedKeyStart + 0)
 	if err != nil {
-		return "", fmt.Errorf("derive account: %w", err)
+		return nil, fmt.Errorf("derive account: %w", err)
 	}
 
-	// Receiving addresses (external chain = 0)
 	external, err := account.Derive(0)
 	if err != nil {
-		return "", fmt.Errorf("derive external chain: %w", err)
+		return nil, fmt.Errorf("derive external chain: %w", err)
+	}
+
+	return external, nil
+}
+
+// deriveMessageSigningPrivateKey returns the wallet's first BIP84 receiving key,
+// hex encoded, so the signature verifies against its first receiving address.
+func deriveMessageSigningPrivateKey(seedHex string, chainParams *chaincfg.Params) (string, error) {
+	external, err := deriveExternalChainKey(seedHex, chainParams)
+	if err != nil {
+		return "", err
 	}
 
 	addrKey, err := external.Derive(0)
@@ -1400,7 +1375,7 @@ func (s *Server) SignMessage(ctx context.Context, c *connect.Request[pb.SignMess
 
 	res, err := crypto.Secp256K1Sign(ctx, connect.NewRequest(&cryptov1.Secp256K1SignRequest{
 		Message: &commonv1.Hex{
-			Hex: &wrapperspb.StringValue{Value: c.Msg.Message},
+			Hex: &wrapperspb.StringValue{Value: hex.EncodeToString([]byte(c.Msg.Message))},
 		},
 		SecretKey: &commonv1.ConsensusHex{
 			Hex: &wrapperspb.StringValue{Value: privKeyHex},
@@ -1432,7 +1407,7 @@ func (s *Server) VerifyMessage(ctx context.Context, c *connect.Request[pb.Verify
 
 	res, err := crypto.Secp256K1Verify(ctx, connect.NewRequest(&cryptov1.Secp256K1VerifyRequest{
 		Message: &commonv1.Hex{
-			Hex: &wrapperspb.StringValue{Value: c.Msg.Message},
+			Hex: &wrapperspb.StringValue{Value: hex.EncodeToString([]byte(c.Msg.Message))},
 		},
 		Signature: &commonv1.Hex{
 			Hex: &wrapperspb.StringValue{Value: c.Msg.Signature},

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1314,6 +1314,60 @@ func (s *Server) createElectrumSidechainDeposit(
 	return connect.NewResponse(&pb.CreateSidechainDepositResponse{Txid: txid}), nil
 }
 
+// deriveMessageSigningPrivateKey derives the private key messages are signed with,
+// the wallet's first BIP84 receiving key at m/84'/coinType'/0'/0/0, and returns it
+// hex encoded. Same path as deriveAndCheckAddresses, so the signature verifies
+// against the wallet's first receiving address.
+func deriveMessageSigningPrivateKey(seedHex string, chainParams *chaincfg.Params) (string, error) {
+	seed, err := hex.DecodeString(seedHex)
+	if err != nil {
+		return "", fmt.Errorf("decode seed: %w", err)
+	}
+
+	masterKey, err := hdkeychain.NewMaster(seed, chainParams)
+	if err != nil {
+		return "", fmt.Errorf("derive master key: %w", err)
+	}
+
+	coinType := uint32(0)
+	if chainParams.Name != "mainnet" {
+		coinType = 1
+	}
+
+	purpose, err := masterKey.Derive(hdkeychain.HardenedKeyStart + 84)
+	if err != nil {
+		return "", fmt.Errorf("derive purpose: %w", err)
+	}
+
+	coin, err := purpose.Derive(hdkeychain.HardenedKeyStart + coinType)
+	if err != nil {
+		return "", fmt.Errorf("derive coin: %w", err)
+	}
+
+	account, err := coin.Derive(hdkeychain.HardenedKeyStart + 0)
+	if err != nil {
+		return "", fmt.Errorf("derive account: %w", err)
+	}
+
+	// Receiving addresses (external chain = 0)
+	external, err := account.Derive(0)
+	if err != nil {
+		return "", fmt.Errorf("derive external chain: %w", err)
+	}
+
+	addrKey, err := external.Derive(0)
+	if err != nil {
+		return "", fmt.Errorf("derive address 0: %w", err)
+	}
+
+	privKey, err := addrKey.ECPrivKey()
+	if err != nil {
+		return "", fmt.Errorf("get private key: %w", err)
+	}
+
+	return hex.EncodeToString(privKey.Serialize()), nil
+}
+
 // SignMessage implements walletv1connect.WalletServiceHandler.
 func (s *Server) SignMessage(ctx context.Context, c *connect.Request[pb.SignMessageRequest]) (*connect.Response[pb.SignMessageResponse], error) {
 	walletId := c.Msg.WalletId
@@ -1324,6 +1378,21 @@ func (s *Server) SignMessage(ctx context.Context, c *connect.Request[pb.SignMess
 		return nil, fmt.Errorf("get wallet type: %w", err)
 	}
 
+	// Signing needs the seed, so the wallet has to be unlocked
+	if !s.walletEngine.IsUnlocked() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
+	}
+
+	seedHex, err := s.walletEngine.GetWalletSeed(walletId)
+	if err != nil {
+		return nil, fmt.Errorf("get wallet seed: %w", err)
+	}
+
+	privKeyHex, err := deriveMessageSigningPrivateKey(seedHex, s.walletEngine.GetChainParams())
+	if err != nil {
+		return nil, fmt.Errorf("derive signing key: %w", err)
+	}
+
 	crypto, err := s.crypto.Get(ctx)
 	if err != nil {
 		return nil, err
@@ -1332,6 +1401,9 @@ func (s *Server) SignMessage(ctx context.Context, c *connect.Request[pb.SignMess
 	res, err := crypto.Secp256K1Sign(ctx, connect.NewRequest(&cryptov1.Secp256K1SignRequest{
 		Message: &commonv1.Hex{
 			Hex: &wrapperspb.StringValue{Value: c.Msg.Message},
+		},
+		SecretKey: &commonv1.ConsensusHex{
+			Hex: &wrapperspb.StringValue{Value: privKeyHex},
 		},
 	}))
 	if err != nil {

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1418,6 +1418,12 @@ func deriveMessageSigningPrivateKey(wallet *engines.WalletInfo, chainParams *cha
 				return "", fmt.Errorf("get private key %d: %w", i, err)
 			}
 
+			// A taproot address commits to the tweaked output key, so the
+			// untweaked internal key would sign for a key nobody can check.
+			if kind == orchwallet.ScriptTaproot {
+				privKey = txscript.TweakTaprootPrivKey(*privKey, []byte{})
+			}
+
 			return hex.EncodeToString(privKey.Serialize()), nil
 		}
 	}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -38,6 +38,8 @@ import (
 	orchwallet "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -571,7 +573,7 @@ func (s *Server) deriveAndCheckAddresses(ctx context.Context, walletId string) (
 
 	chainParams := s.walletEngine.GetChainParams()
 
-	external, err := deriveExternalChainKey(walletInfo, chainParams)
+	external, err := deriveExternalChainKey(walletInfo, chainParams, orchwallet.ScriptNativeSegwit)
 	if err != nil {
 		return "", nil, err
 	}
@@ -602,8 +604,7 @@ func (s *Server) deriveAndCheckAddresses(ctx context.Context, walletId string) (
 	firstUnusedAddress := ""
 
 	// Derive addresses and check usage
-	// BIP44 gap limit is 20, but we'll check more to be safe
-	for i := uint32(0); i < 100; i++ {
+	for i := uint32(0); i < addressScanDepth; i++ {
 		// Derive address at index i
 		addrKey, err := external.Derive(i)
 		if err != nil {
@@ -1281,13 +1282,33 @@ func (s *Server) createElectrumSidechainDeposit(
 	return connect.NewResponse(&pb.CreateSidechainDepositResponse{Txid: txid}), nil
 }
 
-// messageSigningGapLimit is the BIP44 gap limit: how far out the external chain
-// a signable address can sit.
-const messageSigningGapLimit = 20
+// addressScanDepth bounds how far along the external chain the wallet derives
+// receiving addresses, and so how far a signable address can sit.
+const addressScanDepth = 100
 
-// deriveExternalChainKey derives the external chain a wallet's P2WPKH addresses
-// and signing keys come from, at the account path its descriptors were imported with.
-func deriveExternalChainKey(wallet *engines.WalletInfo, chainParams *chaincfg.Params) (*hdkeychain.ExtendedKey, error) {
+// walletScriptKinds returns the script kinds a wallet's receive descriptors were
+// imported with, mirroring engines.coreDescriptors.
+func walletScriptKinds(wallet *engines.WalletInfo) ([]orchwallet.ScriptKind, error) {
+	if strings.TrimSpace(wallet.DerivationPath) == "" {
+		return []orchwallet.ScriptKind{orchwallet.ScriptNativeSegwit, orchwallet.ScriptTaproot}, nil
+	}
+
+	accountPath, err := orchwallet.ParseAccountPath(wallet.DerivationPath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid derivation path: %w", err)
+	}
+
+	kind, ok := orchwallet.PurposeToCoreKind(accountPath.Purpose)
+	if !ok {
+		return nil, fmt.Errorf("unsupported derivation purpose %d'", accountPath.Purpose)
+	}
+
+	return []orchwallet.ScriptKind{kind}, nil
+}
+
+// deriveExternalChainKey derives the external chain a wallet's addresses of this
+// script kind come from, at the account path its descriptors were imported with.
+func deriveExternalChainKey(wallet *engines.WalletInfo, chainParams *chaincfg.Params, kind orchwallet.ScriptKind) (*hdkeychain.ExtendedKey, error) {
 	seed, err := hex.DecodeString(wallet.Master.SeedHex)
 	if err != nil {
 		return nil, fmt.Errorf("decode seed: %w", err)
@@ -1299,14 +1320,10 @@ func deriveExternalChainKey(wallet *engines.WalletInfo, chainParams *chaincfg.Pa
 	}
 
 	accountPath, err := orchwallet.ResolveAccountPath(
-		wallet.AccountIndex, wallet.DerivationPath, orchwallet.ScriptNativeSegwit, chainParams,
+		wallet.AccountIndex, wallet.DerivationPath, kind, chainParams,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("resolve account path: %w", err)
-	}
-
-	if accountPath.Purpose != 84 {
-		return nil, fmt.Errorf("wallet derives from m/%d', which has no P2WPKH addresses", accountPath.Purpose)
 	}
 
 	account, err := engines.DeriveHardenedPath(masterKey, accountPath)
@@ -1322,43 +1339,73 @@ func deriveExternalChainKey(wallet *engines.WalletInfo, chainParams *chaincfg.Pa
 	return external, nil
 }
 
+// receiveAddressForKind builds the receiving address a pubkey produces under kind.
+func receiveAddressForKind(kind orchwallet.ScriptKind, pubKey *btcec.PublicKey, chainParams *chaincfg.Params) (string, error) {
+	switch kind {
+	case orchwallet.ScriptNativeSegwit:
+		addr, err := btcutil.NewAddressWitnessPubKeyHash(btcutil.Hash160(pubKey.SerializeCompressed()), chainParams)
+		if err != nil {
+			return "", err
+		}
+		return addr.EncodeAddress(), nil
+
+	case orchwallet.ScriptTaproot:
+		tapKey := txscript.ComputeTaprootKeyNoScript(pubKey)
+		addr, err := btcutil.NewAddressTaproot(schnorr.SerializePubKey(tapKey), chainParams)
+		if err != nil {
+			return "", err
+		}
+		return addr.EncodeAddress(), nil
+
+	default:
+		return "", fmt.Errorf("unsupported script kind %s", kind)
+	}
+}
+
 // deriveMessageSigningPrivateKey returns the hex encoded key behind address, so
 // the signature proves ownership of that address rather than some other one.
 func deriveMessageSigningPrivateKey(wallet *engines.WalletInfo, chainParams *chaincfg.Params, address string) (string, error) {
-	external, err := deriveExternalChainKey(wallet, chainParams)
+	kinds, err := walletScriptKinds(wallet)
 	if err != nil {
 		return "", err
 	}
 
-	for i := uint32(0); i < messageSigningGapLimit; i++ {
-		addrKey, err := external.Derive(i)
+	for _, kind := range kinds {
+		external, err := deriveExternalChainKey(wallet, chainParams, kind)
 		if err != nil {
-			return "", fmt.Errorf("derive address %d: %w", i, err)
+			return "", err
 		}
 
-		pubKey, err := addrKey.ECPubKey()
-		if err != nil {
-			return "", fmt.Errorf("get public key %d: %w", i, err)
-		}
+		for i := uint32(0); i < addressScanDepth; i++ {
+			addrKey, err := external.Derive(i)
+			if err != nil {
+				return "", fmt.Errorf("derive address %d: %w", i, err)
+			}
 
-		witnessAddr, err := btcutil.NewAddressWitnessPubKeyHash(btcutil.Hash160(pubKey.SerializeCompressed()), chainParams)
-		if err != nil {
-			return "", fmt.Errorf("create address %d: %w", i, err)
-		}
+			pubKey, err := addrKey.ECPubKey()
+			if err != nil {
+				return "", fmt.Errorf("get public key %d: %w", i, err)
+			}
 
-		if witnessAddr.EncodeAddress() != address {
-			continue
-		}
+			derived, err := receiveAddressForKind(kind, pubKey, chainParams)
+			if err != nil {
+				return "", fmt.Errorf("create address %d: %w", i, err)
+			}
 
-		privKey, err := addrKey.ECPrivKey()
-		if err != nil {
-			return "", fmt.Errorf("get private key %d: %w", i, err)
-		}
+			if derived != address {
+				continue
+			}
 
-		return hex.EncodeToString(privKey.Serialize()), nil
+			privKey, err := addrKey.ECPrivKey()
+			if err != nil {
+				return "", fmt.Errorf("get private key %d: %w", i, err)
+			}
+
+			return hex.EncodeToString(privKey.Serialize()), nil
+		}
 	}
 
-	return "", fmt.Errorf("address %s is not one of the wallet's first %d receiving addresses", address, messageSigningGapLimit)
+	return "", fmt.Errorf("address %s is not one of the wallet's first %d receiving addresses", address, addressScanDepth)
 }
 
 // SignMessage implements walletv1connect.WalletServiceHandler.

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -35,6 +35,7 @@ import (
 	validatorpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
 	validatorrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1/mainchainv1connect"
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	orchwallet "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
 	"github.com/btcsuite/btcd/btcutil"
@@ -564,14 +565,13 @@ func (s *Server) deriveAndCheckAddresses(ctx context.Context, walletId string) (
 		return "", nil, fmt.Errorf("get wallet info: %w", err)
 	}
 
-	seedHex := walletInfo.Master.SeedHex
-	if seedHex == "" {
+	if walletInfo.Master.SeedHex == "" {
 		return "", nil, fmt.Errorf("wallet has no seed")
 	}
 
 	chainParams := s.walletEngine.GetChainParams()
 
-	external, err := deriveExternalChainKey(seedHex, chainParams)
+	external, err := deriveExternalChainKey(walletInfo, chainParams)
 	if err != nil {
 		return "", nil, err
 	}
@@ -1281,10 +1281,14 @@ func (s *Server) createElectrumSidechainDeposit(
 	return connect.NewResponse(&pb.CreateSidechainDepositResponse{Txid: txid}), nil
 }
 
-// deriveExternalChainKey derives m/84'/coinType'/0'/0, the BIP84 external chain
-// every single-sig wallet address and signing key comes from.
-func deriveExternalChainKey(seedHex string, chainParams *chaincfg.Params) (*hdkeychain.ExtendedKey, error) {
-	seed, err := hex.DecodeString(seedHex)
+// messageSigningGapLimit is the BIP44 gap limit: how far out the external chain
+// a signable address can sit.
+const messageSigningGapLimit = 20
+
+// deriveExternalChainKey derives the external chain a wallet's P2WPKH addresses
+// and signing keys come from, at the account path its descriptors were imported with.
+func deriveExternalChainKey(wallet *engines.WalletInfo, chainParams *chaincfg.Params) (*hdkeychain.ExtendedKey, error) {
+	seed, err := hex.DecodeString(wallet.Master.SeedHex)
 	if err != nil {
 		return nil, fmt.Errorf("decode seed: %w", err)
 	}
@@ -1294,22 +1298,18 @@ func deriveExternalChainKey(seedHex string, chainParams *chaincfg.Params) (*hdke
 		return nil, fmt.Errorf("derive master key: %w", err)
 	}
 
-	coinType := uint32(0)
-	if chainParams.Name != "mainnet" {
-		coinType = 1
-	}
-
-	purpose, err := masterKey.Derive(hdkeychain.HardenedKeyStart + 84)
+	accountPath, err := orchwallet.ResolveAccountPath(
+		wallet.AccountIndex, wallet.DerivationPath, orchwallet.ScriptNativeSegwit, chainParams,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("derive purpose: %w", err)
+		return nil, fmt.Errorf("resolve account path: %w", err)
 	}
 
-	coin, err := purpose.Derive(hdkeychain.HardenedKeyStart + coinType)
-	if err != nil {
-		return nil, fmt.Errorf("derive coin: %w", err)
+	if accountPath.Purpose != 84 {
+		return nil, fmt.Errorf("wallet derives from m/%d', which has no P2WPKH addresses", accountPath.Purpose)
 	}
 
-	account, err := coin.Derive(hdkeychain.HardenedKeyStart + 0)
+	account, err := engines.DeriveHardenedPath(masterKey, accountPath)
 	if err != nil {
 		return nil, fmt.Errorf("derive account: %w", err)
 	}
@@ -1322,25 +1322,43 @@ func deriveExternalChainKey(seedHex string, chainParams *chaincfg.Params) (*hdke
 	return external, nil
 }
 
-// deriveMessageSigningPrivateKey returns the wallet's first BIP84 receiving key,
-// hex encoded, so the signature verifies against its first receiving address.
-func deriveMessageSigningPrivateKey(seedHex string, chainParams *chaincfg.Params) (string, error) {
-	external, err := deriveExternalChainKey(seedHex, chainParams)
+// deriveMessageSigningPrivateKey returns the hex encoded key behind address, so
+// the signature proves ownership of that address rather than some other one.
+func deriveMessageSigningPrivateKey(wallet *engines.WalletInfo, chainParams *chaincfg.Params, address string) (string, error) {
+	external, err := deriveExternalChainKey(wallet, chainParams)
 	if err != nil {
 		return "", err
 	}
 
-	addrKey, err := external.Derive(0)
-	if err != nil {
-		return "", fmt.Errorf("derive address 0: %w", err)
+	for i := uint32(0); i < messageSigningGapLimit; i++ {
+		addrKey, err := external.Derive(i)
+		if err != nil {
+			return "", fmt.Errorf("derive address %d: %w", i, err)
+		}
+
+		pubKey, err := addrKey.ECPubKey()
+		if err != nil {
+			return "", fmt.Errorf("get public key %d: %w", i, err)
+		}
+
+		witnessAddr, err := btcutil.NewAddressWitnessPubKeyHash(btcutil.Hash160(pubKey.SerializeCompressed()), chainParams)
+		if err != nil {
+			return "", fmt.Errorf("create address %d: %w", i, err)
+		}
+
+		if witnessAddr.EncodeAddress() != address {
+			continue
+		}
+
+		privKey, err := addrKey.ECPrivKey()
+		if err != nil {
+			return "", fmt.Errorf("get private key %d: %w", i, err)
+		}
+
+		return hex.EncodeToString(privKey.Serialize()), nil
 	}
 
-	privKey, err := addrKey.ECPrivKey()
-	if err != nil {
-		return "", fmt.Errorf("get private key: %w", err)
-	}
-
-	return hex.EncodeToString(privKey.Serialize()), nil
+	return "", fmt.Errorf("address %s is not one of the wallet's first %d receiving addresses", address, messageSigningGapLimit)
 }
 
 // SignMessage implements walletv1connect.WalletServiceHandler.
@@ -1358,12 +1376,16 @@ func (s *Server) SignMessage(ctx context.Context, c *connect.Request[pb.SignMess
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("wallet is locked"))
 	}
 
-	seedHex, err := s.walletEngine.GetWalletSeed(walletId)
-	if err != nil {
-		return nil, fmt.Errorf("get wallet seed: %w", err)
+	if c.Msg.Address == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("address is required"))
 	}
 
-	privKeyHex, err := deriveMessageSigningPrivateKey(seedHex, s.walletEngine.GetChainParams())
+	walletInfo, err := s.walletEngine.GetWalletInfo(ctx, walletId)
+	if err != nil {
+		return nil, fmt.Errorf("get wallet info: %w", err)
+	}
+
+	privKeyHex, err := deriveMessageSigningPrivateKey(walletInfo, s.walletEngine.GetChainParams(), c.Msg.Address)
 	if err != nil {
 		return nil, fmt.Errorf("derive signing key: %w", err)
 	}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1289,8 +1289,15 @@ const addressScanDepth = 100
 // walletScriptKinds returns the script kinds a wallet's receive descriptors were
 // imported with, mirroring engines.coreDescriptors.
 func walletScriptKinds(wallet *engines.WalletInfo) ([]orchwallet.ScriptKind, error) {
+	// Core wallets import BIP84+BIP86, Electrum ones can be at m/44' or m/49',
+	// and the stored wallet does not say which — so try every standard purpose.
 	if strings.TrimSpace(wallet.DerivationPath) == "" {
-		return []orchwallet.ScriptKind{orchwallet.ScriptNativeSegwit, orchwallet.ScriptTaproot}, nil
+		return []orchwallet.ScriptKind{
+			orchwallet.ScriptNativeSegwit,
+			orchwallet.ScriptTaproot,
+			orchwallet.ScriptNestedSegwit,
+			orchwallet.ScriptLegacy,
+		}, nil
 	}
 
 	accountPath, err := orchwallet.ParseAccountPath(wallet.DerivationPath)
@@ -1341,13 +1348,32 @@ func deriveExternalChainKey(wallet *engines.WalletInfo, chainParams *chaincfg.Pa
 
 // receiveAddressForKind builds the receiving address a pubkey produces under kind.
 func receiveAddressForKind(kind orchwallet.ScriptKind, pubKey *btcec.PublicKey, chainParams *chaincfg.Params) (btcutil.Address, error) {
+	pkHash := btcutil.Hash160(pubKey.SerializeCompressed())
+
 	if kind == orchwallet.ScriptNativeSegwit {
-		return btcutil.NewAddressWitnessPubKeyHash(btcutil.Hash160(pubKey.SerializeCompressed()), chainParams)
+		return btcutil.NewAddressWitnessPubKeyHash(pkHash, chainParams)
 	}
 
 	if kind == orchwallet.ScriptTaproot {
-		tapKey := txscript.ComputeTaprootKeyNoScript(pubKey)
-		return btcutil.NewAddressTaproot(schnorr.SerializePubKey(tapKey), chainParams)
+		return btcutil.NewAddressTaproot(schnorr.SerializePubKey(txscript.ComputeTaprootKeyNoScript(pubKey)), chainParams)
+	}
+
+	if kind == orchwallet.ScriptLegacy {
+		return btcutil.NewAddressPubKeyHash(pkHash, chainParams)
+	}
+
+	if kind == orchwallet.ScriptNestedSegwit {
+		witness, err := btcutil.NewAddressWitnessPubKeyHash(pkHash, chainParams)
+		if err != nil {
+			return nil, err
+		}
+
+		redeem, err := txscript.PayToAddrScript(witness)
+		if err != nil {
+			return nil, err
+		}
+
+		return btcutil.NewAddressScriptHash(redeem, chainParams)
 	}
 
 	return nil, fmt.Errorf("unsupported script kind %s", kind)

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1340,26 +1340,17 @@ func deriveExternalChainKey(wallet *engines.WalletInfo, chainParams *chaincfg.Pa
 }
 
 // receiveAddressForKind builds the receiving address a pubkey produces under kind.
-func receiveAddressForKind(kind orchwallet.ScriptKind, pubKey *btcec.PublicKey, chainParams *chaincfg.Params) (string, error) {
-	switch kind {
-	case orchwallet.ScriptNativeSegwit:
-		addr, err := btcutil.NewAddressWitnessPubKeyHash(btcutil.Hash160(pubKey.SerializeCompressed()), chainParams)
-		if err != nil {
-			return "", err
-		}
-		return addr.EncodeAddress(), nil
-
-	case orchwallet.ScriptTaproot:
-		tapKey := txscript.ComputeTaprootKeyNoScript(pubKey)
-		addr, err := btcutil.NewAddressTaproot(schnorr.SerializePubKey(tapKey), chainParams)
-		if err != nil {
-			return "", err
-		}
-		return addr.EncodeAddress(), nil
-
-	default:
-		return "", fmt.Errorf("unsupported script kind %s", kind)
+func receiveAddressForKind(kind orchwallet.ScriptKind, pubKey *btcec.PublicKey, chainParams *chaincfg.Params) (btcutil.Address, error) {
+	if kind == orchwallet.ScriptNativeSegwit {
+		return btcutil.NewAddressWitnessPubKeyHash(btcutil.Hash160(pubKey.SerializeCompressed()), chainParams)
 	}
+
+	if kind == orchwallet.ScriptTaproot {
+		tapKey := txscript.ComputeTaprootKeyNoScript(pubKey)
+		return btcutil.NewAddressTaproot(schnorr.SerializePubKey(tapKey), chainParams)
+	}
+
+	return nil, fmt.Errorf("unsupported script kind %s", kind)
 }
 
 // deriveMessageSigningPrivateKey returns the hex encoded key behind address, so
@@ -1392,7 +1383,7 @@ func deriveMessageSigningPrivateKey(wallet *engines.WalletInfo, chainParams *cha
 				return "", fmt.Errorf("create address %d: %w", i, err)
 			}
 
-			if derived != address {
+			if derived.EncodeAddress() != address {
 				continue
 			}
 

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -103,6 +103,24 @@ type BlockResult struct {
 	Error  error
 }
 
+// resetProcessedChain drops processed blocks and everything derived from them;
+// the derived inserts ignore conflicts, so stale rows would survive the rescan.
+func (p *Parser) resetProcessedChain(ctx context.Context) error {
+	if err := blocks.WipeProcessedBlocks(ctx, p.db); err != nil {
+		return fmt.Errorf("wipe processed blocks: %w", err)
+	}
+
+	if err := p.purgeCoinNewsAtOrAbove(ctx, 0); err != nil {
+		return fmt.Errorf("purge coinnews: %w", err)
+	}
+
+	if err := p.purgeM4AtOrAbove(ctx, 0); err != nil {
+		return fmt.Errorf("purge m4: %w", err)
+	}
+
+	return nil
+}
+
 func (p *Parser) handleBlockTick(ctx context.Context) error {
 
 	switch err := p.ensureSyncIsHealthy(ctx); {
@@ -111,8 +129,8 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 
 		// Core has no block 1: a fresh regtest, or a datadir that was wiped and
 		// is back to syncing. Everything we processed is above its tip.
-		if err := blocks.WipeProcessedBlocks(ctx, p.db); err != nil {
-			return fmt.Errorf("wipe processed blocks on empty chain: %w", err)
+		if err := p.resetProcessedChain(ctx); err != nil {
+			return fmt.Errorf("reset processed chain on empty chain: %w", err)
 		}
 
 		zerolog.Ctx(ctx).Debug().
@@ -169,8 +187,8 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 			Uint32("processed_tip", lastProcessedHeight).
 			Uint32("node_tip", currentHeight).
 			Msg("bitcoind_engine/parser: node is behind our processed tip — chain wiped, resetting processed_blocks")
-		if err := blocks.WipeProcessedBlocks(ctx, p.db); err != nil {
-			return fmt.Errorf("wipe processed blocks on chain wipe: %w", err)
+		if err := p.resetProcessedChain(ctx); err != nil {
+			return fmt.Errorf("reset processed chain on chain wipe: %w", err)
 		}
 		return nil
 	}
@@ -838,7 +856,7 @@ func (p *Parser) ensureSyncIsHealthy(ctx context.Context) error {
 			Str("stored_hash", savedBlock1.Hash.String()).
 			Str("current_hash", block1.Header.BlockHash().String()).
 			Msgf("bitcoind_engine/parser: block 1 hash differs from stored — chain switch detected, reprocessing all blocks")
-		return blocks.WipeProcessedBlocks(ctx, p.db)
+		return p.resetProcessedChain(ctx)
 	}
 
 	return nil

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -109,8 +109,12 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 	case err != nil &&
 		strings.Contains(err.Error(), "Block height out of range"):
 
-		// Block 1 doesn't exist yet — normal on a fresh regtest (no blocks
-		// mined) or a header-syncing full chain. Debug, not info; don't spam.
+		// Core has no block 1: a fresh regtest, or a datadir that was wiped and
+		// is back to syncing. Everything we processed is above its tip.
+		if err := blocks.WipeProcessedBlocks(ctx, p.db); err != nil {
+			return fmt.Errorf("wipe processed blocks on empty chain: %w", err)
+		}
+
 		zerolog.Ctx(ctx).Debug().
 			Msgf("bitcoind_engine/parser: no block 1 yet, waiting for chain to advance..")
 		return nil

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -174,19 +174,16 @@ func DetectFileType(content []byte) string {
 	// Try to detect text files
 	sampleSize := min(1024, len(content))
 
-	// Check if content looks like valid UTF-8 text
+	// Check if content is printable ASCII text. Non-ASCII bytes must classify as
+	// "bin": the "txt" path stores content raw in the OP_RETURN, and retrieval
+	// runs it through opreturns.OPReturnToReadable, which hex-encodes anything
+	// containing a byte above 0x7E and so destroys the "metadataB64|content"
+	// framing that DecodeOPReturnData needs.
 	isText := true
 	for i := range sampleSize {
 		b := content[i]
 		// Allow printable ASCII, newlines, tabs
-		if b < 0x09 || (b > 0x0D && b < 0x20) || b == 0x7F {
-			// Check for UTF-8 multi-byte sequences
-			if b >= 0x80 && b <= 0xBF {
-				continue // continuation byte
-			}
-			if b >= 0xC0 && b <= 0xF7 {
-				continue // start of multi-byte
-			}
+		if b < 0x09 || (b > 0x0D && b < 0x20) || b >= 0x7F {
 			isText = false
 			break
 		}

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -88,6 +88,11 @@ type ParsedMetadata struct {
 	IsMultisig bool
 	Timestamp  uint32
 	FileType   string
+
+	// Raw is the exact 9-byte metadata this was parsed from. Encrypt/Decrypt
+	// authenticate these bytes, so tampering with the flags, timestamp or file
+	// type fails the auth tag instead of silently decrypting to garbage.
+	Raw []byte
 }
 
 // ParseMetadata parses the 9-byte metadata from base64
@@ -110,11 +115,17 @@ func ParseMetadata(metadataB64 string) (*ParsedMetadata, error) {
 		IsMultisig: (flags & FlagMultisig) != 0,
 		Timestamp:  timestamp,
 		FileType:   fileType,
+		Raw:        metadataBytes,
 	}, nil
 }
 
 // EncodeMetadata encodes metadata into 9 bytes and returns base64
 func EncodeMetadata(encrypted, isMultisig bool, timestamp uint32, fileType string) string {
+	return base64.StdEncoding.EncodeToString(EncodeMetadataBytes(encrypted, isMultisig, timestamp, fileType))
+}
+
+// EncodeMetadataBytes encodes metadata into its 9-byte on-chain representation
+func EncodeMetadataBytes(encrypted, isMultisig bool, timestamp uint32, fileType string) []byte {
 	metadata := make([]byte, MetadataSize)
 
 	// Flags byte
@@ -140,7 +151,7 @@ func EncodeMetadata(encrypted, isMultisig bool, timestamp uint32, fileType strin
 	}
 	copy(metadata[5:9], fileTypeBytes)
 
-	return base64.StdEncoding.EncodeToString(metadata)
+	return metadata
 }
 
 // DetectFileType detects file type from magic bytes
@@ -359,8 +370,10 @@ func (e *BitDriveEngine) getAuthKey(_ context.Context) ([]byte, error) {
 // Encrypt encrypts content using XOR with derived keystream and appends HMAC auth tag.
 // The output layout is: nonce (NonceSize) || ciphertext || tag (AuthTagSize). The
 // random per-file nonce is mixed into the keystream so repeated (timestamp, fileType)
-// tuples never reuse the keystream.
-func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp uint32, fileType string) ([]byte, error) {
+// tuples never reuse the keystream. metadata is the 9-byte metadata prefix that
+// travels alongside the ciphertext; it is authenticated as associated data because
+// the keystream is derived from the timestamp and file type it carries.
+func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp uint32, fileType string, metadata []byte) ([]byte, error) {
 	// Generate a random per-file nonce
 	nonce := make([]byte, NonceSize)
 	if _, err := rand.Read(nonce); err != nil {
@@ -379,14 +392,17 @@ func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp 
 		encrypted[i] = content[i] ^ keyStream[i]
 	}
 
-	// Generate truncated authentication tag (first 8 bytes of HMAC-SHA256)
-	// over the nonce and ciphertext so nonce tampering is also detected.
+	// Generate truncated authentication tag (first 8 bytes of HMAC-SHA256) over
+	// the metadata, nonce and ciphertext so metadata and nonce tampering is also
+	// detected. All three inputs are fixed-length or trailing, so the
+	// concatenation is unambiguous.
 	authKey, err := e.getAuthKey(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get auth key: %w", err)
 	}
 
 	mac := hmac.New(sha256.New, authKey)
+	mac.Write(metadata)
 	mac.Write(nonce)
 	mac.Write(encrypted)
 	fullTag := mac.Sum(nil)
@@ -401,8 +417,11 @@ func (e *BitDriveEngine) Encrypt(ctx context.Context, content []byte, timestamp 
 	return result, nil
 }
 
-// Decrypt verifies the HMAC auth tag and decrypts content
-func (e *BitDriveEngine) Decrypt(ctx context.Context, encryptedData []byte, timestamp uint32, fileType string) ([]byte, error) {
+// Decrypt verifies the HMAC auth tag and decrypts content. metadata must be the
+// 9-byte metadata prefix the ciphertext arrived with: it is authenticated as
+// associated data, so a tampered timestamp or file type is rejected rather than
+// feeding a wrong keystream seed into DeriveKeyStream.
+func (e *BitDriveEngine) Decrypt(ctx context.Context, encryptedData []byte, timestamp uint32, fileType string, metadata []byte) ([]byte, error) {
 	if len(encryptedData) <= NonceSize+AuthTagSize {
 		return nil, fmt.Errorf("encrypted data too short")
 	}
@@ -413,13 +432,14 @@ func (e *BitDriveEngine) Decrypt(ctx context.Context, encryptedData []byte, time
 	encryptedContent := encryptedData[NonceSize : NonceSize+contentLen]
 	receivedTag := encryptedData[NonceSize+contentLen:]
 
-	// Verify authentication tag over the nonce and ciphertext
+	// Verify authentication tag over the metadata, nonce and ciphertext
 	authKey, err := e.getAuthKey(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get auth key: %w", err)
 	}
 
 	mac := hmac.New(sha256.New, authKey)
+	mac.Write(metadata)
 	mac.Write(nonce)
 	mac.Write(encryptedContent)
 	fullTag := mac.Sum(nil)
@@ -450,11 +470,14 @@ func (e *BitDriveEngine) EncodeOPReturnData(ctx context.Context, content []byte,
 	timestamp := uint32(time.Now().Unix())
 	fileType := DetectFileType(content)
 
+	// Encode metadata up front so it can be authenticated with the ciphertext
+	metadataBytes := EncodeMetadataBytes(encrypt, false, timestamp, fileType)
+
 	var processedContent []byte
 	var err error
 
 	if encrypt {
-		processedContent, err = e.Encrypt(ctx, content, timestamp, fileType)
+		processedContent, err = e.Encrypt(ctx, content, timestamp, fileType, metadataBytes)
 		if err != nil {
 			return "", "", 0, fmt.Errorf("encrypt content: %w", err)
 		}
@@ -462,8 +485,7 @@ func (e *BitDriveEngine) EncodeOPReturnData(ctx context.Context, content []byte,
 		processedContent = content
 	}
 
-	// Encode metadata
-	metadataB64 := EncodeMetadata(encrypt, false, timestamp, fileType)
+	metadataB64 := base64.StdEncoding.EncodeToString(metadataBytes)
 
 	// Encode content
 	var contentStr string
@@ -501,7 +523,7 @@ func (e *BitDriveEngine) DecodeOPReturnData(ctx context.Context, opReturnMessage
 	}
 
 	if metadata.Encrypted {
-		content, err = e.Decrypt(ctx, content, metadata.Timestamp, metadata.FileType)
+		content, err = e.Decrypt(ctx, content, metadata.Timestamp, metadata.FileType, metadata.Raw)
 		if err != nil {
 			return nil, nil, fmt.Errorf("decrypt content: %w", err)
 		}
@@ -666,28 +688,21 @@ func (e *BitDriveEngine) EncodeMultisigData(ctx context.Context, jsonData []byte
 	timestamp := uint32(time.Now().Unix())
 	fileType := "json"
 
+	// Encode metadata with multisig flag up front so it can be authenticated
+	// with the ciphertext
+	metadata := EncodeMetadataBytes(encrypt, true, timestamp, fileType)
+
 	var processedContent []byte
 	var err error
 
 	if encrypt {
-		processedContent, err = e.Encrypt(ctx, jsonData, timestamp, fileType)
+		processedContent, err = e.Encrypt(ctx, jsonData, timestamp, fileType, metadata)
 		if err != nil {
 			return "", fmt.Errorf("encrypt multisig data: %w", err)
 		}
 	} else {
 		processedContent = jsonData
 	}
-
-	// Encode metadata with multisig flag
-	metadata := make([]byte, MetadataSize)
-	var flags byte
-	if encrypt {
-		flags |= FlagEncrypted
-	}
-	flags |= FlagMultisig
-	metadata[0] = flags
-	binary.BigEndian.PutUint32(metadata[1:5], timestamp)
-	copy(metadata[5:9], []byte("json"))
 
 	metadataB64 := base64.StdEncoding.EncodeToString(metadata)
 	contentB64 := base64.StdEncoding.EncodeToString(processedContent)

--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -182,29 +182,15 @@ func DetectFileType(content []byte) string {
 		return "pdf"
 	}
 
-	// Try to detect text files
-	sampleSize := min(1024, len(content))
-
-	// Check if content is printable ASCII text. Non-ASCII bytes must classify as
-	// "bin": the "txt" path stores content raw in the OP_RETURN, and retrieval
-	// runs it through opreturns.OPReturnToReadable, which hex-encodes anything
-	// containing a byte above 0x7E and so destroys the "metadataB64|content"
-	// framing that DecodeOPReturnData needs.
-	isText := true
-	for i := range sampleSize {
-		b := content[i]
-		// Allow printable ASCII, newlines, tabs
+	// Every byte must be checked, not a leading sample: "txt" is stored raw and
+	// retrieval hex-encodes anything above 0x7E, breaking the content framing.
+	for _, b := range content {
 		if b < 0x09 || (b > 0x0D && b < 0x20) || b >= 0x7F {
-			isText = false
-			break
+			return "bin"
 		}
 	}
 
-	if isText {
-		return "txt"
-	}
-
-	return "bin"
+	return "txt"
 }
 
 // DeriveKeyStream derives a keystream for XOR encryption

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/base64"
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"testing"
@@ -96,15 +98,16 @@ func TestEncrypt_SameTimestampSameFileType_NoKeystreamReuse(t *testing.T) {
 
 	const timestamp = uint32(1800000000)
 	const fileType = "txt"
+	metadata := EncodeMetadataBytes(true, false, timestamp, fileType)
 
 	plainA := []byte("BitDrive keystream reuse probe payload block AAAA")
 	plainB := []byte("BitDrive keystream reuse probe payload block BBBB")
 
-	cipherA, err := engine.Encrypt(ctx, plainA, timestamp, fileType)
+	cipherA, err := engine.Encrypt(ctx, plainA, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("encrypt A: %v", err)
 	}
-	cipherB, err := engine.Encrypt(ctx, plainB, timestamp, fileType)
+	cipherB, err := engine.Encrypt(ctx, plainB, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("encrypt B: %v", err)
 	}
@@ -132,7 +135,7 @@ func TestEncrypt_SameTimestampSameFileType_NoKeystreamReuse(t *testing.T) {
 	// Encrypting the SAME plaintext twice must also yield distinct ciphertext
 	// bodies, proving the keystream is randomized per file rather than derived
 	// solely from (timestamp, fileType).
-	cipherA2, err := engine.Encrypt(ctx, plainA, timestamp, fileType)
+	cipherA2, err := engine.Encrypt(ctx, plainA, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("encrypt A again: %v", err)
 	}
@@ -142,19 +145,73 @@ func TestEncrypt_SameTimestampSameFileType_NoKeystreamReuse(t *testing.T) {
 	}
 
 	// Both ciphertexts must still round-trip through Decrypt.
-	gotA, err := engine.Decrypt(ctx, cipherA, timestamp, fileType)
+	gotA, err := engine.Decrypt(ctx, cipherA, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("decrypt A: %v", err)
 	}
 	if !bytes.Equal(gotA, plainA) {
 		t.Fatalf("decrypt A mismatch: got %q want %q", gotA, plainA)
 	}
-	gotB, err := engine.Decrypt(ctx, cipherB, timestamp, fileType)
+	gotB, err := engine.Decrypt(ctx, cipherB, timestamp, fileType, metadata)
 	if err != nil {
 		t.Fatalf("decrypt B: %v", err)
 	}
 	if !bytes.Equal(gotB, plainB) {
 		t.Fatalf("decrypt B mismatch: got %q want %q", gotB, plainB)
+	}
+}
+
+// TestDecodeOPReturnData_MetadataTamperRejected verifies that the auth tag covers
+// the 9-byte metadata prefix. The keystream seed mixes in the timestamp and file
+// type carried by that prefix, so a tag over nonce||ciphertext alone let an
+// attacker flip a metadata byte and have Decrypt return garbage with a nil error.
+func TestDecodeOPReturnData_MetadataTamperRejected(t *testing.T) {
+	ctx := context.Background()
+	engine := newEncryptTestEngine(t)
+
+	plain := []byte("BitDrive metadata binding probe payload")
+
+	metadataB64, contentStr, timestamp, err := engine.EncodeOPReturnData(ctx, plain, true)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	// The untampered message must still round-trip.
+	decoded, _, err := engine.DecodeOPReturnData(ctx, FormatOPReturnData(metadataB64, contentStr))
+	if err != nil {
+		t.Fatalf("decode untampered: %v", err)
+	}
+	if !bytes.Equal(decoded, plain) {
+		t.Fatalf("round trip mismatch: got %q want %q", decoded, plain)
+	}
+
+	metadataBytes, err := base64.StdEncoding.DecodeString(metadataB64)
+	if err != nil {
+		t.Fatalf("decode metadata base64: %v", err)
+	}
+
+	tampers := []struct {
+		name   string
+		mutate func(metadata []byte)
+	}{
+		{"timestamp", func(m []byte) { binary.BigEndian.PutUint32(m[1:5], timestamp+1) }},
+		{"file type", func(m []byte) { copy(m[5:9], []byte("bin ")) }},
+		{"multisig flag", func(m []byte) { m[0] |= FlagMultisig }},
+	}
+
+	for _, tt := range tampers {
+		t.Run(tt.name, func(t *testing.T) {
+			tampered := append([]byte(nil), metadataBytes...)
+			tt.mutate(tampered)
+			if bytes.Equal(tampered, metadataBytes) {
+				t.Fatal("tamper did not change the metadata")
+			}
+
+			opReturnData := FormatOPReturnData(base64.StdEncoding.EncodeToString(tampered), contentStr)
+			if _, _, err := engine.DecodeOPReturnData(ctx, opReturnData); err == nil {
+				t.Fatal("tampered metadata decrypted without error")
+			}
+		})
 	}
 }
 

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -301,6 +301,8 @@ func TestDetectFileType_NonASCIIIsBinary(t *testing.T) {
 		{"continuation byte only", []byte("prefix\xBFsuffix"), "bin"},
 		{"delete char", []byte("prefix\x7Fsuffix"), "bin"},
 		{"nul byte", []byte("prefix\x00suffix"), "bin"},
+		{"high byte past the first 1024", append(bytes.Repeat([]byte("a"), 2048), "ø"...), "bin"},
+		{"long pure ascii", bytes.Repeat([]byte("a"), 2048), "txt"},
 	}
 
 	for _, tt := range tests {

--- a/bitwindow/server/engines/bitdrive_engine_test.go
+++ b/bitwindow/server/engines/bitdrive_engine_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/bitdrive"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/opreturns"
 	"github.com/btcsuite/btcd/chaincfg"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -225,5 +226,69 @@ func TestSaveFile_SameSecondNoCollision(t *testing.T) {
 	}
 	if string(secondContent) != "second file" {
 		t.Fatalf("second file content wrong: got %q", secondContent)
+	}
+}
+
+// TestDetectFileType_NonASCIIIsBinary verifies that any byte above 0x7E makes
+// content classify as "bin" rather than "txt". Classifying it as text sends it
+// down the raw-storage path, which cannot survive retrieval.
+func TestDetectFileType_NonASCIIIsBinary(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		want    string
+	}{
+		{"plain ascii", []byte("hello world\n\tand tabs"), "txt"},
+		{"utf-8 multi-byte", []byte("café"), "bin"},
+		{"high byte", []byte("prefix\xFFsuffix"), "bin"},
+		{"continuation byte only", []byte("prefix\xBFsuffix"), "bin"},
+		{"delete char", []byte("prefix\x7Fsuffix"), "bin"},
+		{"nul byte", []byte("prefix\x00suffix"), "bin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectFileType(tt.content); got != tt.want {
+				t.Fatalf("DetectFileType(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEncodeOPReturnData_NonASCIIRoundTrip walks a payload containing a byte
+// above 0x7F through the full store/retrieve chain:
+// EncodeOPReturnData -> FormatOPReturnData -> OPReturnToReadable ->
+// DecodeOPReturnData. Storing such content as "txt" put raw high bytes on
+// chain, which OPReturnToReadable then hex-encoded, hiding the "|" separator
+// and making DecodeOPReturnData fail with "invalid OP_RETURN format".
+func TestEncodeOPReturnData_NonASCIIRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	engine := &BitDriveEngine{}
+
+	contents := [][]byte{
+		[]byte("café ☕ unicode text"),
+		[]byte("ascii with one high byte: \xFE"),
+		{0x00, 0x01, 0x80, 0xFF, 0x7C, 0x41},
+	}
+
+	for _, content := range contents {
+		metadataB64, contentStr, _, err := engine.EncodeOPReturnData(ctx, content, false)
+		if err != nil {
+			t.Fatalf("encode %q: %v", content, err)
+		}
+
+		opReturnData := FormatOPReturnData(metadataB64, contentStr)
+		readable := opreturns.OPReturnToReadable([]byte(opReturnData))
+
+		decoded, metadata, err := engine.DecodeOPReturnData(ctx, readable)
+		if err != nil {
+			t.Fatalf("decode %q: %v", content, err)
+		}
+		if metadata.FileType != "bin" {
+			t.Fatalf("expected file type bin for %q, got %q", content, metadata.FileType)
+		}
+		if !bytes.Equal(decoded, content) {
+			t.Fatalf("round trip mismatch: got %q, want %q", decoded, content)
+		}
 	}
 }

--- a/bitwindow/server/engines/notification_engine.go
+++ b/bitwindow/server/engines/notification_engine.go
@@ -22,6 +22,10 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// notificationBacklog is how old a wallet transaction has to be before it counts
+// as history: recorded as seen, never announced.
+const notificationBacklog = 24 * time.Hour
+
 type NotificationEngine struct {
 	db       *sql.DB
 	bitcoind *service.Service[corerpc.BitcoinServiceClient]
@@ -243,6 +247,21 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 		}
 
 		if notified && confNotified {
+			continue
+		}
+
+		if txTime := tx.GetTime(); txTime != nil && time.Since(txTime.AsTime()) > notificationBacklog {
+			if !notified {
+				if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, eventID); err != nil {
+					log.Warn().Err(err).Str("txid", txid).Msg("mark backlog transaction notified")
+					continue
+				}
+			}
+			if !confNotified && confirmations >= 1 {
+				if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransactionConf, confEventID); err != nil {
+					log.Warn().Err(err).Str("txid", txid).Msg("mark backlog transaction confirmation notified")
+				}
+			}
 			continue
 		}
 

--- a/bitwindow/server/engines/notification_engine.go
+++ b/bitwindow/server/engines/notification_engine.go
@@ -210,27 +210,32 @@ func (e *NotificationEngine) checkWalletTransactions(ctx context.Context) error 
 			continue
 		}
 
-		e.processWalletTransactions(ctx, resp.Msg.Transactions)
+		e.processWalletTransactions(ctx, walletName, resp.Msg.Transactions)
 	}
 
 	return nil
 }
 
-func (e *NotificationEngine) processWalletTransactions(ctx context.Context, transactions []*corepb.GetTransactionResponse) {
+func (e *NotificationEngine) processWalletTransactions(ctx context.Context, walletName string, transactions []*corepb.GetTransactionResponse) {
 	log := zerolog.Ctx(ctx)
 	for _, tx := range transactions {
 		txid := tx.Txid
 		confirmations := uint32(tx.Confirmations)
 
+		// The same txid can show up in several loaded wallets, so scope the
+		// dedup key by wallet. Otherwise the first wallet we process swallows
+		// the notification for all the others.
+		eventID := walletName + ":" + txid
+
 		// Check if we've already notified about this transaction
-		notified, err := notifications.HasBeenNotified(ctx, e.db, notifications.EventTypeTransaction, txid)
+		notified, err := notifications.HasBeenNotified(ctx, e.db, notifications.EventTypeTransaction, eventID)
 		if err != nil {
 			log.Warn().Err(err).Str("txid", txid).Msg("check transaction notification status")
 			continue
 		}
 
 		// For confirmation notifications, use a separate event type
-		confEventID := txid + ":confirmed"
+		confEventID := eventID + ":confirmed"
 		confNotified, err := notifications.HasBeenNotified(ctx, e.db, notifications.EventTypeTransactionConf, confEventID)
 		if err != nil {
 			log.Warn().Err(err).Str("txid", txid).Msg("check transaction confirmation notification status")
@@ -256,7 +261,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, tran
 				},
 			}
 			e.broadcast(ctx, event)
-			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, txid); err != nil {
+			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, eventID); err != nil {
 				log.Warn().Err(err).Str("txid", txid).Msg("mark transaction notified")
 			}
 			log.Info().
@@ -278,7 +283,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, tran
 				},
 			}
 			e.broadcast(ctx, event)
-			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, txid); err != nil {
+			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, eventID); err != nil {
 				log.Warn().Err(err).Str("txid", txid).Msg("mark transaction notified")
 			}
 			log.Info().
@@ -288,7 +293,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, tran
 
 		case !notified:
 			// New transaction with zero amount - just mark as seen
-			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, txid); err != nil {
+			if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, eventID); err != nil {
 				log.Warn().Err(err).Str("txid", txid).Msg("mark transaction notified")
 			}
 

--- a/bitwindow/server/engines/notification_engine.go
+++ b/bitwindow/server/engines/notification_engine.go
@@ -220,11 +220,52 @@ func (e *NotificationEngine) checkWalletTransactions(ctx context.Context) error 
 	return nil
 }
 
+// walletTx is one transaction's wallet-relevant outputs in a single direction, summed.
+type walletTx struct {
+	txid          string
+	amount        float64
+	confirmations uint32
+	txTime        time.Time
+}
+
+// aggregateByTxid folds Core's per-output rows into one entry per txid and
+// direction; sends and receives stay apart so a self-send can't net to zero.
+func aggregateByTxid(transactions []*corepb.GetTransactionResponse) []walletTx {
+	type bucket struct {
+		txid     string
+		received bool
+	}
+
+	aggregated := make([]walletTx, 0, len(transactions))
+	seen := make(map[bucket]int, len(transactions))
+	for _, tx := range transactions {
+		key := bucket{txid: tx.Txid, received: tx.Amount >= 0}
+		if idx, ok := seen[key]; ok {
+			aggregated[idx].amount += tx.Amount
+			continue
+		}
+
+		var txTime time.Time
+		if t := tx.GetTime(); t != nil {
+			txTime = t.AsTime()
+		}
+
+		seen[key] = len(aggregated)
+		aggregated = append(aggregated, walletTx{
+			txid:          tx.Txid,
+			amount:        tx.Amount,
+			confirmations: uint32(tx.Confirmations),
+			txTime:        txTime,
+		})
+	}
+	return aggregated
+}
+
 func (e *NotificationEngine) processWalletTransactions(ctx context.Context, walletName string, transactions []*corepb.GetTransactionResponse) {
 	log := zerolog.Ctx(ctx)
-	for _, tx := range transactions {
-		txid := tx.Txid
-		confirmations := uint32(tx.Confirmations)
+	for _, tx := range aggregateByTxid(transactions) {
+		txid := tx.txid
+		confirmations := tx.confirmations
 
 		// The same txid can show up in several loaded wallets, so scope the
 		// dedup key by wallet. Otherwise the first wallet we process swallows
@@ -250,7 +291,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 			continue
 		}
 
-		if txTime := tx.GetTime(); txTime != nil && time.Since(txTime.AsTime()) > notificationBacklog {
+		if !tx.txTime.IsZero() && time.Since(tx.txTime) > notificationBacklog {
 			if !notified {
 				if err := notifications.MarkNotified(ctx, e.db, notifications.EventTypeTransaction, eventID); err != nil {
 					log.Warn().Err(err).Str("txid", txid).Msg("mark backlog transaction notified")
@@ -266,7 +307,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 		}
 
 		switch {
-		case !notified && tx.Amount > 0:
+		case !notified && tx.amount > 0:
 			// Received transaction
 			event := &notificationv1.WatchResponse{
 				Timestamp: timestamppb.Now(),
@@ -274,7 +315,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 					Transaction: &notificationv1.TransactionEvent{
 						Type:          notificationv1.TransactionEvent_TYPE_RECEIVED,
 						Txid:          txid,
-						AmountSats:    uint64(math.Round(tx.Amount * 100000000)),
+						AmountSats:    uint64(math.Round(tx.amount * 100000000)),
 						Confirmations: confirmations,
 					},
 				},
@@ -285,10 +326,10 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 			}
 			log.Info().
 				Str("txid", txid).
-				Float64("amount", tx.Amount).
+				Float64("amount", tx.amount).
 				Msg("received transaction notification sent")
 
-		case !notified && tx.Amount < 0:
+		case !notified && tx.amount < 0:
 			// Sent transaction
 			event := &notificationv1.WatchResponse{
 				Timestamp: timestamppb.Now(),
@@ -296,7 +337,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 					Transaction: &notificationv1.TransactionEvent{
 						Type:          notificationv1.TransactionEvent_TYPE_SENT,
 						Txid:          txid,
-						AmountSats:    uint64(math.Round(-tx.Amount * 100000000)),
+						AmountSats:    uint64(math.Round(-tx.amount * 100000000)),
 						Confirmations: confirmations,
 					},
 				},
@@ -307,7 +348,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 			}
 			log.Info().
 				Str("txid", txid).
-				Float64("amount", -tx.Amount).
+				Float64("amount", -tx.amount).
 				Msg("sent transaction notification sent")
 
 		case !notified:
@@ -324,7 +365,7 @@ func (e *NotificationEngine) processWalletTransactions(ctx context.Context, wall
 					Transaction: &notificationv1.TransactionEvent{
 						Type:          notificationv1.TransactionEvent_TYPE_CONFIRMED,
 						Txid:          txid,
-						AmountSats:    uint64(math.Round(tx.Amount * 100000000)),
+						AmountSats:    uint64(math.Round(tx.amount * 100000000)),
 						Confirmations: confirmations,
 					},
 				},

--- a/bitwindow/server/engines/notification_engine_internal_test.go
+++ b/bitwindow/server/engines/notification_engine_internal_test.go
@@ -1,0 +1,50 @@
+package engines
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	notificationv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/notification/v1"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	"github.com/stretchr/testify/require"
+)
+
+// The same txid shows up in every wallet that takes part in it, so dedup has to
+// be per-wallet. Otherwise the first wallet we process swallows the
+// notification for all the others.
+func TestProcessWalletTransactions_DedupIsPerWallet(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	engine := NewNotificationEngine(db, nil)
+	events := engine.Subscribe(ctx)
+
+	const txid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	txs := []*corepb.GetTransactionResponse{{
+		Txid:          txid,
+		Amount:        1,
+		Confirmations: 0,
+	}}
+
+	engine.processWalletTransactions(ctx, "wallet-a", txs)
+	engine.processWalletTransactions(ctx, "wallet-b", txs)
+
+	// A second pass must not notify again for either wallet.
+	engine.processWalletTransactions(ctx, "wallet-a", txs)
+	engine.processWalletTransactions(ctx, "wallet-b", txs)
+
+	var received int
+	for done := false; !done; {
+		select {
+		case event := <-events:
+			require.Equal(t, notificationv1.TransactionEvent_TYPE_RECEIVED, event.GetTransaction().GetType())
+			require.Equal(t, txid, event.GetTransaction().GetTxid())
+			received++
+		default:
+			done = true
+		}
+	}
+
+	require.Equal(t, 2, received)
+}

--- a/bitwindow/server/engines/notification_engine_internal_test.go
+++ b/bitwindow/server/engines/notification_engine_internal_test.go
@@ -85,3 +85,60 @@ func TestProcessWalletTransactions_DedupIsPerWallet(t *testing.T) {
 
 	require.Equal(t, 2, received)
 }
+
+// Bitcoin Core hands back one row per wallet-relevant output, so a transaction
+// paying us twice arrives as two rows sharing a txid. The notification has to
+// carry the summed amount, not just whichever output came first.
+func TestProcessWalletTransactions_SumsOutputsWithSameTxid(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	engine := NewNotificationEngine(db, nil)
+	events := engine.Subscribe(ctx)
+
+	const txid = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	engine.processWalletTransactions(ctx, "wallet-a", []*corepb.GetTransactionResponse{
+		{Txid: txid, Amount: 1.5, Confirmations: 0},
+		{Txid: txid, Amount: 0.25, Confirmations: 0},
+	})
+
+	select {
+	case event := <-events:
+		require.Equal(t, notificationv1.TransactionEvent_TYPE_RECEIVED, event.GetTransaction().GetType())
+		require.Equal(t, txid, event.GetTransaction().GetTxid())
+		require.Equal(t, uint64(175_000_000), event.GetTransaction().GetAmountSats())
+	default:
+		t.Fatal("expected a received notification")
+	}
+
+	select {
+	case event := <-events:
+		t.Fatalf("expected a single notification, got another: %v", event)
+	default:
+	}
+}
+
+// A self-send inside one wallet produces both a send and a receive row for the
+// same txid. Summing across directions nets them to zero and notifies nothing.
+func TestProcessWalletTransactions_SelfSendIsNotNettedToZero(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	engine := NewNotificationEngine(db, nil)
+	events := engine.Subscribe(ctx)
+
+	const txid = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	engine.processWalletTransactions(ctx, "wallet-a", []*corepb.GetTransactionResponse{
+		{Txid: txid, Amount: -1.0, Confirmations: 0},
+		{Txid: txid, Amount: 1.0, Confirmations: 0},
+	})
+
+	select {
+	case event := <-events:
+		require.Equal(t, notificationv1.TransactionEvent_TYPE_SENT, event.GetTransaction().GetType())
+		require.Equal(t, txid, event.GetTransaction().GetTxid())
+		require.Equal(t, uint64(100_000_000), event.GetTransaction().GetAmountSats())
+	default:
+		t.Fatal("expected a sent notification, got none")
+	}
+}

--- a/bitwindow/server/engines/notification_engine_internal_test.go
+++ b/bitwindow/server/engines/notification_engine_internal_test.go
@@ -3,12 +3,49 @@ package engines
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	notificationv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/notification/v1"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/notifications"
 	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// A wallet's transaction history must not be announced: on a fresh database
+// every past transaction is unseen, and there can be a hundred of them.
+func TestProcessWalletTransactions_HistoryIsNotAnnounced(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	engine := NewNotificationEngine(db, nil)
+	events := engine.Subscribe(ctx)
+
+	const txid = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	engine.processWalletTransactions(ctx, "wallet-a", []*corepb.GetTransactionResponse{{
+		Txid:          txid,
+		Amount:        1,
+		Confirmations: 6,
+		Time:          timestamppb.New(time.Now().Add(-notificationBacklog - time.Hour)),
+	}})
+
+	select {
+	case event := <-events:
+		t.Fatalf("announced a historical transaction: %v", event)
+	default:
+	}
+
+	// Both the receive and the confirmation are recorded, so a later poll stays quiet.
+	for _, tc := range []struct{ eventType, eventID string }{
+		{notifications.EventTypeTransaction, "wallet-a:" + txid},
+		{notifications.EventTypeTransactionConf, "wallet-a:" + txid + ":confirmed"},
+	} {
+		notified, err := notifications.HasBeenNotified(ctx, db, tc.eventType, tc.eventID)
+		require.NoError(t, err)
+		require.True(t, notified, tc.eventID)
+	}
+}
 
 // The same txid shows up in every wallet that takes part in it, so dedup has to
 // be per-wallet. Otherwise the first wallet we process swallows the

--- a/bitwindow/server/engines/timestamp_engine.go
+++ b/bitwindow/server/engines/timestamp_engine.go
@@ -239,7 +239,7 @@ func (e *TimestampEngine) TimestampFile(ctx context.Context, filename string, fi
 	if err != nil {
 		return nil, fmt.Errorf("check existing timestamp: %w", err)
 	}
-	if existing != nil {
+	if existing != nil && existing.Status != timestamps.StatusFailed {
 		e.log.Info().
 			Str("filename", filename).
 			Str("hash", fileHash).
@@ -266,13 +266,35 @@ func (e *TimestampEngine) TimestampFile(ctx context.Context, filename string, fi
 		Str("hash", fileHash).
 		Msg("created timestamp transaction on blockchain")
 
+	createdAt := time.Now()
+
+	if existing != nil {
+		if err := timestamps.Retry(ctx, e.db, existing.ID, txid, createdAt); err != nil {
+			return nil, fmt.Errorf("retry timestamp record: %w", err)
+		}
+
+		existing.TxID = &txid
+		existing.Status = timestamps.StatusConfirming
+		existing.CreatedAt = createdAt
+		existing.BlockHeight = nil
+		existing.ConfirmedAt = nil
+
+		e.log.Info().
+			Int64("id", existing.ID).
+			Str("filename", existing.Filename).
+			Str("txid", txid).
+			Msg("failed file timestamp retried")
+
+		return existing, nil
+	}
+
 	// Store timestamp metadata in database
 	timestamp := timestamps.FileTimestamp{
 		Filename:  filename,
 		FileHash:  fileHash,
 		TxID:      &txid,
 		Status:    timestamps.StatusConfirming,
-		CreatedAt: time.Now(),
+		CreatedAt: createdAt,
 	}
 
 	id, err := timestamps.Create(ctx, e.db, timestamp)

--- a/bitwindow/server/engines/timestamp_engine.go
+++ b/bitwindow/server/engines/timestamp_engine.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -22,7 +23,38 @@ import (
 const (
 	// TimestampPrefix is prepended to SHA256 hash in OP_RETURN to identify timestamp transactions
 	TimestampPrefix = "STAMP"
+
+	// timestampFailureGrace is how long a confirming timestamp is given before
+	// bitcoind not knowing its txid is treated as terminal. Core's default
+	// mempool expiry is 336 hours, so a transaction it still has never heard
+	// of after that window is never going to confirm.
+	timestampFailureGrace = 14 * 24 * time.Hour
 )
+
+// txNotFoundPatterns are the shapes Core's -5 "unknown transaction" error
+// arrives in. Unlike an RPC outage this answer is deterministic: bitcoind has
+// neither a mempool entry nor an indexed transaction, so retrying the same
+// txid cannot change it.
+var txNotFoundPatterns = []string{
+	"-5:",
+	"-5 -",
+	"No such mempool",
+}
+
+// isTxNotFoundError reports whether bitcoind answered "I don't know this txid"
+// rather than failing for a transient reason (still starting up, connection
+// refused, timeout).
+func isTxNotFoundError(errMsg string) bool {
+	if IsBitcoinCoreStartupError(errMsg) {
+		return false
+	}
+	for _, p := range txNotFoundPatterns {
+		if strings.Contains(errMsg, p) {
+			return true
+		}
+	}
+	return false
+}
 
 type TimestampEngine struct {
 	db       *sql.DB
@@ -98,6 +130,36 @@ func (e *TimestampEngine) checkConfirmations(ctx context.Context) error {
 			Verbosity: corepb.GetRawTransactionRequest_VERBOSITY_TX_PREVOUT_INFO,
 		}))
 		if err != nil {
+			// A transaction bitcoind has never heard of, long past the point
+			// where it could still be sitting in a mempool, is dead: the
+			// broadcast was dropped, replaced or reorged away. Anything else
+			// (bitcoind down, mid-startup, RPC hiccup) is transient and gets
+			// retried on the next tick.
+			if isTxNotFoundError(err.Error()) && time.Since(ts.CreatedAt) > timestampFailureGrace {
+				if err := timestamps.Update(
+					ctx,
+					e.db,
+					ts.ID,
+					ts.TxID,
+					nil,
+					timestamps.StatusFailed,
+					nil,
+				); err != nil {
+					e.log.Warn().
+						Err(err).
+						Int64("id", ts.ID).
+						Msg("update timestamp")
+					continue
+				}
+
+				e.log.Info().
+					Int64("id", ts.ID).
+					Str("txid", *ts.TxID).
+					Time("created_at", ts.CreatedAt).
+					Msg("timestamp transaction unknown to bitcoind past grace period, marked failed")
+				continue
+			}
+
 			e.log.Warn().
 				Err(err).
 				Str("txid", *ts.TxID).

--- a/bitwindow/server/engines/timestamp_engine.go
+++ b/bitwindow/server/engines/timestamp_engine.go
@@ -116,6 +116,12 @@ func (e *TimestampEngine) checkConfirmations(ctx context.Context) error {
 		return fmt.Errorf("get bitcoind client: %w", err)
 	}
 
+	chainInfo, err := bitcoind.GetBlockchainInfo(ctx, connect.NewRequest(&corepb.GetBlockchainInfoRequest{}))
+	if err != nil {
+		return fmt.Errorf("get blockchain info: %w", err)
+	}
+	inIBD := chainInfo.Msg.InitialBlockDownload
+
 	e.log.Debug().
 		Int("count", len(confirmingTimestamps)).
 		Msg("checking confirmations for timestamps")
@@ -130,12 +136,9 @@ func (e *TimestampEngine) checkConfirmations(ctx context.Context) error {
 			Verbosity: corepb.GetRawTransactionRequest_VERBOSITY_TX_PREVOUT_INFO,
 		}))
 		if err != nil {
-			// A transaction bitcoind has never heard of, long past the point
-			// where it could still be sitting in a mempool, is dead: the
-			// broadcast was dropped, replaced or reorged away. Anything else
-			// (bitcoind down, mid-startup, RPC hiccup) is transient and gets
-			// retried on the next tick.
-			if isTxNotFoundError(err.Error()) && time.Since(ts.CreatedAt) > timestampFailureGrace {
+			// A syncing node reports the same unknown-txid error for blocks it
+			// has not downloaded yet, so the terminal transition waits for IBD.
+			if isTxNotFoundError(err.Error()) && !inIBD && time.Since(ts.CreatedAt) > timestampFailureGrace {
 				if err := timestamps.Update(
 					ctx,
 					e.db,

--- a/bitwindow/server/engines/timestamp_engine_internal_test.go
+++ b/bitwindow/server/engines/timestamp_engine_internal_test.go
@@ -1,0 +1,93 @@
+package engines
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/timestamps"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+)
+
+// A timestamp whose transaction bitcoind has never heard of has to eventually
+// leave "confirming" — otherwise a dropped/replaced broadcast is reported as
+// in-flight forever. A transient RPC failure must NOT do that.
+func TestCheckConfirmations_UnknownTransaction(t *testing.T) {
+	tests := []struct {
+		name      string
+		createdAt time.Time
+		rpcErr    error
+		want      timestamps.Status
+	}{
+		{
+			name:      "unknown transaction past grace period fails",
+			createdAt: time.Now().Add(-timestampFailureGrace - time.Hour),
+			rpcErr:    errors.New("internal: -5: No such mempool or blockchain transaction. Use gettransaction for wallet transactions."),
+			want:      timestamps.StatusFailed,
+		},
+		{
+			name:      "unknown transaction within grace period keeps confirming",
+			createdAt: time.Now().Add(-time.Hour),
+			rpcErr:    errors.New("internal: -5: No such mempool or blockchain transaction. Use gettransaction for wallet transactions."),
+			want:      timestamps.StatusConfirming,
+		},
+		{
+			name:      "bitcoind outage keeps confirming",
+			createdAt: time.Now().Add(-timestampFailureGrace - time.Hour),
+			rpcErr:    errors.New("unavailable: dial tcp 127.0.0.1:8332: connect: connection refused"),
+			want:      timestamps.StatusConfirming,
+		},
+		{
+			name:      "bitcoind still starting up keeps confirming",
+			createdAt: time.Now().Add(-timestampFailureGrace - time.Hour),
+			rpcErr:    errors.New("internal: -28: Loading block index…"),
+			want:      timestamps.StatusConfirming,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			db := database.Test(t)
+
+			core := mocks.NewMockBitcoinServiceClient(gomock.NewController(t))
+			engine := NewTimestampEngine(db, zerolog.Nop(), nil,
+				service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+					return core, nil
+				}),
+			)
+
+			txid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			id, err := timestamps.Create(ctx, db, timestamps.FileTimestamp{
+				Filename:  "test.txt",
+				FileHash:  "cafebabe",
+				TxID:      &txid,
+				Status:    timestamps.StatusConfirming,
+				CreatedAt: tc.createdAt,
+			})
+			require.NoError(t, err)
+
+			core.EXPECT().
+				GetRawTransaction(gomock.Any(), gomock.Any()).
+				Return((*connect.Response[corepb.GetRawTransactionResponse])(nil), tc.rpcErr)
+
+			require.NoError(t, engine.checkConfirmations(ctx))
+
+			got, err := timestamps.Get(ctx, db, id)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.want, got.Status)
+		})
+	}
+}

--- a/bitwindow/server/engines/timestamp_engine_internal_test.go
+++ b/bitwindow/server/engines/timestamp_engine_internal_test.go
@@ -28,8 +28,16 @@ func TestCheckConfirmations_UnknownTransaction(t *testing.T) {
 		name      string
 		createdAt time.Time
 		rpcErr    error
+		inIBD     bool
 		want      timestamps.Status
 	}{
+		{
+			name:      "unknown transaction during initial block download keeps confirming",
+			createdAt: time.Now().Add(-timestampFailureGrace - time.Hour),
+			rpcErr:    errors.New("internal: -5: No such mempool or blockchain transaction. Use gettransaction for wallet transactions."),
+			inIBD:     true,
+			want:      timestamps.StatusConfirming,
+		},
 		{
 			name:      "unknown transaction past grace period fails",
 			createdAt: time.Now().Add(-timestampFailureGrace - time.Hour),
@@ -77,6 +85,12 @@ func TestCheckConfirmations_UnknownTransaction(t *testing.T) {
 				CreatedAt: tc.createdAt,
 			})
 			require.NoError(t, err)
+
+			core.EXPECT().
+				GetBlockchainInfo(gomock.Any(), gomock.Any()).
+				Return(connect.NewResponse(&corepb.GetBlockchainInfoResponse{
+					InitialBlockDownload: tc.inIBD,
+				}), nil)
 
 			core.EXPECT().
 				GetRawTransaction(gomock.Any(), gomock.Any()).

--- a/bitwindow/server/engines/timestamp_engine_test.go
+++ b/bitwindow/server/engines/timestamp_engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
 	"github.com/rs/zerolog"
@@ -45,6 +46,50 @@ type mockWallet struct{}
 
 func (m *mockWallet) SendTransaction(ctx context.Context, opReturnData []byte) (string, error) {
 	return "mock-txid", nil
+}
+
+type sequenceWallet struct {
+	txids []string
+	sent  int
+}
+
+func (w *sequenceWallet) SendTransaction(ctx context.Context, opReturnData []byte) (string, error) {
+	txid := w.txids[w.sent]
+	w.sent++
+	return txid, nil
+}
+
+// The file hash is unique, so a failed record that is never replaced makes the
+// file impossible to timestamp again.
+func TestTimestampEngine_TimestampFailedFileAgain(t *testing.T) {
+	ctx := context.Background()
+	db := setupTestDB(t)
+	defer db.Close()
+
+	engine := engines.NewTimestampEngine(db, zerolog.Nop(), &sequenceWallet{txids: []string{"first-txid", "second-txid"}}, nil)
+
+	fileData := []byte("test file content")
+	first, err := engine.TimestampFile(ctx, "test.txt", fileData)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		`UPDATE file_timestamps SET status = ?, created_at = ? WHERE id = ?`,
+		timestamps.StatusFailed, time.Now().Add(-30*24*time.Hour), first.ID,
+	)
+	require.NoError(t, err)
+
+	second, err := engine.TimestampFile(ctx, "test.txt", fileData)
+	require.NoError(t, err)
+	require.Equal(t, first.ID, second.ID)
+	require.Equal(t, "second-txid", *second.TxID)
+	require.Equal(t, timestamps.StatusConfirming, second.Status)
+
+	stored, err := timestamps.List(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	require.Equal(t, timestamps.StatusConfirming, stored[0].Status)
+	require.Equal(t, "second-txid", *stored[0].TxID)
+	require.WithinDuration(t, time.Now(), stored[0].CreatedAt, time.Minute)
 }
 
 func TestTimestampEngine_TimestampFile(t *testing.T) {

--- a/bitwindow/server/engines/wallet_engine.go
+++ b/bitwindow/server/engines/wallet_engine.go
@@ -727,7 +727,7 @@ func (e *WalletEngine) coreDescriptors(masterKey *hdkeychain.ExtendedKey, accoun
 		if err != nil {
 			return nil, err
 		}
-		acct, err := deriveHardenedPath(masterKey, ap)
+		acct, err := DeriveHardenedPath(masterKey, ap)
 		if err != nil {
 			return nil, err
 		}
@@ -748,8 +748,8 @@ func (e *WalletEngine) coreDescriptors(masterKey *hdkeychain.ExtendedKey, accoun
 	return out, nil
 }
 
-// deriveHardenedPath derives the hardened account-level key for an AccountPath.
-func deriveHardenedPath(masterKey *hdkeychain.ExtendedKey, ap orchwallet.AccountPath) (*hdkeychain.ExtendedKey, error) {
+// DeriveHardenedPath derives the hardened account-level key for an AccountPath.
+func DeriveHardenedPath(masterKey *hdkeychain.ExtendedKey, ap orchwallet.AccountPath) (*hdkeychain.ExtendedKey, error) {
 	const h = hdkeychain.HardenedKeyStart
 	cur := masterKey
 	for _, idx := range []uint32{ap.Purpose, ap.Coin, ap.Account} {

--- a/bitwindow/server/gen/wallet/v1/wallet.pb.go
+++ b/bitwindow/server/gen/wallet/v1/wallet.pb.go
@@ -1346,9 +1346,11 @@ func (x *CreateSidechainDepositResponse) GetTxid() string {
 }
 
 type SignMessageRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	WalletId      string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
-	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	WalletId string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	Message  string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	// Receiving address to sign with. Must belong to the wallet.
+	Address       string `protobuf:"bytes,3,opt,name=address,proto3" json:"address,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1393,6 +1395,13 @@ func (x *SignMessageRequest) GetWalletId() string {
 func (x *SignMessageRequest) GetMessage() string {
 	if x != nil {
 		return x.Message
+	}
+	return ""
+}
+
+func (x *SignMessageRequest) GetAddress() string {
+	if x != nil {
+		return x.Address
 	}
 	return ""
 }
@@ -4207,10 +4216,11 @@ const file_wallet_v1_wallet_proto_rawDesc = "" +
 	"\x06amount\x18\x04 \x01(\x01R\x06amount\x12\x10\n" +
 	"\x03fee\x18\x05 \x01(\x01R\x03fee\"4\n" +
 	"\x1eCreateSidechainDepositResponse\x12\x12\n" +
-	"\x04txid\x18\x01 \x01(\tR\x04txid\"K\n" +
+	"\x04txid\x18\x01 \x01(\tR\x04txid\"e\n" +
 	"\x12SignMessageRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"3\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12\x18\n" +
+	"\aaddress\x18\x03 \x01(\tR\aaddress\"3\n" +
 	"\x13SignMessageResponse\x12\x1c\n" +
 	"\tsignature\x18\x01 \x01(\tR\tsignature\"\x8a\x01\n" +
 	"\x14VerifyMessageRequest\x12\x1b\n" +

--- a/bitwindow/server/models/timestamps/timestamps.go
+++ b/bitwindow/server/models/timestamps/timestamps.go
@@ -209,6 +209,25 @@ func GetByHash(ctx context.Context, db *sql.DB, fileHash string) (*FileTimestamp
 	return &timestamp, nil
 }
 
+// Retry points a failed timestamp at a fresh broadcast, restarting it as confirming.
+func Retry(ctx context.Context, db *sql.DB, id int64, txid string, createdAt time.Time) error {
+	_, err := db.ExecContext(ctx, `
+		UPDATE file_timestamps
+		SET txid = ?, status = ?, created_at = ?, block_height = NULL, confirmed_at = NULL
+		WHERE id = ?
+	`, txid, StatusConfirming, createdAt, id)
+	if err != nil {
+		return fmt.Errorf("retry file timestamp: %w", err)
+	}
+
+	zerolog.Ctx(ctx).Info().
+		Int64("id", id).
+		Str("txid", txid).
+		Msg("retried file timestamp")
+
+	return nil
+}
+
 func UpdateFilename(ctx context.Context, db *sql.DB, id int64, filename string) error {
 	_, err := db.ExecContext(ctx, `
 		UPDATE file_timestamps

--- a/bitwindow/server/proto/wallet/v1/wallet.proto
+++ b/bitwindow/server/proto/wallet/v1/wallet.proto
@@ -228,6 +228,8 @@ message CreateSidechainDepositResponse {
 message SignMessageRequest {
   string wallet_id = 1;
   string message = 2;
+  // Receiving address to sign with. Must belong to the wallet.
+  string address = 3;
 }
 message SignMessageResponse {
   string signature = 1;

--- a/bitwindow/test/mocks/api_mock.dart
+++ b/bitwindow/test/mocks/api_mock.dart
@@ -234,7 +234,7 @@ class MockWalletAPI implements WalletAPI {
   }
 
   @override
-  Future<String> signMessage(String walletId, String message) async {
+  Future<String> signMessage(String walletId, String message, String address) async {
     return 'mock_signature';
   }
 

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.155
+version: 1.0.156
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/gen/wallet/v1/wallet.pb.dart
+++ b/sail_ui/lib/gen/wallet/v1/wallet.pb.dart
@@ -1638,6 +1638,7 @@ class SignMessageRequest extends $pb.GeneratedMessage {
   factory SignMessageRequest({
     $core.String? walletId,
     $core.String? message,
+    $core.String? address,
   }) {
     final $result = create();
     if (walletId != null) {
@@ -1645,6 +1646,9 @@ class SignMessageRequest extends $pb.GeneratedMessage {
     }
     if (message != null) {
       $result.message = message;
+    }
+    if (address != null) {
+      $result.address = address;
     }
     return $result;
   }
@@ -1655,6 +1659,7 @@ class SignMessageRequest extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignMessageRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'wallet.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
     ..aOS(2, _omitFieldNames ? '' : 'message')
+    ..aOS(3, _omitFieldNames ? '' : 'address')
     ..hasRequiredFields = false
   ;
 
@@ -1696,6 +1701,16 @@ class SignMessageRequest extends $pb.GeneratedMessage {
   $core.bool hasMessage() => $_has(1);
   @$pb.TagNumber(2)
   void clearMessage() => clearField(2);
+
+  /// Receiving address to sign with. Must belong to the wallet.
+  @$pb.TagNumber(3)
+  $core.String get address => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set address($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAddress() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearAddress() => clearField(3);
 }
 
 class SignMessageResponse extends $pb.GeneratedMessage {

--- a/sail_ui/lib/gen/wallet/v1/wallet.pbjson.dart
+++ b/sail_ui/lib/gen/wallet/v1/wallet.pbjson.dart
@@ -406,13 +406,14 @@ const SignMessageRequest$json = {
   '2': [
     {'1': 'wallet_id', '3': 1, '4': 1, '5': 9, '10': 'walletId'},
     {'1': 'message', '3': 2, '4': 1, '5': 9, '10': 'message'},
+    {'1': 'address', '3': 3, '4': 1, '5': 9, '10': 'address'},
   ],
 };
 
 /// Descriptor for `SignMessageRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List signMessageRequestDescriptor = $convert.base64Decode(
     'ChJTaWduTWVzc2FnZVJlcXVlc3QSGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZXRJZBIYCgdtZX'
-    'NzYWdlGAIgASgJUgdtZXNzYWdl');
+    'NzYWdlGAIgASgJUgdtZXNzYWdlEhgKB2FkZHJlc3MYAyABKAlSB2FkZHJlc3M=');
 
 @$core.Deprecated('Use signMessageResponseDescriptor instead')
 const SignMessageResponse$json = {

--- a/sail_ui/lib/providers/balance_provider.dart
+++ b/sail_ui/lib/providers/balance_provider.dart
@@ -24,6 +24,10 @@ class BalanceProvider extends ChangeNotifier implements NetworkScoped {
   bool _isFetching = false;
   Timer? _fetchTimer;
 
+  // A recreated transport abandons in-flight requests without ever completing
+  // their futures, which would latch _isFetching for the rest of the session.
+  static const _fetchTimeout = Duration(seconds: 30);
+
   final WalletReaderProvider? _walletReader = GetIt.I.isRegistered<WalletReaderProvider>()
       ? GetIt.I.get<WalletReaderProvider>()
       : null;
@@ -102,7 +106,18 @@ class BalanceProvider extends ChangeNotifier implements NetworkScoped {
           // dont bother fetching balance if connection is down
           continue;
         }
-        final (confirmed, pending) = await rpc.balance();
+        final (double confirmed, double pending) balances;
+        try {
+          balances = await rpc.balance().timeout(_fetchTimeout);
+        } catch (err) {
+          // One unreachable chain must not stop the others from reporting.
+          if (!isExpectedBootError(err)) {
+            log.w('BalanceProvider: ${rpc.binaryType.name} balance failed: $err');
+          }
+          error = err.toString();
+          continue;
+        }
+        final (confirmed, pending) = balances;
         if (!initialized) {
           // wen't from not initialized to initialized, make sure to notify
           changed = true;
@@ -120,6 +135,7 @@ class BalanceProvider extends ChangeNotifier implements NetworkScoped {
         notifyListeners();
       }
     } catch (err) {
+      log.w('BalanceProvider: fetch failed: $err');
       error = err.toString();
     } finally {
       _isFetching = false;

--- a/sail_ui/lib/rpcs/bitwindow_api.dart
+++ b/sail_ui/lib/rpcs/bitwindow_api.dart
@@ -632,7 +632,7 @@ abstract class WalletAPI {
     double amount,
     double fee,
   );
-  Future<String> signMessage(String walletId, String message);
+  Future<String> signMessage(String walletId, String message, String address);
   Future<bool> verifyMessage(
     String walletId,
     String message,
@@ -851,12 +851,13 @@ class _WalletAPILive implements WalletAPI {
   }
 
   @override
-  Future<String> signMessage(String walletId, String message) async {
+  Future<String> signMessage(String walletId, String message, String address) async {
     try {
       final response = await _client.signMessage(
         SignMessageRequest()
           ..walletId = walletId
-          ..message = message,
+          ..message = message
+          ..address = address,
       );
       return response.signature;
     } catch (e) {

--- a/sidechain-orchestrator/process.go
+++ b/sidechain-orchestrator/process.go
@@ -297,19 +297,19 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 	}
 	stderr, stderrW, err := os.Pipe()
 	if err != nil {
-		stdout.Close()
-		stdoutW.Close()
+		stdout.Close()  //nolint:errcheck // cleanup
+		stdoutW.Close() //nolint:errcheck // cleanup
 		return 0, fmt.Errorf("stderr pipe: %w", err)
 	}
 	cmd.Stdout = stdoutW
 	cmd.Stderr = stderrW
 
 	startErr := cmd.Start()
-	stdoutW.Close()
-	stderrW.Close()
+	stdoutW.Close() //nolint:errcheck // cleanup
+	stderrW.Close() //nolint:errcheck // cleanup
 	if startErr != nil {
-		stdout.Close()
-		stderr.Close()
+		stdout.Close() //nolint:errcheck // cleanup
+		stderr.Close() //nolint:errcheck // cleanup
 		return 0, fmt.Errorf("start %s: %w", processName, startErr)
 	}
 
@@ -374,7 +374,7 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 	stdoutDone := make(chan struct{})
 	go func() {
 		defer close(stdoutDone)
-		defer stdout.Close()
+		defer stdout.Close() //nolint:errcheck // cleanup
 		scanner := bufio.NewScanner(stdout)
 		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
 		for scanner.Scan() {
@@ -395,7 +395,7 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 	stderrDone := make(chan struct{})
 	go func() {
 		defer close(stderrDone)
-		defer stderr.Close()
+		defer stderr.Close() //nolint:errcheck // cleanup
 		scanner := bufio.NewScanner(stderr)
 		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
 		for scanner.Scan() {
@@ -426,8 +426,8 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 		// A descendant that inherited the pipes keeps the readers blocked past the
 		// child's exit, so closing them is what bounds the drain.
 		drain := time.AfterFunc(2*time.Second, func() {
-			stdout.Close()
-			stderr.Close()
+			stdout.Close() //nolint:errcheck // cleanup
+			stderr.Close() //nolint:errcheck // cleanup
 			pm.log.Warn().Str("binary", processName).Msg("timed out waiting for output to drain")
 		})
 		<-stdoutDone

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.284
+version: 1.0.285
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.155
+version: 1.0.156
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.282
+version: 1.0.283
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
- **fix: BitDrive `DetectFileType` dead UTF-8 branches mis-classify high-byte binaries as `"txt"`; combined with `OPReturnToReadable` printability heuristic, `RetrieveContent` round-trip fails for any content containing a byte > 0x7F stored as `"txt**
- **fix: BitDrive Encrypt auth tag does not cover metadata, so metadata tamper decrypts to wrong plaintext undetected**
- **fix: BitWindow timestamp orphan never transitions `confirming` -> `failed`**
