### PR TITLE
install: fail closed on bad AppImage downloads

### DIFF
--- a/install/install-bitassets.sh
+++ b/install/install-bitassets.sh
@@ -80,7 +80,7 @@ print_info "This may take a few minutes depending on your connection..."
 
 # Download to temp file first to avoid "Text file busy" error if BitAssets is running
 if command -v curl &> /dev/null; then
-    curl -L --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
+    curl -fL --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
         print_error "Failed to download AppImage"
         rm -f "$APPIMAGE_TEMP"
         exit 1
@@ -91,6 +91,13 @@ elif command -v wget &> /dev/null; then
         rm -f "$APPIMAGE_TEMP"
         exit 1
     }
+fi
+
+# -f only rejects HTTP >=400; a proxy error page still arrives as a 200.
+if ! head -c 4 "$APPIMAGE_TEMP" | grep -q $'\x7fELF'; then
+    print_error "Downloaded file is not an ELF binary (possible download failure or MITM)"
+    rm -f "$APPIMAGE_TEMP"
+    exit 1
 fi
 
 # Remove old AppImage (works even if running) and move new one into place
@@ -106,7 +113,7 @@ chmod +x "$APPIMAGE_PATH"
 ICON_PATH="$HOME/.local/share/icons/$APP_NAME_LOWER.png"
 
 if command -v curl &> /dev/null; then
-    curl -sL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
+    curl -fsL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
         print_warning "Could not download icon, will try to extract from AppImage"
         ICON_PATH=""
     }

--- a/install/install-bitnames.sh
+++ b/install/install-bitnames.sh
@@ -80,7 +80,7 @@ print_info "This may take a few minutes depending on your connection..."
 
 # Download to temp file first to avoid "Text file busy" error if BitNames is running
 if command -v curl &> /dev/null; then
-    curl -L --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
+    curl -fL --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
         print_error "Failed to download AppImage"
         rm -f "$APPIMAGE_TEMP"
         exit 1
@@ -91,6 +91,13 @@ elif command -v wget &> /dev/null; then
         rm -f "$APPIMAGE_TEMP"
         exit 1
     }
+fi
+
+# -f only rejects HTTP >=400; a proxy error page still arrives as a 200.
+if ! head -c 4 "$APPIMAGE_TEMP" | grep -q $'\x7fELF'; then
+    print_error "Downloaded file is not an ELF binary (possible download failure or MITM)"
+    rm -f "$APPIMAGE_TEMP"
+    exit 1
 fi
 
 # Remove old AppImage (works even if running) and move new one into place
@@ -106,7 +113,7 @@ chmod +x "$APPIMAGE_PATH"
 ICON_PATH="$HOME/.local/share/icons/$APP_NAME_LOWER.png"
 
 if command -v curl &> /dev/null; then
-    curl -sL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
+    curl -fsL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
         print_warning "Could not download icon, will try to extract from AppImage"
         ICON_PATH=""
     }

--- a/install/install-bitwindow.sh
+++ b/install/install-bitwindow.sh
@@ -80,7 +80,7 @@ print_info "This may take a few minutes depending on your connection..."
 
 # Download to temp file first to avoid "Text file busy" error if BitWindow is running
 if command -v curl &> /dev/null; then
-    curl -L --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
+    curl -fL --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
         print_error "Failed to download AppImage"
         rm -f "$APPIMAGE_TEMP"
         exit 1
@@ -91,6 +91,13 @@ elif command -v wget &> /dev/null; then
         rm -f "$APPIMAGE_TEMP"
         exit 1
     }
+fi
+
+# -f only rejects HTTP >=400; a proxy error page still arrives as a 200.
+if ! head -c 4 "$APPIMAGE_TEMP" | grep -q $'\x7fELF'; then
+    print_error "Downloaded file is not an ELF binary (possible download failure or MITM)"
+    rm -f "$APPIMAGE_TEMP"
+    exit 1
 fi
 
 # Remove old AppImage (works even if running) and move new one into place
@@ -106,7 +113,7 @@ chmod +x "$APPIMAGE_PATH"
 ICON_PATH="$HOME/.local/share/icons/$APP_NAME_LOWER.png"
 
 if command -v curl &> /dev/null; then
-    curl -sL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
+    curl -fsL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
         print_warning "Could not download icon, will try to extract from AppImage"
         ICON_PATH=""
     }

--- a/install/install-photon.sh
+++ b/install/install-photon.sh
@@ -80,7 +80,7 @@ print_info "This may take a few minutes depending on your connection..."
 
 # Download to temp file first to avoid "Text file busy" error if Photon is running
 if command -v curl &> /dev/null; then
-    curl -L --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
+    curl -fL --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
         print_error "Failed to download AppImage"
         rm -f "$APPIMAGE_TEMP"
         exit 1
@@ -91,6 +91,13 @@ elif command -v wget &> /dev/null; then
         rm -f "$APPIMAGE_TEMP"
         exit 1
     }
+fi
+
+# -f only rejects HTTP >=400; a proxy error page still arrives as a 200.
+if ! head -c 4 "$APPIMAGE_TEMP" | grep -q $'\x7fELF'; then
+    print_error "Downloaded file is not an ELF binary (possible download failure or MITM)"
+    rm -f "$APPIMAGE_TEMP"
+    exit 1
 fi
 
 # Remove old AppImage (works even if running) and move new one into place
@@ -106,7 +113,7 @@ chmod +x "$APPIMAGE_PATH"
 ICON_PATH="$HOME/.local/share/icons/$APP_NAME_LOWER.png"
 
 if command -v curl &> /dev/null; then
-    curl -sL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
+    curl -fsL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
         print_warning "Could not download icon, will try to extract from AppImage"
         ICON_PATH=""
     }

--- a/install/install-thunder.sh
+++ b/install/install-thunder.sh
@@ -80,7 +80,7 @@ print_info "This may take a few minutes depending on your connection..."
 
 # Download to temp file first to avoid "Text file busy" error if Thunder is running
 if command -v curl &> /dev/null; then
-    curl -L --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
+    curl -fL --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
         print_error "Failed to download AppImage"
         rm -f "$APPIMAGE_TEMP"
         exit 1
@@ -91,6 +91,13 @@ elif command -v wget &> /dev/null; then
         rm -f "$APPIMAGE_TEMP"
         exit 1
     }
+fi
+
+# -f only rejects HTTP >=400; a proxy error page still arrives as a 200.
+if ! head -c 4 "$APPIMAGE_TEMP" | grep -q $'\x7fELF'; then
+    print_error "Downloaded file is not an ELF binary (possible download failure or MITM)"
+    rm -f "$APPIMAGE_TEMP"
+    exit 1
 fi
 
 # Remove old AppImage (works even if running) and move new one into place
@@ -106,7 +113,7 @@ chmod +x "$APPIMAGE_PATH"
 ICON_PATH="$HOME/.local/share/icons/$APP_NAME_LOWER.png"
 
 if command -v curl &> /dev/null; then
-    curl -sL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
+    curl -fsL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
         print_warning "Could not download icon, will try to extract from AppImage"
         ICON_PATH=""
     }

--- a/install/install-truthcoin.sh
+++ b/install/install-truthcoin.sh
@@ -80,7 +80,7 @@ print_info "This may take a few minutes depending on your connection..."
 
 # Download to temp file first to avoid "Text file busy" error if Truthcoin is running
 if command -v curl &> /dev/null; then
-    curl -L --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
+    curl -fL --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
         print_error "Failed to download AppImage"
         rm -f "$APPIMAGE_TEMP"
         exit 1
@@ -91,6 +91,13 @@ elif command -v wget &> /dev/null; then
         rm -f "$APPIMAGE_TEMP"
         exit 1
     }
+fi
+
+# -f only rejects HTTP >=400; a proxy error page still arrives as a 200.
+if ! head -c 4 "$APPIMAGE_TEMP" | grep -q $'\x7fELF'; then
+    print_error "Downloaded file is not an ELF binary (possible download failure or MITM)"
+    rm -f "$APPIMAGE_TEMP"
+    exit 1
 fi
 
 # Remove old AppImage (works even if running) and move new one into place
@@ -106,7 +113,7 @@ chmod +x "$APPIMAGE_PATH"
 ICON_PATH="$HOME/.local/share/icons/$APP_NAME_LOWER.png"
 
 if command -v curl &> /dev/null; then
-    curl -sL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
+    curl -fsL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
         print_warning "Could not download icon, will try to extract from AppImage"
         ICON_PATH=""
     }

--- a/install/install-zside.sh
+++ b/install/install-zside.sh
@@ -80,7 +80,7 @@ print_info "This may take a few minutes depending on your connection..."
 
 # Download to temp file first to avoid "Text file busy" error if ZSide is running
 if command -v curl &> /dev/null; then
-    curl -L --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
+    curl -fL --progress-bar -o "$APPIMAGE_TEMP" "$APPIMAGE_URL" || {
         print_error "Failed to download AppImage"
         rm -f "$APPIMAGE_TEMP"
         exit 1
@@ -91,6 +91,13 @@ elif command -v wget &> /dev/null; then
         rm -f "$APPIMAGE_TEMP"
         exit 1
     }
+fi
+
+# -f only rejects HTTP >=400; a proxy error page still arrives as a 200.
+if ! head -c 4 "$APPIMAGE_TEMP" | grep -q $'\x7fELF'; then
+    print_error "Downloaded file is not an ELF binary (possible download failure or MITM)"
+    rm -f "$APPIMAGE_TEMP"
+    exit 1
 fi
 
 # Remove old AppImage (works even if running) and move new one into place
@@ -106,7 +113,7 @@ chmod +x "$APPIMAGE_PATH"
 ICON_PATH="$HOME/.local/share/icons/$APP_NAME_LOWER.png"
 
 if command -v curl &> /dev/null; then
-    curl -sL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
+    curl -fsL -o "$ICON_PATH" "$ICON_URL" 2>/dev/null || {
         print_warning "Could not download icon, will try to extract from AppImage"
         ICON_PATH=""
     }


### PR DESCRIPTION
`curl -L` without `-f` writes a 404/5xx HTML body into $APPIMAGE_TEMP, which then gets moved over the user's app and chmod +x'd. Add `-f` and an ELF magic check so a failed download can't be installed.

Dropped the auto-update URL/body validators from the original commit: `_installScriptUrl` is built entirely from compile-time constants, so the URL check can never fail, and the body checks are trivially satisfied by anyone able to serve the script.