### PR TITLE
orchestrator: rpcbind breaks core on windows

### DIFF
--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -174,8 +174,6 @@ func (m *BitcoinConfManager) GetDefaultConfig() string {
 [main]
 port=8300
 rpcport=18301
-rpcbind=127.0.0.1
-rpcallowip=0.0.0.0/0
 assumevalid=0000000000000000000000000000000000000000000000000000000000000000
 minimumchainwork=0x00
 listenonion=0
@@ -189,8 +187,6 @@ fallbackfee=0.00021
 [main]
 port=8301
 rpcport=18302
-rpcbind=127.0.0.1
-rpcallowip=0.0.0.0/0
 addnode=%s
 uacomment=%s
 assumevalid=0000000000000000000000000000000000000000000000000000000000000000

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -517,8 +517,6 @@ func (m *BitcoinConfManager) applyMainSectionDefaults(n Network) {
 		defaults = []struct{ k, v string }{
 			{"port", "8300"},
 			{"rpcport", "18301"},
-			{"rpcbind", "127.0.0.1"},
-			{"rpcallowip", "0.0.0.0/0"},
 			{"assumevalid", "0000000000000000000000000000000000000000000000000000000000000000"},
 			{"minimumchainwork", "0x00"},
 			{"listenonion", "0"},
@@ -529,8 +527,6 @@ func (m *BitcoinConfManager) applyMainSectionDefaults(n Network) {
 		defaults = []struct{ k, v string }{
 			{"port", "8301"},
 			{"rpcport", "18302"},
-			{"rpcbind", "127.0.0.1"},
-			{"rpcallowip", "0.0.0.0/0"},
 			{"addnode", m.DrynetPeer()},
 			{"uacomment", m.Generation()},
 			{"assumevalid", "0000000000000000000000000000000000000000000000000000000000000000"},


### PR DESCRIPTION
`rpcbind` cannot be set to `127.0.0.1` or `localhost` on Windows — Core breaks. So the key has to go, not change value.

`rpcallowip` goes with it: Core accepts localhost only when no `rpcallowip` is given, and ignores `rpcbind` without it. Dropping both keeps the same posture, also binds ::1, and removes the 0.0.0.0/0 line that prompted the original PR. signet, testnet and regtest already run without either key — this makes [main] match them.

The syncer's existing mainVariantKeys strip clears the stale keys from installed confs, so no migration.

Reverted the docker-compose hunks: those containers reach each other and the host across the bridge, so a loopback-only rpcallowip would 403 every real client while the healthchecks (which curl localhost inside the container) stayed green.