### PR TITLE
ci: mirror go replace targets into build dir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
       - "drivechain_lints/**"
       - "sidechain-orchestrator/**"
       - "sqlitemigrate/**"
+      - "coinnews/codec/**"
+      - "coinnews/server/**"
       - "bitwindow/**"
       - "thunder/**"
       - "truthcoin/**"
@@ -102,6 +104,8 @@ jobs:
               - 'sail_ui/**'
               - 'sidechain-orchestrator/**'
               - 'sqlitemigrate/**'
+              - 'coinnews/codec/**'
+              - 'coinnews/server/**'
               - 'drivechain_lints/**'
               - '.github/workflows/**'
 
@@ -222,20 +226,10 @@ jobs:
           cp -r scripts "$BUILD_DIR/"
           cp -r sail_ui "$BUILD_DIR/"
           cp -r drivechain_lints "$BUILD_DIR/"
-          # Copy sidechain-orchestrator for Go module replace directives
-          if [ -d "sidechain-orchestrator" ]; then
-            cp -r sidechain-orchestrator "$BUILD_DIR/"
-          fi
-          # Copy sqlitemigrate: both sidechain-orchestrator (../sqlitemigrate) and
-          # bitwindow/server (../../sqlitemigrate) replace-resolve to $BUILD_DIR/sqlitemigrate
-          if [ -d "sqlitemigrate" ]; then
-            cp -r sqlitemigrate "$BUILD_DIR/"
-          fi
-          # Copy coinnews/codec for bitwindow's Go module replace directive
-          if [ -d "coinnews/codec" ]; then
-            mkdir -p "$BUILD_DIR/coinnews"
-            cp -r coinnews/codec "$BUILD_DIR/coinnews/"
-          fi
+          # Every client embeds the orchestrator daemon.
+          cp -r sidechain-orchestrator "$BUILD_DIR/"
+          # Pull in whatever those modules replace-resolve to outside their own dir.
+          ./scripts/mirror-go-replace-deps.sh "$BUILD_DIR"
 
           # Recreate assets/bin directory
           mkdir -p "$BUILD_DIR/${{ matrix.client }}/assets/bin"

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.286
+version: 1.0.287
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.286
+version: 1.0.287
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.145
+version: 0.2.146
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.159
+version: 1.0.160
 
 environment:
   sdk: 3.12.2

--- a/scripts/mirror-go-replace-deps.sh
+++ b/scripts/mirror-go-replace-deps.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Mirror every in-repo `replace` target reachable from the modules already in
+# BUILD_DIR, so `go build` inside it resolves the same graph as the repo root.
+#
+# Usage: mirror-go-replace-deps.sh BUILD_DIR
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: $0 BUILD_DIR" >&2
+  exit 1
+fi
+
+build_dir=${1%/}
+repo_root=$PWD
+
+if [ ! -d "$build_dir" ]; then
+  echo "build dir $build_dir does not exist" >&2
+  exit 1
+fi
+
+# Copying a module can pull in further replace targets, so re-scan until a pass
+# copies nothing.
+while :; do
+  copied=0
+
+  while IFS= read -r gomod; do
+    # BUILD_DIR mirrors the repo layout, so strip the prefix to get the module's
+    # path in the repo and resolve its relative replace targets from there.
+    module_dir=$(dirname "$gomod")
+    module_dir=${module_dir#"$build_dir"}
+    module_dir=${module_dir#/}
+    module_dir=${module_dir:-.}
+
+    if [ ! -f "$module_dir/go.mod" ]; then
+      continue
+    fi
+
+    while IFS= read -r target; do
+      case "$target" in
+      ./* | ../*) ;;
+      *) continue ;;
+      esac
+
+      if ! resolved=$(cd "$module_dir/$target" 2>/dev/null && pwd); then
+        echo "replace target $target in $module_dir/go.mod does not exist" >&2
+        exit 1
+      fi
+
+      rel=${resolved#"$repo_root/"}
+      if [ "$rel" = "$resolved" ] || [ -e "$build_dir/$rel" ]; then
+        continue
+      fi
+
+      mkdir -p "$build_dir/$(dirname "$rel")"
+      cp -r "$rel" "$build_dir/$rel"
+      echo "mirrored $rel"
+      copied=1
+    done < <(go mod edit -json "$module_dir/go.mod" | jq -r '.Replace[]?.New.Path')
+  done < <(find "$build_dir" -name go.mod -not -path "*/vendor/*")
+
+  if [ "$copied" -eq 0 ]; then
+    break
+  fi
+done

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.288
+version: 1.0.289
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.159
+version: 1.0.160
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.286
+version: 1.0.287
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
BitWindow releases have been stuck since Aug 4: adding the `coinnews/server` replace to `bitwindow/server/go.mod` broke every BitWindow build job, because the isolated build dir only copied `coinnews/codec`.

Derive the copies from the go.mod replace graph instead of hardcoding them, so a new local replace can't silently stop publishing again.

Also trigger builds on `coinnews/{codec,server}` changes — they are BitWindow build inputs.