### PR TITLE
bitwindow, sailui: fix windows job assertions

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.287
+version: 1.0.288
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.287
+version: 1.0.288
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/e2e/job_object_windows_test.go
+++ b/bitwindow/e2e/job_object_windows_test.go
@@ -3,23 +3,50 @@
 package e2e
 
 import (
+	"fmt"
 	"os/exec"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 	"unsafe"
 )
 
-const processQueryLimitedInformation = 0x1000
+const (
+	processQueryLimitedInformation = 0x1000
+	jobObjectQuery                 = 0x0004
+)
 
 var (
 	kernel32           = syscall.NewLazyDLL("kernel32.dll")
 	procIsProcessInJob = kernel32.NewProc("IsProcessInJob")
+	procOpenJobObjectW = kernel32.NewProc("OpenJobObjectW")
 )
 
-// isProcessInJob reports whether pid belongs to any job object.
-func isProcessInJob(t *testing.T, pid int) bool {
+// openDaemonJob opens the job the runner names after its own pid, and returns
+// the pid that owns it. Asking whether a process is in *any* job is useless
+// here: CI runners already put every process in one.
+func openDaemonJob(t *testing.T, appPIDs []int) (syscall.Handle, int) {
+	t.Helper()
+	for _, pid := range appPIDs {
+		name, err := syscall.UTF16PtrFromString(fmt.Sprintf("bitwindow-daemons-%d", pid))
+		if err != nil {
+			t.Fatalf("job name for pid %d: %v", pid, err)
+		}
+		ret, _, _ := procOpenJobObjectW.Call(
+			uintptr(jobObjectQuery), 0, uintptr(unsafe.Pointer(name)),
+		)
+		if ret != 0 {
+			return syscall.Handle(ret), pid
+		}
+	}
+	t.Fatalf("no daemon job found for app pids %s; the runner never created one", prettyPIDs(appPIDs))
+	return 0, 0
+}
+
+// isProcessInJob reports whether pid belongs to job.
+func isProcessInJob(t *testing.T, pid int, job syscall.Handle) bool {
 	t.Helper()
 	handle, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
 	if err != nil {
@@ -29,12 +56,40 @@ func isProcessInJob(t *testing.T, pid int) bool {
 
 	var inJob int32
 	ret, _, callErr := procIsProcessInJob.Call(
-		uintptr(handle), 0, uintptr(unsafe.Pointer(&inJob)),
+		uintptr(handle), uintptr(job), uintptr(unsafe.Pointer(&inJob)),
 	)
 	if ret == 0 {
 		t.Fatalf("IsProcessInJob(%d): %v", pid, callErr)
 	}
 	return inJob != 0
+}
+
+func daemonPIDsByName(t *testing.T) map[string][]int {
+	t.Helper()
+	return map[string][]int{
+		bitwindowdName:    processPIDs(t, bitwindowdName),
+		orchestratordName: processPIDs(t, orchestratordName),
+	}
+}
+
+// describeJobMembership renders "bitwindowd[500]=in orchestratord[5940]=out",
+// so a reap failure says which daemon escaped instead of only that one did.
+func describeJobMembership(t *testing.T, job syscall.Handle) string {
+	t.Helper()
+	var parts []string
+	for name, pids := range daemonPIDsByName(t) {
+		for _, pid := range pids {
+			state := "out"
+			if isProcessInJob(t, pid, job) {
+				state = "in"
+			}
+			parts = append(parts, fmt.Sprintf("%s[%d]=%s", name, pid, state))
+		}
+	}
+	if len(parts) == 0 {
+		return "no daemons running"
+	}
+	return strings.Join(parts, " ")
 }
 
 func waitForBoot(t *testing.T) (appPIDs, daemonPIDs []int) {
@@ -57,9 +112,10 @@ func waitForBoot(t *testing.T) (appPIDs, daemonPIDs []int) {
 	return processPIDs(t, appName), daemons
 }
 
-// The app must belong to no job: a member of a KILL_ON_JOB_CLOSE job dies with
-// the job, and so does everything it launched — which is what killed the updater.
-func TestFlutterProcessIsNotInAJob(t *testing.T) {
+// The app must not be in its own daemon job: a member of a KILL_ON_JOB_CLOSE
+// job dies with the job, and so does everything it launched — which is what
+// killed the updater.
+func TestFlutterProcessIsNotInTheDaemonJob(t *testing.T) {
 	skipIfNoDisplay(t)
 
 	run := startJustRun(t, nil)
@@ -69,10 +125,12 @@ func TestFlutterProcessIsNotInAJob(t *testing.T) {
 	})
 
 	appPIDs, _ := waitForBoot(t)
+	job, owner := openDaemonJob(t, appPIDs)
+	defer syscall.CloseHandle(job) //nolint:errcheck
 
 	for _, pid := range appPIDs {
-		if isProcessInJob(t, pid) {
-			t.Fatalf("app pid %d is in a job; anything it launches can be killed with it", pid)
+		if isProcessInJob(t, pid, job) {
+			t.Errorf("app pid %d is in the daemon job owned by %d; anything it launches can be killed with it", pid, owner)
 		}
 	}
 }
@@ -88,14 +146,19 @@ func TestDaemonsAreInTheJob(t *testing.T) {
 		run.stop(t, 5*time.Second)
 	})
 
-	_, daemonPIDs := waitForBoot(t)
+	appPIDs, _ := waitForBoot(t)
+	job, _ := openDaemonJob(t, appPIDs)
+	defer syscall.CloseHandle(job) //nolint:errcheck
 
-	if len(daemonPIDs) == 0 {
-		t.Fatal("no daemons found to check")
-	}
-	for _, pid := range daemonPIDs {
-		if !isProcessInJob(t, pid) {
-			t.Fatalf("daemon pid %d is not in the job; it would outlive the app", pid)
+	for name, pids := range daemonPIDsByName(t) {
+		if len(pids) == 0 {
+			t.Errorf("%s is not running", name)
+			continue
+		}
+		for _, pid := range pids {
+			if !isProcessInJob(t, pid, job) {
+				t.Errorf("%s pid %d is not in the daemon job; it would outlive the app", name, pid)
+			}
 		}
 	}
 }
@@ -113,6 +176,14 @@ func TestForceKillingAppReapsDaemons(t *testing.T) {
 
 	appPIDs, _ := waitForBoot(t)
 
+	job, _ := openDaemonJob(t, appPIDs)
+	membership := describeJobMembership(t, job)
+	// KILL_ON_JOB_CLOSE fires when the last handle closes, so ours must go
+	// before the app's.
+	if err := syscall.CloseHandle(job); err != nil {
+		t.Fatalf("close job handle: %v", err)
+	}
+
 	// No /T: the daemons must be reaped by the job, not by taskkill walking
 	// the tree.
 	for _, pid := range appPIDs {
@@ -123,10 +194,10 @@ func TestForceKillingAppReapsDaemons(t *testing.T) {
 
 	const reapDeadline = 60 * time.Second
 	const reapPoll = 500 * time.Millisecond
-	waitUntil(t, reapDeadline, reapPoll, "bitwindowd survived a force-kill of the app", func() bool {
-		return len(processPIDs(t, bitwindowdName)) == 0
-	})
-	waitUntil(t, reapDeadline, reapPoll, "orchestratord survived a force-kill of the app", func() bool {
-		return len(processPIDs(t, orchestratordName)) == 0
-	})
+	for _, name := range []string{bitwindowdName, orchestratordName} {
+		waitUntil(t, reapDeadline, reapPoll,
+			fmt.Sprintf("%s survived a force-kill of the app (job membership at boot: %s)", name, membership),
+			func() bool { return len(processPIDs(t, name)) == 0 },
+		)
+	}
 }

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.146
+version: 0.2.147
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/windows/runner/daemon_job.cpp
+++ b/bitwindow/windows/runner/daemon_job.cpp
@@ -8,11 +8,16 @@ HANDLE g_daemon_job = nullptr;
 
 }  // namespace
 
+std::wstring DaemonJobName() {
+  return L"bitwindow-daemons-" + std::to_wstring(::GetCurrentProcessId());
+}
+
 void CreateDaemonJob() {
   if (g_daemon_job != nullptr) {
     return;
   }
-  HANDLE job = ::CreateJobObjectW(nullptr, nullptr);
+  const std::wstring name = DaemonJobName();
+  HANDLE job = ::CreateJobObjectW(nullptr, name.c_str());
   if (job == nullptr) {
     return;
   }

--- a/bitwindow/windows/runner/daemon_job.h
+++ b/bitwindow/windows/runner/daemon_job.h
@@ -3,6 +3,13 @@
 
 #include <windows.h>
 
+#include <string>
+
+// Name of this process's daemon job: "bitwindow-daemons-<pid>". Named so a test
+// can open the exact job — an unnamed job can't be told apart from the job a CI
+// runner already put every process in.
+std::wstring DaemonJobName();
+
 // Creates the job object that owns the daemon tree. Call once at startup.
 void CreateDaemonJob();
 

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.160
+version: 1.0.161
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/providers/binaries/managers/process_manager.dart
+++ b/sail_ui/lib/providers/binaries/managers/process_manager.dart
@@ -80,7 +80,11 @@ class ProcessManager extends ChangeNotifier {
     );
     // Before anything else it might spawn: job membership is inherited, so
     // binding the child covers its whole tree.
-    await DaemonJob.bind(process.pid);
+    final bound = await DaemonJob.bind(process.pid);
+    if (!bound && Platform.isWindows) {
+      // Anything it already spawned stayed outside the job and will outlive us.
+      log.e('[${binary.name}] not bound to the daemon job (pid ${process.pid})');
+    }
 
     runningProcesses[binary.name] = SailProcess(
       binary: binary,

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.289
+version: 1.0.290
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.160
+version: 1.0.161
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.287
+version: 1.0.288
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
Windows e2e has been red for every run since Jul 31. Two of the three job-object tests asked `IsProcessInJob(h, NULL)` — "in *any* job" — which is always true on a CI runner that already jobs every process, so one could never pass and the other passed vacuously.

Name the job after the runner's pid so the tests open that exact job and assert real membership, and stop discarding the bind result that would have shown a daemon escaping.

The reap test now reports which daemon escaped, to settle whether orchestratord genuinely outlives a force-kill.