### PR TITLE
ci: strip CR from jq output on windows

### DIFF
--- a/scripts/mirror-go-replace-deps.sh
+++ b/scripts/mirror-go-replace-deps.sh
@@ -55,7 +55,8 @@ while :; do
       cp -r "$rel" "$build_dir/$rel"
       echo "mirrored $rel"
       copied=1
-    done < <(go mod edit -json "$module_dir/go.mod" | jq -r '.Replace[]?.New.Path')
+      # jq.exe writes stdout in text mode, so every path arrives CR-terminated.
+    done < <(go mod edit -json "$module_dir/go.mod" | jq -r '.Replace[]?.New.Path' | tr -d '\r')
   done < <(find "$build_dir" -name go.mod -not -path "*/vendor/*")
 
   if [ "$copied" -eq 0 ]; then


### PR DESCRIPTION
The build-dir mirroring landed in #1975 fixed BitWindow on Linux and macOS but broke the Windows rows: jq.exe writes stdout in text mode, so every replace path arrived CR-terminated and no target resolved.

Verified both ways locally against a CR-emitting jq shim — the old script reproduces the exact CI error, the new one mirrors all three targets.