### PR TITLE
Move every Go module to 1.26

### DIFF
--- a/.github/workflows/all-schemas.yml
+++ b/.github/workflows/all-schemas.yml
@@ -7,7 +7,7 @@ on:
       - ".github/workflows/all-schemas.yml"
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 jobs:
   validate-all-schemas:

--- a/.github/workflows/bitwindow-e2e.yml
+++ b/.github/workflows/bitwindow-e2e.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   FLUTTER_VERSION: "3.44.8"
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 jobs:
   e2e:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ on:
       - "coinshift/**"
       - ".github/workflows/build.yml"
 
+env:
+  GO_VERSION: "1.26"
+
 jobs:
   check-changes:
     runs-on: ubuntu-latest
@@ -194,9 +197,9 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: go-build-1.25-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          key: go-build-${{ env.GO_VERSION }}-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            go-build-1.25-${{ runner.os }}-
+            go-build-${{ env.GO_VERSION }}-${{ runner.os }}-
 
       - uses: subosito/flutter-action@v2
         with:
@@ -210,7 +213,7 @@ jobs:
       # Setup go for building bitwindowd
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup build directory
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ on:
       - ".github/workflows/go.yml"
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 jobs:
   config-sync:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ on:
       - ".github/workflows/integration.yml"
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 jobs:
   bitwindow-backend-smoke:

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.288
+version: 1.0.289
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.288
+version: 1.0.289
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/e2e/go.mod
+++ b/bitwindow/e2e/go.mod
@@ -1,3 +1,3 @@
 module github.com/LayerTwo-Labs/sidesail/bitwindow/e2e
 
-go 1.25
+go 1.26.0

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.148
+version: 0.2.149
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/server/cpuminer/Dockerfile
+++ b/bitwindow/server/cpuminer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /build
 

--- a/bitwindow/server/cpuminer/go.mod
+++ b/bitwindow/server/cpuminer/go.mod
@@ -1,6 +1,6 @@
 module github.com/LayerTwo-Labs/sidesail/bitwindow/server/cpuminer
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/btcsuite/btcd v0.25.0

--- a/bitwindow/server/go.mod
+++ b/bitwindow/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/LayerTwo-Labs/sidesail/bitwindow/server
 
-go 1.25.0
+go 1.26.0
 
 require (
 	connectrpc.com/connect v1.20.0

--- a/coinnews/codec/go.mod
+++ b/coinnews/codec/go.mod
@@ -1,6 +1,6 @@
 module github.com/LayerTwo-Labs/sidesail/coinnews/codec
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6

--- a/coinnews/server/Dockerfile
+++ b/coinnews/server/Dockerfile
@@ -1,7 +1,7 @@
 # Build context is the coinnews/ directory (NOT coinnews/server), so
 # both the server source and the codec module are available — the
 # server's go.mod has `replace => ../codec`, so codec must be present.
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # go-sqlite3 is a cgo package: needs a C toolchain to build.
 RUN apk add --no-cache gcc musl-dev

--- a/coinnews/server/go.mod
+++ b/coinnews/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/LayerTwo-Labs/sidesail/coinnews/server
 
-go 1.25.0
+go 1.26.0
 
 require (
 	connectrpc.com/connect v1.19.0

--- a/coinnews/server/main.go
+++ b/coinnews/server/main.go
@@ -17,14 +17,21 @@ import (
 
 	"connectrpc.com/grpcreflect"
 	"github.com/rs/zerolog"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 
 	"github.com/LayerTwo-Labs/sidesail/coinnews/server/api"
 	connectrpc "github.com/LayerTwo-Labs/sidesail/coinnews/server/gen/coinnews/v1/coinnewsv1connect"
 	"github.com/LayerTwo-Labs/sidesail/coinnews/server/scanner"
 	"github.com/LayerTwo-Labs/sidesail/coinnews/server/store"
 )
+
+// h2cProtocols serves cleartext HTTP/2 alongside HTTP/1, which connect-go's
+// gRPC protocol needs.
+func h2cProtocols() *http.Protocols {
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+	return protocols
+}
 
 func main() {
 	var (
@@ -102,7 +109,8 @@ func main() {
 	log.Info().Str("listen", *listen).Str("rpc_path", path).Msg("coinnews-server: starting")
 	srv := &http.Server{
 		Addr:              *listen,
-		Handler:           h2c.NewHandler(corsMiddleware(mux), &http2.Server{}),
+		Handler:           corsMiddleware(mux),
+		Protocols:         h2cProtocols(),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 

--- a/coinnews/server/scanner/client.go
+++ b/coinnews/server/scanner/client.go
@@ -92,15 +92,15 @@ func (c *Client) GetBlockHash(ctx context.Context, height uint32) (string, error
 // Block is the verbose=2 representation we care about. Only fields
 // the scanner reads are unmarshalled.
 type Block struct {
-	Hash         string `json:"hash"`
-	Height       uint32 `json:"height"`
-	Time         int64  `json:"time"`
-	Mediantime   int64  `json:"mediantime"`
-	Tx           []struct {
+	Hash       string `json:"hash"`
+	Height     uint32 `json:"height"`
+	Time       int64  `json:"time"`
+	Mediantime int64  `json:"mediantime"`
+	Tx         []struct {
 		Txid string `json:"txid"`
 		Vout []struct {
 			ScriptPubKey struct {
-				Hex string `json:"hex"`
+				Hex  string `json:"hex"`
 				Type string `json:"type"`
 			} `json:"scriptPubKey"`
 		} `json:"vout"`

--- a/dc-hub/server/go.mod
+++ b/dc-hub/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/LayerTwo-Labs/sidesail/dc-hub/server
 
-go 1.25
+go 1.26.0
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250425153114-8976f5be98c1.1

--- a/dc-hub/server/server/server.go
+++ b/dc-hub/server/server/server.go
@@ -27,8 +27,6 @@ import (
 	"github.com/rs/cors"
 	"github.com/rs/zerolog"
 	"github.com/samber/lo"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 )
 
 // New creates a new Server with interceptors applied.
@@ -120,8 +118,7 @@ func (s *Server) Handler(ctx context.Context) http.Handler {
 		withCORS.ServeHTTP(w, r)
 	})
 
-	// Use h2c, so we can serve HTTP/2 without TLS.
-	return h2c.NewHandler(handler, &http2.Server{})
+	return handler
 }
 
 func (s *Server) Serve(ctx context.Context, address string) error {
@@ -164,8 +161,13 @@ func (s *Server) Serve(ctx context.Context, address string) error {
 			Msg("could not close listener")
 	}()
 
+	// cleartext HTTP/2 alongside HTTP/1, which connect-go's gRPC protocol needs
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
 	s.server = &http.Server{
-		Handler: s.Handler(ctx),
+		Handler:   s.Handler(ctx),
+		Protocols: protocols,
 	}
 	return s.server.Serve(lis)
 }

--- a/ecash-broadcaster/go.mod
+++ b/ecash-broadcaster/go.mod
@@ -1,6 +1,6 @@
 module github.com/LayerTwo-Labs/sidesail/ecash-broadcaster
 
-go 1.25
+go 1.26.0
 
 require (
 	connectrpc.com/connect v1.18.1

--- a/ecash-broadcaster/main.go
+++ b/ecash-broadcaster/main.go
@@ -11,9 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
-
 	"github.com/LayerTwo-Labs/sidesail/ecash-broadcaster/gen/ecash/v1/ecashv1connect"
 )
 
@@ -30,9 +27,13 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle(ecashv1connect.NewECashBroadcastServiceHandler(h))
 
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
 	srv := &http.Server{
-		Addr:    *listen,
-		Handler: h2c.NewHandler(mux, &http2.Server{}),
+		Addr:      *listen,
+		Handler:   mux,
+		Protocols: protocols,
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.161
+version: 1.0.162
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/go.mod
+++ b/sidechain-orchestrator/go.mod
@@ -1,6 +1,6 @@
 module github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator
 
-go 1.25.0
+go 1.26.0
 
 require (
 	connectrpc.com/connect v1.20.0

--- a/sqlitemigrate/go.mod
+++ b/sqlitemigrate/go.mod
@@ -1,3 +1,3 @@
 module github.com/LayerTwo-Labs/sidesail/sqlitemigrate
 
-go 1.25.0
+go 1.26.0

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.290
+version: 1.0.291
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.161
+version: 1.0.162
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.288
+version: 1.0.289
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
Bumps all nine Go modules and the CI pins from 1.25 to 1.26.

Also retires the deprecated `x/net/http2/h2c` in ecash-broadcaster, coinnews and dc-hub, using net/http's native `Protocols` — the pattern orchestratord already uses.