### PR TITLE
security: fix CORS credentials reflection and constant-time compare

### DIFF
--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -732,7 +732,8 @@ func ParseOPReturnParts(opReturnMessage string) (metadataB64, contentStr string,
 	return parts[0], parts[1], nil
 }
 
-// BytesEqual performs constant-time byte comparison
+// BytesEqual performs constant-time byte comparison for secret material.
+// Do not use bytes.Equal here: it short-circuits and leaks timing.
 func BytesEqual(a, b []byte) bool {
-	return bytes.Equal(a, b)
+	return subtle.ConstantTimeCompare(a, b) == 1
 }

--- a/dc-hub/server/server/server.go
+++ b/dc-hub/server/server/server.go
@@ -91,8 +91,10 @@ func (s *Server) Handler(ctx context.Context) http.Handler {
 		}
 
 		corsHandler := cors.New(cors.Options{
+			// Never combine AllowedOrigins: ["*"] with AllowCredentials: true.
+			// That reflects arbitrary Origins with credentials and enables
+			// cross-site abuse of authenticated browser sessions.
 			AllowedOrigins: []string{
-				"*",
 				"https://drivechain.live",
 				"https://api.drivechain.live",
 				"http://localhost:3000", // For local development
@@ -113,7 +115,7 @@ func (s *Server) Handler(ctx context.Context) http.Handler {
 				"Access-Control-Allow-Origin",
 				"Access-Control-Request-Headers",
 			},
-			AllowCredentials: true, // Allow credentials
+			AllowCredentials: true,
 		})
 
 		withCORS := corsHandler.Handler(s.mux)


### PR DESCRIPTION
- dc-hub: remove AllowedOrigins "*" while AllowCredentials is true (credentialed CORS must use an explicit origin allow-list)
- BitDrive: BytesEqual claimed constant-time but used bytes.Equal; switch to crypto/subtle.ConstantTimeCompare