### PR TITLE
sail_ui, orchestrator: fix sidechain app lifecycle

### DIFF
--- a/bitwindow/lib/providers/transactions_provider.dart
+++ b/bitwindow/lib/providers/transactions_provider.dart
@@ -131,6 +131,10 @@ class TransactionProvider extends ChangeNotifier implements NetworkScoped {
       }
       final String walletId = activeId;
 
+      // The receive address is local derivation, so it must not wait on the
+      // chain-data batch below, which stalls whenever the indexer is down.
+      unawaited(_updateReceiveAddress(walletId));
+
       // Run all updates in parallel
       final results = await Future.wait([
         update<List<WalletTransaction>>(
@@ -173,19 +177,6 @@ class TransactionProvider extends ChangeNotifier implements NetworkScoped {
           },
           (v) => walletTransactions = v,
           equals: const DeepCollectionEquality().equals,
-        ),
-        update<({String address, String path})>(
-          (address: address, path: addressDerivationPath),
-          () async {
-            final next = await orchestratorWallet.getNewAddress(walletId, addressType: addressType);
-            return (address: next.address, path: next.derivationPath);
-          },
-          (v) {
-            address = v.address;
-            addressDerivationPath = v.path;
-          },
-          // Always update - backend handles finding unused address
-          equals: (a, b) => false,
         ),
         update<List<UnspentOutput>>(
           utxos,
@@ -278,6 +269,35 @@ class TransactionProvider extends ChangeNotifier implements NetworkScoped {
       if (_refetchQueued) {
         _refetchQueued = false;
         unawaited(fetch());
+      }
+    }
+  }
+
+  Future<void> _updateReceiveAddress(String walletId) async {
+    final requestedType = addressType;
+    try {
+      await update<({String address, String path})>(
+        (address: address, path: addressDerivationPath),
+        () async {
+          final next = await orchestratorWallet.getNewAddress(walletId, addressType: requestedType);
+          return (address: next.address, path: next.derivationPath);
+        },
+        (v) {
+          // A wallet swap or type change while this was in flight would show
+          // the wrong address.
+          if (_walletReader.activeWalletId != walletId || addressType != requestedType) {
+            return;
+          }
+          address = v.address;
+          addressDerivationPath = v.path;
+        },
+        // Always update - backend handles finding unused address
+        equals: (a, b) => false,
+      );
+      notifyListeners();
+    } catch (e) {
+      if (!isExpectedBootError(e)) {
+        _log.w('TransactionProvider: address fetch failed: $e');
       }
     }
   }

--- a/sail_ui/lib/config/backend_sidechain_runtime.dart
+++ b/sail_ui/lib/config/backend_sidechain_runtime.dart
@@ -151,7 +151,6 @@ Future<bool> _waitForBackendReady(OrchestratorRPC orchestrator) async {
 
 void _streamBinaryLogs(OrchestratorRPC orchestrator, String binaryName, BinaryType binaryType) {
   final logProvider = GetIt.I.get<LogProvider>();
-  final log = GetIt.I.get<Logger>();
 
   orchestrator
       .streamLogs(binaryName, tail: 100)
@@ -165,8 +164,6 @@ void _streamBinaryLogs(OrchestratorRPC orchestrator, String binaryName, BinaryTy
               binaryType: binaryType,
             ),
           );
-
-          log.i('[$binaryName] ${response.line}');
         },
         onError: (e) {
           Future.delayed(const Duration(seconds: 5), () {

--- a/sail_ui/lib/config/binaries.dart
+++ b/sail_ui/lib/config/binaries.dart
@@ -44,6 +44,10 @@ Binary defaultBinaryFor(BinaryType type) => switch (type) {
 abstract class Binary {
   Logger get log => GetIt.I.get<Logger>();
 
+  // A sidechain app runs its own daemon, so the alternative build — a GUI
+  // companion BitWindow launches — never applies to it.
+  static bool isSidechainApp = false;
+
   final String name;
   final String version;
   final String description;
@@ -209,7 +213,7 @@ abstract class Binary {
     // plain executable. Mirror sidechain-orchestrator/config.go
     // TestSidechainBinaryPath so chain-settings reads the right mtime
     // instead of the (likely missing) prod-path binary.
-    if (chainLayer == 2 && GetIt.I.get<SettingsProvider>().useTestSidechains) {
+    if (!isSidechainApp && chainLayer == 2 && GetIt.I.get<SettingsProvider>().useTestSidechains) {
       final testDir = Directory(path.join(binDir(appDir.path).path, 'test', baseBinary));
       if (testDir.existsSync()) {
         if (Platform.isMacOS) {
@@ -1562,8 +1566,9 @@ class MetadataConfig {
   final DownloadConfig? _alternativeDownloadConfig;
 
   // if test chains enabled, use those, but only if an alternative config exists
-  DownloadConfig get downloadConfig =>
-      _settingsProvider.useTestSidechains ? _alternativeDownloadConfig ?? _downloadConfig : _downloadConfig;
+  DownloadConfig get downloadConfig => _settingsProvider.useTestSidechains && !Binary.isSidechainApp
+      ? _alternativeDownloadConfig ?? _downloadConfig
+      : _downloadConfig;
 
   bool get hasAlternativeDownloadConfig => _alternativeDownloadConfig != null;
 

--- a/sail_ui/lib/config/sidechain_main.dart
+++ b/sail_ui/lib/config/sidechain_main.dart
@@ -119,6 +119,8 @@ Future<void> initSidechainDependencies({
     GetIt.I.registerSingleton<LogProvider>(LogProvider());
   }
 
+  Binary.isSidechainApp = true;
+
   // Load and register initial binary states
   final binaries = _initialBinaries(
     sidechainType,

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -884,6 +884,7 @@ class DownloadBinaryRequest extends $pb.GeneratedMessage {
   factory DownloadBinaryRequest({
     $core.String? name,
     $core.bool? force,
+    $core.bool? forceBackend,
   }) {
     final $result = create();
     if (name != null) {
@@ -891,6 +892,9 @@ class DownloadBinaryRequest extends $pb.GeneratedMessage {
     }
     if (force != null) {
       $result.force = force;
+    }
+    if (forceBackend != null) {
+      $result.forceBackend = forceBackend;
     }
     return $result;
   }
@@ -905,6 +909,7 @@ class DownloadBinaryRequest extends $pb.GeneratedMessage {
       package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOB(2, _omitFieldNames ? '' : 'force')
+    ..aOB(3, _omitFieldNames ? '' : 'forceBackend')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -951,6 +956,20 @@ class DownloadBinaryRequest extends $pb.GeneratedMessage {
   $core.bool hasForce() => $_has(1);
   @$pb.TagNumber(2)
   void clearForce() => clearField(2);
+
+  /// Download the daemon, never the sidechain's Flutter bundle. Sidechain apps
+  /// set this so an update installs the backend they actually run.
+  @$pb.TagNumber(3)
+  $core.bool get forceBackend => $_getBF(2);
+  @$pb.TagNumber(3)
+  set forceBackend($core.bool v) {
+    $_setBool(2, v);
+  }
+
+  @$pb.TagNumber(3)
+  $core.bool hasForceBackend() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearForceBackend() => clearField(3);
 }
 
 class DownloadBinaryResponse extends $pb.GeneratedMessage {
@@ -1124,6 +1143,7 @@ class StopBinaryRequest extends $pb.GeneratedMessage {
   factory StopBinaryRequest({
     $core.String? name,
     $core.bool? force,
+    $core.bool? forceBackend,
   }) {
     final $result = create();
     if (name != null) {
@@ -1131,6 +1151,9 @@ class StopBinaryRequest extends $pb.GeneratedMessage {
     }
     if (force != null) {
       $result.force = force;
+    }
+    if (forceBackend != null) {
+      $result.forceBackend = forceBackend;
     }
     return $result;
   }
@@ -1145,6 +1168,7 @@ class StopBinaryRequest extends $pb.GeneratedMessage {
       package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOB(2, _omitFieldNames ? '' : 'force')
+    ..aOB(3, _omitFieldNames ? '' : 'forceBackend')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -1191,6 +1215,18 @@ class StopBinaryRequest extends $pb.GeneratedMessage {
   $core.bool hasForce() => $_has(1);
   @$pb.TagNumber(2)
   void clearForce() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get forceBackend => $_getBF(2);
+  @$pb.TagNumber(3)
+  set forceBackend($core.bool v) {
+    $_setBool(2, v);
+  }
+
+  @$pb.TagNumber(3)
+  $core.bool hasForceBackend() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearForceBackend() => clearField(3);
 }
 
 class StopBinaryResponse extends $pb.GeneratedMessage {
@@ -1559,10 +1595,14 @@ class StartWithL1Response extends $pb.GeneratedMessage {
 class RestartDaemonRequest extends $pb.GeneratedMessage {
   factory RestartDaemonRequest({
     $core.String? name,
+    $core.bool? forceBackend,
   }) {
     final $result = create();
     if (name != null) {
       $result.name = name;
+    }
+    if (forceBackend != null) {
+      $result.forceBackend = forceBackend;
     }
     return $result;
   }
@@ -1576,6 +1616,7 @@ class RestartDaemonRequest extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RestartDaemonRequest',
       package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOB(2, _omitFieldNames ? '' : 'forceBackend')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -1610,6 +1651,20 @@ class RestartDaemonRequest extends $pb.GeneratedMessage {
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
   void clearName() => clearField(1);
+
+  /// Restart only the daemon, never the sidechain's Flutter bundle. A stopped
+  /// daemon keeps no boot mode to recover, so the caller states it.
+  @$pb.TagNumber(2)
+  $core.bool get forceBackend => $_getBF(1);
+  @$pb.TagNumber(2)
+  set forceBackend($core.bool v) {
+    $_setBool(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasForceBackend() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearForceBackend() => clearField(2);
 }
 
 class RestartDaemonResponse extends $pb.GeneratedMessage {

--- a/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sail_ui/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -232,13 +232,14 @@ const DownloadBinaryRequest$json = {
   '2': [
     {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
     {'1': 'force', '3': 2, '4': 1, '5': 8, '10': 'force'},
+    {'1': 'force_backend', '3': 3, '4': 1, '5': 8, '10': 'forceBackend'},
   ],
 };
 
 /// Descriptor for `DownloadBinaryRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List downloadBinaryRequestDescriptor =
     $convert.base64Decode('ChVEb3dubG9hZEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIUCgVmb3JjZRgCIA'
-        'EoCFIFZm9yY2U=');
+        'EoCFIFZm9yY2USIwoNZm9yY2VfYmFja2VuZBgDIAEoCFIMZm9yY2VCYWNrZW5k');
 
 @$core.Deprecated('Use downloadBinaryResponseDescriptor instead')
 const DownloadBinaryResponse$json = {
@@ -295,13 +296,14 @@ const StopBinaryRequest$json = {
   '2': [
     {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
     {'1': 'force', '3': 2, '4': 1, '5': 8, '10': 'force'},
+    {'1': 'force_backend', '3': 3, '4': 1, '5': 8, '10': 'forceBackend'},
   ],
 };
 
 /// Descriptor for `StopBinaryRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List stopBinaryRequestDescriptor =
     $convert.base64Decode('ChFTdG9wQmluYXJ5UmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhQKBWZvcmNlGAIgASgIUg'
-        'Vmb3JjZQ==');
+        'Vmb3JjZRIjCg1mb3JjZV9iYWNrZW5kGAMgASgIUgxmb3JjZUJhY2tlbmQ=');
 
 @$core.Deprecated('Use stopBinaryResponseDescriptor instead')
 const StopBinaryResponse$json = {
@@ -395,12 +397,14 @@ const RestartDaemonRequest$json = {
   '1': 'RestartDaemonRequest',
   '2': [
     {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'force_backend', '3': 2, '4': 1, '5': 8, '10': 'forceBackend'},
   ],
 };
 
 /// Descriptor for `RestartDaemonRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List restartDaemonRequestDescriptor =
-    $convert.base64Decode('ChRSZXN0YXJ0RGFlbW9uUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1l');
+    $convert.base64Decode('ChRSZXN0YXJ0RGFlbW9uUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEiMKDWZvcmNlX2JhY2'
+        'tlbmQYAiABKAhSDGZvcmNlQmFja2VuZA==');
 
 @$core.Deprecated('Use restartDaemonResponseDescriptor instead')
 const RestartDaemonResponse$json = {

--- a/sail_ui/lib/providers/backend_state_provider.dart
+++ b/sail_ui/lib/providers/backend_state_provider.dart
@@ -36,8 +36,10 @@ class BackendStateProvider extends ChangeNotifier {
 
   Timer? _pollTimer;
   bool _polling = false;
+  int _consecutiveFailures = 0;
 
   static const Duration _pollInterval = Duration(seconds: 1);
+  static const int _failuresBeforeDisconnected = 5;
 
   BackendStateProvider(this._orchestrator);
 
@@ -61,16 +63,44 @@ class BackendStateProvider extends ChangeNotifier {
     _polling = true;
     try {
       final resp = await _orchestrator.listBinaries();
+      _consecutiveFailures = 0;
       _apply(resp.binaries);
     } catch (e) {
-      // Transport blip — keep last-known state on screen, try again next
-      // tick. The orchestrator-process keepalive watchdog (separate code
-      // path) will recreate the underlying HTTP/2 transport if it's truly
-      // dead.
+      // A blip keeps the last frame on screen, but an orchestrator that stays
+      // unreachable must stop reading as a healthy stack.
+      _consecutiveFailures++;
+      if (_consecutiveFailures == _failuresBeforeDisconnected) {
+        _log.w('BackendStateProvider: orchestrator unreachable, marking binaries disconnected: $e');
+        _markAllDisconnected();
+      }
       _log.d('BackendStateProvider: listBinaries failed: $e');
     } finally {
       _polling = false;
     }
+  }
+
+  void _markAllDisconnected() {
+    final changedRpcs = <RPCConnection>{};
+    for (final name in binaries.keys) {
+      final rpc = _rpcForBinaryName(name);
+      if (rpc == null) {
+        continue;
+      }
+      // An initializing binary is not connected either, and its spinner would
+      // otherwise run forever.
+      if (!rpc.connected && !rpc.initializingBinary && !rpc.stoppingBinary) {
+        continue;
+      }
+      rpc.connected = false;
+      rpc.initializingBinary = false;
+      rpc.stoppingBinary = false;
+      rpc.connectionError = 'orchestrator not reachable';
+      changedRpcs.add(rpc);
+    }
+    for (final rpc in changedRpcs) {
+      rpc.notifyListeners();
+    }
+    notifyListeners();
   }
 
   void _apply(List<BinaryStatusMsg> statuses) {

--- a/sail_ui/lib/providers/binaries/binary_provider.dart
+++ b/sail_ui/lib/providers/binaries/binary_provider.dart
@@ -189,7 +189,7 @@ class BinaryProvider extends ChangeNotifier {
     }
 
     log.i('BinaryProvider: restarting $name via orchestrator');
-    await _orchestrator.restartDaemon(name);
+    await _orchestrator.restartDaemon(name, forceBackend: isSidechainApp && binary.chainLayer == 2);
   }
 
   /// Restart the whole L1 stack (bitcoind + enforcer) in one server-side call.
@@ -232,7 +232,7 @@ class BinaryProvider extends ChangeNotifier {
     }
 
     log.i('BinaryProvider: stopping $name via orchestrator');
-    await _orchestrator.stopBinary(name);
+    await _orchestrator.stopBinary(name, forceBackend: isSidechainApp && binary.chainLayer == 2);
   }
 
   Future<void> download(Binary binary, {bool shouldUpdate = false}) async {
@@ -248,7 +248,11 @@ class BinaryProvider extends ChangeNotifier {
     // and returns. SyncProvider's polled GetSyncStatus picks up MB progress
     // for the matching sidechain slot. Connection state once the binary's
     // up arrives via BackendStateProvider's listBinaries poll.
-    await _orchestrator.downloadBinary(name, force: shouldUpdate);
+    await _orchestrator.downloadBinary(
+      name,
+      force: shouldUpdate,
+      forceBackend: isSidechainApp && binary.chainLayer == 2,
+    );
   }
 
   /// Force-download a binary and restart it if it was running. Used by the
@@ -279,13 +283,13 @@ class BinaryProvider extends ChangeNotifier {
     // conflict and silently leave the old binary in place.
     if (wasRunning) {
       try {
-        await _orchestrator.stopBinary(name);
+        await _orchestrator.stopBinary(name, forceBackend: isSidechainApp && binary.chainLayer == 2);
       } catch (e) {
         log.w('BinaryProvider: stop before update failed for $name: $e');
       }
     }
 
-    await _orchestrator.downloadBinary(name, force: true);
+    await _orchestrator.downloadBinary(name, force: true, forceBackend: isSidechainApp && binary.chainLayer == 2);
 
     // Poll until the orchestrator drops the binary out of its in-flight map.
     // First tick might miss the entry if our poll lands before the server's

--- a/sail_ui/lib/rpcs/orchestrator_rpc.dart
+++ b/sail_ui/lib/rpcs/orchestrator_rpc.dart
@@ -128,8 +128,10 @@ class OrchestratorRPC {
     );
   }
 
-  Future<StopBinaryResponse> stopBinary(String name, {bool force = false}) {
-    return _unaryClient.stopBinary(StopBinaryRequest(name: name, force: force));
+  /// Sidechains pass forceBackend: true to stop the daemon without closing
+  /// themselves — they are the GUI the orchestrator would otherwise stop too.
+  Future<StopBinaryResponse> stopBinary(String name, {bool force = false, bool forceBackend = false}) {
+    return _unaryClient.stopBinary(StopBinaryRequest(name: name, force: force, forceBackend: forceBackend));
   }
 
   Future<GetBTCPriceResponse> getBTCPrice() {
@@ -200,8 +202,10 @@ class OrchestratorRPC {
   /// immediately. Progress is polled out of [getSyncStatus] — the
   /// SyncProvider already shows download MB on the matching sidechain
   /// slot, so callers don't need to subscribe to anything.
-  Future<DownloadBinaryResponse> downloadBinary(String name, {bool force = false}) {
-    return _unaryClient.downloadBinary(DownloadBinaryRequest(name: name, force: force));
+  /// Sidechains pass forceBackend: true so an update installs the daemon they
+  /// run, not the Flutter bundle BitWindow would launch.
+  Future<DownloadBinaryResponse> downloadBinary(String name, {bool force = false, bool forceBackend = false}) {
+    return _unaryClient.downloadBinary(DownloadBinaryRequest(name: name, force: force, forceBackend: forceBackend));
   }
 
   // ─── server-streaming ─────────────────────────────────────────────────────
@@ -241,8 +245,8 @@ class OrchestratorRPC {
   /// can't surface a phantom "bitcoind is already running" error on Bitcoin
   /// Core's card. Use this for per-daemon Restart buttons; reserve
   /// [startWithL1] for full-chain bootstrap.
-  Future<RestartDaemonResponse> restartDaemon(String name) {
-    return _unaryClient.restartDaemon(RestartDaemonRequest(name: name));
+  Future<RestartDaemonResponse> restartDaemon(String name, {bool forceBackend = false}) {
+    return _unaryClient.restartDaemon(RestartDaemonRequest(name: name, forceBackend: forceBackend));
   }
 
   /// Restart the whole L1 stack (bitcoind + enforcer). The orchestrator owns

--- a/sail_ui/lib/widgets/modals/chain_settings_modal.dart
+++ b/sail_ui/lib/widgets/modals/chain_settings_modal.dart
@@ -434,7 +434,7 @@ class ChainSettingsViewModel extends BaseViewModel {
   OS get os => getOS();
 
   // Show update button only if update is available and not currently updating
-  bool get showUpdateButton => _binary.updateAvailable && !_isUpdating;
+  bool get showUpdateButton => binary.updateAvailable && !_isUpdating;
 
   Future<void> handleUpdate(BuildContext context) async {
     if (_isUpdating) {
@@ -446,7 +446,7 @@ class ChainSettingsViewModel extends BaseViewModel {
 
     try {
       Navigator.of(context).pop();
-      await _binaryProvider.update(_binary);
+      await _binaryProvider.update(binary);
     } catch (e) {
       // Handle any errors during the update process
       // You might want to show a snackbar or dialog here

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -75,7 +75,8 @@ func (h *Handler) GetBinaryVersion(ctx context.Context, req *connect.Request[pb.
 // transport blip / client disconnect can't cancel an in-flight download.
 // Progress is polled out of GetSyncStatus (DownloadManager.state-backed).
 func (h *Handler) DownloadBinary(ctx context.Context, req *connect.Request[pb.DownloadBinaryRequest]) (*connect.Response[pb.DownloadBinaryResponse], error) {
-	ch, err := h.orch.Download(context.Background(), req.Msg.Name, req.Msg.Force)
+	opts := orchestrator.DownloadOptions{ForceBackend: req.Msg.ForceBackend}
+	ch, err := h.orch.Download(context.Background(), req.Msg.Name, req.Msg.Force, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +101,8 @@ func (h *Handler) StartBinary(ctx context.Context, req *connect.Request[pb.Start
 }
 
 func (h *Handler) StopBinary(ctx context.Context, req *connect.Request[pb.StopBinaryRequest]) (*connect.Response[pb.StopBinaryResponse], error) {
-	if err := h.orch.Stop(ctx, req.Msg.Name, req.Msg.Force); err != nil {
+	opts := orchestrator.StopOptions{ForceBackend: req.Msg.ForceBackend}
+	if err := h.orch.Stop(ctx, req.Msg.Name, req.Msg.Force, opts); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.StopBinaryResponse{}), nil
@@ -155,7 +157,7 @@ func (h *Handler) StreamLogs(ctx context.Context, req *connect.Request[pb.Stream
 // blip can't kill an in-flight restart. Crucially, it does NOT cascade to
 // sibling daemons — restarting "enforcer" never spawns or adopts bitcoind.
 func (h *Handler) RestartDaemon(ctx context.Context, req *connect.Request[pb.RestartDaemonRequest]) (*connect.Response[pb.RestartDaemonResponse], error) {
-	ch, err := h.orch.RestartDaemon(context.Background(), req.Msg.Name)
+	ch, err := h.orch.RestartDaemon(context.Background(), req.Msg.Name, orchestrator.StopOptions{ForceBackend: req.Msg.ForceBackend})
 	if err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/core_variants_integration_test.go
+++ b/sidechain-orchestrator/core_variants_integration_test.go
@@ -335,7 +335,7 @@ func TestIntegration_SetCoreVariant_StopFailure(t *testing.T) {
 		o.process.AdoptProcess(o.configs["bitcoind"], 1)
 
 		var graceful, force atomic.Int32
-		o.stopBinary = func(_ context.Context, name string, f bool) error {
+		o.stopBinary = func(_ context.Context, name string, f bool, _ ...StopOptions) error {
 			require.Equal(t, "bitcoind", name)
 			if !f {
 				graceful.Add(1)
@@ -377,7 +377,7 @@ func TestIntegration_SetCoreVariant_StopFailure(t *testing.T) {
 		o.process.AdoptProcess(o.configs["bitcoind"], 1)
 
 		preDownloads := counts.knots.Load()
-		o.stopBinary = func(_ context.Context, _ string, _ bool) error {
+		o.stopBinary = func(_ context.Context, _ string, _ bool, _ ...StopOptions) error {
 			return errors.New("kill refused")
 		}
 		o.bootBitcoindForVariantSwap = func(_ context.Context) <-chan StartupProgress {

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -798,9 +798,12 @@ func (x *GetBinaryVersionResponse) GetIsTestBuild() bool {
 }
 
 type DownloadBinaryRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Force         bool                   `protobuf:"varint,2,opt,name=force,proto3" json:"force,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Force bool                   `protobuf:"varint,2,opt,name=force,proto3" json:"force,omitempty"`
+	// Download the daemon, never the sidechain's Flutter bundle. Sidechain apps
+	// set this so an update installs the backend they actually run.
+	ForceBackend  bool `protobuf:"varint,3,opt,name=force_backend,json=forceBackend,proto3" json:"force_backend,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -845,6 +848,13 @@ func (x *DownloadBinaryRequest) GetName() string {
 func (x *DownloadBinaryRequest) GetForce() bool {
 	if x != nil {
 		return x.Force
+	}
+	return false
+}
+
+func (x *DownloadBinaryRequest) GetForceBackend() bool {
+	if x != nil {
+		return x.ForceBackend
 	}
 	return false
 }
@@ -993,6 +1003,7 @@ type StopBinaryRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Force         bool                   `protobuf:"varint,2,opt,name=force,proto3" json:"force,omitempty"`
+	ForceBackend  bool                   `protobuf:"varint,3,opt,name=force_backend,json=forceBackend,proto3" json:"force_backend,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1037,6 +1048,13 @@ func (x *StopBinaryRequest) GetName() string {
 func (x *StopBinaryRequest) GetForce() bool {
 	if x != nil {
 		return x.Force
+	}
+	return false
+}
+
+func (x *StopBinaryRequest) GetForceBackend() bool {
+	if x != nil {
+		return x.ForceBackend
 	}
 	return false
 }
@@ -1322,8 +1340,11 @@ func (*StartWithL1Response) Descriptor() ([]byte, []int) {
 }
 
 type RestartDaemonRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Restart only the daemon, never the sidechain's Flutter bundle. A stopped
+	// daemon keeps no boot mode to recover, so the caller states it.
+	ForceBackend  bool `protobuf:"varint,2,opt,name=force_backend,json=forceBackend,proto3" json:"force_backend,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1363,6 +1384,13 @@ func (x *RestartDaemonRequest) GetName() string {
 		return x.Name
 	}
 	return ""
+}
+
+func (x *RestartDaemonRequest) GetForceBackend() bool {
+	if x != nil {
+		return x.ForceBackend
+	}
+	return false
 }
 
 type RestartDaemonResponse struct {
@@ -4150,10 +4178,11 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x1f\n" +
 	"\vbinary_path\x18\x02 \x01(\tR\n" +
 	"binaryPath\x12\"\n" +
-	"\ris_test_build\x18\x03 \x01(\bR\visTestBuild\"A\n" +
+	"\ris_test_build\x18\x03 \x01(\bR\visTestBuild\"f\n" +
 	"\x15DownloadBinaryRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
-	"\x05force\x18\x02 \x01(\bR\x05force\"\x18\n" +
+	"\x05force\x18\x02 \x01(\bR\x05force\x12#\n" +
+	"\rforce_backend\x18\x03 \x01(\bR\fforceBackend\"\x18\n" +
 	"\x16DownloadBinaryResponse\"\xbf\x01\n" +
 	"\x12StartBinaryRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1d\n" +
@@ -4164,10 +4193,11 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"'\n" +
 	"\x13StartBinaryResponse\x12\x10\n" +
-	"\x03pid\x18\x01 \x01(\x05R\x03pid\"=\n" +
+	"\x03pid\x18\x01 \x01(\x05R\x03pid\"b\n" +
 	"\x11StopBinaryRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
-	"\x05force\x18\x02 \x01(\bR\x05force\"\x14\n" +
+	"\x05force\x18\x02 \x01(\bR\x05force\x12#\n" +
+	"\rforce_backend\x18\x03 \x01(\bR\fforceBackend\"\x14\n" +
 	"\x12StopBinaryResponse\";\n" +
 	"\x11StreamLogsRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
@@ -4189,9 +4219,10 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x0eTargetEnvEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x15\n" +
-	"\x13StartWithL1Response\"*\n" +
+	"\x13StartWithL1Response\"O\n" +
 	"\x14RestartDaemonRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"\x17\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12#\n" +
+	"\rforce_backend\x18\x02 \x01(\bR\fforceBackend\"\x17\n" +
 	"\x15RestartDaemonResponse\"\x12\n" +
 	"\x10RestartL1Request\"\x13\n" +
 	"\x11RestartL1Response\"X\n" +

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -217,7 +217,7 @@ type Orchestrator struct {
 
 	// stopBinary is the Stop primitive used by SetCoreVariant. Production wires
 	// this to o.Stop; tests override it to inject force/graceful failures.
-	stopBinary func(ctx context.Context, name string, force bool) error
+	stopBinary func(ctx context.Context, name string, force bool, options ...StopOptions) error
 
 	// bootBitcoindForVariantSwap boots bitcoind after a variant swap. Returns
 	// a channel that is closed when boot is complete. Production wires this to
@@ -506,12 +506,16 @@ func (o *Orchestrator) UpdateConfigs(configs []BinaryConfig) {
 }
 
 // Download downloads a binary if missing (or forces re-download).
-func (o *Orchestrator) Download(ctx context.Context, name string, force bool) (<-chan DownloadProgress, error) {
+func (o *Orchestrator) Download(ctx context.Context, name string, force bool, options ...DownloadOptions) (<-chan DownloadProgress, error) {
+	var opts DownloadOptions
+	if len(options) > 0 {
+		opts = options[0]
+	}
 	config, err := o.getConfig(name)
 	if err != nil {
 		return nil, err
 	}
-	return o.download.Download(ctx, config, o.Network, force)
+	return o.download.DownloadWithOptions(ctx, config, o.Network, force, opts)
 }
 
 // Start starts a binary with the given args and env.
@@ -525,7 +529,19 @@ func (o *Orchestrator) Start(ctx context.Context, name string, args []string, en
 
 // Stop stops a running binary and marks its monitor as stopped so
 // the restart timer won't automatically bring it back.
-func (o *Orchestrator) Stop(ctx context.Context, name string, force bool) error {
+// StopOptions tweaks Stop behaviour per-call.
+type StopOptions struct {
+	// ForceBackend leaves the sidechain's GUI companion running. Set by
+	// sidechain Flutter apps, which are that companion.
+	ForceBackend bool
+}
+
+func (o *Orchestrator) Stop(ctx context.Context, name string, force bool, options ...StopOptions) error {
+	var opts StopOptions
+	if len(options) > 0 {
+		opts = options[0]
+	}
+
 	// Validate the target up front so stopping an unknown/typo'd binary is a
 	// real error rather than a silent no-op success. A known-but-not-running
 	// binary still passes here and is handled as a no-op below.
@@ -542,7 +558,10 @@ func (o *Orchestrator) Stop(ctx context.Context, name string, force bool) error 
 	}
 	o.monitorsMu.Unlock()
 
-	_, guiErr := o.stopSidechainGUI(ctx, name, force)
+	var guiErr error
+	if !opts.ForceBackend {
+		_, guiErr = o.stopSidechainGUI(ctx, name, force)
+	}
 
 	// Stopping a daemon that isn't running is a no-op success, not an error:
 	// first-launch wallet restore stops the L1 stack before rebooting, and on
@@ -1030,7 +1049,12 @@ func (o *Orchestrator) startBitcoindOnly(ctx context.Context, opts StartOpts, ch
 //
 // The returned channel emits StartupProgress events the same way StartWithL1
 // does and is closed when the restart completes (or fails).
-func (o *Orchestrator) RestartDaemon(ctx context.Context, name string) (<-chan StartupProgress, error) {
+func (o *Orchestrator) RestartDaemon(ctx context.Context, name string, options ...StopOptions) (<-chan StartupProgress, error) {
+	var opts StopOptions
+	if len(options) > 0 {
+		opts = options[0]
+	}
+
 	config, err := o.getConfig(name)
 	if err != nil {
 		return nil, err
@@ -1045,15 +1069,16 @@ func (o *Orchestrator) RestartDaemon(ctx context.Context, name string) (<-chan S
 		// record. Without this, restarting a sidechain that was launched with
 		// --force-backend forgets the flag and spawns the flutter_frontend
 		// variant instead — a second GUI window on top of the existing one.
-		forceBackend := o.process.ForceBackendFor(name)
+		forceBackend := opts.ForceBackend || o.process.ForceBackendFor(name)
 
 		// Best-effort stop. If the binary isn't running, fall straight through
 		// to start.
 		if o.process.IsRunning(name) {
 			ch <- StartupProgress{Stage: "stopping-" + name, Message: fmt.Sprintf("stopping %s...", config.DisplayName)}
-			if err := o.Stop(ctx, name, false); err != nil {
+			stopOpts := StopOptions{ForceBackend: forceBackend}
+			if err := o.Stop(ctx, name, false, stopOpts); err != nil {
 				o.log.Warn().Err(err).Str("binary", name).Msg("graceful stop failed during restart, escalating to SIGKILL")
-				if killErr := o.Stop(ctx, name, true); killErr != nil {
+				if killErr := o.Stop(ctx, name, true, stopOpts); killErr != nil {
 					o.log.Error().Err(killErr).Str("binary", name).Msg("force kill also failed during restart")
 					ch <- StartupProgress{Error: fmt.Errorf("stop %s: %w", name, killErr)}
 					return

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -222,6 +222,9 @@ message GetBinaryVersionResponse {
 message DownloadBinaryRequest {
   string name = 1;
   bool force = 2;
+  // Download the daemon, never the sidechain's Flutter bundle. Sidechain apps
+  // set this so an update installs the backend they actually run.
+  bool force_backend = 3;
 }
 
 message DownloadBinaryResponse {}
@@ -243,6 +246,7 @@ message StartBinaryResponse {
 message StopBinaryRequest {
   string name = 1;
   bool force = 2;
+  bool force_backend = 3;
 }
 
 message StopBinaryResponse {}
@@ -282,6 +286,9 @@ message StartWithL1Response {}
 
 message RestartDaemonRequest {
   string name = 1;
+  // Restart only the daemon, never the sidechain's Flutter bundle. A stopped
+  // daemon keeps no boot mode to recover, so the caller states it.
+  bool force_backend = 2;
 }
 
 message RestartDaemonResponse {}

--- a/thunder/macos/Runner.xcodeproj/project.pbxproj
+++ b/thunder/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
 		BFACAA6DBFC182D90F32CED3 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2BC5C5CF07A4E6608232FCE /* Pods_Runner.framework */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,6 +74,7 @@
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		D2BC5C5CF07A4E6608232FCE /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE677A380AD49A394BF2896D /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +82,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				BFACAA6DBFC182D90F32CED3 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -141,6 +144,7 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
@@ -174,6 +178,9 @@
 
 /* Begin PBXNativeTarget section */
 		33CC10EC2044A3C60003C045 /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -199,6 +206,9 @@
 
 /* Begin PBXProject section */
 		33CC10E52044A3C60003C045 /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
@@ -624,6 +634,18 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/thunder/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/thunder/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "&quot;$FLUTTER_ROOT&quot;/packages/flutter_tools/bin/macos_assemble.sh prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "33CC10EC2044A3C60003C045"
+                     BuildableName = "SideSail.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"


### PR DESCRIPTION
Stops a sidechain app from closing itself when it stops or restarts its own daemon, and fixes the update button, the receive address, and the stale status a dead orchestrator used to leave on screen.