### PR TITLE
e2e: fix windows job-object failures

### DIFF
--- a/.github/workflows/bitwindow-e2e.yml
+++ b/.github/workflows/bitwindow-e2e.yml
@@ -147,7 +147,7 @@ jobs:
         working-directory: bitwindow/e2e
         run:
           go test -tags e2e -v -timeout 25m -run
-          'TestFlutterProcessIsNotInAJob|TestDaemonsAreInTheJob|TestForceKillingAppReapsDaemons'
+          'TestFlutterProcessIsNotInTheDaemonJob|TestDaemonsAreInTheJob|TestForceKillingAppReapsDaemons'
           ./...
         env:
           BITWINDOW_TEST_LOG_DIR: ${{ runner.temp }}/e2e-logs/job-object

--- a/bitwindow/e2e/job_object_windows_test.go
+++ b/bitwindow/e2e/job_object_windows_test.go
@@ -29,6 +29,8 @@ var (
 // here: CI runners already put every process in one.
 func openDaemonJob(t *testing.T, appPIDs []int) (syscall.Handle, int) {
 	t.Helper()
+	var handles []syscall.Handle
+	var owners []int
 	for _, pid := range appPIDs {
 		name, err := syscall.UTF16PtrFromString(fmt.Sprintf("bitwindow-daemons-%d", pid))
 		if err != nil {
@@ -38,11 +40,21 @@ func openDaemonJob(t *testing.T, appPIDs []int) (syscall.Handle, int) {
 			uintptr(jobObjectQuery), 0, uintptr(unsafe.Pointer(name)),
 		)
 		if ret != 0 {
-			return syscall.Handle(ret), pid
+			handles = append(handles, syscall.Handle(ret))
+			owners = append(owners, pid)
 		}
 	}
-	t.Fatalf("no daemon job found for app pids %s; the runner never created one", prettyPIDs(appPIDs))
-	return 0, 0
+	// Reading the wrong app's job reports every daemon as an escapee.
+	if len(owners) > 1 {
+		for _, h := range handles {
+			_ = syscall.CloseHandle(h)
+		}
+		t.Fatalf("app pids %s each own a daemon job; a prior run leaked an app", prettyPIDs(owners))
+	}
+	if len(owners) == 0 {
+		t.Fatalf("no daemon job found for app pids %s; the runner never created one", prettyPIDs(appPIDs))
+	}
+	return handles[0], owners[0]
 }
 
 // isProcessInJob reports whether pid belongs to job.

--- a/bitwindow/e2e/process_windows_test.go
+++ b/bitwindow/e2e/process_windows_test.go
@@ -65,7 +65,15 @@ func runTaskkill(pid int, force bool) error {
 // its RPC ports. In-run shutdown is the orchestrator's responsibility.
 func sweepPriorRunOrphans(t *testing.T) {
 	t.Helper()
-	for _, name := range []string{"bitwindowd.exe", "orchestratord.exe", "bitcoind.exe", "bip300301_enforcer.exe"} {
+	// A live app restarts a daemon it did not stop, so it goes first.
+	images := []string{
+		flutterAppProcessName() + ".exe",
+		"bitwindowd.exe",
+		"orchestratord.exe",
+		"bitcoind.exe",
+		"bip300301_enforcer.exe",
+	}
+	for _, name := range images {
 		_ = exec.Command("taskkill", "/F", "/IM", name).Run()
 	}
 }


### PR DESCRIPTION
The window-close case leaks its BitWindows.exe: taskkill /T walks parent pids, and the flutter tool exits first, so the app survives the tree kill. The next case sweeps the daemons, the leaked app restarts them, and the test then reads the leaked app's job instead of the live one — every daemon looks like an escapee.

The sweep now kills the app image first. openDaemonJob fails loudly when two apps own a job, and the workflow runs the renamed first test.