### PR TITLE
bitwindow: hide BIP47 card on enforcer wallets

### DIFF
--- a/bitwindow/lib/pages/wallet/wallet_receive.dart
+++ b/bitwindow/lib/pages/wallet/wallet_receive.dart
@@ -420,15 +420,12 @@ class ReceivePageViewModel extends BaseViewModel {
   wmpb.AddressType get addressType => transactionsProvider.addressType;
   Future<void> setAddressType(wmpb.AddressType type) => transactionsProvider.setAddressType(type);
 
-  /// BIP47 payment codes derive from a single master seed and a single-key
-  /// receive branch, so they don't apply to watch-only wallets (no seed) or
-  /// multisig wallets (no single seed; funds land on multisig script addresses).
-  /// Hide the BIP47 card for both so the receive tab doesn't show a row the user
-  /// can't populate.
+  /// Hide the BIP47 card for the wallets the backend derives no code for, so
+  /// the receive tab shows no row that can never fill.
   bool get hideBip47 {
     final reader = GetIt.I.get<WalletReaderProvider>();
     final active = reader.activeWallet;
-    return active != null && (active.isWatchOnly || active.isMultisig);
+    return active != null && (active.isWatchOnly || active.isMultisig || active.isEnforcer);
   }
 
   /// A multisig wallet's address kind is fixed by its descriptor, so the receive

--- a/sidechain_core/lib/models/wallet_data.dart
+++ b/sidechain_core/lib/models/wallet_data.dart
@@ -34,6 +34,10 @@ class WalletData {
 
   bool get isMultisig => multisig != null;
 
+  /// True iff this wallet runs against the enforcer, whose wallet service can
+  /// watch no key but its own and so never derives a BIP47 payment code.
+  bool get isEnforcer => walletType == BinaryType.BINARY_TYPE_ENFORCER;
+
   /// Device type and master fingerprint for a single-sig hardware wallet.
   final String hardwareDeviceType;
   final String hardwareFingerprint;


### PR DESCRIPTION
The enforcer derives no BIP47 payment code, so the receive tab showed a card that spun on "Waiting for wallet to sync.." forever.