### PR TITLE
security: delete dead BytesEqual, drop CORS credentials

### DIFF
--- a/bitwindow/server/engines/bitdrive_engine.go
+++ b/bitwindow/server/engines/bitdrive_engine.go
@@ -1,7 +1,6 @@
 package engines
 
 import (
-	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/rand"
@@ -730,9 +729,4 @@ func ParseOPReturnParts(opReturnMessage string) (metadataB64, contentStr string,
 		return "", "", fmt.Errorf("invalid format: expected metadata|content")
 	}
 	return parts[0], parts[1], nil
-}
-
-// BytesEqual performs constant-time byte comparison
-func BytesEqual(a, b []byte) bool {
-	return bytes.Equal(a, b)
 }

--- a/dc-hub/server/server/server.go
+++ b/dc-hub/server/server/server.go
@@ -111,7 +111,6 @@ func (s *Server) Handler(ctx context.Context) http.Handler {
 				"Access-Control-Allow-Origin",
 				"Access-Control-Request-Headers",
 			},
-			AllowCredentials: true, // Allow credentials
 		})
 
 		withCORS := corsHandler.Handler(s.mux)


### PR DESCRIPTION
BytesEqual had no callers. The real HMAC tag check already uses subtle.ConstantTimeCompare.

dc-hub reads no cookie and no Authorization header, so AllowCredentials only made rs/cors reflect arbitrary origins. Dropping it keeps the wildcard working for every caller.

Alternative to #1980, which does not compile.