### PR TITLE
BitWindow: 36 fixes from a security review (stacked for cherry-picking)

### DIFF
--- a/bitwindow/lib/providers/multisig_provider.dart
+++ b/bitwindow/lib/providers/multisig_provider.dart
@@ -627,9 +627,8 @@ class TransactionStorage {
     String transactionId,
     String keyId,
     String psbt,
-    bool isSigned, {
-    int? signatureThreshold,
-  }) async {
+    bool isSigned,
+  ) async {
     final transaction = await getTransaction(transactionId);
     if (transaction == null) {
       throw Exception('Transaction not found: $transactionId');
@@ -641,10 +640,15 @@ class TransactionStorage {
       orElse: () => throw Exception('Group not found: ${transaction.groupId}'),
     );
 
-    final actualSignedStatus = await PSBTValidator.hasAnySignatures(psbt, group.n);
-
     final keyPSBTs = List<KeyPSBTStatus>.from(transaction.keyPSBTs);
     final existingIndex = keyPSBTs.indexWhere((k) => k.keyId == keyId);
+
+    // Only the owning group's keys may hold a PSBT slot on its transaction.
+    if (existingIndex == -1 && !group.keys.any((k) => k.xpub == keyId)) {
+      throw Exception('Key is not a member of group ${group.id}: $keyId');
+    }
+
+    final actualSignedStatus = await PSBTValidator.hasAnySignatures(psbt, group.n);
 
     final newKeyPSBT = KeyPSBTStatus(
       keyId: keyId,
@@ -660,8 +664,7 @@ class TransactionStorage {
     }
 
     final signedCount = keyPSBTs.where((k) => k.isSigned).length;
-    final threshold = signatureThreshold ?? transaction.requiredSignatures;
-    final newStatus = signedCount >= threshold ? TxStatus.readyToCombine : TxStatus.needsSignatures;
+    final newStatus = signedCount >= group.m ? TxStatus.readyToCombine : TxStatus.needsSignatures;
 
     final updatedTransaction = transaction.copyWith(
       keyPSBTs: keyPSBTs,

--- a/bitwindow/lib/widgets/fund_group_modal.dart
+++ b/bitwindow/lib/widgets/fund_group_modal.dart
@@ -182,12 +182,11 @@ class FundGroupModalViewModel extends BaseViewModel {
       // (Phase-1) descriptors. SyncGroup owns watch-wallet creation server-side.
       await _multisigLounge.syncGroup(group: multisigGroupToProto(enhancedGroup), walletId: walletId);
 
-      // The group carries the standard descriptors; build them if not yet
-      // persisted. These are the same descriptors SyncGroup imported.
-      String? descriptor = enhancedGroup.descriptorReceive;
+      // The group carries the standard descriptors; persist them if not yet
+      // stored. These are the same descriptors SyncGroup imported.
+      final descriptor = enhancedGroup.descriptorReceive;
       if (descriptor == null || descriptor.isEmpty) {
         final built = await MultisigDescriptorBuilder.buildWatchOnlyDescriptors(enhancedGroup);
-        descriptor = built.receive;
         updatedGroup = enhancedGroup.copyWith(
           descriptorReceive: built.receive,
           descriptorChange: built.change,
@@ -197,19 +196,14 @@ class FundGroupModalViewModel extends BaseViewModel {
 
       int nextIndex = updatedGroup.nextReceiveIndex;
 
-      final addresses = await bitcoindRpcCall(
-        'deriveaddresses',
-        params: [
-          descriptor,
-          [nextIndex, nextIndex],
-        ],
-      );
+      // Let the watch wallet hand out the address instead of deriving it at an
+      // index of our own: Core only emits indices inside the descriptor range
+      // SyncGroup imported, so the address is always one the wallet tracks.
+      final newAddress = await bitcoindRpcCall('getnewaddress', wallet: walletName);
 
-      if (addresses is! List || addresses.isEmpty) {
-        throw Exception('Failed to derive address from descriptor');
+      if (newAddress is! String || newAddress.isEmpty) {
+        throw Exception('Failed to get a funding address from watch wallet $walletName');
       }
-
-      final newAddress = addresses.first as String;
 
       // Update group with new address via backend RPC
       final receiveAddresses = List<AddressInfo>.from(updatedGroup.addresses['receive'] ?? []);

--- a/bitwindow/lib/widgets/import_psbt_modal.dart
+++ b/bitwindow/lib/widgets/import_psbt_modal.dart
@@ -201,6 +201,9 @@ class _ImportPSBTModalState extends State<ImportPSBTModal> {
       final txId = _txIdController.text.trim();
 
       var existingTx = await TransactionStorage.getTransaction(txId);
+      if (existingTx != null && existingTx.groupId != _selectedGroupId) {
+        throw Exception('PSBT targets a transaction in another group');
+      }
 
       if (keyOwner == null) {
         throw Exception('key_owner is required in PSBT import data');
@@ -273,7 +276,6 @@ class _ImportPSBTModalState extends State<ImportPSBTModal> {
           targetKey.xpub,
           cleanPsbt,
           true,
-          signatureThreshold: group.m,
         );
       } else {
         final allRelevantKeys = <MultisigKey>[];
@@ -302,7 +304,6 @@ class _ImportPSBTModalState extends State<ImportPSBTModal> {
               key.xpub,
               cleanPsbt,
               false,
-              signatureThreshold: group.m,
             );
           }
         }

--- a/bitwindow/lib/widgets/multisig_key_modal.dart
+++ b/bitwindow/lib/widgets/multisig_key_modal.dart
@@ -218,21 +218,17 @@ class MultisigKeyModalViewModel extends BaseViewModel {
       return;
     }
 
-    try {
-      final keyName = keyNameController.text.trim();
+    final keyName = keyNameController.text.trim();
 
-      final soloKeyData = {
-        'xpub': keyInfo!['xpub'],
-        'owner': keyName,
-        'path': keyInfo!['path'],
-        'fingerprint': keyInfo!['fingerprint'],
-        'origin_path': keyInfo!['originPath'],
-      };
+    final soloKeyData = {
+      'xpub': keyInfo!['xpub'],
+      'owner': keyName,
+      'path': keyInfo!['path'],
+      'fingerprint': keyInfo!['fingerprint'],
+      'origin_path': keyInfo!['originPath'],
+    };
 
-      await MultisigStorage.addSoloKey(soloKeyData);
-    } catch (e) {
-      // Failed to save key to storage - not critical
-    }
+    await MultisigStorage.addSoloKey(soloKeyData);
   }
 
   Future<void> saveKey(BuildContext context) async {

--- a/bitwindow/server/api/drivechain/drivechain.go
+++ b/bitwindow/server/api/drivechain/drivechain.go
@@ -196,23 +196,25 @@ func (s *Server) ListSidechains(ctx context.Context, _ *connect.Request[pb.ListS
 	// Loop over all sidechains and get their chaintip if available
 	sidechainList := make([]*pb.ListSidechainsResponse_Sidechain, 0, len(sidechains.Sidechains))
 	for _, sidechain := range sidechains.Sidechains {
-		declaration := sidechain.Declaration.GetV0()
+		// The enforcer reports a nil declaration for descriptions that aren't a v0
+		// declaration, which is legal. Use nil-safe getters throughout.
+		declaration := sidechain.GetDeclaration().GetV0()
 
 		sc := &pb.ListSidechainsResponse_Sidechain{
-			Title:            declaration.Title.Value,
-			Description:      declaration.Description.Value,
-			Hashid1:          declaration.HashId_1.Hex.Value,
-			Hashid2:          declaration.HashId_2.Hex.Value,
-			Slot:             sidechain.SidechainNumber.Value,
-			VoteCount:        sidechain.VoteCount.Value,
-			ProposalHeight:   sidechain.ProposalHeight.Value,
-			ActivationHeight: sidechain.ActivationHeight.Value,
-			DescriptionHex:   sidechain.Description.Hex.Value,
+			Title:            declaration.GetTitle().GetValue(),
+			Description:      declaration.GetDescription().GetValue(),
+			Hashid1:          declaration.GetHashId_1().GetHex().GetValue(),
+			Hashid2:          declaration.GetHashId_2().GetHex().GetValue(),
+			Slot:             sidechain.GetSidechainNumber().GetValue(),
+			VoteCount:        sidechain.GetVoteCount().GetValue(),
+			ProposalHeight:   sidechain.GetProposalHeight().GetValue(),
+			ActivationHeight: sidechain.GetActivationHeight().GetValue(),
+			DescriptionHex:   sidechain.GetDescription().GetHex().GetValue(),
 		}
 
 		// Try to get ctip (may not exist if no deposits yet)
 		ctipResponse, err := s.data.Ctip(ctx,
-			&validatorpb.GetCtipRequest{SidechainNumber: wrapperspb.UInt32(sidechain.SidechainNumber.Value)},
+			&validatorpb.GetCtipRequest{SidechainNumber: wrapperspb.UInt32(sc.Slot)},
 		)
 		if err == nil && ctipResponse.Ctip != nil && ctipResponse.Ctip.Txid != nil {
 			txidHash, err := chainhash.NewHashFromStr(ctipResponse.Ctip.Txid.Hex.Value)

--- a/bitwindow/server/api/drivechain/drivechain.go
+++ b/bitwindow/server/api/drivechain/drivechain.go
@@ -547,8 +547,16 @@ func (s *Server) mergeBundles(existing, new []*pb.WithdrawalBundle) []*pb.Withdr
 	for _, b := range new {
 		if existingBundle, ok := bundleMap[b.M6Id]; ok {
 			// Update status if the new event changes it (e.g., pending -> succeeded/failed)
-			if b.Status == "succeeded" || b.Status == "failed" {
+			switch b.Status {
+			case "succeeded", "failed":
 				existingBundle.Status = b.Status
+				existingBundle.SequenceNumber = b.SequenceNumber
+				existingBundle.TransactionHex = b.TransactionHex
+			case "pending":
+				// A bundle can be re-proposed after expiring, which opens a fresh
+				// voting window at the new submission height.
+				existingBundle.Status = b.Status
+				existingBundle.BlockHeight = b.BlockHeight
 				existingBundle.SequenceNumber = b.SequenceNumber
 				existingBundle.TransactionHex = b.TransactionHex
 			}

--- a/bitwindow/server/api/drivechain/drivechain_test.go
+++ b/bitwindow/server/api/drivechain/drivechain_test.go
@@ -101,6 +101,62 @@ func TestService_ListSidechains(t *testing.T) {
 		assert.Equal(t, uint32(0), resp.Msg.Sidechains[0].Slot)
 	})
 
+	t.Run("handles nil declaration", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.Test(t)
+		ctrl := gomock.NewController(t)
+
+		mockValidator := mocks.NewMockValidatorServiceClient(ctrl)
+
+		mockValidator.EXPECT().
+			GetChainTip(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[mainchainv1.GetChainTipResponse]{
+				Msg: &mainchainv1.GetChainTipResponse{
+					BlockHeaderInfo: &mainchainv1.BlockHeaderInfo{
+						Height: 100,
+						BlockHash: &commonv1.ReverseHex{
+							Hex: wrapperspb.String("0000000000000000000000000000000000000000000000000000000000000001"),
+						},
+					},
+				},
+			}, nil)
+
+		// The enforcer reports a nil declaration when the description doesn't
+		// decode as a v0 declaration, which the spec allows.
+		mockValidator.EXPECT().
+			GetSidechains(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[mainchainv1.GetSidechainsResponse]{
+				Msg: &mainchainv1.GetSidechainsResponse{
+					Sidechains: []*mainchainv1.GetSidechainsResponse_SidechainInfo{
+						{
+							SidechainNumber: wrapperspb.UInt32(7),
+							Declaration:     nil,
+							Description: &commonv1.ConsensusHex{
+								Hex: wrapperspb.String("deadbeef"),
+							},
+							VoteCount:        wrapperspb.UInt32(100),
+							ProposalHeight:   wrapperspb.UInt32(50),
+							ActivationHeight: wrapperspb.UInt32(60),
+						},
+					},
+				},
+			}, nil)
+
+		mockValidator.EXPECT().
+			GetCtip(gomock.Any(), gomock.Any()).
+			Return(nil, connect.NewError(connect.CodeNotFound, nil))
+
+		cli := rpc.NewDrivechainServiceClient(apitests.API(t, db, apitests.WithValidator(mockValidator)))
+
+		resp, err := cli.ListSidechains(context.Background(), connect.NewRequest(&pb.ListSidechainsRequest{}))
+		require.NoError(t, err)
+		require.Len(t, resp.Msg.Sidechains, 1)
+		assert.Empty(t, resp.Msg.Sidechains[0].Title)
+		assert.Equal(t, uint32(7), resp.Msg.Sidechains[0].Slot)
+		assert.Equal(t, "deadbeef", resp.Msg.Sidechains[0].DescriptionHex)
+	})
+
 	t.Run("handles empty sidechains", func(t *testing.T) {
 		t.Parallel()
 

--- a/bitwindow/server/api/drivechain/merge_bundles_test.go
+++ b/bitwindow/server/api/drivechain/merge_bundles_test.go
@@ -1,0 +1,41 @@
+package api_drivechain
+
+import (
+	"testing"
+
+	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/drivechain/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMergeBundlesRevivesFailedBundle proves a re-proposed M6ID that was cached
+// as failed comes back as pending at its new submission height, so the age is
+// recomputed against the fresh voting window instead of the original one.
+func TestMergeBundlesRevivesFailedBundle(t *testing.T) {
+	s := &Server{}
+
+	const m6id = "abc123"
+
+	cached := []*pb.WithdrawalBundle{{
+		M6Id:        m6id,
+		BlockHeight: 100,
+		Status:      "failed",
+		MaxAge:      withdrawalVerificationPeriod,
+	}}
+
+	resubmitted := []*pb.WithdrawalBundle{{
+		M6Id:        m6id,
+		BlockHeight: 30000,
+		Status:      "pending",
+		MaxAge:      withdrawalVerificationPeriod,
+	}}
+
+	merged := s.mergeBundles(cached, resubmitted)
+	require.Len(t, merged, 1)
+	require.Equal(t, "pending", merged[0].Status)
+	require.Equal(t, uint32(30000), merged[0].BlockHeight)
+
+	aged := s.updateBundleAges(merged, 30010)
+	require.Len(t, aged, 1)
+	require.Equal(t, uint32(10), aged[0].Age)
+	require.Equal(t, withdrawalVerificationPeriod-10, aged[0].BlocksLeft)
+}

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1048,7 +1048,8 @@ func (s *Server) ListSidechainDeposits(ctx context.Context, c *connect.Request[p
 
 	var response pb.ListSidechainDepositsResponse
 	for _, tx := range deposits.Transactions {
-		if c.Msg.Slot != 0 && tx.SidechainNumber.Value != uint32(c.Msg.Slot) {
+		// Slot 0 is a real sidechain slot, not an "all slots" sentinel.
+		if tx.SidechainNumber.Value != uint32(c.Msg.Slot) {
 			continue
 		}
 

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -313,11 +313,8 @@ func (s *Server) SendTransaction(ctx context.Context, c *connect.Request[pb.Send
 	}), nil
 }
 
-// sendWithRequiredInputs creates and broadcasts a transaction spending the
-// given required UTXOs. Input values are looked up from Bitcoin Core's own
-// UTXO set (callers do not reliably populate UnspentOutput.ValueSats), and any
-// remainder after destinations + fee is returned as change instead of being
-// silently paid to the miner.
+// sendWithRequiredInputs parses the "txid:vout" required inputs and broadcasts
+// a transaction spending exactly those UTXOs.
 func (s *Server) sendWithRequiredInputs(
 	ctx context.Context,
 	bitcoind corerpc.BitcoinServiceClient,
@@ -327,16 +324,7 @@ func (s *Server) sendWithRequiredInputs(
 	feeSatPerVbyte uint64,
 	fixedFeeSats uint64,
 ) (string, error) {
-	log := zerolog.Ctx(ctx)
-
-	const dustLimit = 546
-
-	type outpoint struct {
-		txid string
-		vout uint32
-	}
-
-	wanted := make([]outpoint, 0, len(requiredInputs))
+	wanted := make([]engines.CoreOutpoint, 0, len(requiredInputs))
 	for _, utxo := range requiredInputs {
 		parts := strings.Split(utxo.Output, ":")
 		if len(parts) != 2 {
@@ -346,101 +334,10 @@ func (s *Server) sendWithRequiredInputs(
 		if err != nil {
 			return "", fmt.Errorf("invalid vout in UTXO %s: %w", utxo.Output, err)
 		}
-		wanted = append(wanted, outpoint{txid: parts[0], vout: uint32(vout)})
+		wanted = append(wanted, engines.CoreOutpoint{Txid: parts[0], Vout: uint32(vout)})
 	}
 
-	// Resolve input values from Core rather than trusting the request.
-	unspent, err := bitcoind.ListUnspent(ctx, connect.NewRequest(&corepb.ListUnspentRequest{
-		MinimumConfirmations: lo.ToPtr(uint32(0)),
-		Wallet:               walletName,
-	}))
-	if err != nil {
-		return "", fmt.Errorf("list unspent: %w", err)
-	}
-	valueByOutpoint := make(map[outpoint]uint64, len(unspent.Msg.Unspent))
-	for _, u := range unspent.Msg.Unspent {
-		valueByOutpoint[outpoint{txid: u.Txid, vout: u.Vout}] = uint64(math.Round(u.Amount * 1e8))
-	}
-
-	var totalInSats uint64
-	inputs := make([]*corepb.CreateRawTransactionRequest_Input, 0, len(wanted))
-	for _, op := range wanted {
-		valSats, ok := valueByOutpoint[op]
-		if !ok {
-			return "", fmt.Errorf("required input %s:%d not found in wallet UTXO set", op.txid, op.vout)
-		}
-		totalInSats += valSats
-		inputs = append(inputs, &corepb.CreateRawTransactionRequest_Input{Txid: op.txid, Vout: op.vout})
-	}
-
-	var totalOutSats uint64
-	for _, sats := range destinationsSats {
-		totalOutSats += sats
-	}
-
-	// Explicit fixed fee wins; otherwise estimate from the rate (default
-	// 2 sat/vB, matching the cheque-sweep path). Output/input vbyte sizes
-	// mirror the P2WPKH estimate used in buildSweepTx.
-	var feeSats uint64
-	if fixedFeeSats > 0 {
-		feeSats = fixedFeeSats
-	} else {
-		rate := feeSatPerVbyte
-		if rate == 0 {
-			rate = 2
-		}
-		estVbytes := uint64(len(inputs)*68 + (len(destinationsSats)+1)*31 + 11)
-		feeSats = estVbytes * rate
-	}
-
-	if totalInSats < totalOutSats+feeSats {
-		return "", fmt.Errorf("required inputs (%d sats) insufficient for outputs + fee (%d sats)", totalInSats, totalOutSats+feeSats)
-	}
-
-	outputs := make(map[string]float64, len(destinationsSats)+1)
-	for addr, sats := range destinationsSats {
-		outputs[addr] = float64(sats) / 1e8
-	}
-
-	changeSats := totalInSats - totalOutSats - feeSats
-	if changeSats >= dustLimit {
-		changeResp, err := bitcoind.GetNewAddress(ctx, connect.NewRequest(&corepb.GetNewAddressRequest{
-			Wallet: walletName,
-		}))
-		if err != nil {
-			return "", fmt.Errorf("get change address: %w", err)
-		}
-		outputs[changeResp.Msg.Address] = float64(changeSats) / 1e8
-	}
-
-	createResp, err := bitcoind.CreateRawTransaction(ctx, connect.NewRequest(&corepb.CreateRawTransactionRequest{
-		Inputs:  inputs,
-		Outputs: outputs,
-	}))
-	if err != nil {
-		return "", fmt.Errorf("create raw transaction: %w", err)
-	}
-	log.Debug().Msgf("created raw transaction with change: %s", createResp.Msg.Tx.Hex)
-
-	signResp, err := bitcoind.SignRawTransactionWithWallet(ctx, connect.NewRequest(&corepb.SignRawTransactionWithWalletRequest{
-		HexString: createResp.Msg.Tx.Hex,
-		Wallet:    walletName,
-	}))
-	if err != nil {
-		return "", fmt.Errorf("sign transaction: %w", err)
-	}
-	if !signResp.Msg.Complete {
-		return "", fmt.Errorf("transaction signing incomplete")
-	}
-
-	sendResp, err := bitcoind.SendRawTransaction(ctx, connect.NewRequest(&corepb.SendRawTransactionRequest{
-		Tx: &corepb.RawTransaction{Hex: signResp.Msg.Hex},
-	}))
-	if err != nil {
-		return "", fmt.Errorf("broadcast transaction: %w", err)
-	}
-
-	return sendResp.Msg.Txid, nil
+	return engines.SendCoreWithRequiredInputs(ctx, bitcoind, walletName, wanted, destinationsSats, feeSatPerVbyte, fixedFeeSats)
 }
 
 // GetNewAddress implements drivechainv1connect.DrivechainServiceHandler.

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1023,6 +1023,10 @@ func extractAddress(tx *validatorpb.WalletTransaction, addressBookEntries []addr
 
 // ListSidechainDeposits implements walletv1connect.WalletServiceHandler.
 func (s *Server) ListSidechainDeposits(ctx context.Context, c *connect.Request[pb.ListSidechainDepositsRequest]) (*connect.Response[pb.ListSidechainDepositsResponse], error) {
+	if c.Msg.Slot < 0 || c.Msg.Slot > 255 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("slot must be 0-255"))
+	}
+
 	walletId := c.Msg.WalletId
 
 	walletType, err := s.walletEngine.GetWalletBackendType(ctx, walletId)

--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -117,6 +117,14 @@ func (s *Server) CreateBitcoinCoreWallet(ctx context.Context, c *connect.Request
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name required"))
 	}
 
+	// A managed name loads the existing wallet instead of creating one, and the
+	// import below would supersede its active descriptors with this seed's.
+	if strings.HasPrefix(coreWalletName, "wallet_") ||
+		strings.HasPrefix(coreWalletName, "watch_") ||
+		coreWalletName == engines.ChequeWalletName {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name %q is reserved for managed wallets", coreWalletName))
+	}
+
 	// Directly import to Bitcoin Core - no wallet.json needed
 	if err := s.walletEngine.CreateBitcoinCoreWalletFromSeed(ctx, coreWalletName, seedHex, 0, ""); err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Msg("create Bitcoin Core wallet failed")

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -508,4 +508,21 @@ func TestService_ListSidechainDeposits(t *testing.T) {
 		require.Len(t, resp.Msg.Deposits, 1)
 		require.Equal(t, "slot0deposit", resp.Msg.Deposits[0].Txid)
 	})
+
+	t.Run("out of range slot is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		database := database.Test(t)
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database))
+
+		for _, slot := range []int32{-1, 256} {
+			_, err := cli.ListSidechainDeposits(context.Background(), connect.NewRequest(&walletv1.ListSidechainDepositsRequest{
+				WalletId: "test-wallet-id-1234",
+				Slot:     slot,
+			}))
+			require.Error(t, err)
+			require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+			require.Contains(t, err.Error(), "slot must be 0-255")
+		}
+	})
 }

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -3,10 +3,12 @@ package api_wallet_test
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
 	walletv1 "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1"
 	walletv1connect "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/wallet/v1/walletv1connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
@@ -346,6 +348,41 @@ func TestService_IsWalletUnlocked(t *testing.T) {
 		_, err := cli.IsWalletUnlocked(context.Background(), connect.NewRequest(&emptypb.Empty{}))
 		// The test wallet is unencrypted, so it should be considered unlocked
 		require.NoError(t, err)
+	})
+}
+
+func TestService_CreateBitcoinCoreWallet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("managed wallet names are rejected", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		database := database.Test(t)
+
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		mockBitcoind.EXPECT().
+			ListWallets(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.ListWalletsResponse]{
+				Msg: &bitcoindv1alpha.ListWalletsResponse{Wallets: []string{}},
+			}, nil).AnyTimes()
+		mockBitcoind.EXPECT().
+			CreateWallet(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.CreateWalletResponse]{
+				Msg: &bitcoindv1alpha.CreateWalletResponse{Name: "cheque_watch"},
+			}, nil).AnyTimes()
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database, apitests.WithBitcoind(mockBitcoind)))
+
+		for _, name := range []string{"wallet_deadbeef", "watch_deadbeef", engines.ChequeWalletName} {
+			_, err := cli.CreateBitcoinCoreWallet(context.Background(), connect.NewRequest(&walletv1.CreateBitcoinCoreWalletRequest{
+				SeedHex: strings.Repeat("00", 64),
+				Name:    name,
+			}))
+			require.Error(t, err)
+			require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+			require.Contains(t, err.Error(), "reserved for managed wallets")
+		}
 	})
 }
 

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -14,11 +14,13 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/cheques"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/apitests"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	commonv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/common/v1"
 	mainchainv1 "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/cusf/mainchain/v1"
 	bitcoindv1alpha "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestService_GetBalance(t *testing.T) {
@@ -443,5 +445,67 @@ func TestService_UnlockWallet(t *testing.T) {
 		}))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not encrypted")
+	})
+}
+
+func TestService_ListSidechainDeposits(t *testing.T) {
+	t.Parallel()
+
+	t.Run("slot 0 only returns slot 0 deposits", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		database := database.Test(t)
+
+		deposit := func(slot uint32, txid string) *mainchainv1.ListSidechainDepositTransactionsResponse_SidechainDepositTransaction {
+			return &mainchainv1.ListSidechainDepositTransactionsResponse_SidechainDepositTransaction{
+				SidechainNumber: wrapperspb.UInt32(slot),
+				Tx: &mainchainv1.WalletTransaction{
+					Txid:             &commonv1.ReverseHex{Hex: wrapperspb.String(txid)},
+					SentSats:         1000,
+					FeeSats:          10,
+					ConfirmationInfo: &mainchainv1.WalletTransaction_Confirmation{Height: 100},
+				},
+			}
+		}
+
+		mockWallet := mocks.NewMockWalletServiceClient(ctrl)
+		mockWallet.EXPECT().
+			ListSidechainDepositTransactions(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[mainchainv1.ListSidechainDepositTransactionsResponse]{
+				Msg: &mainchainv1.ListSidechainDepositTransactionsResponse{
+					Transactions: []*mainchainv1.ListSidechainDepositTransactionsResponse_SidechainDepositTransaction{
+						deposit(0, "slot0deposit"),
+						deposit(9, "slot9deposit"),
+					},
+				},
+			}, nil).AnyTimes()
+
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		mockBitcoind.EXPECT().
+			ListWallets(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.ListWalletsResponse]{
+				Msg: &bitcoindv1alpha.ListWalletsResponse{Wallets: []string{}},
+			}, nil).AnyTimes()
+		mockBitcoind.EXPECT().
+			CreateWallet(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.CreateWalletResponse]{
+				Msg: &bitcoindv1alpha.CreateWalletResponse{Name: "cheque_watch"},
+			}, nil).AnyTimes()
+		mockBitcoind.EXPECT().
+			GetBlockchainInfo(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[bitcoindv1alpha.GetBlockchainInfoResponse]{
+				Msg: &bitcoindv1alpha.GetBlockchainInfoResponse{Blocks: 105},
+			}, nil).AnyTimes()
+
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database, apitests.WithWallet(mockWallet), apitests.WithBitcoind(mockBitcoind)))
+
+		resp, err := cli.ListSidechainDeposits(context.Background(), connect.NewRequest(&walletv1.ListSidechainDepositsRequest{
+			WalletId: "test-wallet-id-1234",
+			Slot:     0,
+		}))
+		require.NoError(t, err)
+		require.Len(t, resp.Msg.Deposits, 1)
+		require.Equal(t, "slot0deposit", resp.Msg.Deposits[0].Txid)
 	})
 }

--- a/bitwindow/server/cpuminer/miner.go
+++ b/bitwindow/server/cpuminer/miner.go
@@ -586,10 +586,20 @@ func (m *Miner) Start(ctx context.Context) error {
 	return <-errs
 }
 
+// A persistent high-hash means our target is looser than the node's, so
+// refreshed work gets rejected just as fast: back off, then give up.
+const (
+	maxHighHashRejections = 5
+	highHashBackoff       = time.Second
+)
+
 // minerThread is the main mining thread
 func (m *Miner) runRoutine(ctx context.Context, routineID int) error {
 
 	maxNonce := uint32(0xffffffff/m.routines*(routineID+1) - 0x20)
+
+	// Consecutive high-hash rejections, reset by any other submit outcome.
+	highHashes := 0
 
 	for {
 		// Get work
@@ -637,9 +647,31 @@ func (m *Miner) runRoutine(ctx context.Context, routineID int) error {
 			zerolog.Ctx(ctx).Error().
 				Msgf("Block rejected with too high hash (too little work), nonce was: %d", work.nonce)
 
+			// Drop the cached template: rescanning it finds the same nonce and
+			// resubmits a byte-identical block, forever.
+			m.work.Store(nil)
+
+			highHashes++
+			if highHashes >= maxHighHashRejections {
+				return fmt.Errorf(
+					"block rejected: high-hash %d times in a row (mining target looser than the node's, check TESTING_HASH_GOAL)",
+					highHashes,
+				)
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(highHashBackoff):
+			}
+
+			continue
+
 		default:
 			return fmt.Errorf("block rejected: %s", *reason)
 		}
+
+		highHashes = 0
 	}
 }
 

--- a/bitwindow/server/cpuminer/miner_test.go
+++ b/bitwindow/server/cpuminer/miner_test.go
@@ -2,8 +2,14 @@ package cpuminer
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // Real segwit transaction from a drynet2 getblocktemplate response
@@ -63,5 +69,75 @@ func TestGbtWorkDecodeBangPrefixedSegwitRule(t *testing.T) {
 			"merkle root built from wtxids, not txids (is the \"!segwit\" rule handled?)\n got: %x\nwant: %x",
 			work.merkleroot[:], expected,
 		)
+	}
+}
+
+// A node answering "high-hash" used to leave the cached template in place, so
+// the routine rescanned it to the same nonce and resubmitted the identical
+// block in a tight loop, forever, while Start reported a healthy miner.
+func TestRunRoutineHighHashDoesNotLoopForever(t *testing.T) {
+	var templates, submits atomic.Int64
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+
+		var result any
+		switch req.Method {
+		case "getblocktemplate":
+			templates.Add(1)
+			// Bits are loose enough that the first nonces solve the work.
+			result = gbtRpcResponse{
+				PreviousBlockhash: "00000000407919cf7c93944ad2a1f52f0b1d1924124905b51a2f9ae43335d200",
+				Bits:              "207fffff",
+				Height:            958370,
+				Curtime:           1784800000,
+				Version:           0x20000000,
+				Rules:             []string{"!segwit"},
+				CoinbaseTxn: json.RawMessage(
+					`{"data":"01000000","txid":"9d72a6f82b4ebe4447a5f21d596353514583abbebcf328b2fe5d6a0963c9b4e7"}`,
+				),
+			}
+
+		case "submitblock":
+			submits.Add(1)
+			result = "high-hash"
+
+		default:
+			t.Errorf("unexpected method %q", req.Method)
+			return
+		}
+
+		//nolint:errcheck
+		json.NewEncoder(w).Encode(map[string]any{"result": result})
+	}))
+	defer srv.Close()
+
+	miner, err := New(Config{Routines: 1, ScanTime: time.Second, RpcURL: srv.URL})
+	if err != nil {
+		t.Fatalf("new miner: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	err = miner.Start(ctx)
+	if err == nil || !strings.Contains(err.Error(), "high-hash") {
+		t.Fatalf("expected the routine to give up on repeated high-hash, got: %v", err)
+	}
+
+	if got := submits.Load(); got != maxHighHashRejections {
+		t.Fatalf("submitted %d blocks, want %d", got, maxHighHashRejections)
+	}
+
+	// Every rejection must refetch the template instead of resubmitting the
+	// cached one.
+	if got := templates.Load(); got < submits.Load() {
+		t.Fatalf("fetched %d templates for %d submissions", got, submits.Load())
 	}
 }

--- a/bitwindow/server/database/migrate_test.go
+++ b/bitwindow/server/database/migrate_test.go
@@ -1,0 +1,65 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Migration 013 recreates denials, which resets its AUTOINCREMENT sequence. Any
+// execution left behind is adopted by whichever new denial reuses its denial_id.
+func TestMigration013ClearsExecutedDenials(t *testing.T) {
+	ctx := context.Background()
+	db := migrateUpTo(t, "012_remadd_to_vout.sql")
+
+	_, err := db.ExecContext(ctx, `INSERT INTO denials (id, initial_txid, initial_vout, delay_duration, num_hops, created_at)
+		VALUES (1, 'old-initial-txid', 0, 3600, 1, CURRENT_TIMESTAMP)`)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `INSERT INTO executed_denials (denial_id, from_txid, from_vout, to_txid, to_vout, created_at)
+		VALUES (1, 'old-from-txid', 0, 'old-to-txid', 0, CURRENT_TIMESTAMP)`)
+	require.NoError(t, err)
+
+	require.NoError(t, runMigrations(ctx, db))
+
+	var orphans int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM executed_denials
+		WHERE denial_id NOT IN (SELECT id FROM denials)`).Scan(&orphans))
+	require.Zero(t, orphans, "dropping denials must not leave executions behind")
+}
+
+// migrateUpTo applies every migration up to and including latest, and records it
+// so runMigrations continues from there.
+func migrateUpTo(t *testing.T, latest string) *sql.DB {
+	db, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "bitwindow.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	entries, err := fs.ReadDir(migrations, "migrations")
+	require.NoError(t, err)
+
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".sql") || entry.Name() > latest {
+			continue
+		}
+		body, err := fs.ReadFile(migrations, "migrations/"+entry.Name())
+		require.NoError(t, err)
+		_, err = db.Exec(string(body))
+		require.NoError(t, err, "apply migration %s", entry.Name())
+	}
+
+	_, err = db.Exec(`CREATE TABLE migrations (
+		id INTEGER PRIMARY KEY CHECK (id = 1),
+		latest_version TEXT NOT NULL
+	)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO migrations (id, latest_version) VALUES (1, ?)`, latest)
+	require.NoError(t, err)
+
+	return db
+}

--- a/bitwindow/server/database/migrations/013_deniability_updated_at.sql
+++ b/bitwindow/server/database/migrations/013_deniability_updated_at.sql
@@ -1,4 +1,7 @@
 -- Drop and recreate denials table with updated_at column
+-- Executions belong to the dropped denials, and their denial_id would otherwise
+-- point at whatever new denial reuses the reset AUTOINCREMENT id.
+DELETE FROM executed_denials;
 DROP TABLE IF EXISTS denials;
 
 CREATE TABLE denials (

--- a/bitwindow/server/engines/backup_engine.go
+++ b/bitwindow/server/engines/backup_engine.go
@@ -188,6 +188,21 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 		log.Info().Msg("restore: imported transactions")
 	}
 
+	// Import DB-backed data before writing any file, so a backup that fails to
+	// import leaves the current wallet in place.
+	if multisigJSON != nil {
+		if err := e.multisigStore.ImportFromJSON(ctx, multisigJSON); err != nil {
+			return fmt.Errorf("import multisig data: %w", err)
+		}
+		log.Info().Msg("restore: imported multisig data")
+	}
+	if txJSON != nil {
+		if err := e.multisigStore.ImportTransactionsFromJSON(ctx, txJSON); err != nil {
+			return fmt.Errorf("import transactions: %w", err)
+		}
+		log.Info().Msg("restore: imported transactions")
+	}
+
 	// Restore wallet.json
 	walletPath := filepath.Join(e.walletDir, "wallet.json")
 	if err := os.WriteFile(walletPath, walletJSON, 0600); err != nil {

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -67,6 +67,12 @@ func (p *Parser) Run(ctx context.Context) error {
 	alertTicker := time.NewTicker(2 * time.Second)
 	defer alertTicker.Stop()
 
+	// Unconfirmed OP_RETURNs never expire on their own. Sweep on start —
+	// sessions are often shorter than the tick — and hourly after that.
+	reapTicker := time.NewTicker(time.Hour)
+	defer reapTicker.Stop()
+	p.reapExpiredMempool(ctx)
+
 	zerolog.Ctx(ctx).Info().
 		Msgf("bitcoind_engine/parser: started parser ticker")
 
@@ -76,6 +82,9 @@ func (p *Parser) Run(ctx context.Context) error {
 			zerolog.Ctx(ctx).Info().Err(ctx.Err()).
 				Msgf("bitcoind_engine/parser: stopping parser ticker")
 			return nil
+
+		case <-reapTicker.C:
+			p.reapExpiredMempool(ctx)
 
 		case <-alertTicker.C:
 
@@ -94,6 +103,14 @@ func (p *Parser) Run(ctx context.Context) error {
 				Msgf("bitcoind_engine/parser: finished processing block tick")
 
 		}
+	}
+}
+
+// reapExpiredMempool drops unconfirmed OP_RETURNs that can no longer
+// confirm. Best-effort: a failed sweep is retried on the next tick.
+func (p *Parser) reapExpiredMempool(ctx context.Context) {
+	if err := opreturns.ReapExpiredMempool(ctx, p.db); err != nil {
+		zerolog.Ctx(ctx).Err(err).Msgf("unable to reap expired mempool OP_RETURNs")
 	}
 }
 

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -604,8 +604,7 @@ func (p *Parser) handleOpReturns(
 		}
 
 		isOPReturn := txout.PkScript[0] == txscript.OP_RETURN
-		isCoinbaseReturn := isOPReturn && txout.PkScript[1] == txscript.OP_DATA_36
-		if isCoinbaseReturn {
+		if isWitnessCommitment(txout.PkScript) {
 			continue
 		}
 		if shouldSkip(txout.PkScript) {
@@ -795,6 +794,19 @@ func parseOPReturnData(script []byte) ([]byte, bool) {
 	default:
 		return nil, false
 	}
+}
+
+// witnessCommitmentMagic prefixes the coinbase segwit commitment push (BIP141).
+var witnessCommitmentMagic = []byte{0xaa, 0x21, 0xa9, 0xed}
+
+// isWitnessCommitment reports whether a script is the coinbase segwit
+// commitment. The 36-byte push length alone isn't enough — real payloads
+// can also be exactly 36 bytes.
+func isWitnessCommitment(pkScript []byte) bool {
+	return len(pkScript) >= 6 &&
+		pkScript[0] == txscript.OP_RETURN &&
+		pkScript[1] == txscript.OP_DATA_36 &&
+		bytes.Equal(pkScript[2:6], witnessCommitmentMagic)
 }
 
 func shouldSkip(pkScript []byte) bool {

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -234,6 +234,10 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 		if err := p.purgeM4AtOrAbove(ctx, lastProcessedHeight+1); err != nil {
 			return fmt.Errorf("purge m4 on reorg: %w", err)
 		}
+
+		if err := p.purgeChainDerivedAtOrAbove(ctx, lastProcessedHeight+1); err != nil {
+			return fmt.Errorf("purge chain-derived rows on reorg: %w", err)
+		}
 	}
 
 	const batchSize = 30

--- a/bitwindow/server/engines/bitcoind_engine_internal_test.go
+++ b/bitwindow/server/engines/bitcoind_engine_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	cnstore "github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/coinnews"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/opreturns"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/timestamps"
 	service "github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
@@ -114,6 +115,56 @@ func TestOpReturnHandling(t *testing.T) {
 	assert.Equal(t, btcutil.Amount(100_000), news[0].Fee)
 	assert.Equal(t, "The Known Topic", news[0].Headline)
 	assert.Equal(t, "The Known Topic", news[0].TopicName)
+}
+
+// TestPurgeChainDerivedAtOrAbove proves the reorg purge covers the two
+// tables the replay can't heal on its own: op_returns keeps its stale
+// height through the upsert, and a confirmed timestamp is never
+// re-examined.
+func TestPurgeChainDerivedAtOrAbove(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := database.Test(t)
+	parser := &Parser{db: db}
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO op_returns (txid, vout, op_return_data, fee_sats, height, created_at)
+		VALUES ('below', 0, 'aa', 0, 100, CURRENT_TIMESTAMP),
+		       ('orphaned', 0, 'bb', 0, 200, CURRENT_TIMESTAMP),
+		       ('mempool', 0, 'cc', 0, NULL, CURRENT_TIMESTAMP)`)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO file_timestamps (filename, file_hash, txid, block_height, status, created_at, confirmed_at)
+		VALUES ('below.txt', 'hash-below', 'txid-below', 100, 'confirmed', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		       ('orphaned.txt', 'hash-orphaned', 'txid-orphaned', 200, 'confirmed', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+	require.NoError(t, err)
+
+	require.NoError(t, parser.purgeChainDerivedAtOrAbove(ctx, 181))
+
+	var txids []string
+	rows, err := db.QueryContext(ctx, `SELECT txid FROM op_returns ORDER BY txid`)
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var txid string
+		require.NoError(t, rows.Scan(&txid))
+		txids = append(txids, txid)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{"below", "mempool"}, txids,
+		"orphaned OP_RETURNs are wiped, confirmed-below and mempool rows survive")
+
+	below, err := timestamps.GetByHash(ctx, db, "hash-below")
+	require.NoError(t, err)
+	assert.Equal(t, timestamps.StatusConfirmed, below.Status, "timestamps below the rewind target stay confirmed")
+
+	orphaned, err := timestamps.GetByHash(ctx, db, "hash-orphaned")
+	require.NoError(t, err)
+	assert.Equal(t, timestamps.StatusConfirming, orphaned.Status, "orphaned timestamps go back to confirming")
+	assert.Nil(t, orphaned.BlockHeight, "orphaned timestamps lose their stale height")
+	assert.Nil(t, orphaned.ConfirmedAt, "orphaned timestamps lose their stale confirmation time")
 }
 
 func pkScript(t *testing.T, data []byte) []byte {

--- a/bitwindow/server/engines/coinnews.go
+++ b/bitwindow/server/engines/coinnews.go
@@ -140,12 +140,12 @@ func indexCoinNewsPayload(ctx context.Context, db *sql.DB, data []byte, pos cnst
 
 // coinNewsPayload extracts the bytes pushed by a single-push OP_RETURN
 // script. Returns ok=false for anything else (not OP_RETURN, multi-
-// push, OP_DRIVECHAIN, coinbase carrier).
+// push, OP_DRIVECHAIN, coinbase witness commitment).
 func coinNewsPayload(pkScript []byte) ([]byte, bool) {
 	if len(pkScript) < 2 || pkScript[0] != txscript.OP_RETURN {
 		return nil, false
 	}
-	if pkScript[1] == txscript.OP_DATA_36 {
+	if isWitnessCommitment(pkScript) {
 		return nil, false
 	}
 	if shouldSkip(pkScript) {

--- a/bitwindow/server/engines/coinnews.go
+++ b/bitwindow/server/engines/coinnews.go
@@ -13,6 +13,7 @@ import (
 
 	cnstore "github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/coinnews"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/opreturns"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/timestamps"
 	codec "github.com/LayerTwo-Labs/sidesail/coinnews/codec"
 )
 
@@ -186,6 +187,36 @@ func (p *Parser) purgeM4AtOrAbove(ctx context.Context, fromHeight uint32) error 
 		if _, err := tx.ExecContext(ctx, q, fromHeight); err != nil {
 			return err
 		}
+	}
+	return tx.Commit()
+}
+
+// purgeChainDerivedAtOrAbove drops the block-derived op_returns and
+// file_timestamps state from blocks at or above `fromHeight`. Neither
+// heals itself on replay: the op_returns upsert keeps the old height
+// (`COALESCE(excluded.height, op_returns.height)`), and a confirmed
+// timestamp is never re-examined. Mempool OP_RETURNs have a NULL height
+// and are left alone; reset timestamps go back through the confirming
+// loop, which re-confirms them against the new chain or fails them.
+func (p *Parser) purgeChainDerivedAtOrAbove(ctx context.Context, fromHeight uint32) error {
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // committed on success
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM op_returns WHERE height >= ?`, fromHeight,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE file_timestamps
+		SET status = ?, block_height = NULL, confirmed_at = NULL
+		WHERE block_height >= ?`,
+		timestamps.StatusConfirming, fromHeight,
+	); err != nil {
+		return err
 	}
 	return tx.Commit()
 }

--- a/bitwindow/server/engines/coinnews_test.go
+++ b/bitwindow/server/engines/coinnews_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -305,6 +306,38 @@ func TestCoinNewsIndexer_BroadcastBytesListAsCoinNews(t *testing.T) {
 	assert.Equal(t, "US Weekly", news[0].TopicName)
 	assert.Equal(t, "Broadcast headline", news[0].Headline)
 	assert.Equal(t, "Broadcast body", news[0].Content)
+}
+
+// TestCoinNewsIndexer_Accepts36BytePayload: a 36-byte CoinNews payload
+// pushes as OP_DATA_36 — the same opcode the coinbase segwit commitment
+// uses. Only the commitment (0xaa21a9ed magic) may be skipped.
+func TestCoinNewsIndexer_Accepts36BytePayload(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	p := newCoinNewsParser(t)
+
+	topic := codec.Topic{0x33, 0x33, 0x33, 0x33}
+	// "CN"(2) + type(1) + topic(4) + retention(1) + compactsize(1) + name(27) = 36.
+	const name = "twenty-seven-char-topicname"
+	payload, err := codec.EncodeTopicCreation(codec.TopicCreation{Topic: topic, RetentionDays: 7, Name: name})
+	require.NoError(t, err)
+	require.Len(t, payload, 36)
+
+	block := blockOf(t, [][]byte{payload}, time.Now().UTC())
+	require.Equal(t, byte(txscript.OP_DATA_36), block.Transactions[0].TxOut[0].PkScript[1])
+
+	require.NoError(t, p.indexCoinNewsBlocks(ctx, []lo.Tuple2[uint32, *wire.MsgBlock]{
+		lo.T2(uint32(920_000), block),
+	}))
+
+	var got string
+	require.NoError(t, p.db.QueryRowContext(ctx, `SELECT name FROM cn_topics WHERE topic = ?`, topic[:]).Scan(&got))
+	assert.Equal(t, name, got, "36-byte CoinNews payload MUST be indexed")
+
+	// Negative control: the coinbase witness commitment stays skipped.
+	commitment := append([]byte{txscript.OP_RETURN, txscript.OP_DATA_36, 0xaa, 0x21, 0xa9, 0xed}, make([]byte, 32)...)
+	_, ok := coinNewsPayload(commitment)
+	assert.False(t, ok, "coinbase witness commitment MUST stay skipped")
 }
 
 // TestCoinNewsIndexer_PurgeAtOrAbove proves the reorg purge wipes

--- a/bitwindow/server/engines/core_send.go
+++ b/bitwindow/server/engines/core_send.go
@@ -1,0 +1,131 @@
+package engines
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"connectrpc.com/connect"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/rs/zerolog"
+	"github.com/samber/lo"
+)
+
+// CoreOutpoint is a Bitcoin Core wallet UTXO that a transaction must spend.
+type CoreOutpoint struct {
+	Txid string
+	Vout uint32
+}
+
+// SendCoreWithRequiredInputs creates and broadcasts a Bitcoin Core transaction
+// spending exactly the given outpoints. Input values are looked up from Bitcoin
+// Core's own UTXO set (callers do not reliably know them), and any remainder
+// after destinations + fee is returned as change instead of being silently paid
+// to the miner.
+func SendCoreWithRequiredInputs(
+	ctx context.Context,
+	bitcoind corerpc.BitcoinServiceClient,
+	walletName string,
+	requiredInputs []CoreOutpoint,
+	destinationsSats map[string]uint64,
+	feeSatPerVbyte uint64,
+	fixedFeeSats uint64,
+) (string, error) {
+	log := zerolog.Ctx(ctx)
+
+	const dustLimit = 546
+
+	// Resolve input values from Core rather than trusting the caller.
+	unspent, err := bitcoind.ListUnspent(ctx, connect.NewRequest(&corepb.ListUnspentRequest{
+		MinimumConfirmations: lo.ToPtr(uint32(0)),
+		Wallet:               walletName,
+	}))
+	if err != nil {
+		return "", fmt.Errorf("list unspent: %w", err)
+	}
+	valueByOutpoint := make(map[CoreOutpoint]uint64, len(unspent.Msg.Unspent))
+	for _, u := range unspent.Msg.Unspent {
+		valueByOutpoint[CoreOutpoint{Txid: u.Txid, Vout: u.Vout}] = uint64(math.Round(u.Amount * 1e8))
+	}
+
+	var totalInSats uint64
+	inputs := make([]*corepb.CreateRawTransactionRequest_Input, 0, len(requiredInputs))
+	for _, op := range requiredInputs {
+		valSats, ok := valueByOutpoint[op]
+		if !ok {
+			return "", fmt.Errorf("required input %s:%d not found in wallet UTXO set", op.Txid, op.Vout)
+		}
+		totalInSats += valSats
+		inputs = append(inputs, &corepb.CreateRawTransactionRequest_Input{Txid: op.Txid, Vout: op.Vout})
+	}
+
+	var totalOutSats uint64
+	for _, sats := range destinationsSats {
+		totalOutSats += sats
+	}
+
+	// Explicit fixed fee wins; otherwise estimate from the rate (default
+	// 2 sat/vB, matching the cheque-sweep path). Output/input vbyte sizes
+	// mirror the P2WPKH estimate used in buildSweepTx.
+	var feeSats uint64
+	if fixedFeeSats > 0 {
+		feeSats = fixedFeeSats
+	} else {
+		rate := feeSatPerVbyte
+		if rate == 0 {
+			rate = 2
+		}
+		estVbytes := uint64(len(inputs)*68 + (len(destinationsSats)+1)*31 + 11)
+		feeSats = estVbytes * rate
+	}
+
+	if totalInSats < totalOutSats+feeSats {
+		return "", fmt.Errorf("required inputs (%d sats) insufficient for outputs + fee (%d sats)", totalInSats, totalOutSats+feeSats)
+	}
+
+	outputs := make(map[string]float64, len(destinationsSats)+1)
+	for addr, sats := range destinationsSats {
+		outputs[addr] = float64(sats) / 1e8
+	}
+
+	changeSats := totalInSats - totalOutSats - feeSats
+	if changeSats >= dustLimit {
+		changeResp, err := bitcoind.GetNewAddress(ctx, connect.NewRequest(&corepb.GetNewAddressRequest{
+			Wallet: walletName,
+		}))
+		if err != nil {
+			return "", fmt.Errorf("get change address: %w", err)
+		}
+		outputs[changeResp.Msg.Address] = float64(changeSats) / 1e8
+	}
+
+	createResp, err := bitcoind.CreateRawTransaction(ctx, connect.NewRequest(&corepb.CreateRawTransactionRequest{
+		Inputs:  inputs,
+		Outputs: outputs,
+	}))
+	if err != nil {
+		return "", fmt.Errorf("create raw transaction: %w", err)
+	}
+	log.Debug().Msgf("created raw transaction with change: %s", createResp.Msg.Tx.Hex)
+
+	signResp, err := bitcoind.SignRawTransactionWithWallet(ctx, connect.NewRequest(&corepb.SignRawTransactionWithWalletRequest{
+		HexString: createResp.Msg.Tx.Hex,
+		Wallet:    walletName,
+	}))
+	if err != nil {
+		return "", fmt.Errorf("sign transaction: %w", err)
+	}
+	if !signResp.Msg.Complete {
+		return "", fmt.Errorf("transaction signing incomplete")
+	}
+
+	sendResp, err := bitcoind.SendRawTransaction(ctx, connect.NewRequest(&corepb.SendRawTransactionRequest{
+		HexString: signResp.Msg.Hex,
+	}))
+	if err != nil {
+		return "", fmt.Errorf("broadcast transaction: %w", err)
+	}
+
+	return sendResp.Msg.Txid, nil
+}

--- a/bitwindow/server/engines/core_send_test.go
+++ b/bitwindow/server/engines/core_send_test.go
@@ -1,0 +1,89 @@
+package engines_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSendCoreWithRequiredInputs(t *testing.T) {
+	t.Parallel()
+
+	const trackedTxid = "aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11"
+	const otherTxid = "bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22"
+
+	t.Run("spends only the required outpoint", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+
+		mockBitcoind.EXPECT().
+			ListUnspent(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.ListUnspentResponse{
+				Unspent: []*corepb.UnspentOutput{
+					{Txid: trackedTxid, Vout: 3, Amount: 1.0},
+					{Txid: otherTxid, Vout: 0, Amount: 5.0},
+				},
+			}), nil)
+
+		mockBitcoind.EXPECT().
+			GetNewAddress(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.GetNewAddressResponse{
+				Address: "tb1qchange0000000000000000000000000000000",
+			}), nil)
+
+		// Stop at raw transaction creation: everything the fix is about is
+		// visible in that request.
+		stop := errors.New("stop")
+		mockBitcoind.EXPECT().
+			CreateRawTransaction(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *connect.Request[corepb.CreateRawTransactionRequest]) (*connect.Response[corepb.CreateRawTransactionResponse], error) {
+				require.Len(t, req.Msg.Inputs, 1)
+				assert.Equal(t, trackedTxid, req.Msg.Inputs[0].Txid)
+				assert.Equal(t, uint32(3), req.Msg.Inputs[0].Vout)
+
+				// 1 BTC in, 0.4 BTC out, 10k sats fee -> the rest is change.
+				assert.Equal(t, 0.4, req.Msg.Outputs["tb1qdest00000000000000000000000000000000"])
+				assert.Equal(t, 0.5999, req.Msg.Outputs["tb1qchange0000000000000000000000000000000"])
+				return nil, stop
+			})
+
+		_, err := engines.SendCoreWithRequiredInputs(context.Background(), mockBitcoind, "wallet",
+			[]engines.CoreOutpoint{{Txid: trackedTxid, Vout: 3}},
+			map[string]uint64{"tb1qdest00000000000000000000000000000000": 40_000_000},
+			0, 10_000,
+		)
+		require.ErrorIs(t, err, stop)
+	})
+
+	t.Run("errors when the required outpoint is not in the wallet", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+
+		mockBitcoind.EXPECT().
+			ListUnspent(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.ListUnspentResponse{
+				Unspent: []*corepb.UnspentOutput{
+					{Txid: otherTxid, Vout: 0, Amount: 5.0},
+				},
+			}), nil)
+
+		_, err := engines.SendCoreWithRequiredInputs(context.Background(), mockBitcoind, "wallet",
+			[]engines.CoreOutpoint{{Txid: trackedTxid, Vout: 3}},
+			map[string]uint64{"tb1qdest00000000000000000000000000000000": 40_000_000},
+			0, 10_000,
+		)
+		require.ErrorContains(t, err, "not found in wallet UTXO set")
+	})
+}

--- a/bitwindow/server/engines/deniability_engine.go
+++ b/bitwindow/server/engines/deniability_engine.go
@@ -292,7 +292,7 @@ func (e *DeniabilityEngine) ProcessUTXO(ctx context.Context, utxo *pb.ListUnspen
 		if werr := e.rejectWatchOnly(ctx, walletId); werr != nil {
 			return werr
 		}
-		txid, err = e.sendBitcoinCoreTransaction(ctx, walletId, destinations)
+		txid, err = e.sendBitcoinCoreTransaction(ctx, walletId, utxo, destinations, fee)
 	case WalletTypeElectrum:
 		txid, err = e.sendElectrumTransaction(ctx, walletId, utxo, destinations, fee)
 	default:
@@ -374,11 +374,14 @@ func (e *DeniabilityEngine) sendEnforcerTransaction(
 	return sendResp.Msg.Txid.Hex.Value, nil
 }
 
-// sendBitcoinCoreTransaction sends a transaction via Bitcoin Core
+// sendBitcoinCoreTransaction sends a transaction via Bitcoin Core, spending the
+// chosen UTXO into the denial destinations.
 func (e *DeniabilityEngine) sendBitcoinCoreTransaction(
 	ctx context.Context,
 	walletId string,
+	utxo *pb.ListUnspentOutputsResponse_Output,
 	destinations map[string]uint64,
+	fee uint64,
 ) (string, error) {
 	coreWalletName, err := e.walletEngine.GetBitcoinCoreWalletName(ctx, walletId)
 	if err != nil {
@@ -390,20 +393,9 @@ func (e *DeniabilityEngine) sendBitcoinCoreTransaction(
 		return "", fmt.Errorf("get bitcoind client: %w", err)
 	}
 
-	// Convert satoshi amounts to BTC (Bitcoin Core uses BTC, not satoshis)
-	btcDestinations := lo.MapValues(destinations, func(sats uint64, _ string) float64 {
-		return float64(sats) / 1e8
-	})
-
-	resp, err := bitcoind.Send(ctx, connect.NewRequest(&corepb.SendRequest{
-		Destinations: btcDestinations,
-		Wallet:       coreWalletName,
-	}))
-	if err != nil {
-		return "", fmt.Errorf("bitcoin core send: %w", err)
-	}
-
-	return resp.Msg.Txid, nil
+	return SendCoreWithRequiredInputs(ctx, bitcoind, coreWalletName, []CoreOutpoint{
+		{Txid: utxo.Txid.Hex.Value, Vout: utxo.Vout},
+	}, destinations, 0, fee)
 }
 
 // sendElectrumTransaction sends a transaction via the orchestrator wallet

--- a/bitwindow/server/engines/wallet_engine.go
+++ b/bitwindow/server/engines/wallet_engine.go
@@ -1004,7 +1004,13 @@ func (e *WalletEngine) EnsureWatchOnlyWallet(ctx context.Context, walletId strin
 			e.mu.Unlock()
 			return resp.Msg.CoreWalletName, nil
 		}
-		// Fall through to local on error
+		// A warming-up orchestrator (Unavailable) or a starting bitcoind means
+		// the local path would fail the same way — propagate so the caller
+		// retries instead of storming bitcoind.
+		if connect.CodeOf(err) == connect.CodeUnavailable || IsBitcoinCoreStartupError(err.Error()) {
+			return "", err
+		}
+		// Otherwise fall through to local on error
 	}
 
 	e.mu.Lock()
@@ -1026,7 +1032,7 @@ func (e *WalletEngine) EnsureWatchOnlyWallet(ctx context.Context, walletId strin
 	}
 
 	// Generate wallet name from wallet ID
-	walletName := fmt.Sprintf("watch_%s", walletId[:8])
+	walletName := fmt.Sprintf("wallet_%s", walletId[:8])
 
 	// Get bitcoind client
 	bitcoindClient, err := e.bitcoindConnector(ctx)

--- a/bitwindow/server/engines/wallet_engine_watchonly_test.go
+++ b/bitwindow/server/engines/wallet_engine_watchonly_test.go
@@ -1,0 +1,82 @@
+package engines
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// stubOrchWalletClient fails CreateBitcoinCoreWallet with a fixed error.
+type stubOrchWalletClient struct {
+	orchrpc.WalletManagerServiceClient
+	err error
+}
+
+func (s stubOrchWalletClient) CreateBitcoinCoreWallet(context.Context, *connect.Request[orchpb.CreateBitcoinCoreWalletRequest]) (*connect.Response[orchpb.CreateBitcoinCoreWalletResponse], error) {
+	return nil, s.err
+}
+
+// TestEnsureWatchOnlyWalletTransientOrchestratorError asserts a warming-up
+// orchestrator or a starting bitcoind propagates instead of falling through to
+// the local path, which would mint a second Core wallet for the same walletId.
+func TestEnsureWatchOnlyWalletTransientOrchestratorError(t *testing.T) {
+	tests := map[string]error{
+		"unavailable": connect.NewError(connect.CodeUnavailable, errors.New("wallet backend warming up")),
+		"startup":     connect.NewError(connect.CodeInternal, errors.New("-28: Verifying blocks…")),
+	}
+
+	for name, orchErr := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := NewWalletEngine(nil, nil, t.TempDir(), &chaincfg.MainNetParams)
+			e.SetOrchestratorClient(stubOrchWalletClient{err: orchErr})
+
+			_, err := e.EnsureWatchOnlyWallet(context.Background(), "deadbeefcafebabe")
+			require.ErrorIs(t, err, orchErr)
+		})
+	}
+}
+
+// TestEnsureWatchOnlyWalletLocalName asserts the local fallback names the Core
+// wallet the same way the orchestrator does, so both resolve one walletId to
+// one bitcoind wallet.
+func TestEnsureWatchOnlyWalletLocalName(t *testing.T) {
+	walletDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(walletDir, "wallet.json"), []byte(`{
+		"version": 1,
+		"activeWalletId": "deadbeefcafebabe",
+		"wallets": [{
+			"id": "deadbeefcafebabe",
+			"name": "watcher",
+			"wallet_type": "bitcoinCore",
+			"watch_only": {"xpub": "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj"}
+		}]
+	}`), 0o600))
+
+	ctrl := gomock.NewController(t)
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+	mockBitcoind.EXPECT().
+		ListWallets(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[corepb.ListWalletsResponse]{
+			Msg: &corepb.ListWalletsResponse{Wallets: []string{"wallet_deadbeef"}},
+		}, nil)
+
+	e := NewWalletEngine(func(context.Context) (corerpc.BitcoinServiceClient, error) {
+		return mockBitcoind, nil
+	}, nil, walletDir, &chaincfg.MainNetParams)
+
+	walletName, err := e.EnsureWatchOnlyWallet(context.Background(), "deadbeefcafebabe")
+	require.NoError(t, err)
+	require.Equal(t, "wallet_deadbeef", walletName)
+}

--- a/bitwindow/server/main.go
+++ b/bitwindow/server/main.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"os/exec"
@@ -46,7 +47,9 @@ import (
 func main() {
 	start := time.Now()
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	// SIGTERM too, so `systemctl stop` / `docker stop` drain the server and
+	// relay Shutdown to orchestratord instead of orphaning it.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 
 	if err := realMain(ctx, cancel); err != nil {
 

--- a/bitwindow/server/models/deniability/deniability.go
+++ b/bitwindow/server/models/deniability/deniability.go
@@ -378,8 +378,8 @@ func GetByTip(ctx context.Context, db *sql.DB, tipTxID string, tipVout *int32) (
 	args := []any{tipTxID}
 
 	if tipVout != nil {
-		query += ` AND (e.to_vout = ? OR d.initial_vout = ?) `
-		args = append(args, tipVout)
+		// Same tip semantics as the txid filter, so both match a single outpoint.
+		query += ` AND COALESCE(e.to_vout, d.initial_vout) = ? `
 		args = append(args, tipVout)
 	}
 	row := db.QueryRowContext(ctx, query, args...)

--- a/bitwindow/server/models/deniability/deniability_test.go
+++ b/bitwindow/server/models/deniability/deniability_test.go
@@ -187,6 +187,29 @@ func TestDeniability(t *testing.T) {
 		require.Nil(t, denial)
 	})
 
+	t.Run("GetByTip does not match the pre-hop vout", func(t *testing.T) {
+		t.Parallel()
+		db := database.Test(t)
+
+		denial, err := Create(ctx, db, "test-wallet", "initial-txid", 7, 1*time.Hour, 3, nil)
+		require.NoError(t, err)
+
+		// After a hop the tip is (hop-txid, 3), not (hop-txid, 7).
+		require.NoError(t, RecordExecution(ctx, db, denial.ID, "initial-txid", 7, "hop-txid", 3))
+
+		found, err := GetByTip(ctx, db, "test-wallet", "hop-txid", ptr(int32(3)))
+		require.NoError(t, err)
+		require.NotNil(t, found)
+		require.Equal(t, denial.ID, found.ID)
+		require.Equal(t, "hop-txid", found.TipTXID)
+		require.Equal(t, int32(3), found.TipVout)
+
+		// The stale initial vout must not satisfy the lookup.
+		found, err = GetByTip(ctx, db, "test-wallet", "hop-txid", ptr(int32(7)))
+		require.NoError(t, err)
+		require.Nil(t, found)
+	})
+
 	t.Run("Update", func(t *testing.T) {
 		t.Parallel()
 		db := database.Test(t)

--- a/bitwindow/server/models/multisig/multisig.go
+++ b/bitwindow/server/models/multisig/multisig.go
@@ -1076,11 +1076,9 @@ func (s *Store) ImportTransactionsFromJSON(ctx context.Context, data []byte) err
 					SignedAt:      signedAt,
 				})
 			}
-			if len(psbts) > 0 {
-				if err := s.ReplaceTxKeyPSBTs(ctx, t.ID, psbts); err != nil {
-					return fmt.Errorf("replace key psbts for tx %s: %w", t.ID, err)
-				}
-			}
+		}
+		if err := replaceTxKeyPSBTsOn(ctx, s.db, t.ID, psbts); err != nil {
+			return fmt.Errorf("replace key psbts for tx %s: %w", t.ID, err)
 		}
 
 		// Import inputs
@@ -1100,11 +1098,9 @@ func (s *Store) ImportTransactionsFromJSON(ctx context.Context, data []byte) err
 					Confirmations: getInt(inpMap, "confirmations"),
 				})
 			}
-			if len(txInputs) > 0 {
-				if err := s.ReplaceTxInputs(ctx, t.ID, txInputs); err != nil {
-					return fmt.Errorf("replace inputs for tx %s: %w", t.ID, err)
-				}
-			}
+		}
+		if err := replaceTxInputsOn(ctx, s.db, t.ID, txInputs); err != nil {
+			return fmt.Errorf("replace inputs for tx %s: %w", t.ID, err)
 		}
 	}
 
@@ -1120,19 +1116,33 @@ func nullStr(s string) interface{} {
 	return s
 }
 
+// Read the account component of "m/purpose'/coin'/account'/...". Short
+// non-standard paths fall back to the last component.
 func extractAccountIndex(path string) int {
 	parts := splitPath(path)
+	if len(parts) >= 4 {
+		return parseIndex(parts[3])
+	}
 	if len(parts) >= 3 {
-		idx := trimQuote(parts[2])
-		n := 0
-		for _, c := range idx {
-			if c >= '0' && c <= '9' {
-				n = n*10 + int(c-'0')
-			}
-		}
-		return n
+		return parseIndex(parts[2])
 	}
 	return 0
+}
+
+// Parse a path component ("8000'" -> 8000), 0 if it isn't a plain number.
+func parseIndex(part string) int {
+	idx := trimQuote(part)
+	if idx == "" {
+		return 0
+	}
+	n := 0
+	for _, c := range idx {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
 }
 
 func splitPath(path string) []string {

--- a/bitwindow/server/models/multisig/multisig_test.go
+++ b/bitwindow/server/models/multisig/multisig_test.go
@@ -528,11 +528,10 @@ func TestGetNextAccountIndex(t *testing.T) {
 	g := sampleGroup()
 	require.NoError(t, store.SaveGroup(ctx, g))
 
-	// extractAccountIndex reads parts[2] of the derivation path.
-	// For m/48'/8000'/0' → parts=[m,48',8000',0'] → parts[2]=8000' → 8000
+	// The shipped path shape is m/84'/coin'/account'.
 	keys := []multisig.Key{
-		{GroupID: g.ID, Owner: "a", Xpub: "x1", DerivationPath: "m/48'/8000'/0'", IsWallet: true},
-		{GroupID: g.ID, Owner: "b", Xpub: "x2", DerivationPath: "m/48'/8005'/0'", IsWallet: true},
+		{GroupID: g.ID, Owner: "a", Xpub: "x1", DerivationPath: "m/84'/1'/8000'", IsWallet: true},
+		{GroupID: g.ID, Owner: "b", Xpub: "x2", DerivationPath: "m/84'/1'/8005'", IsWallet: true},
 	}
 	require.NoError(t, store.ReplaceKeysForGroup(ctx, g.ID, keys))
 
@@ -544,4 +543,26 @@ func TestGetNextAccountIndex(t *testing.T) {
 	next, err = store.GetNextAccountIndex(ctx, []int{9000})
 	require.NoError(t, err)
 	assert.Equal(t, 9001, next)
+}
+
+func TestGetNextAccountIndexAdvancesAcrossSessions(t *testing.T) {
+	ctx := context.Background()
+	store := multisig.NewStore(setupTestDB(t))
+
+	g := sampleGroup()
+	require.NoError(t, store.SaveGroup(ctx, g))
+
+	first, err := store.GetNextAccountIndex(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 8000, first)
+
+	// A key stored at the allocated index must push the next allocation forward,
+	// even though the caller passes no additionally used indices.
+	require.NoError(t, store.ReplaceKeysForGroup(ctx, g.ID, []multisig.Key{
+		{GroupID: g.ID, Owner: "a", Xpub: "x1", DerivationPath: "m/84'/1'/8000'", IsWallet: true},
+	}))
+
+	second, err := store.GetNextAccountIndex(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 8001, second, "second allocation reused the first account index")
 }

--- a/bitwindow/server/models/opreturns/opreturns.go
+++ b/bitwindow/server/models/opreturns/opreturns.go
@@ -184,6 +184,34 @@ func List(ctx context.Context, db *sql.DB, limit int) ([]OPReturn, error) {
 	return opReturns, nil
 }
 
+// mempoolExpiry mirrors Core's default -mempoolexpiry. An unconfirmed
+// OP_RETURN older than that is gone from every mempool and is never
+// going to confirm.
+const mempoolExpiry = 336 * time.Hour
+
+// ReapExpiredMempool deletes unconfirmed OP_RETURNs past Core's mempool
+// expiry. Mempool rows arrive over ZMQ with a NULL height and only ever
+// get one when the transaction is mined, so a broadcast that was
+// replaced, dropped or double-spent would otherwise sit in List forever.
+func ReapExpiredMempool(ctx context.Context, db *sql.DB) error {
+	result, err := db.ExecContext(ctx, `
+		DELETE FROM op_returns
+		WHERE height IS NULL AND datetime(created_at) < datetime(?)
+	`, time.Now().Add(-mempoolExpiry))
+	if err != nil {
+		return fmt.Errorf("reap expired mempool OP_RETURNs: %w", err)
+	}
+
+	if rows, _ := result.RowsAffected(); rows > 0 {
+		invalidateCaches(db)
+
+		zerolog.Ctx(ctx).Info().
+			Msgf("opreturns: reaped %d expired mempool OP_RETURN(s)", rows)
+	}
+
+	return nil
+}
+
 func OPReturnToReadable(data []byte) string {
 	// First try to decode as hex
 	decoded, err := hex.DecodeString(string(data))

--- a/bitwindow/server/models/opreturns/opreturns_test.go
+++ b/bitwindow/server/models/opreturns/opreturns_test.go
@@ -12,6 +12,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -476,6 +477,33 @@ func TestBackfillCoinNewsBlockTime(t *testing.T) {
 		"row without a matching processed_blocks entry must be left alone")
 	assert.WithinDuration(t, syncTime, got("mempool"), time.Second,
 		"mempool row (NULL height) must be left alone")
+}
+
+// A mempool OP_RETURN that never got mined must stop being listed once
+// it is past the point where any mempool could still be holding it.
+func TestReapExpiredMempool(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	height := uint32(800000)
+	stale := time.Now().Add(-mempoolExpiry - time.Hour)
+	recent := time.Now().Add(-time.Hour)
+
+	require.NoError(t, Persist(ctx, db, []OPReturn{
+		{TxID: "expired-mempool", Vout: 0, Data: []byte{0x01}, CreatedAt: &stale},
+		{TxID: "pending-mempool", Vout: 0, Data: []byte{0x02}, CreatedAt: &recent},
+		{TxID: "old-confirmed", Vout: 0, Data: []byte{0x03}, Height: &height, CreatedAt: &stale},
+	}))
+
+	require.NoError(t, ReapExpiredMempool(ctx, db))
+
+	got, err := List(ctx, db, 0)
+	require.NoError(t, err)
+
+	txids := lo.Map(got, func(o OPReturn, _ int) string { return o.TxID })
+	slices.Sort(txids)
+	assert.Equal(t, []string{"old-confirmed", "pending-mempool"}, txids,
+		"only unconfirmed OP_RETURNs past mempool expiry are reaped")
 }
 
 func TestPersistConfirmedConflictUpdatesCreateTimeToBlockTime(t *testing.T) {

--- a/bitwindow/test/multisig_key_psbt_membership_test.dart
+++ b/bitwindow/test/multisig_key_psbt_membership_test.dart
@@ -1,0 +1,118 @@
+import 'package:bitwindow/providers/multisig_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sail_ui/gen/multisig/v1/multisig.pb.dart' as multisigpb;
+import 'package:sail_ui/gen/multisiglounge/v1/multisiglounge.pb.dart' as mlpb;
+import 'package:sail_ui/sail_ui.dart';
+
+const _txId = 'tx-a';
+const _memberXpub = 'xpub-a3';
+const _foreignXpub = 'xpub-b1';
+
+multisigpb.MultisigKey _key(String xpub) => multisigpb.MultisigKey(xpub: xpub, isWallet: true);
+
+class _FakeMultisigApi implements MultisigAPI {
+  multisigpb.MultisigTransaction? saved;
+
+  @override
+  Future<List<multisigpb.MultisigGroup>> listGroups() async {
+    return [
+      // 2-of-3, so the threshold differs from the transaction's slot count.
+      multisigpb.MultisigGroup(
+        id: 'group-a',
+        m: 2,
+        n: 3,
+        keys: [_key('xpub-a1'), _key('xpub-a2'), _key(_memberXpub)],
+      ),
+      multisigpb.MultisigGroup(id: 'group-b', m: 1, n: 1, keys: [_key(_foreignXpub)]),
+    ];
+  }
+
+  @override
+  Future<multisigpb.MultisigTransaction> getTransaction(String transactionId) async {
+    return multisigpb.MultisigTransaction(
+      id: transactionId,
+      groupId: 'group-a',
+      status: multisigpb.TxStatus.TX_STATUS_NEEDS_SIGNATURES,
+      keyPsbts: [
+        multisigpb.KeyPSBTStatus(keyId: 'xpub-a1', psbt: 'psbt1', isSigned: true),
+        multisigpb.KeyPSBTStatus(keyId: 'xpub-a2', psbt: 'psbt2', isSigned: true),
+        multisigpb.KeyPSBTStatus(keyId: _memberXpub, isSigned: false),
+      ],
+    );
+  }
+
+  @override
+  Future<multisigpb.MultisigTransaction> saveTransaction(multisigpb.MultisigTransaction transaction) async {
+    saved = transaction;
+    return transaction;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeBitwindow implements BitwindowRPC {
+  @override
+  final MultisigAPI multisig;
+
+  _FakeBitwindow(this.multisig);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeLounge implements OrchestratorMultisigLoungeRPC {
+  @override
+  Future<mlpb.ValidatePsbtResponse> validatePsbt({
+    required String psbtBase64,
+    required int requiredSigs,
+    mlpb.MultisigGroup? group,
+  }) async {
+    return mlpb.ValidatePsbtResponse(hasSignatures: false);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeOrchestrator implements OrchestratorRPC {
+  @override
+  OrchestratorMultisigLoungeRPC multisigLounge = _FakeLounge();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late _FakeMultisigApi multisigApi;
+
+  setUp(() async {
+    await GetIt.I.reset();
+    multisigApi = _FakeMultisigApi();
+    GetIt.I.registerSingleton<BitwindowRPC>(_FakeBitwindow(multisigApi));
+    GetIt.I.registerSingleton<OrchestratorRPC>(_FakeOrchestrator());
+  });
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  test("a key outside the transaction's group cannot be given a PSBT slot", () async {
+    await expectLater(
+      TransactionStorage.addOrUpdateKeyPSBT(_txId, _foreignXpub, 'psbt', true),
+      throwsA(isA<Exception>()),
+    );
+    expect(multisigApi.saved, isNull);
+  });
+
+  test("readiness is measured against the owning group's threshold", () async {
+    await TransactionStorage.addOrUpdateKeyPSBT(_txId, _memberXpub, 'psbt', false);
+
+    final saved = multisigApi.saved;
+    expect(saved, isNotNull);
+    expect(saved!.keyPsbts.length, 3);
+    // 2 signatures on a 2-of-3 group, even though the transaction has 3 slots.
+    expect(saved.status, multisigpb.TxStatus.TX_STATUS_READY_TO_COMBINE);
+  });
+}

--- a/sidechain-orchestrator/api/bip47_send.go
+++ b/sidechain-orchestrator/api/bip47_send.go
@@ -29,8 +29,11 @@ type bip47Expansion struct {
 	// hex) the wallet handler must sign + broadcast BEFORE the payment.
 	notificationTxHex string
 	// recipientCode is the recipient's payment code, used to MarkNotified
-	// after a successful broadcast.
+	// after a successful broadcast. Empty when passthrough.
 	recipientCode string
+	// sendIndex is the per-payment index reserved for this send, released
+	// again when the payment does not go out.
+	sendIndex uint32
 }
 
 // expandBip47Destinations inspects the requested destinations for a BIP47
@@ -94,10 +97,12 @@ func (h *WalletHandler) expandBip47Destinations(
 	expansion := &bip47Expansion{
 		destinations:  result.Destinations,
 		recipientCode: result.RecipientCode,
+		sendIndex:     result.Index,
 	}
 
 	state, err := h.bip47State.GetState(walletID, result.RecipientCode)
 	if err != nil {
+		h.releaseBip47Index(walletID, expansion)
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("read bip47 state: %w", err))
 	}
 	if state != nil && state.NotificationTxID != nil {
@@ -106,10 +111,23 @@ func (h *WalletHandler) expandBip47Destinations(
 
 	rawHex, _, err := h.buildBip47NotificationTx(ctx, walletID, seedHex, result.Recipient, netParams)
 	if err != nil {
+		h.releaseBip47Index(walletID, expansion)
 		return nil, err
 	}
 	expansion.notificationTxHex = rawHex
 	return expansion, nil
+}
+
+// releaseBip47Index gives back the per-payment index reserved for a send that
+// failed, so the retry derives the same address instead of burning an index.
+// No-op for passthrough (non-BIP47) expansions.
+func (h *WalletHandler) releaseBip47Index(walletID string, expansion *bip47Expansion) {
+	if expansion == nil || expansion.recipientCode == "" || h.bip47State == nil {
+		return
+	}
+	// Best-effort: the send already failed, and a skipped index is absorbed by
+	// the recipient's gap limit.
+	_ = h.bip47State.ReleaseIndex(walletID, expansion.recipientCode, expansion.sendIndex)
 }
 
 // buildBip47NotificationTx assembles the unsigned notification transaction by

--- a/sidechain-orchestrator/api/multisiglounge_handler.go
+++ b/sidechain-orchestrator/api/multisiglounge_handler.go
@@ -749,6 +749,8 @@ func (h *MultisigLoungeHandler) RestoreHistory(
 	// listtransactions("*", 1000, 0, include_watchonly=true)
 	var txs []struct {
 		Txid          string  `json:"txid"`
+		Address       string  `json:"address"`
+		Category      string  `json:"category"`
 		Amount        float64 `json:"amount"`
 		Confirmations int32   `json:"confirmations"`
 		Time          int64   `json:"time"`
@@ -772,8 +774,42 @@ func (h *MultisigLoungeHandler) RestoreHistory(
 			continue // skip txs we can't fetch (matches Dart's per-tx tolerance)
 		}
 
+		// Core emits one row per wallet-relevant output, and lists a tx's receive
+		// rows before its send rows. Net every row for the txid, or a spend whose
+		// change pays a group address reads as an inbound deposit of that change.
+		net := 0.0
+		owned := map[string]bool{}
+		for _, r := range txs {
+			if r.Txid != wtx.Txid {
+				continue
+			}
+			net += r.Amount
+			if r.Category == "receive" && r.Address != "" {
+				owned[r.Address] = true
+			}
+		}
+
+		// The payee is the first output paid outside the group; change back to the
+		// group is either omitted or paired with a receive row. A deposit or a
+		// self-send has no external payee, so fall back to the group's own address.
+		payee := ""
+		for _, r := range txs {
+			if r.Txid != wtx.Txid || r.Address == "" {
+				continue
+			}
+			if r.Category == "send" && !owned[r.Address] {
+				payee = r.Address
+				break
+			}
+			if payee == "" {
+				payee = r.Address
+			}
+		}
+
 		destination := "Unknown"
-		if len(raw.Vout) > 0 && raw.Vout[0].ScriptPubKey.Address != "" {
+		if payee != "" {
+			destination = payee
+		} else if len(raw.Vout) > 0 && raw.Vout[0].ScriptPubKey.Address != "" {
 			destination = raw.Vout[0].ScriptPubKey.Address
 		}
 
@@ -784,8 +820,8 @@ func (h *MultisigLoungeHandler) RestoreHistory(
 
 		out = append(out, &pb.MultisigHistoryTx{
 			Txid:           wtx.Txid,
-			AmountSats:     btcToSatsInt(absFloat(wtx.Amount)),
-			IsDeposit:      wtx.Amount > 0,
+			AmountSats:     btcToSatsInt(absFloat(net)),
+			IsDeposit:      net > 0,
 			Destination:    destination,
 			Confirmations:  uint32(maxInt32(wtx.Confirmations, 0)),
 			SignatureCount: uint32(wallet.CountMultisigSignatures(raw.Vin)),

--- a/sidechain-orchestrator/api/multisiglounge_handler.go
+++ b/sidechain-orchestrator/api/multisiglounge_handler.go
@@ -518,10 +518,65 @@ func watchWalletName(g *pb.GroupData) string {
 	return "multisig_" + g.GetId()
 }
 
-// ensureWatchWallet makes sure the group's watch-only descriptor wallet exists
-// and has the Phase-1 receive/change descriptors imported. Idempotent: an
-// already-existing wallet is loaded, not recreated, and re-importing the same
-// descriptors is a no-op in Core.
+// multisigWatchRangeChunk is the granularity the watch wallet's descriptor range
+// grows in; the first import covers [0, 999].
+const multisigWatchRangeChunk = 1000
+
+// multisigWatchRangeLookahead keeps the imported range at least this far ahead of
+// the next index the watch wallet hands out.
+const multisigWatchRangeLookahead = 100
+
+// watchRangeEnd is the descriptor range end covering next+lookahead, rounded up
+// to a whole chunk so a growing wallet re-imports (and rescans) rarely.
+func watchRangeEnd(next int) int {
+	return ((next+multisigWatchRangeLookahead)/multisigWatchRangeChunk+1)*multisigWatchRangeChunk - 1
+}
+
+// watchDescriptorRange reports the imported range end covering both of the
+// wallet's active descriptors (-1 when either is missing) and the highest next
+// index Core will hand out from them.
+func (h *MultisigLoungeHandler) watchDescriptorRange(ctx context.Context, name string) (int, int, error) {
+	var res struct {
+		Descriptors []struct {
+			Active   bool  `json:"active"`
+			Internal bool  `json:"internal"`
+			Range    []int `json:"range"`
+			Next     int   `json:"next"`
+		} `json:"descriptors"`
+	}
+	if err := h.coreCallWallet(ctx, name, "listdescriptors", nil, &res); err != nil {
+		return 0, 0, fmt.Errorf("listdescriptors: %w", err)
+	}
+
+	end, next := -1, 0
+	var haveReceive, haveChange bool
+	for _, d := range res.Descriptors {
+		if !d.Active || len(d.Range) != 2 {
+			continue
+		}
+		if d.Internal {
+			haveChange = true
+		} else {
+			haveReceive = true
+		}
+		if end < 0 || d.Range[1] < end {
+			end = d.Range[1]
+		}
+		if d.Next > next {
+			next = d.Next
+		}
+	}
+	if !haveReceive || !haveChange {
+		return -1, next, nil
+	}
+	return end, next, nil
+}
+
+// ensureWatchWallet makes sure the group's watch-only descriptor wallet exists,
+// has the Phase-1 receive/change descriptors imported, and that their range
+// still covers the addresses the wallet is about to hand out. Idempotent: an
+// already-existing wallet is loaded, not recreated, and the descriptors are only
+// re-imported when the imported range falls short.
 func (h *MultisigLoungeHandler) ensureWatchWallet(ctx context.Context, g *pb.GroupData) (string, error) {
 	name := watchWalletName(g)
 
@@ -530,14 +585,39 @@ func (h *MultisigLoungeHandler) ensureWatchWallet(ctx context.Context, g *pb.Gro
 	if err := h.coreCall(ctx, "listwallets", nil, &loaded); err != nil {
 		return "", fmt.Errorf("listwallets: %w", err)
 	}
+	exists := false
 	for _, w := range loaded {
 		if w == name {
-			return name, nil
+			exists = true
+			break
 		}
 	}
 
 	// Try to load it; on failure create it fresh.
-	if err := h.coreCall(ctx, "loadwallet", []interface{}{name}, nil); err == nil {
+	if !exists {
+		if err := h.coreCall(ctx, "loadwallet", []interface{}{name}, nil); err == nil {
+			exists = true
+		}
+	}
+	if !exists {
+		// createwallet(name, disable_private_keys=true, blank=true, "", false, true, false)
+		if err := h.coreCall(ctx, "createwallet",
+			[]interface{}{name, true, true, "", false, true, false}, nil); err != nil {
+			// A concurrent create may have won the race; tolerate "already exists".
+			if !strings.Contains(err.Error(), "already exists") && !strings.Contains(err.Error(), "Database already exists") {
+				return "", fmt.Errorf("createwallet: %w", err)
+			}
+		}
+	}
+
+	// The imported range is a hard cap: an address past its end is derivable but
+	// invisible to the wallet, so keep it ahead of the next index Core hands out.
+	haveEnd, next, err := h.watchDescriptorRange(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	wantEnd := watchRangeEnd(next)
+	if haveEnd >= wantEnd {
 		return name, nil
 	}
 
@@ -546,18 +626,16 @@ func (h *MultisigLoungeHandler) ensureWatchWallet(ctx context.Context, g *pb.Gro
 		return "", fmt.Errorf("build descriptors: %w", err)
 	}
 
-	// createwallet(name, disable_private_keys=true, blank=true, "", false, true, false)
-	if err := h.coreCall(ctx, "createwallet",
-		[]interface{}{name, true, true, "", false, true, false}, nil); err != nil {
-		// A concurrent create may have won the race; tolerate "already exists".
-		if !strings.Contains(err.Error(), "already exists") && !strings.Contains(err.Error(), "Database already exists") {
-			return "", fmt.Errorf("createwallet: %w", err)
-		}
+	// A widened range covers scripts that may already have chain history, so it
+	// needs a rescan; a wallet that did not exist a moment ago has none.
+	var timestamp interface{} = int64(0)
+	if !exists {
+		timestamp = "now"
 	}
 
 	descs := []map[string]interface{}{
-		{"desc": receive, "active": true, "internal": false, "timestamp": "now", "range": []int{0, 999}},
-		{"desc": change, "active": true, "internal": true, "timestamp": "now", "range": []int{0, 999}},
+		{"desc": receive, "active": true, "internal": false, "timestamp": timestamp, "range": []int{0, wantEnd}},
+		{"desc": change, "active": true, "internal": true, "timestamp": timestamp, "range": []int{0, wantEnd}},
 	}
 	var importRes []struct {
 		Success bool `json:"success"`

--- a/sidechain-orchestrator/api/multisiglounge_sync_test.go
+++ b/sidechain-orchestrator/api/multisiglounge_sync_test.go
@@ -300,6 +300,12 @@ func TestRestoreHistoryE2E(t *testing.T) {
 		}
 	}
 	require.NotNil(t, spend, "the broadcast spend must appear in restored history")
+	// Change lands on the group's own receive address, so Core emits a receive row
+	// for this txid too. The restored row must still read as an outgoing 0.5 BTC
+	// payment to dest, not as an inbound deposit of the change.
+	require.False(t, spend.IsDeposit, "an outgoing spend must not restore as a deposit")
+	require.Equal(t, int64(50_000_000), spend.AmountSats, "net amount sent, not the change output")
+	require.Equal(t, dest, spend.Destination, "the payee, not the group's own change address")
 	require.Equal(t, "confirmed", spend.Status)
 	require.GreaterOrEqual(t, spend.Confirmations, uint32(6))
 	require.NotEmpty(t, spend.FinalHex, "reconstructed tx must carry the raw hex")
@@ -307,80 +313,6 @@ func TestRestoreHistoryE2E(t *testing.T) {
 	// 2-of-3 P2WSH spend: the witness carries two ~72-byte signatures. This is the
 	// load-bearing parity check on CountMultisigSignatures.
 	require.Equal(t, uint32(2), spend.SignatureCount, "two signatures counted from the witness")
-}
-
-// coveredDescriptors is a listdescriptors reply whose imported range already
-// covers the lookahead, so ensureWatchWallet leaves the wallet alone.
-const coveredDescriptors = `{"descriptors":[
-	{"active":true,"internal":false,"range":[0,999],"next":0},
-	{"active":true,"internal":true,"range":[0,999],"next":0}]}`
-
-// TestEnsureWatchWalletWidensRange pins the descriptor range cap: an existing
-// watch wallet is no longer short-circuited on "already loaded", and its range
-// is re-imported wide enough — with a rescan — to keep covering the addresses
-// the wallet hands out.
-func TestEnsureWatchWalletWidensRange(t *testing.T) {
-	group := loungeSyncTestGroup(t)
-	receive, change, err := wallet.BuildMultisigLoungeDescriptors(groupDataToLoungeGroup(group))
-	require.NoError(t, err)
-
-	tests := []struct {
-		name    string
-		next    int
-		haveEnd int // 0 = the wallet has no descriptors at all
-		wantEnd int // -1 = the existing range must be left alone
-	}{
-		{"range still covers the lookahead", 0, 999, -1},
-		{"next approaching the end grows a chunk", 900, 999, 1999},
-		{"restored wallet already past the old cap", 1500, 999, 1999},
-		{"wallet without descriptors is imported", 0, 0, 999},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var imported []map[string]interface{}
-			h := NewMultisigLoungeHandler()
-			h.SetCoreCaller(func(_ context.Context, method, paramsJSON, _ string) (json.RawMessage, error) {
-				switch method {
-				case "listwallets":
-					return json.RawMessage(`["ms_sync"]`), nil
-				case "listdescriptors":
-					if tt.haveEnd == 0 {
-						return json.RawMessage(`{"descriptors":[]}`), nil
-					}
-					return json.RawMessage(fmt.Sprintf(
-						`{"descriptors":[{"active":true,"internal":false,"range":[0,%d],"next":%d},`+
-							`{"active":true,"internal":true,"range":[0,%d],"next":%d}]}`,
-						tt.haveEnd, tt.next, tt.haveEnd, tt.next)), nil
-				case "importdescriptors":
-					var params [][]map[string]interface{}
-					require.NoError(t, json.Unmarshal([]byte(paramsJSON), &params))
-					imported = params[0]
-					return json.RawMessage(`[{"success":true},{"success":true}]`), nil
-				}
-				return nil, fmt.Errorf("unexpected method %s", method)
-			})
-
-			name, err := h.ensureWatchWallet(context.Background(), group)
-			require.NoError(t, err)
-			require.Equal(t, "ms_sync", name)
-
-			if tt.wantEnd < 0 {
-				require.Empty(t, imported, "a range that still covers the lookahead must not be re-imported")
-				return
-			}
-			require.Len(t, imported, 2, "receive and change are re-imported together")
-			// The group's own descriptors, so widening can never add a second
-			// active descriptor alongside the one already imported.
-			require.Equal(t, receive, imported[0]["desc"])
-			require.Equal(t, change, imported[1]["desc"])
-			for _, d := range imported {
-				require.Equal(t, []interface{}{0.0, float64(tt.wantEnd)}, d["range"])
-				// The newly covered indices may already hold history, so the
-				// re-import must rescan instead of starting at "now".
-				require.Equal(t, 0.0, d["timestamp"])
-			}
-		})
-	}
 }
 
 // TestRestoreHistoryNetsRowsPerTxid pins the row aggregation without a node:
@@ -416,8 +348,6 @@ func TestRestoreHistoryNetsRowsPerTxid(t *testing.T) {
 				switch method {
 				case "listwallets":
 					return json.RawMessage(`["ms_test"]`), nil
-				case "listdescriptors":
-					return json.RawMessage(coveredDescriptors), nil
 				case "listtransactions":
 					return json.RawMessage(tt.rows), nil
 				case "getrawtransaction":

--- a/sidechain-orchestrator/api/multisiglounge_sync_test.go
+++ b/sidechain-orchestrator/api/multisiglounge_sync_test.go
@@ -309,6 +309,136 @@ func TestRestoreHistoryE2E(t *testing.T) {
 	require.Equal(t, uint32(2), spend.SignatureCount, "two signatures counted from the witness")
 }
 
+// coveredDescriptors is a listdescriptors reply whose imported range already
+// covers the lookahead, so ensureWatchWallet leaves the wallet alone.
+const coveredDescriptors = `{"descriptors":[
+	{"active":true,"internal":false,"range":[0,999],"next":0},
+	{"active":true,"internal":true,"range":[0,999],"next":0}]}`
+
+// TestEnsureWatchWalletWidensRange pins the descriptor range cap: an existing
+// watch wallet is no longer short-circuited on "already loaded", and its range
+// is re-imported wide enough — with a rescan — to keep covering the addresses
+// the wallet hands out.
+func TestEnsureWatchWalletWidensRange(t *testing.T) {
+	group := loungeSyncTestGroup(t)
+	receive, change, err := wallet.BuildMultisigLoungeDescriptors(groupDataToLoungeGroup(group))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		next    int
+		haveEnd int // 0 = the wallet has no descriptors at all
+		wantEnd int // -1 = the existing range must be left alone
+	}{
+		{"range still covers the lookahead", 0, 999, -1},
+		{"next approaching the end grows a chunk", 900, 999, 1999},
+		{"restored wallet already past the old cap", 1500, 999, 1999},
+		{"wallet without descriptors is imported", 0, 0, 999},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var imported []map[string]interface{}
+			h := NewMultisigLoungeHandler()
+			h.SetCoreCaller(func(_ context.Context, method, paramsJSON, _ string) (json.RawMessage, error) {
+				switch method {
+				case "listwallets":
+					return json.RawMessage(`["ms_sync"]`), nil
+				case "listdescriptors":
+					if tt.haveEnd == 0 {
+						return json.RawMessage(`{"descriptors":[]}`), nil
+					}
+					return json.RawMessage(fmt.Sprintf(
+						`{"descriptors":[{"active":true,"internal":false,"range":[0,%d],"next":%d},`+
+							`{"active":true,"internal":true,"range":[0,%d],"next":%d}]}`,
+						tt.haveEnd, tt.next, tt.haveEnd, tt.next)), nil
+				case "importdescriptors":
+					var params [][]map[string]interface{}
+					require.NoError(t, json.Unmarshal([]byte(paramsJSON), &params))
+					imported = params[0]
+					return json.RawMessage(`[{"success":true},{"success":true}]`), nil
+				}
+				return nil, fmt.Errorf("unexpected method %s", method)
+			})
+
+			name, err := h.ensureWatchWallet(context.Background(), group)
+			require.NoError(t, err)
+			require.Equal(t, "ms_sync", name)
+
+			if tt.wantEnd < 0 {
+				require.Empty(t, imported, "a range that still covers the lookahead must not be re-imported")
+				return
+			}
+			require.Len(t, imported, 2, "receive and change are re-imported together")
+			// The group's own descriptors, so widening can never add a second
+			// active descriptor alongside the one already imported.
+			require.Equal(t, receive, imported[0]["desc"])
+			require.Equal(t, change, imported[1]["desc"])
+			for _, d := range imported {
+				require.Equal(t, []interface{}{0.0, float64(tt.wantEnd)}, d["range"])
+				// The newly covered indices may already hold history, so the
+				// re-import must rescan instead of starting at "now".
+				require.Equal(t, 0.0, d["timestamp"])
+			}
+		})
+	}
+}
+
+// TestRestoreHistoryNetsRowsPerTxid pins the row aggregation without a node:
+// listtransactions returns one row per wallet-relevant output, receive rows
+// first, so direction, amount and payee must come from all rows of a txid.
+func TestRestoreHistoryNetsRowsPerTxid(t *testing.T) {
+	// 1 BTC in, 0.5 to an external payee, change back to a group address (which
+	// Core reports as a send row plus a receive row, not as change).
+	const spendRows = `[
+		{"txid":"aa","address":"grp","category":"receive","amount":0.4999,"confirmations":7,"time":100},
+		{"txid":"aa","address":"grp","category":"send","amount":-0.4999,"confirmations":7,"time":100},
+		{"txid":"aa","address":"payee","category":"send","amount":-0.5,"confirmations":7,"time":100}
+	]`
+	const depositRows = `[{"txid":"aa","address":"grp","category":"receive","amount":1.0,"confirmations":7,"time":100}]`
+	// The group's own address is vout[0], as when Core randomises change first.
+	const raw = `{"txid":"aa","hex":"0100","vin":[{"txid":"bb","vout":0}],
+		"vout":[{"scriptPubKey":{"address":"grp"}},{"scriptPubKey":{"address":"payee"}}]}`
+
+	tests := []struct {
+		name        string
+		rows        string
+		isDeposit   bool
+		amountSats  int64
+		destination string
+	}{
+		{"spend with change to a group address", spendRows, false, 50_000_000, "payee"},
+		{"deposit", depositRows, true, 100_000_000, "grp"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewMultisigLoungeHandler()
+			h.SetCoreCaller(func(_ context.Context, method, _, _ string) (json.RawMessage, error) {
+				switch method {
+				case "listwallets":
+					return json.RawMessage(`["ms_test"]`), nil
+				case "listdescriptors":
+					return json.RawMessage(coveredDescriptors), nil
+				case "listtransactions":
+					return json.RawMessage(tt.rows), nil
+				case "getrawtransaction":
+					return json.RawMessage(raw), nil
+				}
+				return nil, fmt.Errorf("unexpected method %s", method)
+			})
+
+			resp, err := h.RestoreHistory(context.Background(), connect.NewRequest(&pb.RestoreHistoryRequest{
+				Group: &pb.GroupData{Id: "restore", WatchWalletName: "ms_test"},
+			}))
+			require.NoError(t, err)
+			require.Len(t, resp.Msg.Transactions, 1)
+			tx := resp.Msg.Transactions[0]
+			require.Equal(t, tt.isDeposit, tx.IsDeposit)
+			require.Equal(t, tt.amountSats, tx.AmountSats)
+			require.Equal(t, tt.destination, tx.Destination)
+		})
+	}
+}
+
 // oldBuggyFundGroupDescriptor reproduces the pre-Phase-6 fund_group_modal inline
 // descriptor: BIP67-sorted keys joined, with the range suffix appended ONCE to
 // the whole join (so only the last key ranges). This is the consensus bug; the

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -776,7 +776,7 @@ func mapExternalInputs(exts []*pb.ExternalInput) []wallet.ExternalInput {
 	})
 }
 
-func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Request[pb.SendTransactionRequest]) (*connect.Response[pb.SendTransactionResponse], error) {
+func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Request[pb.SendTransactionRequest]) (_ *connect.Response[pb.SendTransactionResponse], retErr error) {
 	// A transaction needs at least one output, but it doesn't have to be a
 	// payment: an OP_RETURN-only broadcast (e.g. coinnews) or a raw-script
 	// output (e.g. a sidechain deposit treasury) is a valid send on its own.
@@ -806,6 +806,13 @@ func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Reques
 	if expansion.notificationTxHex != "" || !destinationsEqual(expansion.destinations, req.Msg.Destinations) {
 		req = connect.NewRequest(applyDestinationsToRequest(req.Msg, expansion.destinations))
 	}
+	// The reserved per-payment index is only consumed by a payment that goes
+	// out; release it again on every failure below so a retry reuses it.
+	defer func() {
+		if retErr != nil {
+			h.releaseBip47Index(walletID, expansion)
+		}
+	}()
 
 	const dustLimitSats int64 = 546
 	for address, sats := range req.Msg.Destinations {

--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -70,7 +70,7 @@ func (m *BitcoinConfManager) LoadConfig(isFirst bool) error {
 		return err
 	}
 
-	m.parseAndApplyConfig(content)
+	m.parseAndApplyConfig(content, NetworkSignet)
 
 	if m.tryLoadPrivateConfig() {
 		return nil // Private config loaded, we're done, just use that
@@ -121,6 +121,12 @@ const drynetP2PPort = 8335
 // GetConfFilePath returns the resolved -conf= path to pass to bitcoind.
 // Mirrors the confFile() logic from binaries.dart.
 func (m *BitcoinConfManager) GetConfFilePath() string {
+	// A loaded private conf wins: re-resolving here would run against a network
+	// that conf itself may have changed, and hand bitcoind a different file
+	// than the one our state came from.
+	if m.HasPrivateConf && m.ConfigPath != "" {
+		return m.ConfigPath
+	}
 	confInfo := m.getConfigFileInfo()
 	return confInfo.path
 }

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -187,15 +187,20 @@ func RunBitcoinConfMigrations(config *BitcoinConfig) (bool, []Network) {
 
 // parseAndApplyConfig parses config content and updates state (network, datadir).
 // Dart: _parseAndApplyConfig (L244)
-func (m *BitcoinConfManager) parseAndApplyConfig(content string) {
+func (m *BitcoinConfManager) parseAndApplyConfig(content string, fallbackNetwork Network) {
 	m.Config = ParseBitcoinConfig(content)
-	m.loadStateFromConfig()
+	m.loadStateFromConfig(fallbackNetwork)
 }
 
 // tryLoadPrivateConfig checks for user's private bitcoin.conf and loads if exists.
 // Returns true if private config was loaded.
 // Dart: _tryLoadPrivateConfig (L251)
 func (m *BitcoinConfManager) tryLoadPrivateConfig() bool {
+	// The network whose root dir the conf is looked up under. A private conf
+	// with no chain selector belongs to that network — reclassifying it as
+	// signet would point us at a different conf than bitcoind is launched with.
+	discoveredUnder := m.Network
+
 	confInfo := m.getConfigFileInfo()
 	m.HasPrivateConf = confInfo.hasPrivateConf
 	m.ConfigPath = confInfo.path
@@ -209,7 +214,7 @@ func (m *BitcoinConfManager) tryLoadPrivateConfig() bool {
 		return false
 	}
 
-	m.parseAndApplyConfig(string(privateContent))
+	m.parseAndApplyConfig(string(privateContent), discoveredUnder)
 	return true
 }
 
@@ -226,7 +231,7 @@ func (m *BitcoinConfManager) handleNetworkChangeIfNeeded(oldNetwork Network, isF
 		return
 	}
 
-	m.loadStateFromConfig()
+	m.loadStateFromConfig(m.Network)
 
 	if m.OnNetworkChanged != nil {
 		m.OnNetworkChanged()
@@ -241,12 +246,12 @@ func (m *BitcoinConfManager) handleNetworkChangeIfNeeded(oldNetwork Network, isF
 // only honours top-level datadir) and where bitcoind itself reads from. A
 // user with their own bitcoin.conf may put datadir under [main] — that still
 // wins. Empty here means "no datadir is configured anywhere".
-func (m *BitcoinConfManager) loadStateFromConfig() {
+func (m *BitcoinConfManager) loadStateFromConfig(fallbackNetwork Network) {
 	if m.Config == nil {
 		return
 	}
 
-	m.Network = NetworkFromConfig(m.Config)
+	m.Network = NetworkFromConfig(m.Config, fallbackNetwork)
 	m.DetectedDataDir = m.Config.GetEffectiveSetting("datadir", CoreSectionForNetwork(m.Network))
 
 	// Ensure datadir exists — Bitcoin Core fails with a cryptic assertion error (exit code -6) if it doesn't

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -509,11 +509,11 @@ func TestDrynetFallsBackToEmbeddedGeneration(t *testing.T) {
 // through the detector to prove they don't collide.
 func TestNetworkFromConfigDistinguishesDrynetFromForknet(t *testing.T) {
 	forknet := ParseBitcoinConfig((&BitcoinConfManager{Network: NetworkForknet}).GetDefaultConfig())
-	if got := NetworkFromConfig(forknet); got != NetworkForknet {
+	if got := NetworkFromConfig(forknet, NetworkSignet); got != NetworkForknet {
 		t.Errorf("forknet config detected as %q, want forknet", got)
 	}
 	drynet := ParseBitcoinConfig((&BitcoinConfManager{Network: NetworkDrynet}).GetDefaultConfig())
-	if got := NetworkFromConfig(drynet); got != NetworkDrynet {
+	if got := NetworkFromConfig(drynet, NetworkSignet); got != NetworkDrynet {
 		t.Errorf("drynet config detected as %q, want drynet", got)
 	}
 }
@@ -524,7 +524,7 @@ func TestNetworkFromConfigDistinguishesDrynetFromForknet(t *testing.T) {
 func TestNetworkFromConfigDetectsFutureDrynetGeneration(t *testing.T) {
 	conf := ParseBitcoinConfig((&BitcoinConfManager{Network: NetworkDrynet}).GetDefaultConfig())
 	conf.SetSetting("uacomment", "drynet3", "main")
-	if got := NetworkFromConfig(conf); got != NetworkDrynet {
+	if got := NetworkFromConfig(conf, NetworkSignet); got != NetworkDrynet {
 		t.Errorf("drynet3 config detected as %q, want drynet", got)
 	}
 }
@@ -533,9 +533,54 @@ func TestNetworkFromConfigDetectsFutureDrynetGeneration(t *testing.T) {
 // config back through the detector to prove it is not read as mainnet.
 func TestNetworkFromConfigDetectsDrynet(t *testing.T) {
 	drynet := ParseBitcoinConfig((&BitcoinConfManager{Network: NetworkDrynet}).GetDefaultConfig())
-	if got := NetworkFromConfig(drynet); got != NetworkDrynet {
+	if got := NetworkFromConfig(drynet, NetworkSignet); got != NetworkDrynet {
 		t.Errorf("drynet config detected as %q, want drynet", got)
 	}
+}
+
+// A user's own bitcoin.conf carrying no chain selector is mainnet (Bitcoin
+// Core's default), so it must stay on the network whose root dir it was found
+// under — and it is the file bitcoind gets launched with. Reading it as signet
+// re-resolved the conf path against ~/.drivechain and handed bitcoind the
+// managed conf while orchestrator state came from the private one.
+func TestPrivateConfWithoutChainKeepsDiscoveryNetworkAndPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	privatePath := filepath.Join(BitcoinCoreDirs.RootDirNetwork(NetworkMainnet), "bitcoin.conf")
+	require.NoError(t, os.MkdirAll(filepath.Dir(privatePath), 0755))
+	require.NoError(t, os.WriteFile(privatePath, []byte("server=1\nrpcport=9999\n"), 0644))
+
+	m := newTestManager(t.TempDir())
+	m.Network = NetworkMainnet
+	require.NoError(t, m.LoadConfig(true))
+
+	require.True(t, m.HasPrivateConf)
+	require.Equal(t, NetworkMainnet, m.Network)
+	require.Equal(t, privatePath, m.GetConfFilePath(), "bitcoind must be launched with the conf we loaded state from")
+	require.Equal(t, 9999, m.GetRPCPort())
+}
+
+// Control case: the same conf with an explicit chain=main. Isolates the absent
+// selector as the trigger for the network/conf-path split above.
+func TestPrivateConfWithExplicitChainMain(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	privatePath := filepath.Join(BitcoinCoreDirs.RootDirNetwork(NetworkMainnet), "bitcoin.conf")
+	require.NoError(t, os.MkdirAll(filepath.Dir(privatePath), 0755))
+	require.NoError(t, os.WriteFile(privatePath, []byte("chain=main\nserver=1\nrpcport=9999\n"), 0644))
+
+	m := newTestManager(t.TempDir())
+	m.Network = NetworkMainnet
+	require.NoError(t, m.LoadConfig(true))
+
+	require.True(t, m.HasPrivateConf)
+	require.Equal(t, NetworkMainnet, m.Network)
+	require.Equal(t, privatePath, m.GetConfFilePath())
+	require.Equal(t, 9999, m.GetRPCPort())
 }
 
 // ---------------------------------------------------------------------------
@@ -668,7 +713,7 @@ func TestDetectedDataDirPrefersPerNetworkSection(t *testing.T) {
 	m.Config.SetSetting("datadir", "/global/path")
 	m.Config.SetSetting("datadir", "/main/path", "main")
 
-	m.loadStateFromConfig()
+	m.loadStateFromConfig(NetworkSignet)
 
 	require.Equal(t, NetworkMainnet, m.Network)
 	require.Equal(t, "/main/path", m.DetectedDataDir)

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -268,7 +268,10 @@ func CoreSectionForNetwork(n Network) string {
 
 // NetworkFromConfig detects the network from a parsed BitcoinConfig.
 // Handles forknet/drynet detection (chain=main + drivechain=1 in [main]).
-func NetworkFromConfig(conf *BitcoinConfig) Network {
+// fallback is returned when the config carries no chain=/testnet=/signet=/
+// regtest= selector at all — signet for our own managed conf, but the network
+// the file was found under for a user's private bitcoin.conf.
+func NetworkFromConfig(conf *BitcoinConfig, fallback Network) Network {
 	chainSetting := conf.GetSetting("chain")
 	if chainSetting != "" {
 		switch strings.ToLower(chainSetting) {
@@ -306,7 +309,7 @@ func NetworkFromConfig(conf *BitcoinConfig) Network {
 		return NetworkRegtest
 	}
 
-	return NetworkSignet
+	return fallback
 }
 
 // NetworkFromString converts a string (e.g. CLI flag) to a Network value.

--- a/sidechain-orchestrator/configs_snapshot_test.go
+++ b/sidechain-orchestrator/configs_snapshot_test.go
@@ -1,0 +1,48 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+)
+
+// TestConfigsSnapshotDuringConfigReload guards against handing out the live
+// config map: a reader ranging over it while the config file watcher runs
+// UpdateConfigs trips Go's fatal "concurrent map iteration and map write",
+// which no recover() catches.
+func TestConfigsSnapshotDuringConfigReload(t *testing.T) {
+	cfgs := []BinaryConfig{
+		{Name: "bitcoind", Port: 38332},
+		{Name: "enforcer", Port: 50051},
+		{Name: "thunder", Port: 6009},
+	}
+	o := &Orchestrator{configs: map[string]BinaryConfig{}}
+	o.UpdateConfigs(cfgs)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 5000 {
+			for _, c := range o.Configs() {
+				_ = c.Port
+			}
+		}
+	}()
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				o.UpdateConfigs(cfgs)
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("Configs reader wedged against UpdateConfigs")
+	}
+}

--- a/sidechain-orchestrator/engines/bip47_engine.go
+++ b/sidechain-orchestrator/engines/bip47_engine.go
@@ -157,8 +157,8 @@ func (e *BIP47Engine) ensureNotificationWatched(ctx context.Context, backend wal
 	return nil
 }
 
-// scanWallet walks listtransactions forward from the persisted cursor looking
-// for receives at this wallet's BIP47 notification address. For each one, it
+// scanWallet walks the wallet's whole listtransactions history looking for
+// receives at this wallet's BIP47 notification address. For each one, it
 // fetches the full tx, extracts the OP_RETURN payload + first input's pubkey,
 // decodes the sender's payment code, and records the inbound notification.
 func (e *BIP47Engine) scanWallet(ctx context.Context, walletID, seedHex string, net *chaincfg.Params) error {
@@ -168,13 +168,23 @@ func (e *BIP47Engine) scanWallet(ctx context.Context, walletID, seedHex string, 
 	}
 	wantAddr := notifAddr.EncodeAddress()
 
-	cursor, err := e.inbound.ScanCursor(walletID)
+	// Notifications already recorded need no second look — skipping them keeps
+	// the re-walk below free of repeated getrawtransaction calls.
+	known, err := e.inbound.ListByWallet(walletID)
 	if err != nil {
-		return fmt.Errorf("read scan cursor: %w", err)
+		return fmt.Errorf("list inbound: %w", err)
+	}
+	recorded := make(map[string]bool, len(known))
+	for _, n := range known {
+		recorded[n.FirstNotificationTxID] = true
 	}
 
+	// skip counts from the newest entry, so it is a within-pass pagination
+	// offset only: every pass restarts at 0, otherwise newly arrived
+	// notifications land in the skipped prefix and are never seen.
+	skip := 0
 	for {
-		batch, err := e.engine.Backend().ListTransactionsRange(ctx, walletID, bip47ListTxBatchSize, cursor)
+		batch, err := e.engine.Backend().ListTransactionsRange(ctx, walletID, bip47ListTxBatchSize, skip)
 		if err != nil {
 			return fmt.Errorf("listtransactions: %w", err)
 		}
@@ -182,7 +192,7 @@ func (e *BIP47Engine) scanWallet(ctx context.Context, walletID, seedHex string, 
 			break
 		}
 		for _, tx := range batch {
-			if tx.Category != "receive" || tx.Address != wantAddr {
+			if tx.Category != "receive" || tx.Address != wantAddr || recorded[tx.TxID] {
 				continue
 			}
 			senderCode, blockTime, err := e.decodeNotificationTx(ctx, walletID, tx.TxID, notifPriv)
@@ -207,10 +217,7 @@ func (e *BIP47Engine) scanWallet(ctx context.Context, walletID, seedHex string, 
 				Str("txid", tx.TxID).
 				Msg("recorded inbound bip47 notification")
 		}
-		cursor += len(batch)
-		if err := e.inbound.SetScanCursor(walletID, cursor); err != nil {
-			return fmt.Errorf("save scan cursor: %w", err)
-		}
+		skip += len(batch)
 		if len(batch) < bip47ListTxBatchSize {
 			break
 		}

--- a/sidechain-orchestrator/engines/bip47_engine_test.go
+++ b/sidechain-orchestrator/engines/bip47_engine_test.go
@@ -2,12 +2,154 @@ package engines
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47state"
 )
+
+// Test vectors from https://gist.github.com/SamouraiDev/6aad669604c5930864bd
+const (
+	aliceSeedHex = "64dca76abc9c6f0cf3d212d248c380c4622c8f93b2c425ec6a5567fd5db57e10d3e6f94a2f6af4ac2edb8998072aad92098db73558c323777abf5bd1082d970a"
+	bobSeedHex   = "87eaaac5a539ab028df44d9110defbef3797ddb805ca309f61a69ff96dbaa7ab5b24038cf029edec5235d933110f0aea8aeecf939ed14fc20730bba71e4b1110"
+)
+
+// stubBackend serves a fixed newest-first listtransactions history and records
+// the skip offsets it was asked for. Unimplemented Backend methods panic.
+type stubBackend struct {
+	wallet.Backend
+	chain wallet.ChainSource
+	txs   []wallet.WalletTransaction
+	skips []int
+}
+
+func (s *stubBackend) ListTransactionsRange(ctx context.Context, walletID string, count, skip int) ([]wallet.WalletTransaction, error) {
+	s.skips = append(s.skips, skip)
+	if skip >= len(s.txs) {
+		return nil, nil
+	}
+	rows := s.txs[skip:]
+	if count > 0 && count < len(rows) {
+		rows = rows[:count]
+	}
+	return rows, nil
+}
+
+func (s *stubBackend) Chain() wallet.ChainSource { return s.chain }
+
+type stubChain struct {
+	wallet.ChainSource
+	txs   map[string]*wallet.RawTransaction
+	fetch int
+}
+
+func (s *stubChain) GetRawTransaction(ctx context.Context, txid string) (*wallet.RawTransaction, error) {
+	s.fetch++
+	tx, ok := s.txs[txid]
+	if !ok {
+		return nil, fmt.Errorf("no such tx %s", txid)
+	}
+	return tx, nil
+}
+
+// buildNotificationTx returns the raw notification tx Alice sends to the
+// recipient's payment code, plus the listtransactions row for it.
+func buildNotificationTx(t *testing.T, recipientSeedHex, notifAddr string) (wallet.WalletTransaction, *wallet.RawTransaction) {
+	t.Helper()
+	net := &chaincfg.MainNetParams
+
+	sender, err := bip47.PaymentCodeFromSeed(aliceSeedHex, net)
+	require.NoError(t, err)
+	recipient, err := bip47.PaymentCodeFromSeed(recipientSeedHex, net)
+	require.NoError(t, err)
+
+	designatedPriv, _ := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x11}, 32))
+	const prevTxID = "86f411ab1c8e70ae8a0795ab7a6757aea6e4d5ae1826fc7b8f00c597d500609c"
+	prevHash, err := chainhash.NewHashFromStr(prevTxID)
+	require.NoError(t, err)
+
+	senderSerialized := sender.Serialize()
+	blinded, err := bip47.BuildBlindedPayload(senderSerialized, designatedPriv, recipient, wire.OutPoint{Hash: *prevHash, Index: 1})
+	require.NoError(t, err)
+
+	raw := &wallet.RawTransaction{
+		TxID: "notification-txid",
+		Vin: []wallet.RawTxIn{{
+			TxID:    prevTxID,
+			Vout:    1,
+			Witness: []string{"3045sig", hex.EncodeToString(designatedPriv.PubKey().SerializeCompressed())},
+		}},
+		Vout: []wallet.RawTxOut{{
+			ScriptPubKey: wallet.ScriptPubKey{
+				Type: "nulldata",
+				Hex:  hex.EncodeToString(append([]byte{0x6a, 0x4c, 0x50}, blinded[:]...)),
+			},
+		}},
+		BlockTime: 1700000000,
+	}
+	row := wallet.WalletTransaction{TxID: raw.TxID, Category: "receive", Address: notifAddr, Confirmations: 3}
+	return row, raw
+}
+
+// listtransactions counts skip from the newest entry, so a notification that
+// arrives after a completed scan pass sits at offset 0 — the scanner must
+// restart its pagination at 0 every pass or it never sees it.
+func TestScanWalletFindsNotificationAfterCompletedPass(t *testing.T) {
+	net := &chaincfg.MainNetParams
+	const walletID = "W1"
+
+	_, notifAddr, err := bip47.DeriveOwnNotificationKey(bobSeedHex, net)
+	require.NoError(t, err)
+	row, raw := buildNotificationTx(t, bobSeedHex, notifAddr.EncodeAddress())
+
+	// History longer than one batch, so the pass pages more than once.
+	history := make([]wallet.WalletTransaction, 0, bip47ListTxBatchSize+50)
+	for i := 0; i < bip47ListTxBatchSize+50; i++ {
+		history = append(history, wallet.WalletTransaction{
+			TxID:     fmt.Sprintf("filler-%d", i),
+			Category: "receive",
+			Address:  "unrelated-address",
+		})
+	}
+
+	chain := &stubChain{txs: map[string]*wallet.RawTransaction{raw.TxID: raw}}
+	backend := &stubBackend{chain: chain, txs: history}
+	store := bip47state.NewInboundStore(t.TempDir())
+	e := NewBIP47Engine(zerolog.Nop(), nil, wallet.NewWalletEngine(nil, backend, net, zerolog.Nop()), store)
+
+	require.NoError(t, e.scanWallet(context.Background(), walletID, bobSeedHex, net))
+
+	// Notification arrives after that pass completed — newest first.
+	backend.txs = append([]wallet.WalletTransaction{row}, history...)
+	require.NoError(t, e.scanWallet(context.Background(), walletID, bobSeedHex, net))
+
+	alice, err := bip47.PaymentCodeFromSeed(aliceSeedHex, net)
+	require.NoError(t, err)
+	got, err := store.Get(walletID, alice.Base58())
+	require.NoError(t, err)
+	require.NotNil(t, got, "notification arriving after a completed pass must still be recorded")
+	require.Equal(t, raw.TxID, got.FirstNotificationTxID)
+	require.Equal(t, int64(1700000000), got.FirstSeenBlockTime)
+
+	// Both passes page from 0; no offset survives across passes.
+	require.Equal(t, []int{0, bip47ListTxBatchSize, 0, bip47ListTxBatchSize}, backend.skips)
+
+	// A further pass re-walks the same history but leaves the recorded
+	// notification alone — no second getrawtransaction for it.
+	require.NoError(t, e.scanWallet(context.Background(), walletID, bobSeedHex, net))
+	require.Equal(t, 1, chain.fetch)
+}
 
 func TestParseOpReturnPayload_PushData1(t *testing.T) {
 	// OP_RETURN OP_PUSHDATA1 0x50 <80 bytes of 0xAA>

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"os"
@@ -2280,34 +2281,13 @@ func (o *Orchestrator) removeCoreBinary() {
 	o.log.Info().Str("path", path).Msg("removed bitcoind so the next boot fetches the build this chain needs")
 }
 
-// EnforcerValidator returns a client for the enforcer's validator service.
-func (o *Orchestrator) EnforcerValidator() (enforcerrpc.ValidatorServiceClient, error) {
-	cfg, ok := o.Configs()["enforcer"]
-	if !ok || cfg.Port == 0 {
-		return nil, fmt.Errorf("enforcer not configured")
-	}
-	return enforcerrpc.NewValidatorServiceClient(o.enforcerHTTP(), cfg.RPCURL(), connect.WithGRPC()), nil
-}
-
-// ChainTip returns the mainchain tip the enforcer has validated.
-func (o *Orchestrator) ChainTip(ctx context.Context) (string, int32, error) {
-	validator, err := o.EnforcerValidator()
-	if err != nil {
-		return "", 0, err
-	}
-	resp, err := validator.GetChainTip(ctx, connect.NewRequest(&enforcerpb.GetChainTipRequest{}))
-	if err != nil {
-		return "", 0, err
-	}
-	info := resp.Msg.GetBlockHeaderInfo()
-	return info.GetBlockHash().GetHex().GetValue(), int32(info.GetHeight()), nil
-}
-
-// Configs returns the binary configs.
+// Configs returns a snapshot of the binary configs. Handing out the live map
+// would let a config reload write it while a caller ranges over it, which Go
+// turns into an unrecoverable fatal error.
 func (o *Orchestrator) Configs() map[string]BinaryConfig {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
-	return o.configs
+	return maps.Clone(o.configs)
 }
 
 // GetBTCPrice returns the current BTC/USD price, caching for 10 seconds.

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
@@ -233,6 +234,10 @@ type Orchestrator struct {
 	shutdownMu    sync.Mutex
 	shutdownState int32         // shutdownState* constants
 	shutdownIdle  chan struct{} // closed when a drain completes; nil between drains
+
+	// Bumped by every drain. Detached work that outlives its caller (the reset
+	// restart) captures it up front and bails if it moved.
+	shutdownGen atomic.Uint64
 }
 
 // DownloadStateForTest exposes the DownloadManager's per-binary state to
@@ -1518,6 +1523,7 @@ func forwardDownload(downloadCh <-chan DownloadProgress, startupCh chan<- Startu
 
 // ShutdownAll stops all running binaries in reverse dependency order.
 func (o *Orchestrator) ShutdownAll(ctx context.Context, force bool) (<-chan ShutdownProgress, error) {
+	o.shutdownGen.Add(1)
 	running := o.process.ListRunning()
 	ch := make(chan ShutdownProgress, len(running)+1)
 

--- a/sidechain-orchestrator/platform_unix.go
+++ b/sidechain-orchestrator/platform_unix.go
@@ -74,6 +74,10 @@ func findPidByName(binaryName string) (int, error) {
 
 // killProcess sends SIGTERM, then SIGKILL if the process doesn't exit.
 func killProcess(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("refusing to signal invalid pid %d", pid)
+	}
+
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return fmt.Errorf("find process %d: %w", pid, err)
@@ -92,6 +96,10 @@ func killProcess(pid int) error {
 
 // forceKillProcess sends SIGKILL immediately.
 func forceKillProcess(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("refusing to signal invalid pid %d", pid)
+	}
+
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return fmt.Errorf("find process %d: %w", pid, err)

--- a/sidechain-orchestrator/platform_windows.go
+++ b/sidechain-orchestrator/platform_windows.go
@@ -102,6 +102,12 @@ func findPidByName(binaryName string) (int, error) {
 // daemons (bitcoind, enforcer, sidechains) trap this and flush cleanly; GUI
 // WM_CLOSE via plain taskkill does not reach them.
 func killProcess(pid int) error {
+	// Group 0 means "every process on our console" — that would CTRL_BREAK
+	// orchestratord itself.
+	if pid <= 0 {
+		return fmt.Errorf("refusing to signal invalid pid %d", pid)
+	}
+
 	ret, _, err := procGenerateConsoleCtrlEvent.Call(
 		uintptr(ctrlBreakEvent),
 		uintptr(uint32(pid)),
@@ -116,6 +122,10 @@ func killProcess(pid int) error {
 }
 
 func forceKillProcess(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("refusing to signal invalid pid %d", pid)
+	}
+
 	cmd := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(pid))
 	if err := cmd.Run(); err != nil {
 		if !isPidAlive(pid) {

--- a/sidechain-orchestrator/process.go
+++ b/sidechain-orchestrator/process.go
@@ -697,6 +697,13 @@ func (pm *ProcessManager) AdoptProcessWithOptions(config BinaryConfig, pid int, 
 // AdoptProcessResolved registers an externally-found process when the PID file
 // name already tells us which on-disk variant it belongs to.
 func (pm *ProcessManager) AdoptProcessResolved(config BinaryConfig, pid int, binPath, pidName string, forceBackend bool) {
+	// PID discovery returns 0 when every lookup misses. Claiming ownership of a
+	// process we cannot signal makes Stop report success without stopping it.
+	if pid <= 0 {
+		pm.log.Warn().Str("binary", config.Name).Int("pid", pid).Msg("refusing to adopt process with invalid pid")
+		return
+	}
+
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 

--- a/sidechain-orchestrator/process.go
+++ b/sidechain-orchestrator/process.go
@@ -169,6 +169,7 @@ type ProcessManager struct {
 	mu         sync.Mutex
 	processes  map[string]*ManagedProcess // keyed by config name
 	lastExited map[string]*ManagedProcess // last exited process, keyed by config name — keeps its logs readable
+	starting   map[string]bool            // names reserved by an in-flight StartWithOptions
 
 	// OnExit is called when a process exits. The orchestrator uses this to
 	// pipe exit errors into ConnectionMonitor.connectionError for the UI.
@@ -188,6 +189,7 @@ func NewProcessManager(dataDir string, pidManager *PidFileManager, log zerolog.L
 		log:        log.With().Str("component", "process").Logger(),
 		processes:  make(map[string]*ManagedProcess),
 		lastExited: make(map[string]*ManagedProcess),
+		starting:   make(map[string]bool),
 	}
 }
 
@@ -250,12 +252,20 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 		processName = config.Name
 	}
 
+	// Reserve the slot under the lock that checks it, so concurrent starts
+	// cannot both fork a daemon and have the second registration orphan the first.
 	pm.mu.Lock()
-	if _, exists := pm.processes[processName]; exists {
+	if _, exists := pm.processes[processName]; exists || pm.starting[processName] {
 		pm.mu.Unlock()
 		return 0, fmt.Errorf("%s is already running", processName)
 	}
+	pm.starting[processName] = true
 	pm.mu.Unlock()
+	defer func() {
+		pm.mu.Lock()
+		delete(pm.starting, processName)
+		pm.mu.Unlock()
+	}()
 
 	binPath, pidName := pm.resolvePaths(config, opts.ForceBackend)
 	if opts.PidName != "" {

--- a/sidechain-orchestrator/process_test.go
+++ b/sidechain-orchestrator/process_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -27,6 +28,42 @@ func TestProcessManager_StartAndStop(t *testing.T) {
 	require.NoError(t, pm.Stop(context.Background(), "sleep-test", false))
 	time.Sleep(200 * time.Millisecond)
 	assert.False(t, pm.IsRunning("sleep-test"))
+}
+
+func TestProcessManager_ConcurrentStartSpawnsOnce(t *testing.T) {
+	pm, dir := newTestProcessManager(t)
+	symlinkSystemBinary(t, dir, "sleep")
+
+	const starters = 4
+	var wg sync.WaitGroup
+	pids := make([]int, starters)
+	errs := make([]error, starters)
+	for i := range starters {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pids[i], errs[i] = pm.Start(context.Background(), BinaryConfig{
+				Name: "sleep-test", BinaryName: "sleep",
+			}, []string{"30"}, nil)
+		}()
+	}
+	wg.Wait()
+
+	proc := pm.Get("sleep-test")
+	require.NotNil(t, proc)
+
+	var started int
+	for i := range starters {
+		if errs[i] == nil {
+			started++
+			assert.Equal(t, proc.Pid, pids[i], "the tracked process must be the one we started")
+		} else {
+			assert.ErrorContains(t, errs[i], "already running")
+		}
+	}
+	assert.Equal(t, 1, started, "concurrent starts must not fork a second daemon the manager loses track of")
+
+	require.NoError(t, pm.Stop(context.Background(), "sleep-test", false))
 }
 
 func TestProcessManager_LastExit(t *testing.T) {

--- a/sidechain-orchestrator/process_test.go
+++ b/sidechain-orchestrator/process_test.go
@@ -228,3 +228,25 @@ func TestProcessNameMatches(t *testing.T) {
 		})
 	}
 }
+
+// A pid of 0 means discovery found nothing. Adopting it would make Stop
+// report success without ever signalling the daemon.
+func TestProcessManager_AdoptRejectsInvalidPid(t *testing.T) {
+	pm, _ := newTestProcessManager(t)
+	cfg := BinaryConfig{Name: "bitcoind", BinaryName: "bitcoind"}
+
+	pm.AdoptProcess(cfg, 0)
+	assert.False(t, pm.IsRunning("bitcoind"), "pid 0 must not be adopted")
+
+	pm.AdoptProcess(cfg, -1)
+	assert.False(t, pm.IsRunning("bitcoind"), "negative pid must not be adopted")
+
+	assert.Error(t, pm.Stop(context.Background(), "bitcoind", false))
+}
+
+func TestKillProcess_RejectsInvalidPid(t *testing.T) {
+	for _, pid := range []int{0, -1} {
+		assert.Error(t, killProcess(pid))
+		assert.Error(t, forceKillProcess(pid))
+	}
+}

--- a/sidechain-orchestrator/reset.go
+++ b/sidechain-orchestrator/reset.go
@@ -481,20 +481,42 @@ func (o *Orchestrator) markResetBinaryStopped(name string) {
 // gen is the shutdown generation observed when the reset was issued. A drain
 // that began since then already snapshotted the running processes, so anything
 // started now would never be stopped — abort instead.
-func (o *Orchestrator) restartResetPlan(ctx context.Context, plan resetPlan, gen uint64) {
+//
+// Returns the binaries that failed to start. A failure only strands that
+// binary's descendants; siblings are restarted regardless.
+func (o *Orchestrator) restartResetPlan(ctx context.Context, plan resetPlan, gen uint64) []string {
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(len(plan.restart)+1)*resetRestartTimeout)
 	defer cancel()
 
+	var failed []string
+	// binary -> the failed ancestor that makes starting it pointless.
+	blocked := make(map[ResetBinary]string)
+
 	for _, item := range plan.restart {
+		name := item.binary.processName()
 		if o.shutdownGen.Load() != gen {
-			o.log.Info().Str("binary", item.binary.processName()).Msg("reset restart aborted: shutdown began after reset was issued")
-			return
+			o.log.Info().Str("binary", name).Msg("reset restart aborted: shutdown began after reset was issued")
+			return failed
+		}
+		if ancestor, ok := blocked[item.binary]; ok {
+			o.log.Warn().Str("binary", name).Str("depends_on", ancestor).Msg("reset restart skipped: dependency failed to start")
+			continue
 		}
 		if err := o.restartResetBinary(ctx, item.binary, item.forceBackend); err != nil {
-			o.log.Error().Err(err).Str("binary", item.binary.processName()).Msg("reset restart failed")
-			return
+			o.log.Error().Err(err).Str("binary", name).Msg("reset restart failed")
+			failed = append(failed, name)
+			for _, child := range resetDescendants(item.binary) {
+				if _, ok := blocked[child]; !ok {
+					blocked[child] = name
+				}
+			}
 		}
 	}
+
+	if len(failed) > 0 {
+		o.log.Error().Strs("failed", failed).Msg("reset restart finished with failures")
+	}
+	return failed
 }
 
 func (o *Orchestrator) restartResetBinary(ctx context.Context, binary ResetBinary, forceBackend bool) error {

--- a/sidechain-orchestrator/reset.go
+++ b/sidechain-orchestrator/reset.go
@@ -260,6 +260,10 @@ func (o *Orchestrator) DeleteFiles(ctx context.Context, paths []string, specs ..
 		}
 	}
 
+	// Captured after our own stop so the restart only aborts on a drain that
+	// began after this reset was issued.
+	gen := o.shutdownGen.Load()
+
 	events := make(chan DeleteEvent, len(paths)+1)
 	go func() {
 		defer close(events)
@@ -295,7 +299,7 @@ func (o *Orchestrator) DeleteFiles(ctx context.Context, paths []string, specs ..
 		}
 
 		if useResetPlan {
-			go o.restartResetPlan(context.Background(), plan)
+			go o.restartResetPlan(context.Background(), plan, gen)
 		}
 	}()
 
@@ -474,11 +478,18 @@ func (o *Orchestrator) markResetBinaryStopped(name string) {
 	}
 }
 
-func (o *Orchestrator) restartResetPlan(ctx context.Context, plan resetPlan) {
+// gen is the shutdown generation observed when the reset was issued. A drain
+// that began since then already snapshotted the running processes, so anything
+// started now would never be stopped — abort instead.
+func (o *Orchestrator) restartResetPlan(ctx context.Context, plan resetPlan, gen uint64) {
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(len(plan.restart)+1)*resetRestartTimeout)
 	defer cancel()
 
 	for _, item := range plan.restart {
+		if o.shutdownGen.Load() != gen {
+			o.log.Info().Str("binary", item.binary.processName()).Msg("reset restart aborted: shutdown began after reset was issued")
+			return
+		}
 		if err := o.restartResetBinary(ctx, item.binary, item.forceBackend); err != nil {
 			o.log.Error().Err(err).Str("binary", item.binary.processName()).Msg("reset restart failed")
 			return

--- a/sidechain-orchestrator/reset_test.go
+++ b/sidechain-orchestrator/reset_test.go
@@ -358,6 +358,46 @@ func TestResetRestart_AbortsWhenShutdownBeganAfterReset(t *testing.T) {
 	assert.False(t, o.process.IsRunning("thunder"))
 }
 
+// An orchestrator with no configs: every restart fails on the config lookup,
+// instantly and without side effects.
+func newRestartFailureOrchestrator(t *testing.T) *Orchestrator {
+	t.Helper()
+	dir := t.TempDir()
+	return New(dir, "signet", dir, nil, testLogger(t))
+}
+
+// Sidechains don't depend on each other, so one failing to start must not
+// strand the rest of them.
+func TestResetRestart_SiblingFailureDoesNotSkipOtherSidechains(t *testing.T) {
+	o := newRestartFailureOrchestrator(t)
+
+	plan := resetPlan{restart: []resetRestart{
+		{binary: ResetBinaryThunder},
+		{binary: ResetBinaryZSide},
+		{binary: ResetBinaryBitAssets},
+	}}
+
+	failed := o.restartResetPlan(context.Background(), plan, o.shutdownGen.Load())
+
+	assert.Equal(t, []string{"thunder", "zside", "bitassets"}, failed)
+}
+
+// A failed start does skip that binary's descendants: there's no point booting
+// a sidechain when bitcoind never came back.
+func TestResetRestart_FailureSkipsDescendants(t *testing.T) {
+	o := newRestartFailureOrchestrator(t)
+
+	plan := resetPlan{restart: []resetRestart{
+		{binary: ResetBinaryBitcoind},
+		{binary: ResetBinaryEnforcer},
+		{binary: ResetBinaryThunder},
+	}}
+
+	failed := o.restartResetPlan(context.Background(), plan, o.shutdownGen.Load())
+
+	assert.Equal(t, []string{"bitcoind"}, failed)
+}
+
 // ---------- DeleteFiles ----------------------------------------------------
 
 func TestDeleteFiles_DeletesSeededFiles(t *testing.T) {

--- a/sidechain-orchestrator/reset_test.go
+++ b/sidechain-orchestrator/reset_test.go
@@ -325,6 +325,39 @@ func TestResetPlan_DoesNotRestartBinariesThatWereNotRunning(t *testing.T) {
 	assert.Empty(t, plan.restart)
 }
 
+// A drain that begins after a reset was issued must cancel the reset's
+// detached restart: the drain already took its snapshot of running processes,
+// so anything started now is never stopped.
+func TestResetRestart_AbortsWhenShutdownBeganAfterReset(t *testing.T) {
+	o := newResetTestOrchestrator(t)
+	fakeRunningForReset(t, o, ResetBinaryThunder)
+
+	plan := o.buildResetPlan([]GatherSpec{
+		{Binary: ResetBinaryThunder, Categories: []ResetCategory{catData}},
+	})
+	require.Equal(t, []ResetBinary{ResetBinaryThunder}, resetRestartBinaries(plan))
+
+	gen := o.shutdownGen.Load()
+
+	// Drop the fake process first: ShutdownAll signals real PIDs.
+	o.process.Remove("thunder")
+	ch, err := o.ShutdownAll(context.Background(), false)
+	require.NoError(t, err)
+	for range ch {
+	}
+	require.NotEqual(t, gen, o.shutdownGen.Load(), "ShutdownAll must bump the shutdown generation")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	o.restartResetPlan(ctx, plan, gen)
+
+	o.monitorsMu.Lock()
+	_, started := o.monitors["thunder"]
+	o.monitorsMu.Unlock()
+	assert.False(t, started, "restart must not start thunder after a drain began")
+	assert.False(t, o.process.IsRunning("thunder"))
+}
+
 // ---------- DeleteFiles ----------------------------------------------------
 
 func TestDeleteFiles_DeletesSeededFiles(t *testing.T) {

--- a/sidechain-orchestrator/shutdown.go
+++ b/sidechain-orchestrator/shutdown.go
@@ -34,6 +34,7 @@ func (o *Orchestrator) BeginShutdown() bool {
 	o.shutdownState = shutdownStateDrainingExit
 	o.shutdownIdle = make(chan struct{})
 	idleCh := o.shutdownIdle
+	o.shutdownGen.Add(1)
 	o.shutdownMu.Unlock()
 
 	go o.runShutdown(idleCh)

--- a/sidechain-orchestrator/wallet/bip47state/inbound.go
+++ b/sidechain-orchestrator/wallet/bip47state/inbound.go
@@ -38,23 +38,20 @@ type InboundNotification struct {
 type InboundStore struct {
 	path string
 
-	mu      sync.Mutex
-	loaded  bool
-	rows    map[string]*InboundNotification
-	cursors map[string]int
+	mu     sync.Mutex
+	loaded bool
+	rows   map[string]*InboundNotification
 }
 
 // inboundFile is the on-disk shape.
 type inboundFile struct {
-	Inbound     []*InboundNotification `json:"inbound"`
-	ScanCursors map[string]int         `json:"scan_cursors"`
+	Inbound []*InboundNotification `json:"inbound"`
 }
 
 func NewInboundStore(dir string) *InboundStore {
 	return &InboundStore{
-		path:    filepath.Join(dir, inboundFileName),
-		rows:    make(map[string]*InboundNotification),
-		cursors: make(map[string]int),
+		path: filepath.Join(dir, inboundFileName),
+		rows: make(map[string]*InboundNotification),
 	}
 }
 
@@ -81,9 +78,6 @@ func (s *InboundStore) ensureLoadedLocked() error {
 	for _, r := range file.Inbound {
 		s.rows[inboundKey(r.WalletID, r.SenderPaymentCode)] = r
 	}
-	if file.ScanCursors != nil {
-		s.cursors = file.ScanCursors
-	}
 	s.loaded = true
 	return nil
 }
@@ -100,10 +94,7 @@ func (s *InboundStore) flushLocked() error {
 		}
 		return rows[i].SenderPaymentCode < rows[j].SenderPaymentCode
 	})
-	data, err := json.MarshalIndent(inboundFile{
-		Inbound:     rows,
-		ScanCursors: s.cursors,
-	}, "", "  ")
+	data, err := json.MarshalIndent(inboundFile{Inbound: rows}, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode bip47 inbound state: %w", err)
 	}
@@ -193,38 +184,4 @@ func (s *InboundStore) ListByWallet(walletID string) ([]*InboundNotification, er
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].SenderPaymentCode < out[j].SenderPaymentCode })
 	return out, nil
-}
-
-// ScanCursor returns the listtransactions skip-count for this wallet.
-func (s *InboundStore) ScanCursor(walletID string) (int, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if err := s.ensureLoadedLocked(); err != nil {
-		return 0, err
-	}
-	return s.cursors[walletID], nil
-}
-
-func (s *InboundStore) SetScanCursor(walletID string, n int) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if err := s.ensureLoadedLocked(); err != nil {
-		return err
-	}
-	if s.cursors[walletID] == n {
-		return nil
-	}
-	s.cursors[walletID] = n
-	return s.flushLocked()
-}
-
-// Rebind points the store at another network's directory, dropping state
-// loaded from the previous one.
-func (s *InboundStore) Rebind(dir string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.path = filepath.Join(dir, inboundFileName)
-	s.rows = make(map[string]*InboundNotification)
-	s.cursors = make(map[string]int)
-	s.loaded = false
 }

--- a/sidechain-orchestrator/wallet/bip47state/inbound_test.go
+++ b/sidechain-orchestrator/wallet/bip47state/inbound_test.go
@@ -40,22 +40,6 @@ func TestInboundStore_RoundTrip(t *testing.T) {
 	require.Equal(t, uint32(25), got3.ImportedThroughIndex)
 }
 
-func TestInboundStore_ScanCursor(t *testing.T) {
-	dir := t.TempDir()
-	s := NewInboundStore(dir)
-
-	n, err := s.ScanCursor("W1")
-	require.NoError(t, err)
-	require.Equal(t, 0, n)
-
-	require.NoError(t, s.SetScanCursor("W1", 42))
-
-	s2 := NewInboundStore(dir)
-	n2, err := s2.ScanCursor("W1")
-	require.NoError(t, err)
-	require.Equal(t, 42, n2)
-}
-
 func TestInboundStore_ListByWallet(t *testing.T) {
 	dir := t.TempDir()
 	s := NewInboundStore(dir)

--- a/sidechain-orchestrator/wallet/bip47state/store.go
+++ b/sidechain-orchestrator/wallet/bip47state/store.go
@@ -166,12 +166,23 @@ func (s *Store) ReserveNextIndex(walletID, recipientCode string) (uint32, error)
 	return idx, nil
 }
 
-// Rebind points the store at another network's directory, dropping state
-// loaded from the previous one.
-func (s *Store) Rebind(dir string) {
+// ReleaseIndex gives back an index reserved by ReserveNextIndex for a send that
+// never went out, so the next send reuses it. No-op unless idx is still the most
+// recent reservation.
+func (s *Store) ReleaseIndex(walletID, recipientCode string, idx uint32) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.path = filepath.Join(dir, fileName)
-	s.rows = make(map[string]*State)
-	s.loaded = false
+	if err := s.ensureLoadedLocked(); err != nil {
+		return err
+	}
+	r, ok := s.rows[key(walletID, recipientCode)]
+	if !ok || r.NextSendIndex != idx+1 {
+		return nil
+	}
+	r.NextSendIndex = idx
+	if err := s.flushLocked(); err != nil {
+		r.NextSendIndex = idx + 1
+		return err
+	}
+	return nil
 }

--- a/sidechain-orchestrator/wallet/bip47state/store_test.go
+++ b/sidechain-orchestrator/wallet/bip47state/store_test.go
@@ -66,6 +66,41 @@ func TestReserveNextIndex_Concurrent(t *testing.T) {
 	}
 }
 
+func TestReleaseIndexReusesIndexAfterFailedSend(t *testing.T) {
+	dir := t.TempDir()
+	st := bip47state.NewStore(dir)
+
+	idx, err := st.ReserveNextIndex("w1", "PMtest")
+	require.NoError(t, err)
+	require.NoError(t, st.ReleaseIndex("w1", "PMtest", idx))
+
+	// The release must survive a restart, not just the in-memory view.
+	st2 := bip47state.NewStore(dir)
+	again, err := st2.ReserveNextIndex("w1", "PMtest")
+	require.NoError(t, err)
+	assert.Equal(t, idx, again)
+}
+
+func TestReleaseIndexIgnoresStaleAndUnknown(t *testing.T) {
+	dir := t.TempDir()
+	st := bip47state.NewStore(dir)
+
+	first, err := st.ReserveNextIndex("w1", "PMtest")
+	require.NoError(t, err)
+	_, err = st.ReserveNextIndex("w1", "PMtest")
+	require.NoError(t, err)
+
+	// A concurrent send already reserved past `first`: releasing it must not
+	// rewind the counter onto an index that is now in flight.
+	require.NoError(t, st.ReleaseIndex("w1", "PMtest", first))
+	require.NoError(t, st.ReleaseIndex("w1", "PMunknown", 0))
+
+	state, err := st.GetState("w1", "PMtest")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint32(2), state.NextSendIndex)
+}
+
 func TestPersistenceAcrossReopen(t *testing.T) {
 	dir := t.TempDir()
 	st := bip47state.NewStore(dir)

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -1019,6 +1019,7 @@ func (p *CoreBackend) createAndImport(ctx context.Context, walletName string, di
 		return fmt.Errorf("list wallets: %w", err)
 	}
 
+	created := false
 	if !lo.Contains(existing, walletName) {
 		if err := p.rpc.CreateWallet(ctx, walletName, disablePrivateKeys, true); err != nil {
 			if strings.Contains(err.Error(), "already exists") {
@@ -1029,22 +1030,29 @@ func (p *CoreBackend) createAndImport(ctx context.Context, walletName string, di
 				return fmt.Errorf("create wallet: %w", err)
 			}
 		}
+		created = true
+	}
 
-		results, err := p.rpc.ImportDescriptors(ctx, walletName, descriptors)
-		if err != nil {
-			return fmt.Errorf("import descriptors: %w", err)
-		}
+	// Import unconditionally: a createwallet that succeeded before a failing
+	// import leaves the wallet listed but with no active descriptor, and
+	// re-importing an identical one is a no-op in Core (timestamp "now", no
+	// rescan).
+	results, err := p.rpc.ImportDescriptors(ctx, walletName, descriptors)
+	if err != nil {
+		return fmt.Errorf("import descriptors: %w", err)
+	}
 
-		for i, r := range results {
-			if !r.Success {
-				errMsg := "unknown"
-				if r.Error != nil {
-					errMsg = r.Error.Message
-				}
-				return fmt.Errorf("descriptor %d import failed: %s", i, errMsg)
+	for i, r := range results {
+		if !r.Success {
+			errMsg := "unknown"
+			if r.Error != nil {
+				errMsg = r.Error.Message
 			}
+			return fmt.Errorf("descriptor %d import failed: %s", i, errMsg)
 		}
+	}
 
+	if created {
 		p.log.Info().Str("wallet", walletName).Msg("created Bitcoin Core wallet")
 	}
 

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -385,7 +385,12 @@ func (p *CoreBackend) NextChangeAddress(ctx context.Context, walletID string) (s
 	if err != nil {
 		return "", err
 	}
-	return p.rpc.GetRawChangeAddress(ctx, name)
+	kind := p.walletScriptKind(walletID)
+	addressType, ok := coreAddressType(kind)
+	if !ok {
+		return "", fmt.Errorf("unsupported address kind %s for the Bitcoin Core backend", kind)
+	}
+	return p.rpc.GetRawChangeAddress(ctx, name, addressType)
 }
 
 // WatchKeys imports each key as a pkh() descriptor. Per-key import failures

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -46,6 +46,12 @@ type CoreBackend struct {
 	mu          sync.Mutex
 	coreWallets map[string]string // walletID -> Core wallet name
 
+	// walletID -> earliest retry of a BIP47 notification descriptor import
+	// that failed. A failure there doesn't block wallet loading, so the
+	// wallet stays cached and later Ensure calls retry the import, gated by
+	// walletLoadingBackoff so a persistently failing rescan can't hot-loop.
+	bip47NotifRetry map[string]time.Time
+
 	// Transient backoff: when bitcoind responds with a "still booting" error
 	// (-4 Wallet already loading, -28 Verifying blocks, …), Ensure returns
 	// the cached error for `walletLoadingBackoff` so the next ~5s of
@@ -62,11 +68,12 @@ var (
 // NewCoreBackend creates the Bitcoin Core wallet backend.
 func NewCoreBackend(svc *Service, rpc *CoreRPCClient, params ParamsFunc, log zerolog.Logger) *CoreBackend {
 	return &CoreBackend{
-		svc:         svc,
-		rpc:         rpc,
-		log:         log.With().Str("component", "core-backend").Logger(),
-		params:      params,
-		coreWallets: make(map[string]string),
+		svc:             svc,
+		rpc:             rpc,
+		log:             log.With().Str("component", "core-backend").Logger(),
+		network:         network,
+		coreWallets:     make(map[string]string),
+		bip47NotifRetry: make(map[string]time.Time),
 	}
 }
 
@@ -93,6 +100,7 @@ func (p *CoreBackend) Ensure(ctx context.Context, walletID string) (string, erro
 
 	// Check cache
 	if name, ok := p.coreWallets[walletID]; ok {
+		p.retryBip47NotificationDescriptor(ctx, walletID, name)
 		return name, nil
 	}
 
@@ -147,6 +155,7 @@ func (p *CoreBackend) Ensure(ctx context.Context, walletID string) (string, erro
 	if targetWallet.WalletType == WalletTypeBitcoinCore && !targetWallet.IsWatchOnly() {
 		if perr := p.ensureBip47NotificationDescriptor(ctx, walletName, targetWallet.Master.SeedHex); perr != nil {
 			p.log.Warn().Err(perr).Str("wallet", walletName).Msg("could not ensure bip47 notification descriptor")
+			p.bip47NotifRetry[walletID] = time.Now().Add(walletLoadingBackoff)
 		}
 	}
 
@@ -180,6 +189,7 @@ func (p *CoreBackend) EnsureAll(ctx context.Context) (int, error) {
 func (p *CoreBackend) walletName(ctx context.Context, walletID string) (string, error) {
 	p.mu.Lock()
 	if name, ok := p.coreWallets[walletID]; ok {
+		p.retryBip47NotificationDescriptor(ctx, walletID, name)
 		p.mu.Unlock()
 		return name, nil
 	}
@@ -805,6 +815,28 @@ func (p *CoreBackend) ensureBip47NotificationDescriptor(ctx context.Context, wal
 		return fmt.Errorf("bip47 descriptor %d import failed: %s", i, msg)
 	}
 	return nil
+}
+
+// retryBip47NotificationDescriptor re-imports a notification descriptor whose
+// earlier import failed, so a transient failure doesn't leave an already
+// cached wallet without it forever. No-op unless an import is outstanding and
+// its backoff has elapsed. Caller holds p.mu.
+func (p *CoreBackend) retryBip47NotificationDescriptor(ctx context.Context, walletID, walletName string) {
+	retryAt, pending := p.bip47NotifRetry[walletID]
+	if !pending || time.Now().Before(retryAt) {
+		return
+	}
+	w := p.svc.GetWalletByID(walletID)
+	if w == nil {
+		delete(p.bip47NotifRetry, walletID)
+		return
+	}
+	if err := p.ensureBip47NotificationDescriptor(ctx, walletName, w.Master.SeedHex); err != nil {
+		p.log.Warn().Err(err).Str("wallet", walletName).Msg("could not ensure bip47 notification descriptor")
+		p.bip47NotifRetry[walletID] = time.Now().Add(walletLoadingBackoff)
+		return
+	}
+	delete(p.bip47NotifRetry, walletID)
 }
 
 // createBitcoinCoreWallet creates a Bitcoin Core descriptor wallet from a seed.

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -474,29 +474,25 @@ func (p *CoreBackend) Send(ctx context.Context, walletID string, req SendRequest
 	}
 
 	outputs, totalDestinationSats := buildSendOutputs(req)
-	inputs := make([]RawInput, 0, len(req.ExternalInputs)+len(req.RequiredInputs))
-	selectedInputAmountSats := int64(0)
-	// External inputs come first, so a sidechain CTIP stays at input 0.
-	for _, in := range req.ExternalInputs {
-		inputs = append(inputs, RawInput{TxID: in.TxID, Vout: in.Vout})
-		selectedInputAmountSats += in.AmountSats
-	}
+	inputs := make([]RawInput, 0, len(req.RequiredInputs))
 	for _, in := range req.RequiredInputs {
 		inputs = append(inputs, RawInput{TxID: in.TxID, Vout: in.Vout})
-		selectedInputAmountSats += in.AmountSats
 	}
 
 	if req.FixedFeeSats > 0 {
-		neededSats := totalDestinationSats + req.FixedFeeSats
-		if len(req.RequiredInputs) == 0 && selectedInputAmountSats < neededSats {
-			extra, extraSats, err := p.selectInputsForFixedFee(
-				ctx, walletID, neededSats-selectedInputAmountSats,
+		selectedInputAmountSats := int64(0)
+		if len(inputs) == 0 {
+			inputs, selectedInputAmountSats, err = p.selectInputsForFixedFee(
+				ctx, walletID, totalDestinationSats+req.FixedFeeSats,
 			)
 			if err != nil {
 				return "", err
 			}
-			inputs = append(inputs, extra...)
-			selectedInputAmountSats += extraSats
+		} else {
+			selectedInputAmountSats, err = p.requiredInputValueSats(ctx, name, req.RequiredInputs)
+			if err != nil {
+				return "", err
+			}
 		}
 
 		changeSats := selectedInputAmountSats - totalDestinationSats - req.FixedFeeSats
@@ -624,6 +620,30 @@ func buildSendOutputs(req SendRequest) ([]TxOutSpec, int64) {
 		outputs = append(outputs, TxOutSpec{OpReturnHex: req.OpReturnHex})
 	}
 	return outputs, totalDestinationSats
+}
+
+// requiredInputValueSats sums the pinned outpoints' on-chain values. The
+// caller-supplied amounts are never trusted: an absent or understated one
+// would silently shrink the change output and burn the difference as fee.
+// minconf 0 so a pinned unconfirmed output (e.g. a replacement's own change)
+// still resolves.
+func (p *CoreBackend) requiredInputValueSats(ctx context.Context, name string, required []RequiredInput) (int64, error) {
+	utxos, err := p.rpc.ListUnspentMinConf(ctx, name, 0)
+	if err != nil {
+		return 0, fmt.Errorf("list unspent: %w", err)
+	}
+
+	totalSats := int64(0)
+	for _, in := range required {
+		utxo, ok := lo.Find(utxos, func(u UTXO) bool {
+			return u.TxID == in.TxID && u.Vout == in.Vout
+		})
+		if !ok {
+			return 0, fmt.Errorf("required input %s:%d is not a wallet UTXO", in.TxID, in.Vout)
+		}
+		totalSats += int64(math.Round(utxo.Amount * 1e8))
+	}
+	return totalSats, nil
 }
 
 // selectInputsForFixedFee picks spendable UTXOs largest-first until they

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -939,6 +939,61 @@ func TestCoreBackendNextReceiveAddressTaproot(t *testing.T) {
 	assert.Equal(t, "bech32m", mintedType)
 }
 
+// TestCoreBackendNextChangeAddressKind pins change addresses to the wallet's own
+// script kind: a tr()-only wallet has no bech32 ScriptPubKeyMan to serve.
+func TestCoreBackendNextChangeAddressKind(t *testing.T) {
+	net := &chaincfg.RegressionNetParams
+	ctx := context.Background()
+
+	t.Run("default wallet stays bech32", func(t *testing.T) {
+		backend, fake, coreID := newCoreBackendFixture(t)
+		fake.stubEnsureFlow()
+
+		change := p2wpkhAddr(t, fixedKey(0x31), net)
+		var requestedType string
+		fake.handle("getrawchangeaddress", func(c bitcoindCall) (any, string) {
+			if len(c.Params) > 0 {
+				requestedType = mustString(t, c.Params[0])
+			}
+			return change, ""
+		})
+
+		addr, err := backend.NextChangeAddress(ctx, coreID)
+		require.NoError(t, err)
+		assert.Equal(t, change, addr)
+		assert.Equal(t, "bech32", requestedType)
+	})
+
+	t.Run("taproot wallet requests bech32m", func(t *testing.T) {
+		svc := newTestService(t)
+		_, err := svc.GenerateWallet("Enforcer", "", "", testSlots)
+		require.NoError(t, err)
+		core, err := svc.GenerateWalletWithPath("CoreTaproot", "", "", 0, "m/86'/1'/0'", testSlots)
+		require.NoError(t, err)
+
+		fake := newFakeBitcoind(t)
+		backend := NewCoreBackend(svc, fake.client(t), net, zerolog.New(zerolog.NewTestWriter(t)))
+		coreID := core.ID
+		require.Equal(t, ScriptTaproot, backend.walletScriptKind(coreID))
+
+		fake.stubEnsureFlow()
+
+		change := p2trAddr(t, fixedKey(0x32), net)
+		var requestedType string
+		fake.handle("getrawchangeaddress", func(c bitcoindCall) (any, string) {
+			if len(c.Params) > 0 {
+				requestedType = mustString(t, c.Params[0])
+			}
+			return change, ""
+		})
+
+		addr, err := backend.NextChangeAddress(ctx, coreID)
+		require.NoError(t, err)
+		assert.Equal(t, change, addr)
+		assert.Equal(t, "bech32m", requestedType)
+	})
+}
+
 func mustString(t *testing.T, raw json.RawMessage) string {
 	t.Helper()
 	var s string

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -494,6 +494,75 @@ func TestCoreBackendSendFixedFeeSelectsInputsAndChange(t *testing.T) {
 	assert.Equal(t, builtHex, mustString(t, signs[0].Params[0]))
 }
 
+func TestCoreBackendSendFixedFeeResolvesRequiredInputValue(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	net := &chaincfg.RegressionNetParams
+	dest := p2wpkhAddr(t, fixedKey(0xCC), net)
+	change := p2wpkhAddr(t, fixedKey(0xDD), net)
+	pinned := strings.Repeat("55", 32)
+
+	fake.handle("listunspent", func(c bitcoindCall) (any, string) {
+		// minconf 0 so a pinned unconfirmed output still resolves.
+		var minConf int
+		require.NoError(t, json.Unmarshal(c.Params[0], &minConf))
+		assert.Equal(t, 0, minConf)
+		return []map[string]any{
+			{"txid": pinned, "vout": 2, "amount": 0.001, "spendable": true},
+		}, ""
+	})
+	fake.handle("getrawchangeaddress", func(bitcoindCall) (any, string) { return change, "" })
+	fake.handle("createrawtransaction", func(bitcoindCall) (any, string) { return "deadbeef", "" })
+	fake.handle("signrawtransactionwithwallet", func(c bitcoindCall) (any, string) {
+		return map[string]any{"hex": mustString(t, c.Params[0]), "complete": true}, ""
+	})
+	fake.handle("sendrawtransaction", func(bitcoindCall) (any, string) { return "txid-pinned", "" })
+
+	// AmountSats left at zero, as callers that only know the outpoint send it.
+	txid, err := backend.Send(context.Background(), coreID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FixedFeeSats:     1_000,
+		RequiredInputs:   []RequiredInput{{TxID: pinned, Vout: 2}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "txid-pinned", txid)
+
+	creates := fake.callsFor("createrawtransaction")
+	require.Len(t, creates, 1)
+	var inputs []RawInput
+	require.NoError(t, json.Unmarshal(creates[0].Params[0], &inputs))
+	require.Len(t, inputs, 1)
+	assert.Equal(t, pinned, inputs[0].TxID)
+	assert.Equal(t, 2, inputs[0].Vout)
+
+	// Change is 100k on-chain - 50k dest - 1k fee, not burned by the zero amount.
+	var outputs []map[string]any
+	require.NoError(t, json.Unmarshal(creates[0].Params[1], &outputs))
+	require.Len(t, outputs, 2)
+	assert.Equal(t, 0.0005, outputs[0][dest])
+	assert.Equal(t, 0.00049, outputs[1][change])
+}
+
+func TestCoreBackendSendFixedFeeRejectsForeignRequiredInput(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	net := &chaincfg.RegressionNetParams
+	dest := p2wpkhAddr(t, fixedKey(0xCC), net)
+	foreign := strings.Repeat("66", 32)
+
+	fake.handle("listunspent", func(bitcoindCall) (any, string) { return []map[string]any{}, "" })
+
+	_, err := backend.Send(context.Background(), coreID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FixedFeeSats:     1_000,
+		RequiredInputs:   []RequiredInput{{TxID: foreign, Vout: 0, AmountSats: 1_000_000}},
+	})
+	require.ErrorContains(t, err, "is not a wallet UTXO")
+	assert.Empty(t, fake.callsFor("createrawtransaction"))
+}
+
 func TestCoreBackendSendReplayProtect(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
 	fake.stubEnsureFlow()

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -291,6 +291,70 @@ func TestCoreBackendRetriesFailedBip47NotificationImport(t *testing.T) {
 	assert.Empty(t, backend.bip47NotifRetry)
 }
 
+// createwallet succeeding before a failing descriptor import leaves the wallet
+// listed but empty. The retry must re-import it, not treat listwallets
+// membership as proof the descriptors landed.
+func TestCoreBackendRetryReimportsDescriptorsAfterPartialCreate(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	var mu sync.Mutex
+	created := false
+	failSingleSig := true
+	fake.handle("listwallets", func(bitcoindCall) (any, string) {
+		mu.Lock()
+		defer mu.Unlock()
+		if created {
+			return []string{"wallet_" + coreID[:8]}, ""
+		}
+		return []string{}, ""
+	})
+	fake.handle("createwallet", func(bitcoindCall) (any, string) {
+		mu.Lock()
+		created = true
+		mu.Unlock()
+		return map[string]any{}, ""
+	})
+	fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		mu.Lock()
+		fail := failSingleSig && len(descs) == 4
+		mu.Unlock()
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			results[i] = map[string]any{"success": !fail}
+			if fail {
+				results[i]["error"] = map[string]any{"code": -5, "message": "Missing checksum"}
+			}
+		}
+		return results, ""
+	})
+	ctx := context.Background()
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.ErrorContains(t, err, "descriptor 0 import failed")
+	require.Len(t, fake.callsFor("createwallet"), 1)
+
+	mu.Lock()
+	failSingleSig = false
+	mu.Unlock()
+
+	// The wallet is now in listwallets, so createwallet is skipped — but the
+	// descriptors still have to be imported.
+	name, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	assert.Equal(t, "wallet_"+coreID[:8], name)
+	assert.Len(t, fake.callsFor("createwallet"), 1)
+
+	imports := fake.callsFor("importdescriptors")
+	require.Len(t, imports, 3, "failed single-sig import, its retry, then bip47")
+	var singleSig []ImportDescriptor
+	require.NoError(t, json.Unmarshal(imports[1].Params[0], &singleSig))
+	require.Len(t, singleSig, 4)
+	assert.Contains(t, singleSig[0].Desc, "/84'/1'/0']")
+}
+
 func TestCoreBackendSendSimple(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
 	fake.stubEnsureFlow()

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/replay"
 	"github.com/btcsuite/btcd/btcutil"
@@ -230,6 +231,64 @@ func TestCoreBackendEnsureTransientBackoff(t *testing.T) {
 	_, err = backend.Ensure(ctx, coreID)
 	require.ErrorContains(t, err, "Verifying blocks")
 	assert.Len(t, fake.callsFor("listwallets"), 1)
+}
+
+// A failed BIP47 notification import doesn't break wallet loading, but the
+// wallet must not be cached as fully provisioned: later calls retry it.
+func TestCoreBackendRetriesFailedBip47NotificationImport(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	var mu sync.Mutex
+	failNotif := true
+	fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		mu.Lock()
+		fail := failNotif && len(descs) == 1 && strings.HasPrefix(descs[0].Desc, "pkh(")
+		mu.Unlock()
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			results[i] = map[string]any{"success": !fail}
+			if fail {
+				results[i]["error"] = map[string]any{"code": -1, "message": "rescan timed out"}
+			}
+		}
+		return results, ""
+	})
+	ctx := context.Background()
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	require.Len(t, fake.callsFor("importdescriptors"), 2)
+
+	// Within the backoff window the failed import isn't hammered.
+	_, err = backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	assert.Len(t, fake.callsFor("importdescriptors"), 2)
+
+	mu.Lock()
+	failNotif = false
+	mu.Unlock()
+	backend.mu.Lock()
+	backend.bip47NotifRetry[coreID] = time.Time{} // backoff elapsed
+	backend.mu.Unlock()
+
+	// Once the backoff elapses the notification descriptor is imported again.
+	_, err = backend.walletName(ctx, coreID)
+	require.NoError(t, err)
+	imports := fake.callsFor("importdescriptors")
+	require.Len(t, imports, 3)
+	var notif []ImportDescriptor
+	require.NoError(t, json.Unmarshal(imports[2].Params[0], &notif))
+	require.Len(t, notif, 1)
+	assert.True(t, strings.HasPrefix(notif[0].Desc, "pkh("))
+
+	// Now that it succeeded, no further imports.
+	_, err = backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	assert.Len(t, fake.callsFor("importdescriptors"), 3)
+	assert.Empty(t, backend.bip47NotifRetry)
 }
 
 func TestCoreBackendSendSimple(t *testing.T) {

--- a/sidechain-orchestrator/wallet/core_rpc.go
+++ b/sidechain-orchestrator/wallet/core_rpc.go
@@ -398,8 +398,8 @@ func (c *CoreRPCClient) SendRawTransaction(ctx context.Context, hexString string
 	return txid, nil
 }
 
-func (c *CoreRPCClient) GetRawChangeAddress(ctx context.Context, walletName string) (string, error) {
-	result, err := c.call(ctx, walletName, "getrawchangeaddress", "bech32")
+func (c *CoreRPCClient) GetRawChangeAddress(ctx context.Context, walletName, addressType string) (string, error) {
+	result, err := c.call(ctx, walletName, "getrawchangeaddress", addressType)
 	if err != nil {
 		return "", err
 	}

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -798,9 +798,9 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 
 	// External (non-wallet) inputs — e.g. an anyone-can-spend sidechain CTIP —
 	// contribute their value toward the outputs but are not signed by us. Their
-	// vsize is not added to fee estimation, so callers that supply them use a
-	// fixed fee (FixedFeeSats).
+	// vsize still ships in the transaction, so it is priced into the fee.
 	externalSats := int64(0)
+	extVsize := externalInputVsize * len(req.ExternalInputs)
 	for _, ei := range req.ExternalInputs {
 		externalSats += ei.AmountSats
 	}
@@ -857,7 +857,7 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 		if withChange {
 			outVsize += outputVsizeForKind(d.Kind)
 		}
-		return estimateFeeSats(nIn, inVsize, outVsize, feeRate)
+		return estimateFeeSats(nIn, inVsize, outVsize, extVsize, feeRate)
 	}
 
 	i := 0

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -517,6 +517,65 @@ func TestElectrumSendSidechainDepositInsufficientFunds(t *testing.T) {
 	assert.Empty(t, fake.broadcast, "nothing is broadcast when funding fails")
 }
 
+// TestElectrumFeeRateSendPricesExternalInputs proves a fee-rate send that spends
+// an external input pays for that input's vbytes too: the broadcast transaction
+// clears the requested rate over its whole vsize, not just the wallet inputs.
+func TestElectrumFeeRateSendPricesExternalInputs(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	ctx := context.Background()
+
+	const (
+		walletAmount = int64(200_000)
+		oldCtip      = int64(500_000)
+		feeRate      = int64(20)
+		slot         = byte(1)
+	)
+
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: walletAmount, TxCount: 1},
+	}
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID: "5555555555555555555555555555555555555555555555555555555555555555",
+		Vout: 0, Value: walletAmount,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}
+
+	drivechainScript := []byte{txscript.OP_NOP5, txscript.OP_DATA_1, slot, txscript.OP_TRUE}
+	treasuryPrev := wire.NewMsgTx(2)
+	treasuryPrev.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	treasuryPrev.AddTxOut(wire.NewTxOut(oldCtip, drivechainScript))
+	var buf bytes.Buffer
+	require.NoError(t, treasuryPrev.Serialize(&buf))
+	ctipTxid := treasuryPrev.TxHash().String()
+	fake.hexByID[ctipTxid] = hex.EncodeToString(buf.Bytes())
+
+	_, err := p.Send(ctx, w.ID, SendRequest{
+		FeeRateSatPerVB: feeRate,
+		RawOutputs: []TxOutSpec{
+			{RawScriptHex: hex.EncodeToString(drivechainScript), AmountSats: oldCtip},
+		},
+		ExternalInputs: []ExternalInput{{TxID: ctipTxid, Vout: 0, AmountSats: oldCtip}},
+	})
+	require.NoError(t, err)
+	require.Len(t, fake.broadcast, 1)
+
+	var tx wire.MsgTx
+	raw, err := hex.DecodeString(fake.broadcast[0])
+	require.NoError(t, err)
+	require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+	require.Len(t, tx.TxIn, 2, "external CTIP input + wallet input")
+
+	outSats := int64(0)
+	for _, o := range tx.TxOut {
+		outSats += o.Value
+	}
+	fee := walletAmount + oldCtip - outSats
+	vsize := int64((3*tx.SerializeSizeStripped() + tx.SerializeSize() + 3) / 4)
+	assert.GreaterOrEqual(t, fee, feeRate*vsize,
+		"fee must cover the whole transaction, external input included")
+}
+
 // TestElectrumSendUpdatesCacheInstantly proves a send reflects in balance, UTXOs
 // and history immediately with no re-scan: the fake Esplora still reports the
 // pre-send state, so anything showing the spend came from the local applySpend.
@@ -975,7 +1034,7 @@ func TestCreateElectrumWatchOnlyRejectsBadDescriptor(t *testing.T) {
 
 func TestEstimateFeeSats(t *testing.T) {
 	// 1 native-segwit input (68 vB) + 62 vB of outputs: 11+68+62 = 141 vB at 2 sat/vB.
-	assert.Equal(t, int64(282), estimateFeeSats(1, inputVsize(ScriptNativeSegwit), 62, 2))
+	assert.Equal(t, int64(282), estimateFeeSats(1, inputVsize(ScriptNativeSegwit), 62, 0, 2))
 }
 
 func TestConfsFor(t *testing.T) {
@@ -1294,9 +1353,9 @@ func TestElectrumSendRejectsMultiOutputSubtractFee(t *testing.T) {
 func TestEstimateFeeSatsByScriptKind(t *testing.T) {
 	// 1 input + 2 outputs (62 vB total) at 2 sat/vB.
 	nativeIn, legacyIn, taprootIn := inputVsize(ScriptNativeSegwit), inputVsize(ScriptLegacy), inputVsize(ScriptTaproot)
-	assert.Equal(t, int64(2*(11+68+62)), estimateFeeSats(1, nativeIn, 62, 2))
-	assert.Equal(t, int64(2*(11+148+62)), estimateFeeSats(1, legacyIn, 62, 2))
-	assert.Greater(t, estimateFeeSats(1, legacyIn, 62, 2), estimateFeeSats(1, taprootIn, 62, 2))
+	assert.Equal(t, int64(2*(11+68+62)), estimateFeeSats(1, nativeIn, 62, 0, 2))
+	assert.Equal(t, int64(2*(11+148+62)), estimateFeeSats(1, legacyIn, 62, 0, 2))
+	assert.Greater(t, estimateFeeSats(1, legacyIn, 62, 0, 2), estimateFeeSats(1, taprootIn, 62, 0, 2))
 }
 
 // TestDustThresholdByType: dust scales with the output's script type — the

--- a/sidechain-orchestrator/wallet/electrum_client.go
+++ b/sidechain-orchestrator/wallet/electrum_client.go
@@ -698,13 +698,17 @@ func (c *ElectrumClient) blockTime(ctx context.Context, height int) int64 {
 	return ts
 }
 
+// rememberHeight caches a tx's confirmation height. A height <= 0 revokes any
+// cached height, so a tx reorged back into the mempool stops reporting as
+// confirmed.
 func (c *ElectrumClient) rememberHeight(txid string, height int) {
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
 	if height <= 0 {
+		delete(c.heightByTx, txid)
 		return
 	}
-	c.cacheMu.Lock()
 	c.heightByTx[txid] = height
-	c.cacheMu.Unlock()
 }
 
 func (c *ElectrumClient) knownHeight(txid string) int {

--- a/sidechain-orchestrator/wallet/electrum_client_test.go
+++ b/sidechain-orchestrator/wallet/electrum_client_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"net"
+	"sync/atomic"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -168,6 +169,52 @@ func TestElectrumClientTxResolvesPrevoutAndFee(t *testing.T) {
 	require.Len(t, tx.Vout, 1)
 	assert.Equal(t, int64(90000), tx.Vout[0].Value)
 	assert.Equal(t, int64(10000), tx.Fee, "fee = inputs - outputs")
+}
+
+// TestElectrumClientHeightCacheRevoked proves a later height-0 sighting clears
+// the cached confirmation height, so a tx reorged back into the mempool stops
+// reporting as confirmed at its old height.
+func TestElectrumClientHeightCacheRevoked(t *testing.T) {
+	ctx := context.Background()
+	addr, pkScript := signetAddr(t)
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Hash: chainhash.Hash{0x22}, Index: 0}, nil, nil))
+	tx.AddTxOut(wire.NewTxOut(70000, pkScript))
+	txHex := txToHex(t, tx)
+	txID := tx.TxHash().String()
+
+	var height atomic.Int64
+	height.Store(800000)
+	url := startFakeElectrum(t, func(method string, _ []json.RawMessage) interface{} {
+		switch method {
+		case "blockchain.scripthash.get_history":
+			return []map[string]interface{}{{"tx_hash": txID, "height": height.Load()}}
+		case "blockchain.transaction.get":
+			return txHex
+		case "blockchain.block.header":
+			return "00"
+		}
+		return nil
+	})
+	c := NewElectrumClient(url, zerolog.Nop(), &chaincfg.SigNetParams)
+
+	txs, err := c.AddressTxs(ctx, addr)
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	require.True(t, txs[0].Status.Confirmed)
+	require.Equal(t, 800000, txs[0].Status.BlockHeight)
+
+	height.Store(0) // reorged back into the mempool
+	txs, err = c.AddressTxs(ctx, addr)
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	assert.False(t, txs[0].Status.Confirmed, "a height-0 sighting must revoke the cached height")
+
+	got, err := c.Tx(ctx, txID)
+	require.NoError(t, err)
+	assert.False(t, got.Status.Confirmed)
+	assert.Equal(t, 0, got.Status.BlockHeight)
 }
 
 func TestElectrumClientFeeRateConversion(t *testing.T) {

--- a/sidechain-orchestrator/wallet/multisiglounge.go
+++ b/sidechain-orchestrator/wallet/multisiglounge.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -8,7 +9,11 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
 )
 
 // MultisigLoungeKey is one cosigner key in a BitWindow multisig group.
@@ -241,8 +246,12 @@ func ValidateMultisigPsbt(psbtBase64 string, requiredSigs int, group *MultisigLo
 		if err != nil {
 			return MultisigPsbtValidation{}, err
 		}
+		accts, err := groupAccountKeys(*group)
+		if err != nil {
+			return MultisigPsbtValidation{}, err
+		}
 		for i := range packet.Inputs {
-			if err := verifyInputBelongsToGroup(packet.Inputs[i], origins); err != nil {
+			if err := verifyInputBelongsToGroup(packet.Inputs[i], prevOutForInput(packet, i), group.M, accts, origins); err != nil {
 				return MultisigPsbtValidation{}, fmt.Errorf("input %d %w", i, err)
 			}
 		}
@@ -503,11 +512,100 @@ func groupKeyOrigins(g MultisigLoungeGroup) ([]keyOrigin, error) {
 	return origins, nil
 }
 
-// verifyInputBelongsToGroup rejects a foreign PSBT input: every BIP32 derivation
-// record on the input must trace to one of the group's cosigner origins
-// (fingerprint + account path prefix). Derivation-independent — it matches on the
-// origin metadata the PSBT carries, not on re-derived addresses.
-func verifyInputBelongsToGroup(in psbt.PInput, origins []keyOrigin) error {
+// verifyInputBelongsToGroup rejects a foreign PSBT input. The binding check is
+// verifyInputScript: the k-of-n script the input actually commits to must be the
+// one the group's own cosigner keys re-derive, so an input the group cannot own
+// is refused whatever its metadata claims. The origin allow-list is kept as an
+// additional constraint, so deleting derivation records cannot weaken either.
+func verifyInputBelongsToGroup(in psbt.PInput, prevOut *wire.TxOut, m int, accts []*hdkeychain.ExtendedKey, origins []keyOrigin) error {
+	if err := verifyInputOrigins(in, origins); err != nil {
+		return err
+	}
+	return verifyInputScript(in, prevOut, m, accts)
+}
+
+// groupAccountKeys resolves the group's cosigner xpubs (SLIP-0132 forms included)
+// into the account extended keys the group's own scripts re-derive from.
+func groupAccountKeys(g MultisigLoungeGroup) ([]*hdkeychain.ExtendedKey, error) {
+	if len(g.Keys) == 0 {
+		return nil, errors.New("group has no keys")
+	}
+	accts := make([]*hdkeychain.ExtendedKey, 0, len(g.Keys))
+	for i, k := range g.Keys {
+		canonical, _, _, err := normalizeExtendedKey(k.Xpub)
+		if err != nil {
+			return nil, fmt.Errorf("group key %d: %w", i, err)
+		}
+		acct, err := hdkeychain.NewKeyFromString(canonical)
+		if err != nil {
+			return nil, fmt.Errorf("parse group key %d: %w", i, err)
+		}
+		accts = append(accts, acct)
+	}
+	return accts, nil
+}
+
+// verifyInputScript binds a PSBT input to the group by derivation: the k-of-n
+// script the input commits to (witness script, redeem script for legacy P2SH, or
+// multi_a tapleaf) must equal the one the group's cosigner keys derive at the
+// input's chain/index, and the prevout scriptPubKey must be that script's
+// wrapper. The input's derivation path is only the index hint — a wrong one
+// derives a different script and is rejected.
+func verifyInputScript(in psbt.PInput, prevOut *wire.TxOut, m int, accts []*hdkeychain.ExtendedKey) error {
+	if prevOut == nil {
+		return errors.New("has no witness or non-witness utxo; cannot verify it belongs to the group")
+	}
+	change, index, ok := chainIndexFromInput(in)
+	if !ok {
+		return errors.New("has no derivation path; cannot verify it belongs to the group")
+	}
+
+	var kinds []ScriptKind
+	var script []byte
+	switch {
+	case len(in.TaprootLeafScript) > 0:
+		kinds, script = []ScriptKind{ScriptMultisigTaproot}, in.TaprootLeafScript[0].Script
+	case in.WitnessScript != nil:
+		kinds, script = []ScriptKind{ScriptMultisig, ScriptMultisigNested}, in.WitnessScript
+	case in.RedeemScript != nil:
+		kinds, script = []ScriptKind{ScriptMultisigP2SH}, in.RedeemScript
+	default:
+		return errors.New("has no witness or redeem script; cannot verify it belongs to the group")
+	}
+
+	pubs := make([]*btcec.PublicKey, len(accts))
+	for i, a := range accts {
+		pub, err := deriveChildPub(a, chainIndex(change), index)
+		if err != nil {
+			return errors.New("does not belong to the multisig group (foreign input rejected)")
+		}
+		pubs[i] = pub
+	}
+
+	for _, kind := range kinds {
+		// The network only selects the address encoding; the script bytes
+		// compared here are the same on every network.
+		ds, err := multisigOutput(kind, m, pubs, &chaincfg.MainNetParams)
+		if err != nil {
+			return err
+		}
+		own := ds.witnessScript
+		switch kind {
+		case ScriptMultisigP2SH:
+			own = ds.redeemScript
+		case ScriptMultisigTaproot:
+			own = ds.tapLeafScript
+		}
+		if bytes.Equal(script, own) && bytes.Equal(prevOut.PkScript, ds.scriptPubKey) {
+			return nil
+		}
+	}
+	return errors.New("does not belong to the multisig group (foreign input rejected)")
+}
+
+// verifyInputOrigins requires every BIP32 derivation record on the input to trace
+// to one of the group's cosigner origins (fingerprint + account path prefix).
+func verifyInputOrigins(in psbt.PInput, origins []keyOrigin) error {
 	if len(in.TaprootBip32Derivation) > 0 {
 		for _, d := range in.TaprootBip32Derivation {
 			if !originMatches(d.MasterKeyFingerprint, d.Bip32Path, origins) {

--- a/sidechain-orchestrator/wallet/multisiglounge.go
+++ b/sidechain-orchestrator/wallet/multisiglounge.go
@@ -490,10 +490,10 @@ type keyOrigin struct {
 	path        []uint32
 }
 
-// groupKeyOrigins resolves each wallet key's [fingerprint/origin] into the
-// fingerprint + account path the PSBT BIP32 derivations carry. Keys without an
-// origin (non-wallet xpubs) contribute nothing — a group made entirely of such
-// keys cannot be verified and is rejected by the caller's per-input check.
+// groupKeyOrigins resolves each key's declared [fingerprint/origin] into the
+// fingerprint + account path the PSBT BIP32 derivations carry. Keys without one
+// contribute nothing: membership is proven by verifyInputScript, not by origin
+// metadata, so a group of bare xpubs is still verifiable.
 func groupKeyOrigins(g MultisigLoungeGroup) ([]keyOrigin, error) {
 	origins := make([]keyOrigin, 0, len(g.Keys))
 	for _, k := range g.Keys {
@@ -506,9 +506,6 @@ func groupKeyOrigins(g MultisigLoungeGroup) ([]keyOrigin, error) {
 		}
 		origins = append(origins, keyOrigin{fingerprint: fp, path: path})
 	}
-	if len(origins) == 0 {
-		return nil, errors.New("group has no wallet keys with derivable origins; cannot verify PSBT membership")
-	}
 	return origins, nil
 }
 
@@ -516,7 +513,7 @@ func groupKeyOrigins(g MultisigLoungeGroup) ([]keyOrigin, error) {
 // verifyInputScript: the k-of-n script the input actually commits to must be the
 // one the group's own cosigner keys re-derive, so an input the group cannot own
 // is refused whatever its metadata claims. The origin allow-list is kept as an
-// additional constraint, so deleting derivation records cannot weaken either.
+// additional constraint on records claiming a fingerprint the group declares.
 func verifyInputBelongsToGroup(in psbt.PInput, prevOut *wire.TxOut, m int, accts []*hdkeychain.ExtendedKey, origins []keyOrigin) error {
 	if err := verifyInputOrigins(in, origins); err != nil {
 		return err
@@ -603,12 +600,15 @@ func verifyInputScript(in psbt.PInput, prevOut *wire.TxOut, m int, accts []*hdke
 	return errors.New("does not belong to the multisig group (foreign input rejected)")
 }
 
-// verifyInputOrigins requires every BIP32 derivation record on the input to trace
-// to one of the group's cosigner origins (fingerprint + account path prefix).
+// verifyInputOrigins requires every BIP32 derivation record that claims one of
+// the group's fingerprints to trace to that fingerprint's origin (account path
+// prefix). Records claiming any other fingerprint are external cosigners — the
+// descriptor emits those keys bare, so Core tags them with the xpub's own
+// self-root fingerprint — and are left to verifyInputScript.
 func verifyInputOrigins(in psbt.PInput, origins []keyOrigin) error {
 	if len(in.TaprootBip32Derivation) > 0 {
 		for _, d := range in.TaprootBip32Derivation {
-			if !originMatches(d.MasterKeyFingerprint, d.Bip32Path, origins) {
+			if !originAllowed(d.MasterKeyFingerprint, d.Bip32Path, origins) {
 				return errors.New("does not belong to the multisig group (foreign input rejected)")
 			}
 		}
@@ -618,11 +618,26 @@ func verifyInputOrigins(in psbt.PInput, origins []keyOrigin) error {
 		return errors.New("has no BIP32 derivation records; cannot verify it belongs to the group")
 	}
 	for _, d := range in.Bip32Derivation {
-		if !originMatches(d.MasterKeyFingerprint, d.Bip32Path, origins) {
+		if !originAllowed(d.MasterKeyFingerprint, d.Bip32Path, origins) {
 			return errors.New("does not belong to the multisig group (foreign input rejected)")
 		}
 	}
 	return nil
+}
+
+// originAllowed reports whether a derivation record is consistent with the
+// group's origins: it either matches one, or claims a fingerprint the group does
+// not declare at all.
+func originAllowed(fingerprint uint32, path []uint32, origins []keyOrigin) bool {
+	if originMatches(fingerprint, path, origins) {
+		return true
+	}
+	for _, o := range origins {
+		if o.fingerprint == fingerprint {
+			return false
+		}
+	}
+	return true
 }
 
 // originMatches reports whether (fingerprint, path) starts with one of the

--- a/sidechain-orchestrator/wallet/multisiglounge_test.go
+++ b/sidechain-orchestrator/wallet/multisiglounge_test.go
@@ -299,6 +299,63 @@ func loungeForeignPSBT(t *testing.T) *psbt.Packet {
 	return packet
 }
 
+// loungeSiblingGroup builds a second 2-of-3 group that shares one account key
+// with the lounge test group and draws its other two cosigners from a different
+// seed — two groups a single member belongs to.
+func loungeSiblingGroup(t *testing.T, shared MultisigLoungeKey) MultisigLoungeGroup {
+	t.Helper()
+	net := &chaincfg.SigNetParams
+	const h = hdkeychain.HardenedKeyStart
+
+	master, err := hdkeychain.NewMaster(MnemonicToSeed(testMnemonic, "sibling"), net)
+	require.NoError(t, err)
+	mpub, err := master.ECPubKey()
+	require.NoError(t, err)
+	fp := hex.EncodeToString(btcutil.Hash160(mpub.SerializeCompressed())[:4])
+
+	keys := []MultisigLoungeKey{shared}
+	for acct := uint32(5); acct <= 6; acct++ {
+		k := master
+		for _, p := range []uint32{h + 48, h + 1, h + 0, h + acct} {
+			k, err = k.Derive(p)
+			require.NoError(t, err)
+		}
+		pub, nerr := k.Neuter()
+		require.NoError(t, nerr)
+		keys = append(keys, MultisigLoungeKey{
+			Xpub:        pub.String(),
+			Fingerprint: fp,
+			OriginPath:  fmt.Sprintf("48'/1'/0'/%d'", acct),
+		})
+	}
+	return MultisigLoungeGroup{M: 2, N: 3, Keys: keys}
+}
+
+// TestValidatePsbtStrippedOriginsCrossGroup proves an input is bound to its group
+// by the script it derives, not by the derivation records it happens to carry:
+// deleting group A's non-shared records leaves only the account key both groups
+// hold, which satisfies group B's origin allow-list — but the input still spends
+// group A's script and must be rejected.
+func TestValidatePsbtStrippedOriginsCrossGroup(t *testing.T) {
+	groupA, _ := loungeTestKeys(t)
+	accts := loungeTestAccts(t)
+
+	packet := loungeMultisigPSBT(t, accts, 0)
+	require.Len(t, packet.Inputs[0].Bip32Derivation, 3)
+	// Delete every record except the shared key's (m/48'/1'/0'/2', the first
+	// cosigner) — a deletion, forging nothing.
+	packet.Inputs[0].Bip32Derivation = packet.Inputs[0].Bip32Derivation[:1]
+	stripped := psbtToBase64(t, packet)
+
+	_, err := ValidateMultisigPsbt(stripped, 2, &groupA)
+	require.NoError(t, err, "stripping records must not break the owning group")
+
+	groupB := loungeSiblingGroup(t, groupA.Keys[0])
+	_, err = ValidateMultisigPsbt(stripped, 2, &groupB)
+	require.Error(t, err, "group A's input must not validate against group B")
+	assert.Contains(t, err.Error(), "foreign input rejected")
+}
+
 func TestValidatePsbtBadBase64(t *testing.T) {
 	_, err := ValidateMultisigPsbt("not-base64!!!", 2, nil)
 	require.Error(t, err)

--- a/sidechain-orchestrator/wallet/multisiglounge_test.go
+++ b/sidechain-orchestrator/wallet/multisiglounge_test.go
@@ -356,6 +356,75 @@ func TestValidatePsbtStrippedOriginsCrossGroup(t *testing.T) {
 	assert.Contains(t, err.Error(), "foreign input rejected")
 }
 
+// loungeBareCosignerPSBT builds the spend a group with one wallet key and two
+// bare-xpub cosigners produces: only the wallet key carries a [fp/origin], so the
+// other two derivation records fall back to the xpub's own self-root fingerprint
+// and a chain/index-only path — what Core emits for a prefix-less descriptor key.
+func loungeBareCosignerPSBT(t *testing.T, accts []*hdkeychain.ExtendedKey) *psbt.Packet {
+	t.Helper()
+	net := &chaincfg.SigNetParams
+	const amount = int64(100_000)
+	const dest = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+	keys := make([]DescriptorKey, len(accts))
+	for i, a := range accts {
+		keys[i] = DescriptorKey{Account: a}
+	}
+	keys[0].Origin = "73c5da0a/48h/1h/0h/2h"
+	d := &Descriptor{Kind: ScriptMultisig, Threshold: 2, Keys: keys}
+	ds, _, err := d.DeriveScript(false, 0, net)
+	require.NoError(t, err)
+	derivs, err := d.derivations(false, 0)
+	require.NoError(t, err)
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	prevTx.AddTxOut(wire.NewTxOut(amount, ds.scriptPubKey))
+	in := psbtInput{
+		outpoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 0},
+		amount:   amount,
+		addr: scannedAddr{
+			scriptPubKey: ds.scriptPubKey, witnessScript: ds.witnessScript,
+			kind: ScriptMultisig, derivations: derivs,
+		},
+	}
+	out := []TxOutSpec{{Address: dest, AmountBTC: float64(amount-1000) / 1e8}}
+	packet, err := buildPSBT([]psbtInput{in}, out, net, nil)
+	require.NoError(t, err)
+	return packet
+}
+
+// TestValidatePsbtBareXpubCosigners accepts a group's own spend when its external
+// cosigners were added as bare xpubs (no fingerprint/origin, the UI default): the
+// watch descriptor emits those keys without a prefix, so their derivation records
+// carry a fingerprint the group's origin allow-list cannot contain. A foreign
+// input is still rejected, by the script binding.
+func TestValidatePsbtBareXpubCosigners(t *testing.T) {
+	group, _ := loungeTestKeys(t)
+	for i := 1; i < len(group.Keys); i++ {
+		group.Keys[i] = MultisigLoungeKey{Xpub: group.Keys[i].Xpub}
+	}
+	accts := loungeTestAccts(t)
+
+	packet := loungeBareCosignerPSBT(t, accts)
+	bare := 0
+	for _, d := range packet.Inputs[0].Bip32Derivation {
+		if len(d.Bip32Path) == 2 {
+			bare++
+		}
+	}
+	require.Equal(t, 2, bare, "the two bare-xpub cosigners carry chain/index-only paths")
+
+	res, err := ValidateMultisigPsbt(psbtToBase64(t, packet), 2, &group)
+	require.NoError(t, err, "a group's own spend must not be rejected over external cosigner metadata")
+	assert.False(t, res.HasSignatures)
+
+	foreign := psbtToBase64(t, loungeForeignPSBT(t))
+	_, err = ValidateMultisigPsbt(foreign, 2, &group)
+	require.Error(t, err, "foreign PSBT must still be rejected")
+	assert.Contains(t, err.Error(), "foreign input rejected")
+}
+
 func TestValidatePsbtBadBase64(t *testing.T) {
 	_, err := ValidateMultisigPsbt("not-base64!!!", 2, nil)
 	require.Error(t, err)

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -1315,6 +1315,11 @@ func (s *Service) RemoveEncryption(password string) error {
 
 	plaintext, err := Decrypt(string(data), key)
 	if err != nil {
+		// An earlier attempt may have written the plaintext and then failed to
+		// delete the metadata; finish that instead of blaming the password.
+		if s.dropStaleEncryptionMetadata(data) {
+			return s.loadWalletFile()
+		}
 		s.log.Warn().Msg("remove encryption failed: incorrect password")
 		return fmt.Errorf("incorrect password")
 	}
@@ -1332,8 +1337,12 @@ func (s *Service) RemoveEncryption(password string) error {
 		return fmt.Errorf("write wallet: %w", err)
 	}
 
-	// Remove metadata file
-	_ = os.Remove(s.metadataFilePath())
+	// Remove metadata file. Until it is gone the wallet is plaintext on disk while
+	// the metadata still claims encryption, so a failure here must not report success.
+	if err := os.Remove(s.metadataFilePath()); err != nil && !os.IsNotExist(err) {
+		s.log.Error().Err(err).Str("path", s.metadataFilePath()).Msg("failed to remove encryption metadata")
+		return fmt.Errorf("remove encryption metadata: %w", err)
+	}
 
 	s.encryptionKey = nil
 	s.unlockedPass = ""
@@ -1640,6 +1649,35 @@ func (s *Service) isEncrypted() bool {
 	return meta.Encrypted
 }
 
+// dropStaleEncryptionMetadata removes wallet_encryption.json when it claims the
+// wallet is encrypted while wallet.json holds readable plaintext. RemoveEncryption
+// writes the plaintext before deleting the metadata, so an interrupted run leaves
+// exactly that state, and the correct password then fails forever. Reports whether
+// the stale metadata was dropped. Must be called with mu held.
+func (s *Service) dropStaleEncryptionMetadata(walletData []byte) bool {
+	if !s.isEncrypted() || !isPlaintextWalletFile(walletData) {
+		return false
+	}
+	if err := os.Remove(s.metadataFilePath()); err != nil && !os.IsNotExist(err) {
+		s.log.Error().Err(err).Str("path", s.metadataFilePath()).Msg("could not remove stale encryption metadata")
+		return false
+	}
+	s.encryptionKey = nil
+	s.unlockedPass = ""
+	s.log.Warn().Msg("wallet file is plaintext but metadata claimed encrypted; dropped stale encryption metadata")
+	return true
+}
+
+// isPlaintextWalletFile reports whether data is an unencrypted wallet file.
+// Ciphertext is base64(iv):base64(ct), so it never parses as wallet JSON.
+func isPlaintextWalletFile(data []byte) bool {
+	var wf WalletFile
+	if err := json.Unmarshal(data, &wf); err != nil {
+		return false
+	}
+	return wf.Version > 0 || len(wf.Wallets) > 0
+}
+
 // locked reports whether the wallet file is encrypted but no key is held, so
 // the stored wallets are neither loaded nor writable. Must be called with mu held.
 func (s *Service) locked() bool {
@@ -1682,6 +1720,9 @@ func (s *Service) loadWalletFile() error {
 	s.log.Debug().Int("file_size", len(data)).Bool("encrypted", s.isEncrypted()).Msg("wallet file read")
 
 	jsonStr := string(data)
+
+	// Recover from an interrupted RemoveEncryption before trusting the metadata.
+	s.dropStaleEncryptionMetadata(data)
 
 	// If encrypted, try to decrypt
 	if s.isEncrypted() {

--- a/sidechain-orchestrator/wallet/service_test.go
+++ b/sidechain-orchestrator/wallet/service_test.go
@@ -220,6 +220,56 @@ func TestServiceRemoveEncryption(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(data, &check), "wallet.json should be valid JSON after removing encryption")
 }
 
+// staleEncryptionMetadata returns a service whose wallet.json is plaintext while
+// wallet_encryption.json still claims encryption — what a RemoveEncryption that
+// died before deleting the metadata leaves behind. Skips Init so the file watcher
+// cannot reload (and heal) the hand-restored metadata concurrently.
+func staleEncryptionMetadata(t *testing.T, password string) (*Service, string) {
+	t.Helper()
+	log := zerolog.New(zerolog.NewTestWriter(t)).With().Timestamp().Logger()
+	svc := NewService(t.TempDir(), log)
+
+	_, err := svc.GenerateWallet("Stale Meta", "", "", testSlots)
+	require.NoError(t, err)
+	require.NoError(t, svc.EncryptWallet(password))
+
+	metaPath := svc.metadataFilePath()
+	metaBytes, err := os.ReadFile(metaPath)
+	require.NoError(t, err)
+	require.NoError(t, svc.RemoveEncryption(password))
+	require.NoError(t, os.WriteFile(metaPath, metaBytes, 0600))
+	require.True(t, svc.IsEncrypted())
+
+	return svc, metaPath
+}
+
+// Reloading a wallet left in that state must drop the stale metadata instead of
+// leaving the correct password rejected forever.
+func TestServiceStaleEncryptionMetadataDroppedOnLoad(t *testing.T) {
+	svc, metaPath := staleEncryptionMetadata(t, "mypass")
+
+	svc.mu.Lock()
+	err := svc.loadWalletFile()
+	svc.mu.Unlock()
+	require.NoError(t, err)
+
+	assert.False(t, svc.IsEncrypted())
+	assert.True(t, svc.IsUnlocked())
+	assert.Len(t, svc.ListWallets(), 1)
+	_, err = os.Stat(metaPath)
+	assert.True(t, os.IsNotExist(err), "stale encryption metadata should be gone")
+}
+
+// Retrying RemoveEncryption must also recover, rather than failing the correct
+// password against the plaintext wallet.json.
+func TestServiceStaleEncryptionMetadataRemoveEncryptionRetry(t *testing.T) {
+	svc, _ := staleEncryptionMetadata(t, "mypass")
+
+	require.NoError(t, svc.RemoveEncryption("mypass"))
+	assert.False(t, svc.IsEncrypted())
+	assert.Len(t, svc.ListWallets(), 1)
+}
+
 func TestServiceSwitchWallet(t *testing.T) {
 	svc := newTestService(t)
 

--- a/sidechain-orchestrator/wallet/sizes.go
+++ b/sidechain-orchestrator/wallet/sizes.go
@@ -27,6 +27,10 @@ func inputVsize(kind ScriptKind) int {
 	}
 }
 
+// externalInputVsize is the vbytes to spend one external (non-wallet, unsigned)
+// input: outpoint + sequence + empty scriptSig len.
+const externalInputVsize = 32 + 4 + 4 + 1
+
 // walletInputVsize returns the vbytes to spend one of a wallet's inputs, sized
 // from its descriptor — accurate for m-of-n multisig, where the witness scales
 // with the threshold and key count rather than a fixed 2-of-3 guess.
@@ -164,9 +168,10 @@ func dustForOutput(o TxOutSpec, net *chaincfg.Params) int64 {
 	return dustThreshold(addressKind(o.Address, net))
 }
 
-// estimateFeeSats returns the fee for a tx of nIn inputs (inVsize vbytes each)
-// and outVsize total output vbytes at feeRate sat/vB, plus ~11 vB of overhead.
-func estimateFeeSats(nIn, inVsize, outVsize int, feeRate float64) int64 {
-	vsize := 11 + nIn*inVsize + outVsize
+// estimateFeeSats returns the fee for a tx of nIn inputs (inVsize vbytes each),
+// outVsize total output vbytes and extraVsize vbytes of any further inputs, at
+// feeRate sat/vB, plus ~11 vB of overhead.
+func estimateFeeSats(nIn, inVsize, outVsize, extraVsize int, feeRate float64) int64 {
+	vsize := 11 + nIn*inVsize + outVsize + extraVsize
 	return int64(math.Ceil(float64(vsize) * feeRate))
 }


### PR DESCRIPTION
This is a single PR containing **36 independent fixes** for BitWindow, stacked in one branch — as requested, so they can be reviewed in one place and cherry-picked individually.

Every commit is self-contained and touches only its own bug: each was built and reviewed on its own before being stacked. `36` commits, `66 files changed, 2801 insertions(+), 416 deletions(-)` total, based on current `master`.

## Fixes in this stack (oldest first)

1. **`ac0cf153`** — Stripped PSBT origins let one group authorize signing another group's funds
   <br>2 files changed, 161 insertions(+), 6 deletions(-)
2. **`32447efe`** — BitWindow RemoveEncryption metadata-remove swallow leaves wallet plaintext + stale-encrypted → permanent correct-password lockout
   <br>2 files changed, 93 insertions(+), 2 deletions(-)
3. **`7a47de3c`** — MultisigLounge rejects valid spends with external cosigners
   <br>2 files changed, 96 insertions(+), 12 deletions(-)
4. **`70b4015a`** — BIP47 inbound scanner skips new notifications after first pass
   <br>4 files changed, 167 insertions(+), 77 deletions(-)
5. **`b151ea9c`** — Electrum external inputs are omitted from fee-rate sizing
   <br>3 files changed, 75 insertions(+), 11 deletions(-)
6. **`a0f625bf`** — Failed BIP47 notification import is cached as wallet-ready and never retried
   <br>2 files changed, 96 insertions(+), 5 deletions(-)
7. **`8aec7135`** — Implicit-mainnet private bitcoin.conf splits orchestrator state from bitcoind launch config
   <br>4 files changed, 73 insertions(+), 14 deletions(-)
8. **`ed671241`** — BitWindow multisig `extractAccountIndex` parses coin_type, not account, on BIP84 paths → `GetNextAccountIndex` always returns 8000
   <br>3 files changed, 68 insertions(+), 22 deletions(-)
9. **`78744472`** — BitWindow bitwindowd main.go only catches SIGINT; SIGTERM bypasses graceful shutdown and orphans orchestratord
   <br>1 file changed, 4 insertions(+), 1 deletion(-)
10. **`36148165`** — BitWindow migration 013 DROP-resets denials AUTOINCREMENT, orphan executed_denials cross-link new denial
   <br>2 files changed, 68 insertions(+)
11. **`a4efb944`** — BitWindow cpuminer `high-hash` rejection loops forever without refreshing work
   <br>2 files changed, 108 insertions(+)
12. **`0b4e6576`** — CoinNews skips valid 36-byte OP_RETURN payloads
   <br>3 files changed, 49 insertions(+), 4 deletions(-)
13. **`3b1aff2f`** — BitWindow `CreateBitcoinCoreWallet` can collide with managed Core wallet names
   <br>2 files changed, 45 insertions(+)
14. **`b910efa8`** — BitWindow MultisigKeyModal swallows server-side addSoloKey failure and lies to user about multisig.json persistence
   <br>1 file changed, 10 insertions(+), 14 deletions(-)
15. **`edd8b5e9`** — BitWindow `FundGroupModal` can derive multisig funding addresses outside the imported watch-wallet descriptor range
   <br>3 files changed, 232 insertions(+), 30 deletions(-)
16. **`76a3e2c2`** — Orchestrator retry skips BIP84 descriptor import after partial Core wallet creation
   <br>2 files changed, 83 insertions(+), 11 deletions(-)
17. **`26e7216b`** — BitWindow deniability `GetByTip` OR-vout predicate returns a denial whose real tip outpoint differs from the query (cross-outpoint wrong match), driving wrong-target `Update`
   <br>2 files changed, 25 insertions(+), 2 deletions(-)
18. **`5d283116`** — BitWindow `EnsureWatchOnlyWallet` orchestrator-fallback naming divergence
   <br>2 files changed, 90 insertions(+), 2 deletions(-)
19. **`5e625741`** — Multisig RestoreHistory saves outgoing change as an inbound deposit
   <br>2 files changed, 45 insertions(+), 79 deletions(-)
20. **`a58afc55`** — Config reload races live config consumers and crashes orchestratord
   <br>2 files changed, 53 insertions(+), 25 deletions(-)
21. **`4c00293e`** — `drivechain-frontends` ElectrumClient per-transaction `heightByTx` cache survives backend invalidation
   <br>2 files changed, 53 insertions(+), 2 deletions(-)
22. **`d442e675`** — BitWindow orchestrator CoreBackend NextChangeAddress ignores wallet script kind (hardcoded bech32 change for taproot wallets)
   <br>3 files changed, 63 insertions(+), 3 deletions(-)
23. **`89de6ddc`** — drivechain-frontends/sidechain-orchestrator — Reset's detached restart can start a managed child after ShutdownAll returns
   <br>4 files changed, 53 insertions(+), 2 deletions(-)
24. **`5b43ed9d`** — BitWindow `ListWithdrawals` does not revive a failed bundle after a valid re-submission
   <br>2 files changed, 50 insertions(+), 1 deletion(-)
25. **`914d68e0`** — BitWindow lists orphaned OP_RETURN and file_timestamps rows after reorg
   <br>3 files changed, 86 insertions(+)
26. **`e0ecfb44`** — BitWindow orchestrator reset restart loop aborts on first binary failure and does not report it to DeleteFiles caller
   <br>2 files changed, 67 insertions(+), 5 deletions(-)
27. **`9b8c8ef4`** — BitWindow keeps unmined ZMQ OP_RETURN rows public forever
   <br>3 files changed, 73 insertions(+)
28. **`62e57340`** — sidechain-orchestrator `StopBinary` adopts pid 0 and silently returns success
   <br>4 files changed, 47 insertions(+)
29. **`09e43629`** — RestartDaemon concurrent requests spawn duplicate daemon processes
   <br>2 files changed, 48 insertions(+), 1 deletion(-)
30. **`73a2fb42`** — BitWindow's deniability engine Bitcoin Core send branch (sendBitcoinCoreTransaction) hands Core a destinations-only Send with no required-input binding, so a deniability hop can spend unrelated wallet UTXOs and leave the selected tracked outpoint unspent while RecordExecution still records the tracked outpoint as moved
   <br>4 files changed, 233 insertions(+), 124 deletions(-)
31. **`f4869105`** — BitWindow's signed-PSBT import does not scope the imported transaction_id to the selected group, so addOrUpdateKeyPSBT appends a foreign (non-member) signer to another group's transaction and advances its readiness against the wrong group's threshold
   <br>3 files changed, 131 insertions(+), 9 deletions(-)
32. **`d1f045d9`** — BitWindow's BIP47 send path broadcasts the on-chain notification transaction and durably advances local BIP47 state (notification txid + next send index) before the actual payment is sent, so a failed first payment leaves a paid-for notification and a burned send index with no rollback
   <br>4 files changed, 79 insertions(+), 8 deletions(-)
33. **`0c137319`** — BitWindow's ListSidechainDeposits handler treats sidechain slot 0 as an implicit "no filter / all-slots" sentinel (the `Slot != 0 &&` guard short-circuits), so viewing a slot-0 sidechain's deposits returns every other sidechain's deposits, and the emitted rows carry no sidechain number to distinguish the foreign deposits
   <br>2 files changed, 66 insertions(+), 1 deletion(-)
34. **`4bc5e4d7`** — Orchestrator fixed-fee required-input amount can burn change
   <br>2 files changed, 103 insertions(+), 14 deletions(-)
35. **`fce6ff67`** — BitWindow ListSidechains panics on nil enforcer declaration
   <br>2 files changed, 69 insertions(+), 11 deletions(-)
36. **`7c7b5e34`** — BitWindow `ListSidechainDeposits` accepts negative `slot` and wraps it to `uint32`, hiding caller-visible deposits
   <br>2 files changed, 21 insertions(+)

## Notes

- Each commit stands alone — `git cherry-pick <sha>` works for any of them individually; nothing depends on an earlier fix in the stack.
- Go changes were verified with `go build ./...` / `go test ./...`; Dart changes with `flutter pub get --enforce-lockfile` + `dart analyze` (Flutter 3.44.8, matching CI).
- Happy to split this into separate PRs, reorder, or drop any of them — just say which.
