### PR TITLE
drynet4 fixes, seed import and bmm bid bounds

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.292
+version: 1.0.293
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.292
+version: 1.0.293
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/lib/pages/welcome/multisig_config_step.dart
+++ b/bitwindow/lib/pages/welcome/multisig_config_step.dart
@@ -1330,7 +1330,31 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
               ),
             ],
           ),
-          child: SailText.primary16('Generate Key', bold: true, color: SailColorScheme.white),
+          child: SailText.primary16('Generate new seed', bold: true, color: SailColorScheme.white),
+        ),
+      ),
+    );
+  }
+
+  // Equal weight to generating: a user who already has a seed has nowhere else
+  // to put it, and the ghost row below reads as fine print.
+  Widget _pasteSeedButton(BuildContext context, int index) {
+    final theme = SailTheme.of(context);
+    final enabled = _pathError == null;
+    return Opacity(
+      opacity: enabled ? 1 : 0.5,
+      child: SailTappable(
+        onTap: enabled ? () async => _addSoftwareKeystore(context, index, mode: SeedEntryMode.importExisting) : null,
+        child: Container(
+          width: 400,
+          padding: const EdgeInsets.symmetric(horizontal: 36, vertical: 18),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(10),
+            color: theme.colors.backgroundSecondary,
+            border: Border.all(color: theme.colors.border),
+          ),
+          child: SailText.primary16('Paste seed phrase', bold: true),
         ),
       ),
     );
@@ -1348,7 +1372,15 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         const SizedBox(height: 8),
-        _generateKeyButton(context, index),
+        Wrap(
+          alignment: WrapAlignment.center,
+          spacing: 16,
+          runSpacing: 12,
+          children: [
+            _generateKeyButton(context, index),
+            _pasteSeedButton(context, index),
+          ],
+        ),
         const SizedBox(height: 28),
         Wrap(
           alignment: WrapAlignment.center,
@@ -1417,11 +1449,15 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
     }
   }
 
-  Future<void> _addSoftwareKeystore(BuildContext context, int index) async {
+  Future<void> _addSoftwareKeystore(
+    BuildContext context,
+    int index, {
+    SeedEntryMode mode = SeedEntryMode.generate,
+  }) async {
     setState(() => _error = null);
     final seed = await Navigator.of(
       context,
-    ).push<SeedBackup>(MaterialPageRoute(builder: (_) => const WalletBackupPage()));
+    ).push<SeedBackup>(MaterialPageRoute(builder: (_) => WalletBackupPage(mode: mode)));
     if (seed == null || seed.mnemonic.isEmpty) {
       return;
     }

--- a/bitwindow/lib/pages/welcome/wallet_backup_page.dart
+++ b/bitwindow/lib/pages/welcome/wallet_backup_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:bip39_mnemonic/bip39_mnemonic.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
@@ -12,12 +13,19 @@ class SeedBackup {
   const SeedBackup(this.mnemonic, this.passphrase);
 }
 
-enum _Stage { backup, reenter }
+/// Where the seed comes from: minted here, or one the user already has.
+enum SeedEntryMode { generate, importExisting }
+
+enum _Stage { backup, reenter, import }
 
 /// Shows a freshly generated seed, offers a passphrase or the user's own
 /// entropy, then makes the user type the words back before accepting them.
+/// In [SeedEntryMode.importExisting] the same grid starts empty and the user
+/// pastes their own words into it.
 class WalletBackupPage extends StatefulWidget {
-  const WalletBackupPage({super.key});
+  final SeedEntryMode mode;
+
+  const WalletBackupPage({super.key, this.mode = SeedEntryMode.generate});
 
   @override
   State<WalletBackupPage> createState() => _WalletBackupPageState();
@@ -29,8 +37,9 @@ class _WalletBackupPageState extends State<WalletBackupPage> {
   final TextEditingController _entropy = TextEditingController();
   final TextEditingController _passphrase = TextEditingController();
   List<TextEditingController> _reentered = [];
+  List<TextEditingController> _imported = [];
 
-  _Stage _stage = _Stage.backup;
+  late _Stage _stage;
   List<String> _words = [];
   int _wordCount = 12;
   bool _paranoid = false;
@@ -42,6 +51,12 @@ class _WalletBackupPageState extends State<WalletBackupPage> {
   @override
   void initState() {
     super.initState();
+    if (widget.mode == SeedEntryMode.importExisting) {
+      _stage = _Stage.import;
+      _imported = List.generate(_wordCount, (_) => TextEditingController());
+      return;
+    }
+    _stage = _Stage.backup;
     unawaited(_generate());
   }
 
@@ -49,7 +64,7 @@ class _WalletBackupPageState extends State<WalletBackupPage> {
   void dispose() {
     _entropy.dispose();
     _passphrase.dispose();
-    for (final c in _reentered) {
+    for (final c in [..._reentered, ..._imported]) {
       c.dispose();
     }
     super.dispose();
@@ -155,8 +170,88 @@ class _WalletBackupPageState extends State<WalletBackupPage> {
   }
 
   Future<void> _setWordCount(int count) async {
+    if (_stage == _Stage.import) {
+      setState(() => _resizeImported(count));
+      return;
+    }
     setState(() => _wordCount = count);
     await (_paranoid ? _derive(_entropy.text) : _generate());
+  }
+
+  /// Grows or shrinks the input grid, keeping whatever is already typed.
+  /// Call inside setState.
+  void _resizeImported(int count) {
+    _wordCount = count;
+    final kept = _imported.take(count).toList();
+    final dropped = _imported.skip(count).toList();
+    _imported = [
+      ...kept,
+      ...List.generate(count - kept.length, (_) => TextEditingController()),
+    ];
+    // The TextFields holding these are still mounted until the rebuild lands.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      for (final c in dropped) {
+        c.dispose();
+      }
+    });
+  }
+
+  List<String> get _importedWords =>
+      _imported.map((c) => c.text.trim().toLowerCase()).where((w) => w.isNotEmpty).toList();
+
+  int get _importedCount => _importedWords.length;
+
+  /// Valid only when every box is filled and the words form a real BIP39
+  /// sentence — a typo in one word changes the wallet silently, so the
+  /// checksum is what the Create button waits for.
+  bool get _importValid {
+    if (_importedCount != _imported.length) {
+      return false;
+    }
+    try {
+      Mnemonic.fromSentence(_importedWords.join(' '), Language.english);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Spreads a multi-word paste across the boxes. A full 12 or 24 words is the
+  /// whole phrase however it arrived, so it fills the grid from the start and
+  /// resizes it to fit; anything shorter fills forward from [index].
+  void _spread(int index, String value) {
+    final words = value.trim().toLowerCase().split(RegExp(r'\s+')).where((w) => w.isNotEmpty).toList();
+    if (words.length < 2) {
+      setState(() {});
+      return;
+    }
+    final wholePhrase = words.length == 12 || words.length == 24;
+    final start = wholePhrase ? 0 : index;
+    setState(() {
+      if (wholePhrase && words.length != _imported.length) {
+        _resizeImported(words.length);
+      }
+      for (var i = 0; i < words.length && start + i < _imported.length; i++) {
+        _imported[start + i].text = words[i];
+      }
+    });
+  }
+
+  Future<void> _pasteFromClipboard() async {
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    final text = data?.text?.trim() ?? '';
+    if (text.isEmpty) {
+      setState(() => _error = 'Clipboard is empty');
+      return;
+    }
+    setState(() => _error = null);
+    _spread(0, text);
+  }
+
+  void _finishImport() {
+    Navigator.of(context).pop(
+      SeedBackup(_importedWords.join(' '), _wantPassphrase ? _passphrase.text : ''),
+    );
   }
 
   Future<void> _enableParanoid(BuildContext context) async {
@@ -328,7 +423,11 @@ class _WalletBackupPageState extends State<WalletBackupPage> {
                 child: Center(
                   child: SizedBox(
                     width: 900,
-                    child: _stage == _Stage.backup ? _backupBody(context) : _reenterBody(context),
+                    child: switch (_stage) {
+                      _Stage.backup => _backupBody(context),
+                      _Stage.reenter => _reenterBody(context),
+                      _Stage.import => _importBody(context),
+                    },
                   ),
                 ),
               ),
@@ -500,6 +599,107 @@ class _WalletBackupPageState extends State<WalletBackupPage> {
     );
   }
 
+  Widget _importBody(BuildContext context) {
+    final theme = SailTheme.of(context);
+    final complete = _importedCount == _imported.length;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _heading(
+          'Enter your seed phrase',
+          'Paste the words from your backup, or type them into the numbered boxes. '
+              'They rebuild the same keys, so any coins on them come back with the wallet.',
+        ),
+        SailCard(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        SailText.primary16('Mnemonic Words (BIP39)', bold: true),
+                        SailText.secondary13('Paste the whole phrase into the first box, or fill them one by one.'),
+                      ],
+                    ),
+                  ),
+                  SizedBox(
+                    width: 210,
+                    child: SailDropdownButton<int>(
+                      value: _wordCount,
+                      onChanged: (v) async {
+                        if (v != null) {
+                          await _setWordCount(v);
+                        }
+                      },
+                      items: const [
+                        SailDropdownItem<int>(value: 12, label: 'Use 12 Words'),
+                        SailDropdownItem<int>(value: 24, label: 'Use 24 Words'),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              SailMnemonicGrid(
+                controllers: _imported,
+                onChanged: _spread,
+              ),
+              const SizedBox(height: 16),
+              _optionLinks(context),
+              if (_wantPassphrase) ...[
+                const SizedBox(height: 12),
+                SizedBox(
+                  width: 300,
+                  child: SailTextField(
+                    controller: _passphrase,
+                    hintText: 'Passphrase',
+                    size: TextFieldSize.small,
+                  ),
+                ),
+              ],
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: _importValid
+                        ? Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              SailSVG.icon(SailSVGAsset.iconSuccess, width: 12, color: theme.colors.success),
+                              const SizedBox(width: 6),
+                              SailText.secondary13('Valid checksum', color: theme.colors.success),
+                            ],
+                          )
+                        : SailText.secondary13(
+                            complete
+                                ? 'These words are not a valid BIP39 phrase — check for a typo'
+                                : '$_importedCount of ${_imported.length} words entered',
+                            color: complete ? theme.colors.error : theme.colors.textSecondary,
+                          ),
+                  ),
+                  const SizedBox(width: 12),
+                  SailButton(
+                    label: 'Paste from clipboard',
+                    variant: ButtonVariant.secondary,
+                    onPressed: _pasteFromClipboard,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        if (_error != null) ...[
+          const SizedBox(height: 12),
+          SailText.secondary12(_error!, color: theme.colors.error),
+        ],
+      ],
+    );
+  }
+
   Widget _reenterBody(BuildContext context) {
     final theme = SailTheme.of(context);
     return Column(
@@ -534,7 +734,11 @@ class _WalletBackupPageState extends State<WalletBackupPage> {
 
   Widget _bottomBar(BuildContext context) {
     final theme = SailTheme.of(context);
-    final ready = _stage == _Stage.backup ? _words.isNotEmpty && !_busy : _reenterMatches;
+    final ready = switch (_stage) {
+      _Stage.backup => _words.isNotEmpty && !_busy,
+      _Stage.reenter => _reenterMatches,
+      _Stage.import => _importValid,
+    };
     return Container(
       height: 64,
       padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
@@ -556,7 +760,11 @@ class _WalletBackupPageState extends State<WalletBackupPage> {
                 label: 'Create Wallet',
                 loading: _busy,
                 disabled: !ready,
-                onPressed: () async => _stage == _Stage.backup ? await _startReenter(context) : _finish(),
+                onPressed: () async => switch (_stage) {
+                  _Stage.backup => await _startReenter(context),
+                  _Stage.reenter => _finish(),
+                  _Stage.import => _finishImport(),
+                },
               ),
             ],
           ),

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.152
+version: 0.2.153
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/test/wallet_backup_page_test.dart
+++ b/bitwindow/test/wallet_backup_page_test.dart
@@ -34,18 +34,18 @@ class _FakeWriter extends WalletWriterProvider {
 }
 
 /// The page targets a desktop window; the default 800x600 surface overflows it.
-Future<void> _pumpPage(WidgetTester tester) async {
+Future<void> _pumpPage(WidgetTester tester, {SeedEntryMode mode = SeedEntryMode.generate}) async {
   await tester.binding.setSurfaceSize(const Size(1440, 1024));
   addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.pumpWidget(_app());
+  await tester.pumpWidget(_app(mode));
   await tester.pumpAndSettle();
 }
 
-Widget _app() {
+Widget _app(SeedEntryMode mode) {
   return MaterialApp(
     home: SailTheme(
       data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
-      child: const WalletBackupPage(),
+      child: WalletBackupPage(mode: mode),
     ),
   );
 }
@@ -172,5 +172,101 @@ void main() {
     await tester.enterText(boxes.at(4), 'wrong');
     await tester.pump();
     expect(_createWalletButton(tester).disabled, isTrue);
+  });
+
+  group('import mode', () {
+    const phrase = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    final long = '${'abandon ' * 23}art';
+
+    testWidgets('opens on an empty grid without minting a seed', (tester) async {
+      await _pumpPage(tester, mode: SeedEntryMode.importExisting);
+
+      expect(find.text('Enter your seed phrase'), findsOneWidget);
+      expect(find.byType(TextField), findsNWidgets(12));
+      expect(writer.calls, 0, reason: 'importing a seed must not generate one');
+      expect(_createWalletButton(tester).disabled, isTrue);
+    });
+
+    // Nobody types 12 words into 12 boxes; they paste the phrase into the first.
+    testWidgets('pasting the whole phrase into the first box fills the grid', (tester) async {
+      await _pumpPage(tester, mode: SeedEntryMode.importExisting);
+
+      await tester.enterText(find.byType(TextField).first, phrase);
+      await tester.pump();
+
+      expect(find.text('about'), findsOneWidget);
+      expect(find.text('abandon'), findsNWidgets(11));
+      expect(find.text('Valid checksum'), findsOneWidget);
+      expect(_createWalletButton(tester).disabled, isFalse);
+    });
+
+    // A wrong word derives a different wallet in silence, so the checksum has
+    // to hold the button shut.
+    testWidgets('a phrase that fails its checksum cannot continue', (tester) async {
+      await _pumpPage(tester, mode: SeedEntryMode.importExisting);
+
+      await tester.enterText(find.byType(TextField).first, phrase.replaceFirst('about', 'zebra'));
+      await tester.pump();
+
+      expect(find.textContaining('not a valid BIP39 phrase'), findsOneWidget);
+      expect(_createWalletButton(tester).disabled, isTrue);
+    });
+
+    // The grid opens at 12, so a 24-word backup has to grow it on paste.
+    testWidgets('pasting 24 words switches the grid to 24', (tester) async {
+      await _pumpPage(tester, mode: SeedEntryMode.importExisting);
+
+      await tester.enterText(find.byType(TextField).first, long);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextField), findsNWidgets(24));
+      expect(find.text('art'), findsOneWidget);
+      expect(find.text('Valid checksum'), findsOneWidget);
+      expect(_createWalletButton(tester).disabled, isFalse);
+    });
+
+    testWidgets('pasting 12 words into a 24 grid switches back to 12', (tester) async {
+      await _pumpPage(tester, mode: SeedEntryMode.importExisting);
+
+      await tester.enterText(find.byType(TextField).first, long);
+      await tester.pumpAndSettle();
+      expect(find.byType(TextField), findsNWidgets(24));
+
+      await tester.enterText(find.byType(TextField).first, phrase);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextField), findsNWidgets(12));
+      expect(find.text('about'), findsOneWidget);
+      expect(find.text('Valid checksum'), findsOneWidget);
+    });
+
+    // Pasting into whichever box happens to have focus is still a whole-phrase
+    // paste, so it must land in order from the first box, not from that one.
+    testWidgets('a full phrase pasted into a later box still fills from the start', (tester) async {
+      await _pumpPage(tester, mode: SeedEntryMode.importExisting);
+
+      await tester.enterText(find.byType(TextField).at(4), phrase);
+      await tester.pumpAndSettle();
+
+      expect(find.text('about'), findsOneWidget);
+      expect(find.text('abandon'), findsNWidgets(11));
+      expect(find.text('Valid checksum'), findsOneWidget);
+    });
+
+    testWidgets('switching to 24 words keeps what was already typed', (tester) async {
+      await _pumpPage(tester, mode: SeedEntryMode.importExisting);
+
+      await tester.enterText(find.byType(TextField).first, phrase);
+      await tester.pump();
+
+      await tester.tap(find.text('Use 12 Words'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Use 24 Words').last);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextField), findsNWidgets(24));
+      expect(find.text('about'), findsOneWidget);
+      expect(_createWalletButton(tester).disabled, isTrue, reason: '12 of 24 boxes are still empty');
+    });
   });
 }

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.165
+version: 1.0.166
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/pages/create_wallet_page.dart
+++ b/sail_ui/lib/pages/create_wallet_page.dart
@@ -213,135 +213,229 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
   // ignore: avoid_build_methods
   Widget _buildInitialScreen() {
     final theme = SailTheme.of(context);
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 32.0),
-        child: SizedBox(
-          width: 800,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisSize: MainAxisSize.max,
-            children: [
-              BootTitle(
-                title: hasExistingWallet ? 'Create Another Wallet' : 'Set up your wallet',
-                subtitle: hasExistingWallet
-                    ? "Let's create another wallet. This will add a new wallet to your collection without affecting your existing wallets."
-                    : "Welcome to ${widget.appName}! Let's begin by setting up your wallet.",
-              ),
-              if (hasExistingWallet) ...[
-                const SizedBox(height: 32),
-                SizedBox(
-                  width: 400,
-                  child: SailTextField(
+    return SingleChildScrollView(
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32.0),
+          child: SizedBox(
+            width: 560,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                BootTitle(
+                  title: hasExistingWallet ? 'Add a wallet' : 'Set up your wallet',
+                  subtitle: hasExistingWallet
+                      ? 'Runs alongside your existing wallets. Nothing you already have is touched.'
+                      : 'Pick where ${widget.appName} reads chain data from. The seed phrase is the same either way.',
+                ),
+                if (hasExistingWallet) ...[
+                  SailTextField(
                     controller: _walletNameController,
                     hintText: 'Wallet name (required)',
                     textFieldType: TextFieldType.text,
                     size: TextFieldSize.regular,
                   ),
+                  const SizedBox(height: 24),
+                ],
+                _buildProviderCards(theme),
+                const SizedBox(height: 24),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(child: _buildGenerateButton(theme)),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: _buildActionCard(
+                        theme: theme,
+                        title: 'Paste a seed phrase',
+                        subtitle: 'Import an existing 12 or 24-word mnemonic',
+                        onPressed: (_isGenerating || _awaitingBackend) ? null : () => _setScreen(WelcomeScreen.restore),
+                      ),
+                    ),
+                  ],
                 ),
+                if (_error != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: SailStyleValues.padding08),
+                    child: SailText.primary13(_error!, color: theme.colors.error),
+                  ),
+                const SizedBox(height: 16),
+                _buildDerivationOptions(theme),
+                const SizedBox(height: 32),
               ],
-              const SizedBox(height: 16),
-              SizedBox(width: 400, child: _buildDerivationOptions(theme)),
-              const SizedBox(height: 32),
-              Spacer(),
-              SizedBox(
-                width: 400,
-                height: 64,
-                child: MouseRegion(
-                  cursor: (_isGenerating || _awaitingBackend) ? SystemMouseCursors.basic : SystemMouseCursors.click,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        colors: [theme.colors.primary, theme.colors.primary],
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                      ),
-                      borderRadius: BorderRadius.circular(8),
-                      boxShadow: [
-                        BoxShadow(color: Colors.black12, blurRadius: 4, offset: Offset(0, 2)),
-                      ],
-                    ),
-                    child: TextButton(
-                      onPressed: (_isGenerating || _awaitingBackend)
-                          ? null
-                          : () {
-                              setState(() => _isGenerating = true);
-                              // Schedule the wallet generation to run after this frame
-                              WidgetsBinding.instance.addPostFrameCallback((_) {
-                                _handleFastMode();
-                              });
-                            },
-                      style: TextButton.styleFrom(
-                        padding: EdgeInsets.zero,
-                        minimumSize: Size.zero,
-                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                      ),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 16),
-                            child: SailText.primary15(
-                              _awaitingBackend
-                                  ? 'Connecting to bitwindowd…'
-                                  : _isGenerating
-                                  ? 'Generating Your Wallet'
-                                  : hasExistingWallet
-                                  ? 'Create Another Wallet'
-                                  : 'Generate Wallet',
-                              color: Colors.white,
-                              bold: true,
-                            ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // _buildProviderCards renders the wallet type as a choice rather than a
+  // dropdown. Bitcoin Core stays visible while unavailable so it reads as
+  // "not yet" instead of missing.
+  Widget _buildProviderCards(SailThemeData theme) {
+    final available = _availableProviders;
+    return SailColumn(
+      spacing: SailStyleValues.padding08,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SailText.secondary12('WALLET TYPE', bold: true),
+        for (final provider in InitialWalletProvider.values)
+          _buildProviderCard(theme, provider, enabled: available.contains(provider)),
+      ],
+    );
+  }
+
+  Widget _buildProviderCard(SailThemeData theme, InitialWalletProvider provider, {required bool enabled}) {
+    final selected = _selectedProvider == provider;
+    final description = enabled ? provider.description : '${provider.description} · needs an enforcer wallet first';
+
+    return Opacity(
+      opacity: enabled ? 1 : 0.5,
+      child: MouseRegion(
+        cursor: enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
+        child: GestureDetector(
+          onTap: enabled ? () => setState(() => _selectedProvider = provider) : null,
+          child: Container(
+            padding: const EdgeInsets.all(SailStyleValues.padding12),
+            decoration: BoxDecoration(
+              color: theme.colors.backgroundSecondary,
+              border: Border.all(
+                color: selected ? theme.colors.primary : theme.colors.border,
+                width: selected ? 1.5 : 1,
+              ),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 18,
+                  height: 18,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    border: Border.all(color: selected ? theme.colors.primary : theme.colors.textSecondary, width: 1.5),
+                  ),
+                  child: selected
+                      ? Center(
+                          child: Container(
+                            width: 8,
+                            height: 8,
+                            decoration: BoxDecoration(shape: BoxShape.circle, color: theme.colors.primary),
                           ),
-                          if (_awaitingBackend || _isGenerating)
-                            SizedBox(
-                              width: 15,
-                              height: 15,
-                              child: LoadingIndicator.insideButton(Colors.white),
-                            ),
-                        ],
-                      ),
-                    ),
+                        )
+                      : null,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: SailColumn(
+                    spacing: 2,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SailText.primary15(provider.label, bold: true),
+                      SailText.secondary12(description),
+                    ],
                   ),
                 ),
-              ),
-              if (_error != null)
-                Padding(
-                  padding: const EdgeInsets.only(top: SailStyleValues.padding08),
-                  child: SailText.primary13(_error!, color: theme.colors.error),
-                ),
-              const SizedBox(height: 20),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGenerateButton(SailThemeData theme) {
+    final busy = _isGenerating || _awaitingBackend;
+    return MouseRegion(
+      cursor: busy ? SystemMouseCursors.basic : SystemMouseCursors.click,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colors.primary,
+          borderRadius: BorderRadius.circular(8),
+          boxShadow: [
+            BoxShadow(color: Colors.black12, blurRadius: 4, offset: Offset(0, 2)),
+          ],
+        ),
+        child: TextButton(
+          onPressed: busy
+              ? null
+              : () {
+                  setState(() => _isGenerating = true);
+                  // Schedule the wallet generation to run after this frame
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    _handleFastMode();
+                  });
+                },
+          style: TextButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+            minimumSize: Size.zero,
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  SailButton(
-                    label: 'Restore Wallet',
-                    variant: ButtonVariant.ghost,
-                    onPressed: () async => _setScreen(WelcomeScreen.restore),
+                  Flexible(
+                    child: SailText.primary15(
+                      _awaitingBackend
+                          ? 'Connecting to bitwindowd…'
+                          : _isGenerating
+                          ? 'Generating your wallet'
+                          : 'Create a new wallet',
+                      color: Colors.white,
+                      bold: true,
+                      textAlign: TextAlign.center,
+                    ),
                   ),
-                  const SizedBox(width: 24),
-                  SailText.secondary15('·'),
-                  const SizedBox(width: 24),
-                  SailDropdownButton<InitialWalletProvider>(
-                    variant: ButtonVariant.ghost,
-                    value: _selectedProvider,
-                    items: _availableProviders
-                        .map(
-                          (p) => SailDropdownItem<InitialWalletProvider>(value: p, label: p.label),
-                        )
-                        .toList(),
-                    onChanged: (p) {
-                      if (p != null) {
-                        setState(() => _selectedProvider = p);
-                      }
-                    },
-                  ),
+                  if (busy) ...[
+                    const SizedBox(width: 8),
+                    SizedBox(width: 15, height: 15, child: LoadingIndicator.insideButton(Colors.white)),
+                  ],
                 ],
               ),
-              const Spacer(),
-              const Spacer(),
-              const SizedBox(height: 32),
+              const SizedBox(height: 4),
+              SailText.primary12(
+                'Generates a fresh 12-word seed phrase',
+                color: Colors.white70,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildActionCard({
+    required SailThemeData theme,
+    required String title,
+    required String subtitle,
+    required VoidCallback? onPressed,
+  }) {
+    return MouseRegion(
+      cursor: onPressed == null ? SystemMouseCursors.basic : SystemMouseCursors.click,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colors.backgroundSecondary,
+          border: Border.all(color: theme.colors.border),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: TextButton(
+          onPressed: onPressed,
+          style: TextButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+            minimumSize: Size.zero,
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SailText.primary15(title, bold: true, textAlign: TextAlign.center),
+              const SizedBox(height: 4),
+              SailText.secondary12(subtitle, textAlign: TextAlign.center),
             ],
           ),
         ),
@@ -364,9 +458,9 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
               children: [
                 const SizedBox(height: 32),
                 BootTitle(
-                  title: 'Restore your wallet',
+                  title: 'Paste your seed phrase',
                   subtitle:
-                      'Restore your mainchain wallet and all sidechain wallets from a seed phrase, local wallet backup, or backup file.',
+                      'Restores your mainchain wallet and every sidechain wallet from a seed phrase, local wallet backup, or backup file.',
                 ),
                 const SizedBox(height: 24),
                 if (hasExistingWallet) ...[
@@ -378,9 +472,11 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
                   ),
                   const SizedBox(height: 16),
                 ],
+                _buildProviderCards(theme),
+                const SizedBox(height: 16),
                 SailTextField(
                   controller: _mnemonicController,
-                  hintText: 'Enter BIP39 mnemonic (12 or 24 words)',
+                  hintText: 'Paste your seed phrase — 12 or 24 words, separated by spaces',
                   maxLines: 3,
                   textFieldType: TextFieldType.text,
                   size: TextFieldSize.regular,
@@ -587,16 +683,11 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
           derivationPath: derivationPath,
         );
       case InitialWalletProvider.electrum:
-        // The electrum create RPC carries no passphrase field, so importing a
-        // passphrase-protected seed would silently derive the wrong wallet.
-        // Refuse rather than create an unrecoverable wallet.
-        if (passphrase != null && passphrase.isNotEmpty) {
-          throw Exception('BIP39 passphrases are not yet supported for Electrum wallets');
-        }
         await _walletProvider.createElectrumWallet(
           name: name,
           gradient: WalletGradient.fromWalletId(name),
           customMnemonic: customMnemonic,
+          passphrase: passphrase,
           account: account,
           derivationPath: derivationPath,
         );

--- a/sail_ui/lib/pages/datadir_setup_page.dart
+++ b/sail_ui/lib/pages/datadir_setup_page.dart
@@ -79,6 +79,15 @@ class _DataDirSetupPageState extends State<DataDirSetupPage> {
         forNetwork: _targetNetwork,
       );
 
+      // A pick that didn't persist would send the user through this page again
+      // on the next boot, with no sign anything went wrong.
+      if (!_confProvider.hasDataDirFor(_targetNetwork)) {
+        setState(() {
+          _errorMessage = 'Could not save the data directory — check the BitWindow log';
+        });
+        return;
+      }
+
       // sleep for 500 millis because windows file stuff sucks, and we cant await
       await Future.delayed(const Duration(milliseconds: 500));
 

--- a/sail_ui/lib/pages/sidechains/bmm_tab.dart
+++ b/sail_ui/lib/pages/sidechains/bmm_tab.dart
@@ -64,7 +64,7 @@ class _Controls extends StatelessWidget {
         SailText.primary13('Min bid:'),
         SizedBox(
           width: 130,
-          child: SailTextField(controller: viewModel.minBidController, hintText: '0.00005000'),
+          child: SailTextField(controller: viewModel.minBidController, hintText: '0.00000100'),
         ),
         SailText.primary13('Max bid:'),
         SizedBox(
@@ -389,9 +389,9 @@ class BMMViewModel extends BaseViewModel {
   BMMViewModel() {
     minBidController.text = bmmProvider.minBidAmount.toStringAsFixed(8);
     maxBidController.text = bmmProvider.maxBidAmount.toStringAsFixed(8);
-    minBidController.addListener(_onBounds);
-    maxBidController.addListener(_onBounds);
-    bmmProvider.addListener(notifyListeners);
+    minBidController.addListener(_onMinBound);
+    maxBidController.addListener(_onMaxBound);
+    bmmProvider.addListener(_onProviderChanged);
   }
 
   bool get running => bmmProvider.running;
@@ -454,15 +454,37 @@ class BMMViewModel extends BaseViewModel {
     return 'Waiting for a miner to commit to ${shorten(live.criticalHash)}';
   }
 
-  void _onBounds() {
+  // One listener per field: editing one bound must not push the other, whose box
+  // may still show a value the watch stream has since moved on from.
+  void _onMinBound() {
     final min = double.tryParse(minBidController.text.trim());
     if (min != null) {
       bmmProvider.setMinBidAmount(min);
     }
+  }
+
+  void _onMaxBound() {
     final max = double.tryParse(maxBidController.text.trim());
     if (max != null) {
       bmmProvider.setMaxBidAmount(max);
     }
+  }
+
+  void _onProviderChanged() {
+    // Mirror bounds the backend reports, except while an edit is waiting to be
+    // pushed — that value is the user's, mid-typing.
+    if (!bmmProvider.boundsPushPending) {
+      _mirrorBound(minBidController, bmmProvider.minBidAmount);
+      _mirrorBound(maxBidController, bmmProvider.maxBidAmount);
+    }
+    notifyListeners();
+  }
+
+  void _mirrorBound(TextEditingController controller, double value) {
+    if (double.tryParse(controller.text.trim()) == value) {
+      return;
+    }
+    controller.text = value.toStringAsFixed(8);
   }
 
   Future<void> startBidding() => bmmProvider.startBidding();
@@ -620,7 +642,7 @@ class BMMViewModel extends BaseViewModel {
 
   @override
   void dispose() {
-    bmmProvider.removeListener(notifyListeners);
+    bmmProvider.removeListener(_onProviderChanged);
     minBidController.dispose();
     maxBidController.dispose();
     super.dispose();

--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
 	"github.com/fsnotify/fsnotify"
 	"github.com/rs/zerolog"
 )
@@ -103,8 +104,9 @@ func (m *BitcoinConfManager) DrynetPeer() string {
 	return DrynetPeerFor(m.Generation())
 }
 
-// DrynetPeerFor is the seed node for a given drynet generation, empty when the
-// generation is. Falls back to a built name when the catalog publishes none.
+// DrynetPeerFor is the seed node for a given drynet generation, empty when
+// neither the live catalog nor the embedded one publishes an address for it.
+// Every generation seeds on its own port, so a built-up name would be a guess.
 func DrynetPeerFor(generation string) string {
 	if generation == "" {
 		return ""
@@ -112,11 +114,8 @@ func DrynetPeerFor(generation string) string {
 	if address := PublishedDrynetPeer(generation); address != "" {
 		return address
 	}
-	return fmt.Sprintf("%s.drivechain.dev:%d", generation, drynetP2PPort)
+	return netcatalog.EmbeddedPeer(generation)
 }
-
-// drynetP2PPort is the fallback seed port; generations publish their own.
-const drynetP2PPort = 8335
 
 // GetConfFilePath returns the resolved -conf= path to pass to bitcoind.
 // Mirrors the confFile() logic from binaries.dart.
@@ -281,18 +280,21 @@ fallbackfee=0.00021
 	case NetworkDrynet:
 		// Drynet runs chain=main, so fallbackfee belongs here (not in the
 		// common block). It has no DNS seeds, so it needs an explicit peer.
+		addnode := ""
+		if peer := m.DrynetPeer(); peer != "" {
+			addnode = fmt.Sprintf("addnode=%s\n", peer)
+		}
 		mainSection = fmt.Sprintf(`# drynet-specific settings (drivechain testnet on mainnet params)
 [main]
 port=8301
 rpcport=18302
-addnode=%s
-uacomment=%s
+%suacomment=%s
 assumevalid=0000000000000000000000000000000000000000000000000000000000000000
 minimumchainwork=0x00
 listenonion=0
 drivechain=1
 fallbackfee=0.00021
-`, m.DrynetPeer(), m.Generation())
+`, addnode, m.Generation())
 	default:
 		mainSection = `# Mainnet-specific settings
 [main]

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -416,8 +416,11 @@ func (m *BitcoinConfManager) CopyConfigDownstream() error {
 // forNetwork must be a known Network value; the group resolution depends on
 // it (forknet vs default).
 func (m *BitcoinConfManager) UpdateDataDir(dataDir string, forNetwork Network) error {
-	if m.HasPrivateConf || m.Config == nil {
-		return nil
+	if m.HasPrivateConf {
+		return fmt.Errorf("your own bitcoin.conf sets the data directory, so it has to be changed there")
+	}
+	if m.Config == nil {
+		return fmt.Errorf("bitcoin config not loaded")
 	}
 
 	cleanDataDir := strings.ReplaceAll(strings.TrimSpace(dataDir), "\\ ", " ")
@@ -458,6 +461,11 @@ func (m *BitcoinConfManager) materializeDatadirForGroup(g DatadirGroup) {
 func (m *BitcoinConfManager) HasDatadirForNetwork(n Network) bool {
 	if m.Config == nil {
 		return false
+	}
+	// A user's own bitcoin.conf is not ours to write, so we can't require
+	// anything of it — prompting would loop, since the pick can't be saved.
+	if m.HasPrivateConf {
+		return true
 	}
 	if n == NetworkForknet {
 		return m.Config.GetGroupDatadir(DatadirGroupForknet) != ""

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -537,6 +537,10 @@ func (m *BitcoinConfManager) applyMainSectionDefaults(n Network) {
 		}
 	}
 	for _, kv := range defaults {
+		// An unpublished peer must not become `addnode=`, which bitcoind rejects.
+		if kv.v == "" {
+			continue
+		}
 		m.Config.SetSetting(kv.k, kv.v, "main")
 	}
 }

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
@@ -430,11 +431,11 @@ func TestGetDefaultConfigFallbackfeeNotOnMainnet(t *testing.T) {
 }
 
 func TestGetDefaultConfigDrynetHasPeerAndFallbackfee(t *testing.T) {
-	m := &BitcoinConfManager{Network: NetworkDrynet}
+	m := &BitcoinConfManager{Network: NetworkDrynet, DrynetID: "drynet4"}
 	conf := m.GetDefaultConfig()
 	for _, want := range []string{
 		"drivechain=1", "fallbackfee=0.00021",
-		"addnode=drynet2.drivechain.dev:8335", "uacomment=drynet2", "rpcport=18302",
+		"addnode=drynet4.drivechain.dev:8533", "uacomment=drynet4", "rpcport=18302",
 	} {
 		if !strings.Contains(conf, want) {
 			t.Errorf("drynet default config must include %q, got:\n%s", want, conf)
@@ -472,7 +473,7 @@ func TestUpdateNetworkWritesChainMainForForks(t *testing.T) {
 func TestDrynetGenerationDrivesPeerAndSentinel(t *testing.T) {
 	m := &BitcoinConfManager{Network: NetworkDrynet, DrynetID: "drynet3"}
 	conf := m.GetDefaultConfig()
-	for _, want := range []string{"addnode=drynet3.drivechain.dev:8335", "uacomment=drynet3"} {
+	for _, want := range []string{"addnode=drynet3.drivechain.dev:8337", "uacomment=drynet3"} {
 		if !strings.Contains(conf, want) {
 			t.Errorf("drynet3 config must include %q, got:\n%s", want, conf)
 		}
@@ -484,7 +485,7 @@ func TestDrynetGenerationDrivesPeerAndSentinel(t *testing.T) {
 	// applyMainSectionDefaults writes the same values on a network swap.
 	m2 := &BitcoinConfManager{Config: NewBitcoinConfig(), DrynetID: "drynet3", log: zerolog.Nop()}
 	m2.applyMainSectionDefaults(NetworkDrynet)
-	if got := m2.Config.GetSetting("addnode", "main"); got != "drynet3.drivechain.dev:8335" {
+	if got := m2.Config.GetSetting("addnode", "main"); got != "drynet3.drivechain.dev:8337" {
 		t.Errorf("addnode = %q, want the drynet3 peer", got)
 	}
 	if got := m2.Config.GetSetting("uacomment", "main"); got != "drynet3" {
@@ -496,11 +497,30 @@ func TestDrynetGenerationDrivesPeerAndSentinel(t *testing.T) {
 // still writes a reachable peer instead of an empty addnode.
 func TestDrynetFallsBackToEmbeddedGeneration(t *testing.T) {
 	m := &BitcoinConfManager{Network: NetworkDrynet}
-	if got := m.Generation(); got == "" {
+	generation := m.Generation()
+	if generation == "" {
 		t.Fatal("Generation() must fall back to the embedded catalog")
 	}
-	if got := m.DrynetPeer(); !strings.HasSuffix(got, ".drivechain.dev:8335") {
-		t.Errorf("DrynetPeer() = %q, want a drivechain.dev seed node", got)
+	if got := m.DrynetPeer(); got != netcatalog.EmbeddedPeer(generation) || got == "" {
+		t.Errorf("DrynetPeer() = %q, want the embedded seed address for %s", got, generation)
+	}
+}
+
+// A generation nothing has published an address for gets no addnode at all.
+// Guessing the port sent bitcoind somewhere nothing listens.
+func TestDrynetWithoutPublishedPeerWritesNoAddnode(t *testing.T) {
+	m := &BitcoinConfManager{Network: NetworkDrynet, DrynetID: "drynet99"}
+	if got := m.DrynetPeer(); got != "" {
+		t.Errorf("DrynetPeer() = %q, want empty for an unpublished generation", got)
+	}
+	if conf := m.GetDefaultConfig(); strings.Contains(conf, "addnode=drynet") {
+		t.Errorf("unpublished generation must not write an addnode line, got:\n%s", conf)
+	}
+
+	m2 := &BitcoinConfManager{Config: NewBitcoinConfig(), DrynetID: "drynet99", log: zerolog.Nop()}
+	m2.applyMainSectionDefaults(NetworkDrynet)
+	if got := m2.Config.GetSetting("addnode", "main"); got != "" {
+		t.Errorf("addnode = %q, want it left unset", got)
 	}
 }
 
@@ -767,7 +787,7 @@ func TestUpdateNetworkWithinDefaultGroupKeepsDatadir(t *testing.T) {
 // applyMainSectionDefaults: signet → drynet adds drivechain=1 + alt ports
 // under [main]; drynet → mainnet strips them.
 func TestApplyMainSectionDefaultsDrynetThenMainnet(t *testing.T) {
-	m := &BitcoinConfManager{Config: NewBitcoinConfig(), log: zerolog.Nop()}
+	m := &BitcoinConfManager{Config: NewBitcoinConfig(), DrynetID: "drynet4", log: zerolog.Nop()}
 	m.Config.SetSetting("chain", "signet")
 
 	m.applyMainSectionDefaults(NetworkDrynet)
@@ -775,8 +795,8 @@ func TestApplyMainSectionDefaultsDrynetThenMainnet(t *testing.T) {
 	require.Equal(t, "8301", m.Config.GetSetting("port", "main"))
 	require.Equal(t, "18302", m.Config.GetSetting("rpcport", "main"))
 	require.Equal(t, "0.00021", m.Config.GetSetting("fallbackfee", "main"))
-	require.Equal(t, "drynet2.drivechain.dev:8335", m.Config.GetSetting("addnode", "main"))
-	require.Equal(t, "drynet2", m.Config.GetSetting("uacomment", "main"))
+	require.Equal(t, "drynet4.drivechain.dev:8533", m.Config.GetSetting("addnode", "main"))
+	require.Equal(t, "drynet4", m.Config.GetSetting("uacomment", "main"))
 
 	m.applyMainSectionDefaults(NetworkMainnet)
 	require.Equal(t, "", m.Config.GetSetting("drivechain", "main"))

--- a/sidechain-orchestrator/config/enforcer_conf.go
+++ b/sidechain-orchestrator/config/enforcer_conf.go
@@ -27,6 +27,7 @@ var derivedEnforcerSettings = []string{
 	"node-rpc-addr",
 	"node-zmq-addr-sequence",
 	"wallet-esplora-url",
+	"network-preset",
 }
 
 // ---------------------------------------------------------------------------
@@ -314,6 +315,14 @@ func (m *EnforcerConfManager) GetCliArgs() []string {
 	if !seen["wallet-esplora-url"] {
 		if esploraURL := EsploraURLForNetwork(m.bitcoinConf.Network); esploraURL != "" {
 			args = append(args, fmt.Sprintf("--wallet-esplora-url=%s", esploraURL))
+		}
+	}
+
+	// Drynet forks mainnet, so the enforcer needs the generation's preset to
+	// validate against the right chain. Only drynet builds accept the flag.
+	if m.bitcoinConf.Network == NetworkDrynet && !seen["network-preset"] {
+		if generation := m.bitcoinConf.Generation(); generation != "" {
+			args = append(args, fmt.Sprintf("--network-preset=%s", generation))
 		}
 	}
 

--- a/sidechain-orchestrator/config/enforcer_conf_test.go
+++ b/sidechain-orchestrator/config/enforcer_conf_test.go
@@ -172,6 +172,32 @@ func TestWriteConfig(t *testing.T) {
 // GetCliArgs tests
 // ---------------------------------------------------------------------------
 
+// Drynet forks mainnet, so the enforcer needs the generation's preset. Nothing
+// persists it — the conf carries no network-preset on a fresh install.
+func TestGetCliArgsDerivesDrynetNetworkPreset(t *testing.T) {
+	m, _ := newTestEnforcerManager(t)
+	require.NoError(t, m.LoadConfig())
+	m.bitcoinConf.Network = NetworkDrynet
+	m.bitcoinConf.DrynetID = "drynet4"
+
+	require.Contains(t, m.GetCliArgs(), "--network-preset=drynet4")
+
+	// A persisted value wins, same as every other derived setting.
+	m.Config.Settings["network-preset"] = "drynet3"
+	require.Contains(t, m.GetCliArgs(), "--network-preset=drynet3")
+	require.NotContains(t, m.GetCliArgs(), "--network-preset=drynet4")
+}
+
+// Only drynet builds of the enforcer accept the flag.
+func TestGetCliArgsOmitsNetworkPresetOffDrynet(t *testing.T) {
+	m, _ := newTestEnforcerManager(t)
+	require.NoError(t, m.LoadConfig())
+
+	for _, arg := range m.GetCliArgs() {
+		require.NotContains(t, arg, "--network-preset")
+	}
+}
+
 func TestGetCliArgs(t *testing.T) {
 	m, _ := newTestEnforcerManager(t)
 	require.NoError(t, m.LoadConfig())

--- a/sidechain-orchestrator/config/netcatalog/catalog.go
+++ b/sidechain-orchestrator/config/netcatalog/catalog.go
@@ -226,6 +226,20 @@ func EmbeddedDrynetID() string {
 	return c.DrynetID()
 }
 
+// EmbeddedPeer is the seed address the compiled-in catalog publishes for a
+// network id, empty when it lists none.
+func EmbeddedPeer(id string) string {
+	c, err := parse(embedded)
+	if err != nil {
+		return ""
+	}
+	n, ok := c.ByID(id)
+	if !ok {
+		return ""
+	}
+	return n.P2P.Address
+}
+
 // Fetch downloads and parses the live catalog.
 func Fetch(ctx context.Context, url string) (Catalog, error) {
 	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)

--- a/sidechain-orchestrator/config/netcatalog/catalog_test.go
+++ b/sidechain-orchestrator/config/netcatalog/catalog_test.go
@@ -6,16 +6,28 @@ import (
 	"testing"
 )
 
+// embeddedGeneration is the drynet networks.json ships with. Bump it whenever
+// the embedded catalog is refreshed from the published document.
+const embeddedGeneration = "drynet4"
+
 func TestEmbeddedCatalogParses(t *testing.T) {
 	c, fromDisk := Load(t.TempDir())
 	if fromDisk {
 		t.Fatal("empty dir must not report a cached catalog")
 	}
-	if got := c.DrynetID(); got != "drynet2" {
-		t.Errorf("embedded DrynetID() = %q, want drynet2", got)
+	if got := c.DrynetID(); got != embeddedGeneration {
+		t.Errorf("embedded DrynetID() = %q, want %s", got, embeddedGeneration)
 	}
 	if _, ok := c.ByFamily(FamilyECash); !ok {
 		t.Error("embedded catalog must carry an ecash network")
+	}
+}
+
+// Every generation seeds on its own port, so the embedded document must carry
+// the peer — inventing one from the id is what wrote drynet4 with :8335.
+func TestEmbeddedCatalogPublishesPeers(t *testing.T) {
+	if got := EmbeddedPeer(embeddedGeneration); got == "" {
+		t.Errorf("EmbeddedPeer(%s) is empty, want the published seed address", embeddedGeneration)
 	}
 }
 
@@ -71,8 +83,8 @@ func TestCorruptCacheFallsBackToEmbedded(t *testing.T) {
 	if fromDisk {
 		t.Error("corrupt cache must not report as from disk")
 	}
-	if c.DrynetID() != "drynet2" {
-		t.Errorf("DrynetID() = %q, want the embedded drynet2", c.DrynetID())
+	if c.DrynetID() != embeddedGeneration {
+		t.Errorf("DrynetID() = %q, want the embedded %s", c.DrynetID(), embeddedGeneration)
 	}
 }
 

--- a/sidechain-orchestrator/config/netcatalog/networks.json
+++ b/sidechain-orchestrator/config/netcatalog/networks.json
@@ -11,18 +11,18 @@
         "name": "Bitcoin",
         "ticker": "BTC"
       },
+      "network_magic": "f9beb4d9",
+      "fork_height": null,
       "backends": [
         {
           "kind": "esplora",
           "url": "https://esplora.mainnet.drivechain.info",
-          "priority": 1,
           "tls": true,
           "label": "L2L Esplora"
         },
         {
           "kind": "electrum",
           "url": "ssl://explorer.mainnet.drivechain.info:50002",
-          "priority": 2,
           "tls": true,
           "label": "L2L electrs"
         }
@@ -38,12 +38,25 @@
         },
         "coinnews": {
           "url": "https://coinnews.mainnet.drivechain.info"
-        }
-      }
+        },
+        "blockbook": {
+          "url": null
+        },
+        "mining_pool": {
+          "url": null,
+          "stratum": null
+        },
+        "fast_withdrawal": []
+      },
+      "p2p": {
+        "address": "node.mainnet.drivechain.info:8333"
+      },
+      "sidechains": [],
+      "assumeutxo": null
     },
     {
       "id": "signet",
-      "family": "signet",
+      "family": "bitcoin",
       "display_name": "L2L Signet",
       "description": "Bitcoin signet with Drivechain (BIP300/301) enforcement",
       "chain": "signet",
@@ -51,18 +64,18 @@
         "name": "Signet Bitcoin",
         "ticker": "sBTC"
       },
+      "network_magic": null,
+      "fork_height": null,
       "backends": [
         {
           "kind": "esplora",
           "url": "https://esplora.signet.drivechain.info",
-          "priority": 1,
           "tls": true,
           "label": "L2L Esplora"
         },
         {
           "kind": "electrum",
           "url": "ssl://node.signet.drivechain.info:50002",
-          "priority": 2,
           "tls": true,
           "label": "L2L electrs"
         }
@@ -78,8 +91,103 @@
         },
         "coinnews": {
           "url": "https://coinnews.signet.drivechain.info"
+        },
+        "blockbook": {
+          "url": null
+        },
+        "mining_pool": {
+          "url": null,
+          "stratum": null
+        },
+        "fast_withdrawal": [
+          {
+            "url": "https://fw1.signet.drivechain.info"
+          }
+        ]
+      },
+      "p2p": {
+        "address": "node.signet.drivechain.info:38333"
+      },
+      "sidechains": [
+        {
+          "slot": 2,
+          "title": "BitNames",
+          "description": "A variant of Namecoin/BitDNS that aims to replace ICANN",
+          "image": "ghcr.io/layertwo-labs/bitnames:sha-2a9fd14",
+          "version": "v0.14.0",
+          "p2p": {
+            "address": "node.signet.drivechain.info:4002",
+            "transport": "quic"
+          }
+        },
+        {
+          "slot": 4,
+          "title": "BitAssets",
+          "description": "A sidechain for digital assets",
+          "image": "ghcr.io/layertwo-labs/bitassets:sha-8f8a627",
+          "version": "v0.13.1",
+          "p2p": {
+            "address": "node.signet.drivechain.info:4004",
+            "transport": "quic"
+          }
+        },
+        {
+          "slot": 9,
+          "title": "Thunder",
+          "description": "A sidechain with a large & growing blocksize, plus fraud proofs",
+          "image": "ghcr.io/layertwo-labs/thunder:sha-61cbd03",
+          "version": "v0.14.0",
+          "p2p": {
+            "address": "node.signet.drivechain.info:4009",
+            "transport": "quic"
+          }
+        },
+        {
+          "slot": 13,
+          "title": "Truthcoin",
+          "description": "A sidechain for decentralized prediction markets and oracle data",
+          "image": "ghcr.io/layertwo-labs/truthcoin:sha-de1aa6f",
+          "version": "sha-de1aa6f",
+          "p2p": {
+            "address": "node.signet.drivechain.info:4013",
+            "transport": "quic"
+          }
+        },
+        {
+          "slot": 98,
+          "title": "zSide",
+          "description": "Sidechain with private transactions",
+          "image": "ghcr.io/iwakura-rein/thunder-orchard:sha-7e34625",
+          "version": "v0.14.0",
+          "p2p": {
+            "address": "node.signet.drivechain.info:4098",
+            "transport": "quic"
+          }
+        },
+        {
+          "slot": 99,
+          "title": "Photon",
+          "description": "Sidechain using post-quantum cryptography",
+          "image": "ghcr.io/layertwo-labs/photon:sha-13ba3e4",
+          "version": "v0.14.0",
+          "p2p": {
+            "address": "node.signet.drivechain.info:4099",
+            "transport": "quic"
+          }
+        },
+        {
+          "slot": 255,
+          "title": "Coinshift",
+          "description": "Sidechain with a P2P, trustless L2-L1 swap system",
+          "image": "ghcr.io/layertwo-labs/coinshift:sha-9eeb5b2",
+          "version": "sha-9eeb5b2",
+          "p2p": {
+            "address": "node.signet.drivechain.info:4255",
+            "transport": "quic"
+          }
         }
-      }
+      ],
+      "assumeutxo": null
     },
     {
       "id": "drynet2",
@@ -91,25 +199,12 @@
         "name": "eCash",
         "ticker": "ECX"
       },
-      "backends": [
-        {
-          "kind": "esplora",
-          "url": "https://esplora.drynet2.drivechain.dev",
-          "priority": 1,
-          "tls": true,
-          "label": "L2L Esplora"
-        },
-        {
-          "kind": "electrum",
-          "url": "ssl://drynet2.drivechain.dev:50012",
-          "priority": 2,
-          "tls": true,
-          "label": "L2L electrs"
-        }
-      ],
-      "explorer_tx_template": "https://explorer.drynet2.drivechain.dev/tx/{txid}",
-      "explorer_address_template": "https://explorer.drynet2.drivechain.dev/address/{address}",
-      "explorer_block_template": "https://explorer.drynet2.drivechain.dev/block/{hash}",
+      "network_magic": "f9beb4d9",
+      "fork_height": 957600,
+      "backends": [],
+      "explorer_tx_template": null,
+      "explorer_address_template": null,
+      "explorer_block_template": null,
       "services": {
         "faucet": {
           "url": null,
@@ -118,14 +213,261 @@
         },
         "coinnews": {
           "url": "https://coinnews.drynet2.drivechain.dev"
-        }
+        },
+        "blockbook": {
+          "url": null
+        },
+        "mining_pool": {
+          "url": null,
+          "stratum": null
+        },
+        "fast_withdrawal": [
+          {
+            "url": "https://fw1.drynet2.drivechain.dev"
+          }
+        ]
       },
+      "p2p": {
+        "address": "drynet2.drivechain.dev:8335"
+      },
+      "sidechains": [
+        {
+          "slot": 2,
+          "title": "BitNames",
+          "description": "A variant of Namecoin/BitDNS that aims to replace ICANN",
+          "image": "ghcr.io/layertwo-labs/bitnames:sha-2a9fd14",
+          "version": "v0.14.0",
+          "p2p": null
+        },
+        {
+          "slot": 4,
+          "title": "BitAssets",
+          "description": "A sidechain for digital assets",
+          "image": "ghcr.io/layertwo-labs/bitassets:sha-8f8a627",
+          "version": "v0.13.1",
+          "p2p": null
+        },
+        {
+          "slot": 9,
+          "title": "Thunder",
+          "description": "A sidechain with a large & growing blocksize, plus fraud proofs",
+          "image": "ghcr.io/layertwo-labs/thunder:sha-61cbd03",
+          "version": "v0.14.0",
+          "p2p": null
+        },
+        {
+          "slot": 13,
+          "title": "Truthcoin",
+          "description": "A sidechain for decentralized prediction markets and oracle data",
+          "image": "ghcr.io/layertwo-labs/truthcoin:sha-de1aa6f",
+          "version": "sha-de1aa6f",
+          "p2p": null
+        },
+        {
+          "slot": 98,
+          "title": "zSide",
+          "description": "Sidechain with private transactions",
+          "image": "ghcr.io/iwakura-rein/thunder-orchard:sha-7e34625",
+          "version": "v0.14.0",
+          "p2p": null
+        },
+        {
+          "slot": 99,
+          "title": "Photon",
+          "description": "Sidechain using post-quantum cryptography",
+          "image": "ghcr.io/layertwo-labs/photon:sha-13ba3e4",
+          "version": "v0.14.0",
+          "p2p": null
+        }
+      ],
       "assumeutxo": {
         "url": "https://data.drivechain.dev/drynet2/utxo-957600.dat",
         "height": 957600,
         "sha256": "473ae741a3a7c4c5c28c85a54aa166e0ea46d13d83ae0bf2142d332373ed155b",
         "size_bytes": 9498111432
       }
+    },
+    {
+      "id": "drynet3",
+      "family": "ecash",
+      "display_name": "Drynet 3",
+      "description": "Fork of mainnet with PoW difficulty reset",
+      "chain": "main",
+      "currency": {
+        "name": "eCash",
+        "ticker": "ECX"
+      },
+      "network_magic": "f9beb4d9",
+      "fork_height": 957600,
+      "backends": [
+        {
+          "kind": "esplora",
+          "url": "https://esplora.drynet3.drivechain.dev",
+          "tls": true,
+          "label": "L2L Esplora"
+        },
+        {
+          "kind": "electrum",
+          "url": "ssl://drynet3.drivechain.dev:50012",
+          "tls": true,
+          "label": "L2L electrs"
+        }
+      ],
+      "explorer_tx_template": "https://explorer.drynet3.drivechain.dev/tx/{txid}",
+      "explorer_address_template": "https://explorer.drynet3.drivechain.dev/address/{address}",
+      "explorer_block_template": "https://explorer.drynet3.drivechain.dev/block/{hash}",
+      "services": {
+        "faucet": {
+          "url": null,
+          "amount": null,
+          "cooldown_seconds": null
+        },
+        "coinnews": {
+          "url": "https://coinnews.drynet3.drivechain.dev"
+        },
+        "blockbook": {
+          "url": null
+        },
+        "mining_pool": {
+          "url": "https://pool.drynet3.drivechain.dev",
+          "stratum": "stratum+tcp://pool.drynet3.drivechain.dev:3333"
+        },
+        "fast_withdrawal": [
+          {
+            "url": "https://fw1.drynet3.drivechain.dev"
+          }
+        ]
+      },
+      "p2p": {
+        "address": "drynet3.drivechain.dev:8337"
+      },
+      "sidechains": [
+        {
+          "slot": 2,
+          "title": "BitNames",
+          "description": "A variant of Namecoin/BitDNS that aims to replace ICANN",
+          "image": "ghcr.io/layertwo-labs/bitnames:sha-2a9fd14",
+          "version": "v0.14.0",
+          "p2p": {
+            "address": "drynet3.drivechain.dev:4002",
+            "transport": "quic"
+          }
+        },
+        {
+          "slot": 4,
+          "title": "BitAssets",
+          "description": "A sidechain for digital assets",
+          "image": "ghcr.io/layertwo-labs/bitassets:sha-8f8a627",
+          "version": "v0.13.1",
+          "p2p": {
+            "address": "drynet3.drivechain.dev:4004",
+            "transport": "quic"
+          }
+        },
+        {
+          "slot": 9,
+          "title": "Thunder",
+          "description": "A sidechain with a large & growing blocksize, plus fraud proofs",
+          "image": "ghcr.io/layertwo-labs/thunder:sha-8a6b732",
+          "version": "v0.17.0",
+          "p2p": {
+            "address": "drynet3.drivechain.dev:4009",
+            "transport": "quic"
+          }
+        },
+        {
+          "slot": 13,
+          "title": "Truthcoin",
+          "description": "A sidechain for decentralized prediction markets and oracle data",
+          "image": "ghcr.io/layertwo-labs/truthcoin:sha-de1aa6f",
+          "version": "sha-de1aa6f",
+          "p2p": {
+            "address": "drynet3.drivechain.dev:4013",
+            "transport": "quic"
+          }
+        },
+        {
+          "slot": 98,
+          "title": "zSide",
+          "description": "Sidechain with private transactions",
+          "image": "ghcr.io/iwakura-rein/thunder-orchard:sha-7e34625",
+          "version": "v0.14.0",
+          "p2p": {
+            "address": "drynet3.drivechain.dev:4098",
+            "transport": "quic"
+          }
+        },
+        {
+          "slot": 99,
+          "title": "Photon",
+          "description": "Sidechain using post-quantum cryptography",
+          "image": "ghcr.io/layertwo-labs/photon:sha-13ba3e4",
+          "version": "v0.14.0",
+          "p2p": {
+            "address": "drynet3.drivechain.dev:4099",
+            "transport": "quic"
+          }
+        }
+      ],
+      "assumeutxo": {
+        "url": "https://data.drivechain.dev/drynet3/utxo-957600.dat",
+        "height": 957600,
+        "sha256": "473ae741a3a7c4c5c28c85a54aa166e0ea46d13d83ae0bf2142d332373ed155b",
+        "size_bytes": 9498111432
+      }
+    },
+    {
+      "id": "drynet4",
+      "family": "ecash",
+      "display_name": "Drynet 4",
+      "description": "Fork of mainnet with PoW difficulty reset",
+      "chain": "main",
+      "currency": {
+        "name": "eCash",
+        "ticker": "ECX"
+      },
+      "network_magic": "eca5d404",
+      "fork_height": 961632,
+      "backends": [
+        {
+          "kind": "esplora",
+          "url": "https://esplora.drynet4.drivechain.dev",
+          "tls": true,
+          "label": "L2L Esplora"
+        },
+        {
+          "kind": "electrum",
+          "url": "ssl://drynet4.drivechain.dev:50002",
+          "tls": true,
+          "label": "L2L electrs"
+        }
+      ],
+      "explorer_tx_template": "https://explorer.drynet4.drivechain.dev/tx/{txid}",
+      "explorer_address_template": "https://explorer.drynet4.drivechain.dev/address/{address}",
+      "explorer_block_template": "https://explorer.drynet4.drivechain.dev/block/{hash}",
+      "services": {
+        "faucet": {
+          "url": null,
+          "amount": null,
+          "cooldown_seconds": null
+        },
+        "coinnews": {
+          "url": null
+        },
+        "blockbook": {
+          "url": null
+        },
+        "mining_pool": {
+          "url": "https://pool.drynet4.drivechain.dev",
+          "stratum": "stratum+tcp://pool.drynet4.drivechain.dev:3333"
+        },
+        "fast_withdrawal": []
+      },
+      "p2p": {
+        "address": "drynet4.drivechain.dev:8533"
+      },
+      "sidechains": [],
+      "assumeutxo": null
     }
   ]
 }

--- a/sidechain-orchestrator/config/network_generation_test.go
+++ b/sidechain-orchestrator/config/network_generation_test.go
@@ -15,7 +15,7 @@ func TestDrynetURLsFollowTheGeneration(t *testing.T) {
 	}
 
 	m := &BitcoinConfManager{Network: NetworkDrynet}
-	if got := m.DrynetPeer(); got != "drynet3.drivechain.dev:8335" {
+	if got := m.DrynetPeer(); got != "drynet3.drivechain.dev:8337" {
 		t.Errorf("DrynetPeer() = %q, want the drynet3 peer", got)
 	}
 }

--- a/sidechain-orchestrator/network_catalog_pending_test.go
+++ b/sidechain-orchestrator/network_catalog_pending_test.go
@@ -15,11 +15,25 @@ import (
 func catalogWithDrynet(t *testing.T, id string) netcatalog.Catalog {
 	t.Helper()
 	c, _ := netcatalog.Load(t.TempDir())
-	for i := range c.Networks {
-		if c.Networks[i].Family == netcatalog.FamilyECash {
-			c.Networks[i].ID = id
+	// One generation only, with a peer that matches its id: the embedded
+	// catalog lists several, and renaming them all leaves the last one's
+	// address on every entry.
+	networks := make([]netcatalog.Network, 0, len(c.Networks))
+	ecash := false
+	for _, n := range c.Networks {
+		if n.Family != netcatalog.FamilyECash {
+			networks = append(networks, n)
+			continue
 		}
+		if ecash {
+			continue
+		}
+		ecash = true
+		n.ID = id
+		n.P2P.Address = id + ".drivechain.dev:8335"
+		networks = append(networks, n)
 	}
+	c.Networks = networks
 	return c
 }
 

--- a/sidechain-orchestrator/network_change_plan.go
+++ b/sidechain-orchestrator/network_change_plan.go
@@ -53,11 +53,19 @@ func (o *Orchestrator) PlanNetworkChange(req NetworkChangeRequest) NetworkChange
 		targetBackend = req.WalletBackend
 	}
 
+	// With no wallet nothing is about to start Core, so only an explicit network
+	// change is heading for a local node. Treating "no wallet" as Core is what
+	// made a fresh boot demand a Bitcoin datadir before wallet creation.
+	needsLocalBackends := targetBackend != wallet.WalletTypeElectrum
+	if targetBackend == "" && req.Network == "" {
+		needsLocalBackends = false
+	}
+
 	plan := NetworkChangePlan{
 		Network:            target,
 		WalletBackend:      targetBackend,
 		DatadirGroup:       config.DatadirGroupForNetwork(target),
-		NeedsLocalBackends: targetBackend != wallet.WalletTypeElectrum,
+		NeedsLocalBackends: needsLocalBackends,
 		NoOp:               target == current && targetBackend == currentBackend,
 	}
 
@@ -67,8 +75,11 @@ func (o *Orchestrator) PlanNetworkChange(req NetworkChangeRequest) NetworkChange
 
 	// Electrum runs no local Bitcoin backends, so nothing is downloaded and no
 	// chain directory is needed — the same predicate StartWithL1 uses.
-	if !plan.NeedsLocalBackends {
+	if targetBackend == wallet.WalletTypeElectrum {
 		plan.NoChainSource = len(config.WalletChainSourceURLsForNetwork(target)) == 0
+		return plan
+	}
+	if !plan.NeedsLocalBackends {
 		return plan
 	}
 
@@ -80,13 +91,16 @@ func (o *Orchestrator) PlanNetworkChange(req NetworkChangeRequest) NetworkChange
 	return plan
 }
 
+// activeWalletBackend returns the backend of the wallet in use, empty when no
+// wallet is active. Empty is not Core: assuming Core before the user has any
+// wallet is what made a fresh boot demand a Bitcoin datadir.
 func (o *Orchestrator) activeWalletBackend() wallet.WalletType {
 	if o.WalletSvc == nil {
-		return wallet.WalletTypeBitcoinCore
+		return ""
 	}
 	w := o.WalletSvc.ActiveWallet()
 	if w == nil {
-		return wallet.WalletTypeBitcoinCore
+		return ""
 	}
 	return w.WalletType
 }

--- a/sidechain-orchestrator/network_change_plan_test.go
+++ b/sidechain-orchestrator/network_change_plan_test.go
@@ -61,6 +61,30 @@ func TestPlanNetworkChangeDatadirFollowsWalletBackend(t *testing.T) {
 	}
 }
 
+// The boot prompt reads a plan with no request at all. Before a wallet exists
+// nothing is about to start Core, so it must not demand a Bitcoin datadir —
+// that is what made wallet creation open the 700GB directory picker.
+func TestPlanNetworkChangeWithoutWalletAsksForNothing(t *testing.T) {
+	o := planFixture(t, "drynet")
+
+	plan := o.PlanNetworkChange(NetworkChangeRequest{})
+
+	require.False(t, plan.MustSelectDatadir)
+	require.False(t, plan.NeedsLocalBackends)
+	require.False(t, plan.NoChainSource, "no wallet is not an electrum wallet")
+}
+
+// An explicit swap onto a network is a move onto its local node, so it still
+// has to have somewhere to put the chain.
+func TestPlanNetworkChangeWithoutWalletStillGuardsAnExplicitSwap(t *testing.T) {
+	o := planFixture(t, "signet")
+
+	plan := o.PlanNetworkChange(NetworkChangeRequest{Network: "drynet"})
+
+	require.True(t, plan.MustSelectDatadir)
+	require.True(t, plan.NeedsLocalBackends)
+}
+
 // Staying put must not be reported as a change, or the frontend tears down
 // providers for nothing.
 func TestPlanNetworkChangeNoOp(t *testing.T) {

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -807,6 +807,16 @@ func (p *CoreBackend) ensureBip47NotificationDescriptor(ctx context.Context, wal
 	return nil
 }
 
+// importTimestamp is what Core rescans from. A restored seed can have history
+// of any age, and "now" would leave its balance at zero; a seed generated here
+// has none, so it scans from the tip.
+func importTimestamp(w *WalletData) any {
+	if w.Imported {
+		return int64(0)
+	}
+	return "now"
+}
+
 // createBitcoinCoreWallet creates a Bitcoin Core descriptor wallet from a seed.
 // With no derivation override it imports the standard BIP84 + BIP86 descriptors
 // at account 0; an AccountIndex shifts both to that account; an explicit
@@ -864,14 +874,14 @@ func (p *CoreBackend) createBitcoinCoreWallet(ctx context.Context, walletName st
 			ImportDescriptor{
 				Desc:      mustAddChecksum(fmt.Sprintf("%s[%s/%s]%s/0/*%s", open, fingerprint, origin, acctXprv, close)),
 				Active:    true,
-				Timestamp: "now",
+				Timestamp: importTimestamp(w),
 				Internal:  false,
 				Range:     []int{0, 999},
 			},
 			ImportDescriptor{
 				Desc:      mustAddChecksum(fmt.Sprintf("%s[%s/%s]%s/1/*%s", open, fingerprint, origin, acctXprv, close)),
 				Active:    true,
-				Timestamp: "now",
+				Timestamp: importTimestamp(w),
 				Internal:  true,
 				Range:     []int{0, 999},
 			},

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -897,3 +897,35 @@ func TestCoreBackendSendM5Deposit(t *testing.T) {
 	assert.Equal(t, walletFunds-depositSats-feeSats, tx.TxOut[2].Value,
 		"only the deposit and fee leave the wallet; the CTIP passes through")
 }
+
+// A wallet restored from someone's existing seed has history older than the
+// import, so Core has to rescan from genesis to find its coins.
+func TestImportTimestampRescansRestoredSeeds(t *testing.T) {
+	if got := importTimestamp(&WalletData{Imported: true}); got != int64(0) {
+		t.Errorf("importTimestamp(imported) = %v, want int64(0) — a rescan from genesis", got)
+	}
+	if got := importTimestamp(&WalletData{}); got != "now" {
+		t.Errorf("importTimestamp(generated) = %v, want \"now\"", got)
+	}
+}
+
+// The flag is what tells the two apart, and it is set at generation time.
+func TestGenerateFullWalletMarksImportedSeeds(t *testing.T) {
+	const mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+	restored, err := GenerateFullWallet("restored", mnemonic, "", nil, WalletTypeBitcoinCore)
+	if err != nil {
+		t.Fatalf("GenerateFullWallet(custom): %v", err)
+	}
+	if !restored.Imported {
+		t.Error("a wallet built from a supplied mnemonic must be marked imported")
+	}
+
+	fresh, err := GenerateFullWallet("fresh", "", "", nil, WalletTypeBitcoinCore)
+	if err != nil {
+		t.Fatalf("GenerateFullWallet(generated): %v", err)
+	}
+	if fresh.Imported {
+		t.Error("a generated wallet has no history and must not be marked imported")
+	}
+}

--- a/sidechain-orchestrator/wallet/keygen.go
+++ b/sidechain-orchestrator/wallet/keygen.go
@@ -213,5 +213,6 @@ func GenerateFullWallet(name string, customMnemonic string, passphrase string, s
 		Sidechains: sidechains,
 		Name:       name,
 		WalletType: walletType,
+		Imported:   customMnemonic != "",
 	}, nil
 }

--- a/sidechain-orchestrator/wallet/types.go
+++ b/sidechain-orchestrator/wallet/types.go
@@ -45,6 +45,10 @@ type WalletData struct {
 	// wallet imports the single descriptor matching that purpose. Empty means
 	// the standard purposes at AccountIndex.
 	DerivationPath string `json:"derivation_path,omitempty"`
+	// Imported means the seed came from a mnemonic the user supplied, so it may
+	// already have history. Core imports its descriptors with a rescan from
+	// genesis; a freshly generated seed scans from the tip.
+	Imported bool `json:"imported,omitempty"`
 	// Multisig, when set, makes this an m-of-n multisig wallet. Cosigners that
 	// carry a mnemonic or xprv are held on disk and can sign; the rest are
 	// watch-only legs.

--- a/sidechain_core/lib/providers/bitcoin_conf_provider.dart
+++ b/sidechain_core/lib/providers/bitcoin_conf_provider.dart
@@ -246,6 +246,7 @@ class BitcoinConfProvider extends ChangeNotifier {
       await loadConfig();
     } catch (e) {
       log.e('BitcoinConfProvider: failed to update datadir: $e');
+      rethrow;
     }
   }
 

--- a/sidechain_core/lib/providers/parentchain/bmm_provider.dart
+++ b/sidechain_core/lib/providers/parentchain/bmm_provider.dart
@@ -17,13 +17,18 @@ class BMMProvider extends ChangeNotifier {
   StreamSupervisor<bmmpb.WatchResponse>? _supervisor;
 
   bool running = false;
-  double minBidAmount = 0.00005;
+  double minBidAmount = 0.000001;
   double maxBidAmount = 0.0002;
 
   String? _selectedWalletId;
 
   /// Confirmed balance of the funding wallet, null until a fetch lands.
   int? fundingBalanceSats;
+
+  /// Pending push of edited bounds to the backend. While it is armed the watch
+  /// stream's values are stale by definition, so they must not overwrite what
+  /// the user just typed.
+  Timer? _boundsPush;
 
   /// The round being bid on, absent when no tip has been seen yet.
   bmmpb.Round? current;
@@ -53,6 +58,10 @@ class BMMProvider extends ChangeNotifier {
 
   int get minBidSats => btcToSatoshi(minBidAmount);
   int get maxBidSats => btcToSatoshi(maxBidAmount);
+
+  /// True while an edited bound is waiting to be pushed. The bid fields read this
+  /// so they never overwrite what the user is still typing.
+  bool get boundsPushPending => _boundsPush?.isActive ?? false;
 
   /// Wallet every bid spends from. Selecting it never changes the active
   /// wallet. A bid goes out as a raw M8 output, which the enforcer rejects.
@@ -148,13 +157,34 @@ class BMMProvider extends ChangeNotifier {
   int get totalProfitSats => history.where((r) => r.hasProfit).fold(0, (sum, r) => sum + r.profitSats.toInt());
 
   void setMinBidAmount(double value) {
+    if (value == minBidAmount) {
+      return;
+    }
     minBidAmount = value;
+    _scheduleBoundsPush();
     notifyListeners();
   }
 
   void setMaxBidAmount(double value) {
+    if (value == maxBidAmount) {
+      return;
+    }
     maxBidAmount = value;
+    _scheduleBoundsPush();
     notifyListeners();
+  }
+
+  /// A running engine keeps bidding its old bounds until Start is called again,
+  /// so an edit has to reach the backend to mean anything. Debounced because
+  /// the bid fields push on every keystroke.
+  void _scheduleBoundsPush() {
+    _boundsPush?.cancel();
+    _boundsPush = Timer(const Duration(milliseconds: 600), () {
+      if (!running) {
+        return;
+      }
+      unawaited(startBidding());
+    });
   }
 
   void _listen() {
@@ -178,10 +208,11 @@ class BMMProvider extends ChangeNotifier {
       unawaited(refreshFundingBalance());
     }
     history = state.history;
-    if (state.minBidSats > 0) {
+    final edited = boundsPushPending;
+    if (!edited && state.minBidSats > 0) {
       minBidAmount = satoshiToBTC(state.minBidSats.toInt());
     }
-    if (state.maxBidSats > 0) {
+    if (!edited && state.maxBidSats > 0) {
       maxBidAmount = satoshiToBTC(state.maxBidSats.toInt());
     }
     error = null;
@@ -289,6 +320,7 @@ class BMMProvider extends ChangeNotifier {
   @override
   void dispose() {
     _walletReader?.removeListener(_onWalletsChanged);
+    _boundsPush?.cancel();
     unawaited(_supervisor?.dispose());
     super.dispose();
   }

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.294
+version: 1.0.295
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.165
+version: 1.0.166
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.292
+version: 1.0.293
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
Fixes the drynet4 seed peer and enforcer preset, stops the datadir prompt firing before a wallet needs Core, adds pasting an existing seed phrase on wallet setup, and makes the BMM bid bounds actually take effect.