### PR TITLE
sail_ui: give the setup actions an intrinsic height

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.293
+version: 1.0.294
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.293
+version: 1.0.294
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.153
+version: 0.2.154
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.166
+version: 1.0.167
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/pages/create_wallet_page.dart
+++ b/sail_ui/lib/pages/create_wallet_page.dart
@@ -240,20 +240,26 @@ class _SailCreateWalletPageState extends State<SailCreateWalletPage> {
                 ],
                 _buildProviderCards(theme),
                 const SizedBox(height: 24),
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Expanded(child: _buildGenerateButton(theme)),
-                    const SizedBox(width: 16),
-                    Expanded(
-                      child: _buildActionCard(
-                        theme: theme,
-                        title: 'Paste a seed phrase',
-                        subtitle: 'Import an existing 12 or 24-word mnemonic',
-                        onPressed: (_isGenerating || _awaitingBackend) ? null : () => _setScreen(WelcomeScreen.restore),
+                // The scroll view leaves the height unbounded, so the row needs an
+                // intrinsic one before its children can stretch to match.
+                IntrinsicHeight(
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Expanded(child: _buildGenerateButton(theme)),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: _buildActionCard(
+                          theme: theme,
+                          title: 'Paste a seed phrase',
+                          subtitle: 'Import an existing 12 or 24-word mnemonic',
+                          onPressed: (_isGenerating || _awaitingBackend)
+                              ? null
+                              : () => _setScreen(WelcomeScreen.restore),
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
                 if (_error != null)
                   Padding(

--- a/sail_ui/test/pages/create_wallet_screen_test.dart
+++ b/sail_ui/test/pages/create_wallet_screen_test.dart
@@ -50,6 +50,37 @@ void main() {
     expect(find.text('Paste a seed phrase'), findsOneWidget);
   });
 
+  // The paste button is the only way to reach the seed field, and the restore
+  // screen scrolls too — so it carries the same unbounded-height hazard.
+  testWidgets('paste opens a restore screen that lays out', (tester) async {
+    await _pumpPage(tester);
+
+    await tester.tap(find.text('Paste a seed phrase'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Paste your seed phrase'), findsOneWidget);
+    expect(
+      find.widgetWithText(TextField, 'Paste your seed phrase — 12 or 24 words, separated by spaces'),
+      findsOneWidget,
+    );
+  });
+
+  // Electrum takes a passphrase like every other backend; the field used to be
+  // disabled there, which made a typed value unclearable and every restore fail.
+  testWidgets('the passphrase field stays usable on electrum', (tester) async {
+    await _pumpPage(tester);
+    await tester.tap(find.text('Paste a seed phrase'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.widgetWithText(TextField, 'Optional passphrase'), 'hunter2');
+    await tester.tap(find.text('Electrum'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('hunter2'), findsOneWidget, reason: 'switching provider must not discard what was typed');
+  });
+
   // Both actions are equally weighted, which is the point of the row.
   testWidgets('the two actions are the same height', (tester) async {
     await _pumpPage(tester);

--- a/sail_ui/test/pages/create_wallet_screen_test.dart
+++ b/sail_ui/test/pages/create_wallet_screen_test.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+/// Only the "does a wallet already exist" probe is faked — everything else is
+/// the real page, so the widget tree under test is the one that ships.
+class _FakeWriter extends WalletWriterProvider {
+  _FakeWriter() : super(bitwindowAppDir: Directory.systemTemp);
+
+  @override
+  Future<bool> hasExistingWallet() async => false;
+}
+
+Future<void> _pumpPage(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(1440, 1024));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    MaterialApp(
+      home: SailTheme(
+        data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+        child: const SailCreateWalletPage(homeRoute: PageRouteInfo<void>('TestHome')),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUp(() {
+    GetIt.I.registerSingleton<Logger>(Logger());
+    GetIt.I.registerSingleton<WalletReaderProvider>(WalletReaderProvider(Directory.systemTemp));
+    GetIt.I.registerSingleton<WalletWriterProvider>(_FakeWriter());
+  });
+
+  tearDown(() async => GetIt.I.reset());
+
+  // The setup screen scrolls, so its height is unbounded. A row of equal-height
+  // actions has to bring its own intrinsic height or layout throws
+  // "BoxConstraints forces an infinite height" and the screen never renders.
+  testWidgets('the setup screen lays out both wallet actions', (tester) async {
+    await _pumpPage(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Create a new wallet'), findsOneWidget);
+    expect(find.text('Paste a seed phrase'), findsOneWidget);
+  });
+
+  // Both actions are equally weighted, which is the point of the row.
+  testWidgets('the two actions are the same height', (tester) async {
+    await _pumpPage(tester);
+
+    final generate = tester.getSize(
+      find.ancestor(of: find.text('Create a new wallet'), matching: find.byType(TextButton)),
+    );
+    final paste = tester.getSize(
+      find.ancestor(of: find.text('Paste a seed phrase'), matching: find.byType(TextButton)),
+    );
+    expect(generate.height, paste.height);
+  });
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.295
+version: 1.0.296
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.166
+version: 1.0.167
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.293
+version: 1.0.294
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The wallet setup screen's action row stretched inside a scroll view, so it asked for an infinite height and the page threw instead of rendering. IntrinsicHeight bounds it, and the test renders the real page — nothing in the suite did before, which is how it shipped.