### PR TITLE
bitwindow: gate the sidechains tab on a synced L1

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,117 @@
+# Responsible Disclosure Policy
+
+This page is for security researchers who want to report a vulnerability in
+Drivechain software. If you are a user with a question about your wallet, your
+coins, or a lost password, please open a normal issue or use the community
+channels instead — this address is for security reports only.
+
+These applications hold private keys and move real value. We take reports
+seriously and we welcome the work of external researchers.
+
+## How to report
+
+**Preferred:** open a private advisory through GitHub —
+[report a vulnerability](https://github.com/LayerTwo-Labs/drivechain-frontends/security/advisories/new).
+It is encrypted, visible only to maintainers, and keeps the whole exchange in
+one place.
+
+**Email:** security@layertwolabs.com
+
+Please **do not** open a public issue, pull request, or forum post for a
+security bug before it is fixed.
+
+## Scope
+
+In scope — anything in this repository and the artifacts it produces:
+
+- The desktop clients: BitWindow, Thunder, BitNames, BitAssets, Truthcoin,
+  Photon, CoinShift, zSide.
+- `sidechain-orchestrator`, `sail_ui`, `sidechain_core`, and `bitwindowd`.
+- The build and release pipeline, including the binaries this project
+  downloads and launches on a user's machine, and how their authenticity is
+  checked.
+- The network catalog published at `drivechain.dev/config` and the endpoints it
+  points clients at.
+
+Out of scope — report these to the project that owns them:
+
+- **Bitcoin Core itself.** Follow
+  [Bitcoin Core's disclosure process](https://bitcoincore.org/en/contact/).
+- **BIP300/301 protocol design.** Consensus-level findings belong with the
+  specification and the enforcer, not here.
+- **Third-party sidechain daemons** not built in this repository.
+- Anything hosted or operated by a third party.
+
+## What we are most interested in
+
+Ranked roughly by how much damage they do:
+
+1. Extraction or leakage of seeds, private keys, or xprvs — including into
+   logs, crash reports, backups, or the clipboard.
+2. Anything that lets a remote party spend, redirect, or burn a user's coins:
+   forged deposits or withdrawals, address substitution, or a signing flow that
+   signs something other than what the user approved.
+3. Remote code execution, or a downloaded binary that isn't the one we
+   published.
+4. Locally reachable RPC or IPC surfaces that a website or another user account
+   on the same machine can drive.
+5. Corrupting a user's wallet file or chain data such that funds become
+   unrecoverable.
+
+Please do not send us: missing security headers with no exploit path,
+self-XSS, dependency advisories with no reachable call path, rate-limiting
+observations, or automated scanner output. Most such reports have no realistic
+attack scenario — before sending one, consider what an attacker actually gains.
+
+## Safe harbor
+
+We support safe harbor for researchers who:
+
+- Make a good-faith effort to avoid privacy violations, data destruction, and
+  interruption or degradation of any service.
+- Test only against their own wallets, their own funds, and their own nodes.
+  Signet, regtest, and drynet exist for exactly this — use them rather than
+  mainnet.
+- Stop at the first sign of someone else's personal information, tell us, and
+  purge any copy they made.
+- Give us reasonable time to fix the issue before telling anyone else.
+
+Work conducted in line with this policy is authorized conduct. We will not
+pursue civil action or report it to law enforcement, and if a third party takes
+legal action against you for it, we will make clear that your work was
+authorized.
+
+If you are unsure whether something is within these bounds, ask us first.
+
+## What happens next
+
+- We aim to acknowledge a report within **3 working days**.
+- We will tell you whether we consider it a vulnerability, and our assessment
+  of its severity, within **10 working days**.
+- We work to a **90-day** coordinated disclosure window by default, shorter if
+  the issue is being exploited, longer only by agreement with you.
+- We will credit you by name or handle in the advisory and release notes unless
+  you would rather stay anonymous.
+
+Because users run these binaries locally, a fix is not finished when it is
+merged — it lands when a release ships and users have updated. We will tell you
+which release carries the fix.
+
+## Rewards
+
+There is no formal bug bounty programme. We may reward a well-written report of
+a genuine, high-impact vulnerability, decided case by case.
+
+## Writing a good report
+
+Include:
+
+- The version or commit, the operating system, and the network (mainnet,
+  signet, drynet, regtest).
+- Reproduction steps precise enough for us to follow without guessing, and a
+  proof of concept where one is possible.
+- What an attacker gains, and what they need in order to get it.
+
+One vulnerability per report, please. Social engineering of our users,
+contributors, or infrastructure — phishing, vishing, smishing — is not in scope
+and is not authorized.

--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -6,6 +6,8 @@ import 'package:bitwindow/utils/deposit_fee.dart';
 import 'package:bitwindow/pages/explorer/block_explorer_dialog.dart';
 import 'package:bitwindow/pages/sidechain_activation_management_page.dart';
 import 'package:bitwindow/providers/sidechain_provider.dart';
+import 'package:bitwindow/routing/router.dart';
+import 'package:sail_ui/pages/router.gr.dart';
 import 'package:bitwindow/providers/transactions_provider.dart';
 import 'package:bitwindow/widgets/fast_withdrawal_tab.dart';
 import 'package:bitwindow/widgets/starters_tab.dart';
@@ -50,25 +52,149 @@ class SidechainsTab extends ViewModelWidget<SidechainsViewModel> {
   Widget build(BuildContext context, SidechainsViewModel viewModel) {
     final hashWarning = viewModel.hashMismatchWarning;
 
-    final mainContent = Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Expanded(flex: 6, child: SidechainsList(smallVersion: false)),
-        const SizedBox(width: SailStyleValues.padding08),
-        Expanded(flex: 4, child: const DepositWithdrawView()),
-      ],
-    );
+    // Every slot, balance and withdrawal on this tab is BIP300 state, which only
+    // a local Core + enforcer can produce. Without them the tables are empty and
+    // the buttons fail, so say so instead of showing a dead page. A network that
+    // has no sidechains at all says so first — starting daemons wouldn't help.
+    final gated = viewModel.networkSupportsSidechains && viewModel.l1Gate != L1Gate.ready;
+
+    final Widget mainContent = gated
+        ? const _L1RequiredCard()
+        : Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(flex: 6, child: SidechainsList(smallVersion: false)),
+              const SizedBox(width: SailStyleValues.padding08),
+              Expanded(flex: 4, child: const DepositWithdrawView()),
+            ],
+          );
 
     if (hashWarning == null) {
       return mainContent;
     }
 
+    // A possibly-tampered binary outranks the gate: the warning stays up through
+    // an hours-long sync rather than being hidden behind it.
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _HashMismatchBanner(names: hashWarning),
         Expanded(child: mainContent),
       ],
+    );
+  }
+}
+
+/// Why the sidechains tab can't do anything yet.
+enum L1Gate { ready, stopped, starting, syncing }
+
+/// Sidechains live in the enforcer's view of the chain, so both daemons must be
+/// up *and* synced before any slot, balance or withdrawal on this tab is real.
+@visibleForTesting
+L1Gate resolveL1Gate({
+  required bool walletNeedsBackends,
+  required bool coreConnected,
+  required bool enforcerConnected,
+  required bool coming,
+  required bool synced,
+  required bool chainIsEmpty,
+}) {
+  // An electrum wallet reads BIP300 state from the hosted orchestrator instead
+  // (bitwindowd swaps the data source per call), and StartWithL1 is a no-op for
+  // it — gating here would block a working tab behind a button that does
+  // nothing.
+  if (!walletNeedsBackends) {
+    return L1Gate.ready;
+  }
+  if (!coreConnected || !enforcerConnected) {
+    return coming ? L1Gate.starting : L1Gate.stopped;
+  }
+  // A fresh regtest node sits at 0/0 with nothing to sync from, and isSynced
+  // needs a non-zero goal — waiting for it would block the tab until someone
+  // mines. The orchestrator calls that steady state too (health.go). Once the
+  // chain has any height this no longer applies: catching up is real syncing.
+  if (chainIsEmpty) {
+    return L1Gate.ready;
+  }
+  return synced ? L1Gate.ready : L1Gate.syncing;
+}
+
+/// Stands in for the whole tab while the L1 stack is missing, and doubles as the
+/// place to start it — the same daemons the bottom nav reports on.
+class _L1RequiredCard extends ViewModelWidget<SidechainsViewModel> {
+  const _L1RequiredCard();
+
+  @override
+  Widget build(BuildContext context, SidechainsViewModel viewModel) {
+    final gate = viewModel.l1Gate;
+
+    return SailCard(
+      title: switch (gate) {
+        L1Gate.stopped => 'Sidechains need a fully synced Bitcoin Core node',
+        L1Gate.starting => 'Starting Bitcoin Core and the enforcer',
+        _ => 'Bitcoin Core is syncing',
+      },
+      child: Padding(
+        padding: const EdgeInsets.all(SailStyleValues.padding12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 820,
+              child: SailText.secondary13(
+                switch (gate) {
+                  L1Gate.stopped =>
+                    'Deposits, withdrawals and the slot list are read from BIP300 state, which only a local '
+                        'Bitcoin Core plus the enforcer can produce. Both must be running and fully synced '
+                        'before this tab can do anything.',
+                  L1Gate.starting => 'Both daemons are coming up. The slot list appears once they are synced.',
+                  _ =>
+                    'The slot list and balances stay empty until Core and the enforcer have caught up with '
+                        'the chain tip. You can leave this tab — syncing carries on.',
+                },
+              ),
+            ),
+            const SailSpacing(SailStyleValues.padding16),
+            // The same cards the bottom nav shows, so status, sync progress and
+            // the per-daemon restart/logs controls stay in one implementation.
+            DaemonConnectionCard(
+              connection: viewModel.mainchainConnection,
+              syncInfo: viewModel.mainchainSyncInfo,
+              infoMessage: null,
+              restartDaemon: () => viewModel.restartDaemon(BitcoinCore()),
+              stopDaemon: () => viewModel.stopDaemon(BitcoinCore()),
+              navigateToLogs: viewModel.navigateToLogs,
+            ),
+            DaemonConnectionCard(
+              connection: viewModel.enforcerConnection,
+              syncInfo: viewModel.enforcerSyncInfo,
+              infoMessage: viewModel.enforcerInfoMessage,
+              restartDaemon: () => viewModel.restartDaemon(Enforcer()),
+              stopDaemon: () => viewModel.stopDaemon(Enforcer()),
+              navigateToLogs: viewModel.navigateToLogs,
+            ),
+            const SailSpacing(SailStyleValues.padding16),
+            Row(
+              children: [
+                if (gate == L1Gate.stopped)
+                  SailButton(
+                    label: 'Start Bitcoin Core + Enforcer',
+                    onPressed: viewModel.startL1,
+                  ),
+                if (gate == L1Gate.stopped) const SizedBox(width: SailStyleValues.padding12),
+                Flexible(
+                  child: SailText.secondary12(
+                    switch (gate) {
+                      L1Gate.stopped => 'Takes a while on first run — the chain has to download and verify.',
+                      _ => 'Progress also shows in the status bar below.',
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -617,6 +743,81 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
 
   bool get loading => _enforcerRPC.initializingBinary;
 
+  /// What is missing before the tab can read BIP300 state. Sidechains live in
+  /// the enforcer's view of the chain, so a running *and* synced Core plus
+  /// enforcer is the floor — an electrum wallet has neither.
+  L1Gate get l1Gate => resolveL1Gate(
+    walletNeedsBackends: _walletReader.activeWalletNeedsBitcoinBackends,
+    coreConnected: _binaryProvider.isConnected(BitcoinCore()),
+    enforcerConnected: _binaryProvider.isConnected(Enforcer()),
+    coming:
+        _binaryProvider.isInitializing(BitcoinCore()) ||
+        _binaryProvider.isInitializing(Enforcer()) ||
+        _isDownloadingFor(BitcoinCore()) ||
+        _isDownloadingFor(Enforcer()),
+    synced: _syncProvider.isSynced,
+    chainIsEmpty: _regtestChainIsEmpty,
+  );
+
+  /// Regtest alone can legitimately sit at height 0 with nothing to sync from.
+  /// Any reported height means it is catching up like any other chain — and an
+  /// absent or failed sample is unknown, not empty, so it never opens the tab.
+  bool get _regtestChainIsEmpty {
+    if (_confProvider.network != BitcoinNetwork.BITCOIN_NETWORK_REGTEST) {
+      return false;
+    }
+    if (_syncProvider.mainchainError != null || _syncProvider.enforcerError != null) {
+      return false;
+    }
+    final mainchain = _syncProvider.mainchainSyncInfo;
+    final enforcer = _syncProvider.enforcerSyncInfo;
+    if (mainchain == null || enforcer == null) {
+      return false;
+    }
+    return mainchain.progressGoal == 0 &&
+        mainchain.progressCurrent == 0 &&
+        enforcer.progressGoal == 0 &&
+        enforcer.progressCurrent == 0;
+  }
+
+  RPCConnection get mainchainConnection => GetIt.I.get<BitcoindConnection>();
+  RPCConnection get enforcerConnection => _enforcerRPC;
+
+  SyncInfo? get mainchainSyncInfo => _syncProvider.mainchainSyncInfo;
+  SyncInfo? get enforcerSyncInfo => _syncProvider.enforcerSyncInfo;
+
+  /// The enforcer boots behind Core and reports 0/0 until headers land, which
+  /// reads as a fault unless we say what it is waiting for.
+  String? get enforcerInfoMessage {
+    if (mainchainConnection.initializingBinary) {
+      return 'Waiting for mainchain to finish initializing';
+    }
+    if (_syncProvider.inHeaderSync) {
+      return 'Waiting for L1 to sync headers...';
+    }
+    return null;
+  }
+
+  Binary _binaryFor(Binary binary) =>
+      _binaryProvider.binaries.firstWhere((b) => b.name == binary.name, orElse: () => binary);
+
+  Future<void> restartDaemon(Binary binary) => _binaryProvider.restart(_binaryFor(binary));
+
+  Future<void> stopDaemon(Binary binary) => _binaryProvider.stop(_binaryFor(binary));
+
+  Future<void> startL1() async {
+    // Starting the enforcer boots the whole L1 chain: Core first, then this.
+    await _binaryProvider.start(_binaryFor(Enforcer()));
+  }
+
+  /// The daemon cards enable "View logs" on their own and then call this
+  /// unconditionally, so it has to be supplied wherever a card is rendered.
+  void navigateToLogs(String title, String logPath, BinaryType binaryType) {
+    GetIt.I.get<AppRouter>().push(
+      LogRoute(title: title, logPath: logPath, binaryType: binaryType),
+    );
+  }
+
   /// Check if current network supports sidechains (L2L networks only)
   bool get networkSupportsSidechains {
     final network = _confProvider.network;
@@ -1154,6 +1355,10 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
     // Core data that affects the UI
     track('sidechains', _sidechainProvider.sidechains);
     track('recentDeposits', recentDeposits);
+
+    // Switching between an electrum and a backend-backed wallet changes nothing
+    // else tracked here, so without this the tab keeps rendering the old gate.
+    track('l1Gate', l1Gate);
 
     // UI state that affects rendering
     track('showOnlyFilled', showOnlyFilled);

--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -1358,7 +1358,13 @@ class SidechainsViewModel extends BaseViewModel with ChangeTrackingMixin {
 
     // Switching between an electrum and a backend-backed wallet changes nothing
     // else tracked here, so without this the tab keeps rendering the old gate.
-    track('l1Gate', l1Gate);
+    final gate = l1Gate;
+    if (track('l1Gate', gate) && gate == L1Gate.ready) {
+      // SidechainProvider only refetches once isSynced flips, which never
+      // happens on an empty regtest chain — the slot list would stay as it was
+      // when the daemons were still down.
+      unawaited(_sidechainProvider.fetch());
+    }
 
     // UI state that affects rendering
     track('showOnlyFilled', showOnlyFilled);

--- a/bitwindow/test/sidechains_l1_gate_test.dart
+++ b/bitwindow/test/sidechains_l1_gate_test.dart
@@ -1,0 +1,131 @@
+import 'package:bitwindow/pages/sidechains_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('resolveL1Gate', () {
+    // An electrum wallet runs neither daemon, which is the case that used to
+    // leave the tab showing empty tables and buttons that fail.
+    test('nothing running is a stopped gate', () {
+      expect(
+        resolveL1Gate(
+          walletNeedsBackends: true,
+          coreConnected: false,
+          enforcerConnected: false,
+          coming: false,
+          synced: false,
+          chainIsEmpty: false,
+        ),
+        L1Gate.stopped,
+      );
+    });
+
+    test('half the stack still blocks', () {
+      expect(
+        resolveL1Gate(
+          walletNeedsBackends: true,
+          coreConnected: true,
+          enforcerConnected: false,
+          coming: false,
+          synced: true,
+          chainIsEmpty: false,
+        ),
+        L1Gate.stopped,
+      );
+    });
+
+    // Starting must not offer the start button again.
+    test('a boot in flight reads as starting', () {
+      expect(
+        resolveL1Gate(
+          walletNeedsBackends: true,
+          coreConnected: false,
+          enforcerConnected: false,
+          coming: true,
+          synced: false,
+          chainIsEmpty: false,
+        ),
+        L1Gate.starting,
+      );
+    });
+
+    // Running but behind the tip is the subtle one: the tables would populate
+    // with a stale view of BIP300 state.
+    test('running but unsynced is not ready', () {
+      expect(
+        resolveL1Gate(
+          walletNeedsBackends: true,
+          coreConnected: true,
+          enforcerConnected: true,
+          coming: false,
+          synced: false,
+          chainIsEmpty: false,
+        ),
+        L1Gate.syncing,
+      );
+    });
+
+    test('both up and synced opens the tab', () {
+      expect(
+        resolveL1Gate(
+          walletNeedsBackends: true,
+          coreConnected: true,
+          enforcerConnected: true,
+          coming: false,
+          synced: true,
+          chainIsEmpty: false,
+        ),
+        L1Gate.ready,
+      );
+    });
+
+    // An electrum wallet reads BIP300 state from the hosted orchestrator, and
+    // StartWithL1 is a no-op for it — gating would block a working tab behind a
+    // button that cannot do anything.
+    test('an electrum wallet is never gated on local daemons', () {
+      expect(
+        resolveL1Gate(
+          walletNeedsBackends: false,
+          coreConnected: false,
+          enforcerConnected: false,
+          coming: false,
+          synced: false,
+          chainIsEmpty: false,
+        ),
+        L1Gate.ready,
+      );
+    });
+
+    // A fresh regtest node reports 0/0 forever until someone mines, and
+    // SyncInfo.isSynced needs a non-zero goal — the orchestrator calls that
+    // steady state (health.go), so the tab must not sit behind a sync bar.
+    test('an empty regtest chain counts as synced', () {
+      expect(
+        resolveL1Gate(
+          walletNeedsBackends: true,
+          coreConnected: true,
+          enforcerConnected: true,
+          coming: false,
+          synced: false,
+          chainIsEmpty: true,
+        ),
+        L1Gate.ready,
+      );
+    });
+
+    // Once regtest has blocks it is catching up like any other chain, so the
+    // empty-chain bypass must not hand back a stale view of BIP300 state.
+    test('a regtest chain with blocks still has to sync', () {
+      expect(
+        resolveL1Gate(
+          walletNeedsBackends: true,
+          coreConnected: true,
+          enforcerConnected: true,
+          coming: false,
+          synced: false,
+          chainIsEmpty: false,
+        ),
+        L1Gate.syncing,
+      );
+    });
+  });
+}

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -16,6 +16,19 @@ MiningProvider? drynetMiningProvider() {
   return GetIt.I.get<MiningProvider>();
 }
 
+/// Whether a Bitcoin Core / enforcer card belongs in the daemon status dialog.
+///
+/// An electrum wallet needs neither daemon, so an idle card would read as a
+/// fault. But switching to an electrum wallet does not stop a running stack —
+/// while it is up, its sync progress is exactly what the user came to see.
+bool showDaemonCard({
+  required bool walletNeedsBackends,
+  required bool connected,
+  required bool initializing,
+}) {
+  return walletNeedsBackends || connected || initializing;
+}
+
 class BottomNav extends StatelessWidget {
   final List<Widget> endWidgets;
   final List<Widget> balanceEndWidgets;
@@ -180,8 +193,20 @@ class BottomNav extends StatelessWidget {
         builder: ((context, model, child) {
           final binaryProvider = GetIt.I.get<BinaryProvider>();
           // Electrum wallets run no local Core or enforcer by design, so their
-          // cards would sit at a misleading "Not connected" — omit them.
-          final needsBitcoinBackends = GetIt.I.get<WalletReaderProvider>().activeWalletNeedsBitcoinBackends;
+          // cards would sit at a misleading "Not connected" — omit them. Unless
+          // the daemons are up anyway: switching to an electrum wallet leaves
+          // them running, and hiding them loses the sync they still report.
+          final walletNeedsBackends = GetIt.I.get<WalletReaderProvider>().activeWalletNeedsBitcoinBackends;
+          final showMainchain = showDaemonCard(
+            walletNeedsBackends: walletNeedsBackends,
+            connected: model.mainchain.connected,
+            initializing: model.mainchain.initializingBinary,
+          );
+          final showEnforcer = showDaemonCard(
+            walletNeedsBackends: walletNeedsBackends,
+            connected: model.enforcer.connected,
+            initializing: model.enforcer.initializingBinary,
+          );
 
           return SailColumn(
             spacing: SailStyleValues.padding20,
@@ -193,7 +218,7 @@ class BottomNav extends StatelessWidget {
                 spacing: SailStyleValues.padding12,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  if (needsBitcoinBackends &&
+                  if (showMainchain &&
                       (!model.mainchain.connected ||
                           !(model.syncProvider.mainchainSyncInfo?.isSynced ?? false) ||
                           !onlyShowAdditional))
@@ -214,7 +239,7 @@ class BottomNav extends StatelessWidget {
                       navigateToLogs: model.navigateToLogs,
                       onOpenConfConfigurator: onOpenConfConfigurator,
                     ),
-                  if (needsBitcoinBackends &&
+                  if (showEnforcer &&
                       (!model.enforcer.connected ||
                           !(model.syncProvider.enforcerSyncInfo?.isSynced ?? false) ||
                           !onlyShowAdditional))

--- a/sail_ui/test/daemon_card_visibility_test.dart
+++ b/sail_ui/test/daemon_card_visibility_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+void main() {
+  // A wallet that runs the stack always shows both cards, running or not —
+  // "not connected" is the whole point when it should be connected.
+  test('a wallet that needs the daemons always shows them', () {
+    expect(
+      showDaemonCard(walletNeedsBackends: true, connected: false, initializing: false),
+      isTrue,
+    );
+  });
+
+  // Switching to an electrum wallet leaves Core and the enforcer running.
+  // Hiding them then throws away the sync status the user is looking for.
+  test('a running daemon stays visible on an electrum wallet', () {
+    expect(
+      showDaemonCard(walletNeedsBackends: false, connected: true, initializing: false),
+      isTrue,
+    );
+    expect(
+      showDaemonCard(walletNeedsBackends: false, connected: false, initializing: true),
+      isTrue,
+    );
+  });
+
+  // Only when there is genuinely nothing to report does the card go away.
+  test('an electrum wallet with no stack hides the card', () {
+    expect(
+      showDaemonCard(walletNeedsBackends: false, connected: false, initializing: false),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
The sidechains tab reads BIP300 state, so on an electrum wallet it rendered empty tables and buttons that fail. It now explains that a running, synced Bitcoin Core plus enforcer is required, offers a button to start them, and shows both daemons through the same DaemonConnectionCard the bottom nav uses. Also adds a responsible disclosure policy at the repo root.