### PR TITLE
bitwindow: drop the second wallet setup screen

### DIFF
--- a/bitwindow/lib/pages/root_page.dart
+++ b/bitwindow/lib/pages/root_page.dart
@@ -164,11 +164,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
         label: 'Import Wallet Seed',
         category: 'Wallet',
         onSelected: () => GetIt.I.get<AppRouter>().push(
-          SailCreateWalletRoute(
-            homeRoute: const RootRoute(),
-            initialScreen: WelcomeScreen.restore,
-            onRestoreFromFile: restoreBitwindowWalletFromFile,
-          ),
+          CreateAnotherWalletRoute(),
         ),
       ),
       CommandItem(
@@ -491,11 +487,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
                       label: 'Import Wallet Seed',
                       onSelected: () async {
                         await GetIt.I.get<AppRouter>().push(
-                          SailCreateWalletRoute(
-                            homeRoute: const RootRoute(),
-                            initialScreen: WelcomeScreen.restore,
-                            onRestoreFromFile: restoreBitwindowWalletFromFile,
-                          ),
+                          CreateAnotherWalletRoute(),
                         );
                       },
                     ),

--- a/bitwindow/lib/pages/settings/settings_reset.dart
+++ b/bitwindow/lib/pages/settings/settings_reset.dart
@@ -4,7 +4,6 @@ import 'package:bitwindow/routing/router.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
-import 'package:sail_ui/pages/router.gr.dart';
 import 'package:sail_ui/sail_ui.dart';
 
 class SettingsReset extends StatefulWidget {
@@ -232,7 +231,7 @@ class _SettingsResetState extends State<SettingsReset> {
 
       if (needsWalletCreation) {
         final router = GetIt.I.get<AppRouter>();
-        await router.replaceAll([SailCreateWalletRoute(homeRoute: const RootRoute())]);
+        await router.replaceAll([CreateAnotherWalletRoute()]);
       }
     }
   }

--- a/bitwindow/lib/pages/welcome/create_another_wallet_page.dart
+++ b/bitwindow/lib/pages/welcome/create_another_wallet_page.dart
@@ -3,11 +3,16 @@ import 'package:bitwindow/pages/welcome/multisig_config_step.dart';
 import 'package:bitwindow/routing/router.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
 import 'package:sail_ui/sail_ui.dart';
 
 @RoutePage()
 class CreateAnotherWalletPage extends StatefulWidget {
-  const CreateAnotherWalletPage({super.key});
+  /// Set when a route guard is waiting on the first wallet: the guard resolves
+  /// the pending navigation itself, so this page must not replace the stack.
+  final VoidCallback? onWalletCreated;
+
+  const CreateAnotherWalletPage({super.key, this.onWalletCreated});
 
   @override
   State<CreateAnotherWalletPage> createState() => _CreateAnotherWalletPageState();
@@ -46,6 +51,10 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
   String _provider = 'electrum';
   MultisigWalletSpec? _multisigSpec;
   bool _isCreating = false;
+
+  /// True while the keys step is restoring a backup: this page must not be
+  /// popped out from under it.
+  bool _restoringBackup = false;
 
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _accountController = TextEditingController();
@@ -88,6 +97,20 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
     }
   }
 
+  /// True while a route guard holds a suspended navigation waiting on this
+  /// wallet — the page must finish through [onWalletCreated], not by popping.
+  bool get _guarded => widget.onWalletCreated != null;
+
+  /// Hands control back: to the guard when one is waiting, otherwise home.
+  Future<void> _leaveSetup() async {
+    final resume = widget.onWalletCreated;
+    if (resume != null) {
+      resume();
+      return;
+    }
+    await GetIt.I.get<AppRouter>().replaceAll([const RootRoute()]);
+  }
+
   Future<void> _createWallet() async {
     setState(() => _isCreating = true);
 
@@ -114,7 +137,7 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
             change: spec.changeDescriptor,
             coldcardConfig: spec.coldcardConfig(_walletName),
           );
-          await GetIt.I.get<AppRouter>().replaceAll([const RootRoute()]);
+          await _leaveSetup();
         }
         return;
       }
@@ -129,6 +152,31 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
           hardwareDeviceType: _hardwareDeviceType,
           hardwareFingerprint: _hardwareFingerprint,
         );
+      } else if (_provider == 'enforcer') {
+        // The full-node wallet. A pasted seed loads into it like any other.
+        final created = await walletProvider.generateWallet(
+          name: _walletName,
+          customMnemonic: _mnemonic,
+          passphrase: _passphrase,
+          derivationPath: _singleDerivationPath.isEmpty ? null : _singleDerivationPath,
+        );
+        // generateWallet carries no gradient, so the background chosen a step
+        // earlier has to be written back or the wallet falls back to a
+        // deterministic one the user never picked. The wallet already exists at
+        // this point: a failure here is cosmetic, and reporting it as a failed
+        // creation would invite a retry that mints a second wallet.
+        final walletId = created['wallet_id'] as String?;
+        if (walletId != null && walletId.isNotEmpty) {
+          try {
+            await GetIt.I.get<WalletReaderProvider>().updateWalletMetadata(
+              walletId,
+              _walletName,
+              _selectedGradient!,
+            );
+          } catch (e) {
+            GetIt.I.get<Logger>().w('could not set the wallet background: $e');
+          }
+        }
       } else if (_provider == 'core') {
         await walletProvider.createBitcoinCoreWallet(
           name: _walletName,
@@ -149,7 +197,7 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
       }
 
       if (mounted) {
-        await GetIt.I.get<AppRouter>().replaceAll([const RootRoute()]);
+        await _leaveSetup();
       }
     } catch (e) {
       if (mounted) {
@@ -169,6 +217,8 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
   List<Widget> _buildPages() {
     return [
       MultisigConfigStep(
+        onRestored: _leaveSetup,
+        onRestoringChanged: (restoring) => setState(() => _restoringBackup = restoring),
         onConfigured: (result) {
           setState(() {
             if (result.isMultisig) {
@@ -221,34 +271,53 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
 
     final List<Widget> pages = _buildPages();
 
-    return SailScaffold(
-      backgroundColor: theme.colors.background,
-      appBar: SailAppBar.build(
-        context,
-        // Always provide a leading so the material AppBar doesn't auto-imply its
-        // own oversized back button (which gets clipped by toolbarHeight). Step
-        // 0 pops the route; later steps walk back through the wizard.
-        leading: SailButton(
-          variant: ButtonVariant.icon,
-          icon: SailSVGAsset.chevronLeft,
-          onPressed: () async {
-            if (_currentStep > 0) {
-              _previousStep();
-            } else {
-              await GetIt.I.get<AppRouter>().maybePop();
-            }
-          },
-          iconHeight: 14,
-          iconWidth: 14,
-          small: true,
+    // Hiding the back button is not enough: an OS or hardware back still pops
+    // the guard's redirect route without resolving it. Popping is allowed only
+    // when nothing is waiting on this page and there is no wizard step to
+    // unwind; a blocked pop mid-wizard walks back a step instead.
+    return PopScope(
+      canPop: !_guarded && _currentStep == 0 && !_restoringBackup,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) {
+          return;
+        }
+        if (_currentStep > 0) {
+          _previousStep();
+        }
+      },
+      child: SailScaffold(
+        backgroundColor: theme.colors.background,
+        appBar: SailAppBar.build(
+          context,
+          // Always provide a leading so the material AppBar doesn't auto-imply its
+          // own oversized back button (which gets clipped by toolbarHeight). Step
+          // 0 pops the route; later steps walk back through the wizard. With a
+          // guard waiting on the first wallet there is nothing to go back to —
+          // popping would drop its redirect and strand the user with no root page.
+          leading: (_guarded && _currentStep == 0) || _restoringBackup
+              ? const SizedBox.shrink()
+              : SailButton(
+                  variant: ButtonVariant.icon,
+                  icon: SailSVGAsset.chevronLeft,
+                  onPressed: () async {
+                    if (_currentStep > 0) {
+                      _previousStep();
+                    } else {
+                      await GetIt.I.get<AppRouter>().maybePop();
+                    }
+                  },
+                  iconHeight: 14,
+                  iconWidth: 14,
+                  small: true,
+                ),
+          automaticallyImplyLeading: false,
         ),
-        automaticallyImplyLeading: false,
-      ),
-      body: SafeArea(
-        child: PageView(
-          controller: _pageController,
-          physics: const NeverScrollableScrollPhysics(),
-          children: pages,
+        body: SafeArea(
+          child: PageView(
+            controller: _pageController,
+            physics: const NeverScrollableScrollPhysics(),
+            children: pages,
+          ),
         ),
       ),
     );

--- a/bitwindow/lib/pages/welcome/multisig_config_step.dart
+++ b/bitwindow/lib/pages/welcome/multisig_config_step.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:bitwindow/main.dart' show restoreBitwindowWalletFromFile;
 import 'package:bitwindow/pages/welcome/wallet_backup_page.dart';
+import 'package:bitwindow/routing/router.dart';
 import 'package:bitwindow/widgets/hardware_device_picker.dart';
 import 'package:bitwindow/widgets/ur_qr_scanner.dart' show urCameraScanSupported;
 import 'package:file_picker/file_picker.dart';
@@ -182,7 +184,22 @@ class SingleSigResult {
 class MultisigConfigStep extends StatefulWidget {
   final void Function(WalletSetupResult result) onConfigured;
 
-  const MultisigConfigStep({required this.onConfigured, super.key});
+  /// Called when a backup restore produced a wallet, so the caller can hand
+  /// control back the same way it does for a freshly created one — a route
+  /// guard may be holding a suspended navigation.
+  final Future<void> Function()? onRestored;
+
+  /// Reports whether a restore is in flight, so the host can freeze its own
+  /// navigation: the restore rewrites wallet state and restarts L1, and this
+  /// page must outlive it.
+  final ValueChanged<bool>? onRestoringChanged;
+
+  const MultisigConfigStep({
+    required this.onConfigured,
+    this.onRestored,
+    this.onRestoringChanged,
+    super.key,
+  });
 
   @override
   State<MultisigConfigStep> createState() => _MultisigConfigStepState();
@@ -201,12 +218,13 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
   String _scriptType = 'wpkh'; // multi: wsh|sh-wsh|sh|tr; single: wpkh|sh-wpkh|pkh|tr
   int _selectedTab = 0;
   bool _settingsOpen = false;
-  String _provider = 'electrum'; // electrum | core
+  String _provider = 'electrum'; // electrum | core | enforcer
 
   /// One key is a single-sig wallet; the quorum slider is what makes it multisig.
   bool get _isSingle => _total == 1;
   bool _building = false;
   String? _error;
+  bool _restoringBackup = false;
   late List<CosignerKeystore> _keystores;
   final TextEditingController _descriptor = TextEditingController();
   final FocusNode _descriptorFocus = FocusNode();
@@ -221,6 +239,12 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
   @override
   void initState() {
     super.initState();
+    // With no enforcer yet, the full node is the wallet to make: nothing else
+    // can serve chain data, and the backend promotes the first wallet to the
+    // enforcer whatever is picked here.
+    if (GetIt.I.get<WalletReaderProvider>().enforcerWallet == null) {
+      _provider = 'enforcer';
+    }
     _keystores = List.generate(_total, (i) => CosignerKeystore(owner: 'Key ${i + 1}'));
     _descriptor.text = _descriptorPreview;
     // Snapping back over a rejected descriptor would take away the text the
@@ -525,7 +549,7 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
           (k.mnemonic ?? '').isNotEmpty
               ? SingleSigResult(
                   scriptType: _singleHotScriptType(),
-                  provider: _coreAvailable ? _provider : 'electrum',
+                  provider: _effectiveProvider,
                   mnemonic: k.mnemonic,
                   passphrase: k.passphrase,
                   derivationPath: _derivationPathToSubmit(k),
@@ -690,12 +714,15 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
               SailButton(
                 label: '← Back',
                 variant: ButtonVariant.secondary,
+                disabled: _restoringBackup,
                 onPressed: () async => Navigator.of(context).maybePop(),
               ),
               SailButton(
                 label: 'Next',
                 loading: _building,
-                disabled: !_allFilled,
+                // A restore rewrites the wallet and restarts L1; stepping on
+                // through setup would race a second creation against it.
+                disabled: !_allFilled || _restoringBackup,
                 onPressed: () async => _next(),
               ),
             ],
@@ -760,9 +787,36 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
   // backend only watches multisig through Electrum.
   bool get _coreAvailable => _isSingle && _keystores.first.held;
 
+  // The enforcer is the wallet that runs the local node and the backend keeps
+  // exactly one, so it is on offer only until one exists — and, like Core, only
+  // for a single key held as a seed.
+  bool get _hasEnforcerWallet => GetIt.I.get<WalletReaderProvider>().enforcerWallet != null;
+
+  bool get _enforcerAvailable => _coreAvailable && !_hasEnforcerWallet;
+
+  // Without an enforcer wallet the backend promotes whatever is created into
+  // one, so offering Core here would hand back a different type than picked.
+  bool get _bitcoinCoreAvailable => _coreAvailable && _hasEnforcerWallet;
+
+  /// The provider a wallet would actually be created with: what was picked,
+  /// unless it has stopped being on offer (a second key, a watch-only key, or
+  /// an enforcer that now exists).
+  String get _effectiveProvider {
+    if (!_coreAvailable) {
+      return 'electrum';
+    }
+    if (_provider == 'enforcer' && !_enforcerAvailable) {
+      return 'electrum';
+    }
+    if (_provider == 'core' && !_bitcoinCoreAvailable) {
+      return 'electrum';
+    }
+    return _provider;
+  }
+
   Widget _providerDropdown(BuildContext context) {
     return SailDropdownButton<String>(
-      value: _coreAvailable ? _provider : 'electrum',
+      value: _effectiveProvider,
       enabled: _coreAvailable,
       onChanged: (v) async {
         if (v == null) {
@@ -770,9 +824,10 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
         }
         setState(() => _provider = v);
       },
-      items: const [
-        SailDropdownItem<String>(value: 'electrum', label: 'Electrum'),
-        SailDropdownItem<String>(value: 'core', label: 'Bitcoin Core'),
+      items: [
+        if (_enforcerAvailable) const SailDropdownItem<String>(value: 'enforcer', label: 'Enforcer'),
+        const SailDropdownItem<String>(value: 'electrum', label: 'Electrum'),
+        if (_bitcoinCoreAvailable) const SailDropdownItem<String>(value: 'core', label: 'Bitcoin Core'),
       ],
     );
   }
@@ -810,7 +865,11 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
   // Electrum takes the script type directly, so a standard path is left off to
   // keep every address kind open. Core has no script-type input.
   String? _derivationPathToSubmit(CosignerKeystore k) {
-    if (_coreAvailable && _provider == 'core') {
+    // Electrum takes a script type; Core only takes a path, so dropping it
+    // there would silently ignore the address type just chosen. The enforcer
+    // honours neither — it mints its own addresses — so it gets the path only
+    // when the user set one explicitly.
+    if (_coreAvailable && _effectiveProvider == 'core') {
       return k.derivationPath.isNotEmpty ? k.derivationPath : _standardPath;
     }
     return k.derivationPath == _standardPath ? null : k.derivationPath;
@@ -832,6 +891,17 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
   String _addressTypeLabel(String scriptType) => _addressTypes[scriptType] ?? scriptType;
 
   Widget _scriptDropdown(BuildContext context) {
+    // The enforcer mints addresses itself: it ignores the derivation path and
+    // refuses taproot outright, so offering a choice here would be a promise
+    // its backend cannot keep.
+    if (_effectiveProvider == 'enforcer') {
+      return SailDropdownButton<String>(
+        value: 'wpkh',
+        enabled: false,
+        onChanged: (_) async {},
+        items: const [SailDropdownItem<String>(value: 'wpkh', label: 'Native Segwit (bc1q...)')],
+      );
+    }
     final values = _isSingle ? const ['wpkh', 'tr', 'sh-wpkh', 'pkh'] : const ['wsh', 'tr', 'sh-wsh', 'sh'];
     return SailDropdownButton<String>(
       value: _scriptType,
@@ -1305,7 +1375,7 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
   // and carries a lit edge rather than reading as another secondary button.
   Widget _generateKeyButton(BuildContext context, int index) {
     final theme = SailTheme.of(context);
-    final enabled = _pathError == null;
+    final enabled = _pathError == null && !_restoringBackup;
     return Opacity(
       opacity: enabled ? 1 : 0.5,
       child: SailTappable(
@@ -1340,7 +1410,7 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
   // to put it, and the ghost row below reads as fine print.
   Widget _pasteSeedButton(BuildContext context, int index) {
     final theme = SailTheme.of(context);
-    final enabled = _pathError == null;
+    final enabled = _pathError == null && !_restoringBackup;
     return Opacity(
       opacity: enabled ? 1 : 0.5,
       child: SailTappable(
@@ -1363,10 +1433,11 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
   Widget _sourcePicker(BuildContext context, int index) {
     final theme = SailTheme.of(context);
     final links = <(String, bool, Future<void> Function())>[
-      ('xPub/ Watch Only', true, () async => _addFromPaste(context, index)),
-      ('Import file', true, () async => _addFromFile(context, index)),
-      ('Scan QR', urCameraScanSupported, () async => _addFromQr(context, index)),
-      ('Hardware Wallet', _pathError == null, () async => _addFromDevice(context, index)),
+      ('xPub/ Watch Only', !_restoringBackup, () async => _addFromPaste(context, index)),
+      ('Import file', !_restoringBackup, () async => _addFromFile(context, index)),
+      ('Scan QR', urCameraScanSupported && !_restoringBackup, () async => _addFromQr(context, index)),
+      ('Hardware Wallet', _pathError == null && !_restoringBackup, () async => _addFromDevice(context, index)),
+      ('Restore backup', !_restoringBackup, () async => _restoreFromBackup(context)),
     ];
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -1488,6 +1559,41 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
     );
     if (k != null) {
       _setKeystore(index, k);
+    }
+  }
+
+  /// Restores a whole wallet — master seed plus every sidechain wallet — from a
+  /// backup file. Unlike the other sources this doesn't fill a key slot: the
+  /// wallet already exists once the file lands, so it skips the rest of setup.
+  Future<void> _restoreFromBackup(BuildContext context) async {
+    setState(() => _error = null);
+    final result = await FilePicker.pickFiles(
+      dialogTitle: 'Upload wallet backup',
+      type: FileType.custom,
+      allowedExtensions: ['zip', 'json'],
+    );
+    final path = result?.files.singleOrNull?.path;
+    if (path == null) {
+      return;
+    }
+    setState(() => _restoringBackup = true);
+    widget.onRestoringChanged?.call(true);
+    try {
+      await restoreBitwindowWalletFromFile(File(path));
+      final restored = widget.onRestored;
+      if (restored != null) {
+        await restored();
+        return;
+      }
+      await GetIt.I.get<AppRouter>().replaceAll([const RootRoute()]);
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = 'Failed to restore from backup file: ${extractConnectException(e)}';
+          _restoringBackup = false;
+        });
+        widget.onRestoringChanged?.call(false);
+      }
     }
   }
 

--- a/bitwindow/lib/routing/router.dart
+++ b/bitwindow/lib/routing/router.dart
@@ -1,6 +1,5 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:bitwindow/dialogs/network_statistics_dialog.dart';
-import 'package:bitwindow/main.dart' show restoreBitwindowWalletFromFile;
 import 'package:bitwindow/pages/chat_page.dart';
 import 'package:bitwindow/pages/configure_homepage.dart';
 import 'package:bitwindow/pages/console_page.dart';
@@ -90,11 +89,7 @@ class AppRouter extends RootStackRouter {
       guards: [
         DataDirGuard(),
         WalletGuard(
-          createWalletRoute: (onWalletCreated) => SailCreateWalletRoute(
-            homeRoute: const RootRoute(),
-            onWalletCreated: onWalletCreated,
-            onRestoreFromFile: restoreBitwindowWalletFromFile,
-          ),
+          createWalletRoute: (onWalletCreated) => CreateAnotherWalletRoute(onWalletCreated: onWalletCreated),
         ),
         PasswordGuard(),
       ],
@@ -110,10 +105,6 @@ class AppRouter extends RootStackRouter {
     AutoRoute(
       path: '/configure-home',
       page: ConfigureHomeRoute.page,
-    ),
-    AutoRoute(
-      path: '/create-wallet',
-      page: SailCreateWalletRoute.page,
     ),
     AutoRoute(
       path: '/create-another-wallet',

--- a/bitwindow/lib/routing/router.gr.dart
+++ b/bitwindow/lib/routing/router.gr.dart
@@ -200,18 +200,58 @@ class ConsoleRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [CreateAnotherWalletPage]
-class CreateAnotherWalletRoute extends PageRouteInfo<void> {
-  const CreateAnotherWalletRoute({List<PageRouteInfo>? children})
-    : super(CreateAnotherWalletRoute.name, initialChildren: children);
+class CreateAnotherWalletRoute
+    extends PageRouteInfo<CreateAnotherWalletRouteArgs> {
+  CreateAnotherWalletRoute({
+    Key? key,
+    VoidCallback? onWalletCreated,
+    List<PageRouteInfo>? children,
+  }) : super(
+         CreateAnotherWalletRoute.name,
+         args: CreateAnotherWalletRouteArgs(
+           key: key,
+           onWalletCreated: onWalletCreated,
+         ),
+         initialChildren: children,
+       );
 
   static const String name = 'CreateAnotherWalletRoute';
 
   static PageInfo page = PageInfo(
     name,
     builder: (data) {
-      return const CreateAnotherWalletPage();
+      final args = data.argsAs<CreateAnotherWalletRouteArgs>(
+        orElse: () => const CreateAnotherWalletRouteArgs(),
+      );
+      return CreateAnotherWalletPage(
+        key: args.key,
+        onWalletCreated: args.onWalletCreated,
+      );
     },
   );
+}
+
+class CreateAnotherWalletRouteArgs {
+  const CreateAnotherWalletRouteArgs({this.key, this.onWalletCreated});
+
+  final Key? key;
+
+  final VoidCallback? onWalletCreated;
+
+  @override
+  String toString() {
+    return 'CreateAnotherWalletRouteArgs{key: $key, onWalletCreated: $onWalletCreated}';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! CreateAnotherWalletRouteArgs) return false;
+    return key == other.key && onWalletCreated == other.onWalletCreated;
+  }
+
+  @override
+  int get hashCode => key.hashCode ^ onWalletCreated.hashCode;
 }
 
 /// generated route for

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.154
+version: 0.2.155
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.155
+version: 0.2.156
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
BitWindow had two wallet setup screens; it now uses only the keys screen ("Choose how this wallet holds its keys"). Backup-file restore was reachable solely from the screen being removed, so it moves to the keys screen alongside xPub, Import file, Scan QR and Hardware Wallet. sail_ui keeps SailCreateWalletPage for the sidechain clients.