### PR TITLE
Gate BMM on enforcer sync, stop wiping it on swaps

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.295
+version: 1.0.296
 
 environment:
   sdk: 3.12.2

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.294
+version: 1.0.295
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.294
+version: 1.0.295
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.295
+version: 1.0.296
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.157
+version: 0.2.158
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.158
+version: 0.2.159
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.167
+version: 1.0.168
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.168
+version: 1.0.169
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/pages/sidechains/bmm_tab.dart
+++ b/sail_ui/lib/pages/sidechains/bmm_tab.dart
@@ -423,7 +423,7 @@ class BMMViewModel extends BaseViewModel {
     minBidController.addListener(_onMinBound);
     maxBidController.addListener(_onMaxBound);
     bmmProvider.addListener(_onProviderChanged);
-    _sync.addListener(_onProviderChanged);
+    _sync.addListener(_onSyncChanged);
   }
 
   bool get canBid => bidBlockedReason == null;
@@ -503,6 +503,12 @@ class BMMViewModel extends BaseViewModel {
     if (max != null) {
       bmmProvider.setMaxBidAmount(max);
     }
+  }
+
+  // Sync progress moves constantly, and mirroring the bounds on every step
+  // would overwrite a bound the user is still typing.
+  void _onSyncChanged() {
+    notifyListeners();
   }
 
   void _onProviderChanged() {
@@ -678,7 +684,7 @@ class BMMViewModel extends BaseViewModel {
   @override
   void dispose() {
     bmmProvider.removeListener(_onProviderChanged);
-    _sync.removeListener(_onProviderChanged);
+    _sync.removeListener(_onSyncChanged);
     minBidController.dispose();
     maxBidController.dispose();
     super.dispose();

--- a/sail_ui/lib/pages/sidechains/bmm_tab.dart
+++ b/sail_ui/lib/pages/sidechains/bmm_tab.dart
@@ -8,6 +8,24 @@ import 'package:sidechain_core/utils/explorer_url.dart';
 import 'package:stacked/stacked.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+/// Reason bidding is unavailable, or null when it is allowed.
+///
+/// A bid commits to the tip the enforcer has validated, so one built while it
+/// trails Bitcoin Core names a block miners have already built past and can
+/// never be included. The orchestrator rejects those bids too — this only keeps
+/// the controls from offering an action that cannot succeed.
+String? bidBlockedReasonFor(SyncProvider sync) {
+  final enforcer = sync.enforcerSyncInfo;
+  if (enforcer == null || (sync.enforcerError?.isNotEmpty ?? false)) {
+    return 'Waiting for the enforcer to start';
+  }
+  if (enforcer.isSynced) {
+    return null;
+  }
+  return 'Enforcer is syncing — '
+      '${enforcer.progressCurrent.toInt()} of ${enforcer.progressGoal.toInt()} blocks';
+}
+
 class BMMTab extends StatelessWidget {
   const BMMTab({super.key});
 
@@ -43,23 +61,30 @@ class _Controls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Stopping stays available while the enforcer is behind: an engine started
+    // before it fell back has to be stoppable.
+    final blocked = !viewModel.canBid;
     return SailRow(
       spacing: SailStyleValues.padding08,
       children: [
         SailButton(
           label: viewModel.running ? 'Stop auto-bidding' : 'Start auto-bidding',
+          disabled: blocked && !viewModel.running,
           onPressed: () async => viewModel.running ? await viewModel.stopBidding() : await viewModel.startBidding(),
         ),
         SailButton(
           label: 'Bid manually',
           variant: ButtonVariant.secondary,
+          disabled: blocked,
           onPressed: () async => _showManualBidDialog(context, viewModel),
         ),
         SailButton(
           label: 'Attack',
           variant: ButtonVariant.secondary,
+          disabled: blocked,
           onPressed: () async => viewModel.bmmProvider.attackBid(),
         ),
+        if (viewModel.bidBlockedReason case final reason?) SailText.secondary13(reason),
         Expanded(child: Container()),
         SailText.primary13('Min bid:'),
         SizedBox(
@@ -382,6 +407,7 @@ class _HistoricBids extends StatelessWidget {
 class BMMViewModel extends BaseViewModel {
   final BMMProvider bmmProvider = GetIt.I.get<BMMProvider>();
   final BitcoinConfProvider _conf = GetIt.I.get<BitcoinConfProvider>();
+  final SyncProvider _sync = GetIt.I.get<SyncProvider>();
 
   final TextEditingController minBidController = TextEditingController();
   final TextEditingController maxBidController = TextEditingController();
@@ -392,7 +418,11 @@ class BMMViewModel extends BaseViewModel {
     minBidController.addListener(_onMinBound);
     maxBidController.addListener(_onMaxBound);
     bmmProvider.addListener(_onProviderChanged);
+    _sync.addListener(_onProviderChanged);
   }
+
+  bool get canBid => bidBlockedReason == null;
+  String? get bidBlockedReason => bidBlockedReasonFor(_sync);
 
   bool get running => bmmProvider.running;
   String? get bmmError => bmmProvider.error;
@@ -446,7 +476,7 @@ class BMMViewModel extends BaseViewModel {
   String get slotHint {
     final live = bmmProvider.liveBid;
     if (!running && live == null) {
-      return 'Press Start auto-bidding to bid for the next block';
+      return bidBlockedReason ?? 'Press Start auto-bidding to bid for the next block';
     }
     if (live == null) {
       return '';
@@ -643,6 +673,7 @@ class BMMViewModel extends BaseViewModel {
   @override
   void dispose() {
     bmmProvider.removeListener(_onProviderChanged);
+    _sync.removeListener(_onProviderChanged);
     minBidController.dispose();
     maxBidController.dispose();
     super.dispose();

--- a/sail_ui/lib/pages/sidechains/bmm_tab.dart
+++ b/sail_ui/lib/pages/sidechains/bmm_tab.dart
@@ -15,6 +15,11 @@ import 'package:url_launcher/url_launcher.dart';
 /// never be included. The orchestrator rejects those bids too — this only keeps
 /// the controls from offering an action that cannot succeed.
 String? bidBlockedReasonFor(SyncProvider sync) {
+  // Without Core the enforcer's goal falls back to its own height, which reads
+  // as synced however far behind it is.
+  if (sync.mainchainSyncInfo == null || (sync.mainchainError?.isNotEmpty ?? false)) {
+    return 'Waiting for Bitcoin Core';
+  }
   final enforcer = sync.enforcerSyncInfo;
   if (enforcer == null || (sync.enforcerError?.isNotEmpty ?? false)) {
     return 'Waiting for the enforcer to start';

--- a/sail_ui/test/bmm_sync_gate_test.dart
+++ b/sail_ui/test/bmm_sync_gate_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/pages/sidechains/bmm_tab.dart';
+import 'package:sidechain_core/sidechain_core.dart';
+
+SyncInfo _info(int blocks, int headers) =>
+    SyncInfo(progressCurrent: blocks.toDouble(), progressGoal: headers.toDouble(), lastBlockAt: null);
+
+void main() {
+  late SyncProvider sync;
+
+  setUp(() => sync = SyncProvider(startTimer: false));
+
+  test('bidding unlocks once the enforcer is level with core', () {
+    sync.enforcerSyncInfo = _info(8725, 8725);
+    expect(bidBlockedReasonFor(sync), isNull);
+  });
+
+  test('bidding is blocked while the enforcer trails core', () {
+    sync.enforcerSyncInfo = _info(4000, 8725);
+    expect(bidBlockedReasonFor(sync), 'Enforcer is syncing — 4000 of 8725 blocks');
+  });
+
+  test('bidding is blocked before any height is known', () {
+    sync.enforcerSyncInfo = _info(0, 0);
+    expect(bidBlockedReasonFor(sync), isNotNull);
+  });
+
+  test('bidding is blocked when the enforcer is not running', () {
+    sync.enforcerSyncInfo = _info(8725, 8725);
+    sync.enforcerError = 'not running';
+    expect(bidBlockedReasonFor(sync), 'Waiting for the enforcer to start');
+  });
+
+  test('bidding is blocked before the first poll lands', () {
+    expect(bidBlockedReasonFor(sync), 'Waiting for the enforcer to start');
+  });
+}

--- a/sail_ui/test/bmm_sync_gate_test.dart
+++ b/sail_ui/test/bmm_sync_gate_test.dart
@@ -8,11 +8,28 @@ SyncInfo _info(int blocks, int headers) =>
 void main() {
   late SyncProvider sync;
 
-  setUp(() => sync = SyncProvider(startTimer: false));
+  setUp(() {
+    sync = SyncProvider(startTimer: false);
+    sync.mainchainSyncInfo = _info(8725, 8725);
+  });
 
   test('bidding unlocks once the enforcer is level with core', () {
     sync.enforcerSyncInfo = _info(8725, 8725);
     expect(bidBlockedReasonFor(sync), isNull);
+  });
+
+  // Without Core the orchestrator reports the enforcer's goal as its own
+  // height, so it reads as synced however far behind it is.
+  test('bidding is blocked when bitcoin core is unavailable', () {
+    sync.enforcerSyncInfo = _info(4000, 4000);
+    sync.mainchainError = 'not running';
+    expect(bidBlockedReasonFor(sync), 'Waiting for Bitcoin Core');
+  });
+
+  test('bidding is blocked before core reports a height', () {
+    sync.mainchainSyncInfo = null;
+    sync.enforcerSyncInfo = _info(8725, 8725);
+    expect(bidBlockedReasonFor(sync), 'Waiting for Bitcoin Core');
   });
 
   test('bidding is blocked while the enforcer trails core', () {

--- a/sidechain-orchestrator/api/bmm_handler.go
+++ b/sidechain-orchestrator/api/bmm_handler.go
@@ -45,6 +45,42 @@ func (h *BMMHandler) SetEngine(engine *engines.BmmEngine) {
 	h.engine = engine
 }
 
+// requireEnforcerSynced rejects bidding until the enforcer has validated every
+// block Bitcoin Core knows about. A bid assembled against a trailing tip
+// commits to a prev-main-hash miners have already built past, so it can never
+// be included and the sats spent on it are lost.
+//
+// The rule matches SyncInfo.isSynced on the frontend, so both agree on when the
+// controls unlock: GetSyncStatus fills the enforcer's Headers from the
+// mainchain tip, leaving Blocks == Headers as "level with Core".
+func (h *BMMHandler) requireEnforcerSynced(ctx context.Context) error {
+	status, err := h.orch.GetSyncStatus(ctx)
+	if err != nil {
+		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("read sync status: %w", err))
+	}
+	return enforcerBiddingBlocked(status)
+}
+
+// enforcerBiddingBlocked returns the reason bidding is unavailable for status,
+// or nil when it is allowed.
+func enforcerBiddingBlocked(status *orchestrator.SyncStatus) error {
+	if status == nil || status.Mainchain == nil || status.Enforcer == nil {
+		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("sync status unavailable"))
+	}
+	if msg := status.Mainchain.Error; msg != "" {
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("bitcoin core is not available: %s", msg))
+	}
+	if msg := status.Enforcer.Error; msg != "" {
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("enforcer is not available: %s", msg))
+	}
+	if status.Enforcer.Headers <= 0 || status.Enforcer.Blocks != status.Enforcer.Headers {
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
+			"enforcer is still syncing: %d of %d blocks", status.Enforcer.Blocks, status.Enforcer.Headers,
+		))
+	}
+	return nil
+}
+
 func (h *BMMHandler) Start(
 	ctx context.Context, req *connect.Request[bmmpb.StartRequest],
 ) (*connect.Response[bmmpb.StartResponse], error) {
@@ -52,6 +88,9 @@ func (h *BMMHandler) Start(
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("bmm engine not wired"))
 	}
 	if _, err := h.sidechainConfig(req.Msg.Sidechain); err != nil {
+		return nil, err
+	}
+	if err := h.requireEnforcerSynced(ctx); err != nil {
 		return nil, err
 	}
 	if err := h.engine.Start(req.Msg.Sidechain, req.Msg.WalletId, req.Msg.MinBidSats, req.Msg.MaxBidSats); err != nil {
@@ -206,6 +245,9 @@ func (h *BMMHandler) CreateBid(
 ) (*connect.Response[bmmpb.CreateBidResponse], error) {
 	if req.Msg.BidSats <= 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("bid_sats must be positive"))
+	}
+	if err := h.requireEnforcerSynced(ctx); err != nil {
+		return nil, err
 	}
 	cfg, proxy, err := h.sidechainTarget(req.Msg.Sidechain)
 	if err != nil {
@@ -377,6 +419,9 @@ func (h *BMMHandler) AttackBid(
 	}
 	if h.orch != nil && h.orch.CurrentNetwork() == "mainnet" {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("attack bids are disabled on mainnet"))
+	}
+	if err := h.requireEnforcerSynced(ctx); err != nil {
+		return nil, err
 	}
 
 	cfg, proxy, err := h.sidechainTarget(req.Msg.Sidechain)

--- a/sidechain-orchestrator/api/bmm_sync_gate_test.go
+++ b/sidechain-orchestrator/api/bmm_sync_gate_test.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
+)
+
+func syncStatus(mainchain, enforcer *orchestrator.ChainSyncResult) *orchestrator.SyncStatus {
+	return &orchestrator.SyncStatus{Mainchain: mainchain, Enforcer: enforcer}
+}
+
+func TestEnforcerBiddingBlocked(t *testing.T) {
+	tests := []struct {
+		name   string
+		status *orchestrator.SyncStatus
+		code   connect.Code
+		reason string
+	}{
+		{
+			name:   "level with core",
+			status: syncStatus(&orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}, &orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}),
+		},
+		{
+			name:   "enforcer trails core",
+			status: syncStatus(&orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}, &orchestrator.ChainSyncResult{Blocks: 4000, Headers: 8725}),
+			code:   connect.CodeFailedPrecondition,
+			reason: "still syncing",
+		},
+		{
+			name:   "enforcer ahead of core",
+			status: syncStatus(&orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}, &orchestrator.ChainSyncResult{Blocks: 8726, Headers: 8725}),
+			code:   connect.CodeFailedPrecondition,
+			reason: "still syncing",
+		},
+		{
+			name:   "nothing synced yet",
+			status: syncStatus(&orchestrator.ChainSyncResult{}, &orchestrator.ChainSyncResult{}),
+			code:   connect.CodeFailedPrecondition,
+			reason: "still syncing",
+		},
+		{
+			name:   "enforcer not running",
+			status: syncStatus(&orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}, &orchestrator.ChainSyncResult{Error: "not running"}),
+			code:   connect.CodeFailedPrecondition,
+			reason: "enforcer is not available",
+		},
+		{
+			name:   "core not running",
+			status: syncStatus(&orchestrator.ChainSyncResult{Error: "not running"}, &orchestrator.ChainSyncResult{Blocks: 8725, Headers: 8725}),
+			code:   connect.CodeFailedPrecondition,
+			reason: "bitcoin core is not available",
+		},
+		{
+			name:   "no status",
+			status: nil,
+			code:   connect.CodeUnavailable,
+			reason: "sync status unavailable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := enforcerBiddingBlocked(tc.status)
+			if tc.reason == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Equal(t, tc.code, connect.CodeOf(err))
+			assert.Contains(t, err.Error(), tc.reason)
+		})
+	}
+}

--- a/sidechain-orchestrator/config/binaries.go
+++ b/sidechain-orchestrator/config/binaries.go
@@ -374,9 +374,8 @@ func (b BinaryDirConfig) GetBlockchainDataPaths(networkDir string, network Netwo
 		return append(paths, GetMatchingFilesInDir(networkDir, utxoSnapshotPattern, log)...)
 
 	case "bip300301-enforcer":
-		rootdir := b.RootDir()
-		networkName := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(network.ReadableName(), "mainnet", "bitcoin"), "forknet", "bitcoin"), "drynet", "bitcoin")
-		return GetExistingFilesInDir(rootdir, []string{filepath.Join("validator", networkName), networkName}, log)
+		networkName := EnforcerNetworkName(network)
+		return GetExistingFilesInDir(b.RootDir(), []string{filepath.Join("validator", networkName), networkName}, log)
 
 	case "bitwindowd":
 		return GetExistingFilesInDir(networkDir, []string{"bitdrive", "bitwindow.db"}, log)
@@ -520,9 +519,7 @@ func (b BinaryDirConfig) GetWalletPaths(networkDir string, network Network, log 
 
 	switch b.layoutKey() {
 	case "bip300301-enforcer":
-		rootdir := b.RootDir()
-		networkName := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(network.ReadableName(), "mainnet", "bitcoin"), "forknet", "bitcoin"), "drynet", "bitcoin")
-		walletDir := filepath.Join(rootdir, "wallet", networkName)
+		walletDir := EnforcerWalletDir(network)
 		if _, err := os.Stat(walletDir); err == nil {
 			paths = append(paths, walletDir)
 		}
@@ -821,6 +818,37 @@ func (n Network) ReadableName() string {
 	default:
 		return string(n)
 	}
+}
+
+// EnforcerNetworkName is the directory name the enforcer files a network's
+// state under, in <root>/validator/<name> and <root>/wallet/<name>. It follows
+// the chain name Bitcoin Core reports, so mainnet and the networks that fork it
+// share one name.
+func EnforcerNetworkName(n Network) string {
+	switch n {
+	case NetworkMainnet, NetworkForknet, NetworkDrynet:
+		return "bitcoin"
+	default:
+		return n.ReadableName()
+	}
+}
+
+// EnforcerValidatorDir is the enforcer's validator database directory for
+// network.
+func EnforcerValidatorDir(n Network) string {
+	return filepath.Join(EnforcerDirs.RootDir(), "validator", EnforcerNetworkName(n))
+}
+
+// EnforcerWalletDir is the enforcer's BDK wallet directory for network.
+func EnforcerWalletDir(n Network) string {
+	return filepath.Join(EnforcerDirs.RootDir(), "wallet", EnforcerNetworkName(n))
+}
+
+// EnforcerNetworksCollide reports whether two networks share the enforcer's
+// on-disk directories, which is the only case where swapping between them
+// leaves one network's chain sitting where the other will look for its own.
+func EnforcerNetworksCollide(a, b Network) bool {
+	return a != b && EnforcerNetworkName(a) == EnforcerNetworkName(b)
 }
 
 // ---------------------------------------------------------------------------

--- a/sidechain-orchestrator/engines/bmm_engine.go
+++ b/sidechain-orchestrator/engines/bmm_engine.go
@@ -383,8 +383,35 @@ func (e *BmmEngine) openRound(
 	e.current[sidechain] = round
 	e.mu.Unlock()
 
-	e.placeBid(ctx, sidechain, round, target.walletID, target.minBidSats, "")
+	if err := e.placeBid(ctx, sidechain, round, target.walletID, target.minBidSats, ""); err != nil {
+		if connect.CodeOf(err) == connect.CodeFailedPrecondition {
+			e.log.Info().Err(err).Stringer("sidechain", sidechain).Msg("opening bmm bid refused, retrying next tick")
+			e.retryTip(sidechain, tip)
+		} else {
+			e.log.Warn().Err(err).Stringer("sidechain", sidechain).Msg("opening bmm bid failed")
+		}
+	}
 	e.notify()
+}
+
+// retryTip unwinds a round whose opening bid was refused on a precondition, so
+// the next tick opens it again on the same tip. The sync snapshot the backend
+// gates on can trail the tip read here by one poll interval; without this the
+// tip stays marked, every later tick takes the maybeRaise path, and the block
+// is skipped for good.
+func (e *BmmEngine) retryTip(sidechain pb.BinaryType, tip string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if round, ok := e.current[sidechain]; ok && round != nil && round.PrevMainHash == tip {
+		delete(e.current, sidechain)
+	}
+	target, ok := e.targets[sidechain]
+	if !ok || target.lastTip != tip {
+		return
+	}
+	target.lastTip = ""
+	e.targets[sidechain] = target
 }
 
 // snapshotOthers records the competing bids. Once the round is decided these
@@ -435,7 +462,7 @@ func (e *BmmEngine) ourTxids(sidechain pb.BinaryType) map[string]bool {
 func (e *BmmEngine) placeBid(
 	ctx context.Context, sidechain pb.BinaryType, round *bmmstate.Round,
 	walletID string, bidSats int64, replaceTxid string,
-) {
+) error {
 	resp, err := e.backend.CreateBid(ctx, connect.NewRequest(&bmmpb.CreateBidRequest{
 		Sidechain:          sidechain,
 		WalletId:           walletID,
@@ -455,8 +482,7 @@ func (e *BmmEngine) placeBid(
 			State:   BidFailed,
 			Error:   err.Error(),
 		})
-		e.log.Warn().Err(err).Stringer("sidechain", sidechain).Msg("bmm bid failed")
-		return
+		return err
 	}
 
 	if replaceTxid != "" {
@@ -485,6 +511,7 @@ func (e *BmmEngine) placeBid(
 
 	e.log.Info().Stringer("sidechain", sidechain).Str("txid", resp.Msg.BmmTxid).
 		Int64("bid_sats", bidSats).Int64("block_worth_sats", resp.Msg.FeesSats).Msg("bmm bid broadcast")
+	return nil
 }
 
 // maybeRaise replaces our live bid when a competitor has overtaken it, never
@@ -537,7 +564,12 @@ func (e *BmmEngine) maybeRaise(ctx context.Context, sidechain pb.BinaryType, tar
 
 	e.log.Info().Stringer("sidechain", sidechain).
 		Int64("from_sats", live.BidSats).Int64("to_sats", next).Msg("raising bmm bid")
-	e.placeBid(ctx, sidechain, round, walletID, next, live.Txid)
+	// The live bid stands when a raise is refused, so the round carries on at
+	// its current price rather than being unwound.
+	if err := e.placeBid(ctx, sidechain, round, walletID, next, live.Txid); err != nil {
+		e.log.Warn().Err(err).Stringer("sidechain", sidechain).
+			Int64("to_sats", next).Msg("raising bmm bid failed, keeping the live bid")
+	}
 	e.notify()
 }
 

--- a/sidechain-orchestrator/engines/bmm_engine_test.go
+++ b/sidechain-orchestrator/engines/bmm_engine_test.go
@@ -579,3 +579,43 @@ func TestBmmEngineDoesNotSettleAnOpenRoundOnStop(t *testing.T) {
 	assert.Nil(t, engine.Current(testSidechain))
 	assert.NotEmpty(t, mustHistory(t, engine), "the tip moved, so now it settles")
 }
+
+// The sync gate the backend applies reads a snapshot that can trail the tip the
+// engine just read. Skipping the block for good over a one-poll skew would cost
+// a round every time the enforcer catches up mid-tick.
+func TestBmmEngineRetriesAfterAPreconditionRefusal(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.bidErr = connect.NewError(connect.CodeFailedPrecondition, errors.New("enforcer is still syncing"))
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, 10_000))
+
+	ctx := context.Background()
+	engine.tick(ctx)
+	assert.Nil(t, engine.Current(testSidechain), "a refused opening bid leaves no round behind")
+
+	backend.mu.Lock()
+	backend.bidErr = nil
+	backend.mu.Unlock()
+
+	engine.tick(ctx)
+	assert.Equal(t, 1, backend.bids, "the same tip must be retried once the gate opens")
+	require.NotNil(t, engine.Current(testSidechain))
+}
+
+// Any other failure keeps the round on the books, so a real error stays visible
+// instead of being retried forever in silence.
+func TestBmmEngineDoesNotRetryOtherFailures(t *testing.T) {
+	engine, backend, _, _ := newEngine(t)
+	backend.bidErr = errors.New("no block template")
+	require.NoError(t, engine.Start(testSidechain, "", 10_000, 10_000))
+
+	ctx := context.Background()
+	engine.tick(ctx)
+	require.NotNil(t, engine.Current(testSidechain))
+
+	backend.mu.Lock()
+	backend.bidErr = nil
+	backend.mu.Unlock()
+
+	engine.tick(ctx)
+	assert.Zero(t, backend.bids, "same tip, already handled")
+}

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -2041,7 +2041,7 @@ func (o *Orchestrator) finishNetworkSwap(n config.Network, restartL1 bool) error
 func (o *Orchestrator) purgeNetworkSwapState(target config.Network) error {
 	paths := make(map[string]bool)
 
-	for _, path := range enforcerNetworkSwapStatePaths(config.EnforcerDirs.RootDir()) {
+	for _, path := range enforcerNetworkSwapStatePaths(config.Network(o.Network), target) {
 		paths[path] = true
 	}
 
@@ -2074,20 +2074,19 @@ func (o *Orchestrator) purgeNetworkSwapState(target config.Network) error {
 	return nil
 }
 
-func enforcerNetworkSwapStatePaths(root string) []string {
+// enforcerNetworkSwapStatePaths returns the enforcer state a swap from -> to
+// must drop. The enforcer files its validator chain and wallet per network, so
+// both survive a swap and are still valid on the way back; state only has to go
+// when the two networks share those directories, leaving the outgoing chain
+// where the incoming one will look for its own.
+func enforcerNetworkSwapStatePaths(from, to config.Network) []string {
+	if !config.EnforcerNetworksCollide(from, to) {
+		return nil
+	}
 	return []string{
-		filepath.Join(root, "validator"),
-		filepath.Join(root, "wallet"),
-		filepath.Join(root, "bitcoin"),
-		filepath.Join(root, "mainnet"),
-		// forknet/drynet2 are retired network names, still listed so an
-		// upgrade clears the state directories they left behind.
-		filepath.Join(root, "forknet"),
-		filepath.Join(root, "drynet2"),
-		filepath.Join(root, "drynet"),
-		filepath.Join(root, "signet"),
-		filepath.Join(root, "testnet"),
-		filepath.Join(root, "regtest"),
+		config.EnforcerValidatorDir(from),
+		config.EnforcerWalletDir(from),
+		filepath.Join(config.EnforcerDirs.RootDir(), config.EnforcerNetworkName(from)),
 	}
 }
 

--- a/sidechain-orchestrator/swap_network_test.go
+++ b/sidechain-orchestrator/swap_network_test.go
@@ -186,13 +186,28 @@ func TestSwapNetwork_MultipleSwapsFireCallbackEachTime(t *testing.T) {
 	assert.Equal(t, int32(3), atomic.LoadInt32(&called), "OnNetworkChanged must fire on each actual network change")
 }
 
-func TestEnforcerNetworkSwapStatePathsCoverCheckpointStores(t *testing.T) {
-	root := t.TempDir()
-	paths := enforcerNetworkSwapStatePaths(root)
+// Networks the enforcer files separately keep their validator chain across a
+// swap: wiping them cost the user a full resync every time they looked at
+// another network and came back.
+func TestEnforcerNetworkSwapStatePathsSpareSeparateNetworks(t *testing.T) {
+	for _, tc := range []struct{ from, to config.Network }{
+		{config.NetworkSignet, config.NetworkRegtest},
+		{config.NetworkRegtest, config.NetworkSignet},
+		{config.NetworkSignet, config.NetworkMainnet},
+		{config.NetworkTestnet, config.NetworkSignet},
+		{config.NetworkSignet, config.NetworkSignet},
+	} {
+		assert.Empty(t, enforcerNetworkSwapStatePaths(tc.from, tc.to),
+			"%s -> %s must keep both networks' enforcer state", tc.from, tc.to)
+	}
+}
 
-	assert.Contains(t, paths, filepath.Join(root, "validator"))
-	assert.Contains(t, paths, filepath.Join(root, "wallet"))
-	assert.Contains(t, paths, filepath.Join(root, "bitcoin"))
-	assert.Contains(t, paths, filepath.Join(root, "signet"))
-	assert.Contains(t, paths, filepath.Join(root, "drynet"))
+// Networks that share the enforcer's directories are the one case where the
+// outgoing chain sits where the incoming one will look for its own.
+func TestEnforcerNetworkSwapStatePathsClearCollidingNetworks(t *testing.T) {
+	paths := enforcerNetworkSwapStatePaths(config.NetworkMainnet, config.NetworkDrynet)
+
+	require.NotEmpty(t, paths)
+	assert.Contains(t, paths, config.EnforcerValidatorDir(config.NetworkMainnet))
+	assert.Contains(t, paths, config.EnforcerWalletDir(config.NetworkMainnet))
 }

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.296
+version: 1.0.297
 
 environment:
   sdk: 3.12.2

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.297
+version: 1.0.298
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.168
+version: 1.0.169
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.167
+version: 1.0.168
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.295
+version: 1.0.296
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.294
+version: 1.0.295
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
Blocks BMM bidding until the enforcer is level with Bitcoin Core, in the orchestrator (Start/CreateBid/AttackBid) and in the BMM tab's controls.

Also stops a network swap from deleting every network's enforcer validator chain and wallet — it wiped `<root>/validator` and `<root>/wallet` wholesale, so switching networks cost a full resync on the way back. Now scoped to the networks that actually share those directories.

TODO:
- [ ] confirm whether the enforcer files drynet separately (`EnforcerNetworkName` currently maps it onto `bitcoin`)