### PR TITLE
orchestrator, sail_ui: BMM with the enforcer wallet

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.296
+version: 1.0.297
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.296
+version: 1.0.297
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.159
+version: 0.2.160
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.169
+version: 1.0.170
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/pages/sidechains/bmm_tab.dart
+++ b/sail_ui/lib/pages/sidechains/bmm_tab.dart
@@ -178,7 +178,6 @@ class _FundingWallet extends StatelessWidget {
               child: WalletPicker(
                 selectedWalletId: viewModel.fundingWalletId,
                 onChanged: viewModel.setFundingWallet,
-                rawOutputs: true,
               ),
             ),
             SailText.secondary13(

--- a/sail_ui/lib/widgets/from_wallet_field.dart
+++ b/sail_ui/lib/widgets/from_wallet_field.dart
@@ -13,14 +13,10 @@ class WalletPicker extends StatefulWidget {
   final String? selectedWalletId;
   final ValueChanged<String> onChanged;
 
-  /// Lists only wallets that can carry a raw output, which the enforcer cannot.
-  final bool rawOutputs;
-
   const WalletPicker({
     super.key,
     required this.selectedWalletId,
     required this.onChanged,
-    this.rawOutputs = false,
   });
 
   @override
@@ -57,7 +53,7 @@ class _WalletPickerState extends State<WalletPicker> {
     unawaited(_loadBalances());
   }
 
-  List<WalletData> get _wallets => _walletReader.fundingWallets(rawOutputs: widget.rawOutputs);
+  List<WalletData> get _wallets => _walletReader.fundingWallets();
 
   Future<void> _loadBalances() async {
     if (!GetIt.I.isRegistered<OrchestratorRPC>()) {

--- a/sail_ui/test/bmm_provider_test.dart
+++ b/sail_ui/test/bmm_provider_test.dart
@@ -68,8 +68,14 @@ class _FakeSidechainRPC implements SidechainRPC {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-WalletData _wallet(String id, String name, {BinaryType type = BinaryType.BINARY_TYPE_BITCOIND}) {
+WalletData _wallet(
+  String id,
+  String name, {
+  BinaryType type = BinaryType.BINARY_TYPE_BITCOIND,
+  bool watchOnly = false,
+}) {
   return WalletData(
+    isWatchOnly: watchOnly,
     version: 1,
     master: MasterWallet(mnemonic: '', seedHex: '', masterKey: '', chainCode: ''),
     l1: L1Wallet(mnemonic: ''),
@@ -158,29 +164,29 @@ void main() {
     expect(provider.fundingBalanceTooLow, isFalse);
   });
 
-  // A bid goes out as a raw M8 output, which the enforcer wallet service
-  // rejects. Its own BMM endpoint is a path this code does not drive.
-  test('the picker skips an enforcer wallet', () async {
+  // The enforcer takes the M8 as an OP_RETURN payload, so it funds a bid like
+  // any other wallet.
+  test('the picker offers an enforcer wallet', () async {
     final walletReader = WalletReaderProvider(Directory.systemTemp)
       ..wallets = [
         _wallet('enforcer-1', 'Enforcer', type: BinaryType.BINARY_TYPE_ENFORCER),
         _wallet('core-1', 'Savings'),
       ]
-      ..activeWalletId = 'enforcer-1';
+      ..activeWalletId = 'core-1';
     final provider = newProvider(walletReader: walletReader);
 
     expect(provider.fundingWalletId, 'core-1');
 
     provider.setFundingWalletId('enforcer-1');
-    expect(provider.fundingWalletId, 'core-1');
+    expect(provider.fundingWalletId, 'enforcer-1');
   });
 
   // An empty wallet id falls back to the active wallet in the backend, so a
   // bid with no funding wallet must not be sent at all.
   test('bidding stops when no wallet can fund it', () async {
     final walletReader = WalletReaderProvider(Directory.systemTemp)
-      ..wallets = [_wallet('enforcer-1', 'Enforcer', type: BinaryType.BINARY_TYPE_ENFORCER)]
-      ..activeWalletId = 'enforcer-1';
+      ..wallets = [_wallet('watch-1', 'Watcher', watchOnly: true)]
+      ..activeWalletId = 'watch-1';
     final provider = newProvider(walletReader: walletReader);
 
     await provider.startBidding();

--- a/sidechain-orchestrator/wallet/enforcer_backend.go
+++ b/sidechain-orchestrator/wallet/enforcer_backend.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -234,21 +235,36 @@ func enforcerOpReturnHex(req SendRequest) (string, error) {
 	if len(script) == 0 || script[0] != txscript.OP_RETURN {
 		return "", errors.New("raw outputs other than an OP_RETURN need a core or electrum wallet")
 	}
-	// The enforcer rebuilds the script from the payload, so any opcode past the
-	// single data push would broadcast a script the caller never asked for.
 	const scriptVersion = 0
 	tokenizer := txscript.MakeScriptTokenizer(scriptVersion, script[1:])
-	if !tokenizer.Next() || tokenizer.Data() == nil {
+	if !tokenizer.Next() || len(tokenizer.Data()) == 0 {
 		return "", errors.New("enforcer wallet: OP_RETURN must carry one data push")
 	}
 	payload := tokenizer.Data()
-	if tokenizer.Next() {
-		return "", errors.New("enforcer wallet: OP_RETURN must carry one data push")
-	}
-	if err := tokenizer.Err(); err != nil {
-		return "", fmt.Errorf("enforcer wallet: parse OP_RETURN script: %w", err)
+
+	// The enforcer sends back the script it builds from the payload alone. Any
+	// script that does not survive that round trip would go out changed.
+	if !bytes.Equal(script, opReturnScript(payload)) {
+		return "", errors.New("enforcer wallet: OP_RETURN must be one minimally encoded push")
 	}
 	return hex.EncodeToString(payload), nil
+}
+
+// opReturnScript builds the script the enforcer makes from an OP_RETURN
+// payload: the opcode, then one minimally encoded data push.
+func opReturnScript(payload []byte) []byte {
+	script := []byte{txscript.OP_RETURN}
+	switch n := len(payload); {
+	case n < txscript.OP_PUSHDATA1:
+		script = append(script, byte(n))
+	case n <= 0xff:
+		script = append(script, txscript.OP_PUSHDATA1, byte(n))
+	case n <= 0xffff:
+		script = append(script, txscript.OP_PUSHDATA2, byte(n), byte(n>>8))
+	default:
+		script = append(script, txscript.OP_PUSHDATA4, byte(n), byte(n>>8), byte(n>>16), byte(n>>24))
+	}
+	return append(script, payload...)
 }
 
 // Send relays to the enforcer's all-in-one SendTransaction: the daemon does

--- a/sidechain-orchestrator/wallet/enforcer_backend.go
+++ b/sidechain-orchestrator/wallet/enforcer_backend.go
@@ -234,14 +234,21 @@ func enforcerOpReturnHex(req SendRequest) (string, error) {
 	if len(script) == 0 || script[0] != txscript.OP_RETURN {
 		return "", errors.New("raw outputs other than an OP_RETURN need a core or electrum wallet")
 	}
-	pushes, err := txscript.PushedData(script)
-	if err != nil {
+	// The enforcer rebuilds the script from the payload, so any opcode past the
+	// single data push would broadcast a script the caller never asked for.
+	const scriptVersion = 0
+	tokenizer := txscript.MakeScriptTokenizer(scriptVersion, script[1:])
+	if !tokenizer.Next() || tokenizer.Data() == nil {
+		return "", errors.New("enforcer wallet: OP_RETURN must carry one data push")
+	}
+	payload := tokenizer.Data()
+	if tokenizer.Next() {
+		return "", errors.New("enforcer wallet: OP_RETURN must carry one data push")
+	}
+	if err := tokenizer.Err(); err != nil {
 		return "", fmt.Errorf("enforcer wallet: parse OP_RETURN script: %w", err)
 	}
-	if len(pushes) != 1 {
-		return "", fmt.Errorf("enforcer wallet: OP_RETURN must carry one push, got %d", len(pushes))
-	}
-	return hex.EncodeToString(pushes[0]), nil
+	return hex.EncodeToString(payload), nil
 }
 
 // Send relays to the enforcer's all-in-one SendTransaction: the daemon does

--- a/sidechain-orchestrator/wallet/enforcer_backend.go
+++ b/sidechain-orchestrator/wallet/enforcer_backend.go
@@ -2,11 +2,13 @@ package wallet
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sort"
 
 	"connectrpc.com/connect"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -209,6 +211,39 @@ func (p *EnforcerBackend) WatchKeys(ctx context.Context, walletID string, keys [
 	return p.unsupported("watching extra keys")
 }
 
+// enforcerOpReturnHex folds the request's OP_RETURN into the single payload the
+// enforcer's SendTransaction takes. The enforcer builds the scriptPubKey itself,
+// so a zero-value OP_RETURN is the only raw output it can express — which is
+// what a BMM bid needs.
+func enforcerOpReturnHex(req SendRequest) (string, error) {
+	if len(req.RawOutputs) == 0 {
+		return req.OpReturnHex, nil
+	}
+	if len(req.RawOutputs) > 1 || req.OpReturnHex != "" {
+		return "", errors.New("enforcer wallet takes at most one OP_RETURN")
+	}
+
+	out := req.RawOutputs[0]
+	if out.AmountSats != 0 {
+		return "", fmt.Errorf("enforcer wallet: OP_RETURN output must be zero-value, got %d sats", out.AmountSats)
+	}
+	script, err := hex.DecodeString(out.RawScriptHex)
+	if err != nil {
+		return "", fmt.Errorf("enforcer wallet: decode raw output script: %w", err)
+	}
+	if len(script) == 0 || script[0] != txscript.OP_RETURN {
+		return "", errors.New("raw outputs other than an OP_RETURN need a core or electrum wallet")
+	}
+	pushes, err := txscript.PushedData(script)
+	if err != nil {
+		return "", fmt.Errorf("enforcer wallet: parse OP_RETURN script: %w", err)
+	}
+	if len(pushes) != 1 {
+		return "", fmt.Errorf("enforcer wallet: OP_RETURN must carry one push, got %d", len(pushes))
+	}
+	return hex.EncodeToString(pushes[0]), nil
+}
+
 // Send relays to the enforcer's all-in-one SendTransaction: the daemon does
 // coin selection, change, signing, and broadcast.
 func (p *EnforcerBackend) Send(ctx context.Context, walletID string, req SendRequest) (string, error) {
@@ -219,13 +254,16 @@ func (p *EnforcerBackend) Send(ctx context.Context, walletID string, req SendReq
 		)
 	}
 
-	// The enforcer builds the transaction itself and its API takes only
-	// addresses and an OP_RETURN, so a bare scriptPubKey cannot be expressed.
-	if len(req.RawOutputs) > 0 || len(req.ExternalInputs) > 0 {
+	if len(req.ExternalInputs) > 0 {
 		return "", connect.NewError(
 			connect.CodeInvalidArgument,
-			errors.New("raw outputs and external inputs need a core or electrum wallet"),
+			errors.New("external inputs need a core or electrum wallet"),
 		)
+	}
+
+	opReturnHex, err := enforcerOpReturnHex(req)
+	if err != nil {
+		return "", connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
 	var feeRate *enforcerpb.SendTransactionRequest_FeeRate
@@ -241,9 +279,9 @@ func (p *EnforcerBackend) Send(ctx context.Context, walletID string, req SendReq
 	}
 
 	var opReturn *commonv1.Hex
-	if req.OpReturnHex != "" {
+	if opReturnHex != "" {
 		opReturn = &commonv1.Hex{
-			Hex: &wrapperspb.StringValue{Value: req.OpReturnHex},
+			Hex: &wrapperspb.StringValue{Value: opReturnHex},
 		}
 	}
 

--- a/sidechain-orchestrator/wallet/enforcer_backend_test.go
+++ b/sidechain-orchestrator/wallet/enforcer_backend_test.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -272,6 +273,16 @@ func TestEnforcerBackendRawOpReturnBecomesMessage(t *testing.T) {
 	require.NotNil(t, fake.lastSend)
 	assert.Equal(t, "00bf000901", fake.lastSend.OpReturnMessage.GetHex().GetValue())
 	assert.Equal(t, uint64(1000), fake.lastSend.FeeRate.GetSats())
+
+	// A 76-byte payload passes the 75-byte direct push limit, so OP_PUSHDATA1
+	// is its minimal encoding.
+	payload := strings.Repeat("bb", 76)
+	_, err = backend.Send(context.Background(), "wallet", SendRequest{
+		RawOutputs:   []TxOutSpec{{RawScriptHex: "6a4c4c" + payload}},
+		FixedFeeSats: 1000,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, payload, fake.lastSend.OpReturnMessage.GetHex().GetValue())
 }
 
 // The enforcer builds the transaction itself, so anything it cannot express
@@ -310,6 +321,20 @@ func TestEnforcerBackendRejectsUnexpressibleOutputs(t *testing.T) {
 	// A bare OP_RETURN carries no payload at all.
 	_, err = backend.Send(ctx, "wallet", SendRequest{
 		RawOutputs:   []TxOutSpec{{RawScriptHex: "6a"}},
+		FixedFeeSats: 1000,
+	})
+	require.ErrorContains(t, err, "one data push")
+
+	// OP_PUSHDATA1 for 1 byte. The enforcer would rebuild this as 6a01aa.
+	_, err = backend.Send(ctx, "wallet", SendRequest{
+		RawOutputs:   []TxOutSpec{{RawScriptHex: "6a4c01aa"}},
+		FixedFeeSats: 1000,
+	})
+	require.ErrorContains(t, err, "minimally encoded")
+
+	// An empty push gives an empty payload, which drops the output.
+	_, err = backend.Send(ctx, "wallet", SendRequest{
+		RawOutputs:   []TxOutSpec{{RawScriptHex: "6a4c00"}},
 		FixedFeeSats: 1000,
 	})
 	require.ErrorContains(t, err, "one data push")

--- a/sidechain-orchestrator/wallet/enforcer_backend_test.go
+++ b/sidechain-orchestrator/wallet/enforcer_backend_test.go
@@ -256,18 +256,50 @@ func TestEnforcerBackendUnsupportedOps(t *testing.T) {
 	require.Error(t, err)
 }
 
-// The enforcer builds the transaction itself and its API has no raw output, so
-// a BMM bid or an M5 deposit must say so rather than silently drop the output.
-func TestEnforcerBackendRejectsRawOutputs(t *testing.T) {
-	backend := &EnforcerBackend{}
+// A BMM bid carries its M8 as a zero-value OP_RETURN raw output, which the
+// enforcer takes as the payload it builds the scriptPubKey from.
+func TestEnforcerBackendRawOpReturnBecomesMessage(t *testing.T) {
+	fake := &fakeEnforcerClient{}
+	backend := NewEnforcerBackend(fake)
 
+	// OP_RETURN OP_PUSHBYTES_5 <M8 tag, slot 9>
 	_, err := backend.Send(context.Background(), "wallet", SendRequest{
-		RawOutputs:   []TxOutSpec{{RawScriptHex: "6a0100", AmountSats: 0}},
+		RawOutputs:   []TxOutSpec{{RawScriptHex: "6a0500bf000901"}},
+		FixedFeeSats: 1000,
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, fake.lastSend)
+	assert.Equal(t, "00bf000901", fake.lastSend.OpReturnMessage.GetHex().GetValue())
+	assert.Equal(t, uint64(1000), fake.lastSend.FeeRate.GetSats())
+}
+
+// The enforcer builds the transaction itself, so anything it cannot express
+// must be an error rather than a silently dropped output.
+func TestEnforcerBackendRejectsUnexpressibleOutputs(t *testing.T) {
+	backend := &EnforcerBackend{}
+	ctx := context.Background()
+
+	_, err := backend.Send(ctx, "wallet", SendRequest{
+		RawOutputs:   []TxOutSpec{{RawScriptHex: "00141111111111111111111111111111111111111111"}},
 		FixedFeeSats: 1000,
 	})
 	require.ErrorContains(t, err, "core or electrum wallet")
 
-	_, err = backend.Send(context.Background(), "wallet", SendRequest{
+	_, err = backend.Send(ctx, "wallet", SendRequest{
+		RawOutputs:   []TxOutSpec{{RawScriptHex: "6a0100", AmountSats: 500}},
+		FixedFeeSats: 1000,
+	})
+	require.ErrorContains(t, err, "zero-value")
+
+	_, err = backend.Send(ctx, "wallet", SendRequest{
+		RawOutputs:   []TxOutSpec{{RawScriptHex: "6a0100"}},
+		OpReturnHex:  "dead",
+		FixedFeeSats: 1000,
+	})
+	require.ErrorContains(t, err, "at most one OP_RETURN")
+
+	_, err = backend.Send(ctx, "wallet", SendRequest{
 		ExternalInputs: []ExternalInput{{TxID: "aa", Vout: 0, AmountSats: 1}},
 		FixedFeeSats:   1000,
 	})

--- a/sidechain-orchestrator/wallet/enforcer_backend_test.go
+++ b/sidechain-orchestrator/wallet/enforcer_backend_test.go
@@ -299,6 +299,21 @@ func TestEnforcerBackendRejectsUnexpressibleOutputs(t *testing.T) {
 	})
 	require.ErrorContains(t, err, "at most one OP_RETURN")
 
+	// OP_RETURN OP_1 OP_PUSHBYTES_1 aa. The enforcer rebuilds the script from
+	// one payload, so it cannot carry the OP_1.
+	_, err = backend.Send(ctx, "wallet", SendRequest{
+		RawOutputs:   []TxOutSpec{{RawScriptHex: "6a5101aa"}},
+		FixedFeeSats: 1000,
+	})
+	require.ErrorContains(t, err, "one data push")
+
+	// A bare OP_RETURN carries no payload at all.
+	_, err = backend.Send(ctx, "wallet", SendRequest{
+		RawOutputs:   []TxOutSpec{{RawScriptHex: "6a"}},
+		FixedFeeSats: 1000,
+	})
+	require.ErrorContains(t, err, "one data push")
+
 	_, err = backend.Send(ctx, "wallet", SendRequest{
 		ExternalInputs: []ExternalInput{{TxID: "aa", Vout: 0, AmountSats: 1}},
 		FixedFeeSats:   1000,

--- a/sidechain_core/lib/providers/parentchain/bmm_provider.dart
+++ b/sidechain_core/lib/providers/parentchain/bmm_provider.dart
@@ -64,8 +64,8 @@ class BMMProvider extends ChangeNotifier {
   bool get boundsPushPending => _boundsPush?.isActive ?? false;
 
   /// Wallet every bid spends from. Selecting it never changes the active
-  /// wallet. A bid goes out as a raw M8 output, which the enforcer rejects.
-  String? get fundingWalletId => _walletReader?.resolveFundingWalletId(_selectedWalletId, rawOutputs: true);
+  /// wallet.
+  String? get fundingWalletId => _walletReader?.resolveFundingWalletId(_selectedWalletId);
 
   void setFundingWalletId(String walletId) {
     _selectedWalletId = walletId;

--- a/sidechain_core/lib/providers/wallet_reader_provider.dart
+++ b/sidechain_core/lib/providers/wallet_reader_provider.dart
@@ -58,15 +58,13 @@ class WalletReaderProvider extends ChangeNotifier implements NetworkScoped {
       )
       .toList();
 
-  /// Wallets that can fund a transaction: no watch-only, no multisig. The
-  /// enforcer builds its own transactions, so it takes no raw output.
-  List<WalletData> fundingWallets({bool rawOutputs = false}) =>
-      wallets.where((w) => !w.isWatchOnly && !w.isMultisig).where((w) => !rawOutputs || !w.isEnforcer).toList();
+  /// Wallets that can fund a transaction: no watch-only, no multisig.
+  List<WalletData> fundingWallets() => wallets.where((w) => !w.isWatchOnly && !w.isMultisig).toList();
 
   /// The wallet that funds a transaction: [selectedWalletId] while it can
   /// spend, else the active wallet, else any spendable one.
-  String? resolveFundingWalletId(String? selectedWalletId, {bool rawOutputs = false}) {
-    final candidates = fundingWallets(rawOutputs: rawOutputs);
+  String? resolveFundingWalletId(String? selectedWalletId) {
+    final candidates = fundingWallets();
     if (selectedWalletId != null && candidates.any((w) => w.id == selectedWalletId)) {
       return selectedWalletId;
     }

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.298
+version: 1.0.299
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.169
+version: 1.0.170
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.296
+version: 1.0.297
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
This PR lets the enforcer wallet fund a BMM bid: the orchestrator sends the M8 as an OP_RETURN payload, and the picker stops hiding the wallet.

It needs https://github.com/LayerTwo-Labs/bip300301_enforcer/pull/537, which puts the OP_RETURN at output 0.