### PR TITLE
sail_ui, sidechain_core: show why a bid failed

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.297
+version: 1.0.298
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.297
+version: 1.0.298
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.160
+version: 0.2.161
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.170
+version: 1.0.171
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/pages/sidechains/bmm_tab.dart
+++ b/sail_ui/lib/pages/sidechains/bmm_tab.dart
@@ -310,6 +310,7 @@ class _BidsOnNextBlock extends StatelessWidget {
                   SailTableCell(value: viewModel.shorten(bid.txid), copyValue: bid.txid, monospace: true),
                   SailTableCell(
                     value: viewModel.bidStatus(bid, bids),
+                    copyValue: bid.error.isEmpty ? null : bid.error,
                     textColor: viewModel.bidStatusColor(bid, bids, theme.colors),
                   ),
                 ];
@@ -429,7 +430,7 @@ class BMMViewModel extends BaseViewModel {
   String? get bidBlockedReason => bidBlockedReasonFor(_sync);
 
   bool get running => bmmProvider.running;
-  String? get bmmError => bmmProvider.error;
+  String? get bmmError => bmmProvider.error ?? bmmProvider.lastBidError;
 
   String? get fundingWalletId => bmmProvider.fundingWalletId;
   void setFundingWallet(String walletId) => bmmProvider.setFundingWalletId(walletId);

--- a/sail_ui/test/bmm_provider_test.dart
+++ b/sail_ui/test/bmm_provider_test.dart
@@ -94,6 +94,7 @@ bmmpb.Bid _bid({
   bool ours = false,
   String state = 'live',
   String replacedBy = '',
+  String error = '',
 }) {
   return bmmpb.Bid(
     txid: txid,
@@ -102,6 +103,7 @@ bmmpb.Bid _bid({
     isOurs: ours,
     state: state,
     replacedByTxid: replacedBy,
+    error: error,
   );
 }
 
@@ -276,6 +278,50 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(provider.liveBid?.txid, 'second');
+  });
+
+  // The auto-bid loop runs in the backend, so a failure there reaches the user
+  // only through the bid it records.
+  test('a failed bid reports why it failed', () async {
+    final provider = newProvider();
+
+    expect(provider.lastBidError, isNull);
+
+    bmm.emit(
+      bmmpb.WatchResponse(
+        current: bmmpb.Round(
+          prevMainHash: 'tip-1',
+          ourBids: [
+            _bid(txid: 'first', sats: 10000, ours: true, state: 'failed', error: 'insufficient funds'),
+            _bid(txid: 'second', sats: 13000, ours: true, state: 'failed', error: 'wallet is locked'),
+          ],
+        ),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(provider.lastBidError, 'wallet is locked');
+  });
+
+  // A retry that lands after a failed raise means bidding recovered, so the
+  // old reason must leave the screen.
+  test('a later live bid clears the failure', () async {
+    final provider = newProvider();
+
+    bmm.emit(
+      bmmpb.WatchResponse(
+        current: bmmpb.Round(
+          prevMainHash: 'tip-1',
+          ourBids: [
+            _bid(txid: 'first', sats: 10000, ours: true, state: 'failed', error: 'insufficient funds'),
+            _bid(txid: 'second', sats: 13000, ours: true),
+          ],
+        ),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(provider.lastBidError, isNull);
   });
 
   // A bid no miner took never confirmed, so it neither cost nor earned.

--- a/sidechain_core/lib/providers/parentchain/bmm_provider.dart
+++ b/sidechain_core/lib/providers/parentchain/bmm_provider.dart
@@ -141,6 +141,17 @@ class BMMProvider extends ChangeNotifier {
     return null;
   }
 
+  /// Why our newest bid of the current round failed. The auto-bid loop runs in
+  /// the backend, so its failures reach the user only through here. An older
+  /// failure stays hidden, because a newer bid means the loop recovered.
+  String? get lastBidError {
+    final newest = current?.ourBids.lastOrNull;
+    if (newest == null || newest.state != 'failed' || newest.error.isEmpty) {
+      return null;
+    }
+    return newest.error;
+  }
+
   /// Every bid for the current round, ours and others, highest first.
   List<bmmpb.Bid> get currentBids {
     final round = current;
@@ -220,8 +231,8 @@ class BMMProvider extends ChangeNotifier {
   }
 
   /// Set when no wallet can fund a bid. An empty wallet id would fall back to
-  /// the active wallet, which is the enforcer this path cannot use.
-  static const noFundingWallet = 'No wallet can fund a bid. A bid needs a core or electrum wallet.';
+  /// the active wallet, which may be one that cannot spend.
+  static const noFundingWallet = 'No wallet can fund a bid. A bid needs a wallet that can spend.';
 
   Future<void> startBidding() async {
     final walletId = fundingWalletId;

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.299
+version: 1.0.300
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.170
+version: 1.0.171
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.297
+version: 1.0.298
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The auto-bid loop runs in the backend, so a failed bid only showed the word "Failed". The reason was already on the wire in Bid.error, so this PR puts it in the card error banner and behind copy on the status cell.