### PR TITLE
orchestrator: move the binary update check into Go

### DIFF
--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.161
+version: 0.2.162
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/test/bip39_seed_derivation_test.dart
+++ b/bitwindow/test/bip39_seed_derivation_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:bip39_mnemonic/bip39_mnemonic.dart';
+import 'package:bitwindow/providers/hd_wallet_provider.dart';
+import 'package:convert/convert.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+class _Vector {
+  final String mnemonic;
+  final String seedHex;
+  final String masterKey;
+
+  const _Vector(this.mnemonic, this.seedHex, this.masterKey);
+}
+
+const _abandonAbout = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+const _vectors = <_Vector>[
+  _Vector(
+    _abandonAbout,
+    '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc1'
+        '9a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4',
+    '1837c1be8e2995ec11cda2b066151be2cfb48adf9e47b151d46adab3a21cdf67',
+  ),
+  _Vector(
+    'legal winner thank year wave sausage worth useful legal winner thank yellow',
+    '878386efb78845b3355bd15ea4d39ef97d179cb712b77d5c12b6be415fffeffe'
+        '5f377ba02bf3f8544ab800b955e51fbff09828f682052a20faa6addbbddfb096',
+    '7e56ecf5943d79e1f5f87e11c768253d7f3fcf30ae71335611e366c578b4564e',
+  ),
+  _Vector(
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon '
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art',
+    '408b285c123836004f4b8842c89324c1f01382450c0d439af345ba7fc49acf70'
+        '5489c6fc77dbd4e3dc1dd8cc6bc9f043db8ada1e243c4a0eafb290d399480840',
+    '235b34cd7c9f6d7e4595ffe9ae4b1cb5606df8aca2b527d20a07c8f56b2342f4',
+  ),
+  _Vector(
+    'zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote',
+    'e28a37058c7f5112ec9e16a3437cf363a2572d70b6ceb3b6965447623d620f14'
+        'd06bb321a26b33ec15fcd84a3b5ddfd5520e230c924c87aaa0d559749e044fef',
+    '8472fc35dbe9f8ccf7ed306295e84902c0e606e576e5cb3f6c32d98537a21282',
+  ),
+];
+
+WalletData _enforcer(String l1Mnemonic) => WalletData(
+  version: 1,
+  master: MasterWallet(mnemonic: '', seedHex: '', masterKey: '', chainCode: ''),
+  l1: L1Wallet(mnemonic: l1Mnemonic),
+  sidechains: const [],
+  id: 'enf',
+  name: 'Enforcer',
+  gradient: WalletGradient.fromWalletId('enf'),
+  createdAt: DateTime.utc(2026, 1, 1),
+  walletType: BinaryType.BINARY_TYPE_ENFORCER,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('bip39_mnemonic package', () {
+    for (final v in _vectors) {
+      test('seed matches BIP39 vector for "${v.mnemonic.split(' ').take(2).join(' ')}..."', () {
+        final mnemonic = Mnemonic.fromSentence(v.mnemonic, Language.english);
+        expect(hex.encode(mnemonic.seed), v.seedHex);
+      });
+    }
+
+    test('passphrase changes the seed', () {
+      final bare = Mnemonic.fromSentence(_abandonAbout, Language.english);
+      final withPass = Mnemonic.fromSentence(_abandonAbout, Language.english, passphrase: 'TREZOR');
+      expect(hex.encode(bare.seed), _vectors.first.seedHex);
+      expect(
+        hex.encode(withPass.seed),
+        'c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e5349553'
+        '1f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04',
+      );
+    });
+
+    test('rejects a bad checksum', () {
+      final bad = _abandonAbout.replaceFirst(RegExp(r'about$'), 'abandon');
+      expect(() => Mnemonic.fromSentence(bad, Language.english), throwsA(isA<MnemonicException>()));
+    });
+
+    test('rejects a word outside the wordlist', () {
+      final bad = _abandonAbout.replaceFirst(RegExp(r'about$'), 'notaword');
+      expect(() => Mnemonic.fromSentence(bad, Language.english), throwsA(isA<MnemonicException>()));
+    });
+
+    test('generate produces a distinct, valid 12 word sentence', () {
+      final a = Mnemonic.generate(Language.english, length: MnemonicLength.words12);
+      final b = Mnemonic.generate(Language.english, length: MnemonicLength.words12);
+
+      expect(a.words, hasLength(12));
+      expect(a.entropy, hasLength(16));
+      expect(a.sentence, isNot(b.sentence));
+      expect(hex.encode(Mnemonic.fromSentence(a.sentence, Language.english).seed), hex.encode(a.seed));
+    });
+  });
+
+  group('HDWalletProvider derivation', () {
+    setUp(() async {
+      await GetIt.I.reset();
+      GetIt.I.registerSingleton<Logger>(Logger(level: Level.warning));
+      GetIt.I.registerSingleton<WalletReaderProvider>(WalletReaderProvider(Directory.systemTemp));
+      GetIt.I.registerSingleton<WalletWriterProvider>(
+        WalletWriterProvider(bitwindowAppDir: Directory.systemTemp),
+      );
+    });
+
+    tearDown(() async {
+      await GetIt.I.reset();
+    });
+
+    for (final v in _vectors) {
+      test('derives pinned seed and master key for "${v.mnemonic.split(' ').take(2).join(' ')}..."', () async {
+        final reader = GetIt.I.get<WalletReaderProvider>();
+        final hd = HDWalletProvider();
+
+        reader.wallets = [_enforcer(v.mnemonic)];
+        reader.activeWalletId = 'enf';
+        reader.notifyListeners();
+
+        for (int i = 0; i < 50 && !hd.isInitialized; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+
+        expect(hd.isInitialized, isTrue, reason: hd.error ?? 'provider never initialised');
+        expect(hd.seedHex, v.seedHex);
+        // dart_bip32_bip44 keeps BIP32's 0x00 private-key prefix.
+        expect(hd.masterKey, '00${v.masterKey}');
+      });
+    }
+  });
+}

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -889,30 +889,41 @@ func statusToProto(s orchestrator.BinaryStatus) *pb.BinaryStatusMsg {
 		}
 	})
 
+	var remoteUnix, downloadedUnix int64
+	if !s.RemoteTimestamp.IsZero() {
+		remoteUnix = s.RemoteTimestamp.Unix()
+	}
+	if !s.LocalTimestamp.IsZero() {
+		downloadedUnix = s.LocalTimestamp.Unix()
+	}
+
 	return &pb.BinaryStatusMsg{
-		Name:            s.Name,
-		DisplayName:     s.DisplayName,
-		Running:         s.Running,
-		Healthy:         s.Healthy,
-		Pid:             int32(s.Pid),
-		UptimeSeconds:   int64(s.Uptime.Seconds()),
-		ChainLayer:      int32(s.ChainLayer),
-		Port:            int32(s.Port),
-		Error:           s.Error,
-		Connected:       s.Connected,
-		StartupError:    s.StartupError,
-		ConnectionError: s.ConnectionError,
-		Stopping:        s.Stopping,
-		Initializing:    s.Initializing,
-		ConnectModeOnly: s.ConnectModeOnly,
-		Downloadable:    s.Downloadable,
-		Description:     s.Description,
-		Downloaded:      s.Downloaded,
-		BinaryPath:      s.BinaryPath,
-		PortInUse:       s.PortInUse,
-		Version:         s.Version,
-		RepoUrl:         s.RepoURL,
-		StartupLogs:     startupLogs,
+		UpdateAvailable:         s.UpdateAvailable,
+		RemoteTimestampUnix:     remoteUnix,
+		DownloadedTimestampUnix: downloadedUnix,
+		Name:                    s.Name,
+		DisplayName:             s.DisplayName,
+		Running:                 s.Running,
+		Healthy:                 s.Healthy,
+		Pid:                     int32(s.Pid),
+		UptimeSeconds:           int64(s.Uptime.Seconds()),
+		ChainLayer:              int32(s.ChainLayer),
+		Port:                    int32(s.Port),
+		Error:                   s.Error,
+		Connected:               s.Connected,
+		StartupError:            s.StartupError,
+		ConnectionError:         s.ConnectionError,
+		Stopping:                s.Stopping,
+		Initializing:            s.Initializing,
+		ConnectModeOnly:         s.ConnectModeOnly,
+		Downloadable:            s.Downloadable,
+		Description:             s.Description,
+		Downloaded:              s.Downloaded,
+		BinaryPath:              s.BinaryPath,
+		PortInUse:               s.PortInUse,
+		Version:                 s.Version,
+		RepoUrl:                 s.RepoURL,
+		StartupLogs:             startupLogs,
 	}
 }
 

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -200,6 +200,7 @@ func run(cctx *cli.Context) error {
 	configPath := orchestrator.ConfigFilePath(bitwindowDir)
 	configs := orchestrator.LoadConfigFile(configPath, log)
 	orch := orchestrator.New(dataDir, network, bitwindowDir, configs, log)
+	orch.StartReleaseChecks(ctx)
 
 	// Local RPC auth (bitcoind-style cookie). When enabled, a fresh token is
 	// written once this process owns the listener (see WriteCookie below) — it

--- a/sidechain-orchestrator/download.go
+++ b/sidechain-orchestrator/download.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -114,28 +115,8 @@ func (d *DownloadManager) Download(ctx context.Context, config BinaryConfig, net
 
 // DownloadWithOptions is Download with per-call overrides (see DownloadOptions).
 func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config BinaryConfig, network string, force bool, opts DownloadOptions) (<-chan DownloadProgress, error) {
-	// Resolve variants once: callers don't have to know about them, but every
-	// path below (target binary path, download URL, extract dir) must agree
-	// on the choice. Core variants and sidechain test-builds are mutually
-	// exclusive — Core is always layer-1, test sidechains are layer-2.
-	variant, hasVariant := d.activeVariant(config)
-	scVariant, hasSCVariant := d.activeSidechainVariant(config)
-	if opts.ForceBackend {
-		hasSCVariant = false
-		scVariant = sidechainVariantSpec{}
-	}
-
-	binaryName := config.BinaryName
-	if hasSCVariant {
-		binaryName = scVariant.BinaryName
-	}
-
-	binPath := BinaryPath(d.dataDir, binaryName)
-	if hasVariant {
-		binPath = CoreBinaryPath(d.dataDir, variant, config.BinaryName)
-	} else if hasSCVariant {
-		binPath = TestSidechainBinaryPath(d.dataDir, binaryName)
-	}
+	target := d.ResolveTarget(config, network, opts)
+	binPath := target.BinPath
 
 	if !force {
 		if _, err := os.Stat(binPath); err == nil {
@@ -146,39 +127,13 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 		}
 	}
 
-	var fileName string
-	var baseURL string
-	switch {
-	case hasVariant:
-		f, err := variant.FileForPlatform()
-		if err != nil {
-			return nil, err
-		}
-		fileName = f
-		baseURL = variant.BaseURL
-	case hasSCVariant:
-		fileName = scVariant.FileName
-		baseURL = scVariant.BaseURL
-	default:
-		f, err := config.FileForPlatform()
-		if err != nil {
-			return nil, err
-		}
-		fileName = f
-		baseURL = config.BaseURL(network)
-	}
-
+	fileName := target.FileName
+	baseURL := target.BaseURL
 	if fileName == "" || baseURL == "" {
 		return nil, fmt.Errorf("no download available for %s on %s", config.Name, currentPlatform())
 	}
 
-	inFlightKey := config.Name
-	switch {
-	case hasVariant:
-		inFlightKey = config.Name + ":" + variant.ID
-	case hasSCVariant:
-		inFlightKey = config.Name + ":test"
-	}
+	inFlightKey := target.InFlightKey
 	// A second caller attaches to the running download instead of failing.
 	// SwapNetwork drops the core binary and restarts L1, so two paths ask at once.
 	done := make(chan struct{})
@@ -248,11 +203,7 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 		// JSON-parse an HTML 404 and abort the download with a confusing
 		// "decode response: invalid character '<'" error.
 		var downloadURL string
-		source := config.DownloadSource
-		if hasSCVariant {
-			source = DownloadSourceDirect
-		}
-		switch source {
+		switch target.Source {
 		case DownloadSourceGitHub:
 			url, err := d.resolveGitHubURL(ctx, baseURL, fileName)
 			if err != nil {
@@ -300,28 +251,15 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 			return
 		}
 
-		extractName := config.BinaryName
-		stripPrefix := ""
-		if hasSCVariant {
-			extractName = scVariant.BinaryName
-			stripPrefix = scVariant.ExtractSubfolder
-		}
-		hasCLI, err := d.extractBinary(savePath, config, extractName, stripPrefix, d.dataDir, network, hasSCVariant)
+		hasCLI, err := d.extractBinary(savePath, config, target.ExtractName, target.ExtractSubfolder, d.dataDir, network, target.IsTestBuild)
 		if err != nil {
 			d.log.Error().Err(err).Str("binary", config.Name).Msg("extract failed")
 			send(DownloadProgress{Error: fmt.Errorf("extract: %w", err)})
 			return
 		}
-		d.log.Info().Bool("has_cli", hasCLI).Str("binary", extractName).Msg("extraction complete")
+		d.log.Info().Bool("has_cli", hasCLI).Str("binary", target.ExtractName).Msg("extraction complete")
 
-		finalPath := BinaryPath(d.dataDir, extractName)
-		switch {
-		case hasVariant:
-			finalPath = CoreBinaryPath(d.dataDir, variant, config.BinaryName)
-		case hasSCVariant:
-			finalPath = TestSidechainBinaryPath(d.dataDir, extractName)
-		}
-		send(DownloadProgress{Message: finalPath, Done: true})
+		send(DownloadProgress{Message: target.BinPath, Done: true})
 	}()
 
 	return ch, nil
@@ -1055,4 +993,82 @@ func (d *DownloadManager) attachToInFlight(ctx context.Context, done chan struct
 		}
 	}()
 	return ch
+}
+
+// DownloadTarget is where a binary lives on disk and where its archive comes
+// from, after Core variant and test sidechain resolution.
+type DownloadTarget struct {
+	BinPath  string
+	FileName string
+	BaseURL  string
+	// Source is DownloadSourceGitHub when FileName is an asset pattern that
+	// ResolveArchiveURL must look up, not a path to join onto BaseURL.
+	Source DownloadSource
+	// InFlightKey namespaces the download so a production and a test build of
+	// the same binary never wait on each other.
+	InFlightKey string
+	// ExtractName is the file to pull out of the archive, and ExtractSubfolder
+	// the directory prefix to strip off it.
+	ExtractName      string
+	ExtractSubfolder string
+	// IsTestBuild routes extraction to the test build directory.
+	IsTestBuild bool
+}
+
+// ResolveTarget picks the Core variant, the test sidechain build, or the plain
+// config. The downloader and the release check share it, so they can never
+// disagree about which file they act on.
+func (d *DownloadManager) ResolveTarget(config BinaryConfig, network string, opts DownloadOptions) DownloadTarget {
+	variant, hasVariant := d.activeVariant(config)
+	scVariant, hasSCVariant := d.activeSidechainVariant(config)
+	if opts.ForceBackend {
+		hasSCVariant = false
+		scVariant = sidechainVariantSpec{}
+	}
+
+	binaryName := config.BinaryName
+	if hasSCVariant {
+		binaryName = scVariant.BinaryName
+	}
+
+	target := DownloadTarget{
+		BinPath:     BinaryPath(d.dataDir, binaryName),
+		Source:      config.DownloadSource,
+		InFlightKey: config.Name,
+		ExtractName: config.BinaryName,
+		IsTestBuild: hasSCVariant,
+	}
+	switch {
+	case hasVariant:
+		target.BinPath = CoreBinaryPath(d.dataDir, variant, config.BinaryName)
+		target.FileName, _ = variant.FileForPlatform()
+		target.BaseURL = variant.BaseURL
+		target.InFlightKey = config.Name + ":" + variant.ID
+	case hasSCVariant:
+		target.BinPath = TestSidechainBinaryPath(d.dataDir, binaryName)
+		target.FileName = scVariant.FileName
+		target.BaseURL = scVariant.BaseURL
+		target.InFlightKey = config.Name + ":test"
+		target.ExtractName = scVariant.BinaryName
+		target.ExtractSubfolder = scVariant.ExtractSubfolder
+		// Test builds always come straight from releases.drivechain.info, even
+		// when the production build of the same sidechain lives on GitHub.
+		target.Source = DownloadSourceDirect
+	default:
+		target.FileName, _ = config.FileForPlatform()
+		target.BaseURL = config.BaseURL(network)
+	}
+	return target
+}
+
+// ResolveArchiveURL turns a target into the URL of the archive itself. A GitHub
+// target needs a releases API call, because its FileName is an asset pattern.
+func (d *DownloadManager) ResolveArchiveURL(ctx context.Context, target DownloadTarget) (string, error) {
+	if target.FileName == "" || target.BaseURL == "" {
+		return "", errors.New("no download configured")
+	}
+	if target.Source == DownloadSourceGitHub {
+		return d.resolveGitHubURL(ctx, target.BaseURL, target.FileName)
+	}
+	return target.BaseURL + target.FileName, nil
 }

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -268,9 +268,16 @@ type BinaryStatusMsg struct {
 	// Absolute path to the launchable binary on disk (variant-aware: returns
 	// bin/test/<binary>/... for active sidechain alt-builds, the resolved
 	// .app/Contents/MacOS path on macOS, etc.). Empty when not downloaded.
-	BinaryPath    string `protobuf:"bytes,23,opt,name=binary_path,json=binaryPath,proto3" json:"binary_path,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	BinaryPath string `protobuf:"bytes,23,opt,name=binary_path,json=binaryPath,proto3" json:"binary_path,omitempty"`
+	// A newer build is published than the one on disk. False while either side
+	// is unknown, so a failed check never claims an update.
+	UpdateAvailable bool `protobuf:"varint,24,opt,name=update_available,json=updateAvailable,proto3" json:"update_available,omitempty"`
+	// Last-Modified of the published download, 0 when unknown.
+	RemoteTimestampUnix int64 `protobuf:"varint,25,opt,name=remote_timestamp_unix,json=remoteTimestampUnix,proto3" json:"remote_timestamp_unix,omitempty"`
+	// Modification time of the binary on disk, 0 when not downloaded.
+	DownloadedTimestampUnix int64 `protobuf:"varint,26,opt,name=downloaded_timestamp_unix,json=downloadedTimestampUnix,proto3" json:"downloaded_timestamp_unix,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *BinaryStatusMsg) Reset() {
@@ -462,6 +469,27 @@ func (x *BinaryStatusMsg) GetBinaryPath() string {
 		return x.BinaryPath
 	}
 	return ""
+}
+
+func (x *BinaryStatusMsg) GetUpdateAvailable() bool {
+	if x != nil {
+		return x.UpdateAvailable
+	}
+	return false
+}
+
+func (x *BinaryStatusMsg) GetRemoteTimestampUnix() int64 {
+	if x != nil {
+		return x.RemoteTimestampUnix
+	}
+	return 0
+}
+
+func (x *BinaryStatusMsg) GetDownloadedTimestampUnix() int64 {
+	if x != nil {
+		return x.DownloadedTimestampUnix
+	}
+	return 0
 }
 
 type StartupLogEntryMsg struct {
@@ -4144,7 +4172,7 @@ var File_orchestrator_v1_orchestrator_proto protoreflect.FileDescriptor
 
 const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\n" +
-	"\"orchestrator/v1/orchestrator.proto\x12\x0forchestrator.v1\"\xfe\x05\n" +
+	"\"orchestrator/v1/orchestrator.proto\x12\x0forchestrator.v1\"\x99\a\n" +
 	"\x0fBinaryStatusMsg\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
 	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12\x18\n" +
@@ -4173,7 +4201,10 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\brepo_url\x18\x15 \x01(\tR\arepoUrl\x12F\n" +
 	"\fstartup_logs\x18\x16 \x03(\v2#.orchestrator.v1.StartupLogEntryMsgR\vstartupLogs\x12\x1f\n" +
 	"\vbinary_path\x18\x17 \x01(\tR\n" +
-	"binaryPath\"U\n" +
+	"binaryPath\x12)\n" +
+	"\x10update_available\x18\x18 \x01(\bR\x0fupdateAvailable\x122\n" +
+	"\x15remote_timestamp_unix\x18\x19 \x01(\x03R\x13remoteTimestampUnix\x12:\n" +
+	"\x19downloaded_timestamp_unix\x18\x1a \x01(\x03R\x17downloadedTimestampUnix\"U\n" +
 	"\x12StartupLogEntryMsg\x12%\n" +
 	"\x0etimestamp_unix\x18\x01 \x01(\x03R\rtimestampUnix\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\"\x15\n" +

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -60,6 +60,9 @@ type BinaryStatus struct {
 	Version         string // configured version string
 	RepoURL         string // source code repository URL
 	StartupLogs     []StartupLogLine
+	UpdateAvailable bool      // a newer build is published than the one on disk
+	RemoteTimestamp time.Time // Last-Modified of the published download
+	LocalTimestamp  time.Time // mtime of the binary on disk
 }
 
 // StartupProgress reports progress during StartWithL1. Download fields
@@ -137,6 +140,9 @@ type Orchestrator struct {
 	// drynetID is the live drynet generation ("drynet2"). Guarded by mu; read
 	// by UpdateConfigs to expand the placeholder in freshly loaded configs.
 	drynetID string
+
+	// releases reports whether a newer build of each binary is published.
+	releases *ReleaseChecker
 
 	BitcoinConf    *config.BitcoinConfManager
 	EnforcerConf   *config.EnforcerConfManager
@@ -280,14 +286,17 @@ func New(dataDir, network, bitwindowDir string, configs []BinaryConfig, log zero
 		settings = &SettingsStore{bitwindowDir: bitwindowDir, current: defaultOrchestratorSettings()}
 	}
 
+	downloads := NewDownloadManager(dataDir, ConfigFilePath(bitwindowDir), log)
+
 	orch := &Orchestrator{
+		releases:     NewReleaseChecker(downloads, log),
 		DataDir:      dataDir,
 		Network:      network,
 		BitwindowDir: bitwindowDir,
 		Settings:     settings,
 		configs:      lo.SliceToMap(configs, func(c BinaryConfig) (string, BinaryConfig) { return c.Name, c }),
 		rawConfigs:   lo.SliceToMap(configs, func(c BinaryConfig) (string, BinaryConfig) { return c.Name, c }),
-		download:     NewDownloadManager(dataDir, ConfigFilePath(bitwindowDir), log),
+		download:     downloads,
 		process:      NewProcessManager(dataDir, pidMgr, log),
 		pidManager:   pidMgr,
 		monitors:     make(map[string]*ConnectionMonitor),
@@ -318,8 +327,10 @@ func New(dataDir, network, bitwindowDir string, configs []BinaryConfig, log zero
 		return available[0], true
 	}
 	orch.download.CoreVariant = func() (CoreVariantSpec, bool) {
-		cfg, ok := orch.configs["bitcoind"]
-		if !ok {
+		// Through the locked accessor: a config reload rewrites this map while
+		// Status reads it on another goroutine.
+		cfg, err := orch.getConfig("bitcoind")
+		if err != nil {
 			return CoreVariantSpec{}, false
 		}
 		return variantResolver(cfg)
@@ -536,7 +547,33 @@ func (o *Orchestrator) Download(ctx context.Context, name string, force bool, op
 	if err != nil {
 		return nil, err
 	}
-	return o.download.DownloadWithOptions(ctx, config, o.Network, force, opts)
+	ch, err := o.download.DownloadWithOptions(ctx, config, o.Network, force, opts)
+	if err != nil {
+		return nil, err
+	}
+	return o.refreshReleaseWhenDone(ctx, config, ch), nil
+}
+
+// refreshReleaseWhenDone re-probes a binary once its download ends. The cached
+// check holds the old file's timestamp, and a ten minute wait would offer the
+// same update again.
+func (o *Orchestrator) refreshReleaseWhenDone(ctx context.Context, config BinaryConfig, in <-chan DownloadProgress) <-chan DownloadProgress {
+	if o.releases == nil {
+		return in
+	}
+	out := make(chan DownloadProgress, cap(in))
+	go func() {
+		defer close(out)
+		for p := range in {
+			select {
+			case out <- p:
+			case <-ctx.Done():
+				return
+			}
+		}
+		o.releases.Refresh(context.WithoutCancel(ctx), config, o.CurrentNetwork())
+	}()
+	return out
 }
 
 // Start starts a binary with the given args and env.
@@ -662,6 +699,14 @@ func (o *Orchestrator) Status(name string) BinaryStatus {
 	}
 	if downloaded {
 		status.BinaryPath = binPath
+	}
+
+	if o.releases != nil {
+		if check, ok := o.releases.Check(config, o.CurrentNetwork()); ok {
+			status.UpdateAvailable = check.UpdateAvailable()
+			status.RemoteTimestamp = check.Remote
+			status.LocalTimestamp = check.Local
+		}
 	}
 
 	if proc != nil {

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -175,6 +175,13 @@ message BinaryStatusMsg {
   // bin/test/<binary>/... for active sidechain alt-builds, the resolved
   // .app/Contents/MacOS path on macOS, etc.). Empty when not downloaded.
   string binary_path = 23;
+  // A newer build is published than the one on disk. False while either side
+  // is unknown, so a failed check never claims an update.
+  bool update_available = 24;
+  // Last-Modified of the published download, 0 when unknown.
+  int64 remote_timestamp_unix = 25;
+  // Modification time of the binary on disk, 0 when not downloaded.
+  int64 downloaded_timestamp_unix = 26;
 }
 
 message StartupLogEntryMsg {

--- a/sidechain-orchestrator/release_check.go
+++ b/sidechain-orchestrator/release_check.go
@@ -1,0 +1,186 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/samber/lo"
+)
+
+// ReleaseCheckInterval is how often the checker re-reads Last-Modified.
+const ReleaseCheckInterval = 10 * time.Minute
+
+const releaseCheckTimeout = 5 * time.Second
+
+// ReleaseCheck is what the checker knows about one binary.
+type ReleaseCheck struct {
+	// Remote is the Last-Modified time of the download, zero when unknown.
+	Remote time.Time
+	// Local is the mtime of the binary on disk, zero when not downloaded.
+	Local time.Time
+	// Source names the download the probe read. Every Core variant writes to
+	// the same binary path, so the download key is what separates them.
+	Source string
+}
+
+// UpdateAvailable reports whether the published download is newer than the
+// binary on disk. It is false whenever either side is unknown, so a failed
+// probe never shows a false update.
+func (c ReleaseCheck) UpdateAvailable() bool {
+	return !c.Remote.IsZero() && !c.Local.IsZero() && c.Remote.After(c.Local)
+}
+
+// ReleaseChecker tracks whether a newer build of each binary is published.
+//
+// The published archives keep a fixed "latest" name, so only the server's
+// Last-Modified separates one release from the next. Probes run on a timer and
+// land in a cache, because status is read far more often than releases ship.
+type ReleaseChecker struct {
+	client    *http.Client
+	log       zerolog.Logger
+	downloads *DownloadManager
+
+	mu     sync.RWMutex
+	checks map[string]ReleaseCheck
+}
+
+// NewReleaseChecker reads every download through the manager, so a Core
+// variant, a test sidechain build and a GitHub asset all resolve the same way
+// they do for a real download.
+func NewReleaseChecker(downloads *DownloadManager, log zerolog.Logger) *ReleaseChecker {
+	return &ReleaseChecker{
+		client:    &http.Client{Timeout: releaseCheckTimeout},
+		log:       log,
+		downloads: downloads,
+		checks:    make(map[string]ReleaseCheck),
+	}
+}
+
+// StartReleaseChecks polls every configured binary for a newer published build
+// until ctx ends. BinaryStatus reads the cached result, so status never blocks
+// on the network.
+func (o *Orchestrator) StartReleaseChecks(ctx context.Context) {
+	// Every config, not only the Downloadable() ones: Bitcoin Core defines its
+	// downloads through variants, so its own Files are empty and that filter
+	// would drop it. ResolveTarget decides what a probe can reach.
+	//
+	// Accessors, not values: a network swap or a config reload has to reach the
+	// next tick, and a snapshot taken at startup never would.
+	go o.releases.Run(ctx, func() []BinaryConfig { return lo.Values(o.Configs()) }, o.CurrentNetwork)
+}
+
+// Check returns the cached result for a binary. ok is false until a probe runs,
+// and false when the cached probe describes a different file: a Core variant or
+// test sidechain change resolves another path, and the previous target's
+// timestamps say nothing about the new one.
+func (r *ReleaseChecker) Check(config BinaryConfig, network string) (ReleaseCheck, bool) {
+	target := r.downloads.ResolveTarget(config, network, DownloadOptions{})
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	check, ok := r.checks[config.Name]
+	if !ok || check.Source != target.InFlightKey {
+		return ReleaseCheck{}, false
+	}
+	return check, true
+}
+
+// Run probes every binary at once, then again on each tick, until ctx ends.
+// It reads configs and network on every tick, so a swap takes effect at once.
+func (r *ReleaseChecker) Run(ctx context.Context, configs func() []BinaryConfig, network func() string) {
+	ticker := time.NewTicker(ReleaseCheckInterval)
+	defer ticker.Stop()
+
+	// One slow host must not hold up the rest, so the probes run together.
+	refreshAll := func() {
+		var wg sync.WaitGroup
+		current := network()
+		for _, config := range configs() {
+			wg.Add(1)
+			go func(config BinaryConfig) {
+				defer wg.Done()
+				r.Refresh(ctx, config, current)
+			}(config)
+		}
+		wg.Wait()
+	}
+
+	refreshAll()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			refreshAll()
+		}
+	}
+}
+
+// Refresh probes one binary and stores the result. Call it after a download so
+// the update button clears at once instead of at the next tick.
+func (r *ReleaseChecker) Refresh(ctx context.Context, config BinaryConfig, network string) {
+	target := r.downloads.ResolveTarget(config, network, DownloadOptions{})
+
+	var check ReleaseCheck
+	remote, err := r.remoteTime(ctx, target)
+	if err != nil {
+		// A probe that fails leaves the binary with no remote time, which reads
+		// as "no update". Keep the local time so the reason stays visible.
+		r.log.Debug().Err(err).Str("binary", config.Name).Msg("release check failed")
+	} else {
+		check.Remote = remote
+	}
+
+	// Read the mtime after the probe. A download that lands during the probe
+	// would otherwise let this write restore the pre-download time, and the
+	// update button would come back until the next tick.
+	check.Local = localModTime(target.BinPath)
+	check.Source = target.InFlightKey
+
+	r.mu.Lock()
+	r.checks[config.Name] = check
+	r.mu.Unlock()
+}
+
+// localModTime is the mtime of the binary on disk, zero when it is not there.
+func localModTime(path string) time.Time {
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}
+	}
+	return info.ModTime()
+}
+
+// remoteTime reads Last-Modified from the published archive with a HEAD request.
+func (r *ReleaseChecker) remoteTime(ctx context.Context, target DownloadTarget) (time.Time, error) {
+	url, err := r.downloads.ResolveArchiveURL(ctx, target)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer resp.Body.Close() //nolint:errcheck // a HEAD response carries no body
+
+	if resp.StatusCode != http.StatusOK {
+		return time.Time{}, fmt.Errorf("release check: HTTP %d for %s", resp.StatusCode, url)
+	}
+
+	lastModified := resp.Header.Get("Last-Modified")
+	if lastModified == "" {
+		return time.Time{}, fmt.Errorf("release check: no Last-Modified header for %s", url)
+	}
+	return http.ParseTime(lastModified)
+}

--- a/sidechain-orchestrator/release_check_test.go
+++ b/sidechain-orchestrator/release_check_test.go
@@ -1,0 +1,263 @@
+package orchestrator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func releaseTestConfig(baseURL string) BinaryConfig {
+	return BinaryConfig{
+		Name:         "thunder",
+		BinaryName:   "thunder",
+		DownloadURLs: map[string]string{"default": baseURL},
+		Files:        map[string]string{currentPlatform(): "L2-S9-Thunder-latest.zip"},
+	}
+}
+
+// The published archives keep one fixed name per platform, so Last-Modified is
+// the only thing that separates one release from the next.
+func TestReleaseCheckerComparesLastModified(t *testing.T) {
+	published := time.Date(2026, 8, 6, 17, 44, 0, 0, time.UTC)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodHead, r.Method, "a release check must not download the archive")
+		w.Header().Set("Last-Modified", published.Format(http.TimeFormat))
+	}))
+	defer server.Close()
+
+	dataDir := t.TempDir()
+	config := releaseTestConfig(server.URL + "/")
+	binPath := BinaryPath(dataDir, config.BinaryName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(binPath), 0o755))
+	require.NoError(t, os.WriteFile(binPath, []byte("binary"), 0o755))
+
+	checker := NewReleaseChecker(NewDownloadManager(dataDir, "", zerolog.Nop()), zerolog.Nop())
+
+	// Downloaded after the release: nothing to update.
+	require.NoError(t, os.Chtimes(binPath, published.Add(time.Hour), published.Add(time.Hour)))
+	checker.Refresh(context.Background(), config, "signet")
+	check, ok := checker.Check(config, "signet")
+	require.True(t, ok)
+	assert.False(t, check.UpdateAvailable())
+	assert.Equal(t, published, check.Remote.UTC())
+
+	// Downloaded before the release: an update is waiting.
+	require.NoError(t, os.Chtimes(binPath, published.Add(-time.Hour), published.Add(-time.Hour)))
+	checker.Refresh(context.Background(), config, "signet")
+	check, ok = checker.Check(config, "signet")
+	require.True(t, ok)
+	assert.True(t, check.UpdateAvailable())
+}
+
+// A server that cannot answer must not claim an update, because the button it
+// draws would download the same build the user already runs.
+func TestReleaseCheckerStaysQuietWhenTheProbeFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	dataDir := t.TempDir()
+	config := releaseTestConfig(server.URL + "/")
+	binPath := BinaryPath(dataDir, config.BinaryName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(binPath), 0o755))
+	require.NoError(t, os.WriteFile(binPath, []byte("binary"), 0o755))
+
+	checker := NewReleaseChecker(NewDownloadManager(dataDir, "", zerolog.Nop()), zerolog.Nop())
+	checker.Refresh(context.Background(), config, "signet")
+
+	check, ok := checker.Check(config, "signet")
+	require.True(t, ok)
+	assert.False(t, check.UpdateAvailable())
+	assert.True(t, check.Remote.IsZero())
+	assert.False(t, check.Local.IsZero(), "the local time still reads off disk")
+}
+
+// A binary that was never downloaded has nothing to compare against.
+func TestReleaseCheckerNeedsALocalBinary(t *testing.T) {
+	published := time.Date(2026, 8, 6, 17, 44, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Last-Modified", published.Format(http.TimeFormat))
+	}))
+	defer server.Close()
+
+	checker := NewReleaseChecker(NewDownloadManager(t.TempDir(), "", zerolog.Nop()), zerolog.Nop())
+	config := releaseTestConfig(server.URL + "/")
+	checker.Refresh(context.Background(), config, "signet")
+
+	check, ok := checker.Check(config, "signet")
+	require.True(t, ok)
+	assert.False(t, check.UpdateAvailable())
+	assert.True(t, check.Local.IsZero())
+}
+
+// Bitcoin Core defines its downloads through variants only, so its own Files
+// are empty. A check that reads the plain config would skip it entirely.
+func TestReleaseCheckerFollowsTheCoreVariant(t *testing.T) {
+	published := time.Date(2026, 8, 6, 17, 44, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Last-Modified", published.Format(http.TimeFormat))
+	}))
+	defer server.Close()
+
+	dataDir := t.TempDir()
+	downloads := NewDownloadManager(dataDir, "", zerolog.Nop())
+	variant := CoreVariantSpec{
+		ID:      "patched",
+		BaseURL: server.URL + "/",
+		Files:   map[string]string{currentPlatform(): "L1-bitcoin-patched-latest.zip"},
+	}
+	downloads.CoreVariant = func() (CoreVariantSpec, bool) { return variant, true }
+
+	// A variant-only config: no Files of its own, which is what ships today.
+	config := BinaryConfig{Name: "bitcoind", BinaryName: "bitcoind", IsBitcoinCore: true, ChainLayer: 1}
+	binPath := CoreBinaryPath(dataDir, variant, config.BinaryName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(binPath), 0o755))
+	require.NoError(t, os.WriteFile(binPath, []byte("core"), 0o755))
+	require.NoError(t, os.Chtimes(binPath, published.Add(-time.Hour), published.Add(-time.Hour)))
+
+	checker := NewReleaseChecker(downloads, zerolog.Nop())
+	checker.Refresh(context.Background(), config, "signet")
+
+	check, ok := checker.Check(config, "signet")
+	require.True(t, ok)
+	assert.True(t, check.UpdateAvailable(), "the variant download decides, not the empty config")
+}
+
+// A GitHub config carries an asset pattern, not a path. Joining it onto the API
+// URL would probe something that does not exist.
+func TestReleaseCheckerResolvesAGitHubAsset(t *testing.T) {
+	published := time.Date(2026, 8, 6, 17, 44, 0, 0, time.UTC)
+
+	var assetPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/releases/latest" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"assets":[{"name":"zside-1.2.3-x86_64.zip","browser_download_url":"` +
+				"http://" + r.Host + `/assets/zside.zip"}]}`))
+			return
+		}
+		assetPath = r.URL.Path
+		w.Header().Set("Last-Modified", published.Format(http.TimeFormat))
+	}))
+	defer server.Close()
+
+	dataDir := t.TempDir()
+	config := BinaryConfig{
+		Name:           "zside",
+		BinaryName:     "zside",
+		DownloadSource: DownloadSourceGitHub,
+		DownloadURLs:   map[string]string{"default": server.URL + "/releases/latest"},
+		Files:          map[string]string{currentPlatform(): `zside-.*-x86_64\.zip`},
+	}
+	binPath := BinaryPath(dataDir, config.BinaryName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(binPath), 0o755))
+	require.NoError(t, os.WriteFile(binPath, []byte("zside"), 0o755))
+	require.NoError(t, os.Chtimes(binPath, published.Add(-time.Hour), published.Add(-time.Hour)))
+
+	checker := NewReleaseChecker(NewDownloadManager(dataDir, "", zerolog.Nop()), zerolog.Nop())
+	checker.Refresh(context.Background(), config, "signet")
+
+	check, ok := checker.Check(config, "signet")
+	require.True(t, ok)
+	assert.Equal(t, "/assets/zside.zip", assetPath, "the probe must hit the resolved asset")
+	assert.True(t, check.UpdateAvailable())
+}
+
+// A Core variant change resolves a different binary. The previous variant's
+// timestamps describe a file the user no longer runs, so Status must show
+// nothing until the next probe rather than the old variant's answer.
+func TestReleaseCheckerDropsTheCheckWhenTheVariantChanges(t *testing.T) {
+	published := time.Date(2026, 8, 6, 17, 44, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Last-Modified", published.Format(http.TimeFormat))
+	}))
+	defer server.Close()
+
+	dataDir := t.TempDir()
+	downloads := NewDownloadManager(dataDir, "", zerolog.Nop())
+	config := BinaryConfig{Name: "bitcoind", BinaryName: "bitcoind", IsBitcoinCore: true, ChainLayer: 1}
+
+	newVariant := func(id string) CoreVariantSpec {
+		return CoreVariantSpec{
+			ID:      id,
+			BaseURL: server.URL + "/",
+			Files:   map[string]string{currentPlatform(): "L1-bitcoin-" + id + "-latest.zip"},
+		}
+	}
+
+	patched := newVariant("patched")
+	downloads.CoreVariant = func() (CoreVariantSpec, bool) { return patched, true }
+
+	binPath := CoreBinaryPath(dataDir, patched, config.BinaryName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(binPath), 0o755))
+	require.NoError(t, os.WriteFile(binPath, []byte("core"), 0o755))
+	require.NoError(t, os.Chtimes(binPath, published.Add(-time.Hour), published.Add(-time.Hour)))
+
+	checker := NewReleaseChecker(downloads, zerolog.Nop())
+	checker.Refresh(context.Background(), config, "signet")
+
+	check, ok := checker.Check(config, "signet")
+	require.True(t, ok)
+	require.True(t, check.UpdateAvailable())
+
+	// The user picks another variant. Nothing probed it yet.
+	knots := newVariant("knots")
+	downloads.CoreVariant = func() (CoreVariantSpec, bool) { return knots, true }
+
+	_, ok = checker.Check(config, "signet")
+	assert.False(t, ok, "the patched variant's check must not describe knots")
+}
+
+// Run reads the network on every tick. A swap must reach the next probe, and a
+// snapshot taken at startup would keep the daemon on the old network's URL
+// until a restart.
+func TestReleaseCheckerRunFollowsANetworkSwap(t *testing.T) {
+	var mu sync.Mutex
+	var probed []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		probed = append(probed, r.URL.Path)
+		mu.Unlock()
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	}))
+	defer server.Close()
+
+	dataDir := t.TempDir()
+	downloads := NewDownloadManager(dataDir, "", zerolog.Nop())
+	config := releaseTestConfig(server.URL + "/")
+
+	network := "signet"
+	networkOf := func() string { return network }
+
+	checker := NewReleaseChecker(downloads, zerolog.Nop())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Run probes one time before it waits on the ticker, so a single call is
+	// one full pass over the configs.
+	go checker.Run(ctx, func() []BinaryConfig { return []BinaryConfig{config} }, networkOf)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(probed) > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	network = "regtest"
+	checker.Refresh(ctx, config, networkOf())
+
+	check, ok := checker.Check(config, "regtest")
+	require.True(t, ok, "a refresh after the swap must answer for the new network")
+	assert.False(t, check.Remote.IsZero())
+}

--- a/sidechain_core/lib/config/binaries.dart
+++ b/sidechain_core/lib/config/binaries.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:ffi' show Abi;
 import 'dart:io';
 
@@ -7,7 +6,6 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
-import 'package:http/http.dart' as http;
 import 'package:logger/logger.dart';
 import 'package:path/path.dart' as path;
 import 'package:sidechain_core/sidechain_core.dart';
@@ -278,112 +276,6 @@ abstract class Binary {
     return paths;
   }
 
-  /// Check the Last-Modified header for a binary without downloading
-  Future<DateTime?> _checkReleaseDate() async {
-    try {
-      // Handle GitHub API URLs differently
-      final network = GetIt.I.get<BitcoinConfProvider>().network;
-      if (metadata.downloadConfig.baseUrl(network).contains('github.com')) {
-        return await _checkGithubReleaseDate();
-      } else {
-        return await _checkDirectReleaseDate();
-      }
-    } catch (e) {
-      log.w('Warning: Failed to check release date for $name: $e');
-      return null;
-    }
-  }
-
-  Future<DateTime?> _checkGithubReleaseDate() async {
-    final url = metadata.downloadConfig.baseUrl(
-      GetIt.I.get<BitcoinConfProvider>().network,
-    );
-
-    // Check cache first
-    final cached = _GitHubCache.get(url);
-    if (cached != null) {
-      return cached;
-    }
-
-    try {
-      final response = await http.get(
-        Uri.parse(url),
-        headers: {
-          'User-Agent': 'Drivechain-Frontends',
-          'Accept': 'application/vnd.github.v3+json',
-        },
-      );
-
-      if (response.statusCode == 403) {
-        _GitHubCache.set(url, null); // Cache the failure too
-        return null;
-      }
-
-      if (response.statusCode != 200) {
-        _GitHubCache.set(url, null);
-        return null;
-      }
-
-      final publishedAt = json.decode(response.body)['published_at'] as String?;
-
-      if (publishedAt == null) {
-        log.d('No published_at field in GitHub release for $name');
-        _GitHubCache.set(url, null);
-        return null;
-      }
-
-      final releaseDate = DateTime.parse(publishedAt);
-      _GitHubCache.set(url, releaseDate); // Cache the result
-      return releaseDate;
-    } catch (e) {
-      log.d(
-        'Could not check GitHub release date for $name: ${e.toString().split('\n').first}',
-      );
-      _GitHubCache.set(url, null); // Cache the failure
-      return null;
-    }
-  }
-
-  Future<DateTime?> _checkDirectReleaseDate() async {
-    try {
-      final os = getOS();
-      final fileName = metadata.downloadConfig.files[GetIt.I.get<BitcoinConfProvider>().network]?[os];
-      final baseUrl = metadata.downloadConfig.baseUrl(
-        GetIt.I.get<BitcoinConfProvider>().network,
-      );
-      if (fileName == null || fileName.isEmpty || baseUrl.isEmpty) {
-        return null;
-      }
-
-      final downloadUrl = Uri.parse(baseUrl).resolve(fileName).toString();
-      final client = HttpClient()..connectionTimeout = const Duration(seconds: 5);
-      try {
-        final request = await client.headUrl(Uri.parse(downloadUrl));
-        final response = await request.close().timeout(const Duration(seconds: 5));
-
-        if (response.statusCode != 200) {
-          log.w(
-            'Warning: Could not check release date for $name: HTTP ${response.statusCode}',
-          );
-          return null;
-        }
-
-        final lastModified = response.headers.value('last-modified');
-        if (lastModified == null) {
-          log.w('Warning: No Last-Modified header for $name');
-          return null;
-        }
-
-        return HttpDate.parse(lastModified);
-      } finally {
-        client.close(force: true);
-      }
-    } catch (e) {
-      log.w('Warning: Failed to check direct release date for $name: $e');
-      return null;
-    }
-  }
-
   void _log(String message) {
     log.i('Binary: $message');
   }
@@ -422,37 +314,6 @@ abstract class Binary {
 
     extraBootArgs = List<String>.from(extraBootArgs)..add(arg);
   }
-}
-
-// Global cache for GitHub API responses (1 minute TTL)
-class _GitHubCache {
-  static final Map<String, _CacheEntry> _cache = {};
-
-  static DateTime? get(String url) {
-    final entry = _cache[url];
-    if (entry == null) {
-      return null;
-    }
-
-    // Check if cache entry is still valid (1 minute TTL)
-    if (DateTime.now().difference(entry.timestamp).inMinutes >= 1) {
-      _cache.remove(url);
-      return null;
-    }
-
-    return entry.releaseDate;
-  }
-
-  static void set(String url, DateTime? releaseDate) {
-    _cache[url] = _CacheEntry(releaseDate, DateTime.now());
-  }
-}
-
-class _CacheEntry {
-  final DateTime? releaseDate;
-  final DateTime timestamp;
-
-  _CacheEntry(this.releaseDate, this.timestamp);
 }
 
 class BitcoinCore extends Binary {
@@ -1444,10 +1305,9 @@ extension BinaryDownload on Binary {
   Future<Binary> updateMetadata(Directory appDir) async {
     try {
       final updatedLocal = await updateLocalMetadata(appDir);
-      final updatedReleaseDate = await updateReleaseDate(appDir);
       return copyWith(
         metadata: metadata.copyWith(
-          remoteTimestamp: updatedReleaseDate.metadata.remoteTimestamp,
+          remoteTimestamp: metadata.remoteTimestamp,
           downloadedTimestamp: updatedLocal.metadata.downloadedTimestamp,
           binaryPath: updatedLocal.metadata.binaryPath,
           updateable: updatedLocal.metadata.updateable,
@@ -1478,31 +1338,6 @@ extension BinaryDownload on Binary {
     } catch (e) {
       // Log error and return unchanged binary
       log.e('Error updating metadata for $name: $e');
-      return this;
-    }
-  }
-
-  /// Update metadata with current binary information
-  Future<Binary> updateReleaseDate(Directory appDir) async {
-    try {
-      DateTime? serverReleaseDate;
-      try {
-        serverReleaseDate = await _checkReleaseDate();
-      } catch (e) {
-        log.e('could not check release date: $e');
-      }
-
-      final updatedConfig = metadata.copyWith(
-        remoteTimestamp: serverReleaseDate,
-        downloadedTimestamp: metadata.downloadedTimestamp,
-        binaryPath: metadata.binaryPath,
-        updateable: metadata.updateable,
-      );
-
-      return copyWith(metadata: updatedConfig);
-    } catch (e) {
-      // Log error and return unchanged binary
-      log.e('Error updating release date for $name: $e');
       return this;
     }
   }

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -44,6 +44,9 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     $core.String? repoUrl,
     $core.Iterable<StartupLogEntryMsg>? startupLogs,
     $core.String? binaryPath,
+    $core.bool? updateAvailable,
+    $fixnum.Int64? remoteTimestampUnix,
+    $fixnum.Int64? downloadedTimestampUnix,
   }) {
     final $result = create();
     if (name != null) {
@@ -115,6 +118,15 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     if (binaryPath != null) {
       $result.binaryPath = binaryPath;
     }
+    if (updateAvailable != null) {
+      $result.updateAvailable = updateAvailable;
+    }
+    if (remoteTimestampUnix != null) {
+      $result.remoteTimestampUnix = remoteTimestampUnix;
+    }
+    if (downloadedTimestampUnix != null) {
+      $result.downloadedTimestampUnix = downloadedTimestampUnix;
+    }
     return $result;
   }
   BinaryStatusMsg._() : super();
@@ -150,6 +162,9 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
     ..pc<StartupLogEntryMsg>(22, _omitFieldNames ? '' : 'startupLogs', $pb.PbFieldType.PM,
         subBuilder: StartupLogEntryMsg.create)
     ..aOS(23, _omitFieldNames ? '' : 'binaryPath')
+    ..aOB(24, _omitFieldNames ? '' : 'updateAvailable')
+    ..aInt64(25, _omitFieldNames ? '' : 'remoteTimestampUnix')
+    ..aInt64(26, _omitFieldNames ? '' : 'downloadedTimestampUnix')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -442,6 +457,46 @@ class BinaryStatusMsg extends $pb.GeneratedMessage {
   $core.bool hasBinaryPath() => $_has(22);
   @$pb.TagNumber(23)
   void clearBinaryPath() => clearField(23);
+
+  /// A newer build is published than the one on disk. False while either side
+  /// is unknown, so a failed check never claims an update.
+  @$pb.TagNumber(24)
+  $core.bool get updateAvailable => $_getBF(23);
+  @$pb.TagNumber(24)
+  set updateAvailable($core.bool v) {
+    $_setBool(23, v);
+  }
+
+  @$pb.TagNumber(24)
+  $core.bool hasUpdateAvailable() => $_has(23);
+  @$pb.TagNumber(24)
+  void clearUpdateAvailable() => clearField(24);
+
+  /// Last-Modified of the published download, 0 when unknown.
+  @$pb.TagNumber(25)
+  $fixnum.Int64 get remoteTimestampUnix => $_getI64(24);
+  @$pb.TagNumber(25)
+  set remoteTimestampUnix($fixnum.Int64 v) {
+    $_setInt64(24, v);
+  }
+
+  @$pb.TagNumber(25)
+  $core.bool hasRemoteTimestampUnix() => $_has(24);
+  @$pb.TagNumber(25)
+  void clearRemoteTimestampUnix() => clearField(25);
+
+  /// Modification time of the binary on disk, 0 when not downloaded.
+  @$pb.TagNumber(26)
+  $fixnum.Int64 get downloadedTimestampUnix => $_getI64(25);
+  @$pb.TagNumber(26)
+  set downloadedTimestampUnix($fixnum.Int64 v) {
+    $_setInt64(25, v);
+  }
+
+  @$pb.TagNumber(26)
+  $core.bool hasDownloadedTimestampUnix() => $_has(25);
+  @$pb.TagNumber(26)
+  void clearDownloadedTimestampUnix() => clearField(26);
 }
 
 class StartupLogEntryMsg extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbenum.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbenum.dart
@@ -18,16 +18,22 @@ import 'package:protobuf/protobuf.dart' as $pb;
 /// a frontend sees it, the binary is known to the orchestrator but doesn't
 /// have a typed enum value yet.
 class SidechainType extends $pb.ProtobufEnum {
-  static const SidechainType SIDECHAIN_TYPE_UNSPECIFIED = SidechainType._(0, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_UNSPECIFIED');
-  static const SidechainType SIDECHAIN_TYPE_THUNDER = SidechainType._(1, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_THUNDER');
+  static const SidechainType SIDECHAIN_TYPE_UNSPECIFIED =
+      SidechainType._(0, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_UNSPECIFIED');
+  static const SidechainType SIDECHAIN_TYPE_THUNDER =
+      SidechainType._(1, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_THUNDER');
   static const SidechainType SIDECHAIN_TYPE_ZSIDE = SidechainType._(2, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_ZSIDE');
-  static const SidechainType SIDECHAIN_TYPE_BITNAMES = SidechainType._(3, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_BITNAMES');
-  static const SidechainType SIDECHAIN_TYPE_BITASSETS = SidechainType._(4, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_BITASSETS');
-  static const SidechainType SIDECHAIN_TYPE_TRUTHCOIN = SidechainType._(5, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_TRUTHCOIN');
+  static const SidechainType SIDECHAIN_TYPE_BITNAMES =
+      SidechainType._(3, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_BITNAMES');
+  static const SidechainType SIDECHAIN_TYPE_BITASSETS =
+      SidechainType._(4, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_BITASSETS');
+  static const SidechainType SIDECHAIN_TYPE_TRUTHCOIN =
+      SidechainType._(5, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_TRUTHCOIN');
   static const SidechainType SIDECHAIN_TYPE_PHOTON = SidechainType._(6, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_PHOTON');
-  static const SidechainType SIDECHAIN_TYPE_COINSHIFT = SidechainType._(7, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_COINSHIFT');
+  static const SidechainType SIDECHAIN_TYPE_COINSHIFT =
+      SidechainType._(7, _omitEnumNames ? '' : 'SIDECHAIN_TYPE_COINSHIFT');
 
-  static const $core.List<SidechainType> values = <SidechainType> [
+  static const $core.List<SidechainType> values = <SidechainType>[
     SIDECHAIN_TYPE_UNSPECIFIED,
     SIDECHAIN_TYPE_THUNDER,
     SIDECHAIN_TYPE_ZSIDE,
@@ -62,12 +68,14 @@ class BinaryType extends $pb.ProtobufEnum {
   static const BinaryType BINARY_TYPE_PHOTON = BinaryType._(9, _omitEnumNames ? '' : 'BINARY_TYPE_PHOTON');
   static const BinaryType BINARY_TYPE_COINSHIFT = BinaryType._(10, _omitEnumNames ? '' : 'BINARY_TYPE_COINSHIFT');
   static const BinaryType BINARY_TYPE_GRPCURL = BinaryType._(11, _omitEnumNames ? '' : 'BINARY_TYPE_GRPCURL');
-  static const BinaryType BINARY_TYPE_ORCHESTRATORD = BinaryType._(12, _omitEnumNames ? '' : 'BINARY_TYPE_ORCHESTRATORD');
+  static const BinaryType BINARY_TYPE_ORCHESTRATORD =
+      BinaryType._(12, _omitEnumNames ? '' : 'BINARY_TYPE_ORCHESTRATORD');
   static const BinaryType BINARY_TYPE_ZSIDED = BinaryType._(13, _omitEnumNames ? '' : 'BINARY_TYPE_ZSIDED');
-  static const BinaryType BINARY_TYPE_LIQUID_SIGNET = BinaryType._(14, _omitEnumNames ? '' : 'BINARY_TYPE_LIQUID_SIGNET');
+  static const BinaryType BINARY_TYPE_LIQUID_SIGNET =
+      BinaryType._(14, _omitEnumNames ? '' : 'BINARY_TYPE_LIQUID_SIGNET');
   static const BinaryType BINARY_TYPE_INQUISITION = BinaryType._(15, _omitEnumNames ? '' : 'BINARY_TYPE_INQUISITION');
 
-  static const $core.List<BinaryType> values = <BinaryType> [
+  static const $core.List<BinaryType> values = <BinaryType>[
     BINARY_TYPE_UNSPECIFIED,
     BINARY_TYPE_BITCOIND,
     BINARY_TYPE_ENFORCER,
@@ -94,14 +102,15 @@ class BinaryType extends $pb.ProtobufEnum {
 
 /// DeletionType selects which category of a binary's files to gather/delete.
 class DeletionType extends $pb.ProtobufEnum {
-  static const DeletionType DELETION_TYPE_UNSPECIFIED = DeletionType._(0, _omitEnumNames ? '' : 'DELETION_TYPE_UNSPECIFIED');
+  static const DeletionType DELETION_TYPE_UNSPECIFIED =
+      DeletionType._(0, _omitEnumNames ? '' : 'DELETION_TYPE_UNSPECIFIED');
   static const DeletionType DELETION_TYPE_DATA = DeletionType._(1, _omitEnumNames ? '' : 'DELETION_TYPE_DATA');
   static const DeletionType DELETION_TYPE_WALLET = DeletionType._(2, _omitEnumNames ? '' : 'DELETION_TYPE_WALLET');
   static const DeletionType DELETION_TYPE_SETTINGS = DeletionType._(3, _omitEnumNames ? '' : 'DELETION_TYPE_SETTINGS');
   static const DeletionType DELETION_TYPE_LOGS = DeletionType._(4, _omitEnumNames ? '' : 'DELETION_TYPE_LOGS');
   static const DeletionType DELETION_TYPE_SOFTWARE = DeletionType._(5, _omitEnumNames ? '' : 'DELETION_TYPE_SOFTWARE');
 
-  static const $core.List<DeletionType> values = <DeletionType> [
+  static const $core.List<DeletionType> values = <DeletionType>[
     DELETION_TYPE_UNSPECIFIED,
     DELETION_TYPE_DATA,
     DELETION_TYPE_WALLET,
@@ -115,6 +124,5 @@ class DeletionType extends $pb.ProtobufEnum {
 
   const DeletionType._($core.int v, $core.String n) : super(v, n);
 }
-
 
 const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -29,12 +29,12 @@ const SidechainType$json = {
 };
 
 /// Descriptor for `SidechainType`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List sidechainTypeDescriptor = $convert.base64Decode(
-    'Cg1TaWRlY2hhaW5UeXBlEh4KGlNJREVDSEFJTl9UWVBFX1VOU1BFQ0lGSUVEEAASGgoWU0lERU'
-    'NIQUlOX1RZUEVfVEhVTkRFUhABEhgKFFNJREVDSEFJTl9UWVBFX1pTSURFEAISGwoXU0lERUNI'
-    'QUlOX1RZUEVfQklUTkFNRVMQAxIcChhTSURFQ0hBSU5fVFlQRV9CSVRBU1NFVFMQBBIcChhTSU'
-    'RFQ0hBSU5fVFlQRV9UUlVUSENPSU4QBRIZChVTSURFQ0hBSU5fVFlQRV9QSE9UT04QBhIcChhT'
-    'SURFQ0hBSU5fVFlQRV9DT0lOU0hJRlQQBw==');
+final $typed_data.Uint8List sidechainTypeDescriptor =
+    $convert.base64Decode('Cg1TaWRlY2hhaW5UeXBlEh4KGlNJREVDSEFJTl9UWVBFX1VOU1BFQ0lGSUVEEAASGgoWU0lERU'
+        'NIQUlOX1RZUEVfVEhVTkRFUhABEhgKFFNJREVDSEFJTl9UWVBFX1pTSURFEAISGwoXU0lERUNI'
+        'QUlOX1RZUEVfQklUTkFNRVMQAxIcChhTSURFQ0hBSU5fVFlQRV9CSVRBU1NFVFMQBBIcChhTSU'
+        'RFQ0hBSU5fVFlQRV9UUlVUSENPSU4QBRIZChVTSURFQ0hBSU5fVFlQRV9QSE9UT04QBhIcChhT'
+        'SURFQ0hBSU5fVFlQRV9DT0lOU0hJRlQQBw==');
 
 @$core.Deprecated('Use binaryTypeDescriptor instead')
 const BinaryType$json = {
@@ -60,15 +60,15 @@ const BinaryType$json = {
 };
 
 /// Descriptor for `BinaryType`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List binaryTypeDescriptor = $convert.base64Decode(
-    'CgpCaW5hcnlUeXBlEhsKF0JJTkFSWV9UWVBFX1VOU1BFQ0lGSUVEEAASGAoUQklOQVJZX1RZUE'
-    'VfQklUQ09JTkQQARIYChRCSU5BUllfVFlQRV9FTkZPUkNFUhACEhoKFkJJTkFSWV9UWVBFX0JJ'
-    'VFdJTkRPV0QQAxIXChNCSU5BUllfVFlQRV9USFVOREVSEAQSFQoRQklOQVJZX1RZUEVfWlNJRE'
-    'UQBRIYChRCSU5BUllfVFlQRV9CSVROQU1FUxAGEhkKFUJJTkFSWV9UWVBFX0JJVEFTU0VUUxAH'
-    'EhkKFUJJTkFSWV9UWVBFX1RSVVRIQ09JThAIEhYKEkJJTkFSWV9UWVBFX1BIT1RPThAJEhkKFU'
-    'JJTkFSWV9UWVBFX0NPSU5TSElGVBAKEhcKE0JJTkFSWV9UWVBFX0dSUENVUkwQCxIdChlCSU5B'
-    'UllfVFlQRV9PUkNIRVNUUkFUT1JEEAwSFgoSQklOQVJZX1RZUEVfWlNJREVEEA0SHQoZQklOQV'
-    'JZX1RZUEVfTElRVUlEX1NJR05FVBAOEhsKF0JJTkFSWV9UWVBFX0lOUVVJU0lUSU9OEA8=');
+final $typed_data.Uint8List binaryTypeDescriptor =
+    $convert.base64Decode('CgpCaW5hcnlUeXBlEhsKF0JJTkFSWV9UWVBFX1VOU1BFQ0lGSUVEEAASGAoUQklOQVJZX1RZUE'
+        'VfQklUQ09JTkQQARIYChRCSU5BUllfVFlQRV9FTkZPUkNFUhACEhoKFkJJTkFSWV9UWVBFX0JJ'
+        'VFdJTkRPV0QQAxIXChNCSU5BUllfVFlQRV9USFVOREVSEAQSFQoRQklOQVJZX1RZUEVfWlNJRE'
+        'UQBRIYChRCSU5BUllfVFlQRV9CSVROQU1FUxAGEhkKFUJJTkFSWV9UWVBFX0JJVEFTU0VUUxAH'
+        'EhkKFUJJTkFSWV9UWVBFX1RSVVRIQ09JThAIEhYKEkJJTkFSWV9UWVBFX1BIT1RPThAJEhkKFU'
+        'JJTkFSWV9UWVBFX0NPSU5TSElGVBAKEhcKE0JJTkFSWV9UWVBFX0dSUENVUkwQCxIdChlCSU5B'
+        'UllfVFlQRV9PUkNIRVNUUkFUT1JEEAwSFgoSQklOQVJZX1RZUEVfWlNJREVEEA0SHQoZQklOQV'
+        'JZX1RZUEVfTElRVUlEX1NJR05FVBAOEhsKF0JJTkFSWV9UWVBFX0lOUVVJU0lUSU9OEA8=');
 
 @$core.Deprecated('Use deletionTypeDescriptor instead')
 const DeletionType$json = {
@@ -84,11 +84,11 @@ const DeletionType$json = {
 };
 
 /// Descriptor for `DeletionType`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List deletionTypeDescriptor = $convert.base64Decode(
-    'CgxEZWxldGlvblR5cGUSHQoZREVMRVRJT05fVFlQRV9VTlNQRUNJRklFRBAAEhYKEkRFTEVUSU'
-    '9OX1RZUEVfREFUQRABEhgKFERFTEVUSU9OX1RZUEVfV0FMTEVUEAISGgoWREVMRVRJT05fVFlQ'
-    'RV9TRVRUSU5HUxADEhYKEkRFTEVUSU9OX1RZUEVfTE9HUxAEEhoKFkRFTEVUSU9OX1RZUEVfU0'
-    '9GVFdBUkUQBQ==');
+final $typed_data.Uint8List deletionTypeDescriptor =
+    $convert.base64Decode('CgxEZWxldGlvblR5cGUSHQoZREVMRVRJT05fVFlQRV9VTlNQRUNJRklFRBAAEhYKEkRFTEVUSU'
+        '9OX1RZUEVfREFUQRABEhgKFERFTEVUSU9OX1RZUEVfV0FMTEVUEAISGgoWREVMRVRJT05fVFlQ'
+        'RV9TRVRUSU5HUxADEhYKEkRFTEVUSU9OX1RZUEVfTE9HUxAEEhoKFkRFTEVUSU9OX1RZUEVfU0'
+        '9GVFdBUkUQBQ==');
 
 @$core.Deprecated('Use binaryStatusMsgDescriptor instead')
 const BinaryStatusMsg$json = {
@@ -117,25 +117,31 @@ const BinaryStatusMsg$json = {
     {'1': 'repo_url', '3': 21, '4': 1, '5': 9, '10': 'repoUrl'},
     {'1': 'startup_logs', '3': 22, '4': 3, '5': 11, '6': '.orchestrator.v1.StartupLogEntryMsg', '10': 'startupLogs'},
     {'1': 'binary_path', '3': 23, '4': 1, '5': 9, '10': 'binaryPath'},
+    {'1': 'update_available', '3': 24, '4': 1, '5': 8, '10': 'updateAvailable'},
+    {'1': 'remote_timestamp_unix', '3': 25, '4': 1, '5': 3, '10': 'remoteTimestampUnix'},
+    {'1': 'downloaded_timestamp_unix', '3': 26, '4': 1, '5': 3, '10': 'downloadedTimestampUnix'},
   ],
 };
 
 /// Descriptor for `BinaryStatusMsg`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List binaryStatusMsgDescriptor = $convert.base64Decode(
-    'Cg9CaW5hcnlTdGF0dXNNc2cSEgoEbmFtZRgBIAEoCVIEbmFtZRIhCgxkaXNwbGF5X25hbWUYAi'
-    'ABKAlSC2Rpc3BsYXlOYW1lEhgKB3J1bm5pbmcYAyABKAhSB3J1bm5pbmcSGAoHaGVhbHRoeRgE'
-    'IAEoCFIHaGVhbHRoeRIQCgNwaWQYBSABKAVSA3BpZBIlCg51cHRpbWVfc2Vjb25kcxgGIAEoA1'
-    'INdXB0aW1lU2Vjb25kcxIfCgtjaGFpbl9sYXllchgHIAEoBVIKY2hhaW5MYXllchISCgRwb3J0'
-    'GAggASgFUgRwb3J0EhQKBWVycm9yGAkgASgJUgVlcnJvchIcCgljb25uZWN0ZWQYCiABKAhSCW'
-    'Nvbm5lY3RlZBIjCg1zdGFydHVwX2Vycm9yGAsgASgJUgxzdGFydHVwRXJyb3ISKQoQY29ubmVj'
-    'dGlvbl9lcnJvchgMIAEoCVIPY29ubmVjdGlvbkVycm9yEhoKCHN0b3BwaW5nGA0gASgIUghzdG'
-    '9wcGluZxIiCgxpbml0aWFsaXppbmcYDiABKAhSDGluaXRpYWxpemluZxIqChFjb25uZWN0X21v'
-    'ZGVfb25seRgPIAEoCFIPY29ubmVjdE1vZGVPbmx5EiIKDGRvd25sb2FkYWJsZRgQIAEoCFIMZG'
-    '93bmxvYWRhYmxlEiAKC2Rlc2NyaXB0aW9uGBEgASgJUgtkZXNjcmlwdGlvbhIeCgpkb3dubG9h'
-    'ZGVkGBIgASgIUgpkb3dubG9hZGVkEh4KC3BvcnRfaW5fdXNlGBMgASgIUglwb3J0SW5Vc2USGA'
-    'oHdmVyc2lvbhgUIAEoCVIHdmVyc2lvbhIZCghyZXBvX3VybBgVIAEoCVIHcmVwb1VybBJGCgxz'
-    'dGFydHVwX2xvZ3MYFiADKAsyIy5vcmNoZXN0cmF0b3IudjEuU3RhcnR1cExvZ0VudHJ5TXNnUg'
-    'tzdGFydHVwTG9ncxIfCgtiaW5hcnlfcGF0aBgXIAEoCVIKYmluYXJ5UGF0aA==');
+final $typed_data.Uint8List binaryStatusMsgDescriptor =
+    $convert.base64Decode('Cg9CaW5hcnlTdGF0dXNNc2cSEgoEbmFtZRgBIAEoCVIEbmFtZRIhCgxkaXNwbGF5X25hbWUYAi'
+        'ABKAlSC2Rpc3BsYXlOYW1lEhgKB3J1bm5pbmcYAyABKAhSB3J1bm5pbmcSGAoHaGVhbHRoeRgE'
+        'IAEoCFIHaGVhbHRoeRIQCgNwaWQYBSABKAVSA3BpZBIlCg51cHRpbWVfc2Vjb25kcxgGIAEoA1'
+        'INdXB0aW1lU2Vjb25kcxIfCgtjaGFpbl9sYXllchgHIAEoBVIKY2hhaW5MYXllchISCgRwb3J0'
+        'GAggASgFUgRwb3J0EhQKBWVycm9yGAkgASgJUgVlcnJvchIcCgljb25uZWN0ZWQYCiABKAhSCW'
+        'Nvbm5lY3RlZBIjCg1zdGFydHVwX2Vycm9yGAsgASgJUgxzdGFydHVwRXJyb3ISKQoQY29ubmVj'
+        'dGlvbl9lcnJvchgMIAEoCVIPY29ubmVjdGlvbkVycm9yEhoKCHN0b3BwaW5nGA0gASgIUghzdG'
+        '9wcGluZxIiCgxpbml0aWFsaXppbmcYDiABKAhSDGluaXRpYWxpemluZxIqChFjb25uZWN0X21v'
+        'ZGVfb25seRgPIAEoCFIPY29ubmVjdE1vZGVPbmx5EiIKDGRvd25sb2FkYWJsZRgQIAEoCFIMZG'
+        '93bmxvYWRhYmxlEiAKC2Rlc2NyaXB0aW9uGBEgASgJUgtkZXNjcmlwdGlvbhIeCgpkb3dubG9h'
+        'ZGVkGBIgASgIUgpkb3dubG9hZGVkEh4KC3BvcnRfaW5fdXNlGBMgASgIUglwb3J0SW5Vc2USGA'
+        'oHdmVyc2lvbhgUIAEoCVIHdmVyc2lvbhIZCghyZXBvX3VybBgVIAEoCVIHcmVwb1VybBJGCgxz'
+        'dGFydHVwX2xvZ3MYFiADKAsyIy5vcmNoZXN0cmF0b3IudjEuU3RhcnR1cExvZ0VudHJ5TXNnUg'
+        'tzdGFydHVwTG9ncxIfCgtiaW5hcnlfcGF0aBgXIAEoCVIKYmluYXJ5UGF0aBIpChB1cGRhdGVf'
+        'YXZhaWxhYmxlGBggASgIUg91cGRhdGVBdmFpbGFibGUSMgoVcmVtb3RlX3RpbWVzdGFtcF91bm'
+        'l4GBkgASgDUhNyZW1vdGVUaW1lc3RhbXBVbml4EjoKGWRvd25sb2FkZWRfdGltZXN0YW1wX3Vu'
+        'aXgYGiABKANSF2Rvd25sb2FkZWRUaW1lc3RhbXBVbml4');
 
 @$core.Deprecated('Use startupLogEntryMsgDescriptor instead')
 const StartupLogEntryMsg$json = {
@@ -147,9 +153,9 @@ const StartupLogEntryMsg$json = {
 };
 
 /// Descriptor for `StartupLogEntryMsg`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startupLogEntryMsgDescriptor = $convert.base64Decode(
-    'ChJTdGFydHVwTG9nRW50cnlNc2cSJQoOdGltZXN0YW1wX3VuaXgYASABKANSDXRpbWVzdGFtcF'
-    'VuaXgSGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZQ==');
+final $typed_data.Uint8List startupLogEntryMsgDescriptor =
+    $convert.base64Decode('ChJTdGFydHVwTG9nRW50cnlNc2cSJQoOdGltZXN0YW1wX3VuaXgYASABKANSDXRpbWVzdGFtcF'
+        'VuaXgSGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZQ==');
 
 @$core.Deprecated('Use listBinariesRequestDescriptor instead')
 const ListBinariesRequest$json = {
@@ -157,8 +163,7 @@ const ListBinariesRequest$json = {
 };
 
 /// Descriptor for `ListBinariesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listBinariesRequestDescriptor = $convert.base64Decode(
-    'ChNMaXN0QmluYXJpZXNSZXF1ZXN0');
+final $typed_data.Uint8List listBinariesRequestDescriptor = $convert.base64Decode('ChNMaXN0QmluYXJpZXNSZXF1ZXN0');
 
 @$core.Deprecated('Use listBinariesResponseDescriptor instead')
 const ListBinariesResponse$json = {
@@ -169,9 +174,9 @@ const ListBinariesResponse$json = {
 };
 
 /// Descriptor for `ListBinariesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listBinariesResponseDescriptor = $convert.base64Decode(
-    'ChRMaXN0QmluYXJpZXNSZXNwb25zZRI8CghiaW5hcmllcxgBIAMoCzIgLm9yY2hlc3RyYXRvci'
-    '52MS5CaW5hcnlTdGF0dXNNc2dSCGJpbmFyaWVz');
+final $typed_data.Uint8List listBinariesResponseDescriptor =
+    $convert.base64Decode('ChRMaXN0QmluYXJpZXNSZXNwb25zZRI8CghiaW5hcmllcxgBIAMoCzIgLm9yY2hlc3RyYXRvci'
+        '52MS5CaW5hcnlTdGF0dXNNc2dSCGJpbmFyaWVz');
 
 @$core.Deprecated('Use getBinaryStatusRequestDescriptor instead')
 const GetBinaryStatusRequest$json = {
@@ -182,8 +187,8 @@ const GetBinaryStatusRequest$json = {
 };
 
 /// Descriptor for `GetBinaryStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBinaryStatusRequestDescriptor = $convert.base64Decode(
-    'ChZHZXRCaW5hcnlTdGF0dXNSZXF1ZXN0EhIKBG5hbWUYASABKAlSBG5hbWU=');
+final $typed_data.Uint8List getBinaryStatusRequestDescriptor =
+    $convert.base64Decode('ChZHZXRCaW5hcnlTdGF0dXNSZXF1ZXN0EhIKBG5hbWUYASABKAlSBG5hbWU=');
 
 @$core.Deprecated('Use getBinaryStatusResponseDescriptor instead')
 const GetBinaryStatusResponse$json = {
@@ -194,9 +199,9 @@ const GetBinaryStatusResponse$json = {
 };
 
 /// Descriptor for `GetBinaryStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBinaryStatusResponseDescriptor = $convert.base64Decode(
-    'ChdHZXRCaW5hcnlTdGF0dXNSZXNwb25zZRI4CgZzdGF0dXMYASABKAsyIC5vcmNoZXN0cmF0b3'
-    'IudjEuQmluYXJ5U3RhdHVzTXNnUgZzdGF0dXM=');
+final $typed_data.Uint8List getBinaryStatusResponseDescriptor =
+    $convert.base64Decode('ChdHZXRCaW5hcnlTdGF0dXNSZXNwb25zZRI4CgZzdGF0dXMYASABKAsyIC5vcmNoZXN0cmF0b3'
+        'IudjEuQmluYXJ5U3RhdHVzTXNnUgZzdGF0dXM=');
 
 @$core.Deprecated('Use getBinaryVersionRequestDescriptor instead')
 const GetBinaryVersionRequest$json = {
@@ -208,9 +213,9 @@ const GetBinaryVersionRequest$json = {
 };
 
 /// Descriptor for `GetBinaryVersionRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBinaryVersionRequestDescriptor = $convert.base64Decode(
-    'ChdHZXRCaW5hcnlWZXJzaW9uUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEiMKDWZvcmNlX2'
-    'JhY2tlbmQYAiABKAhSDGZvcmNlQmFja2VuZA==');
+final $typed_data.Uint8List getBinaryVersionRequestDescriptor =
+    $convert.base64Decode('ChdHZXRCaW5hcnlWZXJzaW9uUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEiMKDWZvcmNlX2'
+        'JhY2tlbmQYAiABKAhSDGZvcmNlQmFja2VuZA==');
 
 @$core.Deprecated('Use getBinaryVersionResponseDescriptor instead')
 const GetBinaryVersionResponse$json = {
@@ -223,10 +228,10 @@ const GetBinaryVersionResponse$json = {
 };
 
 /// Descriptor for `GetBinaryVersionResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBinaryVersionResponseDescriptor = $convert.base64Decode(
-    'ChhHZXRCaW5hcnlWZXJzaW9uUmVzcG9uc2USGAoHdmVyc2lvbhgBIAEoCVIHdmVyc2lvbhIfCg'
-    'tiaW5hcnlfcGF0aBgCIAEoCVIKYmluYXJ5UGF0aBIiCg1pc190ZXN0X2J1aWxkGAMgASgIUgtp'
-    'c1Rlc3RCdWlsZA==');
+final $typed_data.Uint8List getBinaryVersionResponseDescriptor =
+    $convert.base64Decode('ChhHZXRCaW5hcnlWZXJzaW9uUmVzcG9uc2USGAoHdmVyc2lvbhgBIAEoCVIHdmVyc2lvbhIfCg'
+        'tiaW5hcnlfcGF0aBgCIAEoCVIKYmluYXJ5UGF0aBIiCg1pc190ZXN0X2J1aWxkGAMgASgIUgtp'
+        'c1Rlc3RCdWlsZA==');
 
 @$core.Deprecated('Use downloadBinaryRequestDescriptor instead')
 const DownloadBinaryRequest$json = {
@@ -239,9 +244,9 @@ const DownloadBinaryRequest$json = {
 };
 
 /// Descriptor for `DownloadBinaryRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List downloadBinaryRequestDescriptor = $convert.base64Decode(
-    'ChVEb3dubG9hZEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIUCgVmb3JjZRgCIA'
-    'EoCFIFZm9yY2USIwoNZm9yY2VfYmFja2VuZBgDIAEoCFIMZm9yY2VCYWNrZW5k');
+final $typed_data.Uint8List downloadBinaryRequestDescriptor =
+    $convert.base64Decode('ChVEb3dubG9hZEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIUCgVmb3JjZRgCIA'
+        'EoCFIFZm9yY2USIwoNZm9yY2VfYmFja2VuZBgDIAEoCFIMZm9yY2VCYWNrZW5k');
 
 @$core.Deprecated('Use downloadBinaryResponseDescriptor instead')
 const DownloadBinaryResponse$json = {
@@ -249,8 +254,8 @@ const DownloadBinaryResponse$json = {
 };
 
 /// Descriptor for `DownloadBinaryResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List downloadBinaryResponseDescriptor = $convert.base64Decode(
-    'ChZEb3dubG9hZEJpbmFyeVJlc3BvbnNl');
+final $typed_data.Uint8List downloadBinaryResponseDescriptor =
+    $convert.base64Decode('ChZEb3dubG9hZEJpbmFyeVJlc3BvbnNl');
 
 @$core.Deprecated('Use startBinaryRequestDescriptor instead')
 const StartBinaryRequest$json = {
@@ -274,11 +279,11 @@ const StartBinaryRequest_EnvEntry$json = {
 };
 
 /// Descriptor for `StartBinaryRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startBinaryRequestDescriptor = $convert.base64Decode(
-    'ChJTdGFydEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIdCgpleHRyYV9hcmdzGA'
-    'IgAygJUglleHRyYUFyZ3MSPgoDZW52GAMgAygLMiwub3JjaGVzdHJhdG9yLnYxLlN0YXJ0Qmlu'
-    'YXJ5UmVxdWVzdC5FbnZFbnRyeVIDZW52GjYKCEVudkVudHJ5EhAKA2tleRgBIAEoCVIDa2V5Eh'
-    'QKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+final $typed_data.Uint8List startBinaryRequestDescriptor =
+    $convert.base64Decode('ChJTdGFydEJpbmFyeVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIdCgpleHRyYV9hcmdzGA'
+        'IgAygJUglleHRyYUFyZ3MSPgoDZW52GAMgAygLMiwub3JjaGVzdHJhdG9yLnYxLlN0YXJ0Qmlu'
+        'YXJ5UmVxdWVzdC5FbnZFbnRyeVIDZW52GjYKCEVudkVudHJ5EhAKA2tleRgBIAEoCVIDa2V5Eh'
+        'QKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
 
 @$core.Deprecated('Use startBinaryResponseDescriptor instead')
 const StartBinaryResponse$json = {
@@ -289,8 +294,8 @@ const StartBinaryResponse$json = {
 };
 
 /// Descriptor for `StartBinaryResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startBinaryResponseDescriptor = $convert.base64Decode(
-    'ChNTdGFydEJpbmFyeVJlc3BvbnNlEhAKA3BpZBgBIAEoBVIDcGlk');
+final $typed_data.Uint8List startBinaryResponseDescriptor =
+    $convert.base64Decode('ChNTdGFydEJpbmFyeVJlc3BvbnNlEhAKA3BpZBgBIAEoBVIDcGlk');
 
 @$core.Deprecated('Use stopBinaryRequestDescriptor instead')
 const StopBinaryRequest$json = {
@@ -303,9 +308,9 @@ const StopBinaryRequest$json = {
 };
 
 /// Descriptor for `StopBinaryRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopBinaryRequestDescriptor = $convert.base64Decode(
-    'ChFTdG9wQmluYXJ5UmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhQKBWZvcmNlGAIgASgIUg'
-    'Vmb3JjZRIjCg1mb3JjZV9iYWNrZW5kGAMgASgIUgxmb3JjZUJhY2tlbmQ=');
+final $typed_data.Uint8List stopBinaryRequestDescriptor =
+    $convert.base64Decode('ChFTdG9wQmluYXJ5UmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhQKBWZvcmNlGAIgASgIUg'
+        'Vmb3JjZRIjCg1mb3JjZV9iYWNrZW5kGAMgASgIUgxmb3JjZUJhY2tlbmQ=');
 
 @$core.Deprecated('Use stopBinaryResponseDescriptor instead')
 const StopBinaryResponse$json = {
@@ -313,8 +318,7 @@ const StopBinaryResponse$json = {
 };
 
 /// Descriptor for `StopBinaryResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stopBinaryResponseDescriptor = $convert.base64Decode(
-    'ChJTdG9wQmluYXJ5UmVzcG9uc2U=');
+final $typed_data.Uint8List stopBinaryResponseDescriptor = $convert.base64Decode('ChJTdG9wQmluYXJ5UmVzcG9uc2U=');
 
 @$core.Deprecated('Use streamLogsRequestDescriptor instead')
 const StreamLogsRequest$json = {
@@ -326,9 +330,9 @@ const StreamLogsRequest$json = {
 };
 
 /// Descriptor for `StreamLogsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List streamLogsRequestDescriptor = $convert.base64Decode(
-    'ChFTdHJlYW1Mb2dzUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhIKBHRhaWwYAiABKAVSBH'
-    'RhaWw=');
+final $typed_data.Uint8List streamLogsRequestDescriptor =
+    $convert.base64Decode('ChFTdHJlYW1Mb2dzUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhIKBHRhaWwYAiABKAVSBH'
+        'RhaWw=');
 
 @$core.Deprecated('Use streamLogsResponseDescriptor instead')
 const StreamLogsResponse$json = {
@@ -341,9 +345,9 @@ const StreamLogsResponse$json = {
 };
 
 /// Descriptor for `StreamLogsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List streamLogsResponseDescriptor = $convert.base64Decode(
-    'ChJTdHJlYW1Mb2dzUmVzcG9uc2USFgoGc3RyZWFtGAEgASgJUgZzdHJlYW0SEgoEbGluZRgCIA'
-    'EoCVIEbGluZRIlCg50aW1lc3RhbXBfdW5peBgDIAEoA1INdGltZXN0YW1wVW5peA==');
+final $typed_data.Uint8List streamLogsResponseDescriptor =
+    $convert.base64Decode('ChJTdHJlYW1Mb2dzUmVzcG9uc2USFgoGc3RyZWFtGAEgASgJUgZzdHJlYW0SEgoEbGluZRgCIA'
+        'EoCVIEbGluZRIlCg50aW1lc3RhbXBfdW5peBgDIAEoA1INdGltZXN0YW1wVW5peA==');
 
 @$core.Deprecated('Use startWithL1RequestDescriptor instead')
 const StartWithL1Request$json = {
@@ -351,7 +355,14 @@ const StartWithL1Request$json = {
   '2': [
     {'1': 'target', '3': 1, '4': 1, '5': 9, '10': 'target'},
     {'1': 'target_args', '3': 2, '4': 3, '5': 9, '10': 'targetArgs'},
-    {'1': 'target_env', '3': 3, '4': 3, '5': 11, '6': '.orchestrator.v1.StartWithL1Request.TargetEnvEntry', '10': 'targetEnv'},
+    {
+      '1': 'target_env',
+      '3': 3,
+      '4': 3,
+      '5': 11,
+      '6': '.orchestrator.v1.StartWithL1Request.TargetEnvEntry',
+      '10': 'targetEnv'
+    },
     {'1': 'core_args', '3': 4, '4': 3, '5': 9, '10': 'coreArgs'},
     {'1': 'enforcer_args', '3': 5, '4': 3, '5': 9, '10': 'enforcerArgs'},
     {'1': 'immediate', '3': 6, '4': 1, '5': 8, '10': 'immediate'},
@@ -371,14 +382,14 @@ const StartWithL1Request_TargetEnvEntry$json = {
 };
 
 /// Descriptor for `StartWithL1Request`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startWithL1RequestDescriptor = $convert.base64Decode(
-    'ChJTdGFydFdpdGhMMVJlcXVlc3QSFgoGdGFyZ2V0GAEgASgJUgZ0YXJnZXQSHwoLdGFyZ2V0X2'
-    'FyZ3MYAiADKAlSCnRhcmdldEFyZ3MSUQoKdGFyZ2V0X2VudhgDIAMoCzIyLm9yY2hlc3RyYXRv'
-    'ci52MS5TdGFydFdpdGhMMVJlcXVlc3QuVGFyZ2V0RW52RW50cnlSCXRhcmdldEVudhIbCgljb3'
-    'JlX2FyZ3MYBCADKAlSCGNvcmVBcmdzEiMKDWVuZm9yY2VyX2FyZ3MYBSADKAlSDGVuZm9yY2Vy'
-    'QXJncxIcCglpbW1lZGlhdGUYBiABKAhSCWltbWVkaWF0ZRIjCg1mb3JjZV9iYWNrZW5kGAcgAS'
-    'gIUgxmb3JjZUJhY2tlbmQaPAoOVGFyZ2V0RW52RW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoF'
-    'dmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+final $typed_data.Uint8List startWithL1RequestDescriptor =
+    $convert.base64Decode('ChJTdGFydFdpdGhMMVJlcXVlc3QSFgoGdGFyZ2V0GAEgASgJUgZ0YXJnZXQSHwoLdGFyZ2V0X2'
+        'FyZ3MYAiADKAlSCnRhcmdldEFyZ3MSUQoKdGFyZ2V0X2VudhgDIAMoCzIyLm9yY2hlc3RyYXRv'
+        'ci52MS5TdGFydFdpdGhMMVJlcXVlc3QuVGFyZ2V0RW52RW50cnlSCXRhcmdldEVudhIbCgljb3'
+        'JlX2FyZ3MYBCADKAlSCGNvcmVBcmdzEiMKDWVuZm9yY2VyX2FyZ3MYBSADKAlSDGVuZm9yY2Vy'
+        'QXJncxIcCglpbW1lZGlhdGUYBiABKAhSCWltbWVkaWF0ZRIjCg1mb3JjZV9iYWNrZW5kGAcgAS'
+        'gIUgxmb3JjZUJhY2tlbmQaPAoOVGFyZ2V0RW52RW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoF'
+        'dmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
 
 @$core.Deprecated('Use startWithL1ResponseDescriptor instead')
 const StartWithL1Response$json = {
@@ -386,8 +397,7 @@ const StartWithL1Response$json = {
 };
 
 /// Descriptor for `StartWithL1Response`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List startWithL1ResponseDescriptor = $convert.base64Decode(
-    'ChNTdGFydFdpdGhMMVJlc3BvbnNl');
+final $typed_data.Uint8List startWithL1ResponseDescriptor = $convert.base64Decode('ChNTdGFydFdpdGhMMVJlc3BvbnNl');
 
 @$core.Deprecated('Use restartDaemonRequestDescriptor instead')
 const RestartDaemonRequest$json = {
@@ -399,9 +409,9 @@ const RestartDaemonRequest$json = {
 };
 
 /// Descriptor for `RestartDaemonRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List restartDaemonRequestDescriptor = $convert.base64Decode(
-    'ChRSZXN0YXJ0RGFlbW9uUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEiMKDWZvcmNlX2JhY2'
-    'tlbmQYAiABKAhSDGZvcmNlQmFja2VuZA==');
+final $typed_data.Uint8List restartDaemonRequestDescriptor =
+    $convert.base64Decode('ChRSZXN0YXJ0RGFlbW9uUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEiMKDWZvcmNlX2JhY2'
+        'tlbmQYAiABKAhSDGZvcmNlQmFja2VuZA==');
 
 @$core.Deprecated('Use restartDaemonResponseDescriptor instead')
 const RestartDaemonResponse$json = {
@@ -409,8 +419,7 @@ const RestartDaemonResponse$json = {
 };
 
 /// Descriptor for `RestartDaemonResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List restartDaemonResponseDescriptor = $convert.base64Decode(
-    'ChVSZXN0YXJ0RGFlbW9uUmVzcG9uc2U=');
+final $typed_data.Uint8List restartDaemonResponseDescriptor = $convert.base64Decode('ChVSZXN0YXJ0RGFlbW9uUmVzcG9uc2U=');
 
 @$core.Deprecated('Use restartL1RequestDescriptor instead')
 const RestartL1Request$json = {
@@ -418,8 +427,7 @@ const RestartL1Request$json = {
 };
 
 /// Descriptor for `RestartL1Request`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List restartL1RequestDescriptor = $convert.base64Decode(
-    'ChBSZXN0YXJ0TDFSZXF1ZXN0');
+final $typed_data.Uint8List restartL1RequestDescriptor = $convert.base64Decode('ChBSZXN0YXJ0TDFSZXF1ZXN0');
 
 @$core.Deprecated('Use restartL1ResponseDescriptor instead')
 const RestartL1Response$json = {
@@ -427,8 +435,7 @@ const RestartL1Response$json = {
 };
 
 /// Descriptor for `RestartL1Response`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List restartL1ResponseDescriptor = $convert.base64Decode(
-    'ChFSZXN0YXJ0TDFSZXNwb25zZQ==');
+final $typed_data.Uint8List restartL1ResponseDescriptor = $convert.base64Decode('ChFSZXN0YXJ0TDFSZXNwb25zZQ==');
 
 @$core.Deprecated('Use applyUTXOSnapshotRequestDescriptor instead')
 const ApplyUTXOSnapshotRequest$json = {
@@ -441,9 +448,9 @@ const ApplyUTXOSnapshotRequest$json = {
 };
 
 /// Descriptor for `ApplyUTXOSnapshotRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List applyUTXOSnapshotRequestDescriptor = $convert.base64Decode(
-    'ChhBcHBseVVUWE9TbmFwc2hvdFJlcXVlc3QSEAoDdXJsGAEgASgJUgN1cmwSEgoEcGF0aBgCIA'
-    'EoCVIEcGF0aBIWCgZzaGEyNTYYAyABKAlSBnNoYTI1Ng==');
+final $typed_data.Uint8List applyUTXOSnapshotRequestDescriptor =
+    $convert.base64Decode('ChhBcHBseVVUWE9TbmFwc2hvdFJlcXVlc3QSEAoDdXJsGAEgASgJUgN1cmwSEgoEcGF0aBgCIA'
+        'EoCVIEcGF0aBIWCgZzaGEyNTYYAyABKAlSBnNoYTI1Ng==');
 
 @$core.Deprecated('Use applyUTXOSnapshotResponseDescriptor instead')
 const ApplyUTXOSnapshotResponse$json = {
@@ -456,10 +463,10 @@ const ApplyUTXOSnapshotResponse$json = {
 };
 
 /// Descriptor for `ApplyUTXOSnapshotResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List applyUTXOSnapshotResponseDescriptor = $convert.base64Decode(
-    'ChlBcHBseVVUWE9TbmFwc2hvdFJlc3BvbnNlEhgKB21lc3NhZ2UYASABKAlSB21lc3NhZ2USKQ'
-    'oQZG93bmxvYWRfcGVyY2VudBgCIAEoBVIPZG93bmxvYWRQZXJjZW50EhIKBGRvbmUYAyABKAhS'
-    'BGRvbmU=');
+final $typed_data.Uint8List applyUTXOSnapshotResponseDescriptor =
+    $convert.base64Decode('ChlBcHBseVVUWE9TbmFwc2hvdFJlc3BvbnNlEhgKB21lc3NhZ2UYASABKAlSB21lc3NhZ2USKQ'
+        'oQZG93bmxvYWRfcGVyY2VudBgCIAEoBVIPZG93bmxvYWRQZXJjZW50EhIKBGRvbmUYAyABKAhS'
+        'BGRvbmU=');
 
 @$core.Deprecated('Use getSnapshotStatusRequestDescriptor instead')
 const GetSnapshotStatusRequest$json = {
@@ -467,8 +474,8 @@ const GetSnapshotStatusRequest$json = {
 };
 
 /// Descriptor for `GetSnapshotStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSnapshotStatusRequestDescriptor = $convert.base64Decode(
-    'ChhHZXRTbmFwc2hvdFN0YXR1c1JlcXVlc3Q=');
+final $typed_data.Uint8List getSnapshotStatusRequestDescriptor =
+    $convert.base64Decode('ChhHZXRTbmFwc2hvdFN0YXR1c1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getSnapshotStatusResponseDescriptor instead')
 const GetSnapshotStatusResponse$json = {
@@ -486,14 +493,14 @@ const GetSnapshotStatusResponse$json = {
 };
 
 /// Descriptor for `GetSnapshotStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSnapshotStatusResponseDescriptor = $convert.base64Decode(
-    'ChlHZXRTbmFwc2hvdFN0YXR1c1Jlc3BvbnNlEiMKDWF2YWlsYWJsZV91cmwYASABKAlSDGF2YW'
-    'lsYWJsZVVybBIpChBhdmFpbGFibGVfaGVpZ2h0GAIgASgDUg9hdmFpbGFibGVIZWlnaHQSKQoQ'
-    'YXZhaWxhYmxlX3NoYTI1NhgDIAEoCVIPYXZhaWxhYmxlU2hhMjU2Ei4KE2hhc19hY3RpdmVfc2'
-    '5hcHNob3QYBCABKAhSEWhhc0FjdGl2ZVNuYXBzaG90EikKEGFjdGl2ZV9ibG9ja2hhc2gYBSAB'
-    'KAlSD2FjdGl2ZUJsb2NraGFzaBIjCg1hY3RpdmVfaGVpZ2h0GAYgASgDUgxhY3RpdmVIZWlnaH'
-    'QSKQoQYWN0aXZlX3ZhbGlkYXRlZBgHIAEoCFIPYWN0aXZlVmFsaWRhdGVkEkAKHGFjdGl2ZV92'
-    'ZXJpZmljYXRpb25fcHJvZ3Jlc3MYCCABKAFSGmFjdGl2ZVZlcmlmaWNhdGlvblByb2dyZXNz');
+final $typed_data.Uint8List getSnapshotStatusResponseDescriptor =
+    $convert.base64Decode('ChlHZXRTbmFwc2hvdFN0YXR1c1Jlc3BvbnNlEiMKDWF2YWlsYWJsZV91cmwYASABKAlSDGF2YW'
+        'lsYWJsZVVybBIpChBhdmFpbGFibGVfaGVpZ2h0GAIgASgDUg9hdmFpbGFibGVIZWlnaHQSKQoQ'
+        'YXZhaWxhYmxlX3NoYTI1NhgDIAEoCVIPYXZhaWxhYmxlU2hhMjU2Ei4KE2hhc19hY3RpdmVfc2'
+        '5hcHNob3QYBCABKAhSEWhhc0FjdGl2ZVNuYXBzaG90EikKEGFjdGl2ZV9ibG9ja2hhc2gYBSAB'
+        'KAlSD2FjdGl2ZUJsb2NraGFzaBIjCg1hY3RpdmVfaGVpZ2h0GAYgASgDUgxhY3RpdmVIZWlnaH'
+        'QSKQoQYWN0aXZlX3ZhbGlkYXRlZBgHIAEoCFIPYWN0aXZlVmFsaWRhdGVkEkAKHGFjdGl2ZV92'
+        'ZXJpZmljYXRpb25fcHJvZ3Jlc3MYCCABKAFSGmFjdGl2ZVZlcmlmaWNhdGlvblByb2dyZXNz');
 
 @$core.Deprecated('Use getPendingNetworkGenerationRequestDescriptor instead')
 const GetPendingNetworkGenerationRequest$json = {
@@ -501,8 +508,8 @@ const GetPendingNetworkGenerationRequest$json = {
 };
 
 /// Descriptor for `GetPendingNetworkGenerationRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingNetworkGenerationRequestDescriptor = $convert.base64Decode(
-    'CiJHZXRQZW5kaW5nTmV0d29ya0dlbmVyYXRpb25SZXF1ZXN0');
+final $typed_data.Uint8List getPendingNetworkGenerationRequestDescriptor =
+    $convert.base64Decode('CiJHZXRQZW5kaW5nTmV0d29ya0dlbmVyYXRpb25SZXF1ZXN0');
 
 @$core.Deprecated('Use getPendingNetworkGenerationResponseDescriptor instead')
 const GetPendingNetworkGenerationResponse$json = {
@@ -518,13 +525,13 @@ const GetPendingNetworkGenerationResponse$json = {
 };
 
 /// Descriptor for `GetPendingNetworkGenerationResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getPendingNetworkGenerationResponseDescriptor = $convert.base64Decode(
-    'CiNHZXRQZW5kaW5nTmV0d29ya0dlbmVyYXRpb25SZXNwb25zZRItChJjdXJyZW50X2dlbmVyYX'
-    'Rpb24YASABKAlSEWN1cnJlbnRHZW5lcmF0aW9uEi0KEnBlbmRpbmdfZ2VuZXJhdGlvbhgCIAEo'
-    'CVIRcGVuZGluZ0dlbmVyYXRpb24SJwoPc25hcHNob3RfaGVpZ2h0GAMgASgDUg5zbmFwc2hvdE'
-    'hlaWdodBIuChNzbmFwc2hvdF9zaXplX2J5dGVzGAQgASgDUhFzbmFwc2hvdFNpemVCeXRlcxIh'
-    'CgxwZW5kaW5nX3BlZXIYBSABKAlSC3BlbmRpbmdQZWVyEioKEXVzZXJfbWFuYWdlZF9jb25mGA'
-    'YgASgIUg91c2VyTWFuYWdlZENvbmY=');
+final $typed_data.Uint8List getPendingNetworkGenerationResponseDescriptor =
+    $convert.base64Decode('CiNHZXRQZW5kaW5nTmV0d29ya0dlbmVyYXRpb25SZXNwb25zZRItChJjdXJyZW50X2dlbmVyYX'
+        'Rpb24YASABKAlSEWN1cnJlbnRHZW5lcmF0aW9uEi0KEnBlbmRpbmdfZ2VuZXJhdGlvbhgCIAEo'
+        'CVIRcGVuZGluZ0dlbmVyYXRpb24SJwoPc25hcHNob3RfaGVpZ2h0GAMgASgDUg5zbmFwc2hvdE'
+        'hlaWdodBIuChNzbmFwc2hvdF9zaXplX2J5dGVzGAQgASgDUhFzbmFwc2hvdFNpemVCeXRlcxIh'
+        'CgxwZW5kaW5nX3BlZXIYBSABKAlSC3BlbmRpbmdQZWVyEioKEXVzZXJfbWFuYWdlZF9jb25mGA'
+        'YgASgIUg91c2VyTWFuYWdlZENvbmY=');
 
 @$core.Deprecated('Use confirmPendingNetworkGenerationRequestDescriptor instead')
 const ConfirmPendingNetworkGenerationRequest$json = {
@@ -532,8 +539,8 @@ const ConfirmPendingNetworkGenerationRequest$json = {
 };
 
 /// Descriptor for `ConfirmPendingNetworkGenerationRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List confirmPendingNetworkGenerationRequestDescriptor = $convert.base64Decode(
-    'CiZDb25maXJtUGVuZGluZ05ldHdvcmtHZW5lcmF0aW9uUmVxdWVzdA==');
+final $typed_data.Uint8List confirmPendingNetworkGenerationRequestDescriptor =
+    $convert.base64Decode('CiZDb25maXJtUGVuZGluZ05ldHdvcmtHZW5lcmF0aW9uUmVxdWVzdA==');
 
 @$core.Deprecated('Use confirmPendingNetworkGenerationResponseDescriptor instead')
 const ConfirmPendingNetworkGenerationResponse$json = {
@@ -541,8 +548,8 @@ const ConfirmPendingNetworkGenerationResponse$json = {
 };
 
 /// Descriptor for `ConfirmPendingNetworkGenerationResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List confirmPendingNetworkGenerationResponseDescriptor = $convert.base64Decode(
-    'CidDb25maXJtUGVuZGluZ05ldHdvcmtHZW5lcmF0aW9uUmVzcG9uc2U=');
+final $typed_data.Uint8List confirmPendingNetworkGenerationResponseDescriptor =
+    $convert.base64Decode('CidDb25maXJtUGVuZGluZ05ldHdvcmtHZW5lcmF0aW9uUmVzcG9uc2U=');
 
 @$core.Deprecated('Use shutdownAllRequestDescriptor instead')
 const ShutdownAllRequest$json = {
@@ -553,8 +560,8 @@ const ShutdownAllRequest$json = {
 };
 
 /// Descriptor for `ShutdownAllRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List shutdownAllRequestDescriptor = $convert.base64Decode(
-    'ChJTaHV0ZG93bkFsbFJlcXVlc3QSFAoFZm9yY2UYASABKAhSBWZvcmNl');
+final $typed_data.Uint8List shutdownAllRequestDescriptor =
+    $convert.base64Decode('ChJTaHV0ZG93bkFsbFJlcXVlc3QSFAoFZm9yY2UYASABKAhSBWZvcmNl');
 
 @$core.Deprecated('Use shutdownAllResponseDescriptor instead')
 const ShutdownAllResponse$json = {
@@ -569,11 +576,11 @@ const ShutdownAllResponse$json = {
 };
 
 /// Descriptor for `ShutdownAllResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List shutdownAllResponseDescriptor = $convert.base64Decode(
-    'ChNTaHV0ZG93bkFsbFJlc3BvbnNlEh8KC3RvdGFsX2NvdW50GAEgASgFUgp0b3RhbENvdW50Ei'
-    'cKD2NvbXBsZXRlZF9jb3VudBgCIAEoBVIOY29tcGxldGVkQ291bnQSJQoOY3VycmVudF9iaW5h'
-    'cnkYAyABKAlSDWN1cnJlbnRCaW5hcnkSEgoEZG9uZRgEIAEoCFIEZG9uZRIUCgVlcnJvchgFIA'
-    'EoCVIFZXJyb3I=');
+final $typed_data.Uint8List shutdownAllResponseDescriptor =
+    $convert.base64Decode('ChNTaHV0ZG93bkFsbFJlc3BvbnNlEh8KC3RvdGFsX2NvdW50GAEgASgFUgp0b3RhbENvdW50Ei'
+        'cKD2NvbXBsZXRlZF9jb3VudBgCIAEoBVIOY29tcGxldGVkQ291bnQSJQoOY3VycmVudF9iaW5h'
+        'cnkYAyABKAlSDWN1cnJlbnRCaW5hcnkSEgoEZG9uZRgEIAEoCFIEZG9uZRIUCgVlcnJvchgFIA'
+        'EoCVIFZXJyb3I=');
 
 @$core.Deprecated('Use getBTCPriceRequestDescriptor instead')
 const GetBTCPriceRequest$json = {
@@ -581,8 +588,7 @@ const GetBTCPriceRequest$json = {
 };
 
 /// Descriptor for `GetBTCPriceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBTCPriceRequestDescriptor = $convert.base64Decode(
-    'ChJHZXRCVENQcmljZVJlcXVlc3Q=');
+final $typed_data.Uint8List getBTCPriceRequestDescriptor = $convert.base64Decode('ChJHZXRCVENQcmljZVJlcXVlc3Q=');
 
 @$core.Deprecated('Use getBTCPriceResponseDescriptor instead')
 const GetBTCPriceResponse$json = {
@@ -594,9 +600,9 @@ const GetBTCPriceResponse$json = {
 };
 
 /// Descriptor for `GetBTCPriceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBTCPriceResponseDescriptor = $convert.base64Decode(
-    'ChNHZXRCVENQcmljZVJlc3BvbnNlEhYKBmJ0Y3VzZBgBIAEoAVIGYnRjdXNkEioKEWxhc3RfdX'
-    'BkYXRlZF91bml4GAIgASgDUg9sYXN0VXBkYXRlZFVuaXg=');
+final $typed_data.Uint8List getBTCPriceResponseDescriptor =
+    $convert.base64Decode('ChNHZXRCVENQcmljZVJlc3BvbnNlEhYKBmJ0Y3VzZBgBIAEoAVIGYnRjdXNkEioKEWxhc3RfdX'
+        'BkYXRlZF91bml4GAIgASgDUg9sYXN0VXBkYXRlZFVuaXg=');
 
 @$core.Deprecated('Use getMainchainBlockchainInfoRequestDescriptor instead')
 const GetMainchainBlockchainInfoRequest$json = {
@@ -604,8 +610,8 @@ const GetMainchainBlockchainInfoRequest$json = {
 };
 
 /// Descriptor for `GetMainchainBlockchainInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getMainchainBlockchainInfoRequestDescriptor = $convert.base64Decode(
-    'CiFHZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1JlcXVlc3Q=');
+final $typed_data.Uint8List getMainchainBlockchainInfoRequestDescriptor =
+    $convert.base64Decode('CiFHZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getMainchainBlockchainInfoResponseDescriptor instead')
 const GetMainchainBlockchainInfoResponse$json = {
@@ -627,15 +633,15 @@ const GetMainchainBlockchainInfoResponse$json = {
 };
 
 /// Descriptor for `GetMainchainBlockchainInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getMainchainBlockchainInfoResponseDescriptor = $convert.base64Decode(
-    'CiJHZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1Jlc3BvbnNlEhQKBWNoYWluGAEgASgJUgVjaG'
-    'FpbhIWCgZibG9ja3MYAiABKAVSBmJsb2NrcxIYCgdoZWFkZXJzGAMgASgFUgdoZWFkZXJzEiYK'
-    'D2Jlc3RfYmxvY2tfaGFzaBgEIAEoCVINYmVzdEJsb2NrSGFzaBIeCgpkaWZmaWN1bHR5GAUgAS'
-    'gBUgpkaWZmaWN1bHR5EhIKBHRpbWUYBiABKANSBHRpbWUSHwoLbWVkaWFuX3RpbWUYByABKANS'
-    'Cm1lZGlhblRpbWUSMwoVdmVyaWZpY2F0aW9uX3Byb2dyZXNzGAggASgBUhR2ZXJpZmljYXRpb2'
-    '5Qcm9ncmVzcxI0ChZpbml0aWFsX2Jsb2NrX2Rvd25sb2FkGAkgASgIUhRpbml0aWFsQmxvY2tE'
-    'b3dubG9hZBIdCgpjaGFpbl93b3JrGAogASgJUgljaGFpbldvcmsSIAoMc2l6ZV9vbl9kaXNrGA'
-    'sgASgDUgpzaXplT25EaXNrEhYKBnBydW5lZBgMIAEoCFIGcHJ1bmVk');
+final $typed_data.Uint8List getMainchainBlockchainInfoResponseDescriptor =
+    $convert.base64Decode('CiJHZXRNYWluY2hhaW5CbG9ja2NoYWluSW5mb1Jlc3BvbnNlEhQKBWNoYWluGAEgASgJUgVjaG'
+        'FpbhIWCgZibG9ja3MYAiABKAVSBmJsb2NrcxIYCgdoZWFkZXJzGAMgASgFUgdoZWFkZXJzEiYK'
+        'D2Jlc3RfYmxvY2tfaGFzaBgEIAEoCVINYmVzdEJsb2NrSGFzaBIeCgpkaWZmaWN1bHR5GAUgAS'
+        'gBUgpkaWZmaWN1bHR5EhIKBHRpbWUYBiABKANSBHRpbWUSHwoLbWVkaWFuX3RpbWUYByABKANS'
+        'Cm1lZGlhblRpbWUSMwoVdmVyaWZpY2F0aW9uX3Byb2dyZXNzGAggASgBUhR2ZXJpZmljYXRpb2'
+        '5Qcm9ncmVzcxI0ChZpbml0aWFsX2Jsb2NrX2Rvd25sb2FkGAkgASgIUhRpbml0aWFsQmxvY2tE'
+        'b3dubG9hZBIdCgpjaGFpbl93b3JrGAogASgJUgljaGFpbldvcmsSIAoMc2l6ZV9vbl9kaXNrGA'
+        'sgASgDUgpzaXplT25EaXNrEhYKBnBydW5lZBgMIAEoCFIGcHJ1bmVk');
 
 @$core.Deprecated('Use getEnforcerBlockchainInfoRequestDescriptor instead')
 const GetEnforcerBlockchainInfoRequest$json = {
@@ -643,8 +649,8 @@ const GetEnforcerBlockchainInfoRequest$json = {
 };
 
 /// Descriptor for `GetEnforcerBlockchainInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getEnforcerBlockchainInfoRequestDescriptor = $convert.base64Decode(
-    'CiBHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvUmVxdWVzdA==');
+final $typed_data.Uint8List getEnforcerBlockchainInfoRequestDescriptor =
+    $convert.base64Decode('CiBHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvUmVxdWVzdA==');
 
 @$core.Deprecated('Use getEnforcerBlockchainInfoResponseDescriptor instead')
 const GetEnforcerBlockchainInfoResponse$json = {
@@ -657,9 +663,9 @@ const GetEnforcerBlockchainInfoResponse$json = {
 };
 
 /// Descriptor for `GetEnforcerBlockchainInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getEnforcerBlockchainInfoResponseDescriptor = $convert.base64Decode(
-    'CiFHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvUmVzcG9uc2USFgoGYmxvY2tzGAEgASgFUgZibG'
-    '9ja3MSGAoHaGVhZGVycxgCIAEoBVIHaGVhZGVycxISCgR0aW1lGAMgASgDUgR0aW1l');
+final $typed_data.Uint8List getEnforcerBlockchainInfoResponseDescriptor =
+    $convert.base64Decode('CiFHZXRFbmZvcmNlckJsb2NrY2hhaW5JbmZvUmVzcG9uc2USFgoGYmxvY2tzGAEgASgFUgZibG'
+        '9ja3MSGAoHaGVhZGVycxgCIAEoBVIHaGVhZGVycxISCgR0aW1lGAMgASgDUgR0aW1l');
 
 @$core.Deprecated('Use getSyncStatusRequestDescriptor instead')
 const GetSyncStatusRequest$json = {
@@ -667,8 +673,7 @@ const GetSyncStatusRequest$json = {
 };
 
 /// Descriptor for `GetSyncStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSyncStatusRequestDescriptor = $convert.base64Decode(
-    'ChRHZXRTeW5jU3RhdHVzUmVxdWVzdA==');
+final $typed_data.Uint8List getSyncStatusRequestDescriptor = $convert.base64Decode('ChRHZXRTeW5jU3RhdHVzUmVxdWVzdA==');
 
 @$core.Deprecated('Use getSyncStatusResponseDescriptor instead')
 const GetSyncStatusResponse$json = {
@@ -683,13 +688,13 @@ const GetSyncStatusResponse$json = {
 };
 
 /// Descriptor for `GetSyncStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSyncStatusResponseDescriptor = $convert.base64Decode(
-    'ChVHZXRTeW5jU3RhdHVzUmVzcG9uc2USOAoJbWFpbmNoYWluGAEgASgLMhoub3JjaGVzdHJhdG'
-    '9yLnYxLkNoYWluU3luY1IJbWFpbmNoYWluEjYKCGVuZm9yY2VyGAIgASgLMhoub3JjaGVzdHJh'
-    'dG9yLnYxLkNoYWluU3luY1IIZW5mb3JjZXISQAoKc2lkZWNoYWlucxgDIAMoCzIgLm9yY2hlc3'
-    'RyYXRvci52MS5TaWRlY2hhaW5TdGF0dXNSCnNpZGVjaGFpbnMSLAoSd2FsbGV0X3N5bmNfc3Rh'
-    'dHVzGAQgASgJUhB3YWxsZXRTeW5jU3RhdHVzEkMKD2VuZm9yY2VyX3dhbGxldBgFIAEoCzIaLm'
-    '9yY2hlc3RyYXRvci52MS5DaGFpblN5bmNSDmVuZm9yY2VyV2FsbGV0');
+final $typed_data.Uint8List getSyncStatusResponseDescriptor =
+    $convert.base64Decode('ChVHZXRTeW5jU3RhdHVzUmVzcG9uc2USOAoJbWFpbmNoYWluGAEgASgLMhoub3JjaGVzdHJhdG'
+        '9yLnYxLkNoYWluU3luY1IJbWFpbmNoYWluEjYKCGVuZm9yY2VyGAIgASgLMhoub3JjaGVzdHJh'
+        'dG9yLnYxLkNoYWluU3luY1IIZW5mb3JjZXISQAoKc2lkZWNoYWlucxgDIAMoCzIgLm9yY2hlc3'
+        'RyYXRvci52MS5TaWRlY2hhaW5TdGF0dXNSCnNpZGVjaGFpbnMSLAoSd2FsbGV0X3N5bmNfc3Rh'
+        'dHVzGAQgASgJUhB3YWxsZXRTeW5jU3RhdHVzEkMKD2VuZm9yY2VyX3dhbGxldBgFIAEoCzIaLm'
+        '9yY2hlc3RyYXRvci52MS5DaGFpblN5bmNSDmVuZm9yY2VyV2FsbGV0');
 
 @$core.Deprecated('Use sidechainStatusDescriptor instead')
 const SidechainStatus$json = {
@@ -701,10 +706,10 @@ const SidechainStatus$json = {
 };
 
 /// Descriptor for `SidechainStatus`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List sidechainStatusDescriptor = $convert.base64Decode(
-    'Cg9TaWRlY2hhaW5TdGF0dXMSMgoEdHlwZRgBIAEoDjIeLm9yY2hlc3RyYXRvci52MS5TaWRlY2'
-    'hhaW5UeXBlUgR0eXBlEi4KBHN5bmMYAiABKAsyGi5vcmNoZXN0cmF0b3IudjEuQ2hhaW5TeW5j'
-    'UgRzeW5j');
+final $typed_data.Uint8List sidechainStatusDescriptor =
+    $convert.base64Decode('Cg9TaWRlY2hhaW5TdGF0dXMSMgoEdHlwZRgBIAEoDjIeLm9yY2hlc3RyYXRvci52MS5TaWRlY2'
+        'hhaW5UeXBlUgR0eXBlEi4KBHN5bmMYAiABKAsyGi5vcmNoZXN0cmF0b3IudjEuQ2hhaW5TeW5j'
+        'UgRzeW5j');
 
 @$core.Deprecated('Use chainSyncDescriptor instead')
 const ChainSync$json = {
@@ -718,9 +723,9 @@ const ChainSync$json = {
 };
 
 /// Descriptor for `ChainSync`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List chainSyncDescriptor = $convert.base64Decode(
-    'CglDaGFpblN5bmMSFgoGYmxvY2tzGAEgASgFUgZibG9ja3MSGAoHaGVhZGVycxgCIAEoBVIHaG'
-    'VhZGVycxISCgR0aW1lGAMgASgDUgR0aW1lEhQKBWVycm9yGAQgASgJUgVlcnJvcg==');
+final $typed_data.Uint8List chainSyncDescriptor =
+    $convert.base64Decode('CglDaGFpblN5bmMSFgoGYmxvY2tzGAEgASgFUgZibG9ja3MSGAoHaGVhZGVycxgCIAEoBVIHaG'
+        'VhZGVycxISCgR0aW1lGAMgASgDUgR0aW1lEhQKBWVycm9yGAQgASgJUgVlcnJvcg==');
 
 @$core.Deprecated('Use getDownloadStatusRequestDescriptor instead')
 const GetDownloadStatusRequest$json = {
@@ -728,8 +733,8 @@ const GetDownloadStatusRequest$json = {
 };
 
 /// Descriptor for `GetDownloadStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getDownloadStatusRequestDescriptor = $convert.base64Decode(
-    'ChhHZXREb3dubG9hZFN0YXR1c1JlcXVlc3Q=');
+final $typed_data.Uint8List getDownloadStatusRequestDescriptor =
+    $convert.base64Decode('ChhHZXREb3dubG9hZFN0YXR1c1JlcXVlc3Q=');
 
 @$core.Deprecated('Use getDownloadStatusResponseDescriptor instead')
 const GetDownloadStatusResponse$json = {
@@ -740,9 +745,9 @@ const GetDownloadStatusResponse$json = {
 };
 
 /// Descriptor for `GetDownloadStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getDownloadStatusResponseDescriptor = $convert.base64Decode(
-    'ChlHZXREb3dubG9hZFN0YXR1c1Jlc3BvbnNlEj0KCWRvd25sb2FkcxgBIAMoCzIfLm9yY2hlc3'
-    'RyYXRvci52MS5Eb3dubG9hZFN0YXR1c1IJZG93bmxvYWRz');
+final $typed_data.Uint8List getDownloadStatusResponseDescriptor =
+    $convert.base64Decode('ChlHZXREb3dubG9hZFN0YXR1c1Jlc3BvbnNlEj0KCWRvd25sb2FkcxgBIAMoCzIfLm9yY2hlc3'
+        'RyYXRvci52MS5Eb3dubG9hZFN0YXR1c1IJZG93bmxvYWRz');
 
 @$core.Deprecated('Use downloadStatusDescriptor instead')
 const DownloadStatus$json = {
@@ -756,10 +761,10 @@ const DownloadStatus$json = {
 };
 
 /// Descriptor for `DownloadStatus`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List downloadStatusDescriptor = $convert.base64Decode(
-    'Cg5Eb3dubG9hZFN0YXR1cxIzCgZiaW5hcnkYASABKA4yGy5vcmNoZXN0cmF0b3IudjEuQmluYX'
-    'J5VHlwZVIGYmluYXJ5EiMKDW1iX2Rvd25sb2FkZWQYAiABKANSDG1iRG93bmxvYWRlZBIZCght'
-    'Yl90b3RhbBgDIAEoA1IHbWJUb3RhbBIYCgdtZXNzYWdlGAQgASgJUgdtZXNzYWdl');
+final $typed_data.Uint8List downloadStatusDescriptor =
+    $convert.base64Decode('Cg5Eb3dubG9hZFN0YXR1cxIzCgZiaW5hcnkYASABKA4yGy5vcmNoZXN0cmF0b3IudjEuQmluYX'
+        'J5VHlwZVIGYmluYXJ5EiMKDW1iX2Rvd25sb2FkZWQYAiABKANSDG1iRG93bmxvYWRlZBIZCght'
+        'Yl90b3RhbBgDIAEoA1IHbWJUb3RhbBIYCgdtZXNzYWdlGAQgASgJUgdtZXNzYWdl');
 
 @$core.Deprecated('Use getMainchainBalanceRequestDescriptor instead')
 const GetMainchainBalanceRequest$json = {
@@ -767,8 +772,8 @@ const GetMainchainBalanceRequest$json = {
 };
 
 /// Descriptor for `GetMainchainBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getMainchainBalanceRequestDescriptor = $convert.base64Decode(
-    'ChpHZXRNYWluY2hhaW5CYWxhbmNlUmVxdWVzdA==');
+final $typed_data.Uint8List getMainchainBalanceRequestDescriptor =
+    $convert.base64Decode('ChpHZXRNYWluY2hhaW5CYWxhbmNlUmVxdWVzdA==');
 
 @$core.Deprecated('Use getMainchainBalanceResponseDescriptor instead')
 const GetMainchainBalanceResponse$json = {
@@ -780,9 +785,9 @@ const GetMainchainBalanceResponse$json = {
 };
 
 /// Descriptor for `GetMainchainBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getMainchainBalanceResponseDescriptor = $convert.base64Decode(
-    'ChtHZXRNYWluY2hhaW5CYWxhbmNlUmVzcG9uc2USHAoJY29uZmlybWVkGAEgASgBUgljb25maX'
-    'JtZWQSIAoLdW5jb25maXJtZWQYAiABKAFSC3VuY29uZmlybWVk');
+final $typed_data.Uint8List getMainchainBalanceResponseDescriptor =
+    $convert.base64Decode('ChtHZXRNYWluY2hhaW5CYWxhbmNlUmVzcG9uc2USHAoJY29uZmlybWVkGAEgASgBUgljb25maX'
+        'JtZWQSIAoLdW5jb25maXJtZWQYAiABKAFSC3VuY29uZmlybWVk');
 
 @$core.Deprecated('Use getSidechainBalanceRequestDescriptor instead')
 const GetSidechainBalanceRequest$json = {
@@ -793,9 +798,9 @@ const GetSidechainBalanceRequest$json = {
 };
 
 /// Descriptor for `GetSidechainBalanceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainBalanceRequestDescriptor = $convert.base64Decode(
-    'ChpHZXRTaWRlY2hhaW5CYWxhbmNlUmVxdWVzdBI5CglzaWRlY2hhaW4YASABKA4yGy5vcmNoZX'
-    'N0cmF0b3IudjEuQmluYXJ5VHlwZVIJc2lkZWNoYWlu');
+final $typed_data.Uint8List getSidechainBalanceRequestDescriptor =
+    $convert.base64Decode('ChpHZXRTaWRlY2hhaW5CYWxhbmNlUmVxdWVzdBI5CglzaWRlY2hhaW4YASABKA4yGy5vcmNoZX'
+        'N0cmF0b3IudjEuQmluYXJ5VHlwZVIJc2lkZWNoYWlu');
 
 @$core.Deprecated('Use getSidechainBalanceResponseDescriptor instead')
 const GetSidechainBalanceResponse$json = {
@@ -807,9 +812,9 @@ const GetSidechainBalanceResponse$json = {
 };
 
 /// Descriptor for `GetSidechainBalanceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSidechainBalanceResponseDescriptor = $convert.base64Decode(
-    'ChtHZXRTaWRlY2hhaW5CYWxhbmNlUmVzcG9uc2USJQoOY29uZmlybWVkX3NhdHMYASABKARSDW'
-    'NvbmZpcm1lZFNhdHMSIQoMcGVuZGluZ19zYXRzGAIgASgEUgtwZW5kaW5nU2F0cw==');
+final $typed_data.Uint8List getSidechainBalanceResponseDescriptor =
+    $convert.base64Decode('ChtHZXRTaWRlY2hhaW5CYWxhbmNlUmVzcG9uc2USJQoOY29uZmlybWVkX3NhdHMYASABKARSDW'
+        'NvbmZpcm1lZFNhdHMSIQoMcGVuZGluZ19zYXRzGAIgASgEUgtwZW5kaW5nU2F0cw==');
 
 @$core.Deprecated('Use singleDeletionDescriptor instead')
 const SingleDeletion$json = {
@@ -821,10 +826,10 @@ const SingleDeletion$json = {
 };
 
 /// Descriptor for `SingleDeletion`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List singleDeletionDescriptor = $convert.base64Decode(
-    'Cg5TaW5nbGVEZWxldGlvbhIzCgZiaW5hcnkYASABKA4yGy5vcmNoZXN0cmF0b3IudjEuQmluYX'
-    'J5VHlwZVIGYmluYXJ5EjsKCWRlbGV0aW9ucxgCIAMoDjIdLm9yY2hlc3RyYXRvci52MS5EZWxl'
-    'dGlvblR5cGVSCWRlbGV0aW9ucw==');
+final $typed_data.Uint8List singleDeletionDescriptor =
+    $convert.base64Decode('Cg5TaW5nbGVEZWxldGlvbhIzCgZiaW5hcnkYASABKA4yGy5vcmNoZXN0cmF0b3IudjEuQmluYX'
+        'J5VHlwZVIGYmluYXJ5EjsKCWRlbGV0aW9ucxgCIAMoDjIdLm9yY2hlc3RyYXRvci52MS5EZWxl'
+        'dGlvblR5cGVSCWRlbGV0aW9ucw==');
 
 @$core.Deprecated('Use gatherFilesToDeleteRequestDescriptor instead')
 const GatherFilesToDeleteRequest$json = {
@@ -835,9 +840,9 @@ const GatherFilesToDeleteRequest$json = {
 };
 
 /// Descriptor for `GatherFilesToDeleteRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List gatherFilesToDeleteRequestDescriptor = $convert.base64Decode(
-    'ChpHYXRoZXJGaWxlc1RvRGVsZXRlUmVxdWVzdBI1CgVpdGVtcxgBIAMoCzIfLm9yY2hlc3RyYX'
-    'Rvci52MS5TaW5nbGVEZWxldGlvblIFaXRlbXM=');
+final $typed_data.Uint8List gatherFilesToDeleteRequestDescriptor =
+    $convert.base64Decode('ChpHYXRoZXJGaWxlc1RvRGVsZXRlUmVxdWVzdBI1CgVpdGVtcxgBIAMoCzIfLm9yY2hlc3RyYX'
+        'Rvci52MS5TaW5nbGVEZWxldGlvblIFaXRlbXM=');
 
 @$core.Deprecated('Use gatherFilesToDeleteResponseDescriptor instead')
 const GatherFilesToDeleteResponse$json = {
@@ -848,9 +853,9 @@ const GatherFilesToDeleteResponse$json = {
 };
 
 /// Descriptor for `GatherFilesToDeleteResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List gatherFilesToDeleteResponseDescriptor = $convert.base64Decode(
-    'ChtHYXRoZXJGaWxlc1RvRGVsZXRlUmVzcG9uc2USNAoFZmlsZXMYASADKAsyHi5vcmNoZXN0cm'
-    'F0b3IudjEuUmVzZXRGaWxlSW5mb1IFZmlsZXM=');
+final $typed_data.Uint8List gatherFilesToDeleteResponseDescriptor =
+    $convert.base64Decode('ChtHYXRoZXJGaWxlc1RvRGVsZXRlUmVzcG9uc2USNAoFZmlsZXMYASADKAsyHi5vcmNoZXN0cm'
+        'F0b3IudjEuUmVzZXRGaWxlSW5mb1IFZmlsZXM=');
 
 @$core.Deprecated('Use resetFileInfoDescriptor instead')
 const ResetFileInfo$json = {
@@ -865,11 +870,11 @@ const ResetFileInfo$json = {
 };
 
 /// Descriptor for `ResetFileInfo`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List resetFileInfoDescriptor = $convert.base64Decode(
-    'Cg1SZXNldEZpbGVJbmZvEhIKBHBhdGgYASABKAlSBHBhdGgSQgoNZGVsZXRpb25fdHlwZRgCIA'
-    'EoDjIdLm9yY2hlc3RyYXRvci52MS5EZWxldGlvblR5cGVSDGRlbGV0aW9uVHlwZRIzCgZiaW5h'
-    'cnkYAyABKA4yGy5vcmNoZXN0cmF0b3IudjEuQmluYXJ5VHlwZVIGYmluYXJ5Eh0KCnNpemVfYn'
-    'l0ZXMYBCABKANSCXNpemVCeXRlcxIhCgxpc19kaXJlY3RvcnkYBSABKAhSC2lzRGlyZWN0b3J5');
+final $typed_data.Uint8List resetFileInfoDescriptor =
+    $convert.base64Decode('Cg1SZXNldEZpbGVJbmZvEhIKBHBhdGgYASABKAlSBHBhdGgSQgoNZGVsZXRpb25fdHlwZRgCIA'
+        'EoDjIdLm9yY2hlc3RyYXRvci52MS5EZWxldGlvblR5cGVSDGRlbGV0aW9uVHlwZRIzCgZiaW5h'
+        'cnkYAyABKA4yGy5vcmNoZXN0cmF0b3IudjEuQmluYXJ5VHlwZVIGYmluYXJ5Eh0KCnNpemVfYn'
+        'l0ZXMYBCABKANSCXNpemVCeXRlcxIhCgxpc19kaXJlY3RvcnkYBSABKAhSC2lzRGlyZWN0b3J5');
 
 @$core.Deprecated('Use deleteFilesRequestDescriptor instead')
 const DeleteFilesRequest$json = {
@@ -881,9 +886,9 @@ const DeleteFilesRequest$json = {
 };
 
 /// Descriptor for `DeleteFilesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List deleteFilesRequestDescriptor = $convert.base64Decode(
-    'ChJEZWxldGVGaWxlc1JlcXVlc3QSNQoFaXRlbXMYASADKAsyHy5vcmNoZXN0cmF0b3IudjEuU2'
-    'luZ2xlRGVsZXRpb25SBWl0ZW1zEhYKBmV4Y2VwdBgCIAMoCVIGZXhjZXB0');
+final $typed_data.Uint8List deleteFilesRequestDescriptor =
+    $convert.base64Decode('ChJEZWxldGVGaWxlc1JlcXVlc3QSNQoFaXRlbXMYASADKAsyHy5vcmNoZXN0cmF0b3IudjEuU2'
+        'luZ2xlRGVsZXRpb25SBWl0ZW1zEhYKBmV4Y2VwdBgCIAMoCVIGZXhjZXB0');
 
 @$core.Deprecated('Use deleteFilesResponseDescriptor instead')
 const DeleteFilesResponse$json = {
@@ -895,9 +900,9 @@ const DeleteFilesResponse$json = {
 };
 
 /// Descriptor for `DeleteFilesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List deleteFilesResponseDescriptor = $convert.base64Decode(
-    'ChNEZWxldGVGaWxlc1Jlc3BvbnNlEhIKBHBhdGgYASABKAlSBHBhdGgSFAoFZXJyb3IYAiABKA'
-    'lSBWVycm9y');
+final $typed_data.Uint8List deleteFilesResponseDescriptor =
+    $convert.base64Decode('ChNEZWxldGVGaWxlc1Jlc3BvbnNlEhIKBHBhdGgYASABKAlSBHBhdGgSFAoFZXJyb3IYAiABKA'
+        'lSBWVycm9y');
 
 @$core.Deprecated('Use getCoreMempoolInfoRequestDescriptor instead')
 const GetCoreMempoolInfoRequest$json = {
@@ -905,8 +910,8 @@ const GetCoreMempoolInfoRequest$json = {
 };
 
 /// Descriptor for `GetCoreMempoolInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getCoreMempoolInfoRequestDescriptor = $convert.base64Decode(
-    'ChlHZXRDb3JlTWVtcG9vbEluZm9SZXF1ZXN0');
+final $typed_data.Uint8List getCoreMempoolInfoRequestDescriptor =
+    $convert.base64Decode('ChlHZXRDb3JlTWVtcG9vbEluZm9SZXF1ZXN0');
 
 @$core.Deprecated('Use getCoreMempoolInfoResponseDescriptor instead')
 const GetCoreMempoolInfoResponse$json = {
@@ -927,14 +932,14 @@ const GetCoreMempoolInfoResponse$json = {
 };
 
 /// Descriptor for `GetCoreMempoolInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getCoreMempoolInfoResponseDescriptor = $convert.base64Decode(
-    'ChpHZXRDb3JlTWVtcG9vbEluZm9SZXNwb25zZRIWCgZsb2FkZWQYASABKAhSBmxvYWRlZBISCg'
-    'RzaXplGAIgASgDUgRzaXplEhQKBWJ5dGVzGAMgASgDUgVieXRlcxIUCgV1c2FnZRgEIAEoA1IF'
-    'dXNhZ2USGwoJdG90YWxfZmVlGAUgASgBUgh0b3RhbEZlZRIfCgttYXhfbWVtcG9vbBgGIAEoA1'
-    'IKbWF4TWVtcG9vbBImCg9tZW1wb29sX21pbl9mZWUYByABKAFSDW1lbXBvb2xNaW5GZWUSJwoQ'
-    'bWluX3JlbGF5X3R4X2ZlZRgIIAEoAVINbWluUmVsYXlUeEZlZRIyChVpbmNyZW1lbnRhbF9yZW'
-    'xheV9mZWUYCSABKAFSE2luY3JlbWVudGFsUmVsYXlGZWUSKwoRdW5icm9hZGNhc3RfY291bnQY'
-    'CiABKANSEHVuYnJvYWRjYXN0Q291bnQSGQoIZnVsbF9yYmYYCyABKAhSB2Z1bGxSYmY=');
+final $typed_data.Uint8List getCoreMempoolInfoResponseDescriptor =
+    $convert.base64Decode('ChpHZXRDb3JlTWVtcG9vbEluZm9SZXNwb25zZRIWCgZsb2FkZWQYASABKAhSBmxvYWRlZBISCg'
+        'RzaXplGAIgASgDUgRzaXplEhQKBWJ5dGVzGAMgASgDUgVieXRlcxIUCgV1c2FnZRgEIAEoA1IF'
+        'dXNhZ2USGwoJdG90YWxfZmVlGAUgASgBUgh0b3RhbEZlZRIfCgttYXhfbWVtcG9vbBgGIAEoA1'
+        'IKbWF4TWVtcG9vbBImCg9tZW1wb29sX21pbl9mZWUYByABKAFSDW1lbXBvb2xNaW5GZWUSJwoQ'
+        'bWluX3JlbGF5X3R4X2ZlZRgIIAEoAVINbWluUmVsYXlUeEZlZRIyChVpbmNyZW1lbnRhbF9yZW'
+        'xheV9mZWUYCSABKAFSE2luY3JlbWVudGFsUmVsYXlGZWUSKwoRdW5icm9hZGNhc3RfY291bnQY'
+        'CiABKANSEHVuYnJvYWRjYXN0Q291bnQSGQoIZnVsbF9yYmYYCyABKAhSB2Z1bGxSYmY=');
 
 @$core.Deprecated('Use getBmmContextRequestDescriptor instead')
 const GetBmmContextRequest$json = {
@@ -942,8 +947,7 @@ const GetBmmContextRequest$json = {
 };
 
 /// Descriptor for `GetBmmContextRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmContextRequestDescriptor = $convert.base64Decode(
-    'ChRHZXRCbW1Db250ZXh0UmVxdWVzdA==');
+final $typed_data.Uint8List getBmmContextRequestDescriptor = $convert.base64Decode('ChRHZXRCbW1Db250ZXh0UmVxdWVzdA==');
 
 @$core.Deprecated('Use getBmmContextResponseDescriptor instead')
 const GetBmmContextResponse$json = {
@@ -958,11 +962,11 @@ const GetBmmContextResponse$json = {
 };
 
 /// Descriptor for `GetBmmContextResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getBmmContextResponseDescriptor = $convert.base64Decode(
-    'ChVHZXRCbW1Db250ZXh0UmVzcG9uc2USKQoQbWFpbmNoYWluX2hlaWdodBgBIAEoBVIPbWFpbm'
-    'NoYWluSGVpZ2h0EiMKDW1haW5jaGFpbl90aXAYAiABKAlSDG1haW5jaGFpblRpcBIlCg9mZWVf'
-    'cmF0ZV9zYXRfdmIYAyABKAFSDGZlZVJhdGVTYXRWYhIhCgxtZW1wb29sX3R4bnMYBCABKANSC2'
-    '1lbXBvb2xUeG5zEhoKCHdhcm5pbmdzGAUgASgJUgh3YXJuaW5ncw==');
+final $typed_data.Uint8List getBmmContextResponseDescriptor =
+    $convert.base64Decode('ChVHZXRCbW1Db250ZXh0UmVzcG9uc2USKQoQbWFpbmNoYWluX2hlaWdodBgBIAEoBVIPbWFpbm'
+        'NoYWluSGVpZ2h0EiMKDW1haW5jaGFpbl90aXAYAiABKAlSDG1haW5jaGFpblRpcBIlCg9mZWVf'
+        'cmF0ZV9zYXRfdmIYAyABKAFSDGZlZVJhdGVTYXRWYhIhCgxtZW1wb29sX3R4bnMYBCABKANSC2'
+        '1lbXBvb2xUeG5zEhoKCHdhcm5pbmdzGAUgASgJUgh3YXJuaW5ncw==');
 
 @$core.Deprecated('Use coreRawCallRequestDescriptor instead')
 const CoreRawCallRequest$json = {
@@ -975,9 +979,9 @@ const CoreRawCallRequest$json = {
 };
 
 /// Descriptor for `CoreRawCallRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List coreRawCallRequestDescriptor = $convert.base64Decode(
-    'ChJDb3JlUmF3Q2FsbFJlcXVlc3QSFgoGbWV0aG9kGAEgASgJUgZtZXRob2QSHwoLcGFyYW1zX2'
-    'pzb24YAiABKAlSCnBhcmFtc0pzb24SFgoGd2FsbGV0GAMgASgJUgZ3YWxsZXQ=');
+final $typed_data.Uint8List coreRawCallRequestDescriptor =
+    $convert.base64Decode('ChJDb3JlUmF3Q2FsbFJlcXVlc3QSFgoGbWV0aG9kGAEgASgJUgZtZXRob2QSHwoLcGFyYW1zX2'
+        'pzb24YAiABKAlSCnBhcmFtc0pzb24SFgoGd2FsbGV0GAMgASgJUgZ3YWxsZXQ=');
 
 @$core.Deprecated('Use coreRawCallResponseDescriptor instead')
 const CoreRawCallResponse$json = {
@@ -988,8 +992,8 @@ const CoreRawCallResponse$json = {
 };
 
 /// Descriptor for `CoreRawCallResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List coreRawCallResponseDescriptor = $convert.base64Decode(
-    'ChNDb3JlUmF3Q2FsbFJlc3BvbnNlEh8KC3Jlc3VsdF9qc29uGAEgASgJUgpyZXN1bHRKc29u');
+final $typed_data.Uint8List coreRawCallResponseDescriptor =
+    $convert.base64Decode('ChNDb3JlUmF3Q2FsbFJlc3BvbnNlEh8KC3Jlc3VsdF9qc29uGAEgASgJUgpyZXN1bHRKc29u');
 
 @$core.Deprecated('Use getForkStatusRequestDescriptor instead')
 const GetForkStatusRequest$json = {
@@ -997,8 +1001,7 @@ const GetForkStatusRequest$json = {
 };
 
 /// Descriptor for `GetForkStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getForkStatusRequestDescriptor = $convert.base64Decode(
-    'ChRHZXRGb3JrU3RhdHVzUmVxdWVzdA==');
+final $typed_data.Uint8List getForkStatusRequestDescriptor = $convert.base64Decode('ChRHZXRGb3JrU3RhdHVzUmVxdWVzdA==');
 
 @$core.Deprecated('Use getForkStatusResponseDescriptor instead')
 const GetForkStatusResponse$json = {
@@ -1020,15 +1023,15 @@ const GetForkStatusResponse$json = {
 };
 
 /// Descriptor for `GetForkStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getForkStatusResponseDescriptor = $convert.base64Decode(
-    'ChVHZXRGb3JrU3RhdHVzUmVzcG9uc2USHwoLZm9ya19oZWlnaHQYASABKAVSCmZvcmtIZWlnaH'
-    'QSJQoOY3VycmVudF9oZWlnaHQYAiABKAVSDWN1cnJlbnRIZWlnaHQSJwoPY3VycmVudF9oZWFk'
-    'ZXJzGAQgASgFUg5jdXJyZW50SGVhZGVycxIlCg5jbGFpbV9ib3VuZGFyeRgFIAEoBVINY2xhaW'
-    '1Cb3VuZGFyeRIcCglzaW11bGF0ZWQYBiABKAhSCXNpbXVsYXRlZBIrChJoYXNfZnVuZHNfdG9f'
-    'Y2xhaW0YByABKAhSD2hhc0Z1bmRzVG9DbGFpbRIlCg5zaG93X2NvdW50ZG93bhgIIAEoCFINc2'
-    'hvd0NvdW50ZG93bhI4CgZjbGFpbXMYCSADKAsyIC5vcmNoZXN0cmF0b3IudjEuRm9ya1dhbGxl'
-    'dENsYWltUgZjbGFpbXMSIQoMbmV0d29ya19uYW1lGAogASgJUgtuZXR3b3JrTmFtZUoECAMQBA'
-    '==');
+final $typed_data.Uint8List getForkStatusResponseDescriptor =
+    $convert.base64Decode('ChVHZXRGb3JrU3RhdHVzUmVzcG9uc2USHwoLZm9ya19oZWlnaHQYASABKAVSCmZvcmtIZWlnaH'
+        'QSJQoOY3VycmVudF9oZWlnaHQYAiABKAVSDWN1cnJlbnRIZWlnaHQSJwoPY3VycmVudF9oZWFk'
+        'ZXJzGAQgASgFUg5jdXJyZW50SGVhZGVycxIlCg5jbGFpbV9ib3VuZGFyeRgFIAEoBVINY2xhaW'
+        '1Cb3VuZGFyeRIcCglzaW11bGF0ZWQYBiABKAhSCXNpbXVsYXRlZBIrChJoYXNfZnVuZHNfdG9f'
+        'Y2xhaW0YByABKAhSD2hhc0Z1bmRzVG9DbGFpbRIlCg5zaG93X2NvdW50ZG93bhgIIAEoCFINc2'
+        'hvd0NvdW50ZG93bhI4CgZjbGFpbXMYCSADKAsyIC5vcmNoZXN0cmF0b3IudjEuRm9ya1dhbGxl'
+        'dENsYWltUgZjbGFpbXMSIQoMbmV0d29ya19uYW1lGAogASgJUgtuZXR3b3JrTmFtZUoECAMQBA'
+        '==');
 
 @$core.Deprecated('Use forkWalletClaimDescriptor instead')
 const ForkWalletClaim$json = {
@@ -1043,11 +1046,11 @@ const ForkWalletClaim$json = {
 };
 
 /// Descriptor for `ForkWalletClaim`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List forkWalletClaimDescriptor = $convert.base64Decode(
-    'Cg9Gb3JrV2FsbGV0Q2xhaW0SGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZXRJZBIfCgt3YWxsZX'
-    'RfbmFtZRgCIAEoCVIKd2FsbGV0TmFtZRIlCg5jbGFpbWFibGVfc2F0cxgDIAEoBFINY2xhaW1h'
-    'YmxlU2F0cxI0CgV1dHhvcxgEIAMoCzIeLm9yY2hlc3RyYXRvci52MS5Gb3JrQ2xhaW1VdHhvUg'
-    'V1dHhvcxItChJyZXBsYXlfcHJvdGVjdGFibGUYBSABKAhSEXJlcGxheVByb3RlY3RhYmxl');
+final $typed_data.Uint8List forkWalletClaimDescriptor =
+    $convert.base64Decode('Cg9Gb3JrV2FsbGV0Q2xhaW0SGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZXRJZBIfCgt3YWxsZX'
+        'RfbmFtZRgCIAEoCVIKd2FsbGV0TmFtZRIlCg5jbGFpbWFibGVfc2F0cxgDIAEoBFINY2xhaW1h'
+        'YmxlU2F0cxI0CgV1dHhvcxgEIAMoCzIeLm9yY2hlc3RyYXRvci52MS5Gb3JrQ2xhaW1VdHhvUg'
+        'V1dHhvcxItChJyZXBsYXlfcHJvdGVjdGFibGUYBSABKAhSEXJlcGxheVByb3RlY3RhYmxl');
 
 @$core.Deprecated('Use forkClaimUtxoDescriptor instead')
 const ForkClaimUtxo$json = {
@@ -1061,9 +1064,9 @@ const ForkClaimUtxo$json = {
 };
 
 /// Descriptor for `ForkClaimUtxo`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List forkClaimUtxoDescriptor = $convert.base64Decode(
-    'Cg1Gb3JrQ2xhaW1VdHhvEhoKCG91dHBvaW50GAEgASgJUghvdXRwb2ludBIYCgdhZGRyZXNzGA'
-    'IgASgJUgdhZGRyZXNzEhIKBHNhdHMYAyABKARSBHNhdHMSFAoFbGFiZWwYBCABKAlSBWxhYmVs');
+final $typed_data.Uint8List forkClaimUtxoDescriptor =
+    $convert.base64Decode('Cg1Gb3JrQ2xhaW1VdHhvEhoKCG91dHBvaW50GAEgASgJUghvdXRwb2ludBIYCgdhZGRyZXNzGA'
+        'IgASgJUgdhZGRyZXNzEhIKBHNhdHMYAyABKARSBHNhdHMSFAoFbGFiZWwYBCABKAlSBWxhYmVs');
 
 @$core.Deprecated('Use shutdownRequestDescriptor instead')
 const ShutdownRequest$json = {
@@ -1074,8 +1077,8 @@ const ShutdownRequest$json = {
 };
 
 /// Descriptor for `ShutdownRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List shutdownRequestDescriptor = $convert.base64Decode(
-    'Cg9TaHV0ZG93blJlcXVlc3QSIAoMb25seV9pZl9sYXN0GAEgASgIUgpvbmx5SWZMYXN0');
+final $typed_data.Uint8List shutdownRequestDescriptor =
+    $convert.base64Decode('Cg9TaHV0ZG93blJlcXVlc3QSIAoMb25seV9pZl9sYXN0GAEgASgIUgpvbmx5SWZMYXN0');
 
 @$core.Deprecated('Use shutdownResponseDescriptor instead')
 const ShutdownResponse$json = {
@@ -1083,38 +1086,109 @@ const ShutdownResponse$json = {
 };
 
 /// Descriptor for `ShutdownResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List shutdownResponseDescriptor = $convert.base64Decode(
-    'ChBTaHV0ZG93blJlc3BvbnNl');
+final $typed_data.Uint8List shutdownResponseDescriptor = $convert.base64Decode('ChBTaHV0ZG93blJlc3BvbnNl');
 
 const $core.Map<$core.String, $core.dynamic> OrchestratorServiceBase$json = {
   '1': 'OrchestratorService',
   '2': [
     {'1': 'ListBinaries', '2': '.orchestrator.v1.ListBinariesRequest', '3': '.orchestrator.v1.ListBinariesResponse'},
-    {'1': 'GetBinaryStatus', '2': '.orchestrator.v1.GetBinaryStatusRequest', '3': '.orchestrator.v1.GetBinaryStatusResponse'},
-    {'1': 'GetBinaryVersion', '2': '.orchestrator.v1.GetBinaryVersionRequest', '3': '.orchestrator.v1.GetBinaryVersionResponse'},
-    {'1': 'DownloadBinary', '2': '.orchestrator.v1.DownloadBinaryRequest', '3': '.orchestrator.v1.DownloadBinaryResponse'},
+    {
+      '1': 'GetBinaryStatus',
+      '2': '.orchestrator.v1.GetBinaryStatusRequest',
+      '3': '.orchestrator.v1.GetBinaryStatusResponse'
+    },
+    {
+      '1': 'GetBinaryVersion',
+      '2': '.orchestrator.v1.GetBinaryVersionRequest',
+      '3': '.orchestrator.v1.GetBinaryVersionResponse'
+    },
+    {
+      '1': 'DownloadBinary',
+      '2': '.orchestrator.v1.DownloadBinaryRequest',
+      '3': '.orchestrator.v1.DownloadBinaryResponse'
+    },
     {'1': 'StartBinary', '2': '.orchestrator.v1.StartBinaryRequest', '3': '.orchestrator.v1.StartBinaryResponse'},
     {'1': 'StopBinary', '2': '.orchestrator.v1.StopBinaryRequest', '3': '.orchestrator.v1.StopBinaryResponse'},
-    {'1': 'StreamLogs', '2': '.orchestrator.v1.StreamLogsRequest', '3': '.orchestrator.v1.StreamLogsResponse', '6': true},
+    {
+      '1': 'StreamLogs',
+      '2': '.orchestrator.v1.StreamLogsRequest',
+      '3': '.orchestrator.v1.StreamLogsResponse',
+      '6': true
+    },
     {'1': 'StartWithL1', '2': '.orchestrator.v1.StartWithL1Request', '3': '.orchestrator.v1.StartWithL1Response'},
     {'1': 'RestartDaemon', '2': '.orchestrator.v1.RestartDaemonRequest', '3': '.orchestrator.v1.RestartDaemonResponse'},
     {'1': 'RestartL1', '2': '.orchestrator.v1.RestartL1Request', '3': '.orchestrator.v1.RestartL1Response'},
-    {'1': 'ApplyUTXOSnapshot', '2': '.orchestrator.v1.ApplyUTXOSnapshotRequest', '3': '.orchestrator.v1.ApplyUTXOSnapshotResponse', '6': true},
-    {'1': 'GetSnapshotStatus', '2': '.orchestrator.v1.GetSnapshotStatusRequest', '3': '.orchestrator.v1.GetSnapshotStatusResponse'},
-    {'1': 'GetPendingNetworkGeneration', '2': '.orchestrator.v1.GetPendingNetworkGenerationRequest', '3': '.orchestrator.v1.GetPendingNetworkGenerationResponse'},
-    {'1': 'ConfirmPendingNetworkGeneration', '2': '.orchestrator.v1.ConfirmPendingNetworkGenerationRequest', '3': '.orchestrator.v1.ConfirmPendingNetworkGenerationResponse'},
-    {'1': 'ShutdownAll', '2': '.orchestrator.v1.ShutdownAllRequest', '3': '.orchestrator.v1.ShutdownAllResponse', '6': true},
+    {
+      '1': 'ApplyUTXOSnapshot',
+      '2': '.orchestrator.v1.ApplyUTXOSnapshotRequest',
+      '3': '.orchestrator.v1.ApplyUTXOSnapshotResponse',
+      '6': true
+    },
+    {
+      '1': 'GetSnapshotStatus',
+      '2': '.orchestrator.v1.GetSnapshotStatusRequest',
+      '3': '.orchestrator.v1.GetSnapshotStatusResponse'
+    },
+    {
+      '1': 'GetPendingNetworkGeneration',
+      '2': '.orchestrator.v1.GetPendingNetworkGenerationRequest',
+      '3': '.orchestrator.v1.GetPendingNetworkGenerationResponse'
+    },
+    {
+      '1': 'ConfirmPendingNetworkGeneration',
+      '2': '.orchestrator.v1.ConfirmPendingNetworkGenerationRequest',
+      '3': '.orchestrator.v1.ConfirmPendingNetworkGenerationResponse'
+    },
+    {
+      '1': 'ShutdownAll',
+      '2': '.orchestrator.v1.ShutdownAllRequest',
+      '3': '.orchestrator.v1.ShutdownAllResponse',
+      '6': true
+    },
     {'1': 'Shutdown', '2': '.orchestrator.v1.ShutdownRequest', '3': '.orchestrator.v1.ShutdownResponse'},
     {'1': 'GetBTCPrice', '2': '.orchestrator.v1.GetBTCPriceRequest', '3': '.orchestrator.v1.GetBTCPriceResponse'},
-    {'1': 'GetMainchainBlockchainInfo', '2': '.orchestrator.v1.GetMainchainBlockchainInfoRequest', '3': '.orchestrator.v1.GetMainchainBlockchainInfoResponse'},
-    {'1': 'GetEnforcerBlockchainInfo', '2': '.orchestrator.v1.GetEnforcerBlockchainInfoRequest', '3': '.orchestrator.v1.GetEnforcerBlockchainInfoResponse'},
+    {
+      '1': 'GetMainchainBlockchainInfo',
+      '2': '.orchestrator.v1.GetMainchainBlockchainInfoRequest',
+      '3': '.orchestrator.v1.GetMainchainBlockchainInfoResponse'
+    },
+    {
+      '1': 'GetEnforcerBlockchainInfo',
+      '2': '.orchestrator.v1.GetEnforcerBlockchainInfoRequest',
+      '3': '.orchestrator.v1.GetEnforcerBlockchainInfoResponse'
+    },
     {'1': 'GetSyncStatus', '2': '.orchestrator.v1.GetSyncStatusRequest', '3': '.orchestrator.v1.GetSyncStatusResponse'},
-    {'1': 'GetDownloadStatus', '2': '.orchestrator.v1.GetDownloadStatusRequest', '3': '.orchestrator.v1.GetDownloadStatusResponse'},
-    {'1': 'GetMainchainBalance', '2': '.orchestrator.v1.GetMainchainBalanceRequest', '3': '.orchestrator.v1.GetMainchainBalanceResponse'},
-    {'1': 'GetSidechainBalance', '2': '.orchestrator.v1.GetSidechainBalanceRequest', '3': '.orchestrator.v1.GetSidechainBalanceResponse'},
-    {'1': 'GatherFilesToDelete', '2': '.orchestrator.v1.GatherFilesToDeleteRequest', '3': '.orchestrator.v1.GatherFilesToDeleteResponse'},
-    {'1': 'DeleteFiles', '2': '.orchestrator.v1.DeleteFilesRequest', '3': '.orchestrator.v1.DeleteFilesResponse', '6': true},
-    {'1': 'GetCoreMempoolInfo', '2': '.orchestrator.v1.GetCoreMempoolInfoRequest', '3': '.orchestrator.v1.GetCoreMempoolInfoResponse'},
+    {
+      '1': 'GetDownloadStatus',
+      '2': '.orchestrator.v1.GetDownloadStatusRequest',
+      '3': '.orchestrator.v1.GetDownloadStatusResponse'
+    },
+    {
+      '1': 'GetMainchainBalance',
+      '2': '.orchestrator.v1.GetMainchainBalanceRequest',
+      '3': '.orchestrator.v1.GetMainchainBalanceResponse'
+    },
+    {
+      '1': 'GetSidechainBalance',
+      '2': '.orchestrator.v1.GetSidechainBalanceRequest',
+      '3': '.orchestrator.v1.GetSidechainBalanceResponse'
+    },
+    {
+      '1': 'GatherFilesToDelete',
+      '2': '.orchestrator.v1.GatherFilesToDeleteRequest',
+      '3': '.orchestrator.v1.GatherFilesToDeleteResponse'
+    },
+    {
+      '1': 'DeleteFiles',
+      '2': '.orchestrator.v1.DeleteFilesRequest',
+      '3': '.orchestrator.v1.DeleteFilesResponse',
+      '6': true
+    },
+    {
+      '1': 'GetCoreMempoolInfo',
+      '2': '.orchestrator.v1.GetCoreMempoolInfoRequest',
+      '3': '.orchestrator.v1.GetCoreMempoolInfoResponse'
+    },
     {'1': 'GetBmmContext', '2': '.orchestrator.v1.GetBmmContextRequest', '3': '.orchestrator.v1.GetBmmContextResponse'},
     {'1': 'CoreRawCall', '2': '.orchestrator.v1.CoreRawCallRequest', '3': '.orchestrator.v1.CoreRawCallResponse'},
     {'1': 'GetForkStatus', '2': '.orchestrator.v1.GetForkStatusRequest', '3': '.orchestrator.v1.GetForkStatusResponse'},
@@ -1195,60 +1269,59 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> Orchestrat
 };
 
 /// Descriptor for `OrchestratorService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List orchestratorServiceDescriptor = $convert.base64Decode(
-    'ChNPcmNoZXN0cmF0b3JTZXJ2aWNlElsKDExpc3RCaW5hcmllcxIkLm9yY2hlc3RyYXRvci52MS'
-    '5MaXN0QmluYXJpZXNSZXF1ZXN0GiUub3JjaGVzdHJhdG9yLnYxLkxpc3RCaW5hcmllc1Jlc3Bv'
-    'bnNlEmQKD0dldEJpbmFyeVN0YXR1cxInLm9yY2hlc3RyYXRvci52MS5HZXRCaW5hcnlTdGF0dX'
-    'NSZXF1ZXN0Gigub3JjaGVzdHJhdG9yLnYxLkdldEJpbmFyeVN0YXR1c1Jlc3BvbnNlEmcKEEdl'
-    'dEJpbmFyeVZlcnNpb24SKC5vcmNoZXN0cmF0b3IudjEuR2V0QmluYXJ5VmVyc2lvblJlcXVlc3'
-    'QaKS5vcmNoZXN0cmF0b3IudjEuR2V0QmluYXJ5VmVyc2lvblJlc3BvbnNlEmEKDkRvd25sb2Fk'
-    'QmluYXJ5EiYub3JjaGVzdHJhdG9yLnYxLkRvd25sb2FkQmluYXJ5UmVxdWVzdBonLm9yY2hlc3'
-    'RyYXRvci52MS5Eb3dubG9hZEJpbmFyeVJlc3BvbnNlElgKC1N0YXJ0QmluYXJ5EiMub3JjaGVz'
-    'dHJhdG9yLnYxLlN0YXJ0QmluYXJ5UmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5TdGFydEJpbm'
-    'FyeVJlc3BvbnNlElUKClN0b3BCaW5hcnkSIi5vcmNoZXN0cmF0b3IudjEuU3RvcEJpbmFyeVJl'
-    'cXVlc3QaIy5vcmNoZXN0cmF0b3IudjEuU3RvcEJpbmFyeVJlc3BvbnNlElcKClN0cmVhbUxvZ3'
-    'MSIi5vcmNoZXN0cmF0b3IudjEuU3RyZWFtTG9nc1JlcXVlc3QaIy5vcmNoZXN0cmF0b3IudjEu'
-    'U3RyZWFtTG9nc1Jlc3BvbnNlMAESWAoLU3RhcnRXaXRoTDESIy5vcmNoZXN0cmF0b3IudjEuU3'
-    'RhcnRXaXRoTDFSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLlN0YXJ0V2l0aEwxUmVzcG9uc2US'
-    'XgoNUmVzdGFydERhZW1vbhIlLm9yY2hlc3RyYXRvci52MS5SZXN0YXJ0RGFlbW9uUmVxdWVzdB'
-    'omLm9yY2hlc3RyYXRvci52MS5SZXN0YXJ0RGFlbW9uUmVzcG9uc2USUgoJUmVzdGFydEwxEiEu'
-    'b3JjaGVzdHJhdG9yLnYxLlJlc3RhcnRMMVJlcXVlc3QaIi5vcmNoZXN0cmF0b3IudjEuUmVzdG'
-    'FydEwxUmVzcG9uc2USbAoRQXBwbHlVVFhPU25hcHNob3QSKS5vcmNoZXN0cmF0b3IudjEuQXBw'
-    'bHlVVFhPU25hcHNob3RSZXF1ZXN0Gioub3JjaGVzdHJhdG9yLnYxLkFwcGx5VVRYT1NuYXBzaG'
-    '90UmVzcG9uc2UwARJqChFHZXRTbmFwc2hvdFN0YXR1cxIpLm9yY2hlc3RyYXRvci52MS5HZXRT'
-    'bmFwc2hvdFN0YXR1c1JlcXVlc3QaKi5vcmNoZXN0cmF0b3IudjEuR2V0U25hcHNob3RTdGF0dX'
-    'NSZXNwb25zZRKIAQobR2V0UGVuZGluZ05ldHdvcmtHZW5lcmF0aW9uEjMub3JjaGVzdHJhdG9y'
-    'LnYxLkdldFBlbmRpbmdOZXR3b3JrR2VuZXJhdGlvblJlcXVlc3QaNC5vcmNoZXN0cmF0b3Iudj'
-    'EuR2V0UGVuZGluZ05ldHdvcmtHZW5lcmF0aW9uUmVzcG9uc2USlAEKH0NvbmZpcm1QZW5kaW5n'
-    'TmV0d29ya0dlbmVyYXRpb24SNy5vcmNoZXN0cmF0b3IudjEuQ29uZmlybVBlbmRpbmdOZXR3b3'
-    'JrR2VuZXJhdGlvblJlcXVlc3QaOC5vcmNoZXN0cmF0b3IudjEuQ29uZmlybVBlbmRpbmdOZXR3'
-    'b3JrR2VuZXJhdGlvblJlc3BvbnNlEloKC1NodXRkb3duQWxsEiMub3JjaGVzdHJhdG9yLnYxLl'
-    'NodXRkb3duQWxsUmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5TaHV0ZG93bkFsbFJlc3BvbnNl'
-    'MAESTwoIU2h1dGRvd24SIC5vcmNoZXN0cmF0b3IudjEuU2h1dGRvd25SZXF1ZXN0GiEub3JjaG'
-    'VzdHJhdG9yLnYxLlNodXRkb3duUmVzcG9uc2USWAoLR2V0QlRDUHJpY2USIy5vcmNoZXN0cmF0'
-    'b3IudjEuR2V0QlRDUHJpY2VSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLkdldEJUQ1ByaWNlUm'
-    'VzcG9uc2UShQEKGkdldE1haW5jaGFpbkJsb2NrY2hhaW5JbmZvEjIub3JjaGVzdHJhdG9yLnYx'
-    'LkdldE1haW5jaGFpbkJsb2NrY2hhaW5JbmZvUmVxdWVzdBozLm9yY2hlc3RyYXRvci52MS5HZX'
-    'RNYWluY2hhaW5CbG9ja2NoYWluSW5mb1Jlc3BvbnNlEoIBChlHZXRFbmZvcmNlckJsb2NrY2hh'
-    'aW5JbmZvEjEub3JjaGVzdHJhdG9yLnYxLkdldEVuZm9yY2VyQmxvY2tjaGFpbkluZm9SZXF1ZX'
-    'N0GjIub3JjaGVzdHJhdG9yLnYxLkdldEVuZm9yY2VyQmxvY2tjaGFpbkluZm9SZXNwb25zZRJe'
-    'Cg1HZXRTeW5jU3RhdHVzEiUub3JjaGVzdHJhdG9yLnYxLkdldFN5bmNTdGF0dXNSZXF1ZXN0Gi'
-    'Yub3JjaGVzdHJhdG9yLnYxLkdldFN5bmNTdGF0dXNSZXNwb25zZRJqChFHZXREb3dubG9hZFN0'
-    'YXR1cxIpLm9yY2hlc3RyYXRvci52MS5HZXREb3dubG9hZFN0YXR1c1JlcXVlc3QaKi5vcmNoZX'
-    'N0cmF0b3IudjEuR2V0RG93bmxvYWRTdGF0dXNSZXNwb25zZRJwChNHZXRNYWluY2hhaW5CYWxh'
-    'bmNlEisub3JjaGVzdHJhdG9yLnYxLkdldE1haW5jaGFpbkJhbGFuY2VSZXF1ZXN0Giwub3JjaG'
-    'VzdHJhdG9yLnYxLkdldE1haW5jaGFpbkJhbGFuY2VSZXNwb25zZRJwChNHZXRTaWRlY2hhaW5C'
-    'YWxhbmNlEisub3JjaGVzdHJhdG9yLnYxLkdldFNpZGVjaGFpbkJhbGFuY2VSZXF1ZXN0Giwub3'
-    'JjaGVzdHJhdG9yLnYxLkdldFNpZGVjaGFpbkJhbGFuY2VSZXNwb25zZRJwChNHYXRoZXJGaWxl'
-    'c1RvRGVsZXRlEisub3JjaGVzdHJhdG9yLnYxLkdhdGhlckZpbGVzVG9EZWxldGVSZXF1ZXN0Gi'
-    'wub3JjaGVzdHJhdG9yLnYxLkdhdGhlckZpbGVzVG9EZWxldGVSZXNwb25zZRJaCgtEZWxldGVG'
-    'aWxlcxIjLm9yY2hlc3RyYXRvci52MS5EZWxldGVGaWxlc1JlcXVlc3QaJC5vcmNoZXN0cmF0b3'
-    'IudjEuRGVsZXRlRmlsZXNSZXNwb25zZTABEm0KEkdldENvcmVNZW1wb29sSW5mbxIqLm9yY2hl'
-    'c3RyYXRvci52MS5HZXRDb3JlTWVtcG9vbEluZm9SZXF1ZXN0Gisub3JjaGVzdHJhdG9yLnYxLk'
-    'dldENvcmVNZW1wb29sSW5mb1Jlc3BvbnNlEl4KDUdldEJtbUNvbnRleHQSJS5vcmNoZXN0cmF0'
-    'b3IudjEuR2V0Qm1tQ29udGV4dFJlcXVlc3QaJi5vcmNoZXN0cmF0b3IudjEuR2V0Qm1tQ29udG'
-    'V4dFJlc3BvbnNlElgKC0NvcmVSYXdDYWxsEiMub3JjaGVzdHJhdG9yLnYxLkNvcmVSYXdDYWxs'
-    'UmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5Db3JlUmF3Q2FsbFJlc3BvbnNlEl4KDUdldEZvcm'
-    'tTdGF0dXMSJS5vcmNoZXN0cmF0b3IudjEuR2V0Rm9ya1N0YXR1c1JlcXVlc3QaJi5vcmNoZXN0'
-    'cmF0b3IudjEuR2V0Rm9ya1N0YXR1c1Jlc3BvbnNl');
-
+final $typed_data.Uint8List orchestratorServiceDescriptor =
+    $convert.base64Decode('ChNPcmNoZXN0cmF0b3JTZXJ2aWNlElsKDExpc3RCaW5hcmllcxIkLm9yY2hlc3RyYXRvci52MS'
+        '5MaXN0QmluYXJpZXNSZXF1ZXN0GiUub3JjaGVzdHJhdG9yLnYxLkxpc3RCaW5hcmllc1Jlc3Bv'
+        'bnNlEmQKD0dldEJpbmFyeVN0YXR1cxInLm9yY2hlc3RyYXRvci52MS5HZXRCaW5hcnlTdGF0dX'
+        'NSZXF1ZXN0Gigub3JjaGVzdHJhdG9yLnYxLkdldEJpbmFyeVN0YXR1c1Jlc3BvbnNlEmcKEEdl'
+        'dEJpbmFyeVZlcnNpb24SKC5vcmNoZXN0cmF0b3IudjEuR2V0QmluYXJ5VmVyc2lvblJlcXVlc3'
+        'QaKS5vcmNoZXN0cmF0b3IudjEuR2V0QmluYXJ5VmVyc2lvblJlc3BvbnNlEmEKDkRvd25sb2Fk'
+        'QmluYXJ5EiYub3JjaGVzdHJhdG9yLnYxLkRvd25sb2FkQmluYXJ5UmVxdWVzdBonLm9yY2hlc3'
+        'RyYXRvci52MS5Eb3dubG9hZEJpbmFyeVJlc3BvbnNlElgKC1N0YXJ0QmluYXJ5EiMub3JjaGVz'
+        'dHJhdG9yLnYxLlN0YXJ0QmluYXJ5UmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5TdGFydEJpbm'
+        'FyeVJlc3BvbnNlElUKClN0b3BCaW5hcnkSIi5vcmNoZXN0cmF0b3IudjEuU3RvcEJpbmFyeVJl'
+        'cXVlc3QaIy5vcmNoZXN0cmF0b3IudjEuU3RvcEJpbmFyeVJlc3BvbnNlElcKClN0cmVhbUxvZ3'
+        'MSIi5vcmNoZXN0cmF0b3IudjEuU3RyZWFtTG9nc1JlcXVlc3QaIy5vcmNoZXN0cmF0b3IudjEu'
+        'U3RyZWFtTG9nc1Jlc3BvbnNlMAESWAoLU3RhcnRXaXRoTDESIy5vcmNoZXN0cmF0b3IudjEuU3'
+        'RhcnRXaXRoTDFSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLlN0YXJ0V2l0aEwxUmVzcG9uc2US'
+        'XgoNUmVzdGFydERhZW1vbhIlLm9yY2hlc3RyYXRvci52MS5SZXN0YXJ0RGFlbW9uUmVxdWVzdB'
+        'omLm9yY2hlc3RyYXRvci52MS5SZXN0YXJ0RGFlbW9uUmVzcG9uc2USUgoJUmVzdGFydEwxEiEu'
+        'b3JjaGVzdHJhdG9yLnYxLlJlc3RhcnRMMVJlcXVlc3QaIi5vcmNoZXN0cmF0b3IudjEuUmVzdG'
+        'FydEwxUmVzcG9uc2USbAoRQXBwbHlVVFhPU25hcHNob3QSKS5vcmNoZXN0cmF0b3IudjEuQXBw'
+        'bHlVVFhPU25hcHNob3RSZXF1ZXN0Gioub3JjaGVzdHJhdG9yLnYxLkFwcGx5VVRYT1NuYXBzaG'
+        '90UmVzcG9uc2UwARJqChFHZXRTbmFwc2hvdFN0YXR1cxIpLm9yY2hlc3RyYXRvci52MS5HZXRT'
+        'bmFwc2hvdFN0YXR1c1JlcXVlc3QaKi5vcmNoZXN0cmF0b3IudjEuR2V0U25hcHNob3RTdGF0dX'
+        'NSZXNwb25zZRKIAQobR2V0UGVuZGluZ05ldHdvcmtHZW5lcmF0aW9uEjMub3JjaGVzdHJhdG9y'
+        'LnYxLkdldFBlbmRpbmdOZXR3b3JrR2VuZXJhdGlvblJlcXVlc3QaNC5vcmNoZXN0cmF0b3Iudj'
+        'EuR2V0UGVuZGluZ05ldHdvcmtHZW5lcmF0aW9uUmVzcG9uc2USlAEKH0NvbmZpcm1QZW5kaW5n'
+        'TmV0d29ya0dlbmVyYXRpb24SNy5vcmNoZXN0cmF0b3IudjEuQ29uZmlybVBlbmRpbmdOZXR3b3'
+        'JrR2VuZXJhdGlvblJlcXVlc3QaOC5vcmNoZXN0cmF0b3IudjEuQ29uZmlybVBlbmRpbmdOZXR3'
+        'b3JrR2VuZXJhdGlvblJlc3BvbnNlEloKC1NodXRkb3duQWxsEiMub3JjaGVzdHJhdG9yLnYxLl'
+        'NodXRkb3duQWxsUmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5TaHV0ZG93bkFsbFJlc3BvbnNl'
+        'MAESTwoIU2h1dGRvd24SIC5vcmNoZXN0cmF0b3IudjEuU2h1dGRvd25SZXF1ZXN0GiEub3JjaG'
+        'VzdHJhdG9yLnYxLlNodXRkb3duUmVzcG9uc2USWAoLR2V0QlRDUHJpY2USIy5vcmNoZXN0cmF0'
+        'b3IudjEuR2V0QlRDUHJpY2VSZXF1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLkdldEJUQ1ByaWNlUm'
+        'VzcG9uc2UShQEKGkdldE1haW5jaGFpbkJsb2NrY2hhaW5JbmZvEjIub3JjaGVzdHJhdG9yLnYx'
+        'LkdldE1haW5jaGFpbkJsb2NrY2hhaW5JbmZvUmVxdWVzdBozLm9yY2hlc3RyYXRvci52MS5HZX'
+        'RNYWluY2hhaW5CbG9ja2NoYWluSW5mb1Jlc3BvbnNlEoIBChlHZXRFbmZvcmNlckJsb2NrY2hh'
+        'aW5JbmZvEjEub3JjaGVzdHJhdG9yLnYxLkdldEVuZm9yY2VyQmxvY2tjaGFpbkluZm9SZXF1ZX'
+        'N0GjIub3JjaGVzdHJhdG9yLnYxLkdldEVuZm9yY2VyQmxvY2tjaGFpbkluZm9SZXNwb25zZRJe'
+        'Cg1HZXRTeW5jU3RhdHVzEiUub3JjaGVzdHJhdG9yLnYxLkdldFN5bmNTdGF0dXNSZXF1ZXN0Gi'
+        'Yub3JjaGVzdHJhdG9yLnYxLkdldFN5bmNTdGF0dXNSZXNwb25zZRJqChFHZXREb3dubG9hZFN0'
+        'YXR1cxIpLm9yY2hlc3RyYXRvci52MS5HZXREb3dubG9hZFN0YXR1c1JlcXVlc3QaKi5vcmNoZX'
+        'N0cmF0b3IudjEuR2V0RG93bmxvYWRTdGF0dXNSZXNwb25zZRJwChNHZXRNYWluY2hhaW5CYWxh'
+        'bmNlEisub3JjaGVzdHJhdG9yLnYxLkdldE1haW5jaGFpbkJhbGFuY2VSZXF1ZXN0Giwub3JjaG'
+        'VzdHJhdG9yLnYxLkdldE1haW5jaGFpbkJhbGFuY2VSZXNwb25zZRJwChNHZXRTaWRlY2hhaW5C'
+        'YWxhbmNlEisub3JjaGVzdHJhdG9yLnYxLkdldFNpZGVjaGFpbkJhbGFuY2VSZXF1ZXN0Giwub3'
+        'JjaGVzdHJhdG9yLnYxLkdldFNpZGVjaGFpbkJhbGFuY2VSZXNwb25zZRJwChNHYXRoZXJGaWxl'
+        'c1RvRGVsZXRlEisub3JjaGVzdHJhdG9yLnYxLkdhdGhlckZpbGVzVG9EZWxldGVSZXF1ZXN0Gi'
+        'wub3JjaGVzdHJhdG9yLnYxLkdhdGhlckZpbGVzVG9EZWxldGVSZXNwb25zZRJaCgtEZWxldGVG'
+        'aWxlcxIjLm9yY2hlc3RyYXRvci52MS5EZWxldGVGaWxlc1JlcXVlc3QaJC5vcmNoZXN0cmF0b3'
+        'IudjEuRGVsZXRlRmlsZXNSZXNwb25zZTABEm0KEkdldENvcmVNZW1wb29sSW5mbxIqLm9yY2hl'
+        'c3RyYXRvci52MS5HZXRDb3JlTWVtcG9vbEluZm9SZXF1ZXN0Gisub3JjaGVzdHJhdG9yLnYxLk'
+        'dldENvcmVNZW1wb29sSW5mb1Jlc3BvbnNlEl4KDUdldEJtbUNvbnRleHQSJS5vcmNoZXN0cmF0'
+        'b3IudjEuR2V0Qm1tQ29udGV4dFJlcXVlc3QaJi5vcmNoZXN0cmF0b3IudjEuR2V0Qm1tQ29udG'
+        'V4dFJlc3BvbnNlElgKC0NvcmVSYXdDYWxsEiMub3JjaGVzdHJhdG9yLnYxLkNvcmVSYXdDYWxs'
+        'UmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5Db3JlUmF3Q2FsbFJlc3BvbnNlEl4KDUdldEZvcm'
+        'tTdGF0dXMSJS5vcmNoZXN0cmF0b3IudjEuR2V0Rm9ya1N0YXR1c1JlcXVlc3QaJi5vcmNoZXN0'
+        'cmF0b3IudjEuR2V0Rm9ya1N0YXR1c1Jlc3BvbnNl');

--- a/sidechain_core/lib/providers/backend_state_provider.dart
+++ b/sidechain_core/lib/providers/backend_state_provider.dart
@@ -170,15 +170,20 @@ class BackendStateProvider extends ChangeNotifier {
     final reported = status.binaryPath;
     final next = reported.isEmpty ? null : File(reported);
 
+    final remote = _timeOrNull(status.remoteTimestampUnix.toInt());
+    final downloaded = _timeOrNull(status.downloadedTimestampUnix.toInt());
+
     final binaryProvider = GetIt.I.get<BinaryProvider>();
     binaryProvider.updateBinary(type, (b) {
-      if (b.metadata.binaryPath?.path == next?.path) {
+      if (b.metadata.binaryPath?.path == next?.path &&
+          b.metadata.remoteTimestamp == remote &&
+          b.metadata.downloadedTimestamp == downloaded) {
         return b;
       }
       return b.copyWith(
         metadata: b.metadata.copyWith(
-          remoteTimestamp: b.metadata.remoteTimestamp,
-          downloadedTimestamp: b.metadata.downloadedTimestamp,
+          remoteTimestamp: remote,
+          downloadedTimestamp: downloaded,
           binaryPath: next,
           updateable: b.metadata.updateable,
         ),
@@ -240,3 +245,6 @@ class BackendStateProvider extends ChangeNotifier {
     super.dispose();
   }
 }
+
+/// The orchestrator sends 0 for a timestamp it does not know.
+DateTime? _timeOrNull(int unix) => unix == 0 ? null : DateTime.fromMillisecondsSinceEpoch(unix * 1000, isUtc: true);


### PR DESCRIPTION
The daemon probes Last-Modified on a timer and reports update_available, remote_timestamp_unix and downloaded_timestamp_unix on BinaryStatusMsg. Dart reads those instead of making its own HTTP calls.

The check shares DownloadManager.ResolveTarget with the downloader, so a Core variant, a test sidechain build and a GitHub asset all resolve one way.