### PR TITLE
orchestrator: deposit from the enforcer wallet

### DIFF
--- a/sidechain-orchestrator/api/deposit.go
+++ b/sidechain-orchestrator/api/deposit.go
@@ -53,6 +53,27 @@ func (h *WalletHandler) CreateDeposit(
 	}
 
 	treasurySats := oldTreasurySats + req.Msg.AmountSats
+
+	// The enforcer wallet takes no raw outputs, but it builds the whole M5
+	// itself from the slot and the destination.
+	if err := h.requireEngine(); err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	walletID, err := h.engine.ResolveWalletID(req.Msg.WalletId)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if backend, ok := h.engine.DepositBackendFor(walletID); ok {
+		txid, err := backend.CreateDeposit(ctx, slot, req.Msg.Destination, req.Msg.AmountSats, req.Msg.FeeSats)
+		if err != nil {
+			return nil, rpcError(err)
+		}
+		return connect.NewResponse(&wpb.CreateDepositResponse{
+			Txid:         txid,
+			TreasurySats: treasurySats,
+		}), nil
+	}
+
 	send, err := h.SendTransaction(ctx, connect.NewRequest(&wpb.SendTransactionRequest{
 		WalletId:       req.Msg.WalletId,
 		RawOutputs:     []*wpb.RawOutput{{ValueSats: treasurySats, ScriptHex: treasuryHex}},

--- a/sidechain-orchestrator/wallet/backend.go
+++ b/sidechain-orchestrator/wallet/backend.go
@@ -71,6 +71,13 @@ type Bip47Backend interface {
 	EnsureNotificationWatched(ctx context.Context, walletID string, notifKey WatchKey) error
 }
 
+// DepositBackend is a backend that builds the BIP300 M5 itself, so the caller
+// hands it the slot and the destination instead of a raw treasury output.
+type DepositBackend interface {
+	Backend
+	CreateDeposit(ctx context.Context, slot uint8, destination string, amountSats, feeSats int64) (string, error)
+}
+
 // ChainSource is wallet-agnostic chain access shared by all backends.
 type ChainSource interface {
 	GetRawTransaction(ctx context.Context, txid string) (*RawTransaction, error)

--- a/sidechain-orchestrator/wallet/enforcer_backend.go
+++ b/sidechain-orchestrator/wallet/enforcer_backend.go
@@ -267,6 +267,23 @@ func opReturnScript(payload []byte) []byte {
 	return append(script, payload...)
 }
 
+// CreateDeposit relays to the enforcer's deposit RPC: the daemon reads the
+// ctip, pays the new treasury output, and writes the destination OP_RETURN.
+func (p *EnforcerBackend) CreateDeposit(
+	ctx context.Context, slot uint8, destination string, amountSats, feeSats int64,
+) (string, error) {
+	resp, err := p.client.CreateDepositTransaction(ctx, connect.NewRequest(&enforcerpb.CreateDepositTransactionRequest{
+		SidechainId: wrapperspb.UInt32(uint32(slot)),
+		Address:     wrapperspb.String(destination),
+		ValueSats:   wrapperspb.UInt64(uint64(amountSats)),
+		FeeSats:     wrapperspb.UInt64(uint64(feeSats)),
+	}))
+	if err != nil {
+		return "", fmt.Errorf("enforcer/wallet: create deposit: %w", err)
+	}
+	return resp.Msg.GetTxid().GetHex().GetValue(), nil
+}
+
 // Send relays to the enforcer's all-in-one SendTransaction: the daemon does
 // coin selection, change, signing, and broadcast.
 func (p *EnforcerBackend) Send(ctx context.Context, walletID string, req SendRequest) (string, error) {

--- a/sidechain-orchestrator/wallet/enforcer_backend_test.go
+++ b/sidechain-orchestrator/wallet/enforcer_backend_test.go
@@ -22,11 +22,19 @@ import (
 type fakeEnforcerClient struct {
 	enforcerrpc.WalletServiceClient
 
-	balance  *enforcerpb.GetBalanceResponse
-	unspent  *enforcerpb.ListUnspentOutputsResponse
-	txs      *enforcerpb.ListTransactionsResponse
-	newAddr  string
-	lastSend *enforcerpb.SendTransactionRequest
+	balance     *enforcerpb.GetBalanceResponse
+	unspent     *enforcerpb.ListUnspentOutputsResponse
+	txs         *enforcerpb.ListTransactionsResponse
+	newAddr     string
+	lastSend    *enforcerpb.SendTransactionRequest
+	lastDeposit *enforcerpb.CreateDepositTransactionRequest
+}
+
+func (f *fakeEnforcerClient) CreateDepositTransaction(ctx context.Context, req *connect.Request[enforcerpb.CreateDepositTransactionRequest]) (*connect.Response[enforcerpb.CreateDepositTransactionResponse], error) {
+	f.lastDeposit = req.Msg
+	return connect.NewResponse(&enforcerpb.CreateDepositTransactionResponse{
+		Txid: reverseHex("ccdd"),
+	}), nil
 }
 
 func (f *fakeEnforcerClient) GetBalance(ctx context.Context, _ *connect.Request[enforcerpb.GetBalanceRequest]) (*connect.Response[enforcerpb.GetBalanceResponse], error) {
@@ -344,4 +352,18 @@ func TestEnforcerBackendRejectsUnexpressibleOutputs(t *testing.T) {
 		FixedFeeSats:   1000,
 	})
 	require.ErrorContains(t, err, "core or electrum wallet")
+}
+
+func TestEnforcerBackendCreateDeposit(t *testing.T) {
+	fake := &fakeEnforcerClient{}
+	backend := NewEnforcerBackend(fake)
+
+	txid, err := backend.CreateDeposit(context.Background(), 4, "s4_addr", 100_000, 1_000)
+	require.NoError(t, err)
+	assert.Equal(t, "ccdd", txid)
+
+	assert.Equal(t, uint32(4), fake.lastDeposit.GetSidechainId().GetValue())
+	assert.Equal(t, "s4_addr", fake.lastDeposit.GetAddress().GetValue())
+	assert.Equal(t, uint64(100_000), fake.lastDeposit.GetValueSats().GetValue())
+	assert.Equal(t, uint64(1_000), fake.lastDeposit.GetFeeSats().GetValue())
 }

--- a/sidechain-orchestrator/wallet/engine.go
+++ b/sidechain-orchestrator/wallet/engine.go
@@ -56,6 +56,16 @@ func (e *WalletEngine) Bip47BackendFor(walletID string) (Bip47Backend, bool) {
 	return b, ok
 }
 
+// DepositBackendFor returns the wallet's backend as a DepositBackend when it
+// builds the M5 itself. ok is false for backends that take raw deposit outputs.
+func (e *WalletEngine) DepositBackendFor(walletID string) (DepositBackend, bool) {
+	if r, ok := e.backend.(*BackendRouter); ok {
+		return r.DepositBackendFor(walletID)
+	}
+	b, ok := e.backend.(DepositBackend)
+	return b, ok
+}
+
 // ChainForWallet returns the chain source for a wallet's backend, dispatching
 // by wallet type so electrum wallets read/broadcast over Esplora.
 func (e *WalletEngine) ChainForWallet(walletID string) ChainSource {

--- a/sidechain-orchestrator/wallet/router.go
+++ b/sidechain-orchestrator/wallet/router.go
@@ -57,6 +57,18 @@ func (r *BackendRouter) Bip47BackendFor(walletID string) (Bip47Backend, bool) {
 	return b, ok
 }
 
+// DepositBackendFor returns the wallet's backend as a DepositBackend when it
+// builds the M5 itself (the enforcer). ok is false for the other backends, so
+// the caller builds the deposit outputs itself.
+func (r *BackendRouter) DepositBackendFor(walletID string) (DepositBackend, bool) {
+	p, err := r.pick(walletID)
+	if err != nil {
+		return nil, false
+	}
+	b, ok := p.(DepositBackend)
+	return b, ok
+}
+
 func (r *BackendRouter) pick(walletID string) (Backend, error) {
 	w := r.svc.GetWalletByID(walletID)
 	if w == nil {


### PR DESCRIPTION
CreateDeposit built the M5 by hand: a raw treasury output plus the old CTIP as an external input. The enforcer wallet takes neither, so a deposit from it always failed.

The enforcer daemon builds the whole M5 itself, so the handler hands it the slot and the destination instead. Core and electrum keep the raw-output path.