### PR TITLE
orchestrator, sail_ui: honest daemon status

### DIFF
--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -39,7 +39,8 @@ func NewHandler(orch *orchestrator.Orchestrator) *Handler {
 }
 
 func (h *Handler) ListBinaries(ctx context.Context, req *connect.Request[pb.ListBinariesRequest]) (*connect.Response[pb.ListBinariesResponse], error) {
-	pbStatuses := lo.Map(h.orch.ListAll(), func(s orchestrator.BinaryStatus, _ int) *pb.BinaryStatusMsg {
+	opts := orchestrator.DownloadOptions{ForceBackend: req.Msg.ForceBackend}
+	pbStatuses := lo.Map(h.orch.ListAllWithOptions(opts), func(s orchestrator.BinaryStatus, _ int) *pb.BinaryStatusMsg {
 		return statusToProto(s)
 	})
 	return connect.NewResponse(&pb.ListBinariesResponse{
@@ -48,7 +49,7 @@ func (h *Handler) ListBinaries(ctx context.Context, req *connect.Request[pb.List
 }
 
 func (h *Handler) GetBinaryStatus(ctx context.Context, req *connect.Request[pb.GetBinaryStatusRequest]) (*connect.Response[pb.GetBinaryStatusResponse], error) {
-	s := h.orch.Status(req.Msg.Name)
+	s := h.orch.StatusWithOptions(req.Msg.Name, orchestrator.DownloadOptions{ForceBackend: req.Msg.ForceBackend})
 	return connect.NewResponse(&pb.GetBinaryStatusResponse{
 		Status: statusToProto(s),
 	}), nil

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -545,7 +545,10 @@ func (x *StartupLogEntryMsg) GetMessage() string {
 }
 
 type ListBinariesRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Same lever as launch: when true, skip the UseTestSidechains resolver and
+	// report the prod backend for every layer-2 binary.
+	ForceBackend  bool `protobuf:"varint,1,opt,name=force_backend,json=forceBackend,proto3" json:"force_backend,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -578,6 +581,13 @@ func (x *ListBinariesRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ListBinariesRequest.ProtoReflect.Descriptor instead.
 func (*ListBinariesRequest) Descriptor() ([]byte, []int) {
 	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *ListBinariesRequest) GetForceBackend() bool {
+	if x != nil {
+		return x.ForceBackend
+	}
+	return false
 }
 
 type ListBinariesResponse struct {
@@ -625,8 +635,11 @@ func (x *ListBinariesResponse) GetBinaries() []*BinaryStatusMsg {
 }
 
 type GetBinaryStatusRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Same lever as launch: when true, skip the UseTestSidechains resolver and
+	// report the prod backend.
+	ForceBackend  bool `protobuf:"varint,2,opt,name=force_backend,json=forceBackend,proto3" json:"force_backend,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -666,6 +679,13 @@ func (x *GetBinaryStatusRequest) GetName() string {
 		return x.Name
 	}
 	return ""
+}
+
+func (x *GetBinaryStatusRequest) GetForceBackend() bool {
+	if x != nil {
+		return x.ForceBackend
+	}
+	return false
 }
 
 type GetBinaryStatusResponse struct {
@@ -4207,12 +4227,14 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x19downloaded_timestamp_unix\x18\x1a \x01(\x03R\x17downloadedTimestampUnix\"U\n" +
 	"\x12StartupLogEntryMsg\x12%\n" +
 	"\x0etimestamp_unix\x18\x01 \x01(\x03R\rtimestampUnix\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"\x15\n" +
-	"\x13ListBinariesRequest\"T\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\":\n" +
+	"\x13ListBinariesRequest\x12#\n" +
+	"\rforce_backend\x18\x01 \x01(\bR\fforceBackend\"T\n" +
 	"\x14ListBinariesResponse\x12<\n" +
-	"\bbinaries\x18\x01 \x03(\v2 .orchestrator.v1.BinaryStatusMsgR\bbinaries\",\n" +
+	"\bbinaries\x18\x01 \x03(\v2 .orchestrator.v1.BinaryStatusMsgR\bbinaries\"Q\n" +
 	"\x16GetBinaryStatusRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"S\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12#\n" +
+	"\rforce_backend\x18\x02 \x01(\bR\fforceBackend\"S\n" +
 	"\x17GetBinaryStatusResponse\x128\n" +
 	"\x06status\x18\x01 \x01(\v2 .orchestrator.v1.BinaryStatusMsgR\x06status\"R\n" +
 	"\x17GetBinaryVersionRequest\x12\x12\n" +

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -547,33 +547,7 @@ func (o *Orchestrator) Download(ctx context.Context, name string, force bool, op
 	if err != nil {
 		return nil, err
 	}
-	ch, err := o.download.DownloadWithOptions(ctx, config, o.Network, force, opts)
-	if err != nil {
-		return nil, err
-	}
-	return o.refreshReleaseWhenDone(ctx, config, ch), nil
-}
-
-// refreshReleaseWhenDone re-probes a binary once its download ends. The cached
-// check holds the old file's timestamp, and a ten minute wait would offer the
-// same update again.
-func (o *Orchestrator) refreshReleaseWhenDone(ctx context.Context, config BinaryConfig, in <-chan DownloadProgress) <-chan DownloadProgress {
-	if o.releases == nil {
-		return in
-	}
-	out := make(chan DownloadProgress, cap(in))
-	go func() {
-		defer close(out)
-		for p := range in {
-			select {
-			case out <- p:
-			case <-ctx.Done():
-				return
-			}
-		}
-		o.releases.Refresh(context.WithoutCancel(ctx), config, o.CurrentNetwork())
-	}()
-	return out
+	return o.download.DownloadWithOptions(ctx, config, o.Network, force, opts)
 }
 
 // Start starts a binary with the given args and env.
@@ -664,6 +638,13 @@ func (o *Orchestrator) stopSidechainGUI(ctx context.Context, name string, force 
 
 // Status returns the current status of a binary.
 func (o *Orchestrator) Status(name string) BinaryStatus {
+	return o.StatusWithOptions(name, DownloadOptions{})
+}
+
+// StatusWithOptions returns the current status of a binary. ForceBackend skips
+// the test sidechain resolver, so a sidechain app reports the daemon it runs
+// instead of the test build BitWindow launches.
+func (o *Orchestrator) StatusWithOptions(name string, opts DownloadOptions) BinaryStatus {
 	config, err := o.getConfig(name)
 	if err != nil {
 		return BinaryStatus{Name: name, Error: err.Error()}
@@ -676,7 +657,7 @@ func (o *Orchestrator) Status(name string) BinaryStatus {
 			binPath = CoreBinaryPath(o.DataDir, v, config.BinaryName)
 		}
 	}
-	if o.process.SidechainVariant != nil {
+	if o.process.SidechainVariant != nil && !opts.ForceBackend {
 		if sv, ok := o.process.SidechainVariant(config); ok {
 			binPath = TestSidechainBinaryPath(o.DataDir, sv.BinaryName)
 		}
@@ -702,7 +683,7 @@ func (o *Orchestrator) Status(name string) BinaryStatus {
 	}
 
 	if o.releases != nil {
-		if check, ok := o.releases.Check(config, o.CurrentNetwork()); ok {
+		if check, ok := o.releases.Check(config, o.CurrentNetwork(), binPath); ok {
 			status.UpdateAvailable = check.UpdateAvailable()
 			status.RemoteTimestamp = check.Remote
 			status.LocalTimestamp = check.Local
@@ -744,6 +725,12 @@ func (o *Orchestrator) Status(name string) BinaryStatus {
 // ListAll returns the status of every configured binary,
 // sorted by chain layer (L1 first) then name.
 func (o *Orchestrator) ListAll() []BinaryStatus {
+	return o.ListAllWithOptions(DownloadOptions{})
+}
+
+// ListAllWithOptions is ListAll with the force-backend lever of
+// StatusWithOptions.
+func (o *Orchestrator) ListAllWithOptions(opts DownloadOptions) []BinaryStatus {
 	// Snapshot names and release before Status: it re-acquires o.mu via
 	// getConfig, and a queued writer would deadlock the nested read lock.
 	o.mu.RLock()
@@ -755,7 +742,7 @@ func (o *Orchestrator) ListAll() []BinaryStatus {
 
 	statuses := make([]BinaryStatus, 0, len(names))
 	for _, name := range names {
-		statuses = append(statuses, o.Status(name))
+		statuses = append(statuses, o.StatusWithOptions(name, opts))
 	}
 	sort.Slice(statuses, func(i, j int) bool {
 		if statuses[i].ChainLayer != statuses[j].ChainLayer {

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -651,17 +651,21 @@ func (o *Orchestrator) StatusWithOptions(name string, opts DownloadOptions) Bina
 	}
 
 	proc := o.process.Get(name)
-	binPath := BinaryPath(o.DataDir, config.BinaryName)
+	// requestedPath is the download this caller's own options select. A running
+	// process can come from the other one — a sidechain app boots its prod
+	// backend under the same name — so the release check must not read its path.
+	requestedPath := BinaryPath(o.DataDir, config.BinaryName)
 	if config.IsMainchainCore() && o.Settings != nil {
 		if v, ok := config.Variants[o.Settings.CoreVariant()]; ok {
-			binPath = CoreBinaryPath(o.DataDir, v, config.BinaryName)
+			requestedPath = CoreBinaryPath(o.DataDir, v, config.BinaryName)
 		}
 	}
 	if o.process.SidechainVariant != nil && !opts.ForceBackend {
 		if sv, ok := o.process.SidechainVariant(config); ok {
-			binPath = TestSidechainBinaryPath(o.DataDir, sv.BinaryName)
+			requestedPath = TestSidechainBinaryPath(o.DataDir, sv.BinaryName)
 		}
 	}
+	binPath := requestedPath
 	if proc != nil && proc.BinPath != "" {
 		binPath = proc.BinPath
 	}
@@ -683,7 +687,7 @@ func (o *Orchestrator) StatusWithOptions(name string, opts DownloadOptions) Bina
 	}
 
 	if o.releases != nil {
-		if check, ok := o.releases.Check(config, o.CurrentNetwork(), binPath); ok {
+		if check, ok := o.releases.Check(config, o.CurrentNetwork(), requestedPath); ok {
 			status.UpdateAvailable = check.UpdateAvailable()
 			status.RemoteTimestamp = check.Remote
 			status.LocalTimestamp = check.Local

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -191,7 +191,11 @@ message StartupLogEntryMsg {
 
 // ListBinaries
 
-message ListBinariesRequest {}
+message ListBinariesRequest {
+  // Same lever as launch: when true, skip the UseTestSidechains resolver and
+  // report the prod backend for every layer-2 binary.
+  bool force_backend = 1;
+}
 
 message ListBinariesResponse {
   repeated BinaryStatusMsg binaries = 1;
@@ -201,6 +205,9 @@ message ListBinariesResponse {
 
 message GetBinaryStatusRequest {
   string name = 1;
+  // Same lever as launch: when true, skip the UseTestSidechains resolver and
+  // report the prod backend.
+  bool force_backend = 2;
 }
 
 message GetBinaryStatusResponse {

--- a/sidechain-orchestrator/release_check.go
+++ b/sidechain-orchestrator/release_check.go
@@ -23,9 +23,6 @@ type ReleaseCheck struct {
 	Remote time.Time
 	// Local is the mtime of the binary on disk, zero when not downloaded.
 	Local time.Time
-	// Source names the download the probe read. Every Core variant writes to
-	// the same binary path, so the download key is what separates them.
-	Source string
 }
 
 // UpdateAvailable reports whether the published download is newer than the
@@ -35,18 +32,20 @@ func (c ReleaseCheck) UpdateAvailable() bool {
 	return !c.Remote.IsZero() && !c.Local.IsZero() && c.Remote.After(c.Local)
 }
 
-// ReleaseChecker tracks whether a newer build of each binary is published.
+// ReleaseChecker tracks when each published binary was last built.
 //
 // The published archives keep a fixed "latest" name, so only the server's
 // Last-Modified separates one release from the next. Probes run on a timer and
 // land in a cache, because status is read far more often than releases ship.
+// Only the remote side is cached: the local mtime is a stat, and a stale one
+// would offer an update for a binary that was replaced seconds ago.
 type ReleaseChecker struct {
 	client    *http.Client
 	log       zerolog.Logger
 	downloads *DownloadManager
 
 	mu     sync.RWMutex
-	checks map[string]ReleaseCheck
+	remote map[string]time.Time
 }
 
 // NewReleaseChecker reads every download through the manager, so a Core
@@ -57,7 +56,7 @@ func NewReleaseChecker(downloads *DownloadManager, log zerolog.Logger) *ReleaseC
 		client:    &http.Client{Timeout: releaseCheckTimeout},
 		log:       log,
 		downloads: downloads,
-		checks:    make(map[string]ReleaseCheck),
+		remote:    make(map[string]time.Time),
 	}
 }
 
@@ -74,20 +73,37 @@ func (o *Orchestrator) StartReleaseChecks(ctx context.Context) {
 	go o.releases.Run(ctx, func() []BinaryConfig { return lo.Values(o.Configs()) }, o.CurrentNetwork)
 }
 
-// Check returns the cached result for a binary. ok is false until a probe runs,
-// and false when the cached probe describes a different file: a Core variant or
-// test sidechain change resolves another path, and the previous target's
-// timestamps say nothing about the new one.
-func (r *ReleaseChecker) Check(config BinaryConfig, network string) (ReleaseCheck, bool) {
-	target := r.downloads.ResolveTarget(config, network, DownloadOptions{})
-
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	check, ok := r.checks[config.Name]
-	if !ok || check.Source != target.InFlightKey {
+// Check compares the published build against the binary at binPath. ok is
+// false until a probe covers that path: a test sidechain build and the prod
+// backend are two downloads of one binary, and the other one's timestamp says
+// nothing about this file.
+func (r *ReleaseChecker) Check(config BinaryConfig, network, binPath string) (ReleaseCheck, bool) {
+	target, ok := lo.Find(r.targets(config, network), func(t DownloadTarget) bool {
+		return t.BinPath == binPath
+	})
+	if !ok {
 		return ReleaseCheck{}, false
 	}
-	return check, true
+
+	r.mu.RLock()
+	remote, ok := r.remote[target.InFlightKey]
+	r.mu.RUnlock()
+	if !ok {
+		return ReleaseCheck{}, false
+	}
+	return ReleaseCheck{Remote: remote, Local: localModTime(binPath)}, true
+}
+
+// targets lists every download that writes a binary for this config. A layer-2
+// binary with the test build enabled has two: the test build the launcher picks
+// and the prod backend a sidechain app runs.
+func (r *ReleaseChecker) targets(config BinaryConfig, network string) []DownloadTarget {
+	targets := []DownloadTarget{r.downloads.ResolveTarget(config, network, DownloadOptions{})}
+	backend := r.downloads.ResolveTarget(config, network, DownloadOptions{ForceBackend: true})
+	if backend.InFlightKey != targets[0].InFlightKey {
+		targets = append(targets, backend)
+	}
+	return targets
 }
 
 // Run probes every binary at once, then again on each tick, until ctx ends.
@@ -121,30 +137,23 @@ func (r *ReleaseChecker) Run(ctx context.Context, configs func() []BinaryConfig,
 	}
 }
 
-// Refresh probes one binary and stores the result. Call it after a download so
-// the update button clears at once instead of at the next tick.
+// Refresh probes every download of one binary and stores the published times.
 func (r *ReleaseChecker) Refresh(ctx context.Context, config BinaryConfig, network string) {
-	target := r.downloads.ResolveTarget(config, network, DownloadOptions{})
-
-	var check ReleaseCheck
-	remote, err := r.remoteTime(ctx, target)
-	if err != nil {
-		// A probe that fails leaves the binary with no remote time, which reads
-		// as "no update". Keep the local time so the reason stays visible.
-		r.log.Debug().Err(err).Str("binary", config.Name).Msg("release check failed")
-	} else {
-		check.Remote = remote
+	for _, target := range r.targets(config, network) {
+		remote, err := r.remoteTime(ctx, target)
+		if err != nil {
+			// A probe that fails leaves the binary with no remote time, which
+			// reads as "no update".
+			r.log.Debug().Err(err).Str("binary", config.Name).Msg("release check failed")
+			r.mu.Lock()
+			delete(r.remote, target.InFlightKey)
+			r.mu.Unlock()
+			continue
+		}
+		r.mu.Lock()
+		r.remote[target.InFlightKey] = remote
+		r.mu.Unlock()
 	}
-
-	// Read the mtime after the probe. A download that lands during the probe
-	// would otherwise let this write restore the pre-download time, and the
-	// update button would come back until the next tick.
-	check.Local = localModTime(target.BinPath)
-	check.Source = target.InFlightKey
-
-	r.mu.Lock()
-	r.checks[config.Name] = check
-	r.mu.Unlock()
 }
 
 // localModTime is the mtime of the binary on disk, zero when it is not there.

--- a/sidechain-orchestrator/release_check_test.go
+++ b/sidechain-orchestrator/release_check_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -333,4 +334,52 @@ func TestReleaseCheckerReadsTheLocalTimeLive(t *testing.T) {
 	check, ok = checker.Check(config, "signet", binPath)
 	require.True(t, ok)
 	assert.False(t, check.UpdateAvailable(), "the button must clear as soon as the file changes")
+}
+
+// A sidechain app boots its production backend under the same name, so the
+// running process can be the other download. The check must follow the
+// caller's own options, because that is what its update button will replace.
+func TestStatusChecksTheRequestedDownloadNotTheRunningOne(t *testing.T) {
+	testBuilt := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	prodBuilt := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		built := prodBuilt
+		if strings.Contains(r.URL.Path, "test") {
+			built = testBuilt
+		}
+		w.Header().Set("Last-Modified", built.Format(http.TimeFormat))
+	}))
+	defer server.Close()
+
+	dataDir, bwDir := t.TempDir(), t.TempDir()
+	cfg := makeSidechainConfig(server.URL + "/")
+	o := New(dataDir, "signet", bwDir, []BinaryConfig{cfg}, testLogger(t))
+	require.NoError(t, o.SetTestSidechains(context.Background(), true))
+
+	// The test build is older than its release, so an update is waiting. The
+	// production backend is newer than its release, so it has none.
+	testPath := TestSidechainBinaryPath(dataDir, cfg.AltBinaryName)
+	prodPath := BinaryPath(dataDir, cfg.BinaryName)
+	for path, built := range map[string]time.Time{
+		testPath: testBuilt.Add(-time.Hour),
+		prodPath: prodBuilt.Add(time.Hour),
+	} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("bin"), 0o755))
+		require.NoError(t, os.Chtimes(path, built, built))
+	}
+
+	o.releases.Refresh(context.Background(), cfg, "signet")
+
+	// The sidechain app launched the production backend under the same name.
+	o.process.mu.Lock()
+	o.process.processes[cfg.Name] = &ManagedProcess{Config: cfg, Pid: 1, BinPath: prodPath}
+	o.process.mu.Unlock()
+
+	status := o.Status(cfg.Name)
+	assert.True(t, status.UpdateAvailable, "a default request must read the test build it would replace")
+
+	backend := o.StatusWithOptions(cfg.Name, DownloadOptions{ForceBackend: true})
+	assert.False(t, backend.UpdateAvailable, "force_backend must read the production build")
 }

--- a/sidechain-orchestrator/release_check_test.go
+++ b/sidechain-orchestrator/release_check_test.go
@@ -46,7 +46,7 @@ func TestReleaseCheckerComparesLastModified(t *testing.T) {
 	// Downloaded after the release: nothing to update.
 	require.NoError(t, os.Chtimes(binPath, published.Add(time.Hour), published.Add(time.Hour)))
 	checker.Refresh(context.Background(), config, "signet")
-	check, ok := checker.Check(config, "signet")
+	check, ok := checker.Check(config, "signet", binPath)
 	require.True(t, ok)
 	assert.False(t, check.UpdateAvailable())
 	assert.Equal(t, published, check.Remote.UTC())
@@ -54,7 +54,7 @@ func TestReleaseCheckerComparesLastModified(t *testing.T) {
 	// Downloaded before the release: an update is waiting.
 	require.NoError(t, os.Chtimes(binPath, published.Add(-time.Hour), published.Add(-time.Hour)))
 	checker.Refresh(context.Background(), config, "signet")
-	check, ok = checker.Check(config, "signet")
+	check, ok = checker.Check(config, "signet", binPath)
 	require.True(t, ok)
 	assert.True(t, check.UpdateAvailable())
 }
@@ -76,11 +76,8 @@ func TestReleaseCheckerStaysQuietWhenTheProbeFails(t *testing.T) {
 	checker := NewReleaseChecker(NewDownloadManager(dataDir, "", zerolog.Nop()), zerolog.Nop())
 	checker.Refresh(context.Background(), config, "signet")
 
-	check, ok := checker.Check(config, "signet")
-	require.True(t, ok)
-	assert.False(t, check.UpdateAvailable())
-	assert.True(t, check.Remote.IsZero())
-	assert.False(t, check.Local.IsZero(), "the local time still reads off disk")
+	_, ok := checker.Check(config, "signet", binPath)
+	assert.False(t, ok, "a failed probe leaves nothing to compare against")
 }
 
 // A binary that was never downloaded has nothing to compare against.
@@ -91,11 +88,12 @@ func TestReleaseCheckerNeedsALocalBinary(t *testing.T) {
 	}))
 	defer server.Close()
 
-	checker := NewReleaseChecker(NewDownloadManager(t.TempDir(), "", zerolog.Nop()), zerolog.Nop())
+	dataDir := t.TempDir()
+	checker := NewReleaseChecker(NewDownloadManager(dataDir, "", zerolog.Nop()), zerolog.Nop())
 	config := releaseTestConfig(server.URL + "/")
 	checker.Refresh(context.Background(), config, "signet")
 
-	check, ok := checker.Check(config, "signet")
+	check, ok := checker.Check(config, "signet", BinaryPath(dataDir, config.BinaryName))
 	require.True(t, ok)
 	assert.False(t, check.UpdateAvailable())
 	assert.True(t, check.Local.IsZero())
@@ -129,7 +127,7 @@ func TestReleaseCheckerFollowsTheCoreVariant(t *testing.T) {
 	checker := NewReleaseChecker(downloads, zerolog.Nop())
 	checker.Refresh(context.Background(), config, "signet")
 
-	check, ok := checker.Check(config, "signet")
+	check, ok := checker.Check(config, "signet", binPath)
 	require.True(t, ok)
 	assert.True(t, check.UpdateAvailable(), "the variant download decides, not the empty config")
 }
@@ -168,7 +166,7 @@ func TestReleaseCheckerResolvesAGitHubAsset(t *testing.T) {
 	checker := NewReleaseChecker(NewDownloadManager(dataDir, "", zerolog.Nop()), zerolog.Nop())
 	checker.Refresh(context.Background(), config, "signet")
 
-	check, ok := checker.Check(config, "signet")
+	check, ok := checker.Check(config, "signet", binPath)
 	require.True(t, ok)
 	assert.Equal(t, "/assets/zside.zip", assetPath, "the probe must hit the resolved asset")
 	assert.True(t, check.UpdateAvailable())
@@ -207,7 +205,7 @@ func TestReleaseCheckerDropsTheCheckWhenTheVariantChanges(t *testing.T) {
 	checker := NewReleaseChecker(downloads, zerolog.Nop())
 	checker.Refresh(context.Background(), config, "signet")
 
-	check, ok := checker.Check(config, "signet")
+	check, ok := checker.Check(config, "signet", binPath)
 	require.True(t, ok)
 	require.True(t, check.UpdateAvailable())
 
@@ -215,7 +213,7 @@ func TestReleaseCheckerDropsTheCheckWhenTheVariantChanges(t *testing.T) {
 	knots := newVariant("knots")
 	downloads.CoreVariant = func() (CoreVariantSpec, bool) { return knots, true }
 
-	_, ok = checker.Check(config, "signet")
+	_, ok = checker.Check(config, "signet", binPath)
 	assert.False(t, ok, "the patched variant's check must not describe knots")
 }
 
@@ -257,7 +255,82 @@ func TestReleaseCheckerRunFollowsANetworkSwap(t *testing.T) {
 	network = "regtest"
 	checker.Refresh(ctx, config, networkOf())
 
-	check, ok := checker.Check(config, "regtest")
+	check, ok := checker.Check(config, "regtest", BinaryPath(dataDir, config.BinaryName))
 	require.True(t, ok, "a refresh after the swap must answer for the new network")
 	assert.False(t, check.Remote.IsZero())
+}
+
+// A layer-2 binary with the test build enabled has two downloads: the test
+// build BitWindow launches and the prod backend a sidechain app runs. Each one
+// must answer for its own file, or the app that updates the backend keeps
+// reading the test build's age and offers the same update forever.
+func TestReleaseCheckerSeparatesTheTestBuildFromTheBackend(t *testing.T) {
+	published := time.Date(2026, 8, 6, 17, 44, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Last-Modified", published.Format(http.TimeFormat))
+	}))
+	defer server.Close()
+
+	dataDir := t.TempDir()
+	downloads := NewDownloadManager(dataDir, "", zerolog.Nop())
+	config := makeSidechainConfig(server.URL + "/")
+	downloads.SidechainVariant = func(c BinaryConfig) (sidechainVariantSpec, bool) {
+		return sidechainVariantSpec{
+			BinaryName: c.AltBinaryName,
+			BaseURL:    c.AltBaseURL("default"),
+			FileName:   fileForPlatform(c.AltFiles),
+		}, true
+	}
+
+	testPath := TestSidechainBinaryPath(dataDir, config.AltBinaryName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(testPath), 0o755))
+	require.NoError(t, os.WriteFile(testPath, []byte("test build"), 0o755))
+	require.NoError(t, os.Chtimes(testPath, published.Add(-time.Hour), published.Add(-time.Hour)))
+
+	backendPath := BinaryPath(dataDir, config.BinaryName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(backendPath), 0o755))
+	require.NoError(t, os.WriteFile(backendPath, []byte("backend"), 0o755))
+	require.NoError(t, os.Chtimes(backendPath, published.Add(time.Hour), published.Add(time.Hour)))
+
+	checker := NewReleaseChecker(downloads, zerolog.Nop())
+	checker.Refresh(context.Background(), config, "default")
+
+	stale, ok := checker.Check(config, "default", testPath)
+	require.True(t, ok)
+	assert.True(t, stale.UpdateAvailable(), "the test build predates the release")
+
+	fresh, ok := checker.Check(config, "default", backendPath)
+	require.True(t, ok)
+	assert.False(t, fresh.UpdateAvailable(), "the backend is newer than the release")
+}
+
+// The local mtime reads off disk on every call. A cached one would keep
+// offering the update the user already took until the next probe.
+func TestReleaseCheckerReadsTheLocalTimeLive(t *testing.T) {
+	published := time.Date(2026, 8, 6, 17, 44, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Last-Modified", published.Format(http.TimeFormat))
+	}))
+	defer server.Close()
+
+	dataDir := t.TempDir()
+	config := releaseTestConfig(server.URL + "/")
+	binPath := BinaryPath(dataDir, config.BinaryName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(binPath), 0o755))
+	require.NoError(t, os.WriteFile(binPath, []byte("binary"), 0o755))
+	require.NoError(t, os.Chtimes(binPath, published.Add(-time.Hour), published.Add(-time.Hour)))
+
+	checker := NewReleaseChecker(NewDownloadManager(dataDir, "", zerolog.Nop()), zerolog.Nop())
+	checker.Refresh(context.Background(), config, "signet")
+
+	check, ok := checker.Check(config, "signet", binPath)
+	require.True(t, ok)
+	require.True(t, check.UpdateAvailable())
+
+	// The download lands. No probe runs in between.
+	require.NoError(t, os.Chtimes(binPath, published.Add(time.Hour), published.Add(time.Hour)))
+
+	check, ok = checker.Check(config, "signet", binPath)
+	require.True(t, ok)
+	assert.False(t, check.UpdateAvailable(), "the button must clear as soon as the file changes")
 }

--- a/sidechain_core/lib/gen/orchestrator/v1/bitcoin_conf.pbserver.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/bitcoin_conf.pbserver.dart
@@ -15,35 +15,35 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-import 'bitcoin_conf.pb.dart' as $6;
+import 'bitcoin_conf.pb.dart' as $7;
 import 'bitcoin_conf.pbjson.dart';
 
 export 'bitcoin_conf.pb.dart';
 
 abstract class BitcoinConfServiceBase extends $pb.GeneratedService {
-  $async.Future<$6.GetBitcoinConfigResponse> getBitcoinConfig(
-      $pb.ServerContext ctx, $6.GetBitcoinConfigRequest request);
-  $async.Future<$6.NetworkChangePlan> prepareNetworkChange(
-      $pb.ServerContext ctx, $6.PrepareNetworkChangeRequest request);
-  $async.Future<$6.SetBitcoinConfigNetworkResponse> setBitcoinConfigNetwork(
-      $pb.ServerContext ctx, $6.SetBitcoinConfigNetworkRequest request);
-  $async.Future<$6.SetBitcoinConfigDataDirResponse> setBitcoinConfigDataDir(
-      $pb.ServerContext ctx, $6.SetBitcoinConfigDataDirRequest request);
-  $async.Future<$6.WriteBitcoinConfigResponse> writeBitcoinConfig(
-      $pb.ServerContext ctx, $6.WriteBitcoinConfigRequest request);
+  $async.Future<$7.GetBitcoinConfigResponse> getBitcoinConfig(
+      $pb.ServerContext ctx, $7.GetBitcoinConfigRequest request);
+  $async.Future<$7.NetworkChangePlan> prepareNetworkChange(
+      $pb.ServerContext ctx, $7.PrepareNetworkChangeRequest request);
+  $async.Future<$7.SetBitcoinConfigNetworkResponse> setBitcoinConfigNetwork(
+      $pb.ServerContext ctx, $7.SetBitcoinConfigNetworkRequest request);
+  $async.Future<$7.SetBitcoinConfigDataDirResponse> setBitcoinConfigDataDir(
+      $pb.ServerContext ctx, $7.SetBitcoinConfigDataDirRequest request);
+  $async.Future<$7.WriteBitcoinConfigResponse> writeBitcoinConfig(
+      $pb.ServerContext ctx, $7.WriteBitcoinConfigRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
       case 'GetBitcoinConfig':
-        return $6.GetBitcoinConfigRequest();
+        return $7.GetBitcoinConfigRequest();
       case 'PrepareNetworkChange':
-        return $6.PrepareNetworkChangeRequest();
+        return $7.PrepareNetworkChangeRequest();
       case 'SetBitcoinConfigNetwork':
-        return $6.SetBitcoinConfigNetworkRequest();
+        return $7.SetBitcoinConfigNetworkRequest();
       case 'SetBitcoinConfigDataDir':
-        return $6.SetBitcoinConfigDataDirRequest();
+        return $7.SetBitcoinConfigDataDirRequest();
       case 'WriteBitcoinConfig':
-        return $6.WriteBitcoinConfigRequest();
+        return $7.WriteBitcoinConfigRequest();
       default:
         throw $core.ArgumentError('Unknown method: $methodName');
     }
@@ -53,15 +53,15 @@ abstract class BitcoinConfServiceBase extends $pb.GeneratedService {
       $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
       case 'GetBitcoinConfig':
-        return this.getBitcoinConfig(ctx, request as $6.GetBitcoinConfigRequest);
+        return this.getBitcoinConfig(ctx, request as $7.GetBitcoinConfigRequest);
       case 'PrepareNetworkChange':
-        return this.prepareNetworkChange(ctx, request as $6.PrepareNetworkChangeRequest);
+        return this.prepareNetworkChange(ctx, request as $7.PrepareNetworkChangeRequest);
       case 'SetBitcoinConfigNetwork':
-        return this.setBitcoinConfigNetwork(ctx, request as $6.SetBitcoinConfigNetworkRequest);
+        return this.setBitcoinConfigNetwork(ctx, request as $7.SetBitcoinConfigNetworkRequest);
       case 'SetBitcoinConfigDataDir':
-        return this.setBitcoinConfigDataDir(ctx, request as $6.SetBitcoinConfigDataDirRequest);
+        return this.setBitcoinConfigDataDir(ctx, request as $7.SetBitcoinConfigDataDirRequest);
       case 'WriteBitcoinConfig':
-        return this.writeBitcoinConfig(ctx, request as $6.WriteBitcoinConfigRequest);
+        return this.writeBitcoinConfig(ctx, request as $7.WriteBitcoinConfigRequest);
       default:
         throw $core.ArgumentError('Unknown method: $methodName');
     }

--- a/sidechain_core/lib/gen/orchestrator/v1/enforcer_conf.pbserver.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/enforcer_conf.pbserver.dart
@@ -15,27 +15,27 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-import 'enforcer_conf.pb.dart' as $7;
+import 'enforcer_conf.pb.dart' as $8;
 import 'enforcer_conf.pbjson.dart';
 
 export 'enforcer_conf.pb.dart';
 
 abstract class EnforcerConfServiceBase extends $pb.GeneratedService {
-  $async.Future<$7.GetEnforcerConfigResponse> getEnforcerConfig(
-      $pb.ServerContext ctx, $7.GetEnforcerConfigRequest request);
-  $async.Future<$7.WriteEnforcerConfigResponse> writeEnforcerConfig(
-      $pb.ServerContext ctx, $7.WriteEnforcerConfigRequest request);
-  $async.Future<$7.SyncNodeRpcFromBitcoinConfResponse> syncNodeRpcFromBitcoinConf(
-      $pb.ServerContext ctx, $7.SyncNodeRpcFromBitcoinConfRequest request);
+  $async.Future<$8.GetEnforcerConfigResponse> getEnforcerConfig(
+      $pb.ServerContext ctx, $8.GetEnforcerConfigRequest request);
+  $async.Future<$8.WriteEnforcerConfigResponse> writeEnforcerConfig(
+      $pb.ServerContext ctx, $8.WriteEnforcerConfigRequest request);
+  $async.Future<$8.SyncNodeRpcFromBitcoinConfResponse> syncNodeRpcFromBitcoinConf(
+      $pb.ServerContext ctx, $8.SyncNodeRpcFromBitcoinConfRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
       case 'GetEnforcerConfig':
-        return $7.GetEnforcerConfigRequest();
+        return $8.GetEnforcerConfigRequest();
       case 'WriteEnforcerConfig':
-        return $7.WriteEnforcerConfigRequest();
+        return $8.WriteEnforcerConfigRequest();
       case 'SyncNodeRpcFromBitcoinConf':
-        return $7.SyncNodeRpcFromBitcoinConfRequest();
+        return $8.SyncNodeRpcFromBitcoinConfRequest();
       default:
         throw $core.ArgumentError('Unknown method: $methodName');
     }
@@ -45,11 +45,11 @@ abstract class EnforcerConfServiceBase extends $pb.GeneratedService {
       $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
       case 'GetEnforcerConfig':
-        return this.getEnforcerConfig(ctx, request as $7.GetEnforcerConfigRequest);
+        return this.getEnforcerConfig(ctx, request as $8.GetEnforcerConfigRequest);
       case 'WriteEnforcerConfig':
-        return this.writeEnforcerConfig(ctx, request as $7.WriteEnforcerConfigRequest);
+        return this.writeEnforcerConfig(ctx, request as $8.WriteEnforcerConfigRequest);
       case 'SyncNodeRpcFromBitcoinConf':
-        return this.syncNodeRpcFromBitcoinConf(ctx, request as $7.SyncNodeRpcFromBitcoinConfRequest);
+        return this.syncNodeRpcFromBitcoinConf(ctx, request as $8.SyncNodeRpcFromBitcoinConfRequest);
       default:
         throw $core.ArgumentError('Unknown method: $methodName');
     }

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -573,7 +573,15 @@ class StartupLogEntryMsg extends $pb.GeneratedMessage {
 }
 
 class ListBinariesRequest extends $pb.GeneratedMessage {
-  factory ListBinariesRequest() => create();
+  factory ListBinariesRequest({
+    $core.bool? forceBackend,
+  }) {
+    final $result = create();
+    if (forceBackend != null) {
+      $result.forceBackend = forceBackend;
+    }
+    return $result;
+  }
   ListBinariesRequest._() : super();
   factory ListBinariesRequest.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
@@ -583,6 +591,7 @@ class ListBinariesRequest extends $pb.GeneratedMessage {
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListBinariesRequest',
       package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'forceBackend')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -605,6 +614,20 @@ class ListBinariesRequest extends $pb.GeneratedMessage {
   static ListBinariesRequest getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListBinariesRequest>(create);
   static ListBinariesRequest? _defaultInstance;
+
+  /// Same lever as launch: when true, skip the UseTestSidechains resolver and
+  /// report the prod backend for every layer-2 binary.
+  @$pb.TagNumber(1)
+  $core.bool get forceBackend => $_getBF(0);
+  @$pb.TagNumber(1)
+  set forceBackend($core.bool v) {
+    $_setBool(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasForceBackend() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearForceBackend() => clearField(1);
 }
 
 class ListBinariesResponse extends $pb.GeneratedMessage {
@@ -657,10 +680,14 @@ class ListBinariesResponse extends $pb.GeneratedMessage {
 class GetBinaryStatusRequest extends $pb.GeneratedMessage {
   factory GetBinaryStatusRequest({
     $core.String? name,
+    $core.bool? forceBackend,
   }) {
     final $result = create();
     if (name != null) {
       $result.name = name;
+    }
+    if (forceBackend != null) {
+      $result.forceBackend = forceBackend;
     }
     return $result;
   }
@@ -674,6 +701,7 @@ class GetBinaryStatusRequest extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBinaryStatusRequest',
       package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOB(2, _omitFieldNames ? '' : 'forceBackend')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -708,6 +736,20 @@ class GetBinaryStatusRequest extends $pb.GeneratedMessage {
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
   void clearName() => clearField(1);
+
+  /// Same lever as launch: when true, skip the UseTestSidechains resolver and
+  /// report the prod backend.
+  @$pb.TagNumber(2)
+  $core.bool get forceBackend => $_getBF(1);
+  @$pb.TagNumber(2)
+  set forceBackend($core.bool v) {
+    $_setBool(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasForceBackend() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearForceBackend() => clearField(2);
 }
 
 class GetBinaryStatusResponse extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -160,10 +160,15 @@ final $typed_data.Uint8List startupLogEntryMsgDescriptor =
 @$core.Deprecated('Use listBinariesRequestDescriptor instead')
 const ListBinariesRequest$json = {
   '1': 'ListBinariesRequest',
+  '2': [
+    {'1': 'force_backend', '3': 1, '4': 1, '5': 8, '10': 'forceBackend'},
+  ],
 };
 
 /// Descriptor for `ListBinariesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listBinariesRequestDescriptor = $convert.base64Decode('ChNMaXN0QmluYXJpZXNSZXF1ZXN0');
+final $typed_data.Uint8List listBinariesRequestDescriptor =
+    $convert.base64Decode('ChNMaXN0QmluYXJpZXNSZXF1ZXN0EiMKDWZvcmNlX2JhY2tlbmQYASABKAhSDGZvcmNlQmFja2'
+        'VuZA==');
 
 @$core.Deprecated('Use listBinariesResponseDescriptor instead')
 const ListBinariesResponse$json = {
@@ -183,12 +188,14 @@ const GetBinaryStatusRequest$json = {
   '1': 'GetBinaryStatusRequest',
   '2': [
     {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'force_backend', '3': 2, '4': 1, '5': 8, '10': 'forceBackend'},
   ],
 };
 
 /// Descriptor for `GetBinaryStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List getBinaryStatusRequestDescriptor =
-    $convert.base64Decode('ChZHZXRCaW5hcnlTdGF0dXNSZXF1ZXN0EhIKBG5hbWUYASABKAlSBG5hbWU=');
+    $convert.base64Decode('ChZHZXRCaW5hcnlTdGF0dXNSZXF1ZXN0EhIKBG5hbWUYASABKAlSBG5hbWUSIwoNZm9yY2VfYm'
+        'Fja2VuZBgCIAEoCFIMZm9yY2VCYWNrZW5k');
 
 @$core.Deprecated('Use getBinaryStatusResponseDescriptor instead')
 const GetBinaryStatusResponse$json = {

--- a/sidechain_core/lib/gen/orchestrator/v1/sidechain_conf.pbserver.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/sidechain_conf.pbserver.dart
@@ -15,27 +15,27 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-import 'sidechain_conf.pb.dart' as $8;
+import 'sidechain_conf.pb.dart' as $9;
 import 'sidechain_conf.pbjson.dart';
 
 export 'sidechain_conf.pb.dart';
 
 abstract class SidechainConfServiceBase extends $pb.GeneratedService {
-  $async.Future<$8.GetSidechainConfigResponse> getSidechainConfig(
-      $pb.ServerContext ctx, $8.GetSidechainConfigRequest request);
-  $async.Future<$8.WriteSidechainConfigResponse> writeSidechainConfig(
-      $pb.ServerContext ctx, $8.WriteSidechainConfigRequest request);
-  $async.Future<$8.SyncSidechainNetworkFromBitcoinConfResponse> syncSidechainNetworkFromBitcoinConf(
-      $pb.ServerContext ctx, $8.SyncSidechainNetworkFromBitcoinConfRequest request);
+  $async.Future<$9.GetSidechainConfigResponse> getSidechainConfig(
+      $pb.ServerContext ctx, $9.GetSidechainConfigRequest request);
+  $async.Future<$9.WriteSidechainConfigResponse> writeSidechainConfig(
+      $pb.ServerContext ctx, $9.WriteSidechainConfigRequest request);
+  $async.Future<$9.SyncSidechainNetworkFromBitcoinConfResponse> syncSidechainNetworkFromBitcoinConf(
+      $pb.ServerContext ctx, $9.SyncSidechainNetworkFromBitcoinConfRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
       case 'GetSidechainConfig':
-        return $8.GetSidechainConfigRequest();
+        return $9.GetSidechainConfigRequest();
       case 'WriteSidechainConfig':
-        return $8.WriteSidechainConfigRequest();
+        return $9.WriteSidechainConfigRequest();
       case 'SyncSidechainNetworkFromBitcoinConf':
-        return $8.SyncSidechainNetworkFromBitcoinConfRequest();
+        return $9.SyncSidechainNetworkFromBitcoinConfRequest();
       default:
         throw $core.ArgumentError('Unknown method: $methodName');
     }
@@ -45,11 +45,11 @@ abstract class SidechainConfServiceBase extends $pb.GeneratedService {
       $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
       case 'GetSidechainConfig':
-        return this.getSidechainConfig(ctx, request as $8.GetSidechainConfigRequest);
+        return this.getSidechainConfig(ctx, request as $9.GetSidechainConfigRequest);
       case 'WriteSidechainConfig':
-        return this.writeSidechainConfig(ctx, request as $8.WriteSidechainConfigRequest);
+        return this.writeSidechainConfig(ctx, request as $9.WriteSidechainConfigRequest);
       case 'SyncSidechainNetworkFromBitcoinConf':
-        return this.syncSidechainNetworkFromBitcoinConf(ctx, request as $8.SyncSidechainNetworkFromBitcoinConfRequest);
+        return this.syncSidechainNetworkFromBitcoinConf(ctx, request as $9.SyncSidechainNetworkFromBitcoinConfRequest);
       default:
         throw $core.ArgumentError('Unknown method: $methodName');
     }

--- a/sidechain_core/lib/gen/orchestrator/v1/thunder_conf.pbserver.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/thunder_conf.pbserver.dart
@@ -15,27 +15,27 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-import 'thunder_conf.pb.dart' as $9;
+import 'thunder_conf.pb.dart' as $10;
 import 'thunder_conf.pbjson.dart';
 
 export 'thunder_conf.pb.dart';
 
 abstract class ThunderConfServiceBase extends $pb.GeneratedService {
-  $async.Future<$9.GetThunderConfigResponse> getThunderConfig(
-      $pb.ServerContext ctx, $9.GetThunderConfigRequest request);
-  $async.Future<$9.WriteThunderConfigResponse> writeThunderConfig(
-      $pb.ServerContext ctx, $9.WriteThunderConfigRequest request);
-  $async.Future<$9.SyncNetworkFromBitcoinConfResponse> syncNetworkFromBitcoinConf(
-      $pb.ServerContext ctx, $9.SyncNetworkFromBitcoinConfRequest request);
+  $async.Future<$10.GetThunderConfigResponse> getThunderConfig(
+      $pb.ServerContext ctx, $10.GetThunderConfigRequest request);
+  $async.Future<$10.WriteThunderConfigResponse> writeThunderConfig(
+      $pb.ServerContext ctx, $10.WriteThunderConfigRequest request);
+  $async.Future<$10.SyncNetworkFromBitcoinConfResponse> syncNetworkFromBitcoinConf(
+      $pb.ServerContext ctx, $10.SyncNetworkFromBitcoinConfRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
       case 'GetThunderConfig':
-        return $9.GetThunderConfigRequest();
+        return $10.GetThunderConfigRequest();
       case 'WriteThunderConfig':
-        return $9.WriteThunderConfigRequest();
+        return $10.WriteThunderConfigRequest();
       case 'SyncNetworkFromBitcoinConf':
-        return $9.SyncNetworkFromBitcoinConfRequest();
+        return $10.SyncNetworkFromBitcoinConfRequest();
       default:
         throw $core.ArgumentError('Unknown method: $methodName');
     }
@@ -45,11 +45,11 @@ abstract class ThunderConfServiceBase extends $pb.GeneratedService {
       $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
       case 'GetThunderConfig':
-        return this.getThunderConfig(ctx, request as $9.GetThunderConfigRequest);
+        return this.getThunderConfig(ctx, request as $10.GetThunderConfigRequest);
       case 'WriteThunderConfig':
-        return this.writeThunderConfig(ctx, request as $9.WriteThunderConfigRequest);
+        return this.writeThunderConfig(ctx, request as $10.WriteThunderConfigRequest);
       case 'SyncNetworkFromBitcoinConf':
-        return this.syncNetworkFromBitcoinConf(ctx, request as $9.SyncNetworkFromBitcoinConfRequest);
+        return this.syncNetworkFromBitcoinConf(ctx, request as $10.SyncNetworkFromBitcoinConfRequest);
       default:
         throw $core.ArgumentError('Unknown method: $methodName');
     }

--- a/sidechain_core/lib/gen/orchestrator/v1/zside_conf.pbserver.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/zside_conf.pbserver.dart
@@ -15,26 +15,26 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-import 'zside_conf.pb.dart' as $10;
+import 'zside_conf.pb.dart' as $11;
 import 'zside_conf.pbjson.dart';
 
 export 'zside_conf.pb.dart';
 
 abstract class ZSideConfServiceBase extends $pb.GeneratedService {
-  $async.Future<$10.GetZSideConfigResponse> getZSideConfig($pb.ServerContext ctx, $10.GetZSideConfigRequest request);
-  $async.Future<$10.WriteZSideConfigResponse> writeZSideConfig(
-      $pb.ServerContext ctx, $10.WriteZSideConfigRequest request);
-  $async.Future<$10.ZSideSyncNetworkFromBitcoinConfResponse> syncNetworkFromBitcoinConf(
-      $pb.ServerContext ctx, $10.ZSideSyncNetworkFromBitcoinConfRequest request);
+  $async.Future<$11.GetZSideConfigResponse> getZSideConfig($pb.ServerContext ctx, $11.GetZSideConfigRequest request);
+  $async.Future<$11.WriteZSideConfigResponse> writeZSideConfig(
+      $pb.ServerContext ctx, $11.WriteZSideConfigRequest request);
+  $async.Future<$11.ZSideSyncNetworkFromBitcoinConfResponse> syncNetworkFromBitcoinConf(
+      $pb.ServerContext ctx, $11.ZSideSyncNetworkFromBitcoinConfRequest request);
 
   $pb.GeneratedMessage createRequest($core.String methodName) {
     switch (methodName) {
       case 'GetZSideConfig':
-        return $10.GetZSideConfigRequest();
+        return $11.GetZSideConfigRequest();
       case 'WriteZSideConfig':
-        return $10.WriteZSideConfigRequest();
+        return $11.WriteZSideConfigRequest();
       case 'SyncNetworkFromBitcoinConf':
-        return $10.ZSideSyncNetworkFromBitcoinConfRequest();
+        return $11.ZSideSyncNetworkFromBitcoinConfRequest();
       default:
         throw $core.ArgumentError('Unknown method: $methodName');
     }
@@ -44,11 +44,11 @@ abstract class ZSideConfServiceBase extends $pb.GeneratedService {
       $pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
     switch (methodName) {
       case 'GetZSideConfig':
-        return this.getZSideConfig(ctx, request as $10.GetZSideConfigRequest);
+        return this.getZSideConfig(ctx, request as $11.GetZSideConfigRequest);
       case 'WriteZSideConfig':
-        return this.writeZSideConfig(ctx, request as $10.WriteZSideConfigRequest);
+        return this.writeZSideConfig(ctx, request as $11.WriteZSideConfigRequest);
       case 'SyncNetworkFromBitcoinConf':
-        return this.syncNetworkFromBitcoinConf(ctx, request as $10.ZSideSyncNetworkFromBitcoinConfRequest);
+        return this.syncNetworkFromBitcoinConf(ctx, request as $11.ZSideSyncNetworkFromBitcoinConfRequest);
       default:
         throw $core.ArgumentError('Unknown method: $methodName');
     }

--- a/sidechain_core/lib/providers/backend_state_provider.dart
+++ b/sidechain_core/lib/providers/backend_state_provider.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:sidechain_core/classes/rpc_connection.dart';
+import 'package:sidechain_core/config/binaries.dart';
 import 'package:sidechain_core/gen/orchestrator/v1/orchestrator.pb.dart';
 import 'package:sidechain_core/providers/binaries/binary_provider.dart';
 import 'package:sidechain_core/rpcs/bitassets_rpc.dart';
@@ -62,7 +63,7 @@ class BackendStateProvider extends ChangeNotifier {
     }
     _polling = true;
     try {
-      final resp = await _orchestrator.listBinaries();
+      final resp = await _orchestrator.listBinaries(forceBackend: Binary.isSidechainApp);
       _consecutiveFailures = 0;
       _apply(resp.binaries);
     } catch (e) {

--- a/sidechain_core/lib/rpcs/orchestrator_rpc.dart
+++ b/sidechain_core/lib/rpcs/orchestrator_rpc.dart
@@ -101,12 +101,14 @@ class OrchestratorRPC {
 
   // ─── unary ────────────────────────────────────────────────────────────────
 
-  Future<ListBinariesResponse> listBinaries() {
-    return _unaryClient.listBinaries(ListBinariesRequest());
+  /// Sidechains pass forceBackend: true so the status describes the daemon
+  /// they run, not the test build BitWindow launches.
+  Future<ListBinariesResponse> listBinaries({bool forceBackend = false}) {
+    return _unaryClient.listBinaries(ListBinariesRequest(forceBackend: forceBackend));
   }
 
-  Future<GetBinaryStatusResponse> getBinaryStatus(String name) {
-    return _unaryClient.getBinaryStatus(GetBinaryStatusRequest(name: name));
+  Future<GetBinaryStatusResponse> getBinaryStatus(String name, {bool forceBackend = false}) {
+    return _unaryClient.getBinaryStatus(GetBinaryStatusRequest(name: name, forceBackend: forceBackend));
   }
 
   /// Resolve a binary's path + --version server-side. The orchestrator owns


### PR DESCRIPTION
Two status bugs the daemon dialog showed at the same time.

The Thunder update button never cleared. A layer-2 binary has two downloads, the test build BitWindow launches and the prod backend the sidechain app runs, and the release check cached one answer for both. It now caches the published time per download, reads the local mtime off disk on every call, and ListBinaries/GetBinaryStatus take the same force_backend lever as launch.

Bitcoin Core read 100% while it sat 27 blocks off the network chain. Blocks and headers both match on a node that rejects a branch, so the bar cannot see it. GetSyncStatus now reports what getchaintips and getpeerinfo say, the Core card stays open with the reason, and the bottom bar says Off chain. A chain four blocks short no longer rounds up to 100.00%.