### PR TITLE
orchestrator: keep fork state when a probe fails

### DIFF
--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -2967,9 +2967,12 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 		state, err := o.chainForkCached().Fetch(ctx)
 		if err != nil {
 			o.log.Debug().Err(err).Msg("chain fork probe failed")
-			return
 		}
-		fork = state
+		// The cache returns its last good state next to a transient error, so
+		// a failed refresh must not clear an active off-chain warning.
+		if state != nil {
+			fork = state
+		}
 	}()
 
 	for _, j := range jobs {


### PR DESCRIPTION
The off-chain warning blinked out whenever a fork probe failed. CachedConnection.Fetch hands back its last good state next to a transient error, and GetSyncStatus dropped that state on any error, so RejectedBranch fell back to false until the next good probe.

It now keeps a non-nil state whatever the error says. The rest of this branch is on master already, through #2010.
