### PR TITLE
orchestrator: roll back to a block hash or a height

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.298
+version: 1.0.299
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.298
+version: 1.0.299
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.162
+version: 0.2.163
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.171
+version: 1.0.172
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/widgets/modals/chain_settings_modal.dart
+++ b/sail_ui/lib/widgets/modals/chain_settings_modal.dart
@@ -26,7 +26,7 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
   String? _resolvedBinaryPath;
   bool _loadingVersion = true;
 
-  final TextEditingController _rollbackHeight = TextEditingController();
+  final TextEditingController _rollbackTarget = TextEditingController();
   int? _chainHeight;
   bool _rollingBack = false;
   String? _rollbackError;
@@ -42,7 +42,7 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
 
   @override
   void dispose() {
-    _rollbackHeight.dispose();
+    _rollbackTarget.dispose();
     super.dispose();
   }
 
@@ -125,10 +125,15 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
     }
   }
 
+  /// A 64-character hex string names a block; anything else reads as a height.
+  static final RegExp _blockHashPattern = RegExp(r'^[0-9a-fA-F]{64}$');
+
   Future<void> _rollBack(BuildContext context) async {
-    final height = int.tryParse(_rollbackHeight.text.trim());
-    if (height == null) {
-      setState(() => _rollbackError = 'Type the block height to keep.');
+    final target = _rollbackTarget.text.trim();
+    final isHash = _blockHashPattern.hasMatch(target);
+    final height = isHash ? null : int.tryParse(target);
+    if (!isHash && height == null) {
+      setState(() => _rollbackError = 'Type the block height or the block hash to keep.');
       return;
     }
 
@@ -136,18 +141,18 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
     // validator chain, and the modal cannot undo either.
     await infoDialog(
       context: context,
-      title: 'Roll back to block $height?',
+      title: 'Roll back to block $target?',
       subtitle:
-          'Every block above $height leaves the active chain. '
+          'Every block above $target leaves the active chain. '
           'The enforcer rebuilds from the local Core if it does not follow.',
       onConfirm: () async {
         Navigator.of(context).pop();
-        await _sendRollback(height);
+        await _sendRollback(height: height, blockHash: isHash ? target : null);
       },
     );
   }
 
-  Future<void> _sendRollback(int height) async {
+  Future<void> _sendRollback({int? height, String? blockHash}) async {
     setState(() {
       _rollingBack = true;
       _rollbackError = null;
@@ -155,7 +160,7 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
     });
 
     try {
-      final resp = await GetIt.I.get<OrchestratorRPC>().wipeUntilBlock(height);
+      final resp = await GetIt.I.get<OrchestratorRPC>().wipeUntilBlock(height: height, blockHash: blockHash);
       if (!mounted) {
         return;
       }
@@ -391,7 +396,7 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
               children: [
                 SailText.primary13('Roll back the chain', bold: true),
                 SailText.secondary13(
-                  'Every block above the height leaves the active chain. Blocks below it stay on disk, so nothing downloads again.',
+                  'Name the last block to keep, by height or by hash. Every block above it leaves the active chain, and the blocks below stay on disk.',
                   color: theme.colors.textSecondary,
                 ),
                 SailRow(
@@ -399,9 +404,8 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
                   children: [
                     Expanded(
                       child: SailTextField(
-                        controller: _rollbackHeight,
-                        hintText: 'Block height to keep',
-                        textFieldType: TextFieldType.number,
+                        controller: _rollbackTarget,
+                        hintText: 'Block height or hash to keep',
                         dense: true,
                       ),
                     ),

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -886,7 +886,11 @@ func (h *Handler) DeleteFiles(ctx context.Context, req *connect.Request[pb.Delet
 }
 
 func (h *Handler) WipeUntilBlock(ctx context.Context, req *connect.Request[pb.WipeUntilBlockRequest]) (*connect.Response[pb.WipeUntilBlockResponse], error) {
-	res, err := h.orch.WipeUntilBlock(ctx, req.Msg.Height, time.Duration(req.Msg.EnforcerWaitSeconds)*time.Second)
+	res, err := h.orch.WipeUntilBlock(
+		ctx,
+		orchestrator.RollbackTarget{Height: req.Msg.Height, Hash: strings.TrimSpace(req.Msg.BlockHash)},
+		time.Duration(req.Msg.EnforcerWaitSeconds)*time.Second,
+	)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
 	}

--- a/sidechain-orchestrator/commands/reset.go
+++ b/sidechain-orchestrator/commands/reset.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strconv"
@@ -23,28 +24,33 @@ var resetCommand = &cli.Command{
 
 var resetUntilBlockCommand = &cli.Command{
 	Name:      "until-block",
-	Usage:     "Roll the chain back to a height, keeping every block below it",
-	ArgsUsage: "<height>",
+	Usage:     "Roll the chain back to a block, keeping every block below it",
+	ArgsUsage: "<height|hash>",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{Name: "yes", Usage: "skip the confirmation prompt"},
 		&cli.UintFlag{Name: "enforcer-wait", Usage: "seconds to wait for the enforcer to follow before rebuilding it"},
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("pass the height to keep, e.g. reset until-block 979000")
+			return fmt.Errorf("pass the block to keep, e.g. reset until-block 979000")
 		}
-		height, err := strconv.ParseUint(cctx.Args().First(), 10, 32)
-		if err != nil {
-			return fmt.Errorf("height: %w", err)
+		req := &pb.WipeUntilBlockRequest{EnforcerWaitSeconds: uint32(cctx.Uint("enforcer-wait"))}
+		arg := cctx.Args().First()
+		if isBlockHash(arg) {
+			req.BlockHash = arg
+		} else {
+			height, err := strconv.ParseUint(arg, 10, 32)
+			if err != nil {
+				return fmt.Errorf("read %q as a height or a block hash: %w", arg, err)
+			}
+			req.Height = uint32(height)
 		}
-		if err := confirmOrAbort(cctx, fmt.Sprintf("this drops every block above %d from the active chain. proceed?", height)); err != nil {
+
+		if err := confirmOrAbort(cctx, fmt.Sprintf("this drops every block above %s from the active chain. proceed?", arg)); err != nil {
 			return err
 		}
 
-		resp, err := newClient(cctx).WipeUntilBlock(cctx.Context, connect.NewRequest(&pb.WipeUntilBlockRequest{
-			Height:              uint32(height),
-			EnforcerWaitSeconds: uint32(cctx.Uint("enforcer-wait")),
-		}))
+		resp, err := newClient(cctx).WipeUntilBlock(cctx.Context, connect.NewRequest(req))
 		if err != nil {
 			return err
 		}
@@ -58,6 +64,15 @@ var resetUntilBlockCommand = &cli.Command{
 		fmt.Printf("enforcer:    followed the rollback, tip %d\n", resp.Msg.EnforcerHeight)
 		return nil
 	},
+}
+
+// isBlockHash reports whether s reads as a block hash: 64 hex characters.
+func isBlockHash(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
 }
 
 func resetCategoryFlags() []cli.Flag {

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -3424,12 +3424,16 @@ func (x *DeleteFilesResponse) GetError() string {
 type WipeUntilBlockRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The last height to keep. Every block above it leaves the active chain.
+	// Pass this or block_hash, not both.
 	Height uint32 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	// How long to wait for the enforcer to follow the rollback before its
 	// validator chain is deleted. Zero picks the default.
 	EnforcerWaitSeconds uint32 `protobuf:"varint,2,opt,name=enforcer_wait_seconds,json=enforcerWaitSeconds,proto3" json:"enforcer_wait_seconds,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// The last block to keep, named by its hash. The block must sit on the
+	// active chain. Pass this or height, not both.
+	BlockHash     string `protobuf:"bytes,3,opt,name=block_hash,json=blockHash,proto3" json:"block_hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *WipeUntilBlockRequest) Reset() {
@@ -3474,6 +3478,13 @@ func (x *WipeUntilBlockRequest) GetEnforcerWaitSeconds() uint32 {
 		return x.EnforcerWaitSeconds
 	}
 	return 0
+}
+
+func (x *WipeUntilBlockRequest) GetBlockHash() string {
+	if x != nil {
+		return x.BlockHash
+	}
+	return ""
 }
 
 type WipeUntilBlockResponse struct {
@@ -4562,10 +4573,12 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x06except\x18\x02 \x03(\tR\x06except\"?\n" +
 	"\x13DeleteFilesResponse\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"c\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"\x82\x01\n" +
 	"\x15WipeUntilBlockRequest\x12\x16\n" +
 	"\x06height\x18\x01 \x01(\rR\x06height\x122\n" +
-	"\x15enforcer_wait_seconds\x18\x02 \x01(\rR\x13enforcerWaitSeconds\"\xc3\x01\n" +
+	"\x15enforcer_wait_seconds\x18\x02 \x01(\rR\x13enforcerWaitSeconds\x12\x1d\n" +
+	"\n" +
+	"block_hash\x18\x03 \x01(\tR\tblockHash\"\xc3\x01\n" +
 	"\x16WipeUntilBlockResponse\x12\x1f\n" +
 	"\vcore_height\x18\x01 \x01(\rR\n" +
 	"coreHeight\x124\n" +

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -628,10 +628,14 @@ message DeleteFilesResponse {
 
 message WipeUntilBlockRequest {
   // The last height to keep. Every block above it leaves the active chain.
+  // Pass this or block_hash, not both.
   uint32 height = 1;
   // How long to wait for the enforcer to follow the rollback before its
   // validator chain is deleted. Zero picks the default.
   uint32 enforcer_wait_seconds = 2;
+  // The last block to keep, named by its hash. The block must sit on the
+  // active chain. Pass this or height, not both.
+  string block_hash = 3;
 }
 
 message WipeUntilBlockResponse {

--- a/sidechain-orchestrator/wipe_until_block.go
+++ b/sidechain-orchestrator/wipe_until_block.go
@@ -23,12 +23,47 @@ type WipeUntilBlockResult struct {
 	EnforcerRebuilt      bool
 }
 
-// WipeUntilBlock rolls the chain back to height in place of a full wipe. Core
-// invalidates the first block above the height, which disconnects the branch
-// but leaves every block on disk, so a later sync downloads nothing it already
-// has. The enforcer has no rollback RPC: it gets a window to follow the
-// reorg, and its validator chain is deleted only when it does not.
-func (o *Orchestrator) WipeUntilBlock(ctx context.Context, height uint32, enforcerWait time.Duration) (WipeUntilBlockResult, error) {
+// RollbackTarget names the last block to keep, by height or by hash. Exactly
+// one of the two carries the answer.
+type RollbackTarget struct {
+	Height uint32
+	Hash   string
+}
+
+// resolveRollbackHeight turns a target into the height of the last block to
+// keep. A hash off the active chain names no height, so it is refused rather
+// than rolled back to the wrong branch.
+func resolveRollbackHeight(ctx context.Context, client *CoreStatusClient, target RollbackTarget) (uint32, error) {
+	if target.Hash == "" {
+		return target.Height, nil
+	}
+	if target.Height != 0 {
+		return 0, fmt.Errorf("pass a height or a block hash, not both")
+	}
+
+	raw, err := client.call(ctx, "getblockheader", target.Hash)
+	if err != nil {
+		return 0, fmt.Errorf("get block header %s: %w", target.Hash, err)
+	}
+	var header struct {
+		Height        int64 `json:"height"`
+		Confirmations int64 `json:"confirmations"`
+	}
+	if err := json.Unmarshal(raw, &header); err != nil {
+		return 0, fmt.Errorf("decode block header %s: %w", target.Hash, err)
+	}
+	if header.Confirmations < 0 {
+		return 0, fmt.Errorf("block %s is not on the active chain", target.Hash)
+	}
+	return uint32(header.Height), nil
+}
+
+// WipeUntilBlock rolls the chain back to the target block in place of a full
+// wipe. Core invalidates the first block above it, which disconnects the
+// branch but leaves every block on disk, so a later sync downloads nothing it
+// already has. The enforcer has no rollback RPC: it gets a window to follow
+// the reorg, and its validator chain is deleted only when it does not.
+func (o *Orchestrator) WipeUntilBlock(ctx context.Context, target RollbackTarget, enforcerWait time.Duration) (WipeUntilBlockResult, error) {
 	if enforcerWait <= 0 {
 		enforcerWait = defaultEnforcerReorgWait
 	}
@@ -36,6 +71,11 @@ func (o *Orchestrator) WipeUntilBlock(ctx context.Context, height uint32, enforc
 	client, err := o.CoreStatusClient()
 	if err != nil {
 		return WipeUntilBlockResult{}, fmt.Errorf("bitcoin core rpc: %w", err)
+	}
+
+	height, err := resolveRollbackHeight(ctx, client, target)
+	if err != nil {
+		return WipeUntilBlockResult{}, err
 	}
 
 	hash, err := rollBackCore(ctx, client, height)

--- a/sidechain-orchestrator/wipe_until_block.go
+++ b/sidechain-orchestrator/wipe_until_block.go
@@ -140,7 +140,10 @@ func (o *Orchestrator) rebuildEnforcerChain(ctx context.Context) error {
 
 	config.WipeEnforcerChainDataSync(config.NetworkFromString(o.Network), o.log)
 
-	bootCh, err := o.StartWithL1(context.Background(), "enforcer", StartOpts{})
+	// RestartDaemon starts the one daemon whatever the active wallet is. The
+	// L1 boot path serves an electrum wallet no local backends, so it would
+	// report success and leave the enforcer stopped with no chain data.
+	bootCh, err := o.RestartDaemon(context.Background(), "enforcer")
 	if err != nil {
 		return fmt.Errorf("start the enforcer: %w", err)
 	}

--- a/sidechain-orchestrator/wipe_until_block.go
+++ b/sidechain-orchestrator/wipe_until_block.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
@@ -28,6 +29,14 @@ type WipeUntilBlockResult struct {
 type RollbackTarget struct {
 	Height uint32
 	Hash   string
+}
+
+// normalized puts the hash in the form Core answers with. Core takes a hash
+// in either case but always answers in lower case, and the comparison against
+// its answer has to match.
+func (t RollbackTarget) normalized() RollbackTarget {
+	t.Hash = strings.ToLower(strings.TrimSpace(t.Hash))
+	return t
 }
 
 // resolveRollbackHeight turns a target into the height of the last block to
@@ -72,6 +81,8 @@ func (o *Orchestrator) WipeUntilBlock(ctx context.Context, target RollbackTarget
 	if err != nil {
 		return WipeUntilBlockResult{}, fmt.Errorf("bitcoin core rpc: %w", err)
 	}
+
+	target = target.normalized()
 
 	height, err := resolveRollbackHeight(ctx, client, target)
 	if err != nil {

--- a/sidechain-orchestrator/wipe_until_block.go
+++ b/sidechain-orchestrator/wipe_until_block.go
@@ -78,7 +78,7 @@ func (o *Orchestrator) WipeUntilBlock(ctx context.Context, target RollbackTarget
 		return WipeUntilBlockResult{}, err
 	}
 
-	hash, err := rollBackCore(ctx, client, height)
+	hash, err := rollBackCore(ctx, client, height, target.Hash)
 	if err != nil {
 		return WipeUntilBlockResult{}, err
 	}
@@ -159,7 +159,7 @@ func (o *Orchestrator) rebuildEnforcerChain(ctx context.Context) error {
 
 // rollBackCore invalidates the first block above height and returns its hash.
 // Core disconnects the branch down to height and keeps every block on disk.
-func rollBackCore(ctx context.Context, client *CoreStatusClient, height uint32) (string, error) {
+func rollBackCore(ctx context.Context, client *CoreStatusClient, height uint32, keepHash string) (string, error) {
 	tip, err := client.GetBlockCount(ctx)
 	if err != nil {
 		return "", fmt.Errorf("read core tip: %w", err)
@@ -171,6 +171,17 @@ func rollBackCore(ctx context.Context, client *CoreStatusClient, height uint32) 
 	hash, err := blockHashAt(ctx, client, int64(height)+1)
 	if err != nil {
 		return "", err
+	}
+	// A reorg between the header read and this one can put another block at
+	// the height, and its child is not the block the caller named.
+	if keepHash != "" {
+		parent, err := blockParentHash(ctx, client, hash)
+		if err != nil {
+			return "", err
+		}
+		if parent != keepHash {
+			return "", fmt.Errorf("block %s no longer sits at height %d", keepHash, height)
+		}
 	}
 	if _, err := client.call(ctx, "invalidateblock", hash); err != nil {
 		return "", fmt.Errorf("invalidate block %s: %w", hash, err)
@@ -184,6 +195,21 @@ func rollBackCore(ctx context.Context, client *CoreStatusClient, height uint32) 
 		return "", fmt.Errorf("core tip is %d after the rollback, want %d", newTip, height)
 	}
 	return hash, nil
+}
+
+// blockParentHash reads the hash of the block a block builds on.
+func blockParentHash(ctx context.Context, client *CoreStatusClient, hash string) (string, error) {
+	raw, err := client.call(ctx, "getblockheader", hash)
+	if err != nil {
+		return "", fmt.Errorf("get block header %s: %w", hash, err)
+	}
+	var header struct {
+		PreviousBlockHash string `json:"previousblockhash"`
+	}
+	if err := json.Unmarshal(raw, &header); err != nil {
+		return "", fmt.Errorf("decode block header %s: %w", hash, err)
+	}
+	return header.PreviousBlockHash, nil
 }
 
 func blockHashAt(ctx context.Context, client *CoreStatusClient, height int64) (string, error) {

--- a/sidechain-orchestrator/wipe_until_block_test.go
+++ b/sidechain-orchestrator/wipe_until_block_test.go
@@ -189,3 +189,13 @@ func TestRollBackCoreRefusesWhenTheNamedBlockMoved(t *testing.T) {
 		t.Fatal("rollBackCore invalidated a block whose parent is not the named one")
 	}
 }
+
+// Core takes an upper case hash but answers in lower case, so a hash the CLI
+// and the UI both accept must reach the comparison in Core's own form.
+func TestRollbackTargetNormalizesTheHash(t *testing.T) {
+	target := RollbackTarget{Hash: "  0000000000000000000ABC  "}
+
+	if got := target.normalized().Hash; got != "0000000000000000000abc" {
+		t.Errorf("normalized hash = %q, want the trimmed lower case form", got)
+	}
+}

--- a/sidechain-orchestrator/wipe_until_block_test.go
+++ b/sidechain-orchestrator/wipe_until_block_test.go
@@ -10,12 +10,14 @@ import (
 	"testing"
 )
 
-// fakeCore answers the three RPCs a rollback makes. tips is read one entry per
+// fakeCore answers the RPCs a rollback makes. tips is read one entry per
 // getblockcount, so a test can move the tip after the invalidation.
 type fakeCore struct {
 	tips    []int64
 	hashes  map[int64]string
 	methods []string
+	// headers answers getblockheader by hash: height and confirmations.
+	headers map[string][2]int64
 }
 
 func (f *fakeCore) start(t *testing.T) *CoreStatusClient {
@@ -50,6 +52,18 @@ func (f *fakeCore) start(t *testing.T) *CoreStatusClient {
 				return
 			}
 			result = `"` + hash + `"`
+		case "getblockheader":
+			var hash string
+			if err := json.Unmarshal(req.Params[0], &hash); err != nil {
+				t.Errorf("decode getblockheader hash: %v", err)
+				return
+			}
+			header, ok := f.headers[hash]
+			if !ok {
+				http.Error(w, `{"result":null,"error":{"code":-5,"message":"Block not found"}}`, http.StatusOK)
+				return
+			}
+			result = fmt.Sprintf(`{"height":%d,"confirmations":%d}`, header[0], header[1])
 		case "invalidateblock":
 			result = "null"
 		default:
@@ -103,5 +117,53 @@ func TestRollBackCoreFailsWhenTheTipDoesNotMove(t *testing.T) {
 
 	if _, err := rollBackCore(context.Background(), core.start(t), 979000); err == nil {
 		t.Fatal("rollBackCore reported success with an unchanged tip")
+	}
+}
+
+func TestResolveRollbackHeightReadsTheHeightOfAHash(t *testing.T) {
+	const hash = "0000000000000000000abc"
+	core := &fakeCore{headers: map[string][2]int64{hash: {979000, 473}}}
+
+	got, err := resolveRollbackHeight(context.Background(), core.start(t), RollbackTarget{Hash: hash})
+	if err != nil {
+		t.Fatalf("resolveRollbackHeight: %v", err)
+	}
+	if got != 979000 {
+		t.Errorf("height = %d, want 979000", got)
+	}
+}
+
+// A hash off the active chain names no height to keep, so rolling back to it
+// would land the node on a branch the user never asked for.
+func TestResolveRollbackHeightRejectsAHashOffTheChain(t *testing.T) {
+	const hash = "0000000000000000000dead"
+	core := &fakeCore{headers: map[string][2]int64{hash: {979000, -1}}}
+
+	if _, err := resolveRollbackHeight(context.Background(), core.start(t), RollbackTarget{Hash: hash}); err == nil {
+		t.Fatal("resolveRollbackHeight accepted a block off the active chain")
+	}
+}
+
+func TestResolveRollbackHeightRefusesBothInputs(t *testing.T) {
+	core := &fakeCore{}
+	target := RollbackTarget{Height: 979000, Hash: "0000000000000000000abc"}
+
+	if _, err := resolveRollbackHeight(context.Background(), core.start(t), target); err == nil {
+		t.Fatal("resolveRollbackHeight accepted a height and a hash together")
+	}
+}
+
+func TestResolveRollbackHeightPassesAPlainHeight(t *testing.T) {
+	core := &fakeCore{}
+
+	got, err := resolveRollbackHeight(context.Background(), core.start(t), RollbackTarget{Height: 979000})
+	if err != nil {
+		t.Fatalf("resolveRollbackHeight: %v", err)
+	}
+	if got != 979000 {
+		t.Errorf("height = %d, want 979000", got)
+	}
+	if len(core.methods) != 0 {
+		t.Errorf("rpc calls = %v, want none for a plain height", core.methods)
 	}
 }

--- a/sidechain-orchestrator/wipe_until_block_test.go
+++ b/sidechain-orchestrator/wipe_until_block_test.go
@@ -18,6 +18,8 @@ type fakeCore struct {
 	methods []string
 	// headers answers getblockheader by hash: height and confirmations.
 	headers map[string][2]int64
+	// parents answers getblockheader by hash with a previousblockhash.
+	parents map[string]string
 }
 
 func (f *fakeCore) start(t *testing.T) *CoreStatusClient {
@@ -58,6 +60,10 @@ func (f *fakeCore) start(t *testing.T) *CoreStatusClient {
 				t.Errorf("decode getblockheader hash: %v", err)
 				return
 			}
+			if parent, ok := f.parents[hash]; ok {
+				result = fmt.Sprintf(`{"previousblockhash":%q}`, parent)
+				break
+			}
 			header, ok := f.headers[hash]
 			if !ok {
 				http.Error(w, `{"result":null,"error":{"code":-5,"message":"Block not found"}}`, http.StatusOK)
@@ -83,7 +89,7 @@ func TestRollBackCoreInvalidatesTheBlockAboveTheHeight(t *testing.T) {
 		hashes: map[int64]string{979001: "0000000000000000000abc"},
 	}
 
-	hash, err := rollBackCore(context.Background(), core.start(t), 979000)
+	hash, err := rollBackCore(context.Background(), core.start(t), 979000, "")
 	if err != nil {
 		t.Fatalf("rollBackCore: %v", err)
 	}
@@ -98,7 +104,7 @@ func TestRollBackCoreInvalidatesTheBlockAboveTheHeight(t *testing.T) {
 func TestRollBackCoreRejectsAHeightAtOrAboveTheTip(t *testing.T) {
 	core := &fakeCore{tips: []int64{979000}}
 
-	_, err := rollBackCore(context.Background(), core.start(t), 979000)
+	_, err := rollBackCore(context.Background(), core.start(t), 979000, "")
 	if err == nil {
 		t.Fatal("rollBackCore accepted the tip height, want an error")
 	}
@@ -115,7 +121,7 @@ func TestRollBackCoreFailsWhenTheTipDoesNotMove(t *testing.T) {
 		hashes: map[int64]string{979001: "0000000000000000000abc"},
 	}
 
-	if _, err := rollBackCore(context.Background(), core.start(t), 979000); err == nil {
+	if _, err := rollBackCore(context.Background(), core.start(t), 979000, ""); err == nil {
 		t.Fatal("rollBackCore reported success with an unchanged tip")
 	}
 }
@@ -165,5 +171,21 @@ func TestResolveRollbackHeightPassesAPlainHeight(t *testing.T) {
 	}
 	if len(core.methods) != 0 {
 		t.Errorf("rpc calls = %v, want none for a plain height", core.methods)
+	}
+}
+
+// A reorg can put another block at the height between the header read and the
+// invalidation, and its child is not the block the caller named.
+func TestRollBackCoreRefusesWhenTheNamedBlockMoved(t *testing.T) {
+	core := &fakeCore{
+		tips:    []int64{979472, 979000},
+		hashes:  map[int64]string{979001: "0000000000000000000abc"},
+		headers: map[string][2]int64{},
+		parents: map[string]string{"0000000000000000000abc": "0000000000000000000fff"},
+	}
+
+	_, err := rollBackCore(context.Background(), core.start(t), 979000, "0000000000000000000eee")
+	if err == nil {
+		t.Fatal("rollBackCore invalidated a block whose parent is not the named one")
 	}
 }

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -3905,6 +3905,7 @@ class WipeUntilBlockRequest extends $pb.GeneratedMessage {
   factory WipeUntilBlockRequest({
     $core.int? height,
     $core.int? enforcerWaitSeconds,
+    $core.String? blockHash,
   }) {
     final $result = create();
     if (height != null) {
@@ -3912,6 +3913,9 @@ class WipeUntilBlockRequest extends $pb.GeneratedMessage {
     }
     if (enforcerWaitSeconds != null) {
       $result.enforcerWaitSeconds = enforcerWaitSeconds;
+    }
+    if (blockHash != null) {
+      $result.blockHash = blockHash;
     }
     return $result;
   }
@@ -3922,6 +3926,7 @@ class WipeUntilBlockRequest extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WipeUntilBlockRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'height', $pb.PbFieldType.OU3)
     ..a<$core.int>(2, _omitFieldNames ? '' : 'enforcerWaitSeconds', $pb.PbFieldType.OU3)
+    ..aOS(3, _omitFieldNames ? '' : 'blockHash')
     ..hasRequiredFields = false
   ;
 
@@ -3947,6 +3952,7 @@ class WipeUntilBlockRequest extends $pb.GeneratedMessage {
   static WipeUntilBlockRequest? _defaultInstance;
 
   /// The last height to keep. Every block above it leaves the active chain.
+  /// Pass this or block_hash, not both.
   @$pb.TagNumber(1)
   $core.int get height => $_getIZ(0);
   @$pb.TagNumber(1)
@@ -3966,6 +3972,17 @@ class WipeUntilBlockRequest extends $pb.GeneratedMessage {
   $core.bool hasEnforcerWaitSeconds() => $_has(1);
   @$pb.TagNumber(2)
   void clearEnforcerWaitSeconds() => clearField(2);
+
+  /// The last block to keep, named by its hash. The block must sit on the
+  /// active chain. Pass this or height, not both.
+  @$pb.TagNumber(3)
+  $core.String get blockHash => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set blockHash($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasBlockHash() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearBlockHash() => clearField(3);
 }
 
 class WipeUntilBlockResponse extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -921,13 +921,15 @@ const WipeUntilBlockRequest$json = {
   '2': [
     {'1': 'height', '3': 1, '4': 1, '5': 13, '10': 'height'},
     {'1': 'enforcer_wait_seconds', '3': 2, '4': 1, '5': 13, '10': 'enforcerWaitSeconds'},
+    {'1': 'block_hash', '3': 3, '4': 1, '5': 9, '10': 'blockHash'},
   ],
 };
 
 /// Descriptor for `WipeUntilBlockRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List wipeUntilBlockRequestDescriptor = $convert.base64Decode(
     'ChVXaXBlVW50aWxCbG9ja1JlcXVlc3QSFgoGaGVpZ2h0GAEgASgNUgZoZWlnaHQSMgoVZW5mb3'
-    'JjZXJfd2FpdF9zZWNvbmRzGAIgASgNUhNlbmZvcmNlcldhaXRTZWNvbmRz');
+    'JjZXJfd2FpdF9zZWNvbmRzGAIgASgNUhNlbmZvcmNlcldhaXRTZWNvbmRzEh0KCmJsb2NrX2hh'
+    'c2gYAyABKAlSCWJsb2NrSGFzaA==');
 
 @$core.Deprecated('Use wipeUntilBlockResponseDescriptor instead')
 const WipeUntilBlockResponse$json = {

--- a/sidechain_core/lib/rpcs/orchestrator_rpc.dart
+++ b/sidechain_core/lib/rpcs/orchestrator_rpc.dart
@@ -122,9 +122,18 @@ class OrchestratorRPC {
 
   /// Roll the chain back to a height in place of a full wipe. Core keeps every
   /// block below the height on disk, so a later sync downloads nothing again.
-  Future<WipeUntilBlockResponse> wipeUntilBlock(int height, {int enforcerWaitSeconds = 0}) {
+  /// Names the last block to keep by height or by hash, never both.
+  Future<WipeUntilBlockResponse> wipeUntilBlock({
+    int? height,
+    String? blockHash,
+    int enforcerWaitSeconds = 0,
+  }) {
     return _unaryClient.wipeUntilBlock(
-      WipeUntilBlockRequest(height: height, enforcerWaitSeconds: enforcerWaitSeconds),
+      WipeUntilBlockRequest(
+        height: height ?? 0,
+        blockHash: blockHash ?? '',
+        enforcerWaitSeconds: enforcerWaitSeconds,
+      ),
     );
   }
 

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.300
+version: 1.0.301
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.171
+version: 1.0.172
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.298
+version: 1.0.299
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The rollback only took a height, but an explorer hands you a hash. WipeUntilBlock now takes either: a hash resolves through getblockheader, and one off the active chain is refused rather than rolled back to the wrong branch.

The CLI reads one argument as a hash when it is 64 hex characters, and the chain tab takes both in the same field.
