### PR TITLE
sidechain_core: download Inquisition from its releases

### DIFF
--- a/sidechain-orchestrator/chains_config.json
+++ b/sidechain-orchestrator/chains_config.json
@@ -831,11 +831,11 @@
         "binary": "inquisition",
         "files": {
           "default": {
-            "base_url": "https://github.com/sohibit/bitcoin/releases/download/v29.4-inq/",
-            "linux-x86_64": "",
-            "macos-x86_64": "",
-            "macos-arm64": "",
-            "windows-x86_64": ""
+            "base_url": "https://api.github.com/repos/sohibit/bitcoin/releases/latest",
+            "linux-x86_64": "L2-S119-Inquisition-.+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "L2-S119-Inquisition-.+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "L2-S119-Inquisition-.+-arm64-apple-darwin\\.zip",
+            "windows-x86_64": "L2-S119-Inquisition-.+-x86_64-w64-msvc\\.zip"
           }
         }
       },

--- a/sidechain-orchestrator/config/chains_config.json
+++ b/sidechain-orchestrator/config/chains_config.json
@@ -831,11 +831,11 @@
         "binary": "inquisition",
         "files": {
           "default": {
-            "base_url": "https://github.com/sohibit/bitcoin/releases/download/v29.4-inq/",
-            "linux-x86_64": "",
-            "macos-x86_64": "",
-            "macos-arm64": "",
-            "windows-x86_64": ""
+            "base_url": "https://api.github.com/repos/sohibit/bitcoin/releases/latest",
+            "linux-x86_64": "L2-S119-Inquisition-.+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "L2-S119-Inquisition-.+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "L2-S119-Inquisition-.+-arm64-apple-darwin\\.zip",
+            "windows-x86_64": "L2-S119-Inquisition-.+-x86_64-w64-msvc\\.zip"
           }
         }
       },

--- a/sidechain_core/assets/chains_config.json
+++ b/sidechain_core/assets/chains_config.json
@@ -831,11 +831,11 @@
         "binary": "inquisition",
         "files": {
           "default": {
-            "base_url": "https://github.com/sohibit/bitcoin/releases/download/v29.4-inq/",
-            "linux-x86_64": "",
-            "macos-x86_64": "",
-            "macos-arm64": "",
-            "windows-x86_64": ""
+            "base_url": "https://api.github.com/repos/sohibit/bitcoin/releases/latest",
+            "linux-x86_64": "L2-S119-Inquisition-.+-x86_64-unknown-linux-gnu\\.zip",
+            "macos-x86_64": "L2-S119-Inquisition-.+-x86_64-apple-darwin\\.zip",
+            "macos-arm64": "L2-S119-Inquisition-.+-arm64-apple-darwin\\.zip",
+            "windows-x86_64": "L2-S119-Inquisition-.+-x86_64-w64-msvc\\.zip"
           }
         }
       },

--- a/sidechain_core/lib/config/sidechains.dart
+++ b/sidechain_core/lib/config/sidechains.dart
@@ -46,6 +46,9 @@ abstract class Sidechain extends Binary {
 
       case 'liquid-signet':
         return LiquidSignet();
+
+      case 'inquisition':
+        return Inquisition();
     }
     return null;
   }
@@ -158,6 +161,18 @@ abstract class Sidechain extends Binary {
           port: binary.port,
           chainLayer: binary.chainLayer,
         );
+
+      case 'Inquisition':
+        return Inquisition(
+          name: binary.name,
+          version: binary.version,
+          description: binary.description,
+          repoUrl: binary.repoUrl,
+          directories: binary.directories,
+          metadata: binary.metadata,
+          port: binary.port,
+          chainLayer: binary.chainLayer,
+        );
       default:
         throw Exception('Unknown sidechain binary type: ${binary.runtimeType}');
     }
@@ -250,12 +265,19 @@ class Inquisition extends Sidechain {
              MetadataConfig(
                downloadConfig: DownloadConfig(
                  binary: 'inquisition',
-                 files: allPlatforms(''),
+                 baseUrls: allNetworksUrl('https://api.github.com/repos/sohibit/bitcoin/releases/latest'),
+
+                 // The release tag moves, so match the asset by its platform.
+                 files: allNetworks({
+                   OS.linux: r'L2-S119-Inquisition-.+-x86_64-unknown-linux-gnu\.zip',
+                   OS.macos: r'L2-S119-Inquisition-.+-x86_64-apple-darwin\.zip',
+                   OS.windows: r'L2-S119-Inquisition-.+-x86_64-w64-msvc\.zip',
+                 }),
                ),
                remoteTimestamp: null,
                downloadedTimestamp: null,
                binaryPath: null,
-               updateable: false,
+               updateable: true,
              ),
        );
 
@@ -1011,6 +1033,7 @@ List<Binary> get sidechainBinaries => [
   resolveFromConfig(BinaryType.BINARY_TYPE_COINSHIFT, () => CoinShift()),
   resolveFromConfig(BinaryType.BINARY_TYPE_ZSIDE, () => ZSide()),
   resolveFromConfig(BinaryType.BINARY_TYPE_LIQUID_SIGNET, () => LiquidSignet()),
+  resolveFromConfig(BinaryType.BINARY_TYPE_INQUISITION, () => Inquisition()),
 ];
 
 Binary resolveFromConfig(BinaryType type, Binary Function() fallback) {


### PR DESCRIPTION
This PR points the Inquisition sidechain at its published releases, so it can download and check for updates like every other sidechain.

The chain was already registered, but its download had no URL and no file names. It now reads the latest release on sohibit/bitcoin and matches the asset per platform, including a native arm64 macOS build. The untrusted-download warning already covers it, because Inquisition is not developed by Layer Two Labs.