### PR TITLE
Fix the datadir prompt on a conf without a slot

### DIFF
--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.163
+version: 0.2.164
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/scripts/download-binaries.sh
+++ b/bitwindow/scripts/download-binaries.sh
@@ -92,7 +92,9 @@ done
 if [[ "$os" == "darwin" && "${STAGE_PLAIN_BINARIES:-}" == "1" ]]; then
     host_token="$(uname -m)"
     for daemon in bitwindowd orchestratord orchestratorctl hwi-daemon; do
-        cp -f "$assets_dir/${daemon}-${host_token}" "$assets_dir/${daemon}"
+        # macOS kills an in-place overwrite of a signed Mach-O, so rename instead.
+        cp -f "$assets_dir/${daemon}-${host_token}" "$assets_dir/${daemon}.tmp"
+        mv -f "$assets_dir/${daemon}.tmp" "$assets_dir/${daemon}"
     done
 fi
 

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -250,8 +250,22 @@ func (m *BitcoinConfManager) loadStateFromConfig() {
 	m.DetectedDataDir = m.Config.GetEffectiveSetting("datadir", CoreSectionForNetwork(m.Network))
 
 	// Ensure datadir exists — Bitcoin Core fails with a cryptic assertion error (exit code -6) if it doesn't
-	if m.DetectedDataDir != "" {
-		_ = os.MkdirAll(m.DetectedDataDir, 0755)
+	if m.DetectedDataDir == "" {
+		return
+	}
+	_ = os.MkdirAll(m.DetectedDataDir, 0755)
+
+	// The live datadir= line belongs to whichever group is active, so record it
+	// there. A hand-edited conf carries no slot comment. Adopt only the
+	// top-level line, and only while a section does not override it: the
+	// orchestrator reads DetectedDataDir, so a disagreement points it at a
+	// directory Bitcoin Core does not use.
+	live := m.Config.GetSetting("datadir")
+	if live == "" || live != m.DetectedDataDir {
+		return
+	}
+	if g := DatadirGroupForNetwork(m.Network); m.Config.GetGroupDatadir(g) == "" {
+		m.Config.SetGroupDatadir(g, live)
 	}
 }
 
@@ -453,6 +467,15 @@ func (m *BitcoinConfManager) materializeDatadirForGroup(g DatadirGroup) {
 	m.Config.SetSetting("datadir", path)
 }
 
+// needsExplicitDatadir reports whether n must have a user-chosen path.
+func needsExplicitDatadir(n Network) bool {
+	switch n {
+	case NetworkMainnet, NetworkForknet, NetworkDrynet:
+		return true
+	}
+	return false
+}
+
 // HasDatadirForNetwork reports whether a datadir is configured for n's group.
 // Mainnet/forknet/drynet require an explicit user-chosen path because the platform
 // default sits inside ~/Library/Application Support and isn't suitable for
@@ -467,24 +490,10 @@ func (m *BitcoinConfManager) HasDatadirForNetwork(n Network) bool {
 	if m.HasPrivateConf {
 		return true
 	}
-	if n == NetworkForknet {
-		return m.Config.GetGroupDatadir(DatadirGroupForknet) != ""
+	if !needsExplicitDatadir(n) {
+		return true
 	}
-	if n == NetworkDrynet {
-		return m.Config.GetGroupDatadir(DatadirGroupDrynet) != ""
-	}
-	if n == NetworkMainnet {
-		// Mainnet still needs a user-chosen path — it would otherwise write
-		// 700+ GB into Library/Application Support.
-		if m.Config.GetGroupDatadir(DatadirGroupDefault) != "" {
-			return true
-		}
-		// Tolerate a top-level datadir= without a slot (e.g. user-edited
-		// conf or pre-slot install — first cross-group swap will adopt it
-		// into the slot).
-		return m.Config.GetSetting("datadir") != ""
-	}
-	return true
+	return m.Config.GetGroupDatadir(DatadirGroupForNetwork(n)) != ""
 }
 
 // RefreshMainSectionDefaults rewrites the active network's [main] block and

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -632,15 +632,6 @@ func TestHasDatadirForNetwork(t *testing.T) {
 		t.Error("forknet should be true when forknet slot is set")
 	}
 
-	// Mainnet accepts either the default slot or a top-level datadir= line
-	// (so a hand-edited or pre-slot conf isn't rejected at boot).
-	m2 := newTestManager(tmpDir)
-	m2.Config = NewBitcoinConfig()
-	m2.Config.SetSetting("datadir", "/raw/path")
-	if !m2.HasDatadirForNetwork(NetworkMainnet) {
-		t.Error("mainnet should accept top-level datadir without slot")
-	}
-
 	// Section-scoped datadir is ignored — Bitcoin Core only honours the
 	// top-level value.
 	m3 := newTestManager(tmpDir)
@@ -649,6 +640,62 @@ func TestHasDatadirForNetwork(t *testing.T) {
 	if m3.HasDatadirForNetwork(NetworkMainnet) {
 		t.Error("section-scoped datadir must not satisfy HasDatadirForNetwork")
 	}
+}
+
+// A hand-edited conf carries a top-level datadir= but no slot comment. The
+// load must adopt it, or the app sends the user to the datadir picker again.
+func TestLoadAdoptsTopLevelDatadirIntoActiveSlot(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		conf  string
+		group DatadirGroup
+	}{
+		{"drynet", "chain=main\ndatadir=/vol/drynet\n[main]\ndrivechain=1\nuacomment=drynet4\n", DatadirGroupDrynet},
+		{"mainnet", "chain=main\ndatadir=/vol/mainnet\n", DatadirGroupDefault},
+		{"signet", "chain=signet\ndatadir=/vol/shared\n", DatadirGroupDefault},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestManager(t.TempDir())
+			m.parseAndApplyConfig(tc.conf)
+
+			require.Equal(t, tc.group, DatadirGroupForNetwork(m.Network))
+			require.Equal(t, m.DetectedDataDir, m.Config.GetGroupDatadir(tc.group))
+			require.True(t, m.HasDatadirForNetwork(m.Network))
+		})
+	}
+}
+
+// Bitcoin Core ignores a section-scoped datadir, so adopting one would let the
+// picker pass while Core writes the chain into the platform default folder.
+func TestLoadIgnoresSectionScopedDatadir(t *testing.T) {
+	m := newTestManager(t.TempDir())
+	m.parseAndApplyConfig("chain=main\n[main]\ndatadir=/section/only\n")
+
+	require.Equal(t, NetworkMainnet, m.Network)
+	require.Empty(t, m.Config.GetGroupDatadir(DatadirGroupDefault))
+	require.False(t, m.HasDatadirForNetwork(NetworkMainnet))
+}
+
+// A section that overrides the top-level line points DetectedDataDir somewhere
+// Bitcoin Core does not use, so the picker must still run.
+func TestLoadIgnoresConflictingSectionDatadir(t *testing.T) {
+	m := newTestManager(t.TempDir())
+	m.parseAndApplyConfig("chain=main\ndatadir=/global/path\n[main]\ndatadir=/section/path\n")
+
+	require.Equal(t, "/section/path", m.DetectedDataDir)
+	require.Empty(t, m.Config.GetGroupDatadir(DatadirGroupDefault))
+	require.False(t, m.HasDatadirForNetwork(NetworkMainnet))
+}
+
+// Signet shares the default group's root, so a swap to mainnet must reuse the
+// path the user already picked instead of asking for it again.
+func TestSignetDatadirSatisfiesMainnet(t *testing.T) {
+	m := newTestManager(t.TempDir())
+	m.parseAndApplyConfig("chain=signet\ndatadir=/vol/shared\n")
+
+	require.Equal(t, NetworkSignet, m.Network)
+	require.True(t, m.HasDatadirForNetwork(NetworkMainnet))
+	require.False(t, m.HasDatadirForNetwork(NetworkDrynet), "drynet keeps its own slot")
 }
 
 // Regression: UpdateDataDir writes datadir to the global section (Bitcoin
@@ -763,9 +810,8 @@ func TestSwapAdoptsManuallyEditedDatadirIntoSlot(t *testing.T) {
 	require.Equal(t, "/drynet/path", m.Config.GetSetting("datadir"))
 }
 
-// Within-group swap (mainnet ↔ signet) leaves datadir= alone and writes no
-// slot — Bitcoin Core's chain subdirs partition the four default networks
-// under the same folder.
+// Within-group swap (mainnet ↔ signet) leaves datadir= alone — Bitcoin Core's
+// chain subdirs partition the four default networks under the same folder.
 func TestUpdateNetworkWithinDefaultGroupKeepsDatadir(t *testing.T) {
 	tmpDir := t.TempDir()
 	m := newTestManager(tmpDir)
@@ -780,8 +826,8 @@ func TestUpdateNetworkWithinDefaultGroupKeepsDatadir(t *testing.T) {
 	require.NoError(t, m.UpdateNetwork(NetworkSignet))
 
 	require.Equal(t, "/shared/default", m.Config.GetSetting("datadir"))
-	require.Equal(t, "", m.Config.GetGroupDatadir(DatadirGroupDefault), "no slot writes happen on within-group swap")
-	require.Equal(t, "", m.Config.GetGroupDatadir(DatadirGroupDrynet))
+	require.Equal(t, "/shared/default", m.Config.GetGroupDatadir(DatadirGroupDefault))
+	require.Equal(t, "", m.Config.GetGroupDatadir(DatadirGroupDrynet), "the drynet slot stays its own")
 }
 
 // applyMainSectionDefaults: signet → drynet adds drivechain=1 + alt ports

--- a/sidechain-orchestrator/network_catalog_pending_test.go
+++ b/sidechain-orchestrator/network_catalog_pending_test.go
@@ -72,6 +72,7 @@ func drynetOnPendingGeneration(t *testing.T) *Orchestrator {
 	require.NotNil(t, o.EnforcerConf)
 
 	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupDrynet, t.TempDir())
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupDefault, t.TempDir())
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkDrynet))
 	// Don't let the unmanaged-Core guard find a real node on this machine.
 	o.coreReachable = func() bool { return false }


### PR DESCRIPTION
A conf with a top-level datadir= but no slot comment sent the user to the datadir picker on every boot. The load now records that path in the active network's slot.

Also stages the macOS daemons by rename: an in-place cp invalidates the code signature and the kernel kills bitwindowd with SIGKILL.