### PR TITLE
Finish the block reject: enforcer safety and honest state

### DIFF
--- a/sail_ui/lib/widgets/modals/chain_settings_modal.dart
+++ b/sail_ui/lib/widgets/modals/chain_settings_modal.dart
@@ -32,7 +32,11 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
   bool _working = false;
   String? _error;
   String? _result;
-  String? _rejectedHash;
+  // Which call left the enforcer off Core's chain, and the block it acted on.
+  // The retry has to repeat that same call on that same block: an accept after
+  // a reject would undo the rejection, and the field may have moved on since.
+  _PendingRetry _pendingRetry = _PendingRetry.none;
+  String? _retryHash;
 
   @override
   void initState() {
@@ -115,11 +119,27 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
     if (!_isBitcoinCore) {
       return;
     }
+    // GetSyncStatus keeps serving the last-good numbers through a daemon
+    // outage, on purpose, so progress never snaps to zero. That makes its
+    // height a poor liveness reading: ask the connection itself first.
+    if (!widget.connection.connected) {
+      setState(() => _chainHeightFailed = true);
+      return;
+    }
+
     try {
       final status = await GetIt.I.get<OrchestratorRPC>().getSyncStatus();
-      if (mounted) {
-        setState(() => _chainHeight = status.mainchain.blocks.toInt());
+      if (!mounted) {
+        return;
       }
+      final mainchain = status.mainchain;
+      setState(() {
+        if (mainchain.error.isNotEmpty) {
+          _chainHeightFailed = true;
+        } else {
+          _chainHeight = mainchain.blocks.toInt();
+        }
+      });
     } catch (e) {
       GetIt.I.get<Logger>().d('chain settings: could not read the height: $e');
       if (mounted) {
@@ -162,15 +182,23 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
       if (!mounted) {
         return;
       }
-      final landed = resp.switchedBranch
-          ? 'Core followed another branch to ${resp.coreHeight}.'
-          : 'Core parked at ${resp.coreHeight}, with no other branch yet.';
+      final landed = switch (resp.outcome) {
+        RejectOutcome.REJECT_OUTCOME_SWITCHED_BRANCH => 'Core followed another branch to ${resp.coreHeight}.',
+        RejectOutcome.REJECT_OUTCOME_PARKED_ON_PARENT => 'Core parked at ${resp.coreHeight}, with no other branch yet.',
+        RejectOutcome.REJECT_OUTCOME_ALREADY_INACTIVE =>
+          'Core stays at ${resp.coreHeight}. That block already sat off the active chain.',
+        _ => 'Core is at ${resp.coreHeight}.',
+      };
       setState(() {
         _chainHeight = resp.coreHeight;
-        _rejectedHash = hash;
-        _result = resp.enforcerRebuilt
-            ? '$landed The enforcer rebuilds from the local Core.'
-            : '$landed The enforcer followed at ${resp.enforcerHeight}.';
+        _pendingRetry = resp.enforcerError.isNotEmpty ? _PendingRetry.reject : _PendingRetry.none;
+        _retryHash = resp.enforcerError.isNotEmpty ? hash : null;
+        _result = switch (resp) {
+          _ when resp.enforcerError.isNotEmpty => '$landed The enforcer did not follow: ${resp.enforcerError}',
+          _ when !resp.enforcerChecked => '$landed The enforcer reads the chain on its next start.',
+          _ when resp.enforcerRebuilt => '$landed The enforcer rebuilds from the local Core.',
+          _ => "$landed The enforcer sits on Core's chain at ${resp.enforcerHeight}.",
+        };
       });
     } catch (e) {
       if (mounted) {
@@ -183,9 +211,28 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
     }
   }
 
-  Future<void> _acceptBlock(BuildContext context) async {
-    final hash = _rejectedHash;
+  /// Repeats whichever call left the enforcer unreconciled. Both calls are safe
+  /// to repeat: Core ignores a second reject or accept of the same block, and
+  /// the reconciliation runs again either way.
+  Future<void> _runRetry(BuildContext context) async {
+    final hash = _retryHash;
     if (hash == null) {
+      return;
+    }
+    switch (_pendingRetry) {
+      case _PendingRetry.reject:
+        await _sendReject(hash);
+      case _PendingRetry.accept:
+        await _acceptBlock(context, retryHash: hash);
+      case _PendingRetry.none:
+        return;
+    }
+  }
+
+  Future<void> _acceptBlock(BuildContext context, {String? retryHash}) async {
+    final hash = retryHash ?? _rejectTarget.text.trim();
+    if (!_blockHashPattern.hasMatch(hash)) {
+      setState(() => _error = 'Paste the 64-character hash of the block to accept.');
       return;
     }
     setState(() {
@@ -200,10 +247,17 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
       }
       setState(() {
         _chainHeight = resp.coreHeight;
-        _rejectedHash = null;
-        _result = resp.enforcerRebuilt
-            ? 'Core accepts the block again at ${resp.coreHeight}. The enforcer rebuilds from the local Core.'
-            : 'Core accepts the block again at ${resp.coreHeight}. The enforcer followed at ${resp.enforcerHeight}.';
+        // A reconciliation that failed leaves the enforcer off Core's chain.
+        // Another accept runs it again, so keep the action reachable.
+        _pendingRetry = resp.enforcerError.isNotEmpty ? _PendingRetry.accept : _PendingRetry.none;
+        _retryHash = resp.enforcerError.isNotEmpty ? hash : null;
+        final landed = 'Core accepts the block again at ${resp.coreHeight}.';
+        _result = switch (resp) {
+          _ when resp.enforcerError.isNotEmpty => '$landed The enforcer did not follow: ${resp.enforcerError}',
+          _ when !resp.enforcerChecked => '$landed The enforcer reads the chain on its next start.',
+          _ when resp.enforcerRebuilt => '$landed The enforcer rebuilds from the local Core.',
+          _ => "$landed The enforcer sits on Core's chain at ${resp.enforcerHeight}.",
+        };
       });
     } catch (e) {
       if (mounted) {
@@ -432,9 +486,9 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
               spacing: SailStyleValues.padding12,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                SailText.primary13('Reject a block', bold: true),
+                SailText.primary13('Reject or accept a block', bold: true),
                 SailText.secondary13(
-                  'Name the block this node must not follow, by hash. It and every block above it leave the active chain, and Core takes the best remaining branch.',
+                  'Name the block this node must not follow, by hash. It and every block above it leave the active chain, and Core takes the best remaining branch. Accept takes a rejected block back, whichever session rejected it.',
                   color: theme.colors.textSecondary,
                 ),
                 SailRow(
@@ -443,7 +497,7 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
                     Expanded(
                       child: SailTextField(
                         controller: _rejectTarget,
-                        hintText: 'Block hash to reject',
+                        hintText: 'Block hash',
                         dense: true,
                       ),
                     ),
@@ -452,6 +506,11 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
                       onPressed: _working ? null : () async => _rejectBlock(context),
                       loading: _working,
                       loadingLabel: 'Rejecting',
+                    ),
+                    SailButton(
+                      label: 'Accept',
+                      variant: ButtonVariant.secondary,
+                      onPressed: _working ? null : () async => _acceptBlock(context),
                     ),
                   ],
                 ),
@@ -464,12 +523,13 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
                     'A height names no block when two branches share it, so paste the hash. The enforcer follows the reject, and rebuilds its validator chain from the local Core if it does not.',
                     color: theme.colors.textSecondary,
                   ),
-                // Stays reachable after a failed accept, so the undo can be retried.
-                if (_rejectedHash != null)
+                // Stays reachable after a failed call, so the enforcer can be
+                // reconciled again without undoing a rejection.
+                if (_pendingRetry != _PendingRetry.none)
                   SailButton(
-                    label: 'Undo, accept it again',
+                    label: 'Retry the enforcer',
                     variant: ButtonVariant.ghost,
-                    onPressed: _working ? null : () async => _acceptBlock(context),
+                    onPressed: _working ? null : () async => _runRetry(context),
                   ),
               ],
             ),
@@ -719,3 +779,6 @@ class ChainSettingsViewModel extends BaseViewModel {
     super.dispose();
   }
 }
+
+/// Which call the retry button repeats.
+enum _PendingRetry { none, reject, accept }

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -897,10 +897,24 @@ func (h *Handler) RejectBlock(ctx context.Context, req *connect.Request[pb.Rejec
 	return connect.NewResponse(&pb.RejectBlockResponse{
 		CoreHeight:      res.CoreHeight,
 		CoreTipHash:     res.CoreTipHash,
-		SwitchedBranch:  res.SwitchedBranch,
+		Outcome:         rejectOutcomeToProto(res.Outcome),
 		EnforcerHeight:  res.EnforcerHeight,
 		EnforcerRebuilt: res.EnforcerRebuilt,
+		EnforcerError:   res.EnforcerError,
+		EnforcerChecked: res.EnforcerChecked,
 	}), nil
+}
+
+func rejectOutcomeToProto(o orchestrator.RejectOutcome) pb.RejectOutcome {
+	switch o {
+	case orchestrator.RejectOutcomeSwitchedBranch:
+		return pb.RejectOutcome_REJECT_OUTCOME_SWITCHED_BRANCH
+	case orchestrator.RejectOutcomeParkedOnParent:
+		return pb.RejectOutcome_REJECT_OUTCOME_PARKED_ON_PARENT
+	case orchestrator.RejectOutcomeAlreadyInactive:
+		return pb.RejectOutcome_REJECT_OUTCOME_ALREADY_INACTIVE
+	}
+	return pb.RejectOutcome_REJECT_OUTCOME_UNSPECIFIED
 }
 
 func (h *Handler) AcceptBlock(ctx context.Context, req *connect.Request[pb.AcceptBlockRequest]) (*connect.Response[pb.AcceptBlockResponse], error) {
@@ -917,6 +931,8 @@ func (h *Handler) AcceptBlock(ctx context.Context, req *connect.Request[pb.Accep
 		CoreTipHash:     res.CoreTipHash,
 		EnforcerHeight:  res.EnforcerHeight,
 		EnforcerRebuilt: res.EnforcerRebuilt,
+		EnforcerError:   res.EnforcerError,
+		EnforcerChecked: res.EnforcerChecked,
 	}), nil
 }
 

--- a/sidechain-orchestrator/commands/reset.go
+++ b/sidechain-orchestrator/commands/reset.go
@@ -50,16 +50,28 @@ var rejectBlockCommand = &cli.Command{
 		}
 
 		fmt.Printf("core tip: %d %s\n", resp.Msg.CoreHeight, resp.Msg.CoreTipHash)
-		if resp.Msg.SwitchedBranch {
+		switch resp.Msg.Outcome {
+		case pb.RejectOutcome_REJECT_OUTCOME_SWITCHED_BRANCH:
 			fmt.Println("chain:    followed another branch")
-		} else {
+		case pb.RejectOutcome_REJECT_OUTCOME_PARKED_ON_PARENT:
 			fmt.Println("chain:    parked on the rejected block's parent, no other branch yet")
+		case pb.RejectOutcome_REJECT_OUTCOME_ALREADY_INACTIVE:
+			fmt.Println("chain:    unchanged, the block already sat off the active chain")
+		default:
+			fmt.Println("chain:    unchanged")
+		}
+		if resp.Msg.EnforcerError != "" {
+			return fmt.Errorf("core moved but the enforcer did not follow: %s", resp.Msg.EnforcerError)
+		}
+		if !resp.Msg.EnforcerChecked {
+			fmt.Println("enforcer: not queried, it reads the chain on its next start")
+			return nil
 		}
 		if resp.Msg.EnforcerRebuilt {
 			fmt.Println("enforcer: validator chain deleted, rebuilds from the local core")
 			return nil
 		}
-		fmt.Printf("enforcer: followed the reject, tip %d\n", resp.Msg.EnforcerHeight)
+		fmt.Printf("enforcer: on core's chain, tip %d\n", resp.Msg.EnforcerHeight)
 		return nil
 	},
 }
@@ -92,11 +104,18 @@ var acceptBlockCommand = &cli.Command{
 		}
 
 		fmt.Printf("core tip: %d %s\n", resp.Msg.CoreHeight, resp.Msg.CoreTipHash)
+		if resp.Msg.EnforcerError != "" {
+			return fmt.Errorf("core moved but the enforcer did not follow: %s", resp.Msg.EnforcerError)
+		}
+		if !resp.Msg.EnforcerChecked {
+			fmt.Println("enforcer: not queried, it reads the chain on its next start")
+			return nil
+		}
 		if resp.Msg.EnforcerRebuilt {
 			fmt.Println("enforcer: validator chain deleted, rebuilds from the local core")
 			return nil
 		}
-		fmt.Printf("enforcer: followed the accept, tip %d\n", resp.Msg.EnforcerHeight)
+		fmt.Printf("enforcer: on core's chain, tip %d\n", resp.Msg.EnforcerHeight)
 		return nil
 	},
 }

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -241,6 +241,62 @@ func (DeletionType) EnumDescriptor() ([]byte, []int) {
 	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{2}
 }
 
+// What the reject did to the chain Core follows.
+type RejectOutcome int32
+
+const (
+	RejectOutcome_REJECT_OUTCOME_UNSPECIFIED RejectOutcome = 0
+	// Core dropped the block and followed another branch.
+	RejectOutcome_REJECT_OUTCOME_SWITCHED_BRANCH RejectOutcome = 1
+	// Core dropped the block and parked on its parent, with no branch to take.
+	RejectOutcome_REJECT_OUTCOME_PARKED_ON_PARENT RejectOutcome = 2
+	// The block already sat off the active chain, so the tip did not move.
+	RejectOutcome_REJECT_OUTCOME_ALREADY_INACTIVE RejectOutcome = 3
+)
+
+// Enum value maps for RejectOutcome.
+var (
+	RejectOutcome_name = map[int32]string{
+		0: "REJECT_OUTCOME_UNSPECIFIED",
+		1: "REJECT_OUTCOME_SWITCHED_BRANCH",
+		2: "REJECT_OUTCOME_PARKED_ON_PARENT",
+		3: "REJECT_OUTCOME_ALREADY_INACTIVE",
+	}
+	RejectOutcome_value = map[string]int32{
+		"REJECT_OUTCOME_UNSPECIFIED":      0,
+		"REJECT_OUTCOME_SWITCHED_BRANCH":  1,
+		"REJECT_OUTCOME_PARKED_ON_PARENT": 2,
+		"REJECT_OUTCOME_ALREADY_INACTIVE": 3,
+	}
+)
+
+func (x RejectOutcome) Enum() *RejectOutcome {
+	p := new(RejectOutcome)
+	*p = x
+	return p
+}
+
+func (x RejectOutcome) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RejectOutcome) Descriptor() protoreflect.EnumDescriptor {
+	return file_orchestrator_v1_orchestrator_proto_enumTypes[3].Descriptor()
+}
+
+func (RejectOutcome) Type() protoreflect.EnumType {
+	return &file_orchestrator_v1_orchestrator_proto_enumTypes[3]
+}
+
+func (x RejectOutcome) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RejectOutcome.Descriptor instead.
+func (RejectOutcome) EnumDescriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{3}
+}
+
 type BinaryStatusMsg struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	Name            string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -3484,14 +3540,19 @@ type RejectBlockResponse struct {
 	CoreHeight uint32 `protobuf:"varint,1,opt,name=core_height,json=coreHeight,proto3" json:"core_height,omitempty"`
 	// Hash of that tip.
 	CoreTipHash string `protobuf:"bytes,2,opt,name=core_tip_hash,json=coreTipHash,proto3" json:"core_tip_hash,omitempty"`
-	// True when Core found another branch and followed it. False when Core
-	// parked on the rejected block's parent and waits for a branch.
-	SwitchedBranch bool `protobuf:"varint,3,opt,name=switched_branch,json=switchedBranch,proto3" json:"switched_branch,omitempty"`
+	// What the reject did to the chain Core follows.
+	Outcome RejectOutcome `protobuf:"varint,3,opt,name=outcome,proto3,enum=orchestrator.v1.RejectOutcome" json:"outcome,omitempty"`
 	// The enforcer's tip afterwards. Zero when the enforcer is stopped.
 	EnforcerHeight uint32 `protobuf:"varint,4,opt,name=enforcer_height,json=enforcerHeight,proto3" json:"enforcer_height,omitempty"`
 	// True when the enforcer did not follow, so its validator chain was deleted
 	// and it now rebuilds from the local Core.
 	EnforcerRebuilt bool `protobuf:"varint,5,opt,name=enforcer_rebuilt,json=enforcerRebuilt,proto3" json:"enforcer_rebuilt,omitempty"`
+	// Empty on success; otherwise why the enforcer could not be brought back
+	// onto Core's chain. Core already moved, so the caller keeps its undo path.
+	EnforcerError string `protobuf:"bytes,6,opt,name=enforcer_error,json=enforcerError,proto3" json:"enforcer_error,omitempty"`
+	// False when the enforcer was never asked, so enforcer_height carries no
+	// reading and must not be shown as one.
+	EnforcerChecked bool `protobuf:"varint,7,opt,name=enforcer_checked,json=enforcerChecked,proto3" json:"enforcer_checked,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -3540,11 +3601,11 @@ func (x *RejectBlockResponse) GetCoreTipHash() string {
 	return ""
 }
 
-func (x *RejectBlockResponse) GetSwitchedBranch() bool {
+func (x *RejectBlockResponse) GetOutcome() RejectOutcome {
 	if x != nil {
-		return x.SwitchedBranch
+		return x.Outcome
 	}
-	return false
+	return RejectOutcome_REJECT_OUTCOME_UNSPECIFIED
 }
 
 func (x *RejectBlockResponse) GetEnforcerHeight() uint32 {
@@ -3557,6 +3618,20 @@ func (x *RejectBlockResponse) GetEnforcerHeight() uint32 {
 func (x *RejectBlockResponse) GetEnforcerRebuilt() bool {
 	if x != nil {
 		return x.EnforcerRebuilt
+	}
+	return false
+}
+
+func (x *RejectBlockResponse) GetEnforcerError() string {
+	if x != nil {
+		return x.EnforcerError
+	}
+	return ""
+}
+
+func (x *RejectBlockResponse) GetEnforcerChecked() bool {
+	if x != nil {
+		return x.EnforcerChecked
 	}
 	return false
 }
@@ -3628,6 +3703,12 @@ type AcceptBlockResponse struct {
 	// True when the enforcer did not follow, so its validator chain was deleted
 	// and it now rebuilds from the local Core.
 	EnforcerRebuilt bool `protobuf:"varint,4,opt,name=enforcer_rebuilt,json=enforcerRebuilt,proto3" json:"enforcer_rebuilt,omitempty"`
+	// Empty on success; otherwise why the enforcer could not be brought back
+	// onto Core's chain. Core already moved, so the caller keeps its undo path.
+	EnforcerError string `protobuf:"bytes,5,opt,name=enforcer_error,json=enforcerError,proto3" json:"enforcer_error,omitempty"`
+	// False when the enforcer was never asked, so enforcer_height carries no
+	// reading and must not be shown as one.
+	EnforcerChecked bool `protobuf:"varint,6,opt,name=enforcer_checked,json=enforcerChecked,proto3" json:"enforcer_checked,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -3686,6 +3767,20 @@ func (x *AcceptBlockResponse) GetEnforcerHeight() uint32 {
 func (x *AcceptBlockResponse) GetEnforcerRebuilt() bool {
 	if x != nil {
 		return x.EnforcerRebuilt
+	}
+	return false
+}
+
+func (x *AcceptBlockResponse) GetEnforcerError() string {
+	if x != nil {
+		return x.EnforcerError
+	}
+	return ""
+}
+
+func (x *AcceptBlockResponse) GetEnforcerChecked() bool {
+	if x != nil {
+		return x.EnforcerChecked
 	}
 	return false
 }
@@ -4707,24 +4802,28 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x12RejectBlockRequest\x12\x1d\n" +
 	"\n" +
 	"block_hash\x18\x01 \x01(\tR\tblockHash\x122\n" +
-	"\x15enforcer_wait_seconds\x18\x02 \x01(\rR\x13enforcerWaitSeconds\"\xd7\x01\n" +
+	"\x15enforcer_wait_seconds\x18\x02 \x01(\rR\x13enforcerWaitSeconds\"\xba\x02\n" +
 	"\x13RejectBlockResponse\x12\x1f\n" +
 	"\vcore_height\x18\x01 \x01(\rR\n" +
 	"coreHeight\x12\"\n" +
-	"\rcore_tip_hash\x18\x02 \x01(\tR\vcoreTipHash\x12'\n" +
-	"\x0fswitched_branch\x18\x03 \x01(\bR\x0eswitchedBranch\x12'\n" +
+	"\rcore_tip_hash\x18\x02 \x01(\tR\vcoreTipHash\x128\n" +
+	"\aoutcome\x18\x03 \x01(\x0e2\x1e.orchestrator.v1.RejectOutcomeR\aoutcome\x12'\n" +
 	"\x0fenforcer_height\x18\x04 \x01(\rR\x0eenforcerHeight\x12)\n" +
-	"\x10enforcer_rebuilt\x18\x05 \x01(\bR\x0fenforcerRebuilt\"g\n" +
+	"\x10enforcer_rebuilt\x18\x05 \x01(\bR\x0fenforcerRebuilt\x12%\n" +
+	"\x0eenforcer_error\x18\x06 \x01(\tR\renforcerError\x12)\n" +
+	"\x10enforcer_checked\x18\a \x01(\bR\x0fenforcerChecked\"g\n" +
 	"\x12AcceptBlockRequest\x12\x1d\n" +
 	"\n" +
 	"block_hash\x18\x01 \x01(\tR\tblockHash\x122\n" +
-	"\x15enforcer_wait_seconds\x18\x02 \x01(\rR\x13enforcerWaitSeconds\"\xae\x01\n" +
+	"\x15enforcer_wait_seconds\x18\x02 \x01(\rR\x13enforcerWaitSeconds\"\x80\x02\n" +
 	"\x13AcceptBlockResponse\x12\x1f\n" +
 	"\vcore_height\x18\x01 \x01(\rR\n" +
 	"coreHeight\x12\"\n" +
 	"\rcore_tip_hash\x18\x02 \x01(\tR\vcoreTipHash\x12'\n" +
 	"\x0fenforcer_height\x18\x03 \x01(\rR\x0eenforcerHeight\x12)\n" +
-	"\x10enforcer_rebuilt\x18\x04 \x01(\bR\x0fenforcerRebuilt\"\x1b\n" +
+	"\x10enforcer_rebuilt\x18\x04 \x01(\bR\x0fenforcerRebuilt\x12%\n" +
+	"\x0eenforcer_error\x18\x05 \x01(\tR\renforcerError\x12)\n" +
+	"\x10enforcer_checked\x18\x06 \x01(\bR\x0fenforcerChecked\"\x1b\n" +
 	"\x19GetCoreMempoolInfoRequest\"\xff\x02\n" +
 	"\x1aGetCoreMempoolInfoResponse\x12\x16\n" +
 	"\x06loaded\x18\x01 \x01(\bR\x06loaded\x12\x12\n" +
@@ -4818,7 +4917,12 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x14DELETION_TYPE_WALLET\x10\x02\x12\x1a\n" +
 	"\x16DELETION_TYPE_SETTINGS\x10\x03\x12\x16\n" +
 	"\x12DELETION_TYPE_LOGS\x10\x04\x12\x1a\n" +
-	"\x16DELETION_TYPE_SOFTWARE\x10\x052\x87\x19\n" +
+	"\x16DELETION_TYPE_SOFTWARE\x10\x05*\x9d\x01\n" +
+	"\rRejectOutcome\x12\x1e\n" +
+	"\x1aREJECT_OUTCOME_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eREJECT_OUTCOME_SWITCHED_BRANCH\x10\x01\x12#\n" +
+	"\x1fREJECT_OUTCOME_PARKED_ON_PARENT\x10\x02\x12#\n" +
+	"\x1fREJECT_OUTCOME_ALREADY_INACTIVE\x10\x032\x87\x19\n" +
 	"\x13OrchestratorService\x12[\n" +
 	"\fListBinaries\x12$.orchestrator.v1.ListBinariesRequest\x1a%.orchestrator.v1.ListBinariesResponse\x12d\n" +
 	"\x0fGetBinaryStatus\x12'.orchestrator.v1.GetBinaryStatusRequest\x1a(.orchestrator.v1.GetBinaryStatusResponse\x12g\n" +
@@ -4867,177 +4971,179 @@ func file_orchestrator_v1_orchestrator_proto_rawDescGZIP() []byte {
 	return file_orchestrator_v1_orchestrator_proto_rawDescData
 }
 
-var file_orchestrator_v1_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_orchestrator_v1_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 73)
 var file_orchestrator_v1_orchestrator_proto_goTypes = []any{
 	(SidechainType)(0),                              // 0: orchestrator.v1.SidechainType
 	(BinaryType)(0),                                 // 1: orchestrator.v1.BinaryType
 	(DeletionType)(0),                               // 2: orchestrator.v1.DeletionType
-	(*BinaryStatusMsg)(nil),                         // 3: orchestrator.v1.BinaryStatusMsg
-	(*StartupLogEntryMsg)(nil),                      // 4: orchestrator.v1.StartupLogEntryMsg
-	(*ListBinariesRequest)(nil),                     // 5: orchestrator.v1.ListBinariesRequest
-	(*ListBinariesResponse)(nil),                    // 6: orchestrator.v1.ListBinariesResponse
-	(*GetBinaryStatusRequest)(nil),                  // 7: orchestrator.v1.GetBinaryStatusRequest
-	(*GetBinaryStatusResponse)(nil),                 // 8: orchestrator.v1.GetBinaryStatusResponse
-	(*GetBinaryVersionRequest)(nil),                 // 9: orchestrator.v1.GetBinaryVersionRequest
-	(*GetBinaryVersionResponse)(nil),                // 10: orchestrator.v1.GetBinaryVersionResponse
-	(*DownloadBinaryRequest)(nil),                   // 11: orchestrator.v1.DownloadBinaryRequest
-	(*DownloadBinaryResponse)(nil),                  // 12: orchestrator.v1.DownloadBinaryResponse
-	(*StartBinaryRequest)(nil),                      // 13: orchestrator.v1.StartBinaryRequest
-	(*StartBinaryResponse)(nil),                     // 14: orchestrator.v1.StartBinaryResponse
-	(*StopBinaryRequest)(nil),                       // 15: orchestrator.v1.StopBinaryRequest
-	(*StopBinaryResponse)(nil),                      // 16: orchestrator.v1.StopBinaryResponse
-	(*StreamLogsRequest)(nil),                       // 17: orchestrator.v1.StreamLogsRequest
-	(*StreamLogsResponse)(nil),                      // 18: orchestrator.v1.StreamLogsResponse
-	(*StartWithL1Request)(nil),                      // 19: orchestrator.v1.StartWithL1Request
-	(*StartWithL1Response)(nil),                     // 20: orchestrator.v1.StartWithL1Response
-	(*RestartDaemonRequest)(nil),                    // 21: orchestrator.v1.RestartDaemonRequest
-	(*RestartDaemonResponse)(nil),                   // 22: orchestrator.v1.RestartDaemonResponse
-	(*RestartL1Request)(nil),                        // 23: orchestrator.v1.RestartL1Request
-	(*RestartL1Response)(nil),                       // 24: orchestrator.v1.RestartL1Response
-	(*ApplyUTXOSnapshotRequest)(nil),                // 25: orchestrator.v1.ApplyUTXOSnapshotRequest
-	(*ApplyUTXOSnapshotResponse)(nil),               // 26: orchestrator.v1.ApplyUTXOSnapshotResponse
-	(*GetSnapshotStatusRequest)(nil),                // 27: orchestrator.v1.GetSnapshotStatusRequest
-	(*GetSnapshotStatusResponse)(nil),               // 28: orchestrator.v1.GetSnapshotStatusResponse
-	(*GetPendingNetworkGenerationRequest)(nil),      // 29: orchestrator.v1.GetPendingNetworkGenerationRequest
-	(*GetPendingNetworkGenerationResponse)(nil),     // 30: orchestrator.v1.GetPendingNetworkGenerationResponse
-	(*ConfirmPendingNetworkGenerationRequest)(nil),  // 31: orchestrator.v1.ConfirmPendingNetworkGenerationRequest
-	(*ConfirmPendingNetworkGenerationResponse)(nil), // 32: orchestrator.v1.ConfirmPendingNetworkGenerationResponse
-	(*ShutdownAllRequest)(nil),                      // 33: orchestrator.v1.ShutdownAllRequest
-	(*ShutdownAllResponse)(nil),                     // 34: orchestrator.v1.ShutdownAllResponse
-	(*GetBTCPriceRequest)(nil),                      // 35: orchestrator.v1.GetBTCPriceRequest
-	(*GetBTCPriceResponse)(nil),                     // 36: orchestrator.v1.GetBTCPriceResponse
-	(*GetMainchainBlockchainInfoRequest)(nil),       // 37: orchestrator.v1.GetMainchainBlockchainInfoRequest
-	(*GetMainchainBlockchainInfoResponse)(nil),      // 38: orchestrator.v1.GetMainchainBlockchainInfoResponse
-	(*GetEnforcerBlockchainInfoRequest)(nil),        // 39: orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	(*GetEnforcerBlockchainInfoResponse)(nil),       // 40: orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	(*GetSyncStatusRequest)(nil),                    // 41: orchestrator.v1.GetSyncStatusRequest
-	(*GetSyncStatusResponse)(nil),                   // 42: orchestrator.v1.GetSyncStatusResponse
-	(*SidechainStatus)(nil),                         // 43: orchestrator.v1.SidechainStatus
-	(*ChainSync)(nil),                               // 44: orchestrator.v1.ChainSync
-	(*GetDownloadStatusRequest)(nil),                // 45: orchestrator.v1.GetDownloadStatusRequest
-	(*GetDownloadStatusResponse)(nil),               // 46: orchestrator.v1.GetDownloadStatusResponse
-	(*DownloadStatus)(nil),                          // 47: orchestrator.v1.DownloadStatus
-	(*GetMainchainBalanceRequest)(nil),              // 48: orchestrator.v1.GetMainchainBalanceRequest
-	(*GetMainchainBalanceResponse)(nil),             // 49: orchestrator.v1.GetMainchainBalanceResponse
-	(*GetSidechainBalanceRequest)(nil),              // 50: orchestrator.v1.GetSidechainBalanceRequest
-	(*GetSidechainBalanceResponse)(nil),             // 51: orchestrator.v1.GetSidechainBalanceResponse
-	(*SingleDeletion)(nil),                          // 52: orchestrator.v1.SingleDeletion
-	(*GatherFilesToDeleteRequest)(nil),              // 53: orchestrator.v1.GatherFilesToDeleteRequest
-	(*GatherFilesToDeleteResponse)(nil),             // 54: orchestrator.v1.GatherFilesToDeleteResponse
-	(*ResetFileInfo)(nil),                           // 55: orchestrator.v1.ResetFileInfo
-	(*DeleteFilesRequest)(nil),                      // 56: orchestrator.v1.DeleteFilesRequest
-	(*DeleteFilesResponse)(nil),                     // 57: orchestrator.v1.DeleteFilesResponse
-	(*RejectBlockRequest)(nil),                      // 58: orchestrator.v1.RejectBlockRequest
-	(*RejectBlockResponse)(nil),                     // 59: orchestrator.v1.RejectBlockResponse
-	(*AcceptBlockRequest)(nil),                      // 60: orchestrator.v1.AcceptBlockRequest
-	(*AcceptBlockResponse)(nil),                     // 61: orchestrator.v1.AcceptBlockResponse
-	(*GetCoreMempoolInfoRequest)(nil),               // 62: orchestrator.v1.GetCoreMempoolInfoRequest
-	(*GetCoreMempoolInfoResponse)(nil),              // 63: orchestrator.v1.GetCoreMempoolInfoResponse
-	(*GetBmmContextRequest)(nil),                    // 64: orchestrator.v1.GetBmmContextRequest
-	(*GetBmmContextResponse)(nil),                   // 65: orchestrator.v1.GetBmmContextResponse
-	(*CoreRawCallRequest)(nil),                      // 66: orchestrator.v1.CoreRawCallRequest
-	(*CoreRawCallResponse)(nil),                     // 67: orchestrator.v1.CoreRawCallResponse
-	(*GetForkStatusRequest)(nil),                    // 68: orchestrator.v1.GetForkStatusRequest
-	(*GetForkStatusResponse)(nil),                   // 69: orchestrator.v1.GetForkStatusResponse
-	(*ForkWalletClaim)(nil),                         // 70: orchestrator.v1.ForkWalletClaim
-	(*ForkClaimUtxo)(nil),                           // 71: orchestrator.v1.ForkClaimUtxo
-	(*ShutdownRequest)(nil),                         // 72: orchestrator.v1.ShutdownRequest
-	(*ShutdownResponse)(nil),                        // 73: orchestrator.v1.ShutdownResponse
-	nil,                                             // 74: orchestrator.v1.StartBinaryRequest.EnvEntry
-	nil,                                             // 75: orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	(RejectOutcome)(0),                              // 3: orchestrator.v1.RejectOutcome
+	(*BinaryStatusMsg)(nil),                         // 4: orchestrator.v1.BinaryStatusMsg
+	(*StartupLogEntryMsg)(nil),                      // 5: orchestrator.v1.StartupLogEntryMsg
+	(*ListBinariesRequest)(nil),                     // 6: orchestrator.v1.ListBinariesRequest
+	(*ListBinariesResponse)(nil),                    // 7: orchestrator.v1.ListBinariesResponse
+	(*GetBinaryStatusRequest)(nil),                  // 8: orchestrator.v1.GetBinaryStatusRequest
+	(*GetBinaryStatusResponse)(nil),                 // 9: orchestrator.v1.GetBinaryStatusResponse
+	(*GetBinaryVersionRequest)(nil),                 // 10: orchestrator.v1.GetBinaryVersionRequest
+	(*GetBinaryVersionResponse)(nil),                // 11: orchestrator.v1.GetBinaryVersionResponse
+	(*DownloadBinaryRequest)(nil),                   // 12: orchestrator.v1.DownloadBinaryRequest
+	(*DownloadBinaryResponse)(nil),                  // 13: orchestrator.v1.DownloadBinaryResponse
+	(*StartBinaryRequest)(nil),                      // 14: orchestrator.v1.StartBinaryRequest
+	(*StartBinaryResponse)(nil),                     // 15: orchestrator.v1.StartBinaryResponse
+	(*StopBinaryRequest)(nil),                       // 16: orchestrator.v1.StopBinaryRequest
+	(*StopBinaryResponse)(nil),                      // 17: orchestrator.v1.StopBinaryResponse
+	(*StreamLogsRequest)(nil),                       // 18: orchestrator.v1.StreamLogsRequest
+	(*StreamLogsResponse)(nil),                      // 19: orchestrator.v1.StreamLogsResponse
+	(*StartWithL1Request)(nil),                      // 20: orchestrator.v1.StartWithL1Request
+	(*StartWithL1Response)(nil),                     // 21: orchestrator.v1.StartWithL1Response
+	(*RestartDaemonRequest)(nil),                    // 22: orchestrator.v1.RestartDaemonRequest
+	(*RestartDaemonResponse)(nil),                   // 23: orchestrator.v1.RestartDaemonResponse
+	(*RestartL1Request)(nil),                        // 24: orchestrator.v1.RestartL1Request
+	(*RestartL1Response)(nil),                       // 25: orchestrator.v1.RestartL1Response
+	(*ApplyUTXOSnapshotRequest)(nil),                // 26: orchestrator.v1.ApplyUTXOSnapshotRequest
+	(*ApplyUTXOSnapshotResponse)(nil),               // 27: orchestrator.v1.ApplyUTXOSnapshotResponse
+	(*GetSnapshotStatusRequest)(nil),                // 28: orchestrator.v1.GetSnapshotStatusRequest
+	(*GetSnapshotStatusResponse)(nil),               // 29: orchestrator.v1.GetSnapshotStatusResponse
+	(*GetPendingNetworkGenerationRequest)(nil),      // 30: orchestrator.v1.GetPendingNetworkGenerationRequest
+	(*GetPendingNetworkGenerationResponse)(nil),     // 31: orchestrator.v1.GetPendingNetworkGenerationResponse
+	(*ConfirmPendingNetworkGenerationRequest)(nil),  // 32: orchestrator.v1.ConfirmPendingNetworkGenerationRequest
+	(*ConfirmPendingNetworkGenerationResponse)(nil), // 33: orchestrator.v1.ConfirmPendingNetworkGenerationResponse
+	(*ShutdownAllRequest)(nil),                      // 34: orchestrator.v1.ShutdownAllRequest
+	(*ShutdownAllResponse)(nil),                     // 35: orchestrator.v1.ShutdownAllResponse
+	(*GetBTCPriceRequest)(nil),                      // 36: orchestrator.v1.GetBTCPriceRequest
+	(*GetBTCPriceResponse)(nil),                     // 37: orchestrator.v1.GetBTCPriceResponse
+	(*GetMainchainBlockchainInfoRequest)(nil),       // 38: orchestrator.v1.GetMainchainBlockchainInfoRequest
+	(*GetMainchainBlockchainInfoResponse)(nil),      // 39: orchestrator.v1.GetMainchainBlockchainInfoResponse
+	(*GetEnforcerBlockchainInfoRequest)(nil),        // 40: orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	(*GetEnforcerBlockchainInfoResponse)(nil),       // 41: orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	(*GetSyncStatusRequest)(nil),                    // 42: orchestrator.v1.GetSyncStatusRequest
+	(*GetSyncStatusResponse)(nil),                   // 43: orchestrator.v1.GetSyncStatusResponse
+	(*SidechainStatus)(nil),                         // 44: orchestrator.v1.SidechainStatus
+	(*ChainSync)(nil),                               // 45: orchestrator.v1.ChainSync
+	(*GetDownloadStatusRequest)(nil),                // 46: orchestrator.v1.GetDownloadStatusRequest
+	(*GetDownloadStatusResponse)(nil),               // 47: orchestrator.v1.GetDownloadStatusResponse
+	(*DownloadStatus)(nil),                          // 48: orchestrator.v1.DownloadStatus
+	(*GetMainchainBalanceRequest)(nil),              // 49: orchestrator.v1.GetMainchainBalanceRequest
+	(*GetMainchainBalanceResponse)(nil),             // 50: orchestrator.v1.GetMainchainBalanceResponse
+	(*GetSidechainBalanceRequest)(nil),              // 51: orchestrator.v1.GetSidechainBalanceRequest
+	(*GetSidechainBalanceResponse)(nil),             // 52: orchestrator.v1.GetSidechainBalanceResponse
+	(*SingleDeletion)(nil),                          // 53: orchestrator.v1.SingleDeletion
+	(*GatherFilesToDeleteRequest)(nil),              // 54: orchestrator.v1.GatherFilesToDeleteRequest
+	(*GatherFilesToDeleteResponse)(nil),             // 55: orchestrator.v1.GatherFilesToDeleteResponse
+	(*ResetFileInfo)(nil),                           // 56: orchestrator.v1.ResetFileInfo
+	(*DeleteFilesRequest)(nil),                      // 57: orchestrator.v1.DeleteFilesRequest
+	(*DeleteFilesResponse)(nil),                     // 58: orchestrator.v1.DeleteFilesResponse
+	(*RejectBlockRequest)(nil),                      // 59: orchestrator.v1.RejectBlockRequest
+	(*RejectBlockResponse)(nil),                     // 60: orchestrator.v1.RejectBlockResponse
+	(*AcceptBlockRequest)(nil),                      // 61: orchestrator.v1.AcceptBlockRequest
+	(*AcceptBlockResponse)(nil),                     // 62: orchestrator.v1.AcceptBlockResponse
+	(*GetCoreMempoolInfoRequest)(nil),               // 63: orchestrator.v1.GetCoreMempoolInfoRequest
+	(*GetCoreMempoolInfoResponse)(nil),              // 64: orchestrator.v1.GetCoreMempoolInfoResponse
+	(*GetBmmContextRequest)(nil),                    // 65: orchestrator.v1.GetBmmContextRequest
+	(*GetBmmContextResponse)(nil),                   // 66: orchestrator.v1.GetBmmContextResponse
+	(*CoreRawCallRequest)(nil),                      // 67: orchestrator.v1.CoreRawCallRequest
+	(*CoreRawCallResponse)(nil),                     // 68: orchestrator.v1.CoreRawCallResponse
+	(*GetForkStatusRequest)(nil),                    // 69: orchestrator.v1.GetForkStatusRequest
+	(*GetForkStatusResponse)(nil),                   // 70: orchestrator.v1.GetForkStatusResponse
+	(*ForkWalletClaim)(nil),                         // 71: orchestrator.v1.ForkWalletClaim
+	(*ForkClaimUtxo)(nil),                           // 72: orchestrator.v1.ForkClaimUtxo
+	(*ShutdownRequest)(nil),                         // 73: orchestrator.v1.ShutdownRequest
+	(*ShutdownResponse)(nil),                        // 74: orchestrator.v1.ShutdownResponse
+	nil,                                             // 75: orchestrator.v1.StartBinaryRequest.EnvEntry
+	nil,                                             // 76: orchestrator.v1.StartWithL1Request.TargetEnvEntry
 }
 var file_orchestrator_v1_orchestrator_proto_depIdxs = []int32{
-	4,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
-	3,  // 1: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
-	3,  // 2: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
-	74, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
-	75, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
-	44, // 5: orchestrator.v1.GetSyncStatusResponse.mainchain:type_name -> orchestrator.v1.ChainSync
-	44, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
-	43, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
-	44, // 8: orchestrator.v1.GetSyncStatusResponse.enforcer_wallet:type_name -> orchestrator.v1.ChainSync
+	5,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
+	4,  // 1: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
+	4,  // 2: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
+	75, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
+	76, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	45, // 5: orchestrator.v1.GetSyncStatusResponse.mainchain:type_name -> orchestrator.v1.ChainSync
+	45, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
+	44, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
+	45, // 8: orchestrator.v1.GetSyncStatusResponse.enforcer_wallet:type_name -> orchestrator.v1.ChainSync
 	0,  // 9: orchestrator.v1.SidechainStatus.type:type_name -> orchestrator.v1.SidechainType
-	44, // 10: orchestrator.v1.SidechainStatus.sync:type_name -> orchestrator.v1.ChainSync
-	47, // 11: orchestrator.v1.GetDownloadStatusResponse.downloads:type_name -> orchestrator.v1.DownloadStatus
+	45, // 10: orchestrator.v1.SidechainStatus.sync:type_name -> orchestrator.v1.ChainSync
+	48, // 11: orchestrator.v1.GetDownloadStatusResponse.downloads:type_name -> orchestrator.v1.DownloadStatus
 	1,  // 12: orchestrator.v1.DownloadStatus.binary:type_name -> orchestrator.v1.BinaryType
 	1,  // 13: orchestrator.v1.GetSidechainBalanceRequest.sidechain:type_name -> orchestrator.v1.BinaryType
 	1,  // 14: orchestrator.v1.SingleDeletion.binary:type_name -> orchestrator.v1.BinaryType
 	2,  // 15: orchestrator.v1.SingleDeletion.deletions:type_name -> orchestrator.v1.DeletionType
-	52, // 16: orchestrator.v1.GatherFilesToDeleteRequest.items:type_name -> orchestrator.v1.SingleDeletion
-	55, // 17: orchestrator.v1.GatherFilesToDeleteResponse.files:type_name -> orchestrator.v1.ResetFileInfo
+	53, // 16: orchestrator.v1.GatherFilesToDeleteRequest.items:type_name -> orchestrator.v1.SingleDeletion
+	56, // 17: orchestrator.v1.GatherFilesToDeleteResponse.files:type_name -> orchestrator.v1.ResetFileInfo
 	2,  // 18: orchestrator.v1.ResetFileInfo.deletion_type:type_name -> orchestrator.v1.DeletionType
 	1,  // 19: orchestrator.v1.ResetFileInfo.binary:type_name -> orchestrator.v1.BinaryType
-	52, // 20: orchestrator.v1.DeleteFilesRequest.items:type_name -> orchestrator.v1.SingleDeletion
-	70, // 21: orchestrator.v1.GetForkStatusResponse.claims:type_name -> orchestrator.v1.ForkWalletClaim
-	71, // 22: orchestrator.v1.ForkWalletClaim.utxos:type_name -> orchestrator.v1.ForkClaimUtxo
-	5,  // 23: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
-	7,  // 24: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
-	9,  // 25: orchestrator.v1.OrchestratorService.GetBinaryVersion:input_type -> orchestrator.v1.GetBinaryVersionRequest
-	11, // 26: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
-	13, // 27: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
-	15, // 28: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
-	17, // 29: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
-	19, // 30: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
-	21, // 31: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
-	23, // 32: orchestrator.v1.OrchestratorService.RestartL1:input_type -> orchestrator.v1.RestartL1Request
-	25, // 33: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:input_type -> orchestrator.v1.ApplyUTXOSnapshotRequest
-	27, // 34: orchestrator.v1.OrchestratorService.GetSnapshotStatus:input_type -> orchestrator.v1.GetSnapshotStatusRequest
-	29, // 35: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:input_type -> orchestrator.v1.GetPendingNetworkGenerationRequest
-	31, // 36: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:input_type -> orchestrator.v1.ConfirmPendingNetworkGenerationRequest
-	33, // 37: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
-	72, // 38: orchestrator.v1.OrchestratorService.Shutdown:input_type -> orchestrator.v1.ShutdownRequest
-	35, // 39: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
-	37, // 40: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
-	39, // 41: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	41, // 42: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
-	45, // 43: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
-	48, // 44: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
-	50, // 45: orchestrator.v1.OrchestratorService.GetSidechainBalance:input_type -> orchestrator.v1.GetSidechainBalanceRequest
-	53, // 46: orchestrator.v1.OrchestratorService.GatherFilesToDelete:input_type -> orchestrator.v1.GatherFilesToDeleteRequest
-	56, // 47: orchestrator.v1.OrchestratorService.DeleteFiles:input_type -> orchestrator.v1.DeleteFilesRequest
-	58, // 48: orchestrator.v1.OrchestratorService.RejectBlock:input_type -> orchestrator.v1.RejectBlockRequest
-	60, // 49: orchestrator.v1.OrchestratorService.AcceptBlock:input_type -> orchestrator.v1.AcceptBlockRequest
-	62, // 50: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
-	64, // 51: orchestrator.v1.OrchestratorService.GetBmmContext:input_type -> orchestrator.v1.GetBmmContextRequest
-	66, // 52: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
-	68, // 53: orchestrator.v1.OrchestratorService.GetForkStatus:input_type -> orchestrator.v1.GetForkStatusRequest
-	6,  // 54: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
-	8,  // 55: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
-	10, // 56: orchestrator.v1.OrchestratorService.GetBinaryVersion:output_type -> orchestrator.v1.GetBinaryVersionResponse
-	12, // 57: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
-	14, // 58: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
-	16, // 59: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
-	18, // 60: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
-	20, // 61: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
-	22, // 62: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
-	24, // 63: orchestrator.v1.OrchestratorService.RestartL1:output_type -> orchestrator.v1.RestartL1Response
-	26, // 64: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:output_type -> orchestrator.v1.ApplyUTXOSnapshotResponse
-	28, // 65: orchestrator.v1.OrchestratorService.GetSnapshotStatus:output_type -> orchestrator.v1.GetSnapshotStatusResponse
-	30, // 66: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:output_type -> orchestrator.v1.GetPendingNetworkGenerationResponse
-	32, // 67: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:output_type -> orchestrator.v1.ConfirmPendingNetworkGenerationResponse
-	34, // 68: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
-	73, // 69: orchestrator.v1.OrchestratorService.Shutdown:output_type -> orchestrator.v1.ShutdownResponse
-	36, // 70: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
-	38, // 71: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
-	40, // 72: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	42, // 73: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
-	46, // 74: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
-	49, // 75: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
-	51, // 76: orchestrator.v1.OrchestratorService.GetSidechainBalance:output_type -> orchestrator.v1.GetSidechainBalanceResponse
-	54, // 77: orchestrator.v1.OrchestratorService.GatherFilesToDelete:output_type -> orchestrator.v1.GatherFilesToDeleteResponse
-	57, // 78: orchestrator.v1.OrchestratorService.DeleteFiles:output_type -> orchestrator.v1.DeleteFilesResponse
-	59, // 79: orchestrator.v1.OrchestratorService.RejectBlock:output_type -> orchestrator.v1.RejectBlockResponse
-	61, // 80: orchestrator.v1.OrchestratorService.AcceptBlock:output_type -> orchestrator.v1.AcceptBlockResponse
-	63, // 81: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
-	65, // 82: orchestrator.v1.OrchestratorService.GetBmmContext:output_type -> orchestrator.v1.GetBmmContextResponse
-	67, // 83: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
-	69, // 84: orchestrator.v1.OrchestratorService.GetForkStatus:output_type -> orchestrator.v1.GetForkStatusResponse
-	54, // [54:85] is the sub-list for method output_type
-	23, // [23:54] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	53, // 20: orchestrator.v1.DeleteFilesRequest.items:type_name -> orchestrator.v1.SingleDeletion
+	3,  // 21: orchestrator.v1.RejectBlockResponse.outcome:type_name -> orchestrator.v1.RejectOutcome
+	71, // 22: orchestrator.v1.GetForkStatusResponse.claims:type_name -> orchestrator.v1.ForkWalletClaim
+	72, // 23: orchestrator.v1.ForkWalletClaim.utxos:type_name -> orchestrator.v1.ForkClaimUtxo
+	6,  // 24: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
+	8,  // 25: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
+	10, // 26: orchestrator.v1.OrchestratorService.GetBinaryVersion:input_type -> orchestrator.v1.GetBinaryVersionRequest
+	12, // 27: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
+	14, // 28: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
+	16, // 29: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
+	18, // 30: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
+	20, // 31: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
+	22, // 32: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
+	24, // 33: orchestrator.v1.OrchestratorService.RestartL1:input_type -> orchestrator.v1.RestartL1Request
+	26, // 34: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:input_type -> orchestrator.v1.ApplyUTXOSnapshotRequest
+	28, // 35: orchestrator.v1.OrchestratorService.GetSnapshotStatus:input_type -> orchestrator.v1.GetSnapshotStatusRequest
+	30, // 36: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:input_type -> orchestrator.v1.GetPendingNetworkGenerationRequest
+	32, // 37: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:input_type -> orchestrator.v1.ConfirmPendingNetworkGenerationRequest
+	34, // 38: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
+	73, // 39: orchestrator.v1.OrchestratorService.Shutdown:input_type -> orchestrator.v1.ShutdownRequest
+	36, // 40: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
+	38, // 41: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
+	40, // 42: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	42, // 43: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
+	46, // 44: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
+	49, // 45: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
+	51, // 46: orchestrator.v1.OrchestratorService.GetSidechainBalance:input_type -> orchestrator.v1.GetSidechainBalanceRequest
+	54, // 47: orchestrator.v1.OrchestratorService.GatherFilesToDelete:input_type -> orchestrator.v1.GatherFilesToDeleteRequest
+	57, // 48: orchestrator.v1.OrchestratorService.DeleteFiles:input_type -> orchestrator.v1.DeleteFilesRequest
+	59, // 49: orchestrator.v1.OrchestratorService.RejectBlock:input_type -> orchestrator.v1.RejectBlockRequest
+	61, // 50: orchestrator.v1.OrchestratorService.AcceptBlock:input_type -> orchestrator.v1.AcceptBlockRequest
+	63, // 51: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
+	65, // 52: orchestrator.v1.OrchestratorService.GetBmmContext:input_type -> orchestrator.v1.GetBmmContextRequest
+	67, // 53: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
+	69, // 54: orchestrator.v1.OrchestratorService.GetForkStatus:input_type -> orchestrator.v1.GetForkStatusRequest
+	7,  // 55: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
+	9,  // 56: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
+	11, // 57: orchestrator.v1.OrchestratorService.GetBinaryVersion:output_type -> orchestrator.v1.GetBinaryVersionResponse
+	13, // 58: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
+	15, // 59: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
+	17, // 60: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
+	19, // 61: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
+	21, // 62: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
+	23, // 63: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
+	25, // 64: orchestrator.v1.OrchestratorService.RestartL1:output_type -> orchestrator.v1.RestartL1Response
+	27, // 65: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:output_type -> orchestrator.v1.ApplyUTXOSnapshotResponse
+	29, // 66: orchestrator.v1.OrchestratorService.GetSnapshotStatus:output_type -> orchestrator.v1.GetSnapshotStatusResponse
+	31, // 67: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:output_type -> orchestrator.v1.GetPendingNetworkGenerationResponse
+	33, // 68: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:output_type -> orchestrator.v1.ConfirmPendingNetworkGenerationResponse
+	35, // 69: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
+	74, // 70: orchestrator.v1.OrchestratorService.Shutdown:output_type -> orchestrator.v1.ShutdownResponse
+	37, // 71: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
+	39, // 72: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
+	41, // 73: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	43, // 74: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
+	47, // 75: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
+	50, // 76: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
+	52, // 77: orchestrator.v1.OrchestratorService.GetSidechainBalance:output_type -> orchestrator.v1.GetSidechainBalanceResponse
+	55, // 78: orchestrator.v1.OrchestratorService.GatherFilesToDelete:output_type -> orchestrator.v1.GatherFilesToDeleteResponse
+	58, // 79: orchestrator.v1.OrchestratorService.DeleteFiles:output_type -> orchestrator.v1.DeleteFilesResponse
+	60, // 80: orchestrator.v1.OrchestratorService.RejectBlock:output_type -> orchestrator.v1.RejectBlockResponse
+	62, // 81: orchestrator.v1.OrchestratorService.AcceptBlock:output_type -> orchestrator.v1.AcceptBlockResponse
+	64, // 82: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
+	66, // 83: orchestrator.v1.OrchestratorService.GetBmmContext:output_type -> orchestrator.v1.GetBmmContextResponse
+	68, // 84: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
+	70, // 85: orchestrator.v1.OrchestratorService.GetForkStatus:output_type -> orchestrator.v1.GetForkStatusResponse
+	55, // [55:86] is the sub-list for method output_type
+	24, // [24:55] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_orchestrator_v1_orchestrator_proto_init() }
@@ -5050,7 +5156,7 @@ func file_orchestrator_v1_orchestrator_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_orchestrator_v1_orchestrator_proto_rawDesc), len(file_orchestrator_v1_orchestrator_proto_rawDesc)),
-			NumEnums:      3,
+			NumEnums:      4,
 			NumMessages:   73,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -639,19 +639,35 @@ message RejectBlockRequest {
   uint32 enforcer_wait_seconds = 2;
 }
 
+// What the reject did to the chain Core follows.
+enum RejectOutcome {
+  REJECT_OUTCOME_UNSPECIFIED = 0;
+  // Core dropped the block and followed another branch.
+  REJECT_OUTCOME_SWITCHED_BRANCH = 1;
+  // Core dropped the block and parked on its parent, with no branch to take.
+  REJECT_OUTCOME_PARKED_ON_PARENT = 2;
+  // The block already sat off the active chain, so the tip did not move.
+  REJECT_OUTCOME_ALREADY_INACTIVE = 3;
+}
+
 message RejectBlockResponse {
   // Core's tip after the reject.
   uint32 core_height = 1;
   // Hash of that tip.
   string core_tip_hash = 2;
-  // True when Core found another branch and followed it. False when Core
-  // parked on the rejected block's parent and waits for a branch.
-  bool switched_branch = 3;
+  // What the reject did to the chain Core follows.
+  RejectOutcome outcome = 3;
   // The enforcer's tip afterwards. Zero when the enforcer is stopped.
   uint32 enforcer_height = 4;
   // True when the enforcer did not follow, so its validator chain was deleted
   // and it now rebuilds from the local Core.
   bool enforcer_rebuilt = 5;
+  // Empty on success; otherwise why the enforcer could not be brought back
+  // onto Core's chain. Core already moved, so the caller keeps its undo path.
+  string enforcer_error = 6;
+  // False when the enforcer was never asked, so enforcer_height carries no
+  // reading and must not be shown as one.
+  bool enforcer_checked = 7;
 }
 
 message AcceptBlockRequest {
@@ -673,6 +689,12 @@ message AcceptBlockResponse {
   // True when the enforcer did not follow, so its validator chain was deleted
   // and it now rebuilds from the local Core.
   bool enforcer_rebuilt = 4;
+  // Empty on success; otherwise why the enforcer could not be brought back
+  // onto Core's chain. Core already moved, so the caller keeps its undo path.
+  string enforcer_error = 5;
+  // False when the enforcer was never asked, so enforcer_height carries no
+  // reading and must not be shown as one.
+  bool enforcer_checked = 6;
 }
 
 // ─── Bitcoin Core typed extensions ────────────────────────────────────────

--- a/sidechain-orchestrator/reject_block.go
+++ b/sidechain-orchestrator/reject_block.go
@@ -16,21 +16,40 @@ const defaultEnforcerReorgWait = 60 * time.Second
 
 const enforcerReorgPollInterval = 2 * time.Second
 
+// RejectOutcome says what a reject did to the chain Core follows.
+type RejectOutcome int
+
+const (
+	// RejectOutcomeSwitchedBranch means Core dropped the block and followed
+	// another branch.
+	RejectOutcomeSwitchedBranch RejectOutcome = iota + 1
+	// RejectOutcomeParkedOnParent means Core dropped the block and parked on
+	// its parent, with no branch to take.
+	RejectOutcomeParkedOnParent
+	// RejectOutcomeAlreadyInactive means the block already sat off the active
+	// chain, so the tip did not move.
+	RejectOutcomeAlreadyInactive
+)
+
 // RejectBlockResult reports where Core landed after a reject.
 type RejectBlockResult struct {
 	CoreHeight      uint32
 	CoreTipHash     string
-	SwitchedBranch  bool
+	Outcome         RejectOutcome
+	EnforcerChecked bool
 	EnforcerHeight  uint32
 	EnforcerRebuilt bool
+	EnforcerError   string
 }
 
 // AcceptBlockResult reports where Core landed after a block is accepted again.
 type AcceptBlockResult struct {
 	CoreHeight      uint32
 	CoreTipHash     string
+	EnforcerChecked bool
 	EnforcerHeight  uint32
 	EnforcerRebuilt bool
+	EnforcerError   string
 }
 
 // RejectBlock drops a block Core must not follow. Core disconnects it and every
@@ -59,12 +78,19 @@ func (o *Orchestrator) RejectBlock(ctx context.Context, blockHash string, enforc
 	o.log.Info().
 		Str("rejected", normalizeBlockHash(blockHash)).
 		Uint32("core_height", result.CoreHeight).
-		Bool("switched_branch", result.SwitchedBranch).
+		Int("outcome", int(result.Outcome)).
 		Msg("rejected a block")
 
-	result.EnforcerHeight, result.EnforcerRebuilt, err = o.reconcileEnforcer(ctx, client, enforcerWait)
-	if err != nil {
-		return result, err
+	// Core already moved, so a failure past this point is reported in the
+	// result rather than as an error. An error-only answer would hide the
+	// mutation and take the caller's undo path with it.
+	rec := o.reconcileEnforcer(ctx, client, enforcerWait)
+	result.EnforcerChecked = rec.Checked
+	result.EnforcerHeight = rec.Height
+	result.EnforcerRebuilt = rec.Rebuilt
+	result.EnforcerError = rec.Err
+	if rec.Err != "" {
+		o.log.Error().Str("error", rec.Err).Msg("core moved but the enforcer could not be reconciled")
 	}
 	return result, nil
 }
@@ -94,31 +120,75 @@ func (o *Orchestrator) AcceptBlock(ctx context.Context, blockHash string, enforc
 		Uint32("core_height", result.CoreHeight).
 		Msg("accepted a block again")
 
-	result.EnforcerHeight, result.EnforcerRebuilt, err = o.reconcileEnforcer(ctx, client, enforcerWait)
-	if err != nil {
-		return result, err
+	rec := o.reconcileEnforcer(ctx, client, enforcerWait)
+	result.EnforcerChecked = rec.Checked
+	result.EnforcerHeight = rec.Height
+	result.EnforcerRebuilt = rec.Rebuilt
+	result.EnforcerError = rec.Err
+	if rec.Err != "" {
+		o.log.Error().Str("error", rec.Err).Msg("core moved but the enforcer could not be reconciled")
 	}
 	return result, nil
 }
 
-// reconcileEnforcer brings the enforcer back onto the chain Core follows after
-// a reorg. A stopped enforcer reads the new chain on its next start, so it
-// needs nothing here.
-func (o *Orchestrator) reconcileEnforcer(ctx context.Context, client *CoreStatusClient, wait time.Duration) (uint32, bool, error) {
-	if !o.process.IsRunning("enforcer") {
+// enforcerReconciliation reports what happened to the enforcer after a Core
+// move. Checked stays false when the enforcer was never asked, so a caller
+// never reads Height as an observed tip.
+type enforcerReconciliation struct {
+	Checked bool
+	Height  uint32
+	Rebuilt bool
+	Err     string
+}
+
+// reconcileEnforcer brings the enforcer back onto the chain Core follows. It
+// asks whether the enforcer sits off that chain rather than whether this call
+// moved it, so a retry after a failed read still repairs the divergence.
+func (o *Orchestrator) reconcileEnforcer(ctx context.Context, client *CoreStatusClient, wait time.Duration) enforcerReconciliation {
+	// A connect-only enforcer answers RPC without ever entering ProcessManager,
+	// so IsRunning would read it as stopped and skip a reconciliation it needs.
+	if !o.enforcerReachable() {
 		o.log.Info().Msg("enforcer is stopped, so it reads the new chain on its next start")
-		return 0, false, nil
+		return enforcerReconciliation{}
 	}
 
-	height, followed := o.awaitEnforcerRollback(ctx, client, wait)
-	if followed {
-		return height, false, nil
+	hash, tip, err := o.ChainTip(ctx)
+	if err == nil {
+		onChain, chainErr := blockOnActiveChain(ctx, client, hash)
+		if chainErr == nil && onChain {
+			o.log.Info().Int32("enforcer_tip", tip).Msg("enforcer already sits on core's chain")
+			return enforcerReconciliation{Checked: true, Height: uint32(max(tip, 0))}
+		}
+	}
+
+	height, outcome := o.awaitEnforcerRollback(ctx, client, wait)
+	switch outcome {
+	case enforcerWaitFollowed:
+		return enforcerReconciliation{Checked: true, Height: height}
+	case enforcerWaitCanceled:
+		// The caller left, which says nothing about the enforcer. Deleting a
+		// validator chain over a cancelled wait costs a full rebuild.
+		return enforcerReconciliation{
+			Checked: true,
+			Height:  height,
+			Err:     "the wait for the enforcer was cancelled, so its chain was left alone",
+		}
+	}
+
+	// A rebuild stops the daemon, deletes its chain and starts it again. None of
+	// that is ours to do for an enforcer this process never started.
+	if !o.process.IsRunning("enforcer") {
+		return enforcerReconciliation{
+			Checked: true,
+			Height:  height,
+			Err:     "the enforcer did not follow, and this process does not manage it, so its chain was left alone",
+		}
 	}
 
 	if err := o.rebuildEnforcerChain(ctx); err != nil {
-		return height, false, err
+		return enforcerReconciliation{Checked: true, Height: height, Err: err.Error()}
 	}
-	return height, true, nil
+	return enforcerReconciliation{Checked: true, Height: height, Rebuilt: true}
 }
 
 // rejectBlockOnCore invalidates the named block and reports the tip Core chose
@@ -149,12 +219,18 @@ func rejectBlockOnCore(ctx context.Context, client *CoreStatusClient, blockHash 
 
 	// A block already off the active chain moves nothing, so the tip differing
 	// from its parent says only that the two were never related.
-	wasOnActiveChain := header.Confirmations >= 0
+	outcome := RejectOutcomeSwitchedBranch
+	switch {
+	case header.Confirmations < 0:
+		outcome = RejectOutcomeAlreadyInactive
+	case tipHash == header.PreviousBlockHash:
+		outcome = RejectOutcomeParkedOnParent
+	}
 
 	return RejectBlockResult{
-		CoreHeight:     tipHeight,
-		CoreTipHash:    tipHash,
-		SwitchedBranch: wasOnActiveChain && tipHash != header.PreviousBlockHash,
+		CoreHeight:  tipHeight,
+		CoreTipHash: tipHash,
+		Outcome:     outcome,
 	}, nil
 }
 
@@ -164,6 +240,7 @@ func acceptBlockOnCore(ctx context.Context, client *CoreStatusClient, blockHash 
 	if hash == "" {
 		return AcceptBlockResult{}, fmt.Errorf("name the block to accept by its hash")
 	}
+
 	if _, err := client.call(ctx, "reconsiderblock", hash); err != nil {
 		return AcceptBlockResult{}, fmt.Errorf("accept block %s: %w", hash, err)
 	}
@@ -190,10 +267,20 @@ func blockOnActiveChain(ctx context.Context, client *CoreStatusClient, hash stri
 	return header.Confirmations >= 0, nil
 }
 
+// enforcerWaitOutcome says why the wait for the enforcer ended. A cancelled
+// wait is not a verdict on the enforcer, so it must not cost a chain rebuild.
+type enforcerWaitOutcome int
+
+const (
+	enforcerWaitFollowed enforcerWaitOutcome = iota
+	enforcerWaitExpired
+	enforcerWaitCanceled
+)
+
 // awaitEnforcerRollback watches the enforcer until its tip sits on the chain
 // Core follows. A tip it cannot read counts as no answer, not as a failure:
 // the enforcer refuses GetChainTip while it reorganizes.
-func (o *Orchestrator) awaitEnforcerRollback(ctx context.Context, client *CoreStatusClient, wait time.Duration) (uint32, bool) {
+func (o *Orchestrator) awaitEnforcerRollback(ctx context.Context, client *CoreStatusClient, wait time.Duration) (uint32, enforcerWaitOutcome) {
 	deadline := time.Now().Add(wait)
 	var tip int32
 	for {
@@ -203,18 +290,19 @@ func (o *Orchestrator) awaitEnforcerRollback(ctx context.Context, client *CoreSt
 			onChain, chainErr := blockOnActiveChain(ctx, client, hash)
 			if chainErr == nil && onChain {
 				o.log.Info().Int32("enforcer_tip", tip).Str("enforcer_hash", hash).Msg("enforcer followed the reject")
-				return uint32(max(tip, 0)), true
+				return uint32(max(tip, 0)), enforcerWaitFollowed
 			}
 		}
 		if !time.Now().Before(deadline) {
 			o.log.Warn().
 				Int32("enforcer_tip", tip).
 				Msg("enforcer did not follow the reject, rebuilding its validator chain")
-			return uint32(max(tip, 0)), false
+			return uint32(max(tip, 0)), enforcerWaitExpired
 		}
 		select {
 		case <-ctx.Done():
-			return uint32(max(tip, 0)), false
+			o.log.Warn().Int32("enforcer_tip", tip).Msg("the wait for the enforcer was cancelled")
+			return uint32(max(tip, 0)), enforcerWaitCanceled
 		case <-time.After(enforcerReorgPollInterval):
 		}
 	}
@@ -224,6 +312,14 @@ func (o *Orchestrator) awaitEnforcerRollback(ctx context.Context, client *CoreSt
 // again. Its wallet stays, and it re-reads every block from the local Core, so
 // this costs no network download.
 func (o *Orchestrator) rebuildEnforcerChain(ctx context.Context) error {
+	// A wallet swap owns the enforcer's whole stop and start sequence, and its
+	// guard refuses any start that is not the swap's own. Wiping underneath it
+	// would leave the daemon stopped with no chain data.
+	if !o.swapEnforcerMu.TryLock() {
+		return fmt.Errorf("an enforcer wallet swap is in progress, so the validator chain was left alone")
+	}
+	defer o.swapEnforcerMu.Unlock()
+
 	if err := o.stopForNetworkSwap(ctx, "enforcer"); err != nil {
 		return fmt.Errorf("stop the enforcer: %w", err)
 	}

--- a/sidechain-orchestrator/reject_block_test.go
+++ b/sidechain-orchestrator/reject_block_test.go
@@ -106,8 +106,8 @@ func TestRejectBlockInvalidatesTheNamedHash(t *testing.T) {
 	if got.CoreHeight != 979024 || got.CoreTipHash != parent {
 		t.Errorf("tip = %d/%s, want 979024/%s", got.CoreHeight, got.CoreTipHash, parent)
 	}
-	if got.SwitchedBranch {
-		t.Error("SwitchedBranch = true, want false when Core parks on the parent")
+	if got.Outcome != RejectOutcomeParkedOnParent {
+		t.Errorf("Outcome = %v, want ParkedOnParent", got.Outcome)
 	}
 	if calls := strings.Join(core.methods, ","); calls != "getblockheader,invalidateblock,getblockcount,getblockhash" {
 		t.Errorf("rpc calls = %s", calls)
@@ -131,8 +131,8 @@ func TestRejectBlockReportsASiblingBranch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rejectBlockOnCore: %v", err)
 	}
-	if !got.SwitchedBranch {
-		t.Error("SwitchedBranch = false, want true when Core lands off the parent")
+	if got.Outcome != RejectOutcomeSwitchedBranch {
+		t.Errorf("Outcome = %v, want SwitchedBranch", got.Outcome)
 	}
 	if got.CoreTipHash != other {
 		t.Errorf("tip = %s, want the sibling %s", got.CoreTipHash, other)
@@ -152,8 +152,8 @@ func TestRejectBlockReportsNoSwitchForAnInactiveBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rejectBlockOnCore: %v", err)
 	}
-	if got.SwitchedBranch {
-		t.Error("SwitchedBranch = true, want false when the block was already off the chain")
+	if got.Outcome != RejectOutcomeAlreadyInactive {
+		t.Errorf("Outcome = %v, want AlreadyInactive", got.Outcome)
 	}
 }
 

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -4572,9 +4572,11 @@ class RejectBlockResponse extends $pb.GeneratedMessage {
   factory RejectBlockResponse({
     $core.int? coreHeight,
     $core.String? coreTipHash,
-    $core.bool? switchedBranch,
+    RejectOutcome? outcome,
     $core.int? enforcerHeight,
     $core.bool? enforcerRebuilt,
+    $core.String? enforcerError,
+    $core.bool? enforcerChecked,
   }) {
     final $result = create();
     if (coreHeight != null) {
@@ -4583,14 +4585,20 @@ class RejectBlockResponse extends $pb.GeneratedMessage {
     if (coreTipHash != null) {
       $result.coreTipHash = coreTipHash;
     }
-    if (switchedBranch != null) {
-      $result.switchedBranch = switchedBranch;
+    if (outcome != null) {
+      $result.outcome = outcome;
     }
     if (enforcerHeight != null) {
       $result.enforcerHeight = enforcerHeight;
     }
     if (enforcerRebuilt != null) {
       $result.enforcerRebuilt = enforcerRebuilt;
+    }
+    if (enforcerError != null) {
+      $result.enforcerError = enforcerError;
+    }
+    if (enforcerChecked != null) {
+      $result.enforcerChecked = enforcerChecked;
     }
     return $result;
   }
@@ -4605,9 +4613,14 @@ class RejectBlockResponse extends $pb.GeneratedMessage {
       package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'coreHeight', $pb.PbFieldType.OU3)
     ..aOS(2, _omitFieldNames ? '' : 'coreTipHash')
-    ..aOB(3, _omitFieldNames ? '' : 'switchedBranch')
+    ..e<RejectOutcome>(3, _omitFieldNames ? '' : 'outcome', $pb.PbFieldType.OE,
+        defaultOrMaker: RejectOutcome.REJECT_OUTCOME_UNSPECIFIED,
+        valueOf: RejectOutcome.valueOf,
+        enumValues: RejectOutcome.values)
     ..a<$core.int>(4, _omitFieldNames ? '' : 'enforcerHeight', $pb.PbFieldType.OU3)
     ..aOB(5, _omitFieldNames ? '' : 'enforcerRebuilt')
+    ..aOS(6, _omitFieldNames ? '' : 'enforcerError')
+    ..aOB(7, _omitFieldNames ? '' : 'enforcerChecked')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -4657,19 +4670,18 @@ class RejectBlockResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   void clearCoreTipHash() => clearField(2);
 
-  /// True when Core found another branch and followed it. False when Core
-  /// parked on the rejected block's parent and waits for a branch.
+  /// What the reject did to the chain Core follows.
   @$pb.TagNumber(3)
-  $core.bool get switchedBranch => $_getBF(2);
+  RejectOutcome get outcome => $_getN(2);
   @$pb.TagNumber(3)
-  set switchedBranch($core.bool v) {
-    $_setBool(2, v);
+  set outcome(RejectOutcome v) {
+    setField(3, v);
   }
 
   @$pb.TagNumber(3)
-  $core.bool hasSwitchedBranch() => $_has(2);
+  $core.bool hasOutcome() => $_has(2);
   @$pb.TagNumber(3)
-  void clearSwitchedBranch() => clearField(3);
+  void clearOutcome() => clearField(3);
 
   /// The enforcer's tip afterwards. Zero when the enforcer is stopped.
   @$pb.TagNumber(4)
@@ -4697,6 +4709,34 @@ class RejectBlockResponse extends $pb.GeneratedMessage {
   $core.bool hasEnforcerRebuilt() => $_has(4);
   @$pb.TagNumber(5)
   void clearEnforcerRebuilt() => clearField(5);
+
+  /// Empty on success; otherwise why the enforcer could not be brought back
+  /// onto Core's chain. Core already moved, so the caller keeps its undo path.
+  @$pb.TagNumber(6)
+  $core.String get enforcerError => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set enforcerError($core.String v) {
+    $_setString(5, v);
+  }
+
+  @$pb.TagNumber(6)
+  $core.bool hasEnforcerError() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearEnforcerError() => clearField(6);
+
+  /// False when the enforcer was never asked, so enforcer_height carries no
+  /// reading and must not be shown as one.
+  @$pb.TagNumber(7)
+  $core.bool get enforcerChecked => $_getBF(6);
+  @$pb.TagNumber(7)
+  set enforcerChecked($core.bool v) {
+    $_setBool(6, v);
+  }
+
+  @$pb.TagNumber(7)
+  $core.bool hasEnforcerChecked() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearEnforcerChecked() => clearField(7);
 }
 
 class AcceptBlockRequest extends $pb.GeneratedMessage {
@@ -4782,6 +4822,8 @@ class AcceptBlockResponse extends $pb.GeneratedMessage {
     $core.String? coreTipHash,
     $core.int? enforcerHeight,
     $core.bool? enforcerRebuilt,
+    $core.String? enforcerError,
+    $core.bool? enforcerChecked,
   }) {
     final $result = create();
     if (coreHeight != null) {
@@ -4795,6 +4837,12 @@ class AcceptBlockResponse extends $pb.GeneratedMessage {
     }
     if (enforcerRebuilt != null) {
       $result.enforcerRebuilt = enforcerRebuilt;
+    }
+    if (enforcerError != null) {
+      $result.enforcerError = enforcerError;
+    }
+    if (enforcerChecked != null) {
+      $result.enforcerChecked = enforcerChecked;
     }
     return $result;
   }
@@ -4811,6 +4859,8 @@ class AcceptBlockResponse extends $pb.GeneratedMessage {
     ..aOS(2, _omitFieldNames ? '' : 'coreTipHash')
     ..a<$core.int>(3, _omitFieldNames ? '' : 'enforcerHeight', $pb.PbFieldType.OU3)
     ..aOB(4, _omitFieldNames ? '' : 'enforcerRebuilt')
+    ..aOS(5, _omitFieldNames ? '' : 'enforcerError')
+    ..aOB(6, _omitFieldNames ? '' : 'enforcerChecked')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -4886,6 +4936,34 @@ class AcceptBlockResponse extends $pb.GeneratedMessage {
   $core.bool hasEnforcerRebuilt() => $_has(3);
   @$pb.TagNumber(4)
   void clearEnforcerRebuilt() => clearField(4);
+
+  /// Empty on success; otherwise why the enforcer could not be brought back
+  /// onto Core's chain. Core already moved, so the caller keeps its undo path.
+  @$pb.TagNumber(5)
+  $core.String get enforcerError => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set enforcerError($core.String v) {
+    $_setString(4, v);
+  }
+
+  @$pb.TagNumber(5)
+  $core.bool hasEnforcerError() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearEnforcerError() => clearField(5);
+
+  /// False when the enforcer was never asked, so enforcer_height carries no
+  /// reading and must not be shown as one.
+  @$pb.TagNumber(6)
+  $core.bool get enforcerChecked => $_getBF(5);
+  @$pb.TagNumber(6)
+  set enforcerChecked($core.bool v) {
+    $_setBool(5, v);
+  }
+
+  @$pb.TagNumber(6)
+  $core.bool hasEnforcerChecked() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearEnforcerChecked() => clearField(6);
 }
 
 class GetCoreMempoolInfoRequest extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbenum.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbenum.dart
@@ -125,4 +125,28 @@ class DeletionType extends $pb.ProtobufEnum {
   const DeletionType._($core.int v, $core.String n) : super(v, n);
 }
 
+/// What the reject did to the chain Core follows.
+class RejectOutcome extends $pb.ProtobufEnum {
+  static const RejectOutcome REJECT_OUTCOME_UNSPECIFIED =
+      RejectOutcome._(0, _omitEnumNames ? '' : 'REJECT_OUTCOME_UNSPECIFIED');
+  static const RejectOutcome REJECT_OUTCOME_SWITCHED_BRANCH =
+      RejectOutcome._(1, _omitEnumNames ? '' : 'REJECT_OUTCOME_SWITCHED_BRANCH');
+  static const RejectOutcome REJECT_OUTCOME_PARKED_ON_PARENT =
+      RejectOutcome._(2, _omitEnumNames ? '' : 'REJECT_OUTCOME_PARKED_ON_PARENT');
+  static const RejectOutcome REJECT_OUTCOME_ALREADY_INACTIVE =
+      RejectOutcome._(3, _omitEnumNames ? '' : 'REJECT_OUTCOME_ALREADY_INACTIVE');
+
+  static const $core.List<RejectOutcome> values = <RejectOutcome>[
+    REJECT_OUTCOME_UNSPECIFIED,
+    REJECT_OUTCOME_SWITCHED_BRANCH,
+    REJECT_OUTCOME_PARKED_ON_PARENT,
+    REJECT_OUTCOME_ALREADY_INACTIVE,
+  ];
+
+  static final $core.Map<$core.int, RejectOutcome> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static RejectOutcome? valueOf($core.int value) => _byValue[value];
+
+  const RejectOutcome._($core.int v, $core.String n) : super(v, n);
+}
+
 const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -90,6 +90,23 @@ final $typed_data.Uint8List deletionTypeDescriptor =
         'RV9TRVRUSU5HUxADEhYKEkRFTEVUSU9OX1RZUEVfTE9HUxAEEhoKFkRFTEVUSU9OX1RZUEVfU0'
         '9GVFdBUkUQBQ==');
 
+@$core.Deprecated('Use rejectOutcomeDescriptor instead')
+const RejectOutcome$json = {
+  '1': 'RejectOutcome',
+  '2': [
+    {'1': 'REJECT_OUTCOME_UNSPECIFIED', '2': 0},
+    {'1': 'REJECT_OUTCOME_SWITCHED_BRANCH', '2': 1},
+    {'1': 'REJECT_OUTCOME_PARKED_ON_PARENT', '2': 2},
+    {'1': 'REJECT_OUTCOME_ALREADY_INACTIVE', '2': 3},
+  ],
+};
+
+/// Descriptor for `RejectOutcome`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List rejectOutcomeDescriptor =
+    $convert.base64Decode('Cg1SZWplY3RPdXRjb21lEh4KGlJFSkVDVF9PVVRDT01FX1VOU1BFQ0lGSUVEEAASIgoeUkVKRU'
+        'NUX09VVENPTUVfU1dJVENIRURfQlJBTkNIEAESIwofUkVKRUNUX09VVENPTUVfUEFSS0VEX09O'
+        'X1BBUkVOVBACEiMKH1JFSkVDVF9PVVRDT01FX0FMUkVBRFlfSU5BQ1RJVkUQAw==');
+
 @$core.Deprecated('Use binaryStatusMsgDescriptor instead')
 const BinaryStatusMsg$json = {
   '1': 'BinaryStatusMsg',
@@ -935,18 +952,22 @@ const RejectBlockResponse$json = {
   '2': [
     {'1': 'core_height', '3': 1, '4': 1, '5': 13, '10': 'coreHeight'},
     {'1': 'core_tip_hash', '3': 2, '4': 1, '5': 9, '10': 'coreTipHash'},
-    {'1': 'switched_branch', '3': 3, '4': 1, '5': 8, '10': 'switchedBranch'},
+    {'1': 'outcome', '3': 3, '4': 1, '5': 14, '6': '.orchestrator.v1.RejectOutcome', '10': 'outcome'},
     {'1': 'enforcer_height', '3': 4, '4': 1, '5': 13, '10': 'enforcerHeight'},
     {'1': 'enforcer_rebuilt', '3': 5, '4': 1, '5': 8, '10': 'enforcerRebuilt'},
+    {'1': 'enforcer_error', '3': 6, '4': 1, '5': 9, '10': 'enforcerError'},
+    {'1': 'enforcer_checked', '3': 7, '4': 1, '5': 8, '10': 'enforcerChecked'},
   ],
 };
 
 /// Descriptor for `RejectBlockResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List rejectBlockResponseDescriptor =
     $convert.base64Decode('ChNSZWplY3RCbG9ja1Jlc3BvbnNlEh8KC2NvcmVfaGVpZ2h0GAEgASgNUgpjb3JlSGVpZ2h0Ei'
-        'IKDWNvcmVfdGlwX2hhc2gYAiABKAlSC2NvcmVUaXBIYXNoEicKD3N3aXRjaGVkX2JyYW5jaBgD'
-        'IAEoCFIOc3dpdGNoZWRCcmFuY2gSJwoPZW5mb3JjZXJfaGVpZ2h0GAQgASgNUg5lbmZvcmNlck'
-        'hlaWdodBIpChBlbmZvcmNlcl9yZWJ1aWx0GAUgASgIUg9lbmZvcmNlclJlYnVpbHQ=');
+        'IKDWNvcmVfdGlwX2hhc2gYAiABKAlSC2NvcmVUaXBIYXNoEjgKB291dGNvbWUYAyABKA4yHi5v'
+        'cmNoZXN0cmF0b3IudjEuUmVqZWN0T3V0Y29tZVIHb3V0Y29tZRInCg9lbmZvcmNlcl9oZWlnaH'
+        'QYBCABKA1SDmVuZm9yY2VySGVpZ2h0EikKEGVuZm9yY2VyX3JlYnVpbHQYBSABKAhSD2VuZm9y'
+        'Y2VyUmVidWlsdBIlCg5lbmZvcmNlcl9lcnJvchgGIAEoCVINZW5mb3JjZXJFcnJvchIpChBlbm'
+        'ZvcmNlcl9jaGVja2VkGAcgASgIUg9lbmZvcmNlckNoZWNrZWQ=');
 
 @$core.Deprecated('Use acceptBlockRequestDescriptor instead')
 const AcceptBlockRequest$json = {
@@ -970,6 +991,8 @@ const AcceptBlockResponse$json = {
     {'1': 'core_tip_hash', '3': 2, '4': 1, '5': 9, '10': 'coreTipHash'},
     {'1': 'enforcer_height', '3': 3, '4': 1, '5': 13, '10': 'enforcerHeight'},
     {'1': 'enforcer_rebuilt', '3': 4, '4': 1, '5': 8, '10': 'enforcerRebuilt'},
+    {'1': 'enforcer_error', '3': 5, '4': 1, '5': 9, '10': 'enforcerError'},
+    {'1': 'enforcer_checked', '3': 6, '4': 1, '5': 8, '10': 'enforcerChecked'},
   ],
 };
 
@@ -978,7 +1001,8 @@ final $typed_data.Uint8List acceptBlockResponseDescriptor =
     $convert.base64Decode('ChNBY2NlcHRCbG9ja1Jlc3BvbnNlEh8KC2NvcmVfaGVpZ2h0GAEgASgNUgpjb3JlSGVpZ2h0Ei'
         'IKDWNvcmVfdGlwX2hhc2gYAiABKAlSC2NvcmVUaXBIYXNoEicKD2VuZm9yY2VyX2hlaWdodBgD'
         'IAEoDVIOZW5mb3JjZXJIZWlnaHQSKQoQZW5mb3JjZXJfcmVidWlsdBgEIAEoCFIPZW5mb3JjZX'
-        'JSZWJ1aWx0');
+        'JSZWJ1aWx0EiUKDmVuZm9yY2VyX2Vycm9yGAUgASgJUg1lbmZvcmNlckVycm9yEikKEGVuZm9y'
+        'Y2VyX2NoZWNrZWQYBiABKAhSD2VuZm9yY2VyQ2hlY2tlZA==');
 
 @$core.Deprecated('Use getCoreMempoolInfoRequestDescriptor instead')
 const GetCoreMempoolInfoRequest$json = {


### PR DESCRIPTION
PR 2014 merged an early revision, so thirteen rounds of review fixes never reached master. This carries them.

Two of them stop a validator chain from being deleted for the wrong reason: a cancelled wait now reports instead of rebuilding, and a rebuild during an enforcer wallet swap refuses instead of leaving the daemon stopped. A connect-only enforcer is reconciled by reachability, and never wiped, because this process does not manage it.

The rest make the reported state honest: a three-way outcome in place of a bool that meant two things, an enforcer error that keeps the recovery path, and a retry that repeats the call it belongs to.