### PR TITLE
bitwindow: exit on SIGTERM

### DIFF
--- a/bitwindow/server/main.go
+++ b/bitwindow/server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -273,7 +274,7 @@ func realMain(ctx context.Context, cancelCtx context.CancelFunc) error {
 
 	errs := make(chan error, 1)
 	go func() {
-		errs <- srv.Serve(ctx, conf.APIHost)
+		errs <- exitError(srv.Serve(ctx, conf.APIHost))
 	}()
 
 	go func() {
@@ -285,6 +286,15 @@ func realMain(ctx context.Context, cancelCtx context.CancelFunc) error {
 	}()
 
 	return <-errs
+}
+
+// A graceful shutdown closes the server, so ErrServerClosed is the expected
+// end of Serve, not a failure exit.
+func exitError(err error) error {
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
 }
 
 func initLogger(logFile *os.File, logLevel zerolog.Level) {

--- a/bitwindow/server/main.go
+++ b/bitwindow/server/main.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"os/exec"
@@ -47,7 +48,9 @@ import (
 func main() {
 	start := time.Now()
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	// SIGTERM too, so `systemctl stop` / `docker stop` drain the server and
+	// relay Shutdown to orchestratord instead of orphaning it.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 
 	if err := realMain(ctx, cancel); err != nil {
 

--- a/bitwindow/server/main_test.go
+++ b/bitwindow/server/main_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExitError(t *testing.T) {
+	assert.NoError(t, exitError(nil))
+	assert.NoError(t, exitError(http.ErrServerClosed))
+	assert.NoError(t, exitError(fmt.Errorf("serve: %w", http.ErrServerClosed)))
+
+	boom := errors.New("listen on \"127.0.0.1:8080\": address already in use")
+	assert.ErrorIs(t, exitError(boom), boom)
+}


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

`signal.NotifyContext` caught only SIGINT, so `systemctl stop` orphaned orchestratord.