### PR TITLE
bitwindow: keep 36-byte OP_RETURN payloads

### DIFF
--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -604,8 +604,7 @@ func (p *Parser) handleOpReturns(
 		}
 
 		isOPReturn := txout.PkScript[0] == txscript.OP_RETURN
-		isCoinbaseReturn := isOPReturn && txout.PkScript[1] == txscript.OP_DATA_36
-		if isCoinbaseReturn {
+		if isWitnessCommitment(txout.PkScript) {
 			continue
 		}
 		if shouldSkip(txout.PkScript) {
@@ -795,6 +794,19 @@ func parseOPReturnData(script []byte) ([]byte, bool) {
 	default:
 		return nil, false
 	}
+}
+
+// witnessCommitmentMagic prefixes the coinbase segwit commitment push (BIP141).
+var witnessCommitmentMagic = []byte{0xaa, 0x21, 0xa9, 0xed}
+
+// isWitnessCommitment reports whether a script is the coinbase segwit
+// commitment. The 36-byte push length alone isn't enough — real payloads
+// can also be exactly 36 bytes.
+func isWitnessCommitment(pkScript []byte) bool {
+	return len(pkScript) >= 6 &&
+		pkScript[0] == txscript.OP_RETURN &&
+		pkScript[1] == txscript.OP_DATA_36 &&
+		bytes.Equal(pkScript[2:6], witnessCommitmentMagic)
 }
 
 func shouldSkip(pkScript []byte) bool {

--- a/bitwindow/server/engines/coinnews.go
+++ b/bitwindow/server/engines/coinnews.go
@@ -140,12 +140,12 @@ func indexCoinNewsPayload(ctx context.Context, db *sql.DB, data []byte, pos cnst
 
 // coinNewsPayload extracts the bytes pushed by a single-push OP_RETURN
 // script. Returns ok=false for anything else (not OP_RETURN, multi-
-// push, OP_DRIVECHAIN, coinbase carrier).
+// push, OP_DRIVECHAIN, coinbase witness commitment).
 func coinNewsPayload(pkScript []byte) ([]byte, bool) {
 	if len(pkScript) < 2 || pkScript[0] != txscript.OP_RETURN {
 		return nil, false
 	}
-	if pkScript[1] == txscript.OP_DATA_36 {
+	if isWitnessCommitment(pkScript) {
 		return nil, false
 	}
 	if shouldSkip(pkScript) {

--- a/bitwindow/server/engines/coinnews_test.go
+++ b/bitwindow/server/engines/coinnews_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -305,6 +306,38 @@ func TestCoinNewsIndexer_BroadcastBytesListAsCoinNews(t *testing.T) {
 	assert.Equal(t, "US Weekly", news[0].TopicName)
 	assert.Equal(t, "Broadcast headline", news[0].Headline)
 	assert.Equal(t, "Broadcast body", news[0].Content)
+}
+
+// TestCoinNewsIndexer_Accepts36BytePayload: a 36-byte CoinNews payload
+// pushes as OP_DATA_36 — the same opcode the coinbase segwit commitment
+// uses. Only the commitment (0xaa21a9ed magic) may be skipped.
+func TestCoinNewsIndexer_Accepts36BytePayload(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	p := newCoinNewsParser(t)
+
+	topic := codec.Topic{0x33, 0x33, 0x33, 0x33}
+	// "CN"(2) + type(1) + topic(4) + retention(1) + compactsize(1) + name(27) = 36.
+	const name = "twenty-seven-char-topicname"
+	payload, err := codec.EncodeTopicCreation(codec.TopicCreation{Topic: topic, RetentionDays: 7, Name: name})
+	require.NoError(t, err)
+	require.Len(t, payload, 36)
+
+	block := blockOf(t, [][]byte{payload}, time.Now().UTC())
+	require.Equal(t, byte(txscript.OP_DATA_36), block.Transactions[0].TxOut[0].PkScript[1])
+
+	require.NoError(t, p.indexCoinNewsBlocks(ctx, []lo.Tuple2[uint32, *wire.MsgBlock]{
+		lo.T2(uint32(920_000), block),
+	}))
+
+	var got string
+	require.NoError(t, p.db.QueryRowContext(ctx, `SELECT name FROM cn_topics WHERE topic = ?`, topic[:]).Scan(&got))
+	assert.Equal(t, name, got, "36-byte CoinNews payload MUST be indexed")
+
+	// Negative control: the coinbase witness commitment stays skipped.
+	commitment := append([]byte{txscript.OP_RETURN, txscript.OP_DATA_36, 0xaa, 0x21, 0xa9, 0xed}, make([]byte, 32)...)
+	_, ok := coinNewsPayload(commitment)
+	assert.False(t, ok, "coinbase witness commitment MUST stay skipped")
 }
 
 // TestCoinNewsIndexer_PurgeAtOrAbove proves the reorg purge wipes


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

The coinbase filter matched on the OP_DATA_36 push length alone, so it dropped real 36-byte payloads. It now matches the BIP141 magic.