### PR TITLE
orchestrator: stop a duplicate daemon start

### DIFF
--- a/sidechain-orchestrator/process.go
+++ b/sidechain-orchestrator/process.go
@@ -169,6 +169,7 @@ type ProcessManager struct {
 	mu         sync.Mutex
 	processes  map[string]*ManagedProcess // keyed by config name
 	lastExited map[string]*ManagedProcess // last exited process, keyed by config name — keeps its logs readable
+	starting   map[string]bool            // names reserved by an in-flight StartWithOptions
 
 	// OnExit is called when a process exits. The orchestrator uses this to
 	// pipe exit errors into ConnectionMonitor.connectionError for the UI.
@@ -188,6 +189,7 @@ func NewProcessManager(dataDir string, pidManager *PidFileManager, log zerolog.L
 		log:        log.With().Str("component", "process").Logger(),
 		processes:  make(map[string]*ManagedProcess),
 		lastExited: make(map[string]*ManagedProcess),
+		starting:   make(map[string]bool),
 	}
 }
 
@@ -250,12 +252,20 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 		processName = config.Name
 	}
 
+	// Reserve the slot under the lock that checks it, so concurrent starts
+	// cannot both fork a daemon and have the second registration orphan the first.
 	pm.mu.Lock()
-	if _, exists := pm.processes[processName]; exists {
+	if _, exists := pm.processes[processName]; exists || pm.starting[processName] {
 		pm.mu.Unlock()
 		return 0, fmt.Errorf("%s is already running", processName)
 	}
+	pm.starting[processName] = true
 	pm.mu.Unlock()
+	defer func() {
+		pm.mu.Lock()
+		delete(pm.starting, processName)
+		pm.mu.Unlock()
+	}()
 
 	binPath, pidName := pm.resolvePaths(config, opts.ForceBackend)
 	if opts.PidName != "" {

--- a/sidechain-orchestrator/process_test.go
+++ b/sidechain-orchestrator/process_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -27,6 +28,42 @@ func TestProcessManager_StartAndStop(t *testing.T) {
 	require.NoError(t, pm.Stop(context.Background(), "sleep-test", false))
 	time.Sleep(200 * time.Millisecond)
 	assert.False(t, pm.IsRunning("sleep-test"))
+}
+
+func TestProcessManager_ConcurrentStartSpawnsOnce(t *testing.T) {
+	pm, dir := newTestProcessManager(t)
+	symlinkSystemBinary(t, dir, "sleep")
+
+	const starters = 4
+	var wg sync.WaitGroup
+	pids := make([]int, starters)
+	errs := make([]error, starters)
+	for i := range starters {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pids[i], errs[i] = pm.Start(context.Background(), BinaryConfig{
+				Name: "sleep-test", BinaryName: "sleep",
+			}, []string{"30"}, nil)
+		}()
+	}
+	wg.Wait()
+
+	proc := pm.Get("sleep-test")
+	require.NotNil(t, proc)
+
+	var started int
+	for i := range starters {
+		if errs[i] == nil {
+			started++
+			assert.Equal(t, proc.Pid, pids[i], "the tracked process must be the one we started")
+		} else {
+			assert.ErrorContains(t, errs[i], "already running")
+		}
+	}
+	assert.Equal(t, 1, started, "concurrent starts must not fork a second daemon the manager loses track of")
+
+	require.NoError(t, pm.Stop(context.Background(), "sleep-test", false))
 }
 
 func TestProcessManager_LastExit(t *testing.T) {


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

Two concurrent RestartDaemon calls both passed the running check and forked a daemon; the second registration orphaned the first.