### PR TITLE
orchestrator: drop the height of a reorged tx

### DIFF
--- a/sidechain-orchestrator/wallet/electrum_client.go
+++ b/sidechain-orchestrator/wallet/electrum_client.go
@@ -463,9 +463,11 @@ func (c *ElectrumClient) AddressStats(ctx context.Context, address string) (Espl
 	}
 	confirmed, mempool := 0, 0
 	for _, h := range hist {
+		// Cache every item, so a tx that fell back to the mempool loses its
+		// height here too, not only on the AddressTxs and AddressUTXOs paths.
+		c.rememberHeight(h.TxHash, h.Height)
 		if h.Height > 0 {
 			confirmed++
-			c.rememberHeight(h.TxHash, h.Height)
 		} else {
 			mempool++
 		}
@@ -698,13 +700,17 @@ func (c *ElectrumClient) blockTime(ctx context.Context, height int) int64 {
 	return ts
 }
 
+// rememberHeight caches a tx's confirmation height. A height <= 0 revokes any
+// cached height, so a tx reorged back into the mempool stops reporting as
+// confirmed.
 func (c *ElectrumClient) rememberHeight(txid string, height int) {
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
 	if height <= 0 {
+		delete(c.heightByTx, txid)
 		return
 	}
-	c.cacheMu.Lock()
 	c.heightByTx[txid] = height
-	c.cacheMu.Unlock()
 }
 
 func (c *ElectrumClient) knownHeight(txid string) int {

--- a/sidechain-orchestrator/wallet/electrum_client_test.go
+++ b/sidechain-orchestrator/wallet/electrum_client_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"net"
+	"sync/atomic"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -168,6 +169,52 @@ func TestElectrumClientTxResolvesPrevoutAndFee(t *testing.T) {
 	require.Len(t, tx.Vout, 1)
 	assert.Equal(t, int64(90000), tx.Vout[0].Value)
 	assert.Equal(t, int64(10000), tx.Fee, "fee = inputs - outputs")
+}
+
+// TestElectrumClientHeightCacheRevoked proves a later height-0 sighting clears
+// the cached confirmation height, so a tx reorged back into the mempool stops
+// reporting as confirmed at its old height.
+func TestElectrumClientHeightCacheRevoked(t *testing.T) {
+	ctx := context.Background()
+	addr, pkScript := signetAddr(t)
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Hash: chainhash.Hash{0x22}, Index: 0}, nil, nil))
+	tx.AddTxOut(wire.NewTxOut(70000, pkScript))
+	txHex := txToHex(t, tx)
+	txID := tx.TxHash().String()
+
+	var height atomic.Int64
+	height.Store(800000)
+	url := startFakeElectrum(t, func(method string, _ []json.RawMessage) interface{} {
+		switch method {
+		case "blockchain.scripthash.get_history":
+			return []map[string]interface{}{{"tx_hash": txID, "height": height.Load()}}
+		case "blockchain.transaction.get":
+			return txHex
+		case "blockchain.block.header":
+			return "00"
+		}
+		return nil
+	})
+	c := NewElectrumClient(url, zerolog.Nop(), &chaincfg.SigNetParams)
+
+	txs, err := c.AddressTxs(ctx, addr)
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	require.True(t, txs[0].Status.Confirmed)
+	require.Equal(t, 800000, txs[0].Status.BlockHeight)
+
+	height.Store(0) // reorged back into the mempool
+	txs, err = c.AddressTxs(ctx, addr)
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	assert.False(t, txs[0].Status.Confirmed, "a height-0 sighting must revoke the cached height")
+
+	got, err := c.Tx(ctx, txID)
+	require.NoError(t, err)
+	assert.False(t, got.Status.Confirmed)
+	assert.Equal(t, 0, got.Status.BlockHeight)
 }
 
 func TestElectrumClientFeeRateConversion(t *testing.T) {


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

`rememberHeight` ignored height <= 0, so a tx reorged back to the mempool kept reporting as confirmed.