### PR TITLE
bitwindow: stop the ListSidechains nil panic

### DIFF
--- a/bitwindow/server/api/drivechain/drivechain.go
+++ b/bitwindow/server/api/drivechain/drivechain.go
@@ -197,23 +197,25 @@ func (s *Server) ListSidechains(ctx context.Context, _ *connect.Request[pb.ListS
 	// Loop over all sidechains and get their chaintip if available
 	sidechainList := make([]*pb.ListSidechainsResponse_Sidechain, 0, len(sidechains.Sidechains))
 	for _, sidechain := range sidechains.Sidechains {
-		declaration := sidechain.Declaration.GetV0()
+		// The enforcer reports a nil declaration for descriptions that aren't a v0
+		// declaration, which is legal. Use nil-safe getters throughout.
+		declaration := sidechain.GetDeclaration().GetV0()
 
 		sc := &pb.ListSidechainsResponse_Sidechain{
-			Title:            declaration.Title.Value,
-			Description:      declaration.Description.Value,
-			Hashid1:          declaration.HashId_1.Hex.Value,
-			Hashid2:          declaration.HashId_2.Hex.Value,
-			Slot:             sidechain.SidechainNumber.Value,
-			VoteCount:        sidechain.VoteCount.Value,
-			ProposalHeight:   sidechain.ProposalHeight.Value,
-			ActivationHeight: sidechain.ActivationHeight.Value,
-			DescriptionHex:   sidechain.Description.Hex.Value,
+			Title:            declaration.GetTitle().GetValue(),
+			Description:      declaration.GetDescription().GetValue(),
+			Hashid1:          declaration.GetHashId_1().GetHex().GetValue(),
+			Hashid2:          declaration.GetHashId_2().GetHex().GetValue(),
+			Slot:             sidechain.GetSidechainNumber().GetValue(),
+			VoteCount:        sidechain.GetVoteCount().GetValue(),
+			ProposalHeight:   sidechain.GetProposalHeight().GetValue(),
+			ActivationHeight: sidechain.GetActivationHeight().GetValue(),
+			DescriptionHex:   sidechain.GetDescription().GetHex().GetValue(),
 		}
 
 		// Try to get ctip (may not exist if no deposits yet)
 		ctipResponse, err := s.data.Ctip(ctx,
-			&validatorpb.GetCtipRequest{SidechainNumber: wrapperspb.UInt32(sidechain.SidechainNumber.Value)},
+			&validatorpb.GetCtipRequest{SidechainNumber: wrapperspb.UInt32(sc.Slot)},
 		)
 		if err == nil && ctipResponse.Ctip != nil && ctipResponse.Ctip.Txid != nil {
 			txidHash, err := chainhash.NewHashFromStr(ctipResponse.Ctip.Txid.Hex.Value)

--- a/bitwindow/server/api/drivechain/drivechain_test.go
+++ b/bitwindow/server/api/drivechain/drivechain_test.go
@@ -101,6 +101,62 @@ func TestService_ListSidechains(t *testing.T) {
 		assert.Equal(t, uint32(0), resp.Msg.Sidechains[0].Slot)
 	})
 
+	t.Run("handles nil declaration", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.Test(t)
+		ctrl := gomock.NewController(t)
+
+		mockValidator := mocks.NewMockValidatorServiceClient(ctrl)
+
+		mockValidator.EXPECT().
+			GetChainTip(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[mainchainv1.GetChainTipResponse]{
+				Msg: &mainchainv1.GetChainTipResponse{
+					BlockHeaderInfo: &mainchainv1.BlockHeaderInfo{
+						Height: 100,
+						BlockHash: &commonv1.ReverseHex{
+							Hex: wrapperspb.String("0000000000000000000000000000000000000000000000000000000000000001"),
+						},
+					},
+				},
+			}, nil)
+
+		// The enforcer reports a nil declaration when the description doesn't
+		// decode as a v0 declaration, which the spec allows.
+		mockValidator.EXPECT().
+			GetSidechains(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[mainchainv1.GetSidechainsResponse]{
+				Msg: &mainchainv1.GetSidechainsResponse{
+					Sidechains: []*mainchainv1.GetSidechainsResponse_SidechainInfo{
+						{
+							SidechainNumber: wrapperspb.UInt32(7),
+							Declaration:     nil,
+							Description: &commonv1.ConsensusHex{
+								Hex: wrapperspb.String("deadbeef"),
+							},
+							VoteCount:        wrapperspb.UInt32(100),
+							ProposalHeight:   wrapperspb.UInt32(50),
+							ActivationHeight: wrapperspb.UInt32(60),
+						},
+					},
+				},
+			}, nil)
+
+		mockValidator.EXPECT().
+			GetCtip(gomock.Any(), gomock.Any()).
+			Return(nil, connect.NewError(connect.CodeNotFound, nil))
+
+		cli := rpc.NewDrivechainServiceClient(apitests.API(t, db, apitests.WithValidator(mockValidator)))
+
+		resp, err := cli.ListSidechains(context.Background(), connect.NewRequest(&pb.ListSidechainsRequest{}))
+		require.NoError(t, err)
+		require.Len(t, resp.Msg.Sidechains, 1)
+		assert.Empty(t, resp.Msg.Sidechains[0].Title)
+		assert.Equal(t, uint32(7), resp.Msg.Sidechains[0].Slot)
+		assert.Equal(t, "deadbeef", resp.Msg.Sidechains[0].DescriptionHex)
+	})
+
 	t.Run("handles empty sidechains", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

The enforcer legally reports a nil declaration for a non-v0 description. The handler dereferenced it directly.