### PR TITLE
orchestrator: refuse to signal pid 0

### DIFF
--- a/sidechain-orchestrator/platform_unix.go
+++ b/sidechain-orchestrator/platform_unix.go
@@ -74,6 +74,10 @@ func findPidByName(binaryName string) (int, error) {
 
 // killProcess sends SIGTERM, then SIGKILL if the process doesn't exit.
 func killProcess(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("refusing to signal invalid pid %d", pid)
+	}
+
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return fmt.Errorf("find process %d: %w", pid, err)
@@ -92,6 +96,10 @@ func killProcess(pid int) error {
 
 // forceKillProcess sends SIGKILL immediately.
 func forceKillProcess(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("refusing to signal invalid pid %d", pid)
+	}
+
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return fmt.Errorf("find process %d: %w", pid, err)

--- a/sidechain-orchestrator/platform_windows.go
+++ b/sidechain-orchestrator/platform_windows.go
@@ -102,6 +102,12 @@ func findPidByName(binaryName string) (int, error) {
 // daemons (bitcoind, enforcer, sidechains) trap this and flush cleanly; GUI
 // WM_CLOSE via plain taskkill does not reach them.
 func killProcess(pid int) error {
+	// Group 0 means "every process on our console" — that would CTRL_BREAK
+	// orchestratord itself.
+	if pid <= 0 {
+		return fmt.Errorf("refusing to signal invalid pid %d", pid)
+	}
+
 	ret, _, err := procGenerateConsoleCtrlEvent.Call(
 		uintptr(ctrlBreakEvent),
 		uintptr(uint32(pid)),
@@ -116,6 +122,10 @@ func killProcess(pid int) error {
 }
 
 func forceKillProcess(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("refusing to signal invalid pid %d", pid)
+	}
+
 	cmd := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(pid))
 	if err := cmd.Run(); err != nil {
 		if !isPidAlive(pid) {

--- a/sidechain-orchestrator/process.go
+++ b/sidechain-orchestrator/process.go
@@ -697,6 +697,13 @@ func (pm *ProcessManager) AdoptProcessWithOptions(config BinaryConfig, pid int, 
 // AdoptProcessResolved registers an externally-found process when the PID file
 // name already tells us which on-disk variant it belongs to.
 func (pm *ProcessManager) AdoptProcessResolved(config BinaryConfig, pid int, binPath, pidName string, forceBackend bool) {
+	// PID discovery returns 0 when every lookup misses. Claiming ownership of a
+	// process we cannot signal makes Stop report success without stopping it.
+	if pid <= 0 {
+		pm.log.Warn().Str("binary", config.Name).Int("pid", pid).Msg("refusing to adopt process with invalid pid")
+		return
+	}
+
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 

--- a/sidechain-orchestrator/process_test.go
+++ b/sidechain-orchestrator/process_test.go
@@ -228,3 +228,25 @@ func TestProcessNameMatches(t *testing.T) {
 		})
 	}
 }
+
+// A pid of 0 means discovery found nothing. Adopting it would make Stop
+// report success without ever signalling the daemon.
+func TestProcessManager_AdoptRejectsInvalidPid(t *testing.T) {
+	pm, _ := newTestProcessManager(t)
+	cfg := BinaryConfig{Name: "bitcoind", BinaryName: "bitcoind"}
+
+	pm.AdoptProcess(cfg, 0)
+	assert.False(t, pm.IsRunning("bitcoind"), "pid 0 must not be adopted")
+
+	pm.AdoptProcess(cfg, -1)
+	assert.False(t, pm.IsRunning("bitcoind"), "negative pid must not be adopted")
+
+	assert.Error(t, pm.Stop(context.Background(), "bitcoind", false))
+}
+
+func TestKillProcess_RejectsInvalidPid(t *testing.T) {
+	for _, pid := range []int{0, -1} {
+		assert.Error(t, killProcess(pid))
+		assert.Error(t, forceKillProcess(pid))
+	}
+}


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

PID discovery returns 0 on a miss. Adopting it made Stop report success without a stop, and on Windows CTRL_BREAK hit the whole console group.