### PR TITLE
orchestrator: hand out a Configs snapshot

### DIFF
--- a/sidechain-orchestrator/configs_snapshot_test.go
+++ b/sidechain-orchestrator/configs_snapshot_test.go
@@ -1,0 +1,48 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+)
+
+// TestConfigsSnapshotDuringConfigReload guards against handing out the live
+// config map: a reader ranging over it while the config file watcher runs
+// UpdateConfigs trips Go's fatal "concurrent map iteration and map write",
+// which no recover() catches.
+func TestConfigsSnapshotDuringConfigReload(t *testing.T) {
+	cfgs := []BinaryConfig{
+		{Name: "bitcoind", Port: 38332},
+		{Name: "enforcer", Port: 50051},
+		{Name: "thunder", Port: 6009},
+	}
+	o := &Orchestrator{configs: map[string]BinaryConfig{}}
+	o.UpdateConfigs(cfgs)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 5000 {
+			for _, c := range o.Configs() {
+				_ = c.Port
+			}
+		}
+	}()
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				o.UpdateConfigs(cfgs)
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("Configs reader wedged against UpdateConfigs")
+	}
+}

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"os"
@@ -2381,11 +2382,13 @@ func (o *Orchestrator) ChainTip(ctx context.Context) (string, int32, error) {
 	return info.GetBlockHash().GetHex().GetValue(), int32(info.GetHeight()), nil
 }
 
-// Configs returns the binary configs.
+// Configs returns a snapshot of the binary configs. Handing out the live map
+// would let a config reload write it while a caller ranges over it, which Go
+// turns into an unrecoverable fatal error.
 func (o *Orchestrator) Configs() map[string]BinaryConfig {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
-	return o.configs
+	return maps.Clone(o.configs)
 }
 
 // GetBTCPrice returns the current BTC/USD price, caching for 10 seconds.


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

`Configs()` returned the live map, so a config reload wrote it while a caller ranged over it. Go turns that into an unrecoverable fatal error.