### PR TITLE
bitwindow: match one outpoint in GetByTip

### DIFF
--- a/bitwindow/server/models/deniability/deniability.go
+++ b/bitwindow/server/models/deniability/deniability.go
@@ -378,8 +378,8 @@ func GetByTip(ctx context.Context, db *sql.DB, tipTxID string, tipVout *int32) (
 	args := []any{tipTxID}
 
 	if tipVout != nil {
-		query += ` AND (e.to_vout = ? OR d.initial_vout = ?) `
-		args = append(args, tipVout)
+		// Same tip semantics as the txid filter, so both match a single outpoint.
+		query += ` AND COALESCE(e.to_vout, d.initial_vout) = ? `
 		args = append(args, tipVout)
 	}
 	row := db.QueryRowContext(ctx, query, args...)

--- a/bitwindow/server/models/deniability/deniability_test.go
+++ b/bitwindow/server/models/deniability/deniability_test.go
@@ -187,6 +187,29 @@ func TestDeniability(t *testing.T) {
 		require.Nil(t, denial)
 	})
 
+	t.Run("GetByTip does not match the pre-hop vout", func(t *testing.T) {
+		t.Parallel()
+		db := database.Test(t)
+
+		denial, err := Create(ctx, db, "test-wallet", "initial-txid", 7, 1*time.Hour, 3, nil)
+		require.NoError(t, err)
+
+		// After a hop the tip is (hop-txid, 3), not (hop-txid, 7).
+		require.NoError(t, RecordExecution(ctx, db, denial.ID, "initial-txid", 7, "hop-txid", 3))
+
+		found, err := GetByTip(ctx, db, "hop-txid", ptr(int32(3)))
+		require.NoError(t, err)
+		require.NotNil(t, found)
+		require.Equal(t, denial.ID, found.ID)
+		require.Equal(t, "hop-txid", found.TipTXID)
+		require.Equal(t, int32(3), found.TipVout)
+
+		// The stale initial vout must not satisfy the lookup.
+		found, err = GetByTip(ctx, db, "hop-txid", ptr(int32(7)))
+		require.NoError(t, err)
+		require.Nil(t, found)
+	})
+
 	t.Run("Update", func(t *testing.T) {
 		t.Parallel()
 		db := database.Test(t)


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

The `e.to_vout OR d.initial_vout` predicate matched a denial whose real tip outpoint differed from the query, so Update wrote to the wrong target.