### PR TITLE
bitwindow: read the account index from the path

### DIFF
--- a/bitwindow/server/models/multisig/account_index_internal_test.go
+++ b/bitwindow/server/models/multisig/account_index_internal_test.go
@@ -1,0 +1,19 @@
+package multisig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractAccountIndexHardenedMarkers(t *testing.T) {
+	// BIP32 writes the hardened marker as ', h or H.
+	for _, path := range []string{"m/84'/1'/8005'", "m/84h/1h/8005h", "m/84H/1H/8005H"} {
+		require.Equal(t, 8005, extractAccountIndex(path), path)
+	}
+	require.Equal(t, 0, extractAccountIndex("m/84'/1'/not-a-number'"))
+
+	// The keystore parser accepts a rootless path too.
+	require.Equal(t, 8005, extractAccountIndex("48'/1'/8005'/2'"))
+	require.Equal(t, 8005, extractAccountIndex("m/48'/1'/8005'/2'"))
+}

--- a/bitwindow/server/models/multisig/multisig.go
+++ b/bitwindow/server/models/multisig/multisig.go
@@ -1120,19 +1120,39 @@ func nullStr(s string) interface{} {
 	return s
 }
 
+// Read the account component of "m/purpose'/coin'/account'/...". The root is
+// optional: the keystore parser accepts a rootless "purpose'/coin'/account'"
+// too, and its account sits one component earlier. A short non-standard path
+// falls back to its last component.
 func extractAccountIndex(path string) int {
 	parts := splitPath(path)
+	if len(parts) > 0 && (parts[0] == "m" || parts[0] == "M") {
+		parts = parts[1:]
+	}
 	if len(parts) >= 3 {
-		idx := trimQuote(parts[2])
-		n := 0
-		for _, c := range idx {
-			if c >= '0' && c <= '9' {
-				n = n*10 + int(c-'0')
-			}
-		}
-		return n
+		return parseIndex(parts[2])
+	}
+	if len(parts) >= 2 {
+		return parseIndex(parts[1])
 	}
 	return 0
+}
+
+// Parse a path component ("8000'" -> 8000), 0 if it isn't a plain number.
+// BIP32 writes the hardened marker as ', h or H, and all three are accepted.
+func parseIndex(part string) int {
+	idx := trimHardened(part)
+	if idx == "" {
+		return 0
+	}
+	n := 0
+	for _, c := range idx {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
 }
 
 func splitPath(path string) []string {
@@ -1155,9 +1175,12 @@ func splitPath(path string) []string {
 	return result
 }
 
-func trimQuote(s string) string {
-	if len(s) > 0 && s[len(s)-1] == '\'' {
-		return s[:len(s)-1]
+func trimHardened(s string) string {
+	if len(s) > 0 {
+		switch s[len(s)-1] {
+		case '\'', 'h', 'H':
+			return s[:len(s)-1]
+		}
 	}
 	return s
 }

--- a/bitwindow/server/models/multisig/multisig_test.go
+++ b/bitwindow/server/models/multisig/multisig_test.go
@@ -528,11 +528,10 @@ func TestGetNextAccountIndex(t *testing.T) {
 	g := sampleGroup()
 	require.NoError(t, store.SaveGroup(ctx, g))
 
-	// extractAccountIndex reads parts[2] of the derivation path.
-	// For m/48'/8000'/0' → parts=[m,48',8000',0'] → parts[2]=8000' → 8000
+	// The shipped path shape is m/84'/coin'/account'.
 	keys := []multisig.Key{
-		{GroupID: g.ID, Owner: "a", Xpub: "x1", DerivationPath: "m/48'/8000'/0'", IsWallet: true},
-		{GroupID: g.ID, Owner: "b", Xpub: "x2", DerivationPath: "m/48'/8005'/0'", IsWallet: true},
+		{GroupID: g.ID, Owner: "a", Xpub: "x1", DerivationPath: "m/84'/1'/8000'", IsWallet: true},
+		{GroupID: g.ID, Owner: "b", Xpub: "x2", DerivationPath: "m/84'/1'/8005'", IsWallet: true},
 	}
 	require.NoError(t, store.ReplaceKeysForGroup(ctx, g.ID, keys))
 
@@ -544,4 +543,26 @@ func TestGetNextAccountIndex(t *testing.T) {
 	next, err = store.GetNextAccountIndex(ctx, []int{9000})
 	require.NoError(t, err)
 	assert.Equal(t, 9001, next)
+}
+
+func TestGetNextAccountIndexAdvancesAcrossSessions(t *testing.T) {
+	ctx := context.Background()
+	store := multisig.NewStore(setupTestDB(t))
+
+	g := sampleGroup()
+	require.NoError(t, store.SaveGroup(ctx, g))
+
+	first, err := store.GetNextAccountIndex(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 8000, first)
+
+	// A key stored at the allocated index must push the next allocation forward,
+	// even though the caller passes no additionally used indices.
+	require.NoError(t, store.ReplaceKeysForGroup(ctx, g.ID, []multisig.Key{
+		{GroupID: g.ID, Owner: "a", Xpub: "x1", DerivationPath: "m/84'/1'/8000'", IsWallet: true},
+	}))
+
+	second, err := store.GetNextAccountIndex(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 8001, second, "second allocation reused the first account index")
 }

--- a/tasks/bitwindow-flows.md
+++ b/tasks/bitwindow-flows.md
@@ -1,0 +1,227 @@
+# BitWindow hot path flow designs
+
+## How I picked the paths
+
+I read `bitwindow/lib/routing/router.dart`, the wallet tabs in
+`bitwindow/lib/pages/wallet/wallet_page.dart`, and the sidechain tabs in
+`bitwindow/lib/pages/sidechains_page.dart`.
+
+Three paths carry almost all the traffic:
+
+1. First run. Three route guards block every other screen.
+2. Send bitcoin. The core daily action.
+3. Sidechain deposit. The one action no other wallet gives you.
+
+All tokens below come from `sail_ui`. See `SAIL_UI_REFERENCE.md`.
+
+---
+
+## Flow 1 — First run
+
+### What happens today
+
+`router.dart` puts three guards on the root route, in this order:
+
+1. `DataDirGuard` sends the user to `/datadir-setup`.
+2. `WalletGuard` sends the user to `/create-another-wallet`.
+3. `PasswordGuard` sends the user to `/unlock-wallet`.
+
+Each guard owns a separate full page. The pages do not know about each other.
+The user meets three gates, and each gate looks like a fresh start.
+
+Bitcoin Core and the Enforcer do not start here. That button sits on the
+Sidechains page, at `sidechains_page.dart:181`. So a new user lands on
+Overview with a dead node, an empty balance, and no next step.
+
+### The problem
+
+- The user cannot see how many steps remain.
+- The node start hides on a page the new user has no reason to open.
+- Overview looks broken on first sight, but nothing is broken.
+
+### The design
+
+Replace three separate pages with one stepper. Four steps, one screen, one
+progress rail on the left.
+
+| Step | Title | Primary action | Skip rule |
+|---|---|---|---|
+| 1 | Data folder | Accept the default path | Auto-pass if the folder exists |
+| 2 | Wallet | Create, or restore from seed | Auto-pass if a wallet exists |
+| 3 | Seed phrase | Write down 12 words, then re-type 3 | Skip on restore |
+| 4 | Node | Start Bitcoin Core and the Enforcer | Auto-pass if both run |
+
+Step 4 is the new part. It holds the node start button that lives on the
+Sidechains page today.
+
+### Screen anatomy, step 4
+
+```
++----------------------------------------------------------+
+| (1)--(2)--(3)--[4]        BitWindow setup                 |
++----------------------------------------------------------+
+|                                                          |
+|  Start the node                                          |
+|  BitWindow needs Bitcoin Core and the Enforcer.          |
+|                                                          |
+|  [*] Bitcoin Core        Downloading  62%   ####----     |
+|  [ ] Enforcer            Waits for Core                  |
+|                                                          |
+|  Block 812,004 of 843,110                                |
+|  About 4 hours left                                      |
+|                                                          |
+|  [ Open BitWindow now ]      [ Advanced: edit config ]   |
++----------------------------------------------------------+
+```
+
+`Open BitWindow now` stays live during the sync. The user does not wait.
+Overview then shows a sync banner instead of an empty balance.
+
+### States
+
+- Download fails: show the error, show a `Retry` button, keep the step open.
+- Port in use: name the port, link to `/bitcoin-config`.
+- Already synced: skip step 4, and go straight to Overview.
+
+---
+
+## Flow 2 — Send bitcoin
+
+### What happens today
+
+`wallet_send.dart` builds `SendTab` from two cards and one button row:
+
+- `PayFromAndFeeCard` — source coins and the fee rate.
+- `PayToCard` — destination and amount.
+- Buttons: `Send`, `External signer (airgap)`, `Sign with <device>`,
+  `Clear All`.
+
+### The problem
+
+- Three of the four buttons sign the same transaction. They read as three
+  different actions, but they differ only in the signer.
+- The fee sits in the "pay from" card. The amount sits in the "pay to" card.
+  The user cannot see the fee and the amount at the same time.
+- No review step exists. `Send` broadcasts.
+
+### The design
+
+One primary action. The signer becomes a field, not a button.
+
+```
++----------------------------------------------------------+
+|  Send                                                     |
++----------------------------------------------------------+
+|  Pay from                                                 |
+|  [ Wallet - 0.4213 BTC              v ]                   |
+|  Signer  [ This computer            v ]                   |
+|            This computer                                  |
+|            Airgap (external signer)                       |
+|            Ledger Nano S                                  |
+|                                                           |
+|  Pay to                                                   |
+|  [ bc1q...                            ] [Paste] [Scan]    |
+|  [ 0.0250          ] BTC     ~ 2,140 NOK                  |
+|                                                           |
+|  Fee   ( ) Slow 1h   (*) Normal 20m   ( ) Fast 10m        |
+|        12 sat/vB - 0.00002 BTC                            |
+|                                                           |
+|  You send      0.02502 BTC                                |
+|  Change back   0.39628 BTC                                |
+|                                                           |
+|  [ Review ]                              [ Clear all ]    |
++----------------------------------------------------------+
+```
+
+`Review` opens a sheet. The sheet repeats the address, the amount, the fee,
+the total, and the signer. The sheet holds the only `Sign and broadcast`
+button.
+
+### Why a review step
+
+A bitcoin send does not reverse. The review sheet is the last stop. It also
+gives the airgap path and the hardware path one shared home.
+
+### States
+
+- Airgap signer: the sheet shows the QR steps in place, not in a new page.
+- Hardware signer: the sheet shows "Confirm on your Ledger".
+- Broadcast succeeds: show the txid, a copy button, and an explorer link.
+- Broadcast fails: keep the sheet open, show the node error, allow a retry.
+
+---
+
+## Flow 3 — Sidechain deposit
+
+### What happens today
+
+Sidechains → Overview lists the 256 slots. A filled slot row shows a
+`Deposit` button. The button opens `showDepositModal`.
+
+Two builders make that same button, at `sidechains_page.dart:501` and
+`sidechains_page.dart:656`. Both call `showDepositModal` with the same
+arguments. The only difference is the disabled tooltip.
+
+A second, larger deposit form lives in `MakeDepositsView`, under the
+`Create Deposits` sub-tab. Withdrawals live in `See Withdrawals`, and a
+third page holds `Fast Withdrawal`.
+
+### The problem
+
+- Two code paths build one button. They drift apart over time.
+- Two deposit forms exist. The user cannot tell which one is correct.
+- Withdrawals split across two tabs and one more page.
+
+### The design
+
+One deposit sheet. One withdraw sheet. The slot row is the only entry.
+
+```
++----------------------------------------------------------+
+|  Slot 9   Thunder      Running    0.8100 BTC   [Deposit]  |
+|  Slot 4   BitNames     Stopped         --      [Start]    |
++----------------------------------------------------------+
+
+  Deposit to Thunder
+  +--------------------------------------------------------+
+  |  From   Wallet - 0.4213 BTC                            |
+  |  To     Thunder - address filled from the running node |
+  |         tn1q...                        [Change]        |
+  |                                                        |
+  |  Amount [ 0.1000        ] BTC   [ Max ]                |
+  |  Fee    12 sat/vB - 0.00002 BTC                        |
+  |                                                        |
+  |  Thunder balance after   0.9100 BTC                    |
+  |  Wallet balance after    0.3212 BTC                    |
+  |                                                        |
+  |  [ Deposit 0.1 BTC ]                    [ Cancel ]     |
+  +--------------------------------------------------------+
+```
+
+The address auto-fills from the running sidechain. Today the user types it.
+That is the largest error source on this path.
+
+The `Change` link opens manual entry, for a deposit to another person.
+
+### States
+
+- Sidechain stopped: the row shows `Start`, not `Deposit`.
+- Sidechain starts but does not answer: show "Thunder does not answer" and a
+  `Retry` link on the address field.
+- Deposit sent: show the txid and the confirmation count, in the same sheet.
+
+### Code cleanup this needs
+
+- Delete one of the two deposit button builders. Keep the one with the
+  tooltip.
+- Fold `MakeDepositsView` into the sheet.
+- Move `Fast Withdrawal` into the withdraw sheet, as a fee option.
+
+---
+
+## What to build first
+
+1. Flow 2 review sheet. It is the smallest change, and it stops real money
+   errors.
+2. Flow 3 address auto-fill and the duplicate button delete.
+3. Flow 1 stepper. It is the largest change, and it touches three guards.


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

`extractAccountIndex` read component 2 of `m/84'/1'/8000'`, which is the coin type, so `GetNextAccountIndex` always returned the same value.