### PR TITLE
bitwindow: reject an out of range sidechain slot

### DIFF
--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -1015,6 +1015,10 @@ func extractAddress(tx *validatorpb.WalletTransaction, addressBookEntries []addr
 
 // ListSidechainDeposits implements walletv1connect.WalletServiceHandler.
 func (s *Server) ListSidechainDeposits(ctx context.Context, c *connect.Request[pb.ListSidechainDepositsRequest]) (*connect.Response[pb.ListSidechainDepositsResponse], error) {
+	if c.Msg.Slot < 0 || c.Msg.Slot > 255 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("slot must be 0-255"))
+	}
+
 	walletId := c.Msg.WalletId
 
 	walletType, err := s.walletEngine.GetWalletBackendType(ctx, walletId)

--- a/bitwindow/server/api/wallet/wallet_test.go
+++ b/bitwindow/server/api/wallet/wallet_test.go
@@ -471,4 +471,21 @@ func TestService_ListSidechainDeposits(t *testing.T) {
 		require.Len(t, resp.Msg.Deposits, 1)
 		require.Equal(t, "slot0deposit", resp.Msg.Deposits[0].Txid)
 	})
+
+	t.Run("out of range slot is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		database := database.Test(t)
+		cli := walletv1connect.NewWalletServiceClient(apitests.API(t, database))
+
+		for _, slot := range []int32{-1, 256} {
+			_, err := cli.ListSidechainDeposits(context.Background(), connect.NewRequest(&walletv1.ListSidechainDepositsRequest{
+				WalletId: "test-wallet-id-1234",
+				Slot:     slot,
+			}))
+			require.Error(t, err)
+			require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+			require.Contains(t, err.Error(), "slot must be 0-255")
+		}
+	})
 }


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

`ListSidechainDeposits` cast a negative `slot` to uint32, so it wrapped to a huge number and hid every deposit from the caller.