### PR TITLE
orchestrator: abort a reset restart after a drain

### DIFF
--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -264,6 +264,13 @@ type Orchestrator struct {
 	shutdownMu    sync.Mutex
 	shutdownState int32         // shutdownState* constants
 	shutdownIdle  chan struct{} // closed when a drain completes; nil between drains
+
+	// Bumped by every drain. Detached work that outlives its caller (the reset
+	// restart) captures it up front and bails if it moved.
+	shutdownGen atomic.Uint64
+	// Drains that started but have not finished. A reset issued while one runs
+	// cannot tell its own generation from the drain's, so it refuses instead.
+	drainsActive atomic.Int64
 }
 
 // DownloadStateForTest exposes the DownloadManager's per-binary state to
@@ -1686,11 +1693,14 @@ func forwardDownload(downloadCh <-chan DownloadProgress, startupCh chan<- Startu
 
 // ShutdownAll stops all running binaries in reverse dependency order.
 func (o *Orchestrator) ShutdownAll(ctx context.Context, force bool) (<-chan ShutdownProgress, error) {
+	o.shutdownGen.Add(1)
+	o.drainsActive.Add(1)
 	running := o.process.ListRunning()
 	ch := make(chan ShutdownProgress, len(running)+1)
 
 	go func() {
 		defer close(ch)
+		defer o.drainsActive.Add(-1)
 
 		total := len(running)
 		completed := 0

--- a/sidechain-orchestrator/reset.go
+++ b/sidechain-orchestrator/reset.go
@@ -238,6 +238,18 @@ func (o *Orchestrator) DeleteFiles(ctx context.Context, paths []string, specs ..
 	shutdownCtx, cancel := context.WithTimeout(ctx, shutdownBudget)
 	defer cancel()
 
+	// A drain already in flight took its process snapshot before this reset, so
+	// anything restarted afterwards would never be stopped, and the generation
+	// alone cannot tell that drain apart from a later one.
+	if o.drainsActive.Load() > 0 {
+		return nil, fmt.Errorf("shutdown in progress: retry the reset once it completes")
+	}
+
+	// Captured before our own stop. stopResetPlan stops each binary directly and
+	// never bumps the generation, so an increment from here on is someone else's
+	// drain — including one that starts during the file-lock sleep below.
+	gen := o.shutdownGen.Load()
+
 	if useResetPlan {
 		if err := o.stopResetPlan(shutdownCtx, plan); err != nil {
 			return nil, fmt.Errorf("shutdown binaries: %w", err)
@@ -303,7 +315,7 @@ func (o *Orchestrator) DeleteFiles(ctx context.Context, paths []string, specs ..
 		}
 
 		if useResetPlan {
-			go o.restartResetPlan(context.Background(), plan)
+			go o.restartResetPlan(context.Background(), plan, gen)
 		}
 	}()
 
@@ -485,8 +497,12 @@ func (o *Orchestrator) markResetBinaryStopped(name string) {
 	}
 }
 
+// gen is the shutdown generation observed when the reset was issued. A drain
+// that began since then already snapshotted the running processes, so anything
+// started now would never be stopped — abort instead.
+//
 // A failure only strands that binary's descendants; siblings still restart.
-func (o *Orchestrator) restartResetPlan(ctx context.Context, plan resetPlan) []string {
+func (o *Orchestrator) restartResetPlan(ctx context.Context, plan resetPlan, gen uint64) []string {
 	// An overall cap, plus a fresh per-item deadline below. One binary that
 	// never becomes healthy must not consume its siblings' restart budget.
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(len(plan.restart)+1)*resetRestartTimeout)
@@ -498,13 +514,31 @@ func (o *Orchestrator) restartResetPlan(ctx context.Context, plan resetPlan) []s
 
 	for _, item := range plan.restart {
 		name := item.binary.processName()
+		if o.shutdownGen.Load() != gen {
+			o.log.Info().Str("binary", name).Msg("reset restart aborted: shutdown began after reset was issued")
+			return failed
+		}
 		if ancestor, ok := blocked[item.binary]; ok {
 			o.log.Warn().Str("binary", name).Str("depends_on", ancestor).Msg("reset restart skipped: dependency failed to start")
 			continue
 		}
+
 		itemCtx, itemCancel := context.WithTimeout(ctx, resetRestartTimeout)
 		err := o.restartResetBinary(itemCtx, item.binary, item.forceBackend)
 		itemCancel()
+
+		// A drain that began while this binary was starting snapshotted the
+		// process list without it, so nothing else will ever stop it. Check
+		// this whether or not startup reported an error: a start that fails
+		// late, after the process connects, still leaves the child running.
+		if o.shutdownGen.Load() != gen {
+			o.log.Warn().Str("binary", name).Msg("shutdown began during reset restart: stopping the binary it missed")
+			if stopErr := o.stopResetBinary(context.Background(), item.binary); stopErr != nil {
+				o.log.Error().Err(stopErr).Str("binary", name).Msg("could not stop the binary the drain missed")
+			}
+			return failed
+		}
+
 		if err != nil {
 			o.log.Error().Err(err).Str("binary", name).Msg("reset restart failed")
 			failed = append(failed, name)

--- a/sidechain-orchestrator/reset_test.go
+++ b/sidechain-orchestrator/reset_test.go
@@ -325,6 +325,39 @@ func TestResetPlan_DoesNotRestartBinariesThatWereNotRunning(t *testing.T) {
 	assert.Empty(t, plan.restart)
 }
 
+// A drain that begins after a reset was issued must cancel the reset's
+// detached restart: the drain already took its snapshot of running processes,
+// so anything started now is never stopped.
+func TestResetRestart_AbortsWhenShutdownBeganAfterReset(t *testing.T) {
+	o := newResetTestOrchestrator(t)
+	fakeRunningForReset(t, o, ResetBinaryThunder)
+
+	plan := o.buildResetPlan([]GatherSpec{
+		{Binary: ResetBinaryThunder, Categories: []ResetCategory{catData}},
+	})
+	require.Equal(t, []ResetBinary{ResetBinaryThunder}, resetRestartBinaries(plan))
+
+	gen := o.shutdownGen.Load()
+
+	// Drop the fake process first: ShutdownAll signals real PIDs.
+	o.process.Remove("thunder")
+	ch, err := o.ShutdownAll(context.Background(), false)
+	require.NoError(t, err)
+	for range ch {
+	}
+	require.NotEqual(t, gen, o.shutdownGen.Load(), "ShutdownAll must bump the shutdown generation")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	o.restartResetPlan(ctx, plan, gen)
+
+	o.monitorsMu.Lock()
+	_, started := o.monitors["thunder"]
+	o.monitorsMu.Unlock()
+	assert.False(t, started, "restart must not start thunder after a drain began")
+	assert.False(t, o.process.IsRunning("thunder"))
+}
+
 // ---------- DeleteFiles ----------------------------------------------------
 
 func TestDeleteFiles_DeletesSeededFiles(t *testing.T) {

--- a/sidechain-orchestrator/shutdown.go
+++ b/sidechain-orchestrator/shutdown.go
@@ -50,6 +50,7 @@ func (o *Orchestrator) BeginShutdown() bool {
 	o.shutdownState = shutdownStateDrainingExit
 	o.shutdownIdle = make(chan struct{})
 	idleCh := o.shutdownIdle
+	o.shutdownGen.Add(1)
 	o.shutdownMu.Unlock()
 
 	go o.runShutdown(idleCh)


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

The detached reset restart outlived its caller, so it could start a managed child after ShutdownAll returned and leave it running.