### PR TITLE
orchestrator: recover stale encryption metadata

### DIFF
--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -1319,6 +1319,23 @@ func (s *Service) RemoveEncryption(password string) error {
 
 	plaintext, err := Decrypt(string(data), key)
 	if err != nil {
+		// An earlier attempt may have written the plaintext and then failed to
+		// delete the metadata; finish that instead of blaming the password. A
+		// removal error must surface: it is not a wrong password.
+		stale, dropErr := s.dropStaleEncryptionMetadata(data)
+		if dropErr != nil {
+			return dropErr
+		}
+		if stale {
+			if err := s.loadWalletFile(); err != nil {
+				return err
+			}
+			// The watcher ignores metadata events, and it already consumed the
+			// plaintext write, so subscribers stay on the locked state without
+			// this.
+			s.notifyChanged()
+			return nil
+		}
 		s.log.Warn().Msg("remove encryption failed: incorrect password")
 		return fmt.Errorf("incorrect password")
 	}
@@ -1336,8 +1353,12 @@ func (s *Service) RemoveEncryption(password string) error {
 		return fmt.Errorf("write wallet: %w", err)
 	}
 
-	// Remove metadata file
-	_ = os.Remove(s.metadataFilePath())
+	// Remove metadata file. Until it is gone the wallet is plaintext on disk while
+	// the metadata still claims encryption, so a failure here must not report success.
+	if err := os.Remove(s.metadataFilePath()); err != nil && !os.IsNotExist(err) {
+		s.log.Error().Err(err).Str("path", s.metadataFilePath()).Msg("failed to remove encryption metadata")
+		return fmt.Errorf("remove encryption metadata: %w", err)
+	}
 
 	s.encryptionKey = nil
 	s.unlockedPass = ""
@@ -1644,6 +1665,35 @@ func (s *Service) isEncrypted() bool {
 	return meta.Encrypted
 }
 
+// dropStaleEncryptionMetadata removes wallet_encryption.json when it claims the
+// wallet is encrypted while wallet.json holds readable plaintext. RemoveEncryption
+// writes the plaintext before deleting the metadata, so an interrupted run leaves
+// exactly that state, and the correct password then fails forever. Reports whether
+// the stale metadata was dropped. Must be called with mu held.
+func (s *Service) dropStaleEncryptionMetadata(walletData []byte) (bool, error) {
+	if !s.isEncrypted() || !isPlaintextWalletFile(walletData) {
+		return false, nil
+	}
+	if err := os.Remove(s.metadataFilePath()); err != nil && !os.IsNotExist(err) {
+		s.log.Error().Err(err).Str("path", s.metadataFilePath()).Msg("could not remove stale encryption metadata")
+		return true, fmt.Errorf("remove stale encryption metadata: %w", err)
+	}
+	s.encryptionKey = nil
+	s.unlockedPass = ""
+	s.log.Warn().Msg("wallet file is plaintext but metadata claimed encrypted; dropped stale encryption metadata")
+	return true, nil
+}
+
+// isPlaintextWalletFile reports whether data is an unencrypted wallet file.
+// Ciphertext is base64(iv):base64(ct), so it never parses as wallet JSON.
+func isPlaintextWalletFile(data []byte) bool {
+	var wf WalletFile
+	if err := json.Unmarshal(data, &wf); err != nil {
+		return false
+	}
+	return wf.Version > 0 || len(wf.Wallets) > 0
+}
+
 // locked reports whether the wallet file is encrypted but no key is held, so
 // the stored wallets are neither loaded nor writable. Must be called with mu held.
 func (s *Service) locked() bool {
@@ -1686,6 +1736,11 @@ func (s *Service) loadWalletFile() error {
 	s.log.Debug().Int("file_size", len(data)).Bool("encrypted", s.isEncrypted()).Msg("wallet file read")
 
 	jsonStr := string(data)
+
+	// Recover from an interrupted RemoveEncryption before trusting the metadata.
+	if _, err := s.dropStaleEncryptionMetadata(data); err != nil {
+		return err
+	}
 
 	// If encrypted, try to decrypt
 	if s.isEncrypted() {

--- a/sidechain-orchestrator/wallet/service_test.go
+++ b/sidechain-orchestrator/wallet/service_test.go
@@ -220,6 +220,56 @@ func TestServiceRemoveEncryption(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(data, &check), "wallet.json should be valid JSON after removing encryption")
 }
 
+// staleEncryptionMetadata returns a service whose wallet.json is plaintext while
+// wallet_encryption.json still claims encryption — what a RemoveEncryption that
+// died before deleting the metadata leaves behind. Skips Init so the file watcher
+// cannot reload (and heal) the hand-restored metadata concurrently.
+func staleEncryptionMetadata(t *testing.T, password string) (*Service, string) {
+	t.Helper()
+	log := zerolog.New(zerolog.NewTestWriter(t)).With().Timestamp().Logger()
+	svc := NewService(t.TempDir(), log)
+
+	_, err := svc.GenerateWallet("Stale Meta", "", "", testSlots)
+	require.NoError(t, err)
+	require.NoError(t, svc.EncryptWallet(password))
+
+	metaPath := svc.metadataFilePath()
+	metaBytes, err := os.ReadFile(metaPath)
+	require.NoError(t, err)
+	require.NoError(t, svc.RemoveEncryption(password))
+	require.NoError(t, os.WriteFile(metaPath, metaBytes, 0600))
+	require.True(t, svc.IsEncrypted())
+
+	return svc, metaPath
+}
+
+// Reloading a wallet left in that state must drop the stale metadata instead of
+// leaving the correct password rejected forever.
+func TestServiceStaleEncryptionMetadataDroppedOnLoad(t *testing.T) {
+	svc, metaPath := staleEncryptionMetadata(t, "mypass")
+
+	svc.mu.Lock()
+	err := svc.loadWalletFile()
+	svc.mu.Unlock()
+	require.NoError(t, err)
+
+	assert.False(t, svc.IsEncrypted())
+	assert.True(t, svc.IsUnlocked())
+	assert.Len(t, svc.ListWallets(), 1)
+	_, err = os.Stat(metaPath)
+	assert.True(t, os.IsNotExist(err), "stale encryption metadata should be gone")
+}
+
+// Retrying RemoveEncryption must also recover, rather than failing the correct
+// password against the plaintext wallet.json.
+func TestServiceStaleEncryptionMetadataRemoveEncryptionRetry(t *testing.T) {
+	svc, _ := staleEncryptionMetadata(t, "mypass")
+
+	require.NoError(t, svc.RemoveEncryption("mypass"))
+	assert.False(t, svc.IsEncrypted())
+	assert.Len(t, svc.ListWallets(), 1)
+}
+
 func TestServiceSwitchWallet(t *testing.T) {
 	svc := newTestService(t)
 


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

RemoveEncryption swallowed the metadata delete error. That left the wallet plaintext with metadata that claimed encryption, and locked out the correct password.