### PR TITLE
bitwindow: purge chain-derived rows on a reorg

### DIFF
--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -234,6 +234,10 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 		if err := p.purgeM4AtOrAbove(ctx, lastProcessedHeight+1); err != nil {
 			return fmt.Errorf("purge m4 on reorg: %w", err)
 		}
+
+		if err := p.purgeChainDerivedAtOrAbove(ctx, lastProcessedHeight+1); err != nil {
+			return fmt.Errorf("purge chain-derived rows on reorg: %w", err)
+		}
 	}
 
 	const batchSize = 30
@@ -468,7 +472,11 @@ func (p *Parser) handleTimestamp(
 			if newConfirmedAt == nil {
 				newConfirmedAt = confirmedAt
 			}
-			if err := timestamps.Update(ctx, p.db, existing.ID, existing.TxID, blockHeight, timestamps.StatusConfirmed, newConfirmedAt); err != nil {
+			// Record the transaction being processed, not the stored one. After
+			// a reorg the replacement branch can carry a different transaction
+			// for the same file hash, and the stored id then points at a
+			// transaction that no longer exists.
+			if err := timestamps.Update(ctx, p.db, existing.ID, &txid, blockHeight, timestamps.StatusConfirmed, newConfirmedAt); err != nil {
 				return fmt.Errorf("update existing timestamp: %w", err)
 			}
 		}

--- a/bitwindow/server/engines/bitcoind_engine_internal_test.go
+++ b/bitwindow/server/engines/bitcoind_engine_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
 	cnstore "github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/coinnews"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/opreturns"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/timestamps"
 	service "github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
@@ -114,6 +115,56 @@ func TestOpReturnHandling(t *testing.T) {
 	assert.Equal(t, btcutil.Amount(100_000), news[0].Fee)
 	assert.Equal(t, "The Known Topic", news[0].Headline)
 	assert.Equal(t, "The Known Topic", news[0].TopicName)
+}
+
+// TestPurgeChainDerivedAtOrAbove proves the reorg purge covers the two
+// tables the replay can't heal on its own: op_returns keeps its stale
+// height through the upsert, and a confirmed timestamp is never
+// re-examined.
+func TestPurgeChainDerivedAtOrAbove(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := database.Test(t)
+	parser := &Parser{db: db}
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO op_returns (txid, vout, op_return_data, fee_sats, height, created_at)
+		VALUES ('below', 0, 'aa', 0, 100, CURRENT_TIMESTAMP),
+		       ('orphaned', 0, 'bb', 0, 200, CURRENT_TIMESTAMP),
+		       ('mempool', 0, 'cc', 0, NULL, CURRENT_TIMESTAMP)`)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO file_timestamps (filename, file_hash, txid, block_height, status, created_at, confirmed_at)
+		VALUES ('below.txt', 'hash-below', 'txid-below', 100, 'confirmed', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		       ('orphaned.txt', 'hash-orphaned', 'txid-orphaned', 200, 'confirmed', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+	require.NoError(t, err)
+
+	require.NoError(t, parser.purgeChainDerivedAtOrAbove(ctx, 181))
+
+	var txids []string
+	rows, err := db.QueryContext(ctx, `SELECT txid FROM op_returns ORDER BY txid`)
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var txid string
+		require.NoError(t, rows.Scan(&txid))
+		txids = append(txids, txid)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{"below", "mempool"}, txids,
+		"orphaned OP_RETURNs are wiped, confirmed-below and mempool rows survive")
+
+	below, err := timestamps.GetByHash(ctx, db, "hash-below")
+	require.NoError(t, err)
+	assert.Equal(t, timestamps.StatusConfirmed, below.Status, "timestamps below the rewind target stay confirmed")
+
+	orphaned, err := timestamps.GetByHash(ctx, db, "hash-orphaned")
+	require.NoError(t, err)
+	assert.Equal(t, timestamps.StatusConfirming, orphaned.Status, "orphaned timestamps go back to confirming")
+	assert.Nil(t, orphaned.BlockHeight, "orphaned timestamps lose their stale height")
+	assert.Nil(t, orphaned.ConfirmedAt, "orphaned timestamps lose their stale confirmation time")
 }
 
 func pkScript(t *testing.T, data []byte) []byte {

--- a/bitwindow/server/engines/coinnews.go
+++ b/bitwindow/server/engines/coinnews.go
@@ -13,6 +13,7 @@ import (
 
 	cnstore "github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/coinnews"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/opreturns"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/timestamps"
 	codec "github.com/LayerTwo-Labs/sidesail/coinnews/codec"
 )
 
@@ -186,6 +187,36 @@ func (p *Parser) purgeM4AtOrAbove(ctx context.Context, fromHeight uint32) error 
 		if _, err := tx.ExecContext(ctx, q, fromHeight); err != nil {
 			return err
 		}
+	}
+	return tx.Commit()
+}
+
+// purgeChainDerivedAtOrAbove drops the block-derived op_returns and
+// file_timestamps state from blocks at or above `fromHeight`. Neither
+// heals itself on replay: the op_returns upsert keeps the old height
+// (`COALESCE(excluded.height, op_returns.height)`), and a confirmed
+// timestamp is never re-examined. Mempool OP_RETURNs have a NULL height
+// and are left alone; reset timestamps go back through the confirming
+// loop, which re-confirms them against the new chain or fails them.
+func (p *Parser) purgeChainDerivedAtOrAbove(ctx context.Context, fromHeight uint32) error {
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // committed on success
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM op_returns WHERE height >= ?`, fromHeight,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE file_timestamps
+		SET status = ?, block_height = NULL, confirmed_at = NULL
+		WHERE block_height >= ?`,
+		timestamps.StatusConfirming, fromHeight,
+	); err != nil {
+		return err
 	}
 	return tx.Commit()
 }


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

op_returns and file_timestamps rows from orphaned blocks survived the replay, because the upsert keeps the old height and a confirmed timestamp is never re-examined.