### PR TITLE
bitwindow: reap expired mempool OP_RETURNs

### DIFF
--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -67,6 +67,12 @@ func (p *Parser) Run(ctx context.Context) error {
 	alertTicker := time.NewTicker(2 * time.Second)
 	defer alertTicker.Stop()
 
+	// Unconfirmed OP_RETURNs never expire on their own. Sweep on start —
+	// sessions are often shorter than the tick — and hourly after that.
+	reapTicker := time.NewTicker(time.Hour)
+	defer reapTicker.Stop()
+	p.reapExpiredMempool(ctx)
+
 	zerolog.Ctx(ctx).Info().
 		Msgf("bitcoind_engine/parser: started parser ticker")
 
@@ -76,6 +82,9 @@ func (p *Parser) Run(ctx context.Context) error {
 			zerolog.Ctx(ctx).Info().Err(ctx.Err()).
 				Msgf("bitcoind_engine/parser: stopping parser ticker")
 			return nil
+
+		case <-reapTicker.C:
+			p.reapExpiredMempool(ctx)
 
 		case <-alertTicker.C:
 
@@ -94,6 +103,25 @@ func (p *Parser) Run(ctx context.Context) error {
 				Msgf("bitcoind_engine/parser: finished processing block tick")
 
 		}
+	}
+}
+
+// reapExpiredMempool drops unconfirmed OP_RETURNs that can no longer
+// confirm. Best-effort: a failed sweep is retried on the next tick.
+func (p *Parser) reapExpiredMempool(ctx context.Context) {
+	mempoolTxIDs := func() ([]string, error) {
+		bitcoind, err := p.bitcoind.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
+		res, err := bitcoind.GetRawMempool(ctx, connect.NewRequest(&corepb.GetRawMempoolRequest{}))
+		if err != nil {
+			return nil, err
+		}
+		return res.Msg.Txids, nil
+	}
+	if err := opreturns.ReapExpiredMempool(ctx, p.db, mempoolTxIDs); err != nil {
+		zerolog.Ctx(ctx).Err(err).Msgf("unable to reap expired mempool OP_RETURNs")
 	}
 }
 

--- a/bitwindow/server/models/opreturns/opreturns.go
+++ b/bitwindow/server/models/opreturns/opreturns.go
@@ -184,6 +184,81 @@ func List(ctx context.Context, db *sql.DB, limit int) ([]OPReturn, error) {
 	return opReturns, nil
 }
 
+// mempoolExpiry mirrors Core's default -mempoolexpiry. An unconfirmed
+// OP_RETURN older than that is gone from every mempool and is never
+// going to confirm.
+const mempoolExpiry = 336 * time.Hour
+
+// ReapExpiredMempool deletes unconfirmed OP_RETURNs past Core's mempool
+// expiry. Mempool rows arrive over ZMQ with a NULL height and only ever get one
+// when the transaction is mined, so a broadcast that was replaced, dropped or
+// double-spent would otherwise sit in List forever.
+//
+// mempoolTxIDs reports what the node still holds. It is only called when a row
+// is old enough to delete, because a node can run a longer -mempoolexpiry than
+// the default, and `Persist` keeps the original created_at across a rebroadcast,
+// so age alone does not prove the transaction is gone.
+func ReapExpiredMempool(ctx context.Context, db *sql.DB, mempoolTxIDs func() ([]string, error)) error {
+	cutoff := time.Now().Add(-mempoolExpiry)
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT txid FROM op_returns
+		WHERE height IS NULL AND datetime(created_at) < datetime(?)
+	`, cutoff)
+	if err != nil {
+		return fmt.Errorf("select expired mempool OP_RETURNs: %w", err)
+	}
+	defer rows.Close()
+
+	var candidates []string
+	for rows.Next() {
+		var txid string
+		if err := rows.Scan(&txid); err != nil {
+			return fmt.Errorf("scan expired mempool OP_RETURN: %w", err)
+		}
+		candidates = append(candidates, txid)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("read expired mempool OP_RETURNs: %w", err)
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	live := map[string]bool{}
+	if mempoolTxIDs != nil {
+		txids, err := mempoolTxIDs()
+		if err != nil {
+			return fmt.Errorf("read mempool: %w", err)
+		}
+		for _, txid := range txids {
+			live[txid] = true
+		}
+	}
+
+	reaped := 0
+	for _, txid := range candidates {
+		if live[txid] {
+			continue
+		}
+		if _, err := db.ExecContext(ctx,
+			`DELETE FROM op_returns WHERE txid = ? AND height IS NULL`, txid,
+		); err != nil {
+			return fmt.Errorf("reap expired mempool OP_RETURN %s: %w", txid, err)
+		}
+		reaped++
+	}
+
+	if reaped > 0 {
+		invalidateCaches(db)
+
+		zerolog.Ctx(ctx).Info().
+			Msgf("opreturns: reaped %d expired mempool OP_RETURN(s)", reaped)
+	}
+
+	return nil
+}
+
 func OPReturnToReadable(data []byte) string {
 	// First try to decode as hex
 	decoded, err := hex.DecodeString(string(data))

--- a/bitwindow/server/models/opreturns/opreturns_test.go
+++ b/bitwindow/server/models/opreturns/opreturns_test.go
@@ -12,6 +12,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -476,6 +477,33 @@ func TestBackfillCoinNewsBlockTime(t *testing.T) {
 		"row without a matching processed_blocks entry must be left alone")
 	assert.WithinDuration(t, syncTime, got("mempool"), time.Second,
 		"mempool row (NULL height) must be left alone")
+}
+
+// A mempool OP_RETURN that never got mined must stop being listed once
+// it is past the point where any mempool could still be holding it.
+func TestReapExpiredMempool(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+
+	height := uint32(800000)
+	stale := time.Now().Add(-mempoolExpiry - time.Hour)
+	recent := time.Now().Add(-time.Hour)
+
+	require.NoError(t, Persist(ctx, db, []OPReturn{
+		{TxID: "expired-mempool", Vout: 0, Data: []byte{0x01}, CreatedAt: &stale},
+		{TxID: "pending-mempool", Vout: 0, Data: []byte{0x02}, CreatedAt: &recent},
+		{TxID: "old-confirmed", Vout: 0, Data: []byte{0x03}, Height: &height, CreatedAt: &stale},
+	}))
+
+	require.NoError(t, ReapExpiredMempool(ctx, db, func() ([]string, error) { return nil, nil }))
+
+	got, err := List(ctx, db, 0)
+	require.NoError(t, err)
+
+	txids := lo.Map(got, func(o OPReturn, _ int) string { return o.TxID })
+	slices.Sort(txids)
+	assert.Equal(t, []string{"old-confirmed", "pending-mempool"}, txids,
+		"only unconfirmed OP_RETURNs past mempool expiry are reaped")
 }
 
 func TestPersistConfirmedConflictUpdatesCreateTimeToBlockTime(t *testing.T) {

--- a/bitwindow/server/tests/apitests/apitests.go
+++ b/bitwindow/server/tests/apitests/apitests.go
@@ -258,5 +258,13 @@ func defaultBitcoindMock(ctrl *gomock.Controller) bitcoindv1alphaconnect.Bitcoin
 		}, nil).
 		AnyTimes()
 
+	// The OP_RETURN sweep reads the mempool before it deletes anything.
+	mock.EXPECT().
+		GetRawMempool(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[corepb.GetRawMempoolResponse]{
+			Msg: &corepb.GetRawMempoolResponse{},
+		}, nil).
+		AnyTimes()
+
 	return mock
 }


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

An unconfirmed OP_RETURN row never expires, so a replaced or dropped broadcast stays in List forever.