### PR TITLE
bitwindow: revive a re-proposed withdrawal bundle

### DIFF
--- a/bitwindow/server/api/drivechain/drivechain.go
+++ b/bitwindow/server/api/drivechain/drivechain.go
@@ -20,6 +20,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/rs/zerolog"
 	"github.com/samber/lo"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -543,17 +544,30 @@ func (s *Server) mergeBundles(existing, new []*pb.WithdrawalBundle) []*pb.Withdr
 		return b.M6Id
 	})
 
-	// Update or add new bundles
+	// Update or add new bundles. The existing entries belong to the shared
+	// cache, and a concurrent reader still holds them, so update a copy.
 	for _, b := range new {
-		if existingBundle, ok := bundleMap[b.M6Id]; ok {
-			// Update status if the new event changes it (e.g., pending -> succeeded/failed)
-			if b.Status == "succeeded" || b.Status == "failed" {
-				existingBundle.Status = b.Status
-				existingBundle.SequenceNumber = b.SequenceNumber
-				existingBundle.TransactionHex = b.TransactionHex
-			}
-		} else {
+		existingBundle, ok := bundleMap[b.M6Id]
+		if !ok {
 			bundleMap[b.M6Id] = b
+			continue
+		}
+		switch b.Status {
+		case "succeeded", "failed":
+			merged := proto.Clone(existingBundle).(*pb.WithdrawalBundle)
+			merged.Status = b.Status
+			merged.SequenceNumber = b.SequenceNumber
+			merged.TransactionHex = b.TransactionHex
+			bundleMap[b.M6Id] = merged
+		case "pending":
+			// A bundle can be re-proposed after it expires, which opens a fresh
+			// voting window at the new submission height.
+			merged := proto.Clone(existingBundle).(*pb.WithdrawalBundle)
+			merged.Status = b.Status
+			merged.BlockHeight = b.BlockHeight
+			merged.SequenceNumber = b.SequenceNumber
+			merged.TransactionHex = b.TransactionHex
+			bundleMap[b.M6Id] = merged
 		}
 	}
 

--- a/bitwindow/server/api/drivechain/merge_bundles_test.go
+++ b/bitwindow/server/api/drivechain/merge_bundles_test.go
@@ -1,0 +1,41 @@
+package api_drivechain
+
+import (
+	"testing"
+
+	pb "github.com/LayerTwo-Labs/sidesail/bitwindow/server/gen/drivechain/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMergeBundlesRevivesFailedBundle proves a re-proposed M6ID that was cached
+// as failed comes back as pending at its new submission height, so the age is
+// recomputed against the fresh voting window instead of the original one.
+func TestMergeBundlesRevivesFailedBundle(t *testing.T) {
+	s := &Server{}
+
+	const m6id = "abc123"
+
+	cached := []*pb.WithdrawalBundle{{
+		M6Id:        m6id,
+		BlockHeight: 100,
+		Status:      "failed",
+		MaxAge:      withdrawalVerificationPeriod,
+	}}
+
+	resubmitted := []*pb.WithdrawalBundle{{
+		M6Id:        m6id,
+		BlockHeight: 30000,
+		Status:      "pending",
+		MaxAge:      withdrawalVerificationPeriod,
+	}}
+
+	merged := s.mergeBundles(cached, resubmitted)
+	require.Len(t, merged, 1)
+	require.Equal(t, "pending", merged[0].Status)
+	require.Equal(t, uint32(30000), merged[0].BlockHeight)
+
+	aged := s.updateBundleAges(merged, 30010)
+	require.Len(t, aged, 1)
+	require.Equal(t, uint32(10), aged[0].Age)
+	require.Equal(t, withdrawalVerificationPeriod-10, aged[0].BlocksLeft)
+}


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

mergeBundles ignored a new pending event, so a bundle re-proposed after it expired kept its old failed status and height.