### PR TITLE
bitwindow: align the watch-only wallet name

### DIFF
--- a/bitwindow/server/engines/wallet_engine.go
+++ b/bitwindow/server/engines/wallet_engine.go
@@ -94,6 +94,11 @@ type WalletEngine struct {
 	// Maps walletId -> Bitcoin Core wallet name (cache)
 	coreWallets map[string]string
 
+	// Wallet ids already checked for a pre-rename watch_<prefix> wallet. The
+	// answer cannot change while the process runs, and the frontend polls this
+	// path, so the check must not repeat a listwallets and loadwallet each time.
+	legacyChecked map[string]bool
+
 	// Coalesces concurrent EnsureBitcoinCoreWallet calls for the same
 	// walletId into a single in-flight execution. The frontend polls
 	// listTransactions every 5s, and each call before the cache populates
@@ -993,6 +998,29 @@ func (e *WalletEngine) GetElectrumTransactions(ctx context.Context, walletId str
 
 // EnsureWatchOnlyWallet ensures a watch-only wallet exists in Bitcoin Core
 func (e *WalletEngine) EnsureWatchOnlyWallet(ctx context.Context, walletId string) (string, error) {
+	// This path named the wallet watch_<prefix> before it was aligned with the
+	// orchestrator, and that wallet holds the scan state for this wallet's
+	// history. Check it before delegation: the orchestrator only ever derives
+	// wallet_<prefix>, so it would create an empty wallet beside the populated
+	// one and the balance would read as zero until a manual rescan.
+	e.mu.RLock()
+	cached, ok := e.coreWallets[walletId]
+	e.mu.RUnlock()
+	if ok {
+		return cached, nil
+	}
+
+	legacy, err := e.legacyWatchOnlyWallet(ctx, walletId)
+	if err != nil {
+		return "", err
+	}
+	if legacy != "" {
+		e.mu.Lock()
+		e.coreWallets[walletId] = legacy
+		e.mu.Unlock()
+		return legacy, nil
+	}
+
 	// Try orchestrator first (it handles full and watch-only Core wallets)
 	if e.orchClient != nil {
 		resp, err := e.orchClient.CreateBitcoinCoreWallet(ctx, connect.NewRequest(&orchpb.CreateBitcoinCoreWalletRequest{
@@ -1004,7 +1032,13 @@ func (e *WalletEngine) EnsureWatchOnlyWallet(ctx context.Context, walletId strin
 			e.mu.Unlock()
 			return resp.Msg.CoreWalletName, nil
 		}
-		// Fall through to local on error
+		// A starting bitcoind fails the local path the same way, so propagate
+		// instead of storming it. A transport failure means the orchestrator is
+		// down, and the local path is exactly the fallback for that.
+		if IsBitcoinCoreStartupError(err.Error()) {
+			return "", err
+		}
+		// Otherwise fall through to local on error
 	}
 
 	e.mu.Lock()
@@ -1026,7 +1060,7 @@ func (e *WalletEngine) EnsureWatchOnlyWallet(ctx context.Context, walletId strin
 	}
 
 	// Generate wallet name from wallet ID
-	walletName := fmt.Sprintf("watch_%s", walletId[:8])
+	walletName := fmt.Sprintf("wallet_%s", walletId[:8])
 
 	// Get bitcoind client
 	bitcoindClient, err := e.bitcoindConnector(ctx)
@@ -1475,4 +1509,80 @@ func (e *WalletEngine) EstimateFeeRate(ctx context.Context, confTarget int32) (f
 		rate = 1
 	}
 	return rate, nil
+}
+
+// legacyWatchOnlyWallet returns the pre-rename watch_<prefix> wallet name when
+// Bitcoin Core can serve it, or "" when no such wallet exists. A load failure
+// that does not say the wallet is absent returns an error instead: to treat it
+// as absent would create a second wallet and hide the first one's scan state.
+// The answer is remembered, because the frontend polls this path.
+func (e *WalletEngine) legacyWatchOnlyWallet(ctx context.Context, walletId string) (string, error) {
+	if e.bitcoindConnector == nil || len(walletId) < 8 {
+		return "", nil
+	}
+
+	e.mu.RLock()
+	checked := e.legacyChecked[walletId]
+	e.mu.RUnlock()
+	if checked {
+		return "", nil
+	}
+
+	// Two polls that both find the wallet unloaded would both call loadwallet,
+	// and the loser gets an "already loading" error. Coalesce them, as the
+	// wallet-ensure path beside this one already does.
+	found, err, _ := e.ensureGroup.Do("legacy:"+walletId, func() (interface{}, error) {
+		return e.probeLegacyWatchOnlyWallet(ctx, walletId)
+	})
+	if err != nil {
+		return "", err
+	}
+	return found.(string), nil
+}
+
+func (e *WalletEngine) probeLegacyWatchOnlyWallet(ctx context.Context, walletId string) (string, error) {
+	name := fmt.Sprintf("watch_%s", walletId[:8])
+
+	// A failure here is not proof that the legacy wallet is absent. To read it
+	// that way lets the orchestrator create wallet_<prefix> beside a populated
+	// watch_<prefix>, which hides that wallet's balance and scan history. The
+	// frontend polls this path, so a propagated error costs one cycle.
+	bitcoindClient, err := e.bitcoindConnector(ctx)
+	if err != nil {
+		return "", fmt.Errorf("check for a legacy watch-only wallet: %w", err)
+	}
+	listResp, err := bitcoindClient.ListWallets(ctx, connect.NewRequest(&emptypb.Empty{}))
+	if err != nil {
+		return "", fmt.Errorf("check for a legacy watch-only wallet: %w", err)
+	}
+	if lo.Contains(listResp.Msg.Wallets, name) {
+		return name, nil
+	}
+
+	if _, err := bitcoindClient.LoadWallet(ctx, connect.NewRequest(&corepb.LoadWalletRequest{Filename: name})); err != nil {
+		if isWalletNotFoundError(err.Error()) {
+			e.markLegacyChecked(walletId)
+			return "", nil
+		}
+		return "", fmt.Errorf("load legacy watch-only wallet %s: %w", name, err)
+	}
+	return name, nil
+}
+
+func (e *WalletEngine) markLegacyChecked(walletId string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.legacyChecked == nil {
+		e.legacyChecked = make(map[string]bool)
+	}
+	e.legacyChecked[walletId] = true
+}
+
+// isWalletNotFoundError reports whether Core says the wallet does not exist,
+// rather than that it could not be loaded right now.
+func isWalletNotFoundError(msg string) bool {
+	m := strings.ToLower(msg)
+	return strings.Contains(m, "not found") ||
+		strings.Contains(m, "does not exist") ||
+		strings.Contains(m, "no such file")
 }

--- a/bitwindow/server/engines/wallet_engine_watchonly_test.go
+++ b/bitwindow/server/engines/wallet_engine_watchonly_test.go
@@ -1,0 +1,138 @@
+package engines
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// stubOrchWalletClient fails CreateBitcoinCoreWallet with a fixed error.
+type stubOrchWalletClient struct {
+	orchrpc.WalletManagerServiceClient
+	err error
+}
+
+func (s stubOrchWalletClient) CreateBitcoinCoreWallet(context.Context, *connect.Request[orchpb.CreateBitcoinCoreWalletRequest]) (*connect.Response[orchpb.CreateBitcoinCoreWalletResponse], error) {
+	return nil, s.err
+}
+
+// TestEnsureWatchOnlyWalletTransientOrchestratorError asserts a warming-up
+// orchestrator or a starting bitcoind propagates instead of falling through to
+// the local path, which would mint a second Core wallet for the same walletId.
+func TestEnsureWatchOnlyWalletTransientOrchestratorError(t *testing.T) {
+	// A starting bitcoind fails the local path the same way, so it propagates.
+	t.Run("startup propagates", func(t *testing.T) {
+		orchErr := connect.NewError(connect.CodeInternal, errors.New("-28: Verifying blocks…"))
+		e := NewWalletEngine(nil, nil, t.TempDir(), &chaincfg.MainNetParams)
+		e.SetOrchestratorClient(stubOrchWalletClient{err: orchErr})
+
+		_, err := e.EnsureWatchOnlyWallet(context.Background(), "deadbeefcafebabe")
+		require.ErrorIs(t, err, orchErr)
+	})
+
+	// A down orchestrator is exactly what the local path is the fallback for.
+	t.Run("unavailable falls back to local", func(t *testing.T) {
+		orchErr := connect.NewError(connect.CodeUnavailable, errors.New("connection refused"))
+		e := NewWalletEngine(nil, nil, t.TempDir(), &chaincfg.MainNetParams)
+		e.SetOrchestratorClient(stubOrchWalletClient{err: orchErr})
+
+		_, err := e.EnsureWatchOnlyWallet(context.Background(), "deadbeefcafebabe")
+		require.NotErrorIs(t, err, orchErr)
+	})
+}
+
+// TestEnsureWatchOnlyWalletLocalName asserts the local fallback names the Core
+// wallet the same way the orchestrator does, so both resolve one walletId to
+// one bitcoind wallet.
+func TestEnsureWatchOnlyWalletLocalName(t *testing.T) {
+	walletDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(walletDir, "wallet.json"), []byte(`{
+		"version": 1,
+		"activeWalletId": "deadbeefcafebabe",
+		"wallets": [{
+			"id": "deadbeefcafebabe",
+			"name": "watcher",
+			"wallet_type": "bitcoinCore",
+			"watch_only": {"xpub": "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj"}
+		}]
+	}`), 0o600))
+
+	ctrl := gomock.NewController(t)
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+	mockBitcoind.EXPECT().
+		ListWallets(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[corepb.ListWalletsResponse]{
+			Msg: &corepb.ListWalletsResponse{Wallets: []string{"wallet_deadbeef"}},
+		}, nil).
+		AnyTimes()
+	// No wallet from before the rename, so the local name applies.
+	mockBitcoind.EXPECT().
+		LoadWallet(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("Wallet file verification failed. Path does not exist.")).
+		AnyTimes()
+
+	e := NewWalletEngine(func(context.Context) (corerpc.BitcoinServiceClient, error) {
+		return mockBitcoind, nil
+	}, nil, walletDir, &chaincfg.MainNetParams)
+
+	walletName, err := e.EnsureWatchOnlyWallet(context.Background(), "deadbeefcafebabe")
+	require.NoError(t, err)
+	require.Equal(t, "wallet_deadbeef", walletName)
+}
+
+// A wallet from before the rename holds the scan state, so it wins over a fresh
+// wallet_<prefix>.
+func TestEnsureWatchOnlyWalletPrefersLegacyName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+	mockBitcoind.EXPECT().
+		ListWallets(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[corepb.ListWalletsResponse]{
+			Msg: &corepb.ListWalletsResponse{Wallets: []string{"watch_deadbeef"}},
+		}, nil).
+		AnyTimes()
+
+	e := NewWalletEngine(func(context.Context) (corerpc.BitcoinServiceClient, error) {
+		return mockBitcoind, nil
+	}, nil, t.TempDir(), &chaincfg.MainNetParams)
+
+	walletName, err := e.EnsureWatchOnlyWallet(context.Background(), "deadbeefcafebabe")
+	require.NoError(t, err)
+	require.Equal(t, "watch_deadbeef", walletName)
+}
+
+// A load failure that does not say the wallet is absent must not create a
+// second wallet beside the first one.
+func TestEnsureWatchOnlyWalletPropagatesLegacyLoadError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+	mockBitcoind.EXPECT().
+		ListWallets(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[corepb.ListWalletsResponse]{
+			Msg: &corepb.ListWalletsResponse{Wallets: []string{}},
+		}, nil).
+		AnyTimes()
+	mockBitcoind.EXPECT().
+		LoadWallet(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("Wallet already loading.")).
+		AnyTimes()
+
+	e := NewWalletEngine(func(context.Context) (corerpc.BitcoinServiceClient, error) {
+		return mockBitcoind, nil
+	}, nil, t.TempDir(), &chaincfg.MainNetParams)
+
+	_, err := e.EnsureWatchOnlyWallet(context.Background(), "deadbeefcafebabe")
+	require.ErrorContains(t, err, "load legacy watch-only wallet")
+}


### PR DESCRIPTION
Cherry-picked from #1987, authored by @giaki3003.

The local fallback named the wallet `watch_<id>` while the orchestrator names it `wallet_<id>`, so the two paths addressed different Core wallets.