### PR TITLE
orchestrator: import descriptors on a retry

### DIFF
--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -1004,16 +1004,35 @@ func createAndImport(
 		return fmt.Errorf("list wallets: %w", err)
 	}
 
-	if lo.Contains(existing, walletName) {
-		return nil
+	created := false
+	if !lo.Contains(existing, walletName) {
+		if err := rpc.CreateWallet(ctx, walletName, disablePrivateKeys, true); err != nil {
+			if !strings.Contains(err.Error(), "already exists") {
+				return fmt.Errorf("create wallet: %w", err)
+			}
+			if loadErr := rpc.LoadWallet(ctx, walletName); loadErr != nil {
+				return fmt.Errorf("load existing wallet: %w", loadErr)
+			}
+		}
+		created = true
 	}
 
-	if err := rpc.CreateWallet(ctx, walletName, disablePrivateKeys, true); err != nil {
-		if !strings.Contains(err.Error(), "already exists") {
-			return fmt.Errorf("create wallet: %w", err)
+	// A createwallet that succeeds before a failing import leaves the wallet
+	// listed with no active descriptor, so listwallets membership alone must not
+	// skip the import. Ask the wallet instead: a restored wallet imports at
+	// timestamp 0, and Core restarts a genesis rescan on every re-import of it.
+	if !created {
+		active, err := rpc.CountActiveDescriptors(ctx, walletName)
+		if err != nil {
+			return fmt.Errorf("list descriptors: %w", err)
 		}
-		if loadErr := rpc.LoadWallet(ctx, walletName); loadErr != nil {
-			return fmt.Errorf("load existing wallet: %w", loadErr)
+		// Every requested descriptor has to be there. A batch can land in part,
+		// and one active entry is no proof that the change branch arrived.
+		// Count rather than compare the strings: listdescriptors reports the
+		// public form, while a full wallet asks for descriptors that hold the
+		// account xprv, so the two never read as equal.
+		if len(descriptors) > 0 && active >= len(descriptors) {
+			return nil
 		}
 	}
 
@@ -1032,7 +1051,9 @@ func createAndImport(
 		}
 	}
 
-	log.Info().Str("wallet", walletName).Msg("created Bitcoin Core wallet")
+	if created {
+		log.Info().Str("wallet", walletName).Msg("created Bitcoin Core wallet")
+	}
 	return nil
 }
 

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -929,3 +929,72 @@ func TestGenerateFullWalletMarksImportedSeeds(t *testing.T) {
 		t.Error("a generated wallet has no history and must not be marked imported")
 	}
 }
+
+// createwallet succeeding before a failing descriptor import leaves the wallet
+// listed but empty. The retry must re-import it, not treat listwallets
+// membership as proof the descriptors landed.
+func TestCoreBackendRetryReimportsDescriptorsAfterPartialCreate(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	var mu sync.Mutex
+	created := false
+	failSingleSig := true
+	fake.handle("listwallets", func(bitcoindCall) (any, string) {
+		mu.Lock()
+		defer mu.Unlock()
+		if created {
+			return []string{"wallet_" + coreID[:8]}, ""
+		}
+		return []string{}, ""
+	})
+	fake.handle("createwallet", func(bitcoindCall) (any, string) {
+		mu.Lock()
+		created = true
+		mu.Unlock()
+		return map[string]any{}, ""
+	})
+	// The first import failed, so the wallet holds no active descriptor. That
+	// is exactly what must not be read as "already imported".
+	fake.handle("listdescriptors", func(bitcoindCall) (any, string) {
+		return map[string]any{"descriptors": []map[string]any{}}, ""
+	})
+	fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		mu.Lock()
+		fail := failSingleSig && len(descs) == 4
+		mu.Unlock()
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			results[i] = map[string]any{"success": !fail}
+			if fail {
+				results[i]["error"] = map[string]any{"code": -5, "message": "Missing checksum"}
+			}
+		}
+		return results, ""
+	})
+	ctx := context.Background()
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.ErrorContains(t, err, "descriptor 0 import failed")
+	require.Len(t, fake.callsFor("createwallet"), 1)
+
+	mu.Lock()
+	failSingleSig = false
+	mu.Unlock()
+
+	// The wallet is now in listwallets, so createwallet is skipped — but the
+	// descriptors still have to be imported.
+	name, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	assert.Equal(t, "wallet_"+coreID[:8], name)
+	assert.Len(t, fake.callsFor("createwallet"), 1)
+
+	imports := fake.callsFor("importdescriptors")
+	require.GreaterOrEqual(t, len(imports), 2, "failed single-sig import, then its retry")
+	var singleSig []ImportDescriptor
+	require.NoError(t, json.Unmarshal(imports[1].Params[0], &singleSig))
+	require.Len(t, singleSig, 4)
+	assert.Contains(t, singleSig[0].Desc, "/84'/1'/0']")
+}

--- a/sidechain-orchestrator/wallet/core_rpc.go
+++ b/sidechain-orchestrator/wallet/core_rpc.go
@@ -288,6 +288,31 @@ func (c *CoreRPCClient) ListTransactions(ctx context.Context, walletName string,
 // ListTransactionsRange returns wallet transactions in a sliding window,
 // skipping the first `skip` entries (cursor-based scan). Use to incrementally
 // process new wallet activity without re-walking the entire history each tick.
+// CountActiveDescriptors reports how many active descriptors a wallet holds. A
+// wallet created by a run whose import then failed holds none, and one whose
+// import landed in part holds fewer than the run asked for.
+func (c *CoreRPCClient) CountActiveDescriptors(ctx context.Context, walletName string) (int, error) {
+	result, err := c.call(ctx, walletName, "listdescriptors")
+	if err != nil {
+		return 0, err
+	}
+	var res struct {
+		Descriptors []struct {
+			Active bool `json:"active"`
+		} `json:"descriptors"`
+	}
+	if err := json.Unmarshal(result, &res); err != nil {
+		return 0, fmt.Errorf("decode listdescriptors: %w", err)
+	}
+	n := 0
+	for _, d := range res.Descriptors {
+		if d.Active {
+			n++
+		}
+	}
+	return n, nil
+}
+
 func (c *CoreRPCClient) ListTransactionsRange(ctx context.Context, walletName string, count, skip int) ([]WalletTransaction, error) {
 	if count <= 0 {
 		count = 100


### PR DESCRIPTION
From #1987, authored by @giaki3003. Adapted to master, where `createAndImport` returns early on listwallets membership.

If createwallet succeeds and importdescriptors then fails, the retry sees the wallet listed and returns without importing, so it stays empty forever.