### PR TITLE
orchestrator: read pinned input values from Core

### DIFF
--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -475,18 +475,29 @@ func (p *CoreBackend) Send(ctx context.Context, walletID string, req SendRequest
 
 	outputs, totalDestinationSats := buildSendOutputs(req)
 	inputs := make([]RawInput, 0, len(req.ExternalInputs)+len(req.RequiredInputs))
-	selectedInputAmountSats := int64(0)
+	externalSats := int64(0)
 	// External inputs come first, so a sidechain CTIP stays at input 0.
 	for _, in := range req.ExternalInputs {
 		inputs = append(inputs, RawInput{TxID: in.TxID, Vout: in.Vout})
-		selectedInputAmountSats += in.AmountSats
+		externalSats += in.AmountSats
 	}
 	for _, in := range req.RequiredInputs {
 		inputs = append(inputs, RawInput{TxID: in.TxID, Vout: in.Vout})
-		selectedInputAmountSats += in.AmountSats
 	}
 
 	if req.FixedFeeSats > 0 {
+		selectedInputAmountSats := externalSats
+		if len(req.RequiredInputs) > 0 {
+			// Core owns the pinned outpoints' real values; a caller-supplied
+			// amount that is absent or too small would shrink the change output
+			// and burn the difference as fee.
+			requiredSats, err := p.requiredInputValueSats(ctx, name, req.RequiredInputs)
+			if err != nil {
+				return "", err
+			}
+			selectedInputAmountSats += requiredSats
+		}
+
 		neededSats := totalDestinationSats + req.FixedFeeSats
 		if len(req.RequiredInputs) == 0 && selectedInputAmountSats < neededSats {
 			extra, extraSats, err := p.selectInputsForFixedFee(
@@ -624,6 +635,53 @@ func buildSendOutputs(req SendRequest) ([]TxOutSpec, int64) {
 		outputs = append(outputs, TxOutSpec{OpReturnHex: req.OpReturnHex})
 	}
 	return outputs, totalDestinationSats
+}
+
+// requiredInputValueSats sums the pinned outpoints' on-chain values. The
+// caller-supplied amounts are never trusted: an absent or understated one
+// would silently shrink the change output and burn the difference as fee.
+// minconf 0 so a pinned unconfirmed output (e.g. a replacement's own change)
+// still resolves.
+func (p *CoreBackend) requiredInputValueSats(ctx context.Context, name string, required []RequiredInput) (int64, error) {
+	utxos, err := p.rpc.ListUnspentMinConf(ctx, name, 0)
+	if err != nil {
+		return 0, fmt.Errorf("list unspent: %w", err)
+	}
+
+	totalSats := int64(0)
+	for _, in := range required {
+		utxo, ok := lo.Find(utxos, func(u UTXO) bool {
+			return u.TxID == in.TxID && u.Vout == in.Vout
+		})
+		if ok {
+			totalSats += int64(math.Round(utxo.Amount * 1e8))
+			continue
+		}
+
+		// A replacement pins the inputs of the transaction it replaces, and
+		// that unconfirmed transaction already spends them, so listunspent
+		// does not carry them. Read the value off the previous output.
+		sats, err := p.prevOutValueSats(ctx, in)
+		if err != nil {
+			return 0, err
+		}
+		totalSats += sats
+	}
+	return totalSats, nil
+}
+
+// prevOutValueSats reads a pinned outpoint's value from the transaction that
+// created it. The value comes from chain data, never from the caller, so a
+// foreign outpoint the node cannot serve is still refused.
+func (p *CoreBackend) prevOutValueSats(ctx context.Context, in RequiredInput) (int64, error) {
+	raw, err := p.rpc.GetRawTransaction(ctx, in.TxID)
+	if err != nil {
+		return 0, fmt.Errorf("required input %s:%d is not a wallet UTXO: %w", in.TxID, in.Vout, err)
+	}
+	if raw == nil || in.Vout < 0 || in.Vout >= len(raw.Vout) {
+		return 0, fmt.Errorf("required input %s:%d is not a wallet UTXO", in.TxID, in.Vout)
+	}
+	return int64(math.Round(raw.Vout[in.Vout].Value * 1e8)), nil
 }
 
 // selectInputsForFixedFee picks spendable UTXOs largest-first until they

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -430,6 +430,124 @@ func TestCoreBackendSendFixedFeeSelectsInputsAndChange(t *testing.T) {
 	assert.Equal(t, builtHex, mustString(t, signs[0].Params[0]))
 }
 
+func TestCoreBackendSendFixedFeeResolvesRequiredInputValue(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	net := &chaincfg.RegressionNetParams
+	dest := p2wpkhAddr(t, fixedKey(0xCC), net)
+	change := p2wpkhAddr(t, fixedKey(0xDD), net)
+	pinned := strings.Repeat("55", 32)
+
+	fake.handle("listunspent", func(c bitcoindCall) (any, string) {
+		// minconf 0 so a pinned unconfirmed output still resolves.
+		var minConf int
+		require.NoError(t, json.Unmarshal(c.Params[0], &minConf))
+		assert.Equal(t, 0, minConf)
+		return []map[string]any{
+			{"txid": pinned, "vout": 2, "amount": 0.001, "spendable": true},
+		}, ""
+	})
+	fake.handle("getrawchangeaddress", func(bitcoindCall) (any, string) { return change, "" })
+	fake.handle("createrawtransaction", func(bitcoindCall) (any, string) { return "deadbeef", "" })
+	fake.handle("signrawtransactionwithwallet", func(c bitcoindCall) (any, string) {
+		return map[string]any{"hex": mustString(t, c.Params[0]), "complete": true}, ""
+	})
+	fake.handle("sendrawtransaction", func(bitcoindCall) (any, string) { return "txid-pinned", "" })
+
+	// AmountSats left at zero, as callers that only know the outpoint send it.
+	txid, err := backend.Send(context.Background(), coreID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FixedFeeSats:     1_000,
+		RequiredInputs:   []RequiredInput{{TxID: pinned, Vout: 2}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "txid-pinned", txid)
+
+	creates := fake.callsFor("createrawtransaction")
+	require.Len(t, creates, 1)
+	var inputs []RawInput
+	require.NoError(t, json.Unmarshal(creates[0].Params[0], &inputs))
+	require.Len(t, inputs, 1)
+	assert.Equal(t, pinned, inputs[0].TxID)
+	assert.Equal(t, 2, inputs[0].Vout)
+
+	// Change is 100k on-chain - 50k dest - 1k fee, not burned by the zero amount.
+	var outputs []map[string]any
+	require.NoError(t, json.Unmarshal(creates[0].Params[1], &outputs))
+	require.Len(t, outputs, 2)
+	assert.Equal(t, 0.0005, outputs[0][dest])
+	assert.Equal(t, 0.00049, outputs[1][change])
+}
+
+func TestCoreBackendSendFixedFeeRejectsForeignRequiredInput(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	net := &chaincfg.RegressionNetParams
+	dest := p2wpkhAddr(t, fixedKey(0xCC), net)
+	foreign := strings.Repeat("66", 32)
+
+	fake.handle("listunspent", func(bitcoindCall) (any, string) { return []map[string]any{}, "" })
+	// Core's reply for an outpoint it does not know.
+	fake.handle("getrawtransaction", func(bitcoindCall) (any, string) {
+		return nil, "No such mempool or blockchain transaction"
+	})
+
+	_, err := backend.Send(context.Background(), coreID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FixedFeeSats:     1_000,
+		RequiredInputs:   []RequiredInput{{TxID: foreign, Vout: 0, AmountSats: 1_000_000}},
+	})
+	require.ErrorContains(t, err, "is not a wallet UTXO")
+	assert.Empty(t, fake.callsFor("createrawtransaction"))
+}
+
+// A replacement pins the inputs of the transaction it replaces. That
+// unconfirmed transaction already spends them, so listunspent does not carry
+// them and the value has to come from the previous output.
+func TestCoreBackendSendFixedFeeResolvesSpentRequiredInput(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	net := &chaincfg.RegressionNetParams
+	dest := p2wpkhAddr(t, fixedKey(0xCC), net)
+	prev := strings.Repeat("77", 32)
+
+	fake.handle("listunspent", func(bitcoindCall) (any, string) { return []map[string]any{}, "" })
+	fake.handle("getrawtransaction", func(bitcoindCall) (any, string) {
+		return map[string]any{
+			"txid": prev,
+			"vout": []map[string]any{
+				{"value": 0.001, "n": 0},
+				{"value": 0.01, "n": 1},
+			},
+		}, ""
+	})
+
+	fake.handle("getrawchangeaddress", func(bitcoindCall) (any, string) {
+		return p2wpkhAddr(t, fixedKey(0xDD), net), ""
+	})
+	fake.handle("createrawtransaction", func(bitcoindCall) (any, string) { return "deadbeef", "" })
+	fake.handle("signrawtransactionwithwallet", func(c bitcoindCall) (any, string) {
+		return map[string]any{"hex": mustString(t, c.Params[0]), "complete": true}, ""
+	})
+	fake.handle("sendrawtransaction", func(bitcoindCall) (any, string) { return "txid-replacement", "" })
+
+	// No AmountSats: the caller does not know it, so Core must supply it.
+	_, err := backend.Send(context.Background(), coreID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FixedFeeSats:     1_000,
+		RequiredInputs:   []RequiredInput{{TxID: prev, Vout: 1}},
+	})
+	require.NoError(t, err)
+
+	created := fake.callsFor("createrawtransaction")
+	require.Len(t, created, 1)
+	// 1_000_000 in, 50_000 out, 1_000 fee -> 949_000 change.
+	require.Contains(t, string(created[0].Params[1]), "0.00949")
+}
+
 func TestCoreBackendSendReplayProtect(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
 	fake.stubEnsureFlow()


### PR DESCRIPTION
From #1987, authored by @giaki3003. Rebased on master, and the external-input loop his patch dropped is kept.

A fixed-fee send trusted `RequiredInput.AmountSats`. An absent or low value shrank the change output and burned the difference as fee.