### PR TITLE
orchestrator: rescan for new BIP47 notifications

### DIFF
--- a/sidechain-orchestrator/engines/bip47_engine.go
+++ b/sidechain-orchestrator/engines/bip47_engine.go
@@ -55,6 +55,11 @@ type BIP47Engine struct {
 	// notifWatched records wallets whose own notification key has been
 	// registered with the backend this process, so we only do it once.
 	notifWatched map[string]bool
+	// scanned records every notification txid this process already examined,
+	// keyed by wallet. The store keys a sender's first txid only, so a second
+	// notification from a known sender, and a malformed one, would otherwise be
+	// fetched and decoded on every pass.
+	scanned map[string]map[string]bool
 }
 
 func NewBIP47Engine(log zerolog.Logger, svc *wallet.Service, walletEngine *wallet.WalletEngine, inbound *bip47state.InboundStore) *BIP47Engine {
@@ -64,6 +69,7 @@ func NewBIP47Engine(log zerolog.Logger, svc *wallet.Service, walletEngine *walle
 		engine:       walletEngine,
 		inbound:      inbound,
 		notifWatched: make(map[string]bool),
+		scanned:      make(map[string]map[string]bool),
 	}
 }
 
@@ -74,6 +80,7 @@ func (e *BIP47Engine) ResetForNetwork(networkDir string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.notifWatched = make(map[string]bool)
+	e.scanned = make(map[string]map[string]bool)
 }
 
 // Run loops until ctx is cancelled. Errors from a single tick are logged and
@@ -157,8 +164,8 @@ func (e *BIP47Engine) ensureNotificationWatched(ctx context.Context, backend wal
 	return nil
 }
 
-// scanWallet walks listtransactions forward from the persisted cursor looking
-// for receives at this wallet's BIP47 notification address. For each one, it
+// scanWallet walks the wallet's whole listtransactions history looking for
+// receives at this wallet's BIP47 notification address. For each one, it
 // fetches the full tx, extracts the OP_RETURN payload + first input's pubkey,
 // decodes the sender's payment code, and records the inbound notification.
 func (e *BIP47Engine) scanWallet(ctx context.Context, walletID, seedHex string, net *chaincfg.Params) error {
@@ -168,13 +175,27 @@ func (e *BIP47Engine) scanWallet(ctx context.Context, walletID, seedHex string, 
 	}
 	wantAddr := notifAddr.EncodeAddress()
 
-	cursor, err := e.inbound.ScanCursor(walletID)
+	// Notifications already recorded need no second look — skipping them keeps
+	// the re-walk below free of repeated getrawtransaction calls.
+	known, err := e.inbound.ListByWallet(walletID)
 	if err != nil {
-		return fmt.Errorf("read scan cursor: %w", err)
+		return fmt.Errorf("list inbound: %w", err)
+	}
+	recorded := e.seenTxIDs(walletID)
+	for _, n := range known {
+		recorded[n.FirstNotificationTxID] = true
 	}
 
+	// skip counts from the newest entry, so it is a within-pass pagination
+	// offset only: every pass restarts at 0, otherwise newly arrived
+	// notifications land in the skipped prefix and are never seen. The walk
+	// does not stop at a remembered row: Core returns each page oldest-first
+	// while skip counts from the newest, so no single row bounds the history on
+	// every backend. `scanned` still keeps the costly getrawtransaction calls
+	// down to one per notification.
+	skip := 0
 	for {
-		batch, err := e.engine.Backend().ListTransactionsRange(ctx, walletID, bip47ListTxBatchSize, cursor)
+		batch, err := e.engine.Backend().ListTransactionsRange(ctx, walletID, bip47ListTxBatchSize, skip)
 		if err != nil {
 			return fmt.Errorf("listtransactions: %w", err)
 		}
@@ -182,11 +203,13 @@ func (e *BIP47Engine) scanWallet(ctx context.Context, walletID, seedHex string, 
 			break
 		}
 		for _, tx := range batch {
-			if tx.Category != "receive" || tx.Address != wantAddr {
+			if tx.Category != "receive" || tx.Address != wantAddr || recorded[tx.TxID] {
 				continue
 			}
 			senderCode, blockTime, err := e.decodeNotificationTx(ctx, walletID, tx.TxID, notifPriv)
 			if err != nil {
+				// A backend error here is transient, so leave the transaction
+				// unmarked and let the next pass retry it.
 				e.log.Debug().Err(err).Str("txid", tx.TxID).Msg("skip non-bip47 receive at notification address")
 				continue
 			}
@@ -201,16 +224,18 @@ func (e *BIP47Engine) scanWallet(ctx context.Context, walletID, seedHex string, 
 				e.log.Warn().Err(err).Str("txid", tx.TxID).Msg("record inbound failed")
 				continue
 			}
+			// Recorded, so no later pass has to decode it again. The store keys
+			// a sender's first txid only, so a second notification from a known
+			// sender needs this marker of its own.
+			e.markScanned(walletID, tx.TxID)
+			recorded[tx.TxID] = true
 			e.log.Info().
 				Str("wallet", walletID).
 				Str("sender", senderCode).
 				Str("txid", tx.TxID).
 				Msg("recorded inbound bip47 notification")
 		}
-		cursor += len(batch)
-		if err := e.inbound.SetScanCursor(walletID, cursor); err != nil {
-			return fmt.Errorf("save scan cursor: %w", err)
-		}
+		skip += len(batch)
 		if len(batch) < bip47ListTxBatchSize {
 			break
 		}
@@ -490,4 +515,28 @@ func pushedDataItems(script []byte) ([][]byte, error) {
 		i += size
 	}
 	return out, nil
+}
+
+// seenTxIDs returns a copy of the notification txids already examined for a
+// wallet, so the caller can add to it without holding the lock.
+func (e *BIP47Engine) seenTxIDs(walletID string) map[string]bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make(map[string]bool, len(e.scanned[walletID]))
+	for txid := range e.scanned[walletID] {
+		out[txid] = true
+	}
+	return out
+}
+
+func (e *BIP47Engine) markScanned(walletID, txid string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.scanned == nil {
+		e.scanned = make(map[string]map[string]bool)
+	}
+	if e.scanned[walletID] == nil {
+		e.scanned[walletID] = make(map[string]bool)
+	}
+	e.scanned[walletID][txid] = true
 }

--- a/sidechain-orchestrator/engines/bip47_engine_test.go
+++ b/sidechain-orchestrator/engines/bip47_engine_test.go
@@ -2,12 +2,154 @@ package engines
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47state"
 )
+
+// Test vectors from https://gist.github.com/SamouraiDev/6aad669604c5930864bd
+const (
+	aliceSeedHex = "64dca76abc9c6f0cf3d212d248c380c4622c8f93b2c425ec6a5567fd5db57e10d3e6f94a2f6af4ac2edb8998072aad92098db73558c323777abf5bd1082d970a"
+	bobSeedHex   = "87eaaac5a539ab028df44d9110defbef3797ddb805ca309f61a69ff96dbaa7ab5b24038cf029edec5235d933110f0aea8aeecf939ed14fc20730bba71e4b1110"
+)
+
+// stubBackend serves a fixed newest-first listtransactions history and records
+// the skip offsets it was asked for. Unimplemented Backend methods panic.
+type stubBackend struct {
+	wallet.Backend
+	chain wallet.ChainSource
+	txs   []wallet.WalletTransaction
+	skips []int
+}
+
+func (s *stubBackend) ListTransactionsRange(ctx context.Context, walletID string, count, skip int) ([]wallet.WalletTransaction, error) {
+	s.skips = append(s.skips, skip)
+	if skip >= len(s.txs) {
+		return nil, nil
+	}
+	rows := s.txs[skip:]
+	if count > 0 && count < len(rows) {
+		rows = rows[:count]
+	}
+	return rows, nil
+}
+
+func (s *stubBackend) Chain() wallet.ChainSource { return s.chain }
+
+type stubChain struct {
+	wallet.ChainSource
+	txs   map[string]*wallet.RawTransaction
+	fetch int
+}
+
+func (s *stubChain) GetRawTransaction(ctx context.Context, txid string) (*wallet.RawTransaction, error) {
+	s.fetch++
+	tx, ok := s.txs[txid]
+	if !ok {
+		return nil, fmt.Errorf("no such tx %s", txid)
+	}
+	return tx, nil
+}
+
+// buildNotificationTx returns the raw notification tx Alice sends to the
+// recipient's payment code, plus the listtransactions row for it.
+func buildNotificationTx(t *testing.T, recipientSeedHex, notifAddr string) (wallet.WalletTransaction, *wallet.RawTransaction) {
+	t.Helper()
+	net := &chaincfg.MainNetParams
+
+	sender, err := bip47.PaymentCodeFromSeed(aliceSeedHex, net)
+	require.NoError(t, err)
+	recipient, err := bip47.PaymentCodeFromSeed(recipientSeedHex, net)
+	require.NoError(t, err)
+
+	designatedPriv, _ := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x11}, 32))
+	const prevTxID = "86f411ab1c8e70ae8a0795ab7a6757aea6e4d5ae1826fc7b8f00c597d500609c"
+	prevHash, err := chainhash.NewHashFromStr(prevTxID)
+	require.NoError(t, err)
+
+	senderSerialized := sender.Serialize()
+	blinded, err := bip47.BuildBlindedPayload(senderSerialized, designatedPriv, recipient, wire.OutPoint{Hash: *prevHash, Index: 1})
+	require.NoError(t, err)
+
+	raw := &wallet.RawTransaction{
+		TxID: "notification-txid",
+		Vin: []wallet.RawTxIn{{
+			TxID:    prevTxID,
+			Vout:    1,
+			Witness: []string{"3045sig", hex.EncodeToString(designatedPriv.PubKey().SerializeCompressed())},
+		}},
+		Vout: []wallet.RawTxOut{{
+			ScriptPubKey: wallet.ScriptPubKey{
+				Type: "nulldata",
+				Hex:  hex.EncodeToString(append([]byte{0x6a, 0x4c, 0x50}, blinded[:]...)),
+			},
+		}},
+		BlockTime: 1700000000,
+	}
+	row := wallet.WalletTransaction{TxID: raw.TxID, Category: "receive", Address: notifAddr, Confirmations: 3}
+	return row, raw
+}
+
+// listtransactions counts skip from the newest entry, so a notification that
+// arrives after a completed scan pass sits at offset 0 — the scanner must
+// restart its pagination at 0 every pass or it never sees it.
+func TestScanWalletFindsNotificationAfterCompletedPass(t *testing.T) {
+	net := &chaincfg.MainNetParams
+	const walletID = "W1"
+
+	_, notifAddr, err := bip47.DeriveOwnNotificationKey(bobSeedHex, net)
+	require.NoError(t, err)
+	row, raw := buildNotificationTx(t, bobSeedHex, notifAddr.EncodeAddress())
+
+	// History longer than one batch, so the pass pages more than once.
+	history := make([]wallet.WalletTransaction, 0, bip47ListTxBatchSize+50)
+	for i := 0; i < bip47ListTxBatchSize+50; i++ {
+		history = append(history, wallet.WalletTransaction{
+			TxID:     fmt.Sprintf("filler-%d", i),
+			Category: "receive",
+			Address:  "unrelated-address",
+		})
+	}
+
+	chain := &stubChain{txs: map[string]*wallet.RawTransaction{raw.TxID: raw}}
+	backend := &stubBackend{chain: chain, txs: history}
+	store := bip47state.NewInboundStore(t.TempDir())
+	e := NewBIP47Engine(zerolog.Nop(), nil, wallet.NewWalletEngine(nil, backend, func() *chaincfg.Params { return net }, zerolog.Nop()), store)
+
+	require.NoError(t, e.scanWallet(context.Background(), walletID, bobSeedHex, net))
+
+	// Notification arrives after that pass completed — newest first.
+	backend.txs = append([]wallet.WalletTransaction{row}, history...)
+	require.NoError(t, e.scanWallet(context.Background(), walletID, bobSeedHex, net))
+
+	alice, err := bip47.PaymentCodeFromSeed(aliceSeedHex, net)
+	require.NoError(t, err)
+	got, err := store.Get(walletID, alice.Base58())
+	require.NoError(t, err)
+	require.NotNil(t, got, "notification arriving after a completed pass must still be recorded")
+	require.Equal(t, raw.TxID, got.FirstNotificationTxID)
+	require.Equal(t, int64(1700000000), got.FirstSeenBlockTime)
+
+	// Both passes page from 0; no offset survives across passes.
+	require.Equal(t, []int{0, bip47ListTxBatchSize, 0, bip47ListTxBatchSize}, backend.skips)
+
+	// A further pass leaves the recorded notification alone — no second
+	// getrawtransaction for it.
+	require.NoError(t, e.scanWallet(context.Background(), walletID, bobSeedHex, net))
+	require.Equal(t, 1, chain.fetch)
+}
 
 func TestParseOpReturnPayload_PushData1(t *testing.T) {
 	// OP_RETURN OP_PUSHDATA1 0x50 <80 bytes of 0xAA>

--- a/sidechain-orchestrator/wallet/bip47state/inbound.go
+++ b/sidechain-orchestrator/wallet/bip47state/inbound.go
@@ -38,23 +38,20 @@ type InboundNotification struct {
 type InboundStore struct {
 	path string
 
-	mu      sync.Mutex
-	loaded  bool
-	rows    map[string]*InboundNotification
-	cursors map[string]int
+	mu     sync.Mutex
+	loaded bool
+	rows   map[string]*InboundNotification
 }
 
 // inboundFile is the on-disk shape.
 type inboundFile struct {
-	Inbound     []*InboundNotification `json:"inbound"`
-	ScanCursors map[string]int         `json:"scan_cursors"`
+	Inbound []*InboundNotification `json:"inbound"`
 }
 
 func NewInboundStore(dir string) *InboundStore {
 	return &InboundStore{
-		path:    filepath.Join(dir, inboundFileName),
-		rows:    make(map[string]*InboundNotification),
-		cursors: make(map[string]int),
+		path: filepath.Join(dir, inboundFileName),
+		rows: make(map[string]*InboundNotification),
 	}
 }
 
@@ -81,9 +78,6 @@ func (s *InboundStore) ensureLoadedLocked() error {
 	for _, r := range file.Inbound {
 		s.rows[inboundKey(r.WalletID, r.SenderPaymentCode)] = r
 	}
-	if file.ScanCursors != nil {
-		s.cursors = file.ScanCursors
-	}
 	s.loaded = true
 	return nil
 }
@@ -100,10 +94,7 @@ func (s *InboundStore) flushLocked() error {
 		}
 		return rows[i].SenderPaymentCode < rows[j].SenderPaymentCode
 	})
-	data, err := json.MarshalIndent(inboundFile{
-		Inbound:     rows,
-		ScanCursors: s.cursors,
-	}, "", "  ")
+	data, err := json.MarshalIndent(inboundFile{Inbound: rows}, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode bip47 inbound state: %w", err)
 	}
@@ -195,29 +186,6 @@ func (s *InboundStore) ListByWallet(walletID string) ([]*InboundNotification, er
 	return out, nil
 }
 
-// ScanCursor returns the listtransactions skip-count for this wallet.
-func (s *InboundStore) ScanCursor(walletID string) (int, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if err := s.ensureLoadedLocked(); err != nil {
-		return 0, err
-	}
-	return s.cursors[walletID], nil
-}
-
-func (s *InboundStore) SetScanCursor(walletID string, n int) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if err := s.ensureLoadedLocked(); err != nil {
-		return err
-	}
-	if s.cursors[walletID] == n {
-		return nil
-	}
-	s.cursors[walletID] = n
-	return s.flushLocked()
-}
-
 // Rebind points the store at another network's directory, dropping state
 // loaded from the previous one.
 func (s *InboundStore) Rebind(dir string) {
@@ -225,6 +193,5 @@ func (s *InboundStore) Rebind(dir string) {
 	defer s.mu.Unlock()
 	s.path = filepath.Join(dir, inboundFileName)
 	s.rows = make(map[string]*InboundNotification)
-	s.cursors = make(map[string]int)
 	s.loaded = false
 }

--- a/sidechain-orchestrator/wallet/bip47state/inbound_test.go
+++ b/sidechain-orchestrator/wallet/bip47state/inbound_test.go
@@ -40,22 +40,6 @@ func TestInboundStore_RoundTrip(t *testing.T) {
 	require.Equal(t, uint32(25), got3.ImportedThroughIndex)
 }
 
-func TestInboundStore_ScanCursor(t *testing.T) {
-	dir := t.TempDir()
-	s := NewInboundStore(dir)
-
-	n, err := s.ScanCursor("W1")
-	require.NoError(t, err)
-	require.Equal(t, 0, n)
-
-	require.NoError(t, s.SetScanCursor("W1", 42))
-
-	s2 := NewInboundStore(dir)
-	n2, err := s2.ScanCursor("W1")
-	require.NoError(t, err)
-	require.Equal(t, 42, n2)
-}
-
 func TestInboundStore_ListByWallet(t *testing.T) {
 	dir := t.TempDir()
 	s := NewInboundStore(dir)


### PR DESCRIPTION
From #1987, authored by @giaki3003. Rebased on master: `InboundStore.Rebind` is kept because `ResetForNetwork` calls it, and the test uses the `ParamsFunc` signature.

The scan cursor counted from the newest entry, so each new notification landed in the skipped prefix and the scanner never saw it.