### PR TITLE
orchestrator: release the BIP47 index on failure

### DIFF
--- a/sidechain-orchestrator/api/bip47_send.go
+++ b/sidechain-orchestrator/api/bip47_send.go
@@ -29,8 +29,11 @@ type bip47Expansion struct {
 	// hex) the wallet handler must sign + broadcast BEFORE the payment.
 	notificationTxHex string
 	// recipientCode is the recipient's payment code, used to MarkNotified
-	// after a successful broadcast.
+	// after a successful broadcast. Empty when passthrough.
 	recipientCode string
+	// sendIndex is the per-payment index reserved for this send, released
+	// again when the payment does not go out.
+	sendIndex uint32
 }
 
 // expandBip47Destinations inspects the requested destinations for a BIP47
@@ -94,10 +97,12 @@ func (h *WalletHandler) expandBip47Destinations(
 	expansion := &bip47Expansion{
 		destinations:  result.Destinations,
 		recipientCode: result.RecipientCode,
+		sendIndex:     result.Index,
 	}
 
 	state, err := h.bip47State.GetState(walletID, result.RecipientCode)
 	if err != nil {
+		h.releaseBip47Index(walletID, expansion)
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("read bip47 state: %w", err))
 	}
 	if state != nil && state.NotificationTxID != nil {
@@ -106,10 +111,23 @@ func (h *WalletHandler) expandBip47Destinations(
 
 	rawHex, _, err := h.buildBip47NotificationTx(ctx, walletID, seedHex, result.Recipient, netParams)
 	if err != nil {
+		h.releaseBip47Index(walletID, expansion)
 		return nil, err
 	}
 	expansion.notificationTxHex = rawHex
 	return expansion, nil
+}
+
+// releaseBip47Index gives back the per-payment index reserved for a send that
+// failed, so the retry derives the same address instead of burning an index.
+// No-op for passthrough (non-BIP47) expansions.
+func (h *WalletHandler) releaseBip47Index(walletID string, expansion *bip47Expansion) {
+	if expansion == nil || expansion.recipientCode == "" || h.bip47State == nil {
+		return
+	}
+	// Best-effort: the send already failed, and a skipped index is absorbed by
+	// the recipient's gap limit.
+	_ = h.bip47State.ReleaseIndex(walletID, expansion.recipientCode, expansion.sendIndex)
 }
 
 // buildBip47NotificationTx assembles the unsigned notification transaction by

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -800,10 +800,14 @@ func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Reques
 	if expansion.notificationTxHex != "" || !destinationsEqual(expansion.destinations, req.Msg.Destinations) {
 		req = connect.NewRequest(applyDestinationsToRequest(req.Msg, expansion.destinations))
 	}
-
+	// The reserved per-payment index is only released for a failure that
+	// happens before the payment goes out. A broadcast that times out may
+	// still have published the payment, and reusing that address would defeat
+	// the address isolation BIP47 exists for.
 	const dustLimitSats int64 = 546
 	for address, sats := range req.Msg.Destinations {
 		if sats < dustLimitSats {
+			h.releaseBip47Index(walletID, expansion)
 			return nil, connect.NewError(
 				connect.CodeInvalidArgument,
 				fmt.Errorf("amount to %s is below dust limit (%d sats)", address, dustLimitSats),
@@ -814,6 +818,8 @@ func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Reques
 	if expansion.notificationTxHex != "" {
 		notifTxID, err := h.broadcastBip47Notification(ctx, walletID, expansion.recipientCode, expansion.notificationTxHex)
 		if err != nil {
+			// The payment never went out, so its index is still free.
+			h.releaseBip47Index(walletID, expansion)
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("broadcast bip47 notification: %w", err))
 		}
 		_ = notifTxID

--- a/sidechain-orchestrator/wallet/bip47state/store.go
+++ b/sidechain-orchestrator/wallet/bip47state/store.go
@@ -166,6 +166,27 @@ func (s *Store) ReserveNextIndex(walletID, recipientCode string) (uint32, error)
 	return idx, nil
 }
 
+// ReleaseIndex gives back an index reserved by ReserveNextIndex for a send that
+// never went out, so the next send reuses it. No-op unless idx is still the most
+// recent reservation.
+func (s *Store) ReleaseIndex(walletID, recipientCode string, idx uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.ensureLoadedLocked(); err != nil {
+		return err
+	}
+	r, ok := s.rows[key(walletID, recipientCode)]
+	if !ok || r.NextSendIndex != idx+1 {
+		return nil
+	}
+	r.NextSendIndex = idx
+	if err := s.flushLocked(); err != nil {
+		r.NextSendIndex = idx + 1
+		return err
+	}
+	return nil
+}
+
 // Rebind points the store at another network's directory, dropping state
 // loaded from the previous one.
 func (s *Store) Rebind(dir string) {

--- a/sidechain-orchestrator/wallet/bip47state/store_test.go
+++ b/sidechain-orchestrator/wallet/bip47state/store_test.go
@@ -66,6 +66,41 @@ func TestReserveNextIndex_Concurrent(t *testing.T) {
 	}
 }
 
+func TestReleaseIndexReusesIndexAfterFailedSend(t *testing.T) {
+	dir := t.TempDir()
+	st := bip47state.NewStore(dir)
+
+	idx, err := st.ReserveNextIndex("w1", "PMtest")
+	require.NoError(t, err)
+	require.NoError(t, st.ReleaseIndex("w1", "PMtest", idx))
+
+	// The release must survive a restart, not just the in-memory view.
+	st2 := bip47state.NewStore(dir)
+	again, err := st2.ReserveNextIndex("w1", "PMtest")
+	require.NoError(t, err)
+	assert.Equal(t, idx, again)
+}
+
+func TestReleaseIndexIgnoresStaleAndUnknown(t *testing.T) {
+	dir := t.TempDir()
+	st := bip47state.NewStore(dir)
+
+	first, err := st.ReserveNextIndex("w1", "PMtest")
+	require.NoError(t, err)
+	_, err = st.ReserveNextIndex("w1", "PMtest")
+	require.NoError(t, err)
+
+	// A concurrent send already reserved past `first`: releasing it must not
+	// rewind the counter onto an index that is now in flight.
+	require.NoError(t, st.ReleaseIndex("w1", "PMtest", first))
+	require.NoError(t, st.ReleaseIndex("w1", "PMunknown", 0))
+
+	state, err := st.GetState("w1", "PMtest")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint32(2), state.NextSendIndex)
+}
+
 func TestPersistenceAcrossReopen(t *testing.T) {
 	dir := t.TempDir()
 	st := bip47state.NewStore(dir)


### PR DESCRIPTION
From #1987, authored by @giaki3003. Rebased on master, and `Store.Rebind` is kept because orchestratord calls it on a network reset.

The send path reserved the next payment index before the payment went out, so a failed send burned the index with no rollback.