### PR TITLE
bitwindow: bind a deniability hop to its input

### DIFF
--- a/bitwindow/server/api/wallet/wallet.go
+++ b/bitwindow/server/api/wallet/wallet.go
@@ -305,11 +305,8 @@ func (s *Server) SendTransaction(ctx context.Context, c *connect.Request[pb.Send
 	}), nil
 }
 
-// sendWithRequiredInputs creates and broadcasts a transaction spending the
-// given required UTXOs. Input values are looked up from Bitcoin Core's own
-// UTXO set (callers do not reliably populate UnspentOutput.ValueSats), and any
-// remainder after destinations + fee is returned as change instead of being
-// silently paid to the miner.
+// sendWithRequiredInputs parses the "txid:vout" required inputs and broadcasts
+// a transaction spending exactly those UTXOs.
 func (s *Server) sendWithRequiredInputs(
 	ctx context.Context,
 	bitcoind corerpc.BitcoinServiceClient,
@@ -319,16 +316,7 @@ func (s *Server) sendWithRequiredInputs(
 	feeSatPerVbyte uint64,
 	fixedFeeSats uint64,
 ) (string, error) {
-	log := zerolog.Ctx(ctx)
-
-	const dustLimit = 546
-
-	type outpoint struct {
-		txid string
-		vout uint32
-	}
-
-	wanted := make([]outpoint, 0, len(requiredInputs))
+	wanted := make([]engines.CoreOutpoint, 0, len(requiredInputs))
 	for _, utxo := range requiredInputs {
 		parts := strings.Split(utxo.Output, ":")
 		if len(parts) != 2 {
@@ -338,101 +326,10 @@ func (s *Server) sendWithRequiredInputs(
 		if err != nil {
 			return "", fmt.Errorf("invalid vout in UTXO %s: %w", utxo.Output, err)
 		}
-		wanted = append(wanted, outpoint{txid: parts[0], vout: uint32(vout)})
+		wanted = append(wanted, engines.CoreOutpoint{Txid: parts[0], Vout: uint32(vout)})
 	}
 
-	// Resolve input values from Core rather than trusting the request.
-	unspent, err := bitcoind.ListUnspent(ctx, connect.NewRequest(&corepb.ListUnspentRequest{
-		MinimumConfirmations: lo.ToPtr(uint32(0)),
-		Wallet:               walletName,
-	}))
-	if err != nil {
-		return "", fmt.Errorf("list unspent: %w", err)
-	}
-	valueByOutpoint := make(map[outpoint]uint64, len(unspent.Msg.Unspent))
-	for _, u := range unspent.Msg.Unspent {
-		valueByOutpoint[outpoint{txid: u.Txid, vout: u.Vout}] = uint64(math.Round(u.Amount * 1e8))
-	}
-
-	var totalInSats uint64
-	inputs := make([]*corepb.CreateRawTransactionRequest_Input, 0, len(wanted))
-	for _, op := range wanted {
-		valSats, ok := valueByOutpoint[op]
-		if !ok {
-			return "", fmt.Errorf("required input %s:%d not found in wallet UTXO set", op.txid, op.vout)
-		}
-		totalInSats += valSats
-		inputs = append(inputs, &corepb.CreateRawTransactionRequest_Input{Txid: op.txid, Vout: op.vout})
-	}
-
-	var totalOutSats uint64
-	for _, sats := range destinationsSats {
-		totalOutSats += sats
-	}
-
-	// Explicit fixed fee wins; otherwise estimate from the rate (default
-	// 2 sat/vB, matching the cheque-sweep path). Output/input vbyte sizes
-	// mirror the P2WPKH estimate used in buildSweepTx.
-	var feeSats uint64
-	if fixedFeeSats > 0 {
-		feeSats = fixedFeeSats
-	} else {
-		rate := feeSatPerVbyte
-		if rate == 0 {
-			rate = 2
-		}
-		estVbytes := uint64(len(inputs)*68 + (len(destinationsSats)+1)*31 + 11)
-		feeSats = estVbytes * rate
-	}
-
-	if totalInSats < totalOutSats+feeSats {
-		return "", fmt.Errorf("required inputs (%d sats) insufficient for outputs + fee (%d sats)", totalInSats, totalOutSats+feeSats)
-	}
-
-	outputs := make(map[string]float64, len(destinationsSats)+1)
-	for addr, sats := range destinationsSats {
-		outputs[addr] = float64(sats) / 1e8
-	}
-
-	changeSats := totalInSats - totalOutSats - feeSats
-	if changeSats >= dustLimit {
-		changeResp, err := bitcoind.GetNewAddress(ctx, connect.NewRequest(&corepb.GetNewAddressRequest{
-			Wallet: walletName,
-		}))
-		if err != nil {
-			return "", fmt.Errorf("get change address: %w", err)
-		}
-		outputs[changeResp.Msg.Address] = float64(changeSats) / 1e8
-	}
-
-	createResp, err := bitcoind.CreateRawTransaction(ctx, connect.NewRequest(&corepb.CreateRawTransactionRequest{
-		Inputs:  inputs,
-		Outputs: outputs,
-	}))
-	if err != nil {
-		return "", fmt.Errorf("create raw transaction: %w", err)
-	}
-	log.Debug().Msgf("created raw transaction with change: %s", createResp.Msg.Tx.Hex)
-
-	signResp, err := bitcoind.SignRawTransactionWithWallet(ctx, connect.NewRequest(&corepb.SignRawTransactionWithWalletRequest{
-		HexString: createResp.Msg.Tx.Hex,
-		Wallet:    walletName,
-	}))
-	if err != nil {
-		return "", fmt.Errorf("sign transaction: %w", err)
-	}
-	if !signResp.Msg.Complete {
-		return "", fmt.Errorf("transaction signing incomplete")
-	}
-
-	sendResp, err := bitcoind.SendRawTransaction(ctx, connect.NewRequest(&corepb.SendRawTransactionRequest{
-		Tx: &corepb.RawTransaction{Hex: signResp.Msg.Hex},
-	}))
-	if err != nil {
-		return "", fmt.Errorf("broadcast transaction: %w", err)
-	}
-
-	return sendResp.Msg.Txid, nil
+	return engines.SendCoreWithRequiredInputs(ctx, bitcoind, walletName, wanted, destinationsSats, feeSatPerVbyte, fixedFeeSats)
 }
 
 // GetNewAddress implements drivechainv1connect.DrivechainServiceHandler.

--- a/bitwindow/server/engines/core_send.go
+++ b/bitwindow/server/engines/core_send.go
@@ -1,0 +1,131 @@
+package engines
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"connectrpc.com/connect"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/rs/zerolog"
+	"github.com/samber/lo"
+)
+
+// CoreOutpoint is a Bitcoin Core wallet UTXO that a transaction must spend.
+type CoreOutpoint struct {
+	Txid string
+	Vout uint32
+}
+
+// SendCoreWithRequiredInputs creates and broadcasts a Bitcoin Core transaction
+// spending exactly the given outpoints. Input values are looked up from Bitcoin
+// Core's own UTXO set (callers do not reliably know them), and any remainder
+// after destinations + fee is returned as change instead of being silently paid
+// to the miner.
+func SendCoreWithRequiredInputs(
+	ctx context.Context,
+	bitcoind corerpc.BitcoinServiceClient,
+	walletName string,
+	requiredInputs []CoreOutpoint,
+	destinationsSats map[string]uint64,
+	feeSatPerVbyte uint64,
+	fixedFeeSats uint64,
+) (string, error) {
+	log := zerolog.Ctx(ctx)
+
+	const dustLimit = 546
+
+	// Resolve input values from Core rather than trusting the caller.
+	unspent, err := bitcoind.ListUnspent(ctx, connect.NewRequest(&corepb.ListUnspentRequest{
+		MinimumConfirmations: lo.ToPtr(uint32(0)),
+		Wallet:               walletName,
+	}))
+	if err != nil {
+		return "", fmt.Errorf("list unspent: %w", err)
+	}
+	valueByOutpoint := make(map[CoreOutpoint]uint64, len(unspent.Msg.Unspent))
+	for _, u := range unspent.Msg.Unspent {
+		valueByOutpoint[CoreOutpoint{Txid: u.Txid, Vout: u.Vout}] = uint64(math.Round(u.Amount * 1e8))
+	}
+
+	var totalInSats uint64
+	inputs := make([]*corepb.CreateRawTransactionRequest_Input, 0, len(requiredInputs))
+	for _, op := range requiredInputs {
+		valSats, ok := valueByOutpoint[op]
+		if !ok {
+			return "", fmt.Errorf("required input %s:%d not found in wallet UTXO set", op.Txid, op.Vout)
+		}
+		totalInSats += valSats
+		inputs = append(inputs, &corepb.CreateRawTransactionRequest_Input{Txid: op.Txid, Vout: op.Vout})
+	}
+
+	var totalOutSats uint64
+	for _, sats := range destinationsSats {
+		totalOutSats += sats
+	}
+
+	// Explicit fixed fee wins; otherwise estimate from the rate (default
+	// 2 sat/vB, matching the cheque-sweep path). Output/input vbyte sizes
+	// mirror the P2WPKH estimate used in buildSweepTx.
+	var feeSats uint64
+	if fixedFeeSats > 0 {
+		feeSats = fixedFeeSats
+	} else {
+		rate := feeSatPerVbyte
+		if rate == 0 {
+			rate = 2
+		}
+		estVbytes := uint64(len(inputs)*68 + (len(destinationsSats)+1)*31 + 11)
+		feeSats = estVbytes * rate
+	}
+
+	if totalInSats < totalOutSats+feeSats {
+		return "", fmt.Errorf("required inputs (%d sats) insufficient for outputs + fee (%d sats)", totalInSats, totalOutSats+feeSats)
+	}
+
+	outputs := make(map[string]float64, len(destinationsSats)+1)
+	for addr, sats := range destinationsSats {
+		outputs[addr] = float64(sats) / 1e8
+	}
+
+	changeSats := totalInSats - totalOutSats - feeSats
+	if changeSats >= dustLimit {
+		changeResp, err := bitcoind.GetNewAddress(ctx, connect.NewRequest(&corepb.GetNewAddressRequest{
+			Wallet: walletName,
+		}))
+		if err != nil {
+			return "", fmt.Errorf("get change address: %w", err)
+		}
+		outputs[changeResp.Msg.Address] = float64(changeSats) / 1e8
+	}
+
+	createResp, err := bitcoind.CreateRawTransaction(ctx, connect.NewRequest(&corepb.CreateRawTransactionRequest{
+		Inputs:  inputs,
+		Outputs: outputs,
+	}))
+	if err != nil {
+		return "", fmt.Errorf("create raw transaction: %w", err)
+	}
+	log.Debug().Msgf("created raw transaction with change: %s", createResp.Msg.Tx.Hex)
+
+	signResp, err := bitcoind.SignRawTransactionWithWallet(ctx, connect.NewRequest(&corepb.SignRawTransactionWithWalletRequest{
+		HexString: createResp.Msg.Tx.Hex,
+		Wallet:    walletName,
+	}))
+	if err != nil {
+		return "", fmt.Errorf("sign transaction: %w", err)
+	}
+	if !signResp.Msg.Complete {
+		return "", fmt.Errorf("transaction signing incomplete")
+	}
+
+	sendResp, err := bitcoind.SendRawTransaction(ctx, connect.NewRequest(&corepb.SendRawTransactionRequest{
+		Tx: &corepb.RawTransaction{Hex: signResp.Msg.Hex},
+	}))
+	if err != nil {
+		return "", fmt.Errorf("broadcast transaction: %w", err)
+	}
+
+	return sendResp.Msg.Txid, nil
+}

--- a/bitwindow/server/engines/core_send_test.go
+++ b/bitwindow/server/engines/core_send_test.go
@@ -1,0 +1,89 @@
+package engines_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSendCoreWithRequiredInputs(t *testing.T) {
+	t.Parallel()
+
+	const trackedTxid = "aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11aa11"
+	const otherTxid = "bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22bb22"
+
+	t.Run("spends only the required outpoint", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+
+		mockBitcoind.EXPECT().
+			ListUnspent(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.ListUnspentResponse{
+				Unspent: []*corepb.UnspentOutput{
+					{Txid: trackedTxid, Vout: 3, Amount: 1.0},
+					{Txid: otherTxid, Vout: 0, Amount: 5.0},
+				},
+			}), nil)
+
+		mockBitcoind.EXPECT().
+			GetNewAddress(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.GetNewAddressResponse{
+				Address: "tb1qchange0000000000000000000000000000000",
+			}), nil)
+
+		// Stop at raw transaction creation: everything the fix is about is
+		// visible in that request.
+		stop := errors.New("stop")
+		mockBitcoind.EXPECT().
+			CreateRawTransaction(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *connect.Request[corepb.CreateRawTransactionRequest]) (*connect.Response[corepb.CreateRawTransactionResponse], error) {
+				require.Len(t, req.Msg.Inputs, 1)
+				assert.Equal(t, trackedTxid, req.Msg.Inputs[0].Txid)
+				assert.Equal(t, uint32(3), req.Msg.Inputs[0].Vout)
+
+				// 1 BTC in, 0.4 BTC out, 10k sats fee -> the rest is change.
+				assert.Equal(t, 0.4, req.Msg.Outputs["tb1qdest00000000000000000000000000000000"])
+				assert.Equal(t, 0.5999, req.Msg.Outputs["tb1qchange0000000000000000000000000000000"])
+				return nil, stop
+			})
+
+		_, err := engines.SendCoreWithRequiredInputs(context.Background(), mockBitcoind, "wallet",
+			[]engines.CoreOutpoint{{Txid: trackedTxid, Vout: 3}},
+			map[string]uint64{"tb1qdest00000000000000000000000000000000": 40_000_000},
+			0, 10_000,
+		)
+		require.ErrorIs(t, err, stop)
+	})
+
+	t.Run("errors when the required outpoint is not in the wallet", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+
+		mockBitcoind.EXPECT().
+			ListUnspent(gomock.Any(), gomock.Any()).
+			Return(connect.NewResponse(&corepb.ListUnspentResponse{
+				Unspent: []*corepb.UnspentOutput{
+					{Txid: otherTxid, Vout: 0, Amount: 5.0},
+				},
+			}), nil)
+
+		_, err := engines.SendCoreWithRequiredInputs(context.Background(), mockBitcoind, "wallet",
+			[]engines.CoreOutpoint{{Txid: trackedTxid, Vout: 3}},
+			map[string]uint64{"tb1qdest00000000000000000000000000000000": 40_000_000},
+			0, 10_000,
+		)
+		require.ErrorContains(t, err, "not found in wallet UTXO set")
+	})
+}

--- a/bitwindow/server/engines/deniability_engine.go
+++ b/bitwindow/server/engines/deniability_engine.go
@@ -292,7 +292,7 @@ func (e *DeniabilityEngine) ProcessUTXO(ctx context.Context, utxo *pb.ListUnspen
 		if werr := e.rejectWatchOnly(ctx, walletId); werr != nil {
 			return werr
 		}
-		txid, err = e.sendBitcoinCoreTransaction(ctx, walletId, destinations)
+		txid, err = e.sendBitcoinCoreTransaction(ctx, walletId, utxo, destinations, fee)
 	case WalletTypeElectrum:
 		txid, err = e.sendElectrumTransaction(ctx, walletId, utxo, destinations, fee)
 	default:
@@ -374,11 +374,14 @@ func (e *DeniabilityEngine) sendEnforcerTransaction(
 	return sendResp.Msg.Txid.Hex.Value, nil
 }
 
-// sendBitcoinCoreTransaction sends a transaction via Bitcoin Core
+// sendBitcoinCoreTransaction sends a transaction via Bitcoin Core, spending the
+// chosen UTXO into the denial destinations.
 func (e *DeniabilityEngine) sendBitcoinCoreTransaction(
 	ctx context.Context,
 	walletId string,
+	utxo *pb.ListUnspentOutputsResponse_Output,
 	destinations map[string]uint64,
+	fee uint64,
 ) (string, error) {
 	coreWalletName, err := e.walletEngine.GetBitcoinCoreWalletName(ctx, walletId)
 	if err != nil {
@@ -390,20 +393,9 @@ func (e *DeniabilityEngine) sendBitcoinCoreTransaction(
 		return "", fmt.Errorf("get bitcoind client: %w", err)
 	}
 
-	// Convert satoshi amounts to BTC (Bitcoin Core uses BTC, not satoshis)
-	btcDestinations := lo.MapValues(destinations, func(sats uint64, _ string) float64 {
-		return float64(sats) / 1e8
-	})
-
-	resp, err := bitcoind.Send(ctx, connect.NewRequest(&corepb.SendRequest{
-		Destinations: btcDestinations,
-		Wallet:       coreWalletName,
-	}))
-	if err != nil {
-		return "", fmt.Errorf("bitcoin core send: %w", err)
-	}
-
-	return resp.Msg.Txid, nil
+	return SendCoreWithRequiredInputs(ctx, bitcoind, coreWalletName, []CoreOutpoint{
+		{Txid: utxo.Txid.Hex.Value, Vout: utxo.Vout},
+	}, destinations, 0, fee)
 }
 
 // sendElectrumTransaction sends a transaction via the orchestrator wallet


### PR DESCRIPTION
From #1987, authored by @giaki3003. Rebased on master, where `SendRawTransactionRequest` carries `Tx`, not `HexString`.

The Core send branch handed Core a destinations-only Send with no required input, so a hop could spend unrelated UTXOs while RecordExecution still recorded the tracked outpoint as moved.