### PR TITLE
orchestrator: keep a private bitcoin.conf network

### DIFF
--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -71,7 +71,7 @@ func (m *BitcoinConfManager) LoadConfig(isFirst bool) error {
 		return err
 	}
 
-	m.parseAndApplyConfig(content)
+	m.parseAndApplyConfig(content, NetworkSignet)
 
 	if m.tryLoadPrivateConfig() {
 		return nil // Private config loaded, we're done, just use that
@@ -120,6 +120,12 @@ func DrynetPeerFor(generation string) string {
 // GetConfFilePath returns the resolved -conf= path to pass to bitcoind.
 // Mirrors the confFile() logic from binaries.dart.
 func (m *BitcoinConfManager) GetConfFilePath() string {
+	// A loaded private conf wins: re-resolving here would run against a network
+	// that conf itself may have changed, and hand bitcoind a different file
+	// than the one our state came from.
+	if m.HasPrivateConf && m.ConfigPath != "" {
+		return m.ConfigPath
+	}
 	confInfo := m.getConfigFileInfo()
 	return confInfo.path
 }
@@ -485,7 +491,7 @@ func (m *BitcoinConfManager) wipeStaleChainData(config *BitcoinConfig, networks 
 	}
 	// m.Network is still the CLI/build seed here, so the live network comes from
 	// the config being migrated.
-	activeGroup := DatadirGroupForNetwork(NetworkFromConfig(config))
+	activeGroup := DatadirGroupForNetwork(NetworkFromConfig(config, NetworkSignet))
 
 	for _, n := range networks {
 		group := DatadirGroupForNetwork(n)
@@ -545,7 +551,7 @@ func ResolveNetwork(bitwindowDir string) (Network, error) {
 	if err != nil {
 		return "", fmt.Errorf("read %s: %w", bitwindowBitcoinConfFilename, err)
 	}
-	m.parseAndApplyConfig(string(content))
+	m.parseAndApplyConfig(string(content), NetworkSignet)
 
 	// A user's own bitcoin.conf overrides ours, same as on the load path.
 	m.tryLoadPrivateConfig()

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -187,15 +187,20 @@ func RunBitcoinConfMigrations(config *BitcoinConfig) (bool, []Network) {
 
 // parseAndApplyConfig parses config content and updates state (network, datadir).
 // Dart: _parseAndApplyConfig (L244)
-func (m *BitcoinConfManager) parseAndApplyConfig(content string) {
+func (m *BitcoinConfManager) parseAndApplyConfig(content string, fallbackNetwork Network) {
 	m.Config = ParseBitcoinConfig(content)
-	m.loadStateFromConfig()
+	m.loadStateFromConfig(fallbackNetwork)
 }
 
 // tryLoadPrivateConfig checks for user's private bitcoin.conf and loads if exists.
 // Returns true if private config was loaded.
 // Dart: _tryLoadPrivateConfig (L251)
 func (m *BitcoinConfManager) tryLoadPrivateConfig() bool {
+	// The network whose root dir the conf is looked up under. A private conf
+	// with no chain selector belongs to that network — reclassifying it as
+	// signet would point us at a different conf than bitcoind is launched with.
+	discoveredUnder := m.Network
+
 	confInfo := m.getConfigFileInfo()
 	m.HasPrivateConf = confInfo.hasPrivateConf
 	m.ConfigPath = confInfo.path
@@ -209,7 +214,7 @@ func (m *BitcoinConfManager) tryLoadPrivateConfig() bool {
 		return false
 	}
 
-	m.parseAndApplyConfig(string(privateContent))
+	m.parseAndApplyConfig(string(privateContent), discoveredUnder)
 	return true
 }
 
@@ -226,7 +231,7 @@ func (m *BitcoinConfManager) handleNetworkChangeIfNeeded(oldNetwork Network, isF
 		return
 	}
 
-	m.loadStateFromConfig()
+	m.loadStateFromConfig(m.Network)
 
 	if m.OnNetworkChanged != nil {
 		m.OnNetworkChanged()
@@ -241,12 +246,12 @@ func (m *BitcoinConfManager) handleNetworkChangeIfNeeded(oldNetwork Network, isF
 // only honours top-level datadir) and where bitcoind itself reads from. A
 // user with their own bitcoin.conf may put datadir under [main] — that still
 // wins. Empty here means "no datadir is configured anywhere".
-func (m *BitcoinConfManager) loadStateFromConfig() {
+func (m *BitcoinConfManager) loadStateFromConfig(fallbackNetwork Network) {
 	if m.Config == nil {
 		return
 	}
 
-	m.Network = NetworkFromConfig(m.Config)
+	m.Network = NetworkFromConfig(m.Config, fallbackNetwork)
 	m.DetectedDataDir = m.Config.GetEffectiveSetting("datadir", CoreSectionForNetwork(m.Network))
 
 	// Ensure datadir exists — Bitcoin Core fails with a cryptic assertion error (exit code -6) if it doesn't

--- a/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer_test.go
@@ -529,11 +529,11 @@ func TestDrynetWithoutPublishedPeerWritesNoAddnode(t *testing.T) {
 // through the detector to prove they don't collide.
 func TestNetworkFromConfigDistinguishesDrynetFromForknet(t *testing.T) {
 	forknet := ParseBitcoinConfig((&BitcoinConfManager{Network: NetworkForknet}).GetDefaultConfig())
-	if got := NetworkFromConfig(forknet); got != NetworkForknet {
+	if got := NetworkFromConfig(forknet, NetworkSignet); got != NetworkForknet {
 		t.Errorf("forknet config detected as %q, want forknet", got)
 	}
 	drynet := ParseBitcoinConfig((&BitcoinConfManager{Network: NetworkDrynet}).GetDefaultConfig())
-	if got := NetworkFromConfig(drynet); got != NetworkDrynet {
+	if got := NetworkFromConfig(drynet, NetworkSignet); got != NetworkDrynet {
 		t.Errorf("drynet config detected as %q, want drynet", got)
 	}
 }
@@ -544,7 +544,7 @@ func TestNetworkFromConfigDistinguishesDrynetFromForknet(t *testing.T) {
 func TestNetworkFromConfigDetectsFutureDrynetGeneration(t *testing.T) {
 	conf := ParseBitcoinConfig((&BitcoinConfManager{Network: NetworkDrynet}).GetDefaultConfig())
 	conf.SetSetting("uacomment", "drynet3", "main")
-	if got := NetworkFromConfig(conf); got != NetworkDrynet {
+	if got := NetworkFromConfig(conf, NetworkSignet); got != NetworkDrynet {
 		t.Errorf("drynet3 config detected as %q, want drynet", got)
 	}
 }
@@ -553,9 +553,54 @@ func TestNetworkFromConfigDetectsFutureDrynetGeneration(t *testing.T) {
 // config back through the detector to prove it is not read as mainnet.
 func TestNetworkFromConfigDetectsDrynet(t *testing.T) {
 	drynet := ParseBitcoinConfig((&BitcoinConfManager{Network: NetworkDrynet}).GetDefaultConfig())
-	if got := NetworkFromConfig(drynet); got != NetworkDrynet {
+	if got := NetworkFromConfig(drynet, NetworkSignet); got != NetworkDrynet {
 		t.Errorf("drynet config detected as %q, want drynet", got)
 	}
+}
+
+// A user's own bitcoin.conf carrying no chain selector is mainnet (Bitcoin
+// Core's default), so it must stay on the network whose root dir it was found
+// under — and it is the file bitcoind gets launched with. Reading it as signet
+// re-resolved the conf path against ~/.drivechain and handed bitcoind the
+// managed conf while orchestrator state came from the private one.
+func TestPrivateConfWithoutChainKeepsDiscoveryNetworkAndPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	privatePath := filepath.Join(BitcoinCoreDirs.RootDirNetwork(NetworkMainnet), "bitcoin.conf")
+	require.NoError(t, os.MkdirAll(filepath.Dir(privatePath), 0755))
+	require.NoError(t, os.WriteFile(privatePath, []byte("server=1\nrpcport=9999\n"), 0644))
+
+	m := newTestManager(t.TempDir())
+	m.Network = NetworkMainnet
+	require.NoError(t, m.LoadConfig(true))
+
+	require.True(t, m.HasPrivateConf)
+	require.Equal(t, NetworkMainnet, m.Network)
+	require.Equal(t, privatePath, m.GetConfFilePath(), "bitcoind must be launched with the conf we loaded state from")
+	require.Equal(t, 9999, m.GetRPCPort())
+}
+
+// Control case: the same conf with an explicit chain=main. Isolates the absent
+// selector as the trigger for the network/conf-path split above.
+func TestPrivateConfWithExplicitChainMain(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	privatePath := filepath.Join(BitcoinCoreDirs.RootDirNetwork(NetworkMainnet), "bitcoin.conf")
+	require.NoError(t, os.MkdirAll(filepath.Dir(privatePath), 0755))
+	require.NoError(t, os.WriteFile(privatePath, []byte("chain=main\nserver=1\nrpcport=9999\n"), 0644))
+
+	m := newTestManager(t.TempDir())
+	m.Network = NetworkMainnet
+	require.NoError(t, m.LoadConfig(true))
+
+	require.True(t, m.HasPrivateConf)
+	require.Equal(t, NetworkMainnet, m.Network)
+	require.Equal(t, privatePath, m.GetConfFilePath())
+	require.Equal(t, 9999, m.GetRPCPort())
 }
 
 // ---------------------------------------------------------------------------
@@ -656,7 +701,7 @@ func TestLoadAdoptsTopLevelDatadirIntoActiveSlot(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := newTestManager(t.TempDir())
-			m.parseAndApplyConfig(tc.conf)
+			m.parseAndApplyConfig(tc.conf, NetworkSignet)
 
 			require.Equal(t, tc.group, DatadirGroupForNetwork(m.Network))
 			require.Equal(t, m.DetectedDataDir, m.Config.GetGroupDatadir(tc.group))
@@ -669,7 +714,7 @@ func TestLoadAdoptsTopLevelDatadirIntoActiveSlot(t *testing.T) {
 // picker pass while Core writes the chain into the platform default folder.
 func TestLoadIgnoresSectionScopedDatadir(t *testing.T) {
 	m := newTestManager(t.TempDir())
-	m.parseAndApplyConfig("chain=main\n[main]\ndatadir=/section/only\n")
+	m.parseAndApplyConfig("chain=main\n[main]\ndatadir=/section/only\n", NetworkSignet)
 
 	require.Equal(t, NetworkMainnet, m.Network)
 	require.Empty(t, m.Config.GetGroupDatadir(DatadirGroupDefault))
@@ -680,7 +725,7 @@ func TestLoadIgnoresSectionScopedDatadir(t *testing.T) {
 // Bitcoin Core does not use, so the picker must still run.
 func TestLoadIgnoresConflictingSectionDatadir(t *testing.T) {
 	m := newTestManager(t.TempDir())
-	m.parseAndApplyConfig("chain=main\ndatadir=/global/path\n[main]\ndatadir=/section/path\n")
+	m.parseAndApplyConfig("chain=main\ndatadir=/global/path\n[main]\ndatadir=/section/path\n", NetworkSignet)
 
 	require.Equal(t, "/section/path", m.DetectedDataDir)
 	require.Empty(t, m.Config.GetGroupDatadir(DatadirGroupDefault))
@@ -691,7 +736,7 @@ func TestLoadIgnoresConflictingSectionDatadir(t *testing.T) {
 // path the user already picked instead of asking for it again.
 func TestSignetDatadirSatisfiesMainnet(t *testing.T) {
 	m := newTestManager(t.TempDir())
-	m.parseAndApplyConfig("chain=signet\ndatadir=/vol/shared\n")
+	m.parseAndApplyConfig("chain=signet\ndatadir=/vol/shared\n", NetworkSignet)
 
 	require.Equal(t, NetworkSignet, m.Network)
 	require.True(t, m.HasDatadirForNetwork(NetworkMainnet))
@@ -735,7 +780,7 @@ func TestDetectedDataDirPrefersPerNetworkSection(t *testing.T) {
 	m.Config.SetSetting("datadir", "/global/path")
 	m.Config.SetSetting("datadir", "/main/path", "main")
 
-	m.loadStateFromConfig()
+	m.loadStateFromConfig(NetworkSignet)
 
 	require.Equal(t, NetworkMainnet, m.Network)
 	require.Equal(t, "/main/path", m.DetectedDataDir)

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -284,7 +284,10 @@ func CoreSectionForNetwork(n Network) string {
 
 // NetworkFromConfig detects the network from a parsed BitcoinConfig.
 // Handles forknet/drynet detection (chain=main + drivechain=1 in [main]).
-func NetworkFromConfig(conf *BitcoinConfig) Network {
+// fallback is returned when the config carries no chain=/testnet=/signet=/
+// regtest= selector at all — signet for our own managed conf, but the network
+// the file was found under for a user's private bitcoin.conf.
+func NetworkFromConfig(conf *BitcoinConfig, fallback Network) Network {
 	chainSetting := conf.GetSetting("chain")
 	if chainSetting != "" {
 		switch strings.ToLower(chainSetting) {
@@ -322,7 +325,7 @@ func NetworkFromConfig(conf *BitcoinConfig) Network {
 		return NetworkRegtest
 	}
 
-	return NetworkSignet
+	return fallback
 }
 
 // NetworkFromString converts a string (e.g. CLI flag) to a Network value.


### PR DESCRIPTION
From #1987, authored by @giaki3003. Rebased on master; the managed-conf call sites pass the signet fallback they had before.

A private bitcoin.conf with no chain selector was reclassified as signet, so orchestrator state and the bitcoind launch conf pointed at different networks.