### PR TITLE
orchestrator: retry a failed BIP47 import

### DIFF
--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -46,6 +46,12 @@ type CoreBackend struct {
 	mu          sync.Mutex
 	coreWallets map[string]string // walletID -> Core wallet name
 
+	// walletID -> earliest retry of a BIP47 notification descriptor import
+	// that failed. A failure there doesn't block wallet loading, so the
+	// wallet stays cached and later Ensure calls retry the import, gated by
+	// walletLoadingBackoff so a persistently failing rescan can't hot-loop.
+	bip47NotifRetry map[string]time.Time
+
 	// Transient backoff: when bitcoind responds with a "still booting" error
 	// (-4 Wallet already loading, -28 Verifying blocks, …), Ensure returns
 	// the cached error for `walletLoadingBackoff` so the next ~5s of
@@ -62,11 +68,12 @@ var (
 // NewCoreBackend creates the Bitcoin Core wallet backend.
 func NewCoreBackend(svc *Service, rpc *CoreRPCClient, params ParamsFunc, log zerolog.Logger) *CoreBackend {
 	return &CoreBackend{
-		svc:         svc,
-		rpc:         rpc,
-		log:         log.With().Str("component", "core-backend").Logger(),
-		params:      params,
-		coreWallets: make(map[string]string),
+		svc:             svc,
+		rpc:             rpc,
+		log:             log.With().Str("component", "core-backend").Logger(),
+		params:          params,
+		coreWallets:     make(map[string]string),
+		bip47NotifRetry: make(map[string]time.Time),
 	}
 }
 
@@ -93,6 +100,7 @@ func (p *CoreBackend) Ensure(ctx context.Context, walletID string) (string, erro
 
 	// Check cache
 	if name, ok := p.coreWallets[walletID]; ok {
+		p.retryBip47NotificationDescriptor(ctx, walletID, name)
 		return name, nil
 	}
 
@@ -147,6 +155,7 @@ func (p *CoreBackend) Ensure(ctx context.Context, walletID string) (string, erro
 	if targetWallet.WalletType == WalletTypeBitcoinCore && !targetWallet.IsWatchOnly() {
 		if perr := p.ensureBip47NotificationDescriptor(ctx, walletName, targetWallet.Master.SeedHex); perr != nil {
 			p.log.Warn().Err(perr).Str("wallet", walletName).Msg("could not ensure bip47 notification descriptor")
+			p.bip47NotifRetry[walletID] = time.Now().Add(walletLoadingBackoff)
 		}
 	}
 
@@ -180,6 +189,7 @@ func (p *CoreBackend) EnsureAll(ctx context.Context) (int, error) {
 func (p *CoreBackend) walletName(ctx context.Context, walletID string) (string, error) {
 	p.mu.Lock()
 	if name, ok := p.coreWallets[walletID]; ok {
+		p.retryBip47NotificationDescriptor(ctx, walletID, name)
 		p.mu.Unlock()
 		return name, nil
 	}
@@ -815,6 +825,28 @@ func importTimestamp(w *WalletData) any {
 		return int64(0)
 	}
 	return "now"
+}
+
+// retryBip47NotificationDescriptor re-imports a notification descriptor whose
+// earlier import failed, so a transient failure doesn't leave an already
+// cached wallet without it forever. No-op unless an import is outstanding and
+// its backoff has elapsed. Caller holds p.mu.
+func (p *CoreBackend) retryBip47NotificationDescriptor(ctx context.Context, walletID, walletName string) {
+	retryAt, pending := p.bip47NotifRetry[walletID]
+	if !pending || time.Now().Before(retryAt) {
+		return
+	}
+	w := p.svc.GetWalletByID(walletID)
+	if w == nil {
+		delete(p.bip47NotifRetry, walletID)
+		return
+	}
+	if err := p.ensureBip47NotificationDescriptor(ctx, walletName, w.Master.SeedHex); err != nil {
+		p.log.Warn().Err(err).Str("wallet", walletName).Msg("could not ensure bip47 notification descriptor")
+		p.bip47NotifRetry[walletID] = time.Now().Add(walletLoadingBackoff)
+		return
+	}
+	delete(p.bip47NotifRetry, walletID)
 }
 
 // createBitcoinCoreWallet creates a Bitcoin Core descriptor wallet from a seed.

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/replay"
 	"github.com/btcsuite/btcd/btcutil"
@@ -230,6 +231,64 @@ func TestCoreBackendEnsureTransientBackoff(t *testing.T) {
 	_, err = backend.Ensure(ctx, coreID)
 	require.ErrorContains(t, err, "Verifying blocks")
 	assert.Len(t, fake.callsFor("listwallets"), 1)
+}
+
+// A failed BIP47 notification import doesn't break wallet loading, but the
+// wallet must not be cached as fully provisioned: later calls retry it.
+func TestCoreBackendRetriesFailedBip47NotificationImport(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	var mu sync.Mutex
+	failNotif := true
+	fake.handle("importdescriptors", func(c bitcoindCall) (any, string) {
+		var descs []ImportDescriptor
+		_ = json.Unmarshal(c.Params[0], &descs)
+		mu.Lock()
+		fail := failNotif && len(descs) == 1 && strings.HasPrefix(descs[0].Desc, "pkh(")
+		mu.Unlock()
+		results := make([]map[string]any, len(descs))
+		for i := range results {
+			results[i] = map[string]any{"success": !fail}
+			if fail {
+				results[i]["error"] = map[string]any{"code": -1, "message": "rescan timed out"}
+			}
+		}
+		return results, ""
+	})
+	ctx := context.Background()
+
+	_, err := backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	require.Len(t, fake.callsFor("importdescriptors"), 2)
+
+	// Within the backoff window the failed import isn't hammered.
+	_, err = backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	assert.Len(t, fake.callsFor("importdescriptors"), 2)
+
+	mu.Lock()
+	failNotif = false
+	mu.Unlock()
+	backend.mu.Lock()
+	backend.bip47NotifRetry[coreID] = time.Time{} // backoff elapsed
+	backend.mu.Unlock()
+
+	// Once the backoff elapses the notification descriptor is imported again.
+	_, err = backend.walletName(ctx, coreID)
+	require.NoError(t, err)
+	imports := fake.callsFor("importdescriptors")
+	require.Len(t, imports, 3)
+	var notif []ImportDescriptor
+	require.NoError(t, json.Unmarshal(imports[2].Params[0], &notif))
+	require.Len(t, notif, 1)
+	assert.True(t, strings.HasPrefix(notif[0].Desc, "pkh("))
+
+	// Now that it succeeded, no further imports.
+	_, err = backend.Ensure(ctx, coreID)
+	require.NoError(t, err)
+	assert.Len(t, fake.callsFor("importdescriptors"), 3)
+	assert.Empty(t, backend.bip47NotifRetry)
 }
 
 func TestCoreBackendSendSimple(t *testing.T) {


### PR DESCRIPTION
From #1987, authored by @giaki3003. Rebased on master, which renamed the backend's network field to `params`.

A failed notification-descriptor import only logged a warning while the wallet stayed cached, so the wallet never got the descriptor. A backoff gates the retry.