### PR TITLE
bitwindow: drop orphan denial executions

### DIFF
--- a/bitwindow/server/database/migrate_orphan_denials_test.go
+++ b/bitwindow/server/database/migrate_orphan_denials_test.go
@@ -1,0 +1,51 @@
+package database
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Migration 013 recreated `denials` and reset its AUTOINCREMENT counter, so an
+// execution of a dropped denial can point at a new denial that reused its id.
+func TestMigration044DropsOrphanExecutedDenials(t *testing.T) {
+	ctx := context.Background()
+	db := Test(t)
+
+	_, err := db.ExecContext(ctx, `INSERT INTO denials (id, wallet_id, initial_txid, initial_vout, delay_duration, num_hops, created_at)
+		VALUES (1, 'w', 'new-initial-txid', 0, 3600, 1, '2026-08-18 10:00:00')`)
+	require.NoError(t, err)
+
+	// Left behind by the dropped denial: it predates the denial it points at.
+	_, err = db.ExecContext(ctx, `INSERT INTO executed_denials (denial_id, from_txid, from_vout, to_txid, to_vout, created_at)
+		VALUES (1, 'stale-from', 0, 'stale-to', 0, '2026-01-01 10:00:00')`)
+	require.NoError(t, err)
+	// A real execution of that denial.
+	_, err = db.ExecContext(ctx, `INSERT INTO executed_denials (denial_id, from_txid, from_vout, to_txid, to_vout, created_at)
+		VALUES (1, 'live-from', 0, 'live-to', 0, '2026-08-18 11:00:00')`)
+	require.NoError(t, err)
+	// An execution whose denial is gone entirely.
+	_, err = db.ExecContext(ctx, `INSERT INTO executed_denials (denial_id, from_txid, from_vout, to_txid, to_vout, created_at)
+		VALUES (99, 'gone-from', 0, 'gone-to', 0, '2026-08-18 11:00:00')`)
+	require.NoError(t, err)
+
+	body, err := fs.ReadFile(migrations, "migrations/044_drop_orphan_executed_denials.sql")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, string(body))
+	require.NoError(t, err)
+
+	rows, err := db.QueryContext(ctx, `SELECT from_txid FROM executed_denials`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var kept []string
+	for rows.Next() {
+		var s string
+		require.NoError(t, rows.Scan(&s))
+		kept = append(kept, s)
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, []string{"live-from"}, kept)
+}

--- a/bitwindow/server/database/migrations/044_drop_orphan_executed_denials.sql
+++ b/bitwindow/server/database/migrations/044_drop_orphan_executed_denials.sql
@@ -1,0 +1,13 @@
+-- Migration 013 dropped and recreated `denials`, which reset its AUTOINCREMENT
+-- counter. The executions of the dropped denials stayed behind, so a denial_id
+-- can point at a new denial that reused the same id. An execution can never
+-- predate the denial it belongs to, so that pair identifies a stale cross-link.
+DELETE FROM executed_denials
+WHERE NOT EXISTS (
+        SELECT 1 FROM denials d WHERE d.id = executed_denials.denial_id
+      )
+   OR EXISTS (
+        SELECT 1 FROM denials d
+        WHERE d.id = executed_denials.denial_id
+          AND julianday(executed_denials.created_at) < julianday(d.created_at)
+      );


### PR DESCRIPTION
From #1987, authored by @giaki3003. His patch edited the applied migration 013, which never runs again, so this is a new migration instead.

Migration 013 recreated `denials` and reset AUTOINCREMENT, so an execution of a dropped denial can point at a new denial that reused its id. An execution that predates its denial identifies the stale cross-link.