### PR TITLE
orchestrator: keep the watch wallet range ahead

### DIFF
--- a/bitwindow/lib/pages/wallet/wallet_multisig_lounge.dart
+++ b/bitwindow/lib/pages/wallet/wallet_multisig_lounge.dart
@@ -1016,7 +1016,10 @@ class MultisigLoungeViewModel extends BaseViewModel {
 
   Future<void> fundGroup(BuildContext context, MultisigGroup group) async {
     try {
-      await _getNewAddress(group);
+      // Make sure the watch wallet is loaded. The modal asks it for the
+      // address, so taking one here would consume a second one and leave a
+      // gap in the group's recorded addresses.
+      await _ensureWatchWalletLoaded(group);
 
       if (context.mounted) {
         await showThemedDialog<bool>(
@@ -1056,7 +1059,7 @@ class MultisigLoungeViewModel extends BaseViewModel {
     }
   }
 
-  Future<String> _getNewAddress(MultisigGroup group) async {
+  Future<void> _ensureWatchWalletLoaded(MultisigGroup group) async {
     final walletName = group.watchWalletName ?? 'multisig_${group.id}';
 
     try {
@@ -1064,8 +1067,6 @@ class MultisigLoungeViewModel extends BaseViewModel {
     } catch (e) {
       await BalanceManager.updateGroupBalance(group);
     }
-
-    return await _walletManager.getNewAddress(walletName);
   }
 
   Future<void> createTransaction(

--- a/bitwindow/lib/widgets/fund_group_modal.dart
+++ b/bitwindow/lib/widgets/fund_group_modal.dart
@@ -9,10 +9,7 @@ import 'package:stacked/stacked.dart';
 class FundGroupModal extends StatelessWidget {
   final List<MultisigGroup> groups;
 
-  const FundGroupModal({
-    super.key,
-    required this.groups,
-  });
+  const FundGroupModal({super.key, required this.groups});
 
   @override
   Widget build(BuildContext context) {
@@ -35,9 +32,7 @@ class FundGroupModal extends StatelessWidget {
                       hintText: 'Funding address',
                       controller: TextEditingController(text: viewModel.currentAddress),
                       readOnly: true,
-                      suffixWidget: CopyButton(
-                        text: viewModel.currentAddress,
-                      ),
+                      suffixWidget: CopyButton(text: viewModel.currentAddress),
                     ),
                     SailButton(
                       label: 'Close',
@@ -86,6 +81,11 @@ class FundGroupModal extends StatelessWidget {
                             const SizedBox(width: SailStyleValues.padding16),
                             SailButton(
                               label: 'Fund This Group',
+                              // Address generation moves Core's cursor, so a
+                              // second click would take a second address and
+                              // then overwrite the first one's record.
+                              disabled: viewModel.isBusy,
+                              loading: viewModel.isBusy,
                               onPressed: () async => viewModel.selectGroup(group),
                               variant: ButtonVariant.primary,
                             ),
@@ -182,12 +182,11 @@ class FundGroupModalViewModel extends BaseViewModel {
       // (Phase-1) descriptors. SyncGroup owns watch-wallet creation server-side.
       await _multisigLounge.syncGroup(group: multisigGroupToProto(enhancedGroup), walletId: walletId);
 
-      // The group carries the standard descriptors; build them if not yet
-      // persisted. These are the same descriptors SyncGroup imported.
-      String? descriptor = enhancedGroup.descriptorReceive;
+      // The group carries the standard descriptors; persist them if not yet
+      // stored. These are the same descriptors SyncGroup imported.
+      final descriptor = enhancedGroup.descriptorReceive;
       if (descriptor == null || descriptor.isEmpty) {
         final built = await MultisigDescriptorBuilder.buildWatchOnlyDescriptors(enhancedGroup);
-        descriptor = built.receive;
         updatedGroup = enhancedGroup.copyWith(
           descriptorReceive: built.receive,
           descriptorChange: built.change,
@@ -195,37 +194,81 @@ class FundGroupModalViewModel extends BaseViewModel {
         );
       }
 
-      int nextIndex = updatedGroup.nextReceiveIndex;
+      final receiveAddresses = List<AddressInfo>.from(updatedGroup.addresses['receive'] ?? []);
+      // Let the watch wallet hand out the address instead of deriving it at an
+      // index of our own: Core only emits indices inside the descriptor range
+      // SyncGroup imported, so the address is always one the wallet tracks.
+      final wantNext = updatedGroup.nextReceiveIndex;
 
-      final addresses = await bitcoindRpcCall(
-        'deriveaddresses',
-        params: [
-          descriptor,
-          [nextIndex, nextIndex],
-        ],
-      );
+      Map<dynamic, dynamic>? receiveDescriptor;
+      final descriptors = await bitcoindRpcCall('listdescriptors', wallet: walletName);
+      if (descriptors is Map && descriptors['descriptors'] is List) {
+        for (final d in descriptors['descriptors'] as List) {
+          if (d is Map && d['active'] == true && d['internal'] != true) {
+            receiveDescriptor = d;
+            break;
+          }
+        }
+      }
+      final coreNext = (receiveDescriptor?['next'] is int) ? receiveDescriptor!['next'] as int : 0;
 
-      if (addresses is! List || addresses.isEmpty) {
-        throw Exception('Failed to derive address from descriptor');
+      // A group funded through the earlier deriveaddresses flow left Core's own
+      // cursor at 0, so it would hand out addresses this group already holds.
+      // Move the cursor in one call. One call per address would take over a
+      // thousand round trips for a group at the old range boundary.
+      if (receiveDescriptor != null && coreNext < wantNext) {
+        // The range is a hard cap. A next_index outside it makes Core reject
+        // the import, and the cursor would stay at 0 while we record a high
+        // index — a reused address under the wrong label.
+        final currentRange = receiveDescriptor['range'];
+        var rangeEnd = wantNext + 100;
+        if (currentRange is List && currentRange.length == 2 && currentRange[1] is int) {
+          final existingEnd = currentRange[1] as int;
+          if (existingEnd > rangeEnd) {
+            rangeEnd = existingEnd;
+          }
+        }
+
+        final imported = await bitcoindRpcCall(
+          'importdescriptors',
+          params: [
+            [
+              {
+                'desc': receiveDescriptor['desc'],
+                'active': true,
+                'internal': false,
+                'range': [0, rangeEnd],
+                'next_index': wantNext,
+                'timestamp': 'now',
+              },
+            ],
+          ],
+          wallet: walletName,
+        );
+
+        // A silent failure here hands out index 0 again, so read the result.
+        if (imported is! List ||
+            imported.isEmpty ||
+            !(imported.first is Map && (imported.first as Map)['success'] == true)) {
+          throw Exception('Could not move the watch wallet cursor to index $wantNext');
+        }
       }
 
-      final newAddress = addresses.first as String;
+      final newAddress = await bitcoindRpcCall('getnewaddress', wallet: walletName);
+      if (newAddress is! String || newAddress.isEmpty) {
+        throw Exception('Failed to get a funding address from watch wallet $walletName');
+      }
 
-      // Update group with new address via backend RPC
-      final receiveAddresses = List<AddressInfo>.from(updatedGroup.addresses['receive'] ?? []);
-      receiveAddresses.add(
-        AddressInfo(
-          index: nextIndex,
-          address: newAddress,
-          used: false,
-        ),
-      );
+      // Core hands out the cursor it holds, so that is the index just used.
+      int nextIndex = coreNext > wantNext ? coreNext : wantNext;
+      if (nextIndex < 0) {
+        nextIndex = 0;
+      }
+
+      receiveAddresses.add(AddressInfo(index: nextIndex, address: newAddress, used: false));
 
       final finalGroup = updatedGroup.copyWith(
-        addresses: {
-          'receive': receiveAddresses,
-          'change': updatedGroup.addresses['change'] ?? [],
-        },
+        addresses: {'receive': receiveAddresses, 'change': updatedGroup.addresses['change'] ?? []},
         nextReceiveIndex: nextIndex + 1,
       );
 

--- a/sidechain-orchestrator/api/multisiglounge_handler.go
+++ b/sidechain-orchestrator/api/multisiglounge_handler.go
@@ -518,10 +518,65 @@ func watchWalletName(g *pb.GroupData) string {
 	return "multisig_" + g.GetId()
 }
 
-// ensureWatchWallet makes sure the group's watch-only descriptor wallet exists
-// and has the Phase-1 receive/change descriptors imported. Idempotent: an
-// already-existing wallet is loaded, not recreated, and re-importing the same
-// descriptors is a no-op in Core.
+// multisigWatchRangeChunk is the granularity the watch wallet's descriptor range
+// grows in; the first import covers [0, 999].
+const multisigWatchRangeChunk = 1000
+
+// multisigWatchRangeLookahead keeps the imported range at least this far ahead of
+// the next index the watch wallet hands out.
+const multisigWatchRangeLookahead = 100
+
+// watchRangeEnd is the descriptor range end covering next+lookahead, rounded up
+// to a whole chunk so a growing wallet re-imports (and rescans) rarely.
+func watchRangeEnd(next int) int {
+	return ((next+multisigWatchRangeLookahead)/multisigWatchRangeChunk+1)*multisigWatchRangeChunk - 1
+}
+
+// watchDescriptorRange reports the imported range end covering both of the
+// wallet's active descriptors (-1 when either is missing) and the highest next
+// index Core will hand out from them.
+func (h *MultisigLoungeHandler) watchDescriptorRange(ctx context.Context, name string) (int, int, error) {
+	var res struct {
+		Descriptors []struct {
+			Active   bool  `json:"active"`
+			Internal bool  `json:"internal"`
+			Range    []int `json:"range"`
+			Next     int   `json:"next"`
+		} `json:"descriptors"`
+	}
+	if err := h.coreCallWallet(ctx, name, "listdescriptors", nil, &res); err != nil {
+		return 0, 0, fmt.Errorf("listdescriptors: %w", err)
+	}
+
+	end, next := -1, 0
+	var haveReceive, haveChange bool
+	for _, d := range res.Descriptors {
+		if !d.Active || len(d.Range) != 2 {
+			continue
+		}
+		if d.Internal {
+			haveChange = true
+		} else {
+			haveReceive = true
+		}
+		if end < 0 || d.Range[1] < end {
+			end = d.Range[1]
+		}
+		if d.Next > next {
+			next = d.Next
+		}
+	}
+	if !haveReceive || !haveChange {
+		return -1, next, nil
+	}
+	return end, next, nil
+}
+
+// ensureWatchWallet makes sure the group's watch-only descriptor wallet exists,
+// has the Phase-1 receive/change descriptors imported, and that their range
+// still covers the addresses the wallet is about to hand out. Idempotent: an
+// already-existing wallet is loaded, not recreated, and the descriptors are only
+// re-imported when the imported range falls short.
 func (h *MultisigLoungeHandler) ensureWatchWallet(ctx context.Context, g *pb.GroupData) (string, error) {
 	name := watchWalletName(g)
 
@@ -530,14 +585,39 @@ func (h *MultisigLoungeHandler) ensureWatchWallet(ctx context.Context, g *pb.Gro
 	if err := h.coreCall(ctx, "listwallets", nil, &loaded); err != nil {
 		return "", fmt.Errorf("listwallets: %w", err)
 	}
+	exists := false
 	for _, w := range loaded {
 		if w == name {
-			return name, nil
+			exists = true
+			break
 		}
 	}
 
 	// Try to load it; on failure create it fresh.
-	if err := h.coreCall(ctx, "loadwallet", []interface{}{name}, nil); err == nil {
+	if !exists {
+		if err := h.coreCall(ctx, "loadwallet", []interface{}{name}, nil); err == nil {
+			exists = true
+		}
+	}
+	if !exists {
+		// createwallet(name, disable_private_keys=true, blank=true, "", false, true, false)
+		if err := h.coreCall(ctx, "createwallet",
+			[]interface{}{name, true, true, "", false, true, false}, nil); err != nil {
+			// A concurrent create may have won the race; tolerate "already exists".
+			if !strings.Contains(err.Error(), "already exists") && !strings.Contains(err.Error(), "Database already exists") {
+				return "", fmt.Errorf("createwallet: %w", err)
+			}
+		}
+	}
+
+	// The imported range is a hard cap: an address past its end is derivable but
+	// invisible to the wallet, so keep it ahead of the next index Core hands out.
+	haveEnd, next, err := h.watchDescriptorRange(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	wantEnd := watchRangeEnd(next)
+	if haveEnd >= wantEnd {
 		return name, nil
 	}
 
@@ -546,18 +626,13 @@ func (h *MultisigLoungeHandler) ensureWatchWallet(ctx context.Context, g *pb.Gro
 		return "", fmt.Errorf("build descriptors: %w", err)
 	}
 
-	// createwallet(name, disable_private_keys=true, blank=true, "", false, true, false)
-	if err := h.coreCall(ctx, "createwallet",
-		[]interface{}{name, true, true, "", false, true, false}, nil); err != nil {
-		// A concurrent create may have won the race; tolerate "already exists".
-		if !strings.Contains(err.Error(), "already exists") && !strings.Contains(err.Error(), "Database already exists") {
-			return "", fmt.Errorf("createwallet: %w", err)
-		}
-	}
+	// The widened indices were never handed out, so they carry no history and
+	// need no rescan. Keep "now", as the first import always used.
+	var timestamp interface{} = "now"
 
 	descs := []map[string]interface{}{
-		{"desc": receive, "active": true, "internal": false, "timestamp": "now", "range": []int{0, 999}},
-		{"desc": change, "active": true, "internal": true, "timestamp": "now", "range": []int{0, 999}},
+		{"desc": receive, "active": true, "internal": false, "timestamp": timestamp, "range": []int{0, wantEnd}},
+		{"desc": change, "active": true, "internal": true, "timestamp": timestamp, "range": []int{0, wantEnd}},
 	}
 	var importRes []struct {
 		Success bool `json:"success"`

--- a/sidechain-orchestrator/api/multisiglounge_sync_test.go
+++ b/sidechain-orchestrator/api/multisiglounge_sync_test.go
@@ -356,6 +356,12 @@ func TestRestoreHistoryNetsRowsPerTxid(t *testing.T) {
 					return json.RawMessage(`{"details":` + tt.rows + `}`), nil
 				case "getrawtransaction":
 					return json.RawMessage(raw), nil
+				case "listdescriptors":
+					// The watch wallet already covers the indices it hands out.
+					return json.RawMessage(`{"descriptors":[
+						{"desc":"wsh(x)","active":true,"internal":false,"range":[0,999],"next":0},
+						{"desc":"wsh(y)","active":true,"internal":true,"range":[0,999],"next":0}
+					]}`), nil
 				}
 				return nil, fmt.Errorf("unexpected method %s", method)
 			})


### PR DESCRIPTION
From #1987, authored by @giaki3003. Rebased on master. His version rescanned from block 0 on every range growth; the widened indices were never handed out, so the import keeps "now".

The descriptors were imported at a fixed [0, 999] range. An address past that end is derivable but invisible to the wallet, so funds sent to it never showed up.