### PR TITLE
bitwindow: scope an imported PSBT to its own group

### DIFF
--- a/bitwindow/lib/providers/multisig_provider.dart
+++ b/bitwindow/lib/providers/multisig_provider.dart
@@ -627,9 +627,8 @@ class TransactionStorage {
     String transactionId,
     String keyId,
     String psbt,
-    bool isSigned, {
-    int? signatureThreshold,
-  }) async {
+    bool isSigned,
+  ) async {
     final transaction = await getTransaction(transactionId);
     if (transaction == null) {
       throw Exception('Transaction not found: $transactionId');
@@ -641,10 +640,18 @@ class TransactionStorage {
       orElse: () => throw Exception('Group not found: ${transaction.groupId}'),
     );
 
-    final actualSignedStatus = await PSBTValidator.hasAnySignatures(psbt, group.n);
+    // Only the owning group's keys may hold a PSBT slot on its transaction. An
+    // existing slot proves nothing: a wallet corrupted before this check holds
+    // foreign slots already, so drop them instead of trusting them.
+    bool isMember(String xpub) => group.keys.any((k) => k.xpub == xpub);
+    if (!isMember(keyId)) {
+      throw Exception('Key is not a member of group ${group.id}: $keyId');
+    }
 
-    final keyPSBTs = List<KeyPSBTStatus>.from(transaction.keyPSBTs);
+    final keyPSBTs = List<KeyPSBTStatus>.from(transaction.keyPSBTs)..removeWhere((k) => !isMember(k.keyId));
     final existingIndex = keyPSBTs.indexWhere((k) => k.keyId == keyId);
+
+    final actualSignedStatus = await PSBTValidator.hasAnySignatures(psbt, group.n);
 
     final newKeyPSBT = KeyPSBTStatus(
       keyId: keyId,
@@ -660,8 +667,7 @@ class TransactionStorage {
     }
 
     final signedCount = keyPSBTs.where((k) => k.isSigned).length;
-    final threshold = signatureThreshold ?? transaction.requiredSignatures;
-    final newStatus = signedCount >= threshold ? TxStatus.readyToCombine : TxStatus.needsSignatures;
+    final newStatus = signedCount >= group.m ? TxStatus.readyToCombine : TxStatus.needsSignatures;
 
     final updatedTransaction = transaction.copyWith(
       keyPSBTs: keyPSBTs,

--- a/bitwindow/lib/widgets/import_psbt_modal.dart
+++ b/bitwindow/lib/widgets/import_psbt_modal.dart
@@ -201,6 +201,9 @@ class _ImportPSBTModalState extends State<ImportPSBTModal> {
       final txId = _txIdController.text.trim();
 
       var existingTx = await TransactionStorage.getTransaction(txId);
+      if (existingTx != null && existingTx.groupId != _selectedGroupId) {
+        throw Exception('PSBT targets a transaction in another group');
+      }
 
       if (keyOwner == null) {
         throw Exception('key_owner is required in PSBT import data');
@@ -273,7 +276,6 @@ class _ImportPSBTModalState extends State<ImportPSBTModal> {
           targetKey.xpub,
           cleanPsbt,
           true,
-          signatureThreshold: group.m,
         );
       } else {
         final allRelevantKeys = <MultisigKey>[];
@@ -302,7 +304,6 @@ class _ImportPSBTModalState extends State<ImportPSBTModal> {
               key.xpub,
               cleanPsbt,
               false,
-              signatureThreshold: group.m,
             );
           }
         }


### PR DESCRIPTION
From #1987, authored by @giaki3003. His test is dropped: it targets protobuf multisig types this tree does not have.

A signed-PSBT import did not scope the transaction id to the selected group, so it appended a non-member signer to another group's transaction and counted it against the wrong threshold.