### PR TITLE
bitwindow: report an addSoloKey failure

### DIFF
--- a/bitwindow/lib/widgets/multisig_key_modal.dart
+++ b/bitwindow/lib/widgets/multisig_key_modal.dart
@@ -218,21 +218,17 @@ class MultisigKeyModalViewModel extends BaseViewModel {
       return;
     }
 
-    try {
-      final keyName = keyNameController.text.trim();
+    final keyName = keyNameController.text.trim();
 
-      final soloKeyData = {
-        'xpub': keyInfo!['xpub'],
-        'owner': keyName,
-        'path': keyInfo!['path'],
-        'fingerprint': keyInfo!['fingerprint'],
-        'origin_path': keyInfo!['originPath'],
-      };
+    final soloKeyData = {
+      'xpub': keyInfo!['xpub'],
+      'owner': keyName,
+      'path': keyInfo!['path'],
+      'fingerprint': keyInfo!['fingerprint'],
+      'origin_path': keyInfo!['originPath'],
+    };
 
-      await MultisigStorage.addSoloKey(soloKeyData);
-    } catch (e) {
-      // Failed to save key to storage - not critical
-    }
+    await MultisigStorage.addSoloKey(soloKeyData);
   }
 
   Future<void> saveKey(BuildContext context) async {


### PR DESCRIPTION
From #1987, authored by @giaki3003.

MultisigKeyModal swallowed the addSoloKey error and told the user the key reached multisig.json. `saveKey` already catches and shows the error.