### PR TITLE
orchestrator: pick change type from the wallet kind

### DIFF
--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -375,7 +375,12 @@ func (p *CoreBackend) NextChangeAddress(ctx context.Context, walletID string) (s
 	if err != nil {
 		return "", err
 	}
-	return p.rpc.GetRawChangeAddress(ctx, name)
+	kind := p.walletScriptKind(walletID)
+	addressType, ok := coreAddressType(kind)
+	if !ok {
+		return "", fmt.Errorf("unsupported address kind %s for the Bitcoin Core backend", kind)
+	}
+	return p.rpc.GetRawChangeAddress(ctx, name, addressType)
 }
 
 // WatchKeys imports each key as a pkh() descriptor. Per-key import failures

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -816,6 +816,61 @@ func TestCoreBackendNextReceiveAddressTaproot(t *testing.T) {
 	assert.Equal(t, "bech32m", mintedType)
 }
 
+// TestCoreBackendNextChangeAddressKind pins change addresses to the wallet's own
+// script kind: a tr()-only wallet has no bech32 ScriptPubKeyMan to serve.
+func TestCoreBackendNextChangeAddressKind(t *testing.T) {
+	net := &chaincfg.RegressionNetParams
+	ctx := context.Background()
+
+	t.Run("default wallet stays bech32", func(t *testing.T) {
+		backend, fake, coreID := newCoreBackendFixture(t)
+		fake.stubEnsureFlow()
+
+		change := p2wpkhAddr(t, fixedKey(0x31), net)
+		var requestedType string
+		fake.handle("getrawchangeaddress", func(c bitcoindCall) (any, string) {
+			if len(c.Params) > 0 {
+				requestedType = mustString(t, c.Params[0])
+			}
+			return change, ""
+		})
+
+		addr, err := backend.NextChangeAddress(ctx, coreID)
+		require.NoError(t, err)
+		assert.Equal(t, change, addr)
+		assert.Equal(t, "bech32", requestedType)
+	})
+
+	t.Run("taproot wallet requests bech32m", func(t *testing.T) {
+		svc := newTestService(t)
+		_, err := svc.GenerateWallet("Enforcer", "", "", testSlots)
+		require.NoError(t, err)
+		core, err := svc.GenerateWalletWithPath("CoreTaproot", "", "", 0, "m/86'/1'/0'", testSlots)
+		require.NoError(t, err)
+
+		fake := newFakeBitcoind(t)
+		backend := NewCoreBackend(svc, fake.client(t), func() *chaincfg.Params { return net }, zerolog.New(zerolog.NewTestWriter(t)))
+		coreID := core.ID
+		require.Equal(t, ScriptTaproot, backend.walletScriptKind(coreID))
+
+		fake.stubEnsureFlow()
+
+		change := p2trAddr(t, fixedKey(0x32), net)
+		var requestedType string
+		fake.handle("getrawchangeaddress", func(c bitcoindCall) (any, string) {
+			if len(c.Params) > 0 {
+				requestedType = mustString(t, c.Params[0])
+			}
+			return change, ""
+		})
+
+		addr, err := backend.NextChangeAddress(ctx, coreID)
+		require.NoError(t, err)
+		assert.Equal(t, change, addr)
+		assert.Equal(t, "bech32m", requestedType)
+	})
+}
+
 func mustString(t *testing.T, raw json.RawMessage) string {
 	t.Helper()
 	var s string

--- a/sidechain-orchestrator/wallet/core_rpc.go
+++ b/sidechain-orchestrator/wallet/core_rpc.go
@@ -398,8 +398,8 @@ func (c *CoreRPCClient) SendRawTransaction(ctx context.Context, hexString string
 	return txid, nil
 }
 
-func (c *CoreRPCClient) GetRawChangeAddress(ctx context.Context, walletName string) (string, error) {
-	result, err := c.call(ctx, walletName, "getrawchangeaddress", "bech32")
+func (c *CoreRPCClient) GetRawChangeAddress(ctx context.Context, walletName, addressType string) (string, error) {
+	result, err := c.call(ctx, walletName, "getrawchangeaddress", addressType)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
From #1987, authored by @giaki3003. Rebased on master, whose CoreBackend takes a ParamsFunc.

`NextChangeAddress` asked Core for a bech32 change address for every wallet, so a taproot wallet got a P2WPKH change output.