### PR TITLE
orchestrator: give each core variant its own path

### DIFF
--- a/bitwindow/server/integrationtest/backend_runtime_smoke_test.go
+++ b/bitwindow/server/integrationtest/backend_runtime_smoke_test.go
@@ -205,7 +205,7 @@ func newOrchestratorOnlyNode(t *testing.T) *orchestratorOnlyNode {
 		0o600,
 	))
 	smokeConfigs := orchestrator.AllDefaults()
-	bitcoindDestPath := orchestrator.ActiveCoreBinaryPath(bitwindowDir, bitwindowDir, smokeConfigs, "bitcoind")
+	bitcoindDestPath := orchestrator.ActiveCoreBinaryPath(bitwindowDir, bitwindowDir, smokeConfigs, "bitcoind", "regtest")
 	copyManagedBinary(t, bitcoindBin, bitcoindDestPath)
 	enforcerBin := findEnforcer(t)
 	copyManagedBinary(t, enforcerBin, orchestrator.BinaryPath(bitwindowDir, "bip300301-enforcer"))
@@ -374,7 +374,7 @@ func findBitcoind(t *testing.T) string {
 	bitwindowDir := orchestrator.DefaultBitwindowDir()
 	configPath := orchestrator.ConfigFilePath(bitwindowDir)
 	configs := orchestrator.LoadConfigFile(configPath, log)
-	orchPath := orchestrator.ActiveCoreBinaryPath(dataDir, bitwindowDir, configs, "bitcoind")
+	orchPath := orchestrator.ActiveCoreBinaryPath(dataDir, bitwindowDir, configs, "bitcoind", "regtest")
 
 	if _, err := os.Stat(orchPath); err == nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/sail_ui/lib/widgets/console/cli_console_service.dart
+++ b/sail_ui/lib/widgets/console/cli_console_service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
 import 'package:path/path.dart' as path;
 import 'package:sail_ui/sail_ui.dart';
 
@@ -66,10 +67,23 @@ class CLIConsole {
     'Orchestratord': 'orchestratorctl',
   };
 
+  /// The orchestrator binary each CLI ships with. Every Core variant owns a
+  /// folder, so only the folder the daemon runs from holds the matching CLI.
+  static const _cliToBinary = {
+    'bitcoin-cli': 'bitcoind',
+    'bitwindow-cli': 'bitwindowd',
+    'thunder-cli': 'thunder',
+    'truthcoin-cli': 'truthcoin',
+    'photon-cli': 'photon',
+    'bitnames-cli': 'bitnames',
+    'bitassets-cli': 'bitassets',
+    'coinshift-cli': 'coinshift',
+    'zside-cli': 'zside',
+    'orchestratorctl': 'orchestratord',
+  };
+
   /// Discover available CLI executables on disk. Returns map of cli name →
-  /// absolute path. Walks `assets/bin` recursively so binaries that landed in
-  /// per-variant subfolders (Core variants, test sidechain builds) are
-  /// still found.
+  /// absolute path, each taken from the folder its daemon runs from.
   static Future<Map<String, String>> discoverCLIs() async {
     final available = <String, String>{};
     final exeSuffix = Platform.isWindows ? '.exe' : '';
@@ -79,8 +93,11 @@ class CLIConsole {
       return available;
     }
 
+    final daemonDirs = await _daemonDirs();
+
     for (final cliName in _binaryToCLI.values) {
-      final found = _findExecutable(bindir, '$cliName$exeSuffix');
+      final filename = '$cliName$exeSuffix';
+      final found = _besideDaemon(daemonDirs[_cliToBinary[cliName]], filename) ?? _findExecutable(bindir, filename);
       if (found != null) {
         await _ensureExecutable(found);
         available[cliName] = found.path;
@@ -90,22 +107,51 @@ class CLIConsole {
     return available;
   }
 
+  /// The directory each daemon runs from, by orchestrator binary name. An
+  /// unreachable daemon returns an empty map, and the caller searches instead.
+  static Future<Map<String, String>> _daemonDirs() async {
+    if (!GetIt.I.isRegistered<OrchestratorRPC>()) {
+      return {};
+    }
+    try {
+      // forceBackend reports the real daemon, not the Flutter test build.
+      final resp = await GetIt.I.get<OrchestratorRPC>().listBinaries(forceBackend: true);
+      return {
+        for (final b in resp.binaries)
+          if (b.binaryPath.isNotEmpty) b.name: path.dirname(b.binaryPath),
+      };
+    } catch (e) {
+      GetIt.I.get<Logger>().w('discoverCLIs: the orchestrator did not report binary paths: $e');
+      return {};
+    }
+  }
+
+  static File? _besideDaemon(String? daemonDir, String filename) {
+    if (daemonDir == null) {
+      return null;
+    }
+    final beside = File(path.join(daemonDir, filename));
+    return beside.existsSync() ? beside : null;
+  }
+
   static File? _findExecutable(Directory bindir, String filename) {
     final direct = File(path.join(bindir.path, filename));
     if (direct.existsSync()) {
       return direct;
     }
 
+    final matches = <File>[];
     for (final entity in bindir.listSync()) {
       if (entity is! Directory) {
         continue;
       }
       final inSubdir = File(path.join(entity.path, filename));
       if (inSubdir.existsSync()) {
-        return inSubdir;
+        matches.add(inSubdir);
       }
     }
-    return null;
+    // listSync gives no order, so a pick between two variants is arbitrary.
+    return matches.length == 1 ? matches.first : null;
   }
 
   static Future<void> _ensureExecutable(File f) async {

--- a/sail_ui/test/widgets/cli_console_discover_test.dart
+++ b/sail_ui/test/widgets/cli_console_discover_test.dart
@@ -2,11 +2,35 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/gen/orchestrator/v1/orchestrator.pb.dart' as orch_pb;
+
+class _FakeOrchestratorRPC extends OrchestratorRPC {
+  _FakeOrchestratorRPC(this.paths) : super(host: '127.0.0.1', port: 1);
+
+  /// Binary name → the path the daemon runs.
+  final Map<String, String> paths;
+
+  @override
+  Future<orch_pb.ListBinariesResponse> listBinaries({bool forceBackend = false}) async {
+    return orch_pb.ListBinariesResponse(
+      binaries: [
+        for (final e in paths.entries) orch_pb.BinaryStatusMsg(name: e.key, binaryPath: e.value),
+      ],
+    );
+  }
+}
 
 void main() {
   late Directory tempAppDir;
+
+  setUpAll(() {
+    if (!GetIt.I.isRegistered<Logger>()) {
+      GetIt.I.registerSingleton<Logger>(Logger(level: Level.warning));
+    }
+  });
 
   setUp(() async {
     tempAppDir = await Directory.systemTemp.createTemp('cli-console-test-');
@@ -17,6 +41,9 @@ void main() {
   });
 
   tearDown(() async {
+    if (GetIt.I.isRegistered<OrchestratorRPC>()) {
+      await GetIt.I.unregister<OrchestratorRPC>();
+    }
     await GetIt.I.unregister<BinaryProvider>();
     if (tempAppDir.existsSync()) {
       await tempAppDir.delete(recursive: true);
@@ -55,5 +82,29 @@ void main() {
     await Directory(p.join(tempAppDir.path, 'assets', 'bin')).delete(recursive: true);
     final results = await CLIConsole.discoverCLIs();
     expect(results, isEmpty);
+  });
+
+  test('discoverCLIs takes bitcoin-cli from the folder the daemon runs', () async {
+    final suffix = Platform.isWindows ? '.exe' : '';
+    final active = await seed('drynet4/bitcoin-cli$suffix');
+    await seed('knots/bitcoin-cli$suffix');
+    final daemon = await seed('drynet4/bitcoind$suffix');
+    GetIt.I.registerSingleton<OrchestratorRPC>(_FakeOrchestratorRPC({'bitcoind': daemon.path}));
+
+    final results = await CLIConsole.discoverCLIs();
+
+    expect(results['bitcoin-cli'], active.path);
+  });
+
+  // Every Core variant ships a bitcoin-cli, and listSync gives no order. A pick
+  // between them is arbitrary, and the wrong one speaks another fork.
+  test('discoverCLIs drops bitcoin-cli when two variants hold one and no daemon answers', () async {
+    final suffix = Platform.isWindows ? '.exe' : '';
+    await seed('drynet4/bitcoin-cli$suffix');
+    await seed('knots/bitcoin-cli$suffix');
+
+    final results = await CLIConsole.discoverCLIs();
+
+    expect(results['bitcoin-cli'], isNull);
   });
 }

--- a/sidechain-orchestrator/commands/commands.go
+++ b/sidechain-orchestrator/commands/commands.go
@@ -19,6 +19,7 @@ import (
 	"connectrpc.com/connect"
 	orchestrator "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1"
 	rpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/localauth"
@@ -401,7 +402,7 @@ var wipeCommand = &cli.Command{
 		if dataDir == "" {
 			dataDir = orchestrator.DefaultDataDir()
 		}
-		binPath := binaryPathFor(dataDir, name)
+		binPath := binaryPathFor(cctx, dataDir, name)
 		if err := os.Remove(binPath); err == nil {
 			fmt.Printf("removed %s\n", binPath)
 		}
@@ -567,11 +568,6 @@ var versionCommand = &cli.Command{
 	Name:  "version",
 	Usage: "Show version info for all binaries",
 	Action: func(cctx *cli.Context) error {
-		dataDir := cctx.String("datadir")
-		if dataDir == "" {
-			dataDir = orchestrator.DefaultDataDir()
-		}
-
 		client := newClient(cctx)
 		resp, err := client.ListBinaries(cctx.Context, connect.NewRequest(&pb.ListBinariesRequest{}))
 		if err != nil {
@@ -583,9 +579,11 @@ var versionCommand = &cli.Command{
 				continue
 			}
 
+			// The daemon reports the path it resolved. A second resolution
+			// here can name another generation.
 			ver := "not downloaded"
 			if b.Downloaded {
-				ver = binaryVersion(binaryPathFor(dataDir, b.Name))
+				ver = binaryVersion(b.BinaryPath)
 			}
 
 			fmt.Printf("  %-20s %-25s %s\n", b.Name, ver, b.RepoUrl)
@@ -689,7 +687,7 @@ var whichCommand = &cli.Command{
 		}
 
 		name := cctx.Args().First()
-		binPath := binaryPathFor(dataDir, name)
+		binPath := binaryPathFor(cctx, dataDir, name)
 
 		if _, err := os.Stat(binPath); err != nil {
 			fmt.Printf("%s (not downloaded)\n", binPath)
@@ -701,19 +699,47 @@ var whichCommand = &cli.Command{
 }
 
 // binaryPathFor returns the on-disk path the orchestrator currently uses for
-// a binary. For bitcoind it consults orchestrator_settings.json so it picks
-// up whichever Core variant is active; for everything else it falls back to
-// the legacy flat layout.
-func binaryPathFor(dataDir, name string) string {
+// a binary. For bitcoind it reads the persisted variant and the persisted
+// network, because a variant the network does not offer clamps to one it does;
+// for everything else it falls back to the legacy flat layout.
+func binaryPathFor(cctx *cli.Context, dataDir, name string) string {
 	if name != "bitcoind" {
 		return orchestrator.BinaryPath(dataDir, name)
 	}
+	bitwindowDir := cctx.String("bitwindow-dir")
+	network := cctx.String("network")
+	if n, err := config.ResolveNetwork(bitwindowDir); err == nil {
+		network = string(n)
+	}
 	return orchestrator.ActiveCoreBinaryPath(
 		dataDir,
-		orchestrator.DefaultBitwindowDir(),
-		orchestrator.AllDefaults(),
+		bitwindowDir,
+		orchestrator.LoadConfigFile(orchestrator.ConfigFilePath(bitwindowDir), zerolog.Nop()),
 		name,
+		network,
+		servedDrynetGeneration(cctx, bitwindowDir),
 	)
+}
+
+// servedDrynetGeneration returns the drynet generation the daemon runs. Do not
+// read the catalog cache instead: the confirm writes a new generation there
+// before the restart that starts to use it, so a path from the cache names a
+// build no process runs, and `wipe` deletes that one while the live build stays.
+func servedDrynetGeneration(cctx *cli.Context, bitwindowDir string) string {
+	// A path lookup must not wait forever on an address that never answers.
+	ctx, cancel := context.WithTimeout(cctx.Context, 2*time.Second)
+	defer cancel()
+
+	resp, err := newClient(cctx).GetPendingNetworkGeneration(
+		ctx, connect.NewRequest(&pb.GetPendingNetworkGenerationRequest{}),
+	)
+	if err == nil {
+		return resp.Msg.CurrentGeneration
+	}
+	// No daemon answers, so no process serves an older generation. The cached
+	// one is what the next start uses.
+	c, _ := netcatalog.Load(bitwindowDir)
+	return c.DrynetID()
 }
 
 func extractVersion(s string) string {

--- a/sidechain-orchestrator/config.go
+++ b/sidechain-orchestrator/config.go
@@ -218,15 +218,16 @@ func BinDir(dataDir string) string {
 	return filepath.Join(dataDir, "assets", "bin")
 }
 
-// CoreBinaryPath returns the on-disk path for the active Bitcoin Core
-// daemon. All variants share a single `bin/bitcoind` location — switching
-// variants re-downloads and overwrites whatever was there.
-func CoreBinaryPath(dataDir string, _ CoreVariantSpec, binaryName string) string {
+// CoreBinaryPath returns the on-disk path for a Bitcoin Core variant. Each
+// variant owns a subfolder, so a stat of this path proves the build is the
+// selected one — a shared path let a stale variant boot against the wrong
+// chain. An empty subfolder keeps the flat layout for callers with no spec.
+func CoreBinaryPath(dataDir string, v CoreVariantSpec, binaryName string) string {
 	name := binaryName
 	if runtime.GOOS == "windows" {
 		name += ".exe"
 	}
-	return filepath.Join(BinDir(dataDir), name)
+	return filepath.Join(BinDir(dataDir), v.Subfolder, name)
 }
 
 // testSidechainSubfolder is the on-disk namespace for layer-2 test/alternative

--- a/sidechain-orchestrator/core_variants.go
+++ b/sidechain-orchestrator/core_variants.go
@@ -2,6 +2,9 @@ package orchestrator
 
 import (
 	"os"
+	"sort"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
 )
 
 // CoreVariantInstalled reports whether the variant's binary exists on disk.
@@ -54,13 +57,42 @@ func FilterVariantsForNetwork(variants map[string]CoreVariantSpec, network strin
 	return out
 }
 
-// ActiveCoreBinaryPath returns the on-disk path for the bitcoind variant
-// currently selected in orchestrator_settings.json. Used by CLI commands and
-// the testharness to find the active build without constructing a full
-// Orchestrator. Non-bitcoind names always resolve via the legacy flat layout.
-func ActiveCoreBinaryPath(dataDir, bitwindowDir string, configs []BinaryConfig, binaryName string) string {
+// ResolveCoreVariant returns the Core variant a network boots: the requested
+// one when the network offers it, otherwise the preferred variant that network
+// does offer. Every consumer of a Core path goes through here, so the launcher,
+// the status check and the CLI never disagree about which build is active.
+func ResolveCoreVariant(c BinaryConfig, requestedID, network string) (CoreVariantSpec, bool) {
+	if !c.IsMainchainCore() {
+		return CoreVariantSpec{}, false
+	}
+	if v, ok := c.Variants[requestedID]; ok && v.AvailableOn(network) {
+		return v, true
+	}
+	available := FilterVariantsForNetwork(c.Variants, network)
+	if len(available) == 0 {
+		return CoreVariantSpec{}, false
+	}
+	sort.Slice(available, func(i, j int) bool {
+		return preferenceLess(available[i].ID, available[j].ID)
+	})
+	return available[0], true
+}
+
+// ActiveCoreBinaryPath returns the on-disk path for the bitcoind variant the
+// given network boots. Used by CLI commands and the testharness to find the
+// active build without constructing a full Orchestrator. Non-bitcoind names
+// always resolve via the legacy flat layout.
+//
+// drynetID is the drynet generation to resolve. Read it from the running
+// daemon, not from the catalog cache: the confirm writes a new generation to
+// the cache before the restart that starts to use it.
+func ActiveCoreBinaryPath(dataDir, bitwindowDir string, configs []BinaryConfig, binaryName, network, drynetID string) string {
 	if binaryName != "bitcoind" {
 		return BinaryPath(dataDir, binaryName)
+	}
+	if drynetID == "" {
+		// An empty id keeps the placeholder, and the path becomes bin/{drynet}.
+		drynetID = netcatalog.EmbeddedDrynetID()
 	}
 	variantID := DefaultCoreVariantID
 	if bitwindowDir != "" {
@@ -72,7 +104,8 @@ func ActiveCoreBinaryPath(dataDir, bitwindowDir string, configs []BinaryConfig, 
 		if !c.IsMainchainCore() {
 			continue
 		}
-		if v, ok := c.Variants[variantID]; ok {
+		expanded := expandDrynetPlaceholder(c, drynetID)
+		if v, ok := ResolveCoreVariant(expanded, variantID, network); ok {
 			return CoreBinaryPath(dataDir, v, binaryName)
 		}
 	}

--- a/sidechain-orchestrator/core_variants_integration_test.go
+++ b/sidechain-orchestrator/core_variants_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -22,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
 )
 
 // variantArchive is the fake archive served by the mock server for a given
@@ -121,7 +123,7 @@ func TestIntegration_SetCoreVariant_FreshSwitchInstallsBinary(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "knots", persisted.CoreVariant)
 
-	// Knots binary landed at the single shared bin/bitcoind path.
+	// The knots binary landed in the knots subfolder.
 	knots := o.configs["bitcoind"].Variants["knots"]
 	got, err := os.ReadFile(variantBinary(dataDir, knots))
 	require.NoError(t, err)
@@ -147,8 +149,8 @@ func TestIntegration_SetCoreVariant_PersistsAcrossRestart(t *testing.T) {
 	assert.Equal(t, "knots", second.CoreVariant())
 }
 
-// All variants share bin/bitcoind, so every switch wipes-and-redownloads.
-// Final on-disk binary is whichever variant was selected last.
+// Every switch downloads the selected variant, and the settings report the
+// variant selected last.
 func TestIntegration_SetCoreVariant_RedownloadsOnEverySwitch(t *testing.T) {
 	counts := &requestCount{}
 	srv := newVariantServer(t, counts)
@@ -263,9 +265,9 @@ func TestIntegration_VariantResolver_FallbackWhenSettingsEmpty(t *testing.T) {
 	assert.Equal(t, "patched", v.ID)
 }
 
-// Verifies the launcher path after a switch. With the single-bitcoind layout
-// the path is always BinDir/bitcoind regardless of variant — the active
-// variant only changes which payload was last downloaded into that file.
+// Verifies the launcher path after a switch. The download has to land in the
+// active variant's own subfolder, or the boot check stats a file another
+// variant wrote and starts the wrong build.
 func TestIntegration_SetCoreVariant_ResolverPointsAtActiveVariant(t *testing.T) {
 	srv := newVariantServer(t, &requestCount{})
 	defer srv.Close()
@@ -276,8 +278,13 @@ func TestIntegration_SetCoreVariant_ResolverPointsAtActiveVariant(t *testing.T) 
 	require.NoError(t, o.SetCoreVariant(context.Background(), "knots"))
 
 	knots := o.configs["bitcoind"].Variants["knots"]
-	expected := BinaryPath(dataDir, "bitcoind")
+	expected := filepath.Join(BinDir(dataDir), knots.Subfolder, "bitcoind")
 	assert.Equal(t, expected, CoreBinaryPath(dataDir, knots, "bitcoind"))
+	assert.FileExists(t, expected, "the switch must download into the variant's subfolder")
+
+	core := o.configs["bitcoind"].Variants["core"]
+	assert.NoFileExists(t, CoreBinaryPath(dataDir, core, "bitcoind"),
+		"another variant must not read as downloaded")
 }
 
 // Five concurrent SetCoreVariant calls must not race the on-disk state. The
@@ -471,24 +478,103 @@ func TestIntegration_ListCoreVariants_ClampsActiveOnNetworkMismatch(t *testing.T
 	assert.Equal(t, "", clamped, "active must clamp to empty when not in visible list")
 }
 
-// All variants share BinDir/bitcoind, so the active resolver always returns
-// the flat path regardless of which variant is active. Settings still drive
-// which payload is on disk; the path is invariant.
+// The active resolver follows the persisted variant into its own subfolder, so
+// the CLI and the testharness point at the build the app runs.
 func TestIntegration_ActiveCoreBinaryPath(t *testing.T) {
 	dataDir := t.TempDir()
 	bwDir := t.TempDir()
 
 	configs := []BinaryConfig{makeBitcoindCoreConfig("http://unused/")}
+	variants := configs[0].Variants
 
 	require.NoError(t, SaveSettings(bwDir, OrchestratorSettings{CoreVariant: "knots"}))
-	got := ActiveCoreBinaryPath(dataDir, bwDir, configs, "bitcoind")
-	assert.Equal(t, BinaryPath(dataDir, "bitcoind"), got)
+	assert.Equal(t, CoreBinaryPath(dataDir, variants["knots"], "bitcoind"),
+		ActiveCoreBinaryPath(dataDir, bwDir, configs, "bitcoind", "signet", "drynet4"))
 
-	// Switching settings to a different variant doesn't change the path.
+	// A different variant resolves to a different file.
 	require.NoError(t, SaveSettings(bwDir, OrchestratorSettings{CoreVariant: "core"}))
-	assert.Equal(t, BinaryPath(dataDir, "bitcoind"), ActiveCoreBinaryPath(dataDir, bwDir, configs, "bitcoind"))
+	assert.Equal(t, CoreBinaryPath(dataDir, variants["core"], "bitcoind"),
+		ActiveCoreBinaryPath(dataDir, bwDir, configs, "bitcoind", "signet", "drynet4"))
+
+	// A variant the catalog dropped falls back to the preferred one the
+	// network offers, never to the flat path where any other build can sit.
+	require.NoError(t, SaveSettings(bwDir, OrchestratorSettings{CoreVariant: "gone"}))
+	assert.Equal(t, CoreBinaryPath(dataDir, variants[DefaultCoreVariantID], "bitcoind"),
+		ActiveCoreBinaryPath(dataDir, bwDir, configs, "bitcoind", "signet", "drynet4"))
+
+	// The network clamps the persisted variant: knots is not on drynet, so the
+	// path must be the one drynet actually boots.
+	require.NoError(t, SaveSettings(bwDir, OrchestratorSettings{CoreVariant: "knots"}))
+	assert.Equal(t, CoreBinaryPath(dataDir, variants["patched"], "bitcoind"),
+		ActiveCoreBinaryPath(dataDir, bwDir, configs, "bitcoind", "drynet", "drynet4"))
 
 	// Non-bitcoind binaries always use the flat layout.
-	other := ActiveCoreBinaryPath(dataDir, bwDir, configs, "enforcer")
+	other := ActiveCoreBinaryPath(dataDir, bwDir, configs, "enforcer", "signet", "drynet4")
 	assert.Equal(t, BinaryPath(dataDir, "enforcer"), other)
+}
+
+// Status must report the build the launcher boots. The persisted variant is
+// not available on drynet, so status has to follow the same clamp the process
+// manager applies, not the raw settings value.
+func TestIntegration_Status_FollowsNetworkClamp(t *testing.T) {
+	srv := newVariantServer(t, &requestCount{})
+	defer srv.Close()
+
+	dataDir := t.TempDir()
+	bwDir := t.TempDir()
+
+	first := newIntegrationOrchestrator(t, "signet", srv.URL+"/", dataDir, bwDir)
+	require.NoError(t, first.SetCoreVariant(context.Background(), "knots"))
+	require.NoError(t, first.BitcoinConf.UpdateNetwork(config.NetworkDrynet))
+
+	second := newIntegrationOrchestrator(t, "signet", srv.URL+"/", dataDir, bwDir)
+	require.Equal(t, string(config.NetworkDrynet), second.CurrentNetwork())
+
+	// The knots build is on disk, but drynet does not boot it.
+	assert.False(t, second.Status("bitcoind").Downloaded,
+		"a variant the network never boots must not read as downloaded")
+
+	coreCfg, err := second.getConfig("bitcoind")
+	require.NoError(t, err)
+	ch, err := second.download.Download(context.Background(), coreCfg, second.CurrentNetwork(), true)
+	require.NoError(t, err)
+	for p := range ch {
+		require.NoError(t, p.Error)
+	}
+
+	patched := coreCfg.Variants["patched"]
+	st := second.Status("bitcoind")
+	assert.True(t, st.Downloaded)
+	assert.Equal(t, CoreBinaryPath(dataDir, patched, "bitcoind"), st.BinaryPath)
+}
+
+// The CLI resolves a drynet path from the generation it is given, so the
+// subfolder carries that generation instead of the raw placeholder.
+func TestIntegration_ActiveCoreBinaryPath_ExpandsDrynetPlaceholder(t *testing.T) {
+	dataDir := t.TempDir()
+	bwDir := t.TempDir()
+
+	cfg := makeBitcoindCoreConfig("http://unused/")
+	cfg.Variants["drynet"] = CoreVariantSpec{
+		ID:                "drynet",
+		Subfolder:         "{drynet}",
+		BaseURL:           "http://unused/",
+		Files:             map[string]string{currentPlatform(): "L1-ecash-bitcoin-{drynet}.zip"},
+		AvailableNetworks: []string{"drynet"},
+	}
+	require.NoError(t, SaveSettings(bwDir, OrchestratorSettings{CoreVariant: "drynet"}))
+
+	assert.Equal(t, filepath.Join(BinDir(dataDir), "drynet4", "bitcoind"),
+		ActiveCoreBinaryPath(dataDir, bwDir, []BinaryConfig{cfg}, "bitcoind", "drynet", "drynet4"))
+
+	// The daemon keeps its generation until it restarts, and the confirm
+	// writes the next one to the cache at once. The path must follow the
+	// daemon, or `wipe bitcoind` deletes a build no process runs.
+	require.NoError(t, netcatalog.Save(bwDir, catalogWithDrynet(t, "drynet5")))
+	assert.Equal(t, filepath.Join(BinDir(dataDir), "drynet4", "bitcoind"),
+		ActiveCoreBinaryPath(dataDir, bwDir, []BinaryConfig{cfg}, "bitcoind", "drynet", "drynet4"))
+
+	// No generation must never leave the placeholder in the path.
+	assert.Equal(t, filepath.Join(BinDir(dataDir), netcatalog.EmbeddedDrynetID(), "bitcoind"),
+		ActiveCoreBinaryPath(dataDir, bwDir, []BinaryConfig{cfg}, "bitcoind", "drynet", ""))
 }

--- a/sidechain-orchestrator/core_variants_test.go
+++ b/sidechain-orchestrator/core_variants_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"github.com/rs/zerolog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -43,15 +44,15 @@ func makeBitcoindCoreConfig(baseURL string) BinaryConfig {
 func TestCoreBinaryPath(t *testing.T) {
 	dir := t.TempDir()
 
-	// All variants resolve to the single bin/bitcoind location — variant
-	// switching wipes-and-replaces, no per-variant subfolders.
-	v := CoreVariantSpec{ID: "core", Subfolder: "bitcoin"}
-	got := CoreBinaryPath(dir, v, "bitcoind")
-	want := BinaryPath(dir, "bitcoind")
-	assert.Equal(t, want, got)
+	// Each variant owns a subfolder, so two variants never share a file.
+	core := CoreVariantSpec{ID: "core", Subfolder: "bitcoin"}
+	knots := CoreVariantSpec{ID: "knots", Subfolder: "knots"}
+	assert.Equal(t, filepath.Join(BinDir(dir), "bitcoin", "bitcoind"), CoreBinaryPath(dir, core, "bitcoind"))
+	assert.Equal(t, filepath.Join(BinDir(dir), "knots", "bitcoind"), CoreBinaryPath(dir, knots, "bitcoind"))
+	assert.NotEqual(t, CoreBinaryPath(dir, core, "bitcoind"), CoreBinaryPath(dir, knots, "bitcoind"))
 
-	v2 := CoreVariantSpec{ID: "x"}
-	assert.Equal(t, BinaryPath(dir, "bitcoind"), CoreBinaryPath(dir, v2, "bitcoind"))
+	// No subfolder keeps the flat layout for callers with no spec.
+	assert.Equal(t, BinaryPath(dir, "bitcoind"), CoreBinaryPath(dir, CoreVariantSpec{ID: "x"}, "bitcoind"))
 }
 
 func TestCoreVariantSpec_AvailableOn(t *testing.T) {
@@ -168,15 +169,19 @@ func TestDownload_VariantSelectsURLAndDestination(t *testing.T) {
 	assert.True(t, last.Done)
 	assert.Equal(t, "/knots.zip", requested, "must hit the variant's filename")
 
-	// All variants share bin/bitcoind — no per-variant subfolder.
+	// The extract has to land in the variant's own subfolder, so a stat of
+	// that path proves the build is the selected one.
 	binName := "bitcoind"
 	if runtime.GOOS == "windows" {
 		binName += ".exe"
 	}
-	expected := filepath.Join(BinDir(dir), binName)
+	knots := cfg.Variants["knots"]
+	expected := filepath.Join(BinDir(dir), knots.Subfolder, binName)
 	got, err := os.ReadFile(expected)
 	require.NoError(t, err)
 	assert.Equal(t, "knots-bin", string(got))
+	assert.NoFileExists(t, filepath.Join(BinDir(dir), binName),
+		"the flat path must stay empty, it is what let a stale build boot")
 }
 
 func TestDownload_VariantSkipsWhenInstalled(t *testing.T) {
@@ -221,5 +226,59 @@ func TestOrchestrator_ListCoreVariants(t *testing.T) {
 			got := variantIDs(o.ListCoreVariants())
 			assert.ElementsMatch(t, tc.want, got)
 		})
+	}
+}
+
+// The incident this layout fixes: a stale stock Core sat in the shared
+// bin/bitcoind, the boot check stated that path, and Core ran chain=main
+// against the drynet datadir. Each variant must own its own file, and the
+// drynet generation must ride in the subfolder so a rollover moves too.
+func TestCoreBinaryPathSeparatesEveryVariant(t *testing.T) {
+	dir := t.TempDir()
+	cfg := expandDrynetPlaceholder(makeBitcoindCoreConfig("http://example/"), "drynet4")
+
+	seen := map[string]string{}
+	for id, v := range cfg.Variants {
+		path := CoreBinaryPath(dir, v, "bitcoind")
+		require.NotEqual(t, BinaryPath(dir, "bitcoind"), path, "variant %s must not use the flat path", id)
+		if other, clash := seen[path]; clash {
+			t.Fatalf("variants %s and %s share %s", id, other, path)
+		}
+		seen[path] = id
+	}
+
+}
+
+// The shipped chains_config.json is the real composition: it is the file that
+// gives drynet a {drynet} subfolder, so the generation has to reach the path.
+func TestCoreBinaryPathCarriesTheDrynetGeneration(t *testing.T) {
+	dir := t.TempDir()
+	configs := LoadConfigFile("chains_config.json", zerolog.Nop())
+	require.NotEmpty(t, configs, "the shipped chains_config.json must parse")
+
+	var core BinaryConfig
+	for _, c := range configs {
+		if c.IsMainchainCore() {
+			core = c
+			break
+		}
+	}
+	require.NotEmpty(t, core.Variants, "no mainchain core config in chains_config.json")
+
+	four := expandDrynetPlaceholder(core, "drynet4").Variants["drynet"]
+	five := expandDrynetPlaceholder(core, "drynet5").Variants["drynet"]
+	assert.Equal(t, filepath.Join(BinDir(dir), "drynet4", "bitcoind"), CoreBinaryPath(dir, four, "bitcoind"))
+	assert.NotEqual(t, CoreBinaryPath(dir, four, "bitcoind"), CoreBinaryPath(dir, five, "bitcoind"),
+		"a generation rollover must resolve to a new file")
+
+	// Every shipped variant keeps its own file, stock Core included.
+	seen := map[string]string{}
+	for id, v := range expandDrynetPlaceholder(core, "drynet4").Variants {
+		path := CoreBinaryPath(dir, v, "bitcoind")
+		require.NotEqual(t, BinaryPath(dir, "bitcoind"), path, "variant %s must not use the flat path", id)
+		if other, clash := seen[path]; clash {
+			t.Fatalf("variants %s and %s share %s", id, other, path)
+		}
+		seen[path] = id
 	}
 }

--- a/sidechain-orchestrator/download.go
+++ b/sidechain-orchestrator/download.go
@@ -251,7 +251,7 @@ func (d *DownloadManager) DownloadWithOptions(ctx context.Context, config Binary
 			return
 		}
 
-		hasCLI, err := d.extractBinary(savePath, config, target.ExtractName, target.ExtractSubfolder, d.dataDir, network, target.IsTestBuild)
+		hasCLI, err := d.extractBinary(savePath, config, target, d.dataDir, network)
 		if err != nil {
 			d.log.Error().Err(err).Str("binary", config.Name).Msg("extract failed")
 			send(DownloadProgress{Error: fmt.Errorf("extract: %w", err)})
@@ -496,10 +496,16 @@ func (d *DownloadManager) downloadFile(ctx context.Context, url, savePath string
 // extractBinary extracts a downloaded archive to the bin directory.
 // Returns hasCLI=true iff a companion CLI binary (name contains "-cli") was
 // extracted alongside the main binary. Raw binaries never have a CLI.
-func (d *DownloadManager) extractBinary(archivePath string, config BinaryConfig, extractName, stripPrefix, dataDir, network string, hasSCVariant bool) (bool, error) {
+func (d *DownloadManager) extractBinary(archivePath string, config BinaryConfig, target DownloadTarget, dataDir, network string) (bool, error) {
+	extractName, stripPrefix := target.ExtractName, target.ExtractSubfolder
+	hasSCVariant := target.IsTestBuild
 	destDir := BinDir(dataDir)
 
 	switch {
+	case target.BinSubfolder != "":
+		// Each Core variant owns a subfolder, so the extract has to follow
+		// BinPath or the boot check stats a directory nothing wrote to.
+		destDir = filepath.Join(destDir, target.BinSubfolder)
 	case hasSCVariant:
 		// Test sidechain builds need a private dir so per-binary lib/data
 		// trees don't collide.
@@ -1013,6 +1019,9 @@ type DownloadTarget struct {
 	ExtractSubfolder string
 	// IsTestBuild routes extraction to the test build directory.
 	IsTestBuild bool
+	// BinSubfolder is the Core variant's directory under bin/, empty for
+	// everything else. Extraction must land where BinPath says it does.
+	BinSubfolder string
 }
 
 // ResolveTarget picks the Core variant, the test sidechain build, or the plain
@@ -1041,6 +1050,7 @@ func (d *DownloadManager) ResolveTarget(config BinaryConfig, network string, opt
 	switch {
 	case hasVariant:
 		target.BinPath = CoreBinaryPath(d.dataDir, variant, config.BinaryName)
+		target.BinSubfolder = variant.Subfolder
 		target.FileName, _ = variant.FileForPlatform()
 		target.BaseURL = variant.BaseURL
 		target.InFlightKey = config.Name + ":" + variant.ID

--- a/sidechain-orchestrator/network_catalog.go
+++ b/sidechain-orchestrator/network_catalog.go
@@ -363,9 +363,6 @@ func (o *Orchestrator) wipeOnDrynetGenerationChange(ctx context.Context, oldID, 
 		Str("current", newID).
 		Msg("drynet generation changed, wiping stale chain data")
 
-	// The drynet build is per generation, and every variant shares one path.
-	o.removeCoreBinary()
-
 	// Synchronous: the caller persists the new generation next, and recording
 	// a wipe that has not happened is worse than not wiping at all. Runs on
 	// the refresh goroutine, so a slow volume cannot delay startup.

--- a/sidechain-orchestrator/network_catalog_pending_test.go
+++ b/sidechain-orchestrator/network_catalog_pending_test.go
@@ -188,30 +188,49 @@ func TestPromotionIsANoOpForTheSameGeneration(t *testing.T) {
 
 // Core is per-chain and every variant shares one path, so a build left by the
 // outgoing network must not survive into the incoming one.
-func TestSwappingNetworksDropsTheCoreBinary(t *testing.T) {
+func TestSwappingNetworksResolvesTheIncomingBuild(t *testing.T) {
 	o := drynetOnPendingGeneration(t)
-	core := CoreBinaryPath(o.DataDir, CoreVariantSpec{}, "bitcoind")
-	require.NoError(t, os.MkdirAll(filepath.Dir(core), 0o755))
-	require.NoError(t, os.WriteFile(core, []byte("drynet2 build"), 0o755))
+	stale := writeResolvedCoreBinary(t, o, "drynet2 build")
 
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
 
-	require.NoFileExists(t, core, "the outgoing network's bitcoind must be gone")
+	fresh := resolvedCoreBinaryPath(t, o)
+	require.NotEqual(t, stale, fresh, "mainnet must not resolve to the drynet build")
+	require.NoFileExists(t, fresh, "mainnet must read as not-downloaded so boot fetches its own build")
+	require.FileExists(t, stale, "the drynet build stays cached for the swap back")
 }
 
 // The drynet build is per generation even though the variant id doesn't change.
-func TestGenerationChangeDropsTheCoreBinary(t *testing.T) {
+// The generation rides in the subfolder, so a rollover resolves to a new path.
+func TestGenerationChangeResolvesANewCoreBinary(t *testing.T) {
 	o := drynetOnPendingGeneration(t)
 	o.ResolveNetworkCatalog(context.Background())
 	require.NoError(t, o.ConfirmPendingDrynetGeneration(context.Background()))
 
-	core := CoreBinaryPath(o.DataDir, CoreVariantSpec{}, "bitcoind")
-	require.NoError(t, os.MkdirAll(filepath.Dir(core), 0o755))
-	require.NoError(t, os.WriteFile(core, []byte("drynet2 build"), 0o755))
+	stale := writeResolvedCoreBinary(t, o, "drynet2 build")
 
 	o.ResolveNetworkCatalog(context.Background())
 
-	require.NoFileExists(t, core, "the retired generation's bitcoind must be gone")
+	fresh := resolvedCoreBinaryPath(t, o)
+	require.NotEqual(t, stale, fresh, "the retired generation's build must not resolve")
+	require.NoFileExists(t, fresh, "the new generation must read as not-downloaded")
+}
+
+// resolvedCoreBinaryPath is the bitcoind path the download and process managers
+// agree on for the orchestrator's current network.
+func resolvedCoreBinaryPath(t *testing.T, o *Orchestrator) string {
+	t.Helper()
+	v, ok := o.download.CoreVariant()
+	require.True(t, ok, "no core variant resolves for network %s", o.Network)
+	return CoreBinaryPath(o.DataDir, v, "bitcoind")
+}
+
+func writeResolvedCoreBinary(t *testing.T, o *Orchestrator, body string) string {
+	t.Helper()
+	path := resolvedCoreBinaryPath(t, o)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o755))
+	return path
 }
 
 // Generations publish their own seed port — drynet4 answers on 8533 — so a

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -315,28 +315,9 @@ func New(dataDir, network, bitwindowDir string, configs []BinaryConfig, log zero
 		log:          log.With().Str("component", "orchestrator").Logger(),
 	}
 
-	// Variant resolver shared by download + process managers. The persisted
-	// ID wins when it's available on the current network; otherwise we clamp
-	// to the first network-compatible variant so a user who switched
-	// networks doesn't end up launching the wrong build. knots is always
-	// ranked last in the fallback order — pure alphabetical was silently
-	// picking it over vanilla / drivechain-patched on signet.
+	// Variant resolver shared by download + process managers.
 	variantResolver := func(c BinaryConfig) (CoreVariantSpec, bool) {
-		if !c.IsMainchainCore() {
-			return CoreVariantSpec{}, false
-		}
-		id := orch.Settings.CoreVariant()
-		if v, ok := c.Variants[id]; ok && v.AvailableOn(orch.Network) {
-			return v, true
-		}
-		available := FilterVariantsForNetwork(c.Variants, orch.Network)
-		if len(available) == 0 {
-			return CoreVariantSpec{}, false
-		}
-		sort.Slice(available, func(i, j int) bool {
-			return preferenceLess(available[i].ID, available[j].ID)
-		})
-		return available[0], true
+		return ResolveCoreVariant(c, orch.Settings.CoreVariant(), orch.CurrentNetwork())
 	}
 	orch.download.CoreVariant = func() (CoreVariantSpec, bool) {
 		// Through the locked accessor: a config reload rewrites this map while
@@ -677,8 +658,8 @@ func (o *Orchestrator) StatusWithOptions(name string, opts DownloadOptions) Bina
 	// process can come from the other one — a sidechain app boots its prod
 	// backend under the same name — so the release check must not read its path.
 	requestedPath := BinaryPath(o.DataDir, config.BinaryName)
-	if config.IsMainchainCore() && o.Settings != nil {
-		if v, ok := config.Variants[o.Settings.CoreVariant()]; ok {
+	if config.IsMainchainCore() && o.process.CoreVariant != nil {
+		if v, ok := o.process.CoreVariant(config); ok {
 			requestedPath = CoreBinaryPath(o.DataDir, v, config.BinaryName)
 		}
 	}
@@ -1984,15 +1965,6 @@ func (o *Orchestrator) SetCoreVariant(ctx context.Context, id string) error {
 		return fmt.Errorf("persist core variant: %w", err)
 	}
 
-	// All variants share `bin/bitcoind` — wipe whatever's there so the new
-	// variant downloads clean. Without this, force=true on Download would
-	// still skip the network fetch when the file's hash matched something
-	// it shouldn't (different variant, same path).
-	binPath := CoreBinaryPath(o.DataDir, variant, coreCfg.BinaryName)
-	if err := os.Remove(binPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("wipe existing bitcoind: %w", err)
-	}
-
 	progressCh, err := o.download.Download(ctx, coreCfg, o.Network, true)
 	if err != nil {
 		return fmt.Errorf("ensure variant binary: %w", err)
@@ -2073,10 +2045,6 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 	if err := o.purgeNetworkSwapState(n); err != nil {
 		return err
 	}
-
-	// Variants share bin/bitcoind, and the next network wants a different
-	// build, so drop it rather than boot the outgoing network's binary.
-	o.removeCoreBinary()
 
 	if err := o.BitcoinConf.UpdateNetwork(n); err != nil {
 		return fmt.Errorf("persist network: %w", err)
@@ -2351,22 +2319,6 @@ func (o *Orchestrator) defaultBootBitcoindForVariantSwap(ctx context.Context) <-
 		return out
 	}
 	return ch
-}
-
-// removeCoreBinary deletes the shared bin/bitcoind. Every Core variant lives at
-// that one path, so a build left by another network — or another drynet
-// generation — has to go before the next boot downloads the right one.
-func (o *Orchestrator) removeCoreBinary() {
-	cfg, ok := o.configs["bitcoind"]
-	if !ok {
-		return
-	}
-	path := CoreBinaryPath(o.DataDir, CoreVariantSpec{}, cfg.BinaryName)
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		o.log.Warn().Err(err).Str("path", path).Msg("could not remove bitcoind, the next boot may run the wrong build")
-		return
-	}
-	o.log.Info().Str("path", path).Msg("removed bitcoind so the next boot fetches the build this chain needs")
 }
 
 // EnforcerValidator returns a client for the enforcer's validator service.


### PR DESCRIPTION
This PR gives each Bitcoin Core variant its own subfolder under bin/, so a stale build can no longer boot against the wrong chain.