### PR TITLE
orchestrator: reset the chain to a block

### DIFF
--- a/bitwindow/server/integrationtest/backend_runtime_smoke_test.go
+++ b/bitwindow/server/integrationtest/backend_runtime_smoke_test.go
@@ -205,7 +205,7 @@ func newOrchestratorOnlyNode(t *testing.T) *orchestratorOnlyNode {
 		0o600,
 	))
 	smokeConfigs := orchestrator.AllDefaults()
-	bitcoindDestPath := orchestrator.ActiveCoreBinaryPath(bitwindowDir, bitwindowDir, smokeConfigs, "bitcoind", "regtest")
+	bitcoindDestPath := orchestrator.ActiveCoreBinaryPath(bitwindowDir, bitwindowDir, smokeConfigs, "bitcoind", "regtest", "")
 	copyManagedBinary(t, bitcoindBin, bitcoindDestPath)
 	enforcerBin := findEnforcer(t)
 	copyManagedBinary(t, enforcerBin, orchestrator.BinaryPath(bitwindowDir, "bip300301-enforcer"))
@@ -374,7 +374,7 @@ func findBitcoind(t *testing.T) string {
 	bitwindowDir := orchestrator.DefaultBitwindowDir()
 	configPath := orchestrator.ConfigFilePath(bitwindowDir)
 	configs := orchestrator.LoadConfigFile(configPath, log)
-	orchPath := orchestrator.ActiveCoreBinaryPath(dataDir, bitwindowDir, configs, "bitcoind", "regtest")
+	orchPath := orchestrator.ActiveCoreBinaryPath(dataDir, bitwindowDir, configs, "bitcoind", "regtest", "")
 
 	if _, err := os.Stat(orchPath); err == nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/sail_ui/lib/widgets/modals/chain_settings_modal.dart
+++ b/sail_ui/lib/widgets/modals/chain_settings_modal.dart
@@ -31,6 +31,7 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
   int? _chainHeight;
   int? _enforcerHeight;
   bool _chainHeightFailed = false;
+  bool _enforcerFailed = false;
   String? _error;
   // The last progress message. A finished reset keeps its result on screen.
   ResetToBlockResponse? _reset;
@@ -134,12 +135,17 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
         return;
       }
       final mainchain = status.mainchain;
+      final enforcer = status.enforcer;
       setState(() {
         if (mainchain.error.isNotEmpty) {
           _chainHeightFailed = true;
         } else {
           _chainHeight = mainchain.blocks.toInt();
         }
+        // A stopped enforcer reports an error, and its row says so rather than
+        // showing a height it never read.
+        _enforcerHeight = enforcer.error.isNotEmpty ? null : enforcer.blocks.toInt();
+        _enforcerFailed = enforcer.error.isNotEmpty;
       });
     } catch (e) {
       GetIt.I.get<Logger>().d('chain settings: could not read the height: $e');
@@ -191,6 +197,7 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
             }
             if (msg.done && msg.enforcerChecked) {
               _enforcerHeight = msg.enforcerHeight;
+              _enforcerFailed = false;
             }
           });
         },
@@ -408,7 +415,8 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
 
   Widget _chainTab(BuildContext context, SailThemeData theme) {
     final height = _chainHeight?.toString() ?? (_chainHeightFailed ? 'Unavailable' : 'Loading...');
-    final enforcer = _enforcerHeight?.toString() ?? (_chainHeightFailed ? 'Unavailable' : 'Loading...');
+    final enforcer =
+        _enforcerHeight?.toString() ?? (_chainHeightFailed || _enforcerFailed ? 'Unavailable' : 'Loading...');
 
     return SingleChildScrollView(
       child: SailColumn(

--- a/sail_ui/lib/widgets/modals/chain_settings_modal.dart
+++ b/sail_ui/lib/widgets/modals/chain_settings_modal.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -26,17 +27,16 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
   String? _resolvedBinaryPath;
   bool _loadingVersion = true;
 
-  final TextEditingController _rejectTarget = TextEditingController();
+  final TextEditingController _resetTarget = TextEditingController();
   int? _chainHeight;
+  int? _enforcerHeight;
   bool _chainHeightFailed = false;
-  bool _working = false;
   String? _error;
-  String? _result;
-  // Which call left the enforcer off Core's chain, and the block it acted on.
-  // The retry has to repeat that same call on that same block: an accept after
-  // a reject would undo the rejection, and the field may have moved on since.
-  _PendingRetry _pendingRetry = _PendingRetry.none;
-  String? _retryHash;
+  // The last progress message. A finished reset keeps its result on screen.
+  ResetToBlockResponse? _reset;
+  StreamSubscription<ResetToBlockResponse>? _resetStream;
+
+  bool get _resetting => _resetStream != null;
 
   @override
   void initState() {
@@ -48,7 +48,8 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
 
   @override
   void dispose() {
-    _rejectTarget.dispose();
+    unawaited(_resetStream?.cancel());
+    _resetTarget.dispose();
     super.dispose();
   }
 
@@ -148,126 +149,72 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
     }
   }
 
-  static final RegExp _blockHashPattern = RegExp(r'^[0-9a-fA-F]{64}$');
-
-  Future<void> _rejectBlock(BuildContext context) async {
-    final hash = _rejectTarget.text.trim();
-    if (!_blockHashPattern.hasMatch(hash)) {
-      setState(() => _error = 'Paste the 64-character hash of the block to reject.');
+  /// Starts a reset. The orchestrator resolves the target, so a bad height or
+  /// a bad hash fails before the stream opens.
+  Future<void> _startReset(BuildContext context) async {
+    final target = _resetTarget.text.trim();
+    if (target.isEmpty) {
+      setState(() => _error = 'Give a height or a block hash.');
       return;
     }
 
     await infoDialog(
       context: context,
-      title: 'Reject block $hash?',
+      title: 'Reset to block $target?',
       subtitle:
-          'It and every block above it leave the active chain, and Core takes the best remaining branch. '
-          'The enforcer rebuilds from the local Core if it does not follow.',
+          'That block and every block above it leave the active chain, then the node replays them from disk. '
+          'The blocks stay on disk, so the replay downloads nothing.',
       onConfirm: () async {
         Navigator.of(context).pop();
-        await _sendReject(hash);
+        await _runReset(target);
       },
     );
   }
 
-  Future<void> _sendReject(String hash) async {
+  Future<void> _runReset(String target) async {
     setState(() {
-      _working = true;
       _error = null;
-      _result = null;
+      _reset = null;
     });
 
-    try {
-      final resp = await GetIt.I.get<OrchestratorRPC>().rejectBlock(blockHash: hash);
-      if (!mounted) {
-        return;
-      }
-      final landed = switch (resp.outcome) {
-        RejectOutcome.REJECT_OUTCOME_SWITCHED_BRANCH => 'Core followed another branch to ${resp.coreHeight}.',
-        RejectOutcome.REJECT_OUTCOME_PARKED_ON_PARENT => 'Core parked at ${resp.coreHeight}, with no other branch yet.',
-        RejectOutcome.REJECT_OUTCOME_ALREADY_INACTIVE =>
-          'Core stays at ${resp.coreHeight}. That block already sat off the active chain.',
-        _ => 'Core is at ${resp.coreHeight}.',
-      };
-      setState(() {
-        _chainHeight = resp.coreHeight;
-        _pendingRetry = resp.enforcerError.isNotEmpty ? _PendingRetry.reject : _PendingRetry.none;
-        _retryHash = resp.enforcerError.isNotEmpty ? hash : null;
-        _result = switch (resp) {
-          _ when resp.enforcerError.isNotEmpty => '$landed The enforcer did not follow: ${resp.enforcerError}',
-          _ when !resp.enforcerChecked => '$landed The enforcer reads the chain on its next start.',
-          _ when resp.enforcerRebuilt => '$landed The enforcer rebuilds from the local Core.',
-          _ => "$landed The enforcer sits on Core's chain at ${resp.enforcerHeight}.",
-        };
-      });
-    } catch (e) {
-      if (mounted) {
-        setState(() => _error = '$e');
-      }
-    } finally {
-      if (mounted) {
-        setState(() => _working = false);
-      }
-    }
-  }
-
-  /// Repeats whichever call left the enforcer unreconciled. Both calls are safe
-  /// to repeat: Core ignores a second reject or accept of the same block, and
-  /// the reconciliation runs again either way.
-  Future<void> _runRetry(BuildContext context) async {
-    final hash = _retryHash;
-    if (hash == null) {
-      return;
-    }
-    switch (_pendingRetry) {
-      case _PendingRetry.reject:
-        await _sendReject(hash);
-      case _PendingRetry.accept:
-        await _acceptBlock(context, retryHash: hash);
-      case _PendingRetry.none:
-        return;
-    }
-  }
-
-  Future<void> _acceptBlock(BuildContext context, {String? retryHash}) async {
-    final hash = retryHash ?? _rejectTarget.text.trim();
-    if (!_blockHashPattern.hasMatch(hash)) {
-      setState(() => _error = 'Paste the 64-character hash of the block to accept.');
-      return;
-    }
+    final stream = GetIt.I.get<OrchestratorRPC>().resetToBlock(target: target);
     setState(() {
-      _working = true;
-      _error = null;
+      _resetStream = stream.listen(
+        (msg) {
+          if (!mounted) {
+            return;
+          }
+          setState(() {
+            _reset = msg;
+            if (msg.coreHeight != 0) {
+              _chainHeight = msg.coreHeight;
+            }
+            if (msg.done && msg.enforcerChecked) {
+              _enforcerHeight = msg.enforcerHeight;
+            }
+          });
+        },
+        onError: (Object e) {
+          if (!mounted) {
+            return;
+          }
+          setState(() {
+            _error = '$e';
+            _resetStream = null;
+          });
+        },
+        onDone: () {
+          if (!mounted) {
+            return;
+          }
+          setState(() {
+            _resetStream = null;
+            _resetTarget.clear();
+          });
+          unawaited(_loadChainHeight());
+        },
+      );
     });
-
-    try {
-      final resp = await GetIt.I.get<OrchestratorRPC>().acceptBlock(blockHash: hash);
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _chainHeight = resp.coreHeight;
-        // A reconciliation that failed leaves the enforcer off Core's chain.
-        // Another accept runs it again, so keep the action reachable.
-        _pendingRetry = resp.enforcerError.isNotEmpty ? _PendingRetry.accept : _PendingRetry.none;
-        _retryHash = resp.enforcerError.isNotEmpty ? hash : null;
-        final landed = 'Core accepts the block again at ${resp.coreHeight}.';
-        _result = switch (resp) {
-          _ when resp.enforcerError.isNotEmpty => '$landed The enforcer did not follow: ${resp.enforcerError}',
-          _ when !resp.enforcerChecked => '$landed The enforcer reads the chain on its next start.',
-          _ when resp.enforcerRebuilt => '$landed The enforcer rebuilds from the local Core.',
-          _ => "$landed The enforcer sits on Core's chain at ${resp.enforcerHeight}.",
-        };
-      });
-    } catch (e) {
-      if (mounted) {
-        setState(() => _error = '$e');
-      }
-    } finally {
-      if (mounted) {
-        setState(() => _working = false);
-      }
-    }
   }
 
   Future<void> _showWipeReset(BuildContext context, Binary binary) async {
@@ -460,6 +407,9 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
   }
 
   Widget _chainTab(BuildContext context, SailThemeData theme) {
+    final height = _chainHeight?.toString() ?? (_chainHeightFailed ? 'Unavailable' : 'Loading...');
+    final enforcer = _enforcerHeight?.toString() ?? (_chainHeightFailed ? 'Unavailable' : 'Loading...');
+
     return SingleChildScrollView(
       child: SailColumn(
         spacing: SailStyleValues.padding20,
@@ -470,10 +420,8 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               _FieldRow(label: 'Network', value: GetIt.I.get<BitcoinConfProvider>().network.name),
-              _FieldRow(
-                label: 'Height',
-                value: _chainHeight?.toString() ?? (_chainHeightFailed ? 'Unavailable' : 'Loading...'),
-              ),
+              _FieldRow(label: 'Core height', value: height),
+              _FieldRow(label: 'Enforcer height', value: enforcer),
             ],
           ),
           Container(
@@ -486,9 +434,10 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
               spacing: SailStyleValues.padding12,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                SailText.primary13('Reject or accept a block', bold: true),
+                SailText.primary13('Reset to Block', bold: true),
                 SailText.secondary13(
-                  'Name the block this node must not follow, by hash. It and every block above it leave the active chain, and Core takes the best remaining branch. Accept takes a rejected block back, whichever session rejected it.',
+                  'Give a height or a block hash. The node moves back to that block, then syncs forward to the tip again. '
+                  'The blocks stay on disk, so it downloads nothing.',
                   color: theme.colors.textSecondary,
                 ),
                 SailRow(
@@ -496,47 +445,82 @@ class _ChainSettingsModalState extends State<ChainSettingsModal> {
                   children: [
                     Expanded(
                       child: SailTextField(
-                        controller: _rejectTarget,
-                        hintText: 'Block hash',
+                        controller: _resetTarget,
+                        hintText: 'Height or block hash',
+                        enabled: !_resetting,
                         dense: true,
                       ),
                     ),
                     SailButton(
-                      label: 'Reject',
-                      onPressed: _working ? null : () async => _rejectBlock(context),
-                      loading: _working,
-                      loadingLabel: 'Rejecting',
-                    ),
-                    SailButton(
-                      label: 'Accept',
-                      variant: ButtonVariant.secondary,
-                      onPressed: _working ? null : () async => _acceptBlock(context),
+                      label: 'Reset to Block',
+                      onPressed: _resetting ? null : () async => _startReset(context),
+                      loading: _resetting,
+                      loadingLabel: _resetLoadingLabel(),
                     ),
                   ],
                 ),
-                if (_error != null)
-                  SailText.secondary12(_error!, color: theme.colors.error)
-                else if (_result != null)
-                  SailText.secondary12(_result!, color: theme.colors.success)
-                else
-                  SailText.secondary12(
-                    'A height names no block when two branches share it, so paste the hash. The enforcer follows the reject, and rebuilds its validator chain from the local Core if it does not.',
-                    color: theme.colors.textSecondary,
-                  ),
-                // Stays reachable after a failed call, so the enforcer can be
-                // reconciled again without undoing a rejection.
-                if (_pendingRetry != _PendingRetry.none)
-                  SailButton(
-                    label: 'Retry the enforcer',
-                    variant: ButtonVariant.ghost,
-                    onPressed: _working ? null : () async => _runRetry(context),
-                  ),
+                ..._resetStatus(theme),
               ],
             ),
           ),
         ],
       ),
     );
+  }
+
+  String _resetLoadingLabel() {
+    return switch (_reset?.phase) {
+      ResetPhase.RESET_PHASE_SYNC_FORWARD => 'Syncs forward',
+      ResetPhase.RESET_PHASE_ENFORCER => 'Enforcer',
+      _ => 'Moves back',
+    };
+  }
+
+  /// The panel under the field: the failure, the live progress, or the result.
+  List<Widget> _resetStatus(SailThemeData theme) {
+    if (_error != null) {
+      return [SailText.secondary12(_error!, color: theme.colors.error)];
+    }
+
+    final reset = _reset;
+    if (reset == null) {
+      return [
+        SailText.secondary12(
+          'A height names the block on the chain this node follows today. Paste a hash to name one exactly.',
+          color: theme.colors.textSecondary,
+        ),
+      ];
+    }
+
+    if (reset.done) {
+      return [
+        SailText.secondary12(reset.message, color: theme.colors.success),
+        SailText.secondary12(_enforcerResult(reset), color: theme.colors.textSecondary),
+      ];
+    }
+
+    return [
+      SailText.secondary12(reset.message, color: theme.colors.textSecondary),
+      if (reset.phase == ResetPhase.RESET_PHASE_SYNC_FORWARD && reset.blocksTotal != 0)
+        ProgressBar(
+          current: reset.blocksDone.toDouble(),
+          goal: reset.blocksTotal.toDouble(),
+          color: theme.colors.primary,
+        ),
+    ];
+  }
+
+  String _enforcerResult(ResetToBlockResponse reset) {
+    if (reset.enforcerError.isNotEmpty) {
+      return 'The enforcer did not follow: ${reset.enforcerError}';
+    }
+    if (!reset.enforcerChecked) {
+      return 'The enforcer reads the chain on its next start.';
+    }
+    if (reset.enforcerRebuilt) {
+      return 'The enforcer rebuilds from the local Core.';
+    }
+    return "The enforcer sits on Core's chain at ${reset.enforcerHeight}.";
   }
 
   Widget _footer(BuildContext context, ChainSettingsViewModel viewModel) {
@@ -781,4 +765,3 @@ class ChainSettingsViewModel extends BaseViewModel {
 }
 
 /// Which call the retry button repeats.
-enum _PendingRetry { none, reject, accept }

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -936,6 +936,64 @@ func (h *Handler) AcceptBlock(ctx context.Context, req *connect.Request[pb.Accep
 	}), nil
 }
 
+// ResetToBlock moves the chain back to a block, then syncs forward to the tip
+// again, streaming one message per phase. A bad target fails before the stream
+// opens, so the caller sees it as an RPC error.
+func (h *Handler) ResetToBlock(
+	ctx context.Context,
+	req *connect.Request[pb.ResetToBlockRequest],
+	stream *connect.ServerStream[pb.ResetToBlockResponse],
+) error {
+	ch, err := h.orch.ResetToBlock(
+		ctx,
+		req.Msg.Target,
+		time.Duration(req.Msg.EnforcerWaitSeconds)*time.Second,
+	)
+	if err != nil {
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	for p := range ch {
+		if p.Error != nil {
+			return connect.NewError(connect.CodeFailedPrecondition, p.Error)
+		}
+		if err := stream.Send(&pb.ResetToBlockResponse{
+			Phase:           resetPhaseToProto(p.Phase),
+			Message:         p.Message,
+			TargetHeight:    p.TargetHeight,
+			TargetHash:      p.TargetHash,
+			CoreHeight:      p.CoreHeight,
+			TipHeight:       p.TipHeight,
+			BlocksDone:      p.BlocksDone,
+			BlocksTotal:     p.BlocksTotal,
+			EnforcerHeight:  p.EnforcerHeight,
+			EnforcerChecked: p.EnforcerChecked,
+			EnforcerRebuilt: p.EnforcerRebuilt,
+			EnforcerError:   p.EnforcerError,
+			Done:            p.Done,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resetPhaseToProto(p orchestrator.ResetPhase) pb.ResetPhase {
+	switch p {
+	case orchestrator.ResetPhaseResolve:
+		return pb.ResetPhase_RESET_PHASE_RESOLVE
+	case orchestrator.ResetPhaseMoveBack:
+		return pb.ResetPhase_RESET_PHASE_MOVE_BACK
+	case orchestrator.ResetPhaseSyncForward:
+		return pb.ResetPhase_RESET_PHASE_SYNC_FORWARD
+	case orchestrator.ResetPhaseEnforcer:
+		return pb.ResetPhase_RESET_PHASE_ENFORCER
+	case orchestrator.ResetPhaseDone:
+		return pb.ResetPhase_RESET_PHASE_DONE
+	}
+	return pb.ResetPhase_RESET_PHASE_UNSPECIFIED
+}
+
 func statusToProto(s orchestrator.BinaryStatus) *pb.BinaryStatusMsg {
 	startupLogs := lo.Map(s.StartupLogs, func(l orchestrator.StartupLogLine, _ int) *pb.StartupLogEntryMsg {
 		return &pb.StartupLogEntryMsg{

--- a/sidechain-orchestrator/commands/reset.go
+++ b/sidechain-orchestrator/commands/reset.go
@@ -19,6 +19,7 @@ var resetCommand = &cli.Command{
 		resetRunCommand,
 		rejectBlockCommand,
 		acceptBlockCommand,
+		resetToBlockCommand,
 	},
 }
 
@@ -74,6 +75,78 @@ var rejectBlockCommand = &cli.Command{
 		fmt.Printf("enforcer: on core's chain, tip %d\n", resp.Msg.EnforcerHeight)
 		return nil
 	},
+}
+
+var resetToBlockCommand = &cli.Command{
+	Name:      "reset-to-block",
+	Usage:     "Move the chain back to a block, then sync forward to the tip again",
+	ArgsUsage: "<height|hash>",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{Name: "yes", Usage: "skip the confirmation prompt"},
+		&cli.UintFlag{Name: "enforcer-wait", Usage: "seconds to wait for the enforcer to follow before rebuilding it"},
+	},
+	Action: func(cctx *cli.Context) error {
+		target := cctx.Args().First()
+		if cctx.NArg() != 1 || target == "" {
+			return fmt.Errorf("pass the height or the 64-character hash of the block to reset to")
+		}
+
+		if err := confirmOrAbort(cctx, fmt.Sprintf("this drops every block above %s, then replays them. proceed?", target)); err != nil {
+			return err
+		}
+
+		req := &pb.ResetToBlockRequest{
+			Target:              target,
+			EnforcerWaitSeconds: uint32(cctx.Uint("enforcer-wait")),
+		}
+		stream, err := newClient(cctx).ResetToBlock(cctx.Context, connect.NewRequest(req))
+		if err != nil {
+			return err
+		}
+		defer func() { _ = stream.Close() }()
+
+		var last *pb.ResetToBlockResponse
+		for stream.Receive() {
+			msg := stream.Msg()
+			last = msg
+			fmt.Printf("%-13s %s\n", resetPhaseLabel(msg.Phase), msg.Message)
+		}
+		if err := stream.Err(); err != nil {
+			return err
+		}
+		if last == nil {
+			return fmt.Errorf("the reset reported nothing")
+		}
+		if last.EnforcerError != "" {
+			return fmt.Errorf("core replayed but the enforcer did not follow: %s", last.EnforcerError)
+		}
+		if !last.EnforcerChecked {
+			fmt.Println("enforcer:     not queried, it reads the chain on its next start")
+			return nil
+		}
+		if last.EnforcerRebuilt {
+			fmt.Println("enforcer:     validator chain deleted, rebuilds from the local core")
+			return nil
+		}
+		fmt.Printf("enforcer:     on core's chain, tip %d\n", last.EnforcerHeight)
+		return nil
+	},
+}
+
+func resetPhaseLabel(p pb.ResetPhase) string {
+	switch p {
+	case pb.ResetPhase_RESET_PHASE_RESOLVE:
+		return "resolve:"
+	case pb.ResetPhase_RESET_PHASE_MOVE_BACK:
+		return "move back:"
+	case pb.ResetPhase_RESET_PHASE_SYNC_FORWARD:
+		return "sync forward:"
+	case pb.ResetPhase_RESET_PHASE_ENFORCER:
+		return "enforcer:"
+	case pb.ResetPhase_RESET_PHASE_DONE:
+		return "done:"
+	}
+	return "reset:"
 }
 
 var acceptBlockCommand = &cli.Command{

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -297,6 +297,70 @@ func (RejectOutcome) EnumDescriptor() ([]byte, []int) {
 	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{3}
 }
 
+// Which step of a reset a progress message reports.
+type ResetPhase int32
+
+const (
+	ResetPhase_RESET_PHASE_UNSPECIFIED ResetPhase = 0
+	// The target reads as a height or a hash, and Core holds the block.
+	ResetPhase_RESET_PHASE_RESOLVE ResetPhase = 1
+	// Core drops the target block and every block above it.
+	ResetPhase_RESET_PHASE_MOVE_BACK ResetPhase = 2
+	// Core re-validates the dropped blocks from disk and climbs to the old tip.
+	ResetPhase_RESET_PHASE_SYNC_FORWARD ResetPhase = 3
+	// The enforcer comes back onto the chain Core follows.
+	ResetPhase_RESET_PHASE_ENFORCER ResetPhase = 4
+	// The reset is over.
+	ResetPhase_RESET_PHASE_DONE ResetPhase = 5
+)
+
+// Enum value maps for ResetPhase.
+var (
+	ResetPhase_name = map[int32]string{
+		0: "RESET_PHASE_UNSPECIFIED",
+		1: "RESET_PHASE_RESOLVE",
+		2: "RESET_PHASE_MOVE_BACK",
+		3: "RESET_PHASE_SYNC_FORWARD",
+		4: "RESET_PHASE_ENFORCER",
+		5: "RESET_PHASE_DONE",
+	}
+	ResetPhase_value = map[string]int32{
+		"RESET_PHASE_UNSPECIFIED":  0,
+		"RESET_PHASE_RESOLVE":      1,
+		"RESET_PHASE_MOVE_BACK":    2,
+		"RESET_PHASE_SYNC_FORWARD": 3,
+		"RESET_PHASE_ENFORCER":     4,
+		"RESET_PHASE_DONE":         5,
+	}
+)
+
+func (x ResetPhase) Enum() *ResetPhase {
+	p := new(ResetPhase)
+	*p = x
+	return p
+}
+
+func (x ResetPhase) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ResetPhase) Descriptor() protoreflect.EnumDescriptor {
+	return file_orchestrator_v1_orchestrator_proto_enumTypes[4].Descriptor()
+}
+
+func (ResetPhase) Type() protoreflect.EnumType {
+	return &file_orchestrator_v1_orchestrator_proto_enumTypes[4]
+}
+
+func (x ResetPhase) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ResetPhase.Descriptor instead.
+func (ResetPhase) EnumDescriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{4}
+}
+
 type BinaryStatusMsg struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	Name            string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -3785,6 +3849,217 @@ func (x *AcceptBlockResponse) GetEnforcerChecked() bool {
 	return false
 }
 
+type ResetToBlockRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The block to move back to. A 64-character hash names one block. Anything
+	// else reads as a decimal height, and a height resolves against the chain
+	// this node follows today.
+	Target string `protobuf:"bytes,1,opt,name=target,proto3" json:"target,omitempty"`
+	// How long to wait for the enforcer to follow before its validator chain is
+	// deleted. Zero picks the default.
+	EnforcerWaitSeconds uint32 `protobuf:"varint,2,opt,name=enforcer_wait_seconds,json=enforcerWaitSeconds,proto3" json:"enforcer_wait_seconds,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *ResetToBlockRequest) Reset() {
+	*x = ResetToBlockRequest{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[59]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResetToBlockRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResetToBlockRequest) ProtoMessage() {}
+
+func (x *ResetToBlockRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[59]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResetToBlockRequest.ProtoReflect.Descriptor instead.
+func (*ResetToBlockRequest) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{59}
+}
+
+func (x *ResetToBlockRequest) GetTarget() string {
+	if x != nil {
+		return x.Target
+	}
+	return ""
+}
+
+func (x *ResetToBlockRequest) GetEnforcerWaitSeconds() uint32 {
+	if x != nil {
+		return x.EnforcerWaitSeconds
+	}
+	return 0
+}
+
+type ResetToBlockResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Phase ResetPhase             `protobuf:"varint,1,opt,name=phase,proto3,enum=orchestrator.v1.ResetPhase" json:"phase,omitempty"`
+	// Human-readable status for the phase.
+	Message string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	// The block the reset moves back to.
+	TargetHeight uint32 `protobuf:"varint,3,opt,name=target_height,json=targetHeight,proto3" json:"target_height,omitempty"`
+	TargetHash   string `protobuf:"bytes,4,opt,name=target_hash,json=targetHash,proto3" json:"target_hash,omitempty"`
+	// Core's tip as the phase reports it. It falls to target_height - 1 on the
+	// move back, then climbs again.
+	CoreHeight uint32 `protobuf:"varint,5,opt,name=core_height,json=coreHeight,proto3" json:"core_height,omitempty"`
+	// Core's tip before the reset. The replay ends here.
+	TipHeight uint32 `protobuf:"varint,6,opt,name=tip_height,json=tipHeight,proto3" json:"tip_height,omitempty"`
+	// Blocks re-validated so far, out of the blocks the reset drops.
+	BlocksDone  uint32 `protobuf:"varint,7,opt,name=blocks_done,json=blocksDone,proto3" json:"blocks_done,omitempty"`
+	BlocksTotal uint32 `protobuf:"varint,8,opt,name=blocks_total,json=blocksTotal,proto3" json:"blocks_total,omitempty"`
+	// The enforcer's tip afterwards. Zero when the enforcer is stopped.
+	EnforcerHeight uint32 `protobuf:"varint,9,opt,name=enforcer_height,json=enforcerHeight,proto3" json:"enforcer_height,omitempty"`
+	// False when the enforcer was never asked, so enforcer_height carries no
+	// reading and must not be shown as one.
+	EnforcerChecked bool `protobuf:"varint,10,opt,name=enforcer_checked,json=enforcerChecked,proto3" json:"enforcer_checked,omitempty"`
+	// True when the enforcer did not follow, so its validator chain was deleted
+	// and it rebuilds from the local Core.
+	EnforcerRebuilt bool `protobuf:"varint,11,opt,name=enforcer_rebuilt,json=enforcerRebuilt,proto3" json:"enforcer_rebuilt,omitempty"`
+	// Empty on success; otherwise why the enforcer could not be brought back
+	// onto Core's chain.
+	EnforcerError string `protobuf:"bytes,12,opt,name=enforcer_error,json=enforcerError,proto3" json:"enforcer_error,omitempty"`
+	// Set on the last message.
+	Done          bool `protobuf:"varint,13,opt,name=done,proto3" json:"done,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResetToBlockResponse) Reset() {
+	*x = ResetToBlockResponse{}
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResetToBlockResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResetToBlockResponse) ProtoMessage() {}
+
+func (x *ResetToBlockResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResetToBlockResponse.ProtoReflect.Descriptor instead.
+func (*ResetToBlockResponse) Descriptor() ([]byte, []int) {
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *ResetToBlockResponse) GetPhase() ResetPhase {
+	if x != nil {
+		return x.Phase
+	}
+	return ResetPhase_RESET_PHASE_UNSPECIFIED
+}
+
+func (x *ResetToBlockResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *ResetToBlockResponse) GetTargetHeight() uint32 {
+	if x != nil {
+		return x.TargetHeight
+	}
+	return 0
+}
+
+func (x *ResetToBlockResponse) GetTargetHash() string {
+	if x != nil {
+		return x.TargetHash
+	}
+	return ""
+}
+
+func (x *ResetToBlockResponse) GetCoreHeight() uint32 {
+	if x != nil {
+		return x.CoreHeight
+	}
+	return 0
+}
+
+func (x *ResetToBlockResponse) GetTipHeight() uint32 {
+	if x != nil {
+		return x.TipHeight
+	}
+	return 0
+}
+
+func (x *ResetToBlockResponse) GetBlocksDone() uint32 {
+	if x != nil {
+		return x.BlocksDone
+	}
+	return 0
+}
+
+func (x *ResetToBlockResponse) GetBlocksTotal() uint32 {
+	if x != nil {
+		return x.BlocksTotal
+	}
+	return 0
+}
+
+func (x *ResetToBlockResponse) GetEnforcerHeight() uint32 {
+	if x != nil {
+		return x.EnforcerHeight
+	}
+	return 0
+}
+
+func (x *ResetToBlockResponse) GetEnforcerChecked() bool {
+	if x != nil {
+		return x.EnforcerChecked
+	}
+	return false
+}
+
+func (x *ResetToBlockResponse) GetEnforcerRebuilt() bool {
+	if x != nil {
+		return x.EnforcerRebuilt
+	}
+	return false
+}
+
+func (x *ResetToBlockResponse) GetEnforcerError() string {
+	if x != nil {
+		return x.EnforcerError
+	}
+	return ""
+}
+
+func (x *ResetToBlockResponse) GetDone() bool {
+	if x != nil {
+		return x.Done
+	}
+	return false
+}
+
 type GetCoreMempoolInfoRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -3793,7 +4068,7 @@ type GetCoreMempoolInfoRequest struct {
 
 func (x *GetCoreMempoolInfoRequest) Reset() {
 	*x = GetCoreMempoolInfoRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[59]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3805,7 +4080,7 @@ func (x *GetCoreMempoolInfoRequest) String() string {
 func (*GetCoreMempoolInfoRequest) ProtoMessage() {}
 
 func (x *GetCoreMempoolInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[59]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3818,7 +4093,7 @@ func (x *GetCoreMempoolInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreMempoolInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetCoreMempoolInfoRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{59}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{61}
 }
 
 // Mirrors bitcoind's getmempoolinfo. Aggregate stats — distinct from
@@ -3851,7 +4126,7 @@ type GetCoreMempoolInfoResponse struct {
 
 func (x *GetCoreMempoolInfoResponse) Reset() {
 	*x = GetCoreMempoolInfoResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[60]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3863,7 +4138,7 @@ func (x *GetCoreMempoolInfoResponse) String() string {
 func (*GetCoreMempoolInfoResponse) ProtoMessage() {}
 
 func (x *GetCoreMempoolInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[60]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3876,7 +4151,7 @@ func (x *GetCoreMempoolInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreMempoolInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetCoreMempoolInfoResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{60}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *GetCoreMempoolInfoResponse) GetLoaded() bool {
@@ -3964,7 +4239,7 @@ type GetBmmContextRequest struct {
 
 func (x *GetBmmContextRequest) Reset() {
 	*x = GetBmmContextRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[61]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3976,7 +4251,7 @@ func (x *GetBmmContextRequest) String() string {
 func (*GetBmmContextRequest) ProtoMessage() {}
 
 func (x *GetBmmContextRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[61]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3989,7 +4264,7 @@ func (x *GetBmmContextRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBmmContextRequest.ProtoReflect.Descriptor instead.
 func (*GetBmmContextRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{61}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{63}
 }
 
 // Parent-chain state a BMM miner bids against. A sidechain block only
@@ -4010,7 +4285,7 @@ type GetBmmContextResponse struct {
 
 func (x *GetBmmContextResponse) Reset() {
 	*x = GetBmmContextResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[62]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4022,7 +4297,7 @@ func (x *GetBmmContextResponse) String() string {
 func (*GetBmmContextResponse) ProtoMessage() {}
 
 func (x *GetBmmContextResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[62]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4035,7 +4310,7 @@ func (x *GetBmmContextResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBmmContextResponse.ProtoReflect.Descriptor instead.
 func (*GetBmmContextResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{62}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *GetBmmContextResponse) GetMainchainHeight() int32 {
@@ -4091,7 +4366,7 @@ type CoreRawCallRequest struct {
 
 func (x *CoreRawCallRequest) Reset() {
 	*x = CoreRawCallRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[63]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4103,7 +4378,7 @@ func (x *CoreRawCallRequest) String() string {
 func (*CoreRawCallRequest) ProtoMessage() {}
 
 func (x *CoreRawCallRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[63]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4116,7 +4391,7 @@ func (x *CoreRawCallRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoreRawCallRequest.ProtoReflect.Descriptor instead.
 func (*CoreRawCallRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{63}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *CoreRawCallRequest) GetMethod() string {
@@ -4150,7 +4425,7 @@ type CoreRawCallResponse struct {
 
 func (x *CoreRawCallResponse) Reset() {
 	*x = CoreRawCallResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[64]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4162,7 +4437,7 @@ func (x *CoreRawCallResponse) String() string {
 func (*CoreRawCallResponse) ProtoMessage() {}
 
 func (x *CoreRawCallResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[64]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4175,7 +4450,7 @@ func (x *CoreRawCallResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoreRawCallResponse.ProtoReflect.Descriptor instead.
 func (*CoreRawCallResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{64}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *CoreRawCallResponse) GetResultJson() string {
@@ -4193,7 +4468,7 @@ type GetForkStatusRequest struct {
 
 func (x *GetForkStatusRequest) Reset() {
 	*x = GetForkStatusRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[65]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4205,7 +4480,7 @@ func (x *GetForkStatusRequest) String() string {
 func (*GetForkStatusRequest) ProtoMessage() {}
 
 func (x *GetForkStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[65]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4218,7 +4493,7 @@ func (x *GetForkStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetForkStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetForkStatusRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{65}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{67}
 }
 
 // Canonical fork snapshot produced by the orchestrator's single ForkEngine.
@@ -4254,7 +4529,7 @@ type GetForkStatusResponse struct {
 
 func (x *GetForkStatusResponse) Reset() {
 	*x = GetForkStatusResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[66]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4266,7 +4541,7 @@ func (x *GetForkStatusResponse) String() string {
 func (*GetForkStatusResponse) ProtoMessage() {}
 
 func (x *GetForkStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[66]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4279,7 +4554,7 @@ func (x *GetForkStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetForkStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetForkStatusResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{66}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *GetForkStatusResponse) GetForkHeight() int32 {
@@ -4360,7 +4635,7 @@ type ForkWalletClaim struct {
 
 func (x *ForkWalletClaim) Reset() {
 	*x = ForkWalletClaim{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[67]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4372,7 +4647,7 @@ func (x *ForkWalletClaim) String() string {
 func (*ForkWalletClaim) ProtoMessage() {}
 
 func (x *ForkWalletClaim) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[67]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4385,7 +4660,7 @@ func (x *ForkWalletClaim) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForkWalletClaim.ProtoReflect.Descriptor instead.
 func (*ForkWalletClaim) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{67}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *ForkWalletClaim) GetWalletId() string {
@@ -4435,7 +4710,7 @@ type ForkClaimUtxo struct {
 
 func (x *ForkClaimUtxo) Reset() {
 	*x = ForkClaimUtxo{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[68]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4447,7 +4722,7 @@ func (x *ForkClaimUtxo) String() string {
 func (*ForkClaimUtxo) ProtoMessage() {}
 
 func (x *ForkClaimUtxo) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[68]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4460,7 +4735,7 @@ func (x *ForkClaimUtxo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForkClaimUtxo.ProtoReflect.Descriptor instead.
 func (*ForkClaimUtxo) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{68}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *ForkClaimUtxo) GetOutpoint() string {
@@ -4502,7 +4777,7 @@ type ShutdownRequest struct {
 
 func (x *ShutdownRequest) Reset() {
 	*x = ShutdownRequest{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[69]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4514,7 +4789,7 @@ func (x *ShutdownRequest) String() string {
 func (*ShutdownRequest) ProtoMessage() {}
 
 func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[69]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4527,7 +4802,7 @@ func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownRequest.ProtoReflect.Descriptor instead.
 func (*ShutdownRequest) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{69}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *ShutdownRequest) GetOnlyIfLast() bool {
@@ -4545,7 +4820,7 @@ type ShutdownResponse struct {
 
 func (x *ShutdownResponse) Reset() {
 	*x = ShutdownResponse{}
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[70]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4557,7 +4832,7 @@ func (x *ShutdownResponse) String() string {
 func (*ShutdownResponse) ProtoMessage() {}
 
 func (x *ShutdownResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[70]
+	mi := &file_orchestrator_v1_orchestrator_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4570,7 +4845,7 @@ func (x *ShutdownResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownResponse.ProtoReflect.Descriptor instead.
 func (*ShutdownResponse) Descriptor() ([]byte, []int) {
-	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{70}
+	return file_orchestrator_v1_orchestrator_proto_rawDescGZIP(), []int{72}
 }
 
 var File_orchestrator_v1_orchestrator_proto protoreflect.FileDescriptor
@@ -4823,7 +5098,29 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x0fenforcer_height\x18\x03 \x01(\rR\x0eenforcerHeight\x12)\n" +
 	"\x10enforcer_rebuilt\x18\x04 \x01(\bR\x0fenforcerRebuilt\x12%\n" +
 	"\x0eenforcer_error\x18\x05 \x01(\tR\renforcerError\x12)\n" +
-	"\x10enforcer_checked\x18\x06 \x01(\bR\x0fenforcerChecked\"\x1b\n" +
+	"\x10enforcer_checked\x18\x06 \x01(\bR\x0fenforcerChecked\"a\n" +
+	"\x13ResetToBlockRequest\x12\x16\n" +
+	"\x06target\x18\x01 \x01(\tR\x06target\x122\n" +
+	"\x15enforcer_wait_seconds\x18\x02 \x01(\rR\x13enforcerWaitSeconds\"\xe7\x03\n" +
+	"\x14ResetToBlockResponse\x121\n" +
+	"\x05phase\x18\x01 \x01(\x0e2\x1b.orchestrator.v1.ResetPhaseR\x05phase\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12#\n" +
+	"\rtarget_height\x18\x03 \x01(\rR\ftargetHeight\x12\x1f\n" +
+	"\vtarget_hash\x18\x04 \x01(\tR\n" +
+	"targetHash\x12\x1f\n" +
+	"\vcore_height\x18\x05 \x01(\rR\n" +
+	"coreHeight\x12\x1d\n" +
+	"\n" +
+	"tip_height\x18\x06 \x01(\rR\ttipHeight\x12\x1f\n" +
+	"\vblocks_done\x18\a \x01(\rR\n" +
+	"blocksDone\x12!\n" +
+	"\fblocks_total\x18\b \x01(\rR\vblocksTotal\x12'\n" +
+	"\x0fenforcer_height\x18\t \x01(\rR\x0eenforcerHeight\x12)\n" +
+	"\x10enforcer_checked\x18\n" +
+	" \x01(\bR\x0fenforcerChecked\x12)\n" +
+	"\x10enforcer_rebuilt\x18\v \x01(\bR\x0fenforcerRebuilt\x12%\n" +
+	"\x0eenforcer_error\x18\f \x01(\tR\renforcerError\x12\x12\n" +
+	"\x04done\x18\r \x01(\bR\x04done\"\x1b\n" +
 	"\x19GetCoreMempoolInfoRequest\"\xff\x02\n" +
 	"\x1aGetCoreMempoolInfoResponse\x12\x16\n" +
 	"\x06loaded\x18\x01 \x01(\bR\x06loaded\x12\x12\n" +
@@ -4922,7 +5219,15 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x1aREJECT_OUTCOME_UNSPECIFIED\x10\x00\x12\"\n" +
 	"\x1eREJECT_OUTCOME_SWITCHED_BRANCH\x10\x01\x12#\n" +
 	"\x1fREJECT_OUTCOME_PARKED_ON_PARENT\x10\x02\x12#\n" +
-	"\x1fREJECT_OUTCOME_ALREADY_INACTIVE\x10\x032\x87\x19\n" +
+	"\x1fREJECT_OUTCOME_ALREADY_INACTIVE\x10\x03*\xab\x01\n" +
+	"\n" +
+	"ResetPhase\x12\x1b\n" +
+	"\x17RESET_PHASE_UNSPECIFIED\x10\x00\x12\x17\n" +
+	"\x13RESET_PHASE_RESOLVE\x10\x01\x12\x19\n" +
+	"\x15RESET_PHASE_MOVE_BACK\x10\x02\x12\x1c\n" +
+	"\x18RESET_PHASE_SYNC_FORWARD\x10\x03\x12\x18\n" +
+	"\x14RESET_PHASE_ENFORCER\x10\x04\x12\x14\n" +
+	"\x10RESET_PHASE_DONE\x10\x052\xe6\x19\n" +
 	"\x13OrchestratorService\x12[\n" +
 	"\fListBinaries\x12$.orchestrator.v1.ListBinariesRequest\x1a%.orchestrator.v1.ListBinariesResponse\x12d\n" +
 	"\x0fGetBinaryStatus\x12'.orchestrator.v1.GetBinaryStatusRequest\x1a(.orchestrator.v1.GetBinaryStatusResponse\x12g\n" +
@@ -4952,7 +5257,8 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x13GatherFilesToDelete\x12+.orchestrator.v1.GatherFilesToDeleteRequest\x1a,.orchestrator.v1.GatherFilesToDeleteResponse\x12Z\n" +
 	"\vDeleteFiles\x12#.orchestrator.v1.DeleteFilesRequest\x1a$.orchestrator.v1.DeleteFilesResponse0\x01\x12X\n" +
 	"\vRejectBlock\x12#.orchestrator.v1.RejectBlockRequest\x1a$.orchestrator.v1.RejectBlockResponse\x12X\n" +
-	"\vAcceptBlock\x12#.orchestrator.v1.AcceptBlockRequest\x1a$.orchestrator.v1.AcceptBlockResponse\x12m\n" +
+	"\vAcceptBlock\x12#.orchestrator.v1.AcceptBlockRequest\x1a$.orchestrator.v1.AcceptBlockResponse\x12]\n" +
+	"\fResetToBlock\x12$.orchestrator.v1.ResetToBlockRequest\x1a%.orchestrator.v1.ResetToBlockResponse0\x01\x12m\n" +
 	"\x12GetCoreMempoolInfo\x12*.orchestrator.v1.GetCoreMempoolInfoRequest\x1a+.orchestrator.v1.GetCoreMempoolInfoResponse\x12^\n" +
 	"\rGetBmmContext\x12%.orchestrator.v1.GetBmmContextRequest\x1a&.orchestrator.v1.GetBmmContextResponse\x12X\n" +
 	"\vCoreRawCall\x12#.orchestrator.v1.CoreRawCallRequest\x1a$.orchestrator.v1.CoreRawCallResponse\x12^\n" +
@@ -4971,179 +5277,185 @@ func file_orchestrator_v1_orchestrator_proto_rawDescGZIP() []byte {
 	return file_orchestrator_v1_orchestrator_proto_rawDescData
 }
 
-var file_orchestrator_v1_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 73)
+var file_orchestrator_v1_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_orchestrator_v1_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 75)
 var file_orchestrator_v1_orchestrator_proto_goTypes = []any{
 	(SidechainType)(0),                              // 0: orchestrator.v1.SidechainType
 	(BinaryType)(0),                                 // 1: orchestrator.v1.BinaryType
 	(DeletionType)(0),                               // 2: orchestrator.v1.DeletionType
 	(RejectOutcome)(0),                              // 3: orchestrator.v1.RejectOutcome
-	(*BinaryStatusMsg)(nil),                         // 4: orchestrator.v1.BinaryStatusMsg
-	(*StartupLogEntryMsg)(nil),                      // 5: orchestrator.v1.StartupLogEntryMsg
-	(*ListBinariesRequest)(nil),                     // 6: orchestrator.v1.ListBinariesRequest
-	(*ListBinariesResponse)(nil),                    // 7: orchestrator.v1.ListBinariesResponse
-	(*GetBinaryStatusRequest)(nil),                  // 8: orchestrator.v1.GetBinaryStatusRequest
-	(*GetBinaryStatusResponse)(nil),                 // 9: orchestrator.v1.GetBinaryStatusResponse
-	(*GetBinaryVersionRequest)(nil),                 // 10: orchestrator.v1.GetBinaryVersionRequest
-	(*GetBinaryVersionResponse)(nil),                // 11: orchestrator.v1.GetBinaryVersionResponse
-	(*DownloadBinaryRequest)(nil),                   // 12: orchestrator.v1.DownloadBinaryRequest
-	(*DownloadBinaryResponse)(nil),                  // 13: orchestrator.v1.DownloadBinaryResponse
-	(*StartBinaryRequest)(nil),                      // 14: orchestrator.v1.StartBinaryRequest
-	(*StartBinaryResponse)(nil),                     // 15: orchestrator.v1.StartBinaryResponse
-	(*StopBinaryRequest)(nil),                       // 16: orchestrator.v1.StopBinaryRequest
-	(*StopBinaryResponse)(nil),                      // 17: orchestrator.v1.StopBinaryResponse
-	(*StreamLogsRequest)(nil),                       // 18: orchestrator.v1.StreamLogsRequest
-	(*StreamLogsResponse)(nil),                      // 19: orchestrator.v1.StreamLogsResponse
-	(*StartWithL1Request)(nil),                      // 20: orchestrator.v1.StartWithL1Request
-	(*StartWithL1Response)(nil),                     // 21: orchestrator.v1.StartWithL1Response
-	(*RestartDaemonRequest)(nil),                    // 22: orchestrator.v1.RestartDaemonRequest
-	(*RestartDaemonResponse)(nil),                   // 23: orchestrator.v1.RestartDaemonResponse
-	(*RestartL1Request)(nil),                        // 24: orchestrator.v1.RestartL1Request
-	(*RestartL1Response)(nil),                       // 25: orchestrator.v1.RestartL1Response
-	(*ApplyUTXOSnapshotRequest)(nil),                // 26: orchestrator.v1.ApplyUTXOSnapshotRequest
-	(*ApplyUTXOSnapshotResponse)(nil),               // 27: orchestrator.v1.ApplyUTXOSnapshotResponse
-	(*GetSnapshotStatusRequest)(nil),                // 28: orchestrator.v1.GetSnapshotStatusRequest
-	(*GetSnapshotStatusResponse)(nil),               // 29: orchestrator.v1.GetSnapshotStatusResponse
-	(*GetPendingNetworkGenerationRequest)(nil),      // 30: orchestrator.v1.GetPendingNetworkGenerationRequest
-	(*GetPendingNetworkGenerationResponse)(nil),     // 31: orchestrator.v1.GetPendingNetworkGenerationResponse
-	(*ConfirmPendingNetworkGenerationRequest)(nil),  // 32: orchestrator.v1.ConfirmPendingNetworkGenerationRequest
-	(*ConfirmPendingNetworkGenerationResponse)(nil), // 33: orchestrator.v1.ConfirmPendingNetworkGenerationResponse
-	(*ShutdownAllRequest)(nil),                      // 34: orchestrator.v1.ShutdownAllRequest
-	(*ShutdownAllResponse)(nil),                     // 35: orchestrator.v1.ShutdownAllResponse
-	(*GetBTCPriceRequest)(nil),                      // 36: orchestrator.v1.GetBTCPriceRequest
-	(*GetBTCPriceResponse)(nil),                     // 37: orchestrator.v1.GetBTCPriceResponse
-	(*GetMainchainBlockchainInfoRequest)(nil),       // 38: orchestrator.v1.GetMainchainBlockchainInfoRequest
-	(*GetMainchainBlockchainInfoResponse)(nil),      // 39: orchestrator.v1.GetMainchainBlockchainInfoResponse
-	(*GetEnforcerBlockchainInfoRequest)(nil),        // 40: orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	(*GetEnforcerBlockchainInfoResponse)(nil),       // 41: orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	(*GetSyncStatusRequest)(nil),                    // 42: orchestrator.v1.GetSyncStatusRequest
-	(*GetSyncStatusResponse)(nil),                   // 43: orchestrator.v1.GetSyncStatusResponse
-	(*SidechainStatus)(nil),                         // 44: orchestrator.v1.SidechainStatus
-	(*ChainSync)(nil),                               // 45: orchestrator.v1.ChainSync
-	(*GetDownloadStatusRequest)(nil),                // 46: orchestrator.v1.GetDownloadStatusRequest
-	(*GetDownloadStatusResponse)(nil),               // 47: orchestrator.v1.GetDownloadStatusResponse
-	(*DownloadStatus)(nil),                          // 48: orchestrator.v1.DownloadStatus
-	(*GetMainchainBalanceRequest)(nil),              // 49: orchestrator.v1.GetMainchainBalanceRequest
-	(*GetMainchainBalanceResponse)(nil),             // 50: orchestrator.v1.GetMainchainBalanceResponse
-	(*GetSidechainBalanceRequest)(nil),              // 51: orchestrator.v1.GetSidechainBalanceRequest
-	(*GetSidechainBalanceResponse)(nil),             // 52: orchestrator.v1.GetSidechainBalanceResponse
-	(*SingleDeletion)(nil),                          // 53: orchestrator.v1.SingleDeletion
-	(*GatherFilesToDeleteRequest)(nil),              // 54: orchestrator.v1.GatherFilesToDeleteRequest
-	(*GatherFilesToDeleteResponse)(nil),             // 55: orchestrator.v1.GatherFilesToDeleteResponse
-	(*ResetFileInfo)(nil),                           // 56: orchestrator.v1.ResetFileInfo
-	(*DeleteFilesRequest)(nil),                      // 57: orchestrator.v1.DeleteFilesRequest
-	(*DeleteFilesResponse)(nil),                     // 58: orchestrator.v1.DeleteFilesResponse
-	(*RejectBlockRequest)(nil),                      // 59: orchestrator.v1.RejectBlockRequest
-	(*RejectBlockResponse)(nil),                     // 60: orchestrator.v1.RejectBlockResponse
-	(*AcceptBlockRequest)(nil),                      // 61: orchestrator.v1.AcceptBlockRequest
-	(*AcceptBlockResponse)(nil),                     // 62: orchestrator.v1.AcceptBlockResponse
-	(*GetCoreMempoolInfoRequest)(nil),               // 63: orchestrator.v1.GetCoreMempoolInfoRequest
-	(*GetCoreMempoolInfoResponse)(nil),              // 64: orchestrator.v1.GetCoreMempoolInfoResponse
-	(*GetBmmContextRequest)(nil),                    // 65: orchestrator.v1.GetBmmContextRequest
-	(*GetBmmContextResponse)(nil),                   // 66: orchestrator.v1.GetBmmContextResponse
-	(*CoreRawCallRequest)(nil),                      // 67: orchestrator.v1.CoreRawCallRequest
-	(*CoreRawCallResponse)(nil),                     // 68: orchestrator.v1.CoreRawCallResponse
-	(*GetForkStatusRequest)(nil),                    // 69: orchestrator.v1.GetForkStatusRequest
-	(*GetForkStatusResponse)(nil),                   // 70: orchestrator.v1.GetForkStatusResponse
-	(*ForkWalletClaim)(nil),                         // 71: orchestrator.v1.ForkWalletClaim
-	(*ForkClaimUtxo)(nil),                           // 72: orchestrator.v1.ForkClaimUtxo
-	(*ShutdownRequest)(nil),                         // 73: orchestrator.v1.ShutdownRequest
-	(*ShutdownResponse)(nil),                        // 74: orchestrator.v1.ShutdownResponse
-	nil,                                             // 75: orchestrator.v1.StartBinaryRequest.EnvEntry
-	nil,                                             // 76: orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	(ResetPhase)(0),                                 // 4: orchestrator.v1.ResetPhase
+	(*BinaryStatusMsg)(nil),                         // 5: orchestrator.v1.BinaryStatusMsg
+	(*StartupLogEntryMsg)(nil),                      // 6: orchestrator.v1.StartupLogEntryMsg
+	(*ListBinariesRequest)(nil),                     // 7: orchestrator.v1.ListBinariesRequest
+	(*ListBinariesResponse)(nil),                    // 8: orchestrator.v1.ListBinariesResponse
+	(*GetBinaryStatusRequest)(nil),                  // 9: orchestrator.v1.GetBinaryStatusRequest
+	(*GetBinaryStatusResponse)(nil),                 // 10: orchestrator.v1.GetBinaryStatusResponse
+	(*GetBinaryVersionRequest)(nil),                 // 11: orchestrator.v1.GetBinaryVersionRequest
+	(*GetBinaryVersionResponse)(nil),                // 12: orchestrator.v1.GetBinaryVersionResponse
+	(*DownloadBinaryRequest)(nil),                   // 13: orchestrator.v1.DownloadBinaryRequest
+	(*DownloadBinaryResponse)(nil),                  // 14: orchestrator.v1.DownloadBinaryResponse
+	(*StartBinaryRequest)(nil),                      // 15: orchestrator.v1.StartBinaryRequest
+	(*StartBinaryResponse)(nil),                     // 16: orchestrator.v1.StartBinaryResponse
+	(*StopBinaryRequest)(nil),                       // 17: orchestrator.v1.StopBinaryRequest
+	(*StopBinaryResponse)(nil),                      // 18: orchestrator.v1.StopBinaryResponse
+	(*StreamLogsRequest)(nil),                       // 19: orchestrator.v1.StreamLogsRequest
+	(*StreamLogsResponse)(nil),                      // 20: orchestrator.v1.StreamLogsResponse
+	(*StartWithL1Request)(nil),                      // 21: orchestrator.v1.StartWithL1Request
+	(*StartWithL1Response)(nil),                     // 22: orchestrator.v1.StartWithL1Response
+	(*RestartDaemonRequest)(nil),                    // 23: orchestrator.v1.RestartDaemonRequest
+	(*RestartDaemonResponse)(nil),                   // 24: orchestrator.v1.RestartDaemonResponse
+	(*RestartL1Request)(nil),                        // 25: orchestrator.v1.RestartL1Request
+	(*RestartL1Response)(nil),                       // 26: orchestrator.v1.RestartL1Response
+	(*ApplyUTXOSnapshotRequest)(nil),                // 27: orchestrator.v1.ApplyUTXOSnapshotRequest
+	(*ApplyUTXOSnapshotResponse)(nil),               // 28: orchestrator.v1.ApplyUTXOSnapshotResponse
+	(*GetSnapshotStatusRequest)(nil),                // 29: orchestrator.v1.GetSnapshotStatusRequest
+	(*GetSnapshotStatusResponse)(nil),               // 30: orchestrator.v1.GetSnapshotStatusResponse
+	(*GetPendingNetworkGenerationRequest)(nil),      // 31: orchestrator.v1.GetPendingNetworkGenerationRequest
+	(*GetPendingNetworkGenerationResponse)(nil),     // 32: orchestrator.v1.GetPendingNetworkGenerationResponse
+	(*ConfirmPendingNetworkGenerationRequest)(nil),  // 33: orchestrator.v1.ConfirmPendingNetworkGenerationRequest
+	(*ConfirmPendingNetworkGenerationResponse)(nil), // 34: orchestrator.v1.ConfirmPendingNetworkGenerationResponse
+	(*ShutdownAllRequest)(nil),                      // 35: orchestrator.v1.ShutdownAllRequest
+	(*ShutdownAllResponse)(nil),                     // 36: orchestrator.v1.ShutdownAllResponse
+	(*GetBTCPriceRequest)(nil),                      // 37: orchestrator.v1.GetBTCPriceRequest
+	(*GetBTCPriceResponse)(nil),                     // 38: orchestrator.v1.GetBTCPriceResponse
+	(*GetMainchainBlockchainInfoRequest)(nil),       // 39: orchestrator.v1.GetMainchainBlockchainInfoRequest
+	(*GetMainchainBlockchainInfoResponse)(nil),      // 40: orchestrator.v1.GetMainchainBlockchainInfoResponse
+	(*GetEnforcerBlockchainInfoRequest)(nil),        // 41: orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	(*GetEnforcerBlockchainInfoResponse)(nil),       // 42: orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	(*GetSyncStatusRequest)(nil),                    // 43: orchestrator.v1.GetSyncStatusRequest
+	(*GetSyncStatusResponse)(nil),                   // 44: orchestrator.v1.GetSyncStatusResponse
+	(*SidechainStatus)(nil),                         // 45: orchestrator.v1.SidechainStatus
+	(*ChainSync)(nil),                               // 46: orchestrator.v1.ChainSync
+	(*GetDownloadStatusRequest)(nil),                // 47: orchestrator.v1.GetDownloadStatusRequest
+	(*GetDownloadStatusResponse)(nil),               // 48: orchestrator.v1.GetDownloadStatusResponse
+	(*DownloadStatus)(nil),                          // 49: orchestrator.v1.DownloadStatus
+	(*GetMainchainBalanceRequest)(nil),              // 50: orchestrator.v1.GetMainchainBalanceRequest
+	(*GetMainchainBalanceResponse)(nil),             // 51: orchestrator.v1.GetMainchainBalanceResponse
+	(*GetSidechainBalanceRequest)(nil),              // 52: orchestrator.v1.GetSidechainBalanceRequest
+	(*GetSidechainBalanceResponse)(nil),             // 53: orchestrator.v1.GetSidechainBalanceResponse
+	(*SingleDeletion)(nil),                          // 54: orchestrator.v1.SingleDeletion
+	(*GatherFilesToDeleteRequest)(nil),              // 55: orchestrator.v1.GatherFilesToDeleteRequest
+	(*GatherFilesToDeleteResponse)(nil),             // 56: orchestrator.v1.GatherFilesToDeleteResponse
+	(*ResetFileInfo)(nil),                           // 57: orchestrator.v1.ResetFileInfo
+	(*DeleteFilesRequest)(nil),                      // 58: orchestrator.v1.DeleteFilesRequest
+	(*DeleteFilesResponse)(nil),                     // 59: orchestrator.v1.DeleteFilesResponse
+	(*RejectBlockRequest)(nil),                      // 60: orchestrator.v1.RejectBlockRequest
+	(*RejectBlockResponse)(nil),                     // 61: orchestrator.v1.RejectBlockResponse
+	(*AcceptBlockRequest)(nil),                      // 62: orchestrator.v1.AcceptBlockRequest
+	(*AcceptBlockResponse)(nil),                     // 63: orchestrator.v1.AcceptBlockResponse
+	(*ResetToBlockRequest)(nil),                     // 64: orchestrator.v1.ResetToBlockRequest
+	(*ResetToBlockResponse)(nil),                    // 65: orchestrator.v1.ResetToBlockResponse
+	(*GetCoreMempoolInfoRequest)(nil),               // 66: orchestrator.v1.GetCoreMempoolInfoRequest
+	(*GetCoreMempoolInfoResponse)(nil),              // 67: orchestrator.v1.GetCoreMempoolInfoResponse
+	(*GetBmmContextRequest)(nil),                    // 68: orchestrator.v1.GetBmmContextRequest
+	(*GetBmmContextResponse)(nil),                   // 69: orchestrator.v1.GetBmmContextResponse
+	(*CoreRawCallRequest)(nil),                      // 70: orchestrator.v1.CoreRawCallRequest
+	(*CoreRawCallResponse)(nil),                     // 71: orchestrator.v1.CoreRawCallResponse
+	(*GetForkStatusRequest)(nil),                    // 72: orchestrator.v1.GetForkStatusRequest
+	(*GetForkStatusResponse)(nil),                   // 73: orchestrator.v1.GetForkStatusResponse
+	(*ForkWalletClaim)(nil),                         // 74: orchestrator.v1.ForkWalletClaim
+	(*ForkClaimUtxo)(nil),                           // 75: orchestrator.v1.ForkClaimUtxo
+	(*ShutdownRequest)(nil),                         // 76: orchestrator.v1.ShutdownRequest
+	(*ShutdownResponse)(nil),                        // 77: orchestrator.v1.ShutdownResponse
+	nil,                                             // 78: orchestrator.v1.StartBinaryRequest.EnvEntry
+	nil,                                             // 79: orchestrator.v1.StartWithL1Request.TargetEnvEntry
 }
 var file_orchestrator_v1_orchestrator_proto_depIdxs = []int32{
-	5,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
-	4,  // 1: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
-	4,  // 2: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
-	75, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
-	76, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
-	45, // 5: orchestrator.v1.GetSyncStatusResponse.mainchain:type_name -> orchestrator.v1.ChainSync
-	45, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
-	44, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
-	45, // 8: orchestrator.v1.GetSyncStatusResponse.enforcer_wallet:type_name -> orchestrator.v1.ChainSync
+	6,  // 0: orchestrator.v1.BinaryStatusMsg.startup_logs:type_name -> orchestrator.v1.StartupLogEntryMsg
+	5,  // 1: orchestrator.v1.ListBinariesResponse.binaries:type_name -> orchestrator.v1.BinaryStatusMsg
+	5,  // 2: orchestrator.v1.GetBinaryStatusResponse.status:type_name -> orchestrator.v1.BinaryStatusMsg
+	78, // 3: orchestrator.v1.StartBinaryRequest.env:type_name -> orchestrator.v1.StartBinaryRequest.EnvEntry
+	79, // 4: orchestrator.v1.StartWithL1Request.target_env:type_name -> orchestrator.v1.StartWithL1Request.TargetEnvEntry
+	46, // 5: orchestrator.v1.GetSyncStatusResponse.mainchain:type_name -> orchestrator.v1.ChainSync
+	46, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
+	45, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
+	46, // 8: orchestrator.v1.GetSyncStatusResponse.enforcer_wallet:type_name -> orchestrator.v1.ChainSync
 	0,  // 9: orchestrator.v1.SidechainStatus.type:type_name -> orchestrator.v1.SidechainType
-	45, // 10: orchestrator.v1.SidechainStatus.sync:type_name -> orchestrator.v1.ChainSync
-	48, // 11: orchestrator.v1.GetDownloadStatusResponse.downloads:type_name -> orchestrator.v1.DownloadStatus
+	46, // 10: orchestrator.v1.SidechainStatus.sync:type_name -> orchestrator.v1.ChainSync
+	49, // 11: orchestrator.v1.GetDownloadStatusResponse.downloads:type_name -> orchestrator.v1.DownloadStatus
 	1,  // 12: orchestrator.v1.DownloadStatus.binary:type_name -> orchestrator.v1.BinaryType
 	1,  // 13: orchestrator.v1.GetSidechainBalanceRequest.sidechain:type_name -> orchestrator.v1.BinaryType
 	1,  // 14: orchestrator.v1.SingleDeletion.binary:type_name -> orchestrator.v1.BinaryType
 	2,  // 15: orchestrator.v1.SingleDeletion.deletions:type_name -> orchestrator.v1.DeletionType
-	53, // 16: orchestrator.v1.GatherFilesToDeleteRequest.items:type_name -> orchestrator.v1.SingleDeletion
-	56, // 17: orchestrator.v1.GatherFilesToDeleteResponse.files:type_name -> orchestrator.v1.ResetFileInfo
+	54, // 16: orchestrator.v1.GatherFilesToDeleteRequest.items:type_name -> orchestrator.v1.SingleDeletion
+	57, // 17: orchestrator.v1.GatherFilesToDeleteResponse.files:type_name -> orchestrator.v1.ResetFileInfo
 	2,  // 18: orchestrator.v1.ResetFileInfo.deletion_type:type_name -> orchestrator.v1.DeletionType
 	1,  // 19: orchestrator.v1.ResetFileInfo.binary:type_name -> orchestrator.v1.BinaryType
-	53, // 20: orchestrator.v1.DeleteFilesRequest.items:type_name -> orchestrator.v1.SingleDeletion
+	54, // 20: orchestrator.v1.DeleteFilesRequest.items:type_name -> orchestrator.v1.SingleDeletion
 	3,  // 21: orchestrator.v1.RejectBlockResponse.outcome:type_name -> orchestrator.v1.RejectOutcome
-	71, // 22: orchestrator.v1.GetForkStatusResponse.claims:type_name -> orchestrator.v1.ForkWalletClaim
-	72, // 23: orchestrator.v1.ForkWalletClaim.utxos:type_name -> orchestrator.v1.ForkClaimUtxo
-	6,  // 24: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
-	8,  // 25: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
-	10, // 26: orchestrator.v1.OrchestratorService.GetBinaryVersion:input_type -> orchestrator.v1.GetBinaryVersionRequest
-	12, // 27: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
-	14, // 28: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
-	16, // 29: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
-	18, // 30: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
-	20, // 31: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
-	22, // 32: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
-	24, // 33: orchestrator.v1.OrchestratorService.RestartL1:input_type -> orchestrator.v1.RestartL1Request
-	26, // 34: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:input_type -> orchestrator.v1.ApplyUTXOSnapshotRequest
-	28, // 35: orchestrator.v1.OrchestratorService.GetSnapshotStatus:input_type -> orchestrator.v1.GetSnapshotStatusRequest
-	30, // 36: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:input_type -> orchestrator.v1.GetPendingNetworkGenerationRequest
-	32, // 37: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:input_type -> orchestrator.v1.ConfirmPendingNetworkGenerationRequest
-	34, // 38: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
-	73, // 39: orchestrator.v1.OrchestratorService.Shutdown:input_type -> orchestrator.v1.ShutdownRequest
-	36, // 40: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
-	38, // 41: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
-	40, // 42: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	42, // 43: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
-	46, // 44: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
-	49, // 45: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
-	51, // 46: orchestrator.v1.OrchestratorService.GetSidechainBalance:input_type -> orchestrator.v1.GetSidechainBalanceRequest
-	54, // 47: orchestrator.v1.OrchestratorService.GatherFilesToDelete:input_type -> orchestrator.v1.GatherFilesToDeleteRequest
-	57, // 48: orchestrator.v1.OrchestratorService.DeleteFiles:input_type -> orchestrator.v1.DeleteFilesRequest
-	59, // 49: orchestrator.v1.OrchestratorService.RejectBlock:input_type -> orchestrator.v1.RejectBlockRequest
-	61, // 50: orchestrator.v1.OrchestratorService.AcceptBlock:input_type -> orchestrator.v1.AcceptBlockRequest
-	63, // 51: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
-	65, // 52: orchestrator.v1.OrchestratorService.GetBmmContext:input_type -> orchestrator.v1.GetBmmContextRequest
-	67, // 53: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
-	69, // 54: orchestrator.v1.OrchestratorService.GetForkStatus:input_type -> orchestrator.v1.GetForkStatusRequest
-	7,  // 55: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
-	9,  // 56: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
-	11, // 57: orchestrator.v1.OrchestratorService.GetBinaryVersion:output_type -> orchestrator.v1.GetBinaryVersionResponse
-	13, // 58: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
-	15, // 59: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
-	17, // 60: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
-	19, // 61: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
-	21, // 62: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
-	23, // 63: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
-	25, // 64: orchestrator.v1.OrchestratorService.RestartL1:output_type -> orchestrator.v1.RestartL1Response
-	27, // 65: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:output_type -> orchestrator.v1.ApplyUTXOSnapshotResponse
-	29, // 66: orchestrator.v1.OrchestratorService.GetSnapshotStatus:output_type -> orchestrator.v1.GetSnapshotStatusResponse
-	31, // 67: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:output_type -> orchestrator.v1.GetPendingNetworkGenerationResponse
-	33, // 68: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:output_type -> orchestrator.v1.ConfirmPendingNetworkGenerationResponse
-	35, // 69: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
-	74, // 70: orchestrator.v1.OrchestratorService.Shutdown:output_type -> orchestrator.v1.ShutdownResponse
-	37, // 71: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
-	39, // 72: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
-	41, // 73: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	43, // 74: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
-	47, // 75: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
-	50, // 76: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
-	52, // 77: orchestrator.v1.OrchestratorService.GetSidechainBalance:output_type -> orchestrator.v1.GetSidechainBalanceResponse
-	55, // 78: orchestrator.v1.OrchestratorService.GatherFilesToDelete:output_type -> orchestrator.v1.GatherFilesToDeleteResponse
-	58, // 79: orchestrator.v1.OrchestratorService.DeleteFiles:output_type -> orchestrator.v1.DeleteFilesResponse
-	60, // 80: orchestrator.v1.OrchestratorService.RejectBlock:output_type -> orchestrator.v1.RejectBlockResponse
-	62, // 81: orchestrator.v1.OrchestratorService.AcceptBlock:output_type -> orchestrator.v1.AcceptBlockResponse
-	64, // 82: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
-	66, // 83: orchestrator.v1.OrchestratorService.GetBmmContext:output_type -> orchestrator.v1.GetBmmContextResponse
-	68, // 84: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
-	70, // 85: orchestrator.v1.OrchestratorService.GetForkStatus:output_type -> orchestrator.v1.GetForkStatusResponse
-	55, // [55:86] is the sub-list for method output_type
-	24, // [24:55] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	4,  // 22: orchestrator.v1.ResetToBlockResponse.phase:type_name -> orchestrator.v1.ResetPhase
+	74, // 23: orchestrator.v1.GetForkStatusResponse.claims:type_name -> orchestrator.v1.ForkWalletClaim
+	75, // 24: orchestrator.v1.ForkWalletClaim.utxos:type_name -> orchestrator.v1.ForkClaimUtxo
+	7,  // 25: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
+	9,  // 26: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
+	11, // 27: orchestrator.v1.OrchestratorService.GetBinaryVersion:input_type -> orchestrator.v1.GetBinaryVersionRequest
+	13, // 28: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
+	15, // 29: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
+	17, // 30: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
+	19, // 31: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
+	21, // 32: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
+	23, // 33: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
+	25, // 34: orchestrator.v1.OrchestratorService.RestartL1:input_type -> orchestrator.v1.RestartL1Request
+	27, // 35: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:input_type -> orchestrator.v1.ApplyUTXOSnapshotRequest
+	29, // 36: orchestrator.v1.OrchestratorService.GetSnapshotStatus:input_type -> orchestrator.v1.GetSnapshotStatusRequest
+	31, // 37: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:input_type -> orchestrator.v1.GetPendingNetworkGenerationRequest
+	33, // 38: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:input_type -> orchestrator.v1.ConfirmPendingNetworkGenerationRequest
+	35, // 39: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
+	76, // 40: orchestrator.v1.OrchestratorService.Shutdown:input_type -> orchestrator.v1.ShutdownRequest
+	37, // 41: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
+	39, // 42: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
+	41, // 43: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	43, // 44: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
+	47, // 45: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
+	50, // 46: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
+	52, // 47: orchestrator.v1.OrchestratorService.GetSidechainBalance:input_type -> orchestrator.v1.GetSidechainBalanceRequest
+	55, // 48: orchestrator.v1.OrchestratorService.GatherFilesToDelete:input_type -> orchestrator.v1.GatherFilesToDeleteRequest
+	58, // 49: orchestrator.v1.OrchestratorService.DeleteFiles:input_type -> orchestrator.v1.DeleteFilesRequest
+	60, // 50: orchestrator.v1.OrchestratorService.RejectBlock:input_type -> orchestrator.v1.RejectBlockRequest
+	62, // 51: orchestrator.v1.OrchestratorService.AcceptBlock:input_type -> orchestrator.v1.AcceptBlockRequest
+	64, // 52: orchestrator.v1.OrchestratorService.ResetToBlock:input_type -> orchestrator.v1.ResetToBlockRequest
+	66, // 53: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
+	68, // 54: orchestrator.v1.OrchestratorService.GetBmmContext:input_type -> orchestrator.v1.GetBmmContextRequest
+	70, // 55: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
+	72, // 56: orchestrator.v1.OrchestratorService.GetForkStatus:input_type -> orchestrator.v1.GetForkStatusRequest
+	8,  // 57: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
+	10, // 58: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
+	12, // 59: orchestrator.v1.OrchestratorService.GetBinaryVersion:output_type -> orchestrator.v1.GetBinaryVersionResponse
+	14, // 60: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
+	16, // 61: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
+	18, // 62: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
+	20, // 63: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
+	22, // 64: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
+	24, // 65: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
+	26, // 66: orchestrator.v1.OrchestratorService.RestartL1:output_type -> orchestrator.v1.RestartL1Response
+	28, // 67: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:output_type -> orchestrator.v1.ApplyUTXOSnapshotResponse
+	30, // 68: orchestrator.v1.OrchestratorService.GetSnapshotStatus:output_type -> orchestrator.v1.GetSnapshotStatusResponse
+	32, // 69: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:output_type -> orchestrator.v1.GetPendingNetworkGenerationResponse
+	34, // 70: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:output_type -> orchestrator.v1.ConfirmPendingNetworkGenerationResponse
+	36, // 71: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
+	77, // 72: orchestrator.v1.OrchestratorService.Shutdown:output_type -> orchestrator.v1.ShutdownResponse
+	38, // 73: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
+	40, // 74: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
+	42, // 75: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	44, // 76: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
+	48, // 77: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
+	51, // 78: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
+	53, // 79: orchestrator.v1.OrchestratorService.GetSidechainBalance:output_type -> orchestrator.v1.GetSidechainBalanceResponse
+	56, // 80: orchestrator.v1.OrchestratorService.GatherFilesToDelete:output_type -> orchestrator.v1.GatherFilesToDeleteResponse
+	59, // 81: orchestrator.v1.OrchestratorService.DeleteFiles:output_type -> orchestrator.v1.DeleteFilesResponse
+	61, // 82: orchestrator.v1.OrchestratorService.RejectBlock:output_type -> orchestrator.v1.RejectBlockResponse
+	63, // 83: orchestrator.v1.OrchestratorService.AcceptBlock:output_type -> orchestrator.v1.AcceptBlockResponse
+	65, // 84: orchestrator.v1.OrchestratorService.ResetToBlock:output_type -> orchestrator.v1.ResetToBlockResponse
+	67, // 85: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
+	69, // 86: orchestrator.v1.OrchestratorService.GetBmmContext:output_type -> orchestrator.v1.GetBmmContextResponse
+	71, // 87: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
+	73, // 88: orchestrator.v1.OrchestratorService.GetForkStatus:output_type -> orchestrator.v1.GetForkStatusResponse
+	57, // [57:89] is the sub-list for method output_type
+	25, // [25:57] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_orchestrator_v1_orchestrator_proto_init() }
@@ -5156,8 +5468,8 @@ func file_orchestrator_v1_orchestrator_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_orchestrator_v1_orchestrator_proto_rawDesc), len(file_orchestrator_v1_orchestrator_proto_rawDesc)),
-			NumEnums:      4,
-			NumMessages:   73,
+			NumEnums:      5,
+			NumMessages:   75,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect/orchestrator.connect.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect/orchestrator.connect.go
@@ -114,6 +114,9 @@ const (
 	// OrchestratorServiceAcceptBlockProcedure is the fully-qualified name of the OrchestratorService's
 	// AcceptBlock RPC.
 	OrchestratorServiceAcceptBlockProcedure = "/orchestrator.v1.OrchestratorService/AcceptBlock"
+	// OrchestratorServiceResetToBlockProcedure is the fully-qualified name of the OrchestratorService's
+	// ResetToBlock RPC.
+	OrchestratorServiceResetToBlockProcedure = "/orchestrator.v1.OrchestratorService/ResetToBlock"
 	// OrchestratorServiceGetCoreMempoolInfoProcedure is the fully-qualified name of the
 	// OrchestratorService's GetCoreMempoolInfo RPC.
 	OrchestratorServiceGetCoreMempoolInfoProcedure = "/orchestrator.v1.OrchestratorService/GetCoreMempoolInfo"
@@ -229,6 +232,10 @@ type OrchestratorServiceClient interface {
 	// Undo RejectBlock. Core re-checks the block and its branch, and follows it
 	// again when it has the most work.
 	AcceptBlock(context.Context, *connect.Request[v1.AcceptBlockRequest]) (*connect.Response[v1.AcceptBlockResponse], error)
+	// Move the chain back to a block, then sync forward to the tip again. Core
+	// drops the block and every block above it, then re-validates them from
+	// disk. Streams one message per phase.
+	ResetToBlock(context.Context, *connect.Request[v1.ResetToBlockRequest]) (*connect.ServerStreamForClient[v1.ResetToBlockResponse], error)
 	// Full bitcoind getmempoolinfo response. Distinct from getrawmempool.
 	GetCoreMempoolInfo(context.Context, *connect.Request[v1.GetCoreMempoolInfoRequest]) (*connect.Response[v1.GetCoreMempoolInfoResponse], error)
 	// Parent-chain state the sidechain BMM tab bids against: the tip a request
@@ -420,6 +427,12 @@ func NewOrchestratorServiceClient(httpClient connect.HTTPClient, baseURL string,
 			connect.WithSchema(orchestratorServiceMethods.ByName("AcceptBlock")),
 			connect.WithClientOptions(opts...),
 		),
+		resetToBlock: connect.NewClient[v1.ResetToBlockRequest, v1.ResetToBlockResponse](
+			httpClient,
+			baseURL+OrchestratorServiceResetToBlockProcedure,
+			connect.WithSchema(orchestratorServiceMethods.ByName("ResetToBlock")),
+			connect.WithClientOptions(opts...),
+		),
 		getCoreMempoolInfo: connect.NewClient[v1.GetCoreMempoolInfoRequest, v1.GetCoreMempoolInfoResponse](
 			httpClient,
 			baseURL+OrchestratorServiceGetCoreMempoolInfoProcedure,
@@ -476,6 +489,7 @@ type orchestratorServiceClient struct {
 	deleteFiles                     *connect.Client[v1.DeleteFilesRequest, v1.DeleteFilesResponse]
 	rejectBlock                     *connect.Client[v1.RejectBlockRequest, v1.RejectBlockResponse]
 	acceptBlock                     *connect.Client[v1.AcceptBlockRequest, v1.AcceptBlockResponse]
+	resetToBlock                    *connect.Client[v1.ResetToBlockRequest, v1.ResetToBlockResponse]
 	getCoreMempoolInfo              *connect.Client[v1.GetCoreMempoolInfoRequest, v1.GetCoreMempoolInfoResponse]
 	getBmmContext                   *connect.Client[v1.GetBmmContextRequest, v1.GetBmmContextResponse]
 	coreRawCall                     *connect.Client[v1.CoreRawCallRequest, v1.CoreRawCallResponse]
@@ -619,6 +633,11 @@ func (c *orchestratorServiceClient) AcceptBlock(ctx context.Context, req *connec
 	return c.acceptBlock.CallUnary(ctx, req)
 }
 
+// ResetToBlock calls orchestrator.v1.OrchestratorService.ResetToBlock.
+func (c *orchestratorServiceClient) ResetToBlock(ctx context.Context, req *connect.Request[v1.ResetToBlockRequest]) (*connect.ServerStreamForClient[v1.ResetToBlockResponse], error) {
+	return c.resetToBlock.CallServerStream(ctx, req)
+}
+
 // GetCoreMempoolInfo calls orchestrator.v1.OrchestratorService.GetCoreMempoolInfo.
 func (c *orchestratorServiceClient) GetCoreMempoolInfo(ctx context.Context, req *connect.Request[v1.GetCoreMempoolInfoRequest]) (*connect.Response[v1.GetCoreMempoolInfoResponse], error) {
 	return c.getCoreMempoolInfo.CallUnary(ctx, req)
@@ -741,6 +760,10 @@ type OrchestratorServiceHandler interface {
 	// Undo RejectBlock. Core re-checks the block and its branch, and follows it
 	// again when it has the most work.
 	AcceptBlock(context.Context, *connect.Request[v1.AcceptBlockRequest]) (*connect.Response[v1.AcceptBlockResponse], error)
+	// Move the chain back to a block, then sync forward to the tip again. Core
+	// drops the block and every block above it, then re-validates them from
+	// disk. Streams one message per phase.
+	ResetToBlock(context.Context, *connect.Request[v1.ResetToBlockRequest], *connect.ServerStream[v1.ResetToBlockResponse]) error
 	// Full bitcoind getmempoolinfo response. Distinct from getrawmempool.
 	GetCoreMempoolInfo(context.Context, *connect.Request[v1.GetCoreMempoolInfoRequest]) (*connect.Response[v1.GetCoreMempoolInfoResponse], error)
 	// Parent-chain state the sidechain BMM tab bids against: the tip a request
@@ -928,6 +951,12 @@ func NewOrchestratorServiceHandler(svc OrchestratorServiceHandler, opts ...conne
 		connect.WithSchema(orchestratorServiceMethods.ByName("AcceptBlock")),
 		connect.WithHandlerOptions(opts...),
 	)
+	orchestratorServiceResetToBlockHandler := connect.NewServerStreamHandler(
+		OrchestratorServiceResetToBlockProcedure,
+		svc.ResetToBlock,
+		connect.WithSchema(orchestratorServiceMethods.ByName("ResetToBlock")),
+		connect.WithHandlerOptions(opts...),
+	)
 	orchestratorServiceGetCoreMempoolInfoHandler := connect.NewUnaryHandler(
 		OrchestratorServiceGetCoreMempoolInfoProcedure,
 		svc.GetCoreMempoolInfo,
@@ -1008,6 +1037,8 @@ func NewOrchestratorServiceHandler(svc OrchestratorServiceHandler, opts ...conne
 			orchestratorServiceRejectBlockHandler.ServeHTTP(w, r)
 		case OrchestratorServiceAcceptBlockProcedure:
 			orchestratorServiceAcceptBlockHandler.ServeHTTP(w, r)
+		case OrchestratorServiceResetToBlockProcedure:
+			orchestratorServiceResetToBlockHandler.ServeHTTP(w, r)
 		case OrchestratorServiceGetCoreMempoolInfoProcedure:
 			orchestratorServiceGetCoreMempoolInfoHandler.ServeHTTP(w, r)
 		case OrchestratorServiceGetBmmContextProcedure:
@@ -1131,6 +1162,10 @@ func (UnimplementedOrchestratorServiceHandler) RejectBlock(context.Context, *con
 
 func (UnimplementedOrchestratorServiceHandler) AcceptBlock(context.Context, *connect.Request[v1.AcceptBlockRequest]) (*connect.Response[v1.AcceptBlockResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("orchestrator.v1.OrchestratorService.AcceptBlock is not implemented"))
+}
+
+func (UnimplementedOrchestratorServiceHandler) ResetToBlock(context.Context, *connect.Request[v1.ResetToBlockRequest], *connect.ServerStream[v1.ResetToBlockResponse]) error {
+	return connect.NewError(connect.CodeUnimplemented, errors.New("orchestrator.v1.OrchestratorService.ResetToBlock is not implemented"))
 }
 
 func (UnimplementedOrchestratorServiceHandler) GetCoreMempoolInfo(context.Context, *connect.Request[v1.GetCoreMempoolInfoRequest]) (*connect.Response[v1.GetCoreMempoolInfoResponse], error) {

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -129,6 +129,11 @@ service OrchestratorService {
   // again when it has the most work.
   rpc AcceptBlock(AcceptBlockRequest) returns (AcceptBlockResponse);
 
+  // Move the chain back to a block, then sync forward to the tip again. Core
+  // drops the block and every block above it, then re-validates them from
+  // disk. Streams one message per phase.
+  rpc ResetToBlock(ResetToBlockRequest) returns (stream ResetToBlockResponse);
+
   // ─── Bitcoin Core typed extensions ────────────────────────────────────────
   // Sit alongside the btc-buf BitcoinService for methods btc-buf doesn't type
   // (getmempoolinfo) plus a generic raw-call escape hatch (finalizepsbt,
@@ -695,6 +700,61 @@ message AcceptBlockResponse {
   // False when the enforcer was never asked, so enforcer_height carries no
   // reading and must not be shown as one.
   bool enforcer_checked = 6;
+}
+
+message ResetToBlockRequest {
+  // The block to move back to. A 64-character hash names one block. Anything
+  // else reads as a decimal height, and a height resolves against the chain
+  // this node follows today.
+  string target = 1;
+  // How long to wait for the enforcer to follow before its validator chain is
+  // deleted. Zero picks the default.
+  uint32 enforcer_wait_seconds = 2;
+}
+
+// Which step of a reset a progress message reports.
+enum ResetPhase {
+  RESET_PHASE_UNSPECIFIED = 0;
+  // The target reads as a height or a hash, and Core holds the block.
+  RESET_PHASE_RESOLVE = 1;
+  // Core drops the target block and every block above it.
+  RESET_PHASE_MOVE_BACK = 2;
+  // Core re-validates the dropped blocks from disk and climbs to the old tip.
+  RESET_PHASE_SYNC_FORWARD = 3;
+  // The enforcer comes back onto the chain Core follows.
+  RESET_PHASE_ENFORCER = 4;
+  // The reset is over.
+  RESET_PHASE_DONE = 5;
+}
+
+message ResetToBlockResponse {
+  ResetPhase phase = 1;
+  // Human-readable status for the phase.
+  string message = 2;
+  // The block the reset moves back to.
+  uint32 target_height = 3;
+  string target_hash = 4;
+  // Core's tip as the phase reports it. It falls to target_height - 1 on the
+  // move back, then climbs again.
+  uint32 core_height = 5;
+  // Core's tip before the reset. The replay ends here.
+  uint32 tip_height = 6;
+  // Blocks re-validated so far, out of the blocks the reset drops.
+  uint32 blocks_done = 7;
+  uint32 blocks_total = 8;
+  // The enforcer's tip afterwards. Zero when the enforcer is stopped.
+  uint32 enforcer_height = 9;
+  // False when the enforcer was never asked, so enforcer_height carries no
+  // reading and must not be shown as one.
+  bool enforcer_checked = 10;
+  // True when the enforcer did not follow, so its validator chain was deleted
+  // and it rebuilds from the local Core.
+  bool enforcer_rebuilt = 11;
+  // Empty on success; otherwise why the enforcer could not be brought back
+  // onto Core's chain.
+  string enforcer_error = 12;
+  // Set on the last message.
+  bool done = 13;
 }
 
 // ─── Bitcoin Core typed extensions ────────────────────────────────────────

--- a/sidechain-orchestrator/reject_block_test.go
+++ b/sidechain-orchestrator/reject_block_test.go
@@ -42,6 +42,11 @@ func (f *fakeCore) start(t *testing.T) *CoreStatusClient {
 		var result string
 		switch req.Method {
 		case "getblockcount":
+			// An empty list stands for a Core that refuses the read.
+			if len(f.tips) == 0 {
+				http.Error(w, `{"result":null,"error":{"code":-28,"message":"Loading block index"}}`, http.StatusOK)
+				return
+			}
 			result = fmt.Sprintf("%d", f.tips[0])
 			if len(f.tips) > 1 {
 				f.tips = f.tips[1:]

--- a/sidechain-orchestrator/reset_to_block.go
+++ b/sidechain-orchestrator/reset_to_block.go
@@ -137,20 +137,14 @@ func (o *Orchestrator) runResetToBlock(
 	client *CoreStatusClient,
 	target resetTarget,
 	enforcerWait time.Duration,
-	ch chan<- ResetProgress,
+	ch chan ResetProgress,
 ) {
 	// An accept or a reject landing mid-reset would move the chain this call
 	// still replays.
 	o.rejectMu.Lock()
 	defer o.rejectMu.Unlock()
 
-	// A reader that left must not stall the chain work behind it.
-	emit := func(p ResetProgress) {
-		select {
-		case ch <- p:
-		default:
-		}
-	}
+	emit := resetEmitter(ch)
 
 	// A reject landing between the resolve and this lock moves the active
 	// chain, and a stale target would take that rejection back.
@@ -203,6 +197,30 @@ func (o *Orchestrator) runResetToBlock(
 	step.Done = true
 	step.Message = fmt.Sprintf("The chain is back at %d.", final)
 	emit(step)
+}
+
+// resetEmitter writes progress without a stall behind a reader that left.
+// Progress is a snapshot, so a slow reader may miss ticks. A terminal message
+// carries the outcome, so it takes the place of the oldest tick rather than
+// drop.
+func resetEmitter(ch chan ResetProgress) func(ResetProgress) {
+	return func(p ResetProgress) {
+		terminal := p.Done || p.Error != nil
+		for {
+			select {
+			case ch <- p:
+				return
+			default:
+				if !terminal {
+					return
+				}
+				select {
+				case <-ch:
+				default:
+				}
+			}
+		}
+	}
 }
 
 // newResetProgress reads the tip the replay ends on and counts the blocks the

--- a/sidechain-orchestrator/reset_to_block.go
+++ b/sidechain-orchestrator/reset_to_block.go
@@ -1,0 +1,309 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// resetSyncPollInterval is how often the replay reads Core's tip while
+// reconsiderblock runs. Tests shorten it.
+var resetSyncPollInterval = time.Second
+
+// ResetPhase says which step of a reset a progress message reports.
+type ResetPhase int
+
+const (
+	ResetPhaseResolve ResetPhase = iota + 1
+	ResetPhaseMoveBack
+	ResetPhaseSyncForward
+	ResetPhaseEnforcer
+	ResetPhaseDone
+)
+
+// ResetProgress is one step of a reset.
+type ResetProgress struct {
+	Phase           ResetPhase
+	Message         string
+	TargetHeight    uint32
+	TargetHash      string
+	CoreHeight      uint32
+	TipHeight       uint32
+	BlocksDone      uint32
+	BlocksTotal     uint32
+	EnforcerChecked bool
+	EnforcerHeight  uint32
+	EnforcerRebuilt bool
+	EnforcerError   string
+	Done            bool
+	Error           error
+}
+
+var resetHashPattern = regexp.MustCompile(`^[0-9a-fA-F]{64}$`)
+
+// resetTarget is the block a reset moves back to.
+type resetTarget struct {
+	Hash   string
+	Height uint32
+}
+
+// resolveResetTarget reads a target as a hash or as a height. Two branches can
+// share a height, so a height only ever names the block on the chain Core
+// follows today.
+func resolveResetTarget(ctx context.Context, client *CoreStatusClient, target string) (resetTarget, error) {
+	trimmed := strings.TrimSpace(target)
+	if trimmed == "" {
+		return resetTarget{}, fmt.Errorf("name the block to reset to, by height or by hash")
+	}
+
+	hash := ""
+	if resetHashPattern.MatchString(trimmed) {
+		hash = normalizeBlockHash(trimmed)
+	} else {
+		height, err := strconv.ParseUint(strings.ReplaceAll(trimmed, " ", ""), 10, 32)
+		if err != nil {
+			return resetTarget{}, fmt.Errorf("read %q as a height or as a 64-character hash", trimmed)
+		}
+		tipHeight, _, err := coreTip(ctx, client)
+		if err != nil {
+			return resetTarget{}, err
+		}
+		if uint32(height) > tipHeight {
+			return resetTarget{}, fmt.Errorf("no block at height %d: this node holds a chain that ends at %d", height, tipHeight)
+		}
+		raw, err := client.call(ctx, "getblockhash", height)
+		if err != nil {
+			return resetTarget{}, fmt.Errorf("get block hash at %d: %w", height, err)
+		}
+		if err := json.Unmarshal(raw, &hash); err != nil {
+			return resetTarget{}, fmt.Errorf("decode block hash at %d: %w", height, err)
+		}
+	}
+
+	header, err := readBlockHeader(ctx, client, hash)
+	if err != nil {
+		return resetTarget{}, err
+	}
+	// A block off the active chain has nothing above it to replay, and Core
+	// would climb back to a tip the caller never named.
+	if header.Confirmations < 0 {
+		return resetTarget{}, fmt.Errorf("block %s sits off the chain this node follows", hash)
+	}
+	if header.Height < 0 {
+		return resetTarget{}, fmt.Errorf("block %s reports no height", hash)
+	}
+	return resetTarget{Hash: hash, Height: uint32(header.Height)}, nil
+}
+
+// ResetToBlock moves the chain back to a block, then syncs forward to the tip
+// again. Core drops the block and every block above it, and immediately takes
+// the drop back: invalidateblock alone marks the branch bad, so Core would park
+// on the parent and never follow that branch again. The blocks stay on disk, so
+// the replay downloads nothing.
+func (o *Orchestrator) ResetToBlock(ctx context.Context, target string, enforcerWait time.Duration) (<-chan ResetProgress, error) {
+	if enforcerWait <= 0 {
+		enforcerWait = defaultEnforcerReorgWait
+	}
+
+	client, err := o.CoreStatusClient()
+	if err != nil {
+		return nil, fmt.Errorf("bitcoin core rpc: %w", err)
+	}
+
+	// Resolve before the channel so a bad target is an RPC error, not a stream
+	// that opens and then fails.
+	resolved, err := resolveResetTarget(ctx, client, target)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan ResetProgress, 8)
+	go func() {
+		defer close(ch)
+		o.runResetToBlock(ctx, client, resolved, enforcerWait, ch)
+	}()
+	return ch, nil
+}
+
+func (o *Orchestrator) runResetToBlock(
+	ctx context.Context,
+	client *CoreStatusClient,
+	target resetTarget,
+	enforcerWait time.Duration,
+	ch chan<- ResetProgress,
+) {
+	// An accept or a reject landing mid-reset would move the chain this call
+	// still replays.
+	o.rejectMu.Lock()
+	defer o.rejectMu.Unlock()
+
+	emit := func(p ResetProgress) { ch <- p }
+
+	base, err := newResetProgress(ctx, client, target)
+	if err != nil {
+		emit(ResetProgress{Phase: ResetPhaseResolve, Error: err})
+		return
+	}
+
+	o.log.Info().
+		Str("target", target.Hash).
+		Uint32("target_height", target.Height).
+		Uint32("tip_height", base.TipHeight).
+		Msg("reset the chain to a block")
+
+	final, err := resetCoreToBlock(ctx, client, base, emit)
+	if err != nil {
+		return
+	}
+
+	step := base
+	step.Phase = ResetPhaseEnforcer
+	step.CoreHeight = final
+	step.BlocksDone = base.BlocksTotal
+	step.Message = "The enforcer follows Core."
+	emit(step)
+
+	rec := o.reconcileEnforcer(ctx, client, enforcerWait)
+	if rec.Err != "" {
+		o.log.Error().Str("error", rec.Err).Msg("core replayed but the enforcer could not be reconciled")
+	}
+
+	step = base
+	step.Phase = ResetPhaseDone
+	step.CoreHeight = final
+	step.BlocksDone = base.BlocksTotal
+	step.EnforcerChecked = rec.Checked
+	step.EnforcerHeight = rec.Height
+	step.EnforcerRebuilt = rec.Rebuilt
+	step.EnforcerError = rec.Err
+	step.Done = true
+	step.Message = fmt.Sprintf("The chain is back at %d.", final)
+	emit(step)
+}
+
+// newResetProgress reads the tip the replay ends on and counts the blocks the
+// reset drops.
+func newResetProgress(ctx context.Context, client *CoreStatusClient, target resetTarget) (ResetProgress, error) {
+	tipHeight, _, err := coreTip(ctx, client)
+	if err != nil {
+		return ResetProgress{}, err
+	}
+	if target.Height > tipHeight {
+		return ResetProgress{}, fmt.Errorf(
+			"no block at height %d: this node holds a chain that ends at %d", target.Height, tipHeight)
+	}
+	return ResetProgress{
+		TargetHeight: target.Height,
+		TargetHash:   target.Hash,
+		TipHeight:    tipHeight,
+		BlocksTotal:  tipHeight - target.Height + 1,
+	}, nil
+}
+
+// resetCoreToBlock drops the target block and takes the drop back at once, then
+// reports the replay. invalidateblock alone marks the branch bad, so Core would
+// park on the parent and never follow that branch again. It returns Core's tip
+// when the replay ends, and emits its own failure before it returns the error.
+func resetCoreToBlock(
+	ctx context.Context,
+	client *CoreStatusClient,
+	base ResetProgress,
+	emit func(ResetProgress),
+) (uint32, error) {
+	fail := func(phase ResetPhase, err error) (uint32, error) {
+		step := base
+		step.Phase = phase
+		step.Error = err
+		emit(step)
+		return 0, err
+	}
+
+	step := base
+	step.Phase = ResetPhaseResolve
+	step.CoreHeight = base.TipHeight
+	step.Message = fmt.Sprintf("Block %d is on the chain this node follows.", base.TargetHeight)
+	emit(step)
+
+	if _, err := client.call(ctx, "invalidateblock", base.TargetHash); err != nil {
+		return fail(ResetPhaseMoveBack, fmt.Errorf("move back to block %s: %w", base.TargetHash, err))
+	}
+
+	parked, _, err := coreTip(ctx, client)
+	if err != nil {
+		return fail(ResetPhaseMoveBack, err)
+	}
+	step = base
+	step.Phase = ResetPhaseMoveBack
+	step.CoreHeight = parked
+	step.Message = fmt.Sprintf("Core dropped %d blocks and sits at %d.", base.BlocksTotal, parked)
+	emit(step)
+
+	// Core clears the mark and re-validates every dropped block before
+	// reconsiderblock returns, so that one call is the whole replay. A poll on
+	// the side is the only way to report how far it got.
+	replay := make(chan error, 1)
+	go func() {
+		_, err := client.call(ctx, "reconsiderblock", base.TargetHash)
+		replay <- err
+	}()
+
+	step = base
+	step.Phase = ResetPhaseSyncForward
+	step.CoreHeight = parked
+	step.Message = fmt.Sprintf("Core replays %d blocks from disk.", base.BlocksTotal)
+	emit(step)
+
+	if err := awaitResetReplay(ctx, client, base, parked, replay, emit); err != nil {
+		return fail(ResetPhaseSyncForward, err)
+	}
+
+	final, _, err := coreTip(ctx, client)
+	if err != nil {
+		return fail(ResetPhaseSyncForward, err)
+	}
+	return final, nil
+}
+
+// awaitResetReplay reports Core's tip while reconsiderblock runs. A tip it
+// cannot read counts as no answer: Core refuses RPC while it re-validates a
+// long branch, and one refusal must not end the replay.
+func awaitResetReplay(
+	ctx context.Context,
+	client *CoreStatusClient,
+	base ResetProgress,
+	parked uint32,
+	replay <-chan error,
+	emit func(ResetProgress),
+) error {
+	last := parked
+	for {
+		select {
+		case err := <-replay:
+			if err != nil {
+				return fmt.Errorf("sync forward from block %s: %w", base.TargetHash, err)
+			}
+			return nil
+		case <-ctx.Done():
+			// Core owns the replay from here. Leaving it alone is safer than a
+			// second move on a chain that is mid-flight.
+			return ctx.Err()
+		case <-time.After(resetSyncPollInterval):
+		}
+
+		height, _, err := coreTip(ctx, client)
+		if err != nil || height <= last {
+			continue
+		}
+		last = height
+		step := base
+		step.Phase = ResetPhaseSyncForward
+		step.CoreHeight = height
+		step.BlocksDone = height - base.TargetHeight + 1
+		step.Message = fmt.Sprintf("Core is at %d of %d.", height, base.TipHeight)
+		emit(step)
+	}
+}

--- a/sidechain-orchestrator/reset_to_block.go
+++ b/sidechain-orchestrator/reset_to_block.go
@@ -121,10 +121,13 @@ func (o *Orchestrator) ResetToBlock(ctx context.Context, target string, enforcer
 		return nil, err
 	}
 
-	ch := make(chan ResetProgress, 8)
+	// Core keeps replaying whatever the caller does, so the run must outlive the
+	// request. A cancelled reset would release rejectMu while Core still moves.
+	run := context.WithoutCancel(ctx)
+	ch := make(chan ResetProgress, 32)
 	go func() {
 		defer close(ch)
-		o.runResetToBlock(ctx, client, resolved, enforcerWait, ch)
+		o.runResetToBlock(run, client, resolved, enforcerWait, ch)
 	}()
 	return ch, nil
 }
@@ -141,7 +144,24 @@ func (o *Orchestrator) runResetToBlock(
 	o.rejectMu.Lock()
 	defer o.rejectMu.Unlock()
 
-	emit := func(p ResetProgress) { ch <- p }
+	// A reader that left must not stall the chain work behind it.
+	emit := func(p ResetProgress) {
+		select {
+		case ch <- p:
+		default:
+		}
+	}
+
+	// A reject landing between the resolve and this lock moves the active
+	// chain, and a stale target would take that rejection back.
+	onChain, err := blockOnActiveChain(ctx, client, target.Hash)
+	if err == nil && !onChain {
+		err = fmt.Errorf("block %s left the chain this node follows", target.Hash)
+	}
+	if err != nil {
+		emit(ResetProgress{Phase: ResetPhaseResolve, Error: err})
+		return
+	}
 
 	base, err := newResetProgress(ctx, client, target)
 	if err != nil {
@@ -232,6 +252,15 @@ func resetCoreToBlock(
 		return fail(ResetPhaseMoveBack, fmt.Errorf("move back to block %s: %w", base.TargetHash, err))
 	}
 
+	// A block left invalid sits off the active chain, so a retry on the same
+	// target is refused. Every path from here clears the mark.
+	reconsidered := false
+	defer func() {
+		if !reconsidered {
+			_, _ = client.call(ctx, "reconsiderblock", base.TargetHash)
+		}
+	}()
+
 	parked, _, err := coreTip(ctx, client)
 	if err != nil {
 		return fail(ResetPhaseMoveBack, err)
@@ -246,6 +275,7 @@ func resetCoreToBlock(
 	// reconsiderblock returns, so that one call is the whole replay. A poll on
 	// the side is the only way to report how far it got.
 	replay := make(chan error, 1)
+	reconsidered = true
 	go func() {
 		_, err := client.call(ctx, "reconsiderblock", base.TargetHash)
 		replay <- err
@@ -288,8 +318,8 @@ func awaitResetReplay(
 			}
 			return nil
 		case <-ctx.Done():
-			// Core owns the replay from here. Leaving it alone is safer than a
-			// second move on a chain that is mid-flight.
+			// The run context outlives the request, so only a shutdown lands
+			// here. Core owns the replay either way.
 			return ctx.Err()
 		case <-time.After(resetSyncPollInterval):
 		}

--- a/sidechain-orchestrator/reset_to_block_test.go
+++ b/sidechain-orchestrator/reset_to_block_test.go
@@ -195,6 +195,27 @@ func TestNewResetProgressCountsTheDroppedBlocks(t *testing.T) {
 	}
 }
 
+// A block left invalid sits off the active chain, so a retry on the same
+// target is refused. A failure after the invalidate must clear the mark.
+func TestResetCoreToBlockClearsTheMarkWhenTheTipReadFails(t *testing.T) {
+	core := &fakeCore{
+		// One tip only: the read after the invalidate finds no entry and fails.
+		tips:    []int64{},
+		hashes:  map[int64]string{},
+		headers: map[string]blockHeader{target979000: {Height: 979000, Confirmations: 473, PreviousBlockHash: parent}},
+	}
+
+	base := ResetProgress{TargetHeight: 979000, TargetHash: target979000, TipHeight: 979472, BlocksTotal: 473}
+	if _, err := resetCoreToBlock(context.Background(), core.start(t), base, func(ResetProgress) {}); err == nil {
+		t.Fatal("resetCoreToBlock reported no error after a failed tip read")
+	}
+
+	calls := strings.Join(core.methods, ",")
+	if !strings.Contains(calls, "reconsiderblock") {
+		t.Errorf("rpc calls = %s, want reconsiderblock after the failed tip read", calls)
+	}
+}
+
 func phases(steps []ResetProgress) []ResetPhase {
 	out := make([]ResetPhase, 0, len(steps))
 	for _, s := range steps {

--- a/sidechain-orchestrator/reset_to_block_test.go
+++ b/sidechain-orchestrator/reset_to_block_test.go
@@ -216,6 +216,42 @@ func TestResetCoreToBlockClearsTheMarkWhenTheTipReadFails(t *testing.T) {
 	}
 }
 
+// Progress is a snapshot, so a slow reader may miss ticks. The terminal
+// message carries the outcome, so a full buffer must not drop it.
+func TestResetEmitKeepsTheTerminalMessage(t *testing.T) {
+	ch := make(chan ResetProgress, 2)
+	emit := resetEmitter(ch)
+
+	emit(ResetProgress{Phase: ResetPhaseSyncForward, CoreHeight: 1})
+	emit(ResetProgress{Phase: ResetPhaseSyncForward, CoreHeight: 2})
+	emit(ResetProgress{Phase: ResetPhaseSyncForward, CoreHeight: 3})
+	emit(ResetProgress{Phase: ResetPhaseDone, Done: true})
+
+	var last ResetProgress
+	for len(ch) > 0 {
+		last = <-ch
+	}
+	if !last.Done {
+		t.Errorf("last message = %+v, want the terminal one", last)
+	}
+}
+
+func TestResetEmitKeepsTheError(t *testing.T) {
+	ch := make(chan ResetProgress, 1)
+	emit := resetEmitter(ch)
+
+	emit(ResetProgress{Phase: ResetPhaseSyncForward, CoreHeight: 1})
+	emit(ResetProgress{Phase: ResetPhaseSyncForward, Error: context.Canceled})
+
+	var last ResetProgress
+	for len(ch) > 0 {
+		last = <-ch
+	}
+	if last.Error == nil {
+		t.Errorf("last message = %+v, want the error", last)
+	}
+}
+
 func phases(steps []ResetProgress) []ResetPhase {
 	out := make([]ResetPhase, 0, len(steps))
 	for _, s := range steps {

--- a/sidechain-orchestrator/reset_to_block_test.go
+++ b/sidechain-orchestrator/reset_to_block_test.go
@@ -1,0 +1,213 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	target979000 = "0000000000000000000000000000000000000000000000000000000079000000"
+	tipHash      = "0000000000000000000000000000000000000000000000000000000079472000"
+)
+
+// A height names the block on the chain Core follows today, so the reset asks
+// Core for that hash rather than trusting the number on its own.
+func TestResolveResetTargetReadsAHeight(t *testing.T) {
+	core := &fakeCore{
+		tips:    []int64{979472},
+		hashes:  map[int64]string{979000: target979000, 979472: tipHash},
+		headers: map[string]blockHeader{target979000: {Height: 979000, Confirmations: 473, PreviousBlockHash: parent}},
+	}
+
+	got, err := resolveResetTarget(context.Background(), core.start(t), "979000")
+	if err != nil {
+		t.Fatalf("resolveResetTarget: %v", err)
+	}
+	if got.Hash != target979000 || got.Height != 979000 {
+		t.Errorf("target = %s/%d, want %s/979000", got.Hash, got.Height, target979000)
+	}
+}
+
+// The field takes a copied height, and a copied height carries the group
+// separators the UI prints.
+func TestResolveResetTargetReadsASpacedHeight(t *testing.T) {
+	core := &fakeCore{
+		tips:    []int64{979472},
+		hashes:  map[int64]string{979000: target979000, 979472: tipHash},
+		headers: map[string]blockHeader{target979000: {Height: 979000, Confirmations: 473, PreviousBlockHash: parent}},
+	}
+
+	got, err := resolveResetTarget(context.Background(), core.start(t), " 979 000 ")
+	if err != nil {
+		t.Fatalf("resolveResetTarget: %v", err)
+	}
+	if got.Height != 979000 {
+		t.Errorf("height = %d, want 979000", got.Height)
+	}
+}
+
+// A hash names one block, so the reset never asks Core to resolve a height.
+func TestResolveResetTargetReadsAHash(t *testing.T) {
+	core := &fakeCore{
+		tips:    []int64{979472},
+		headers: map[string]blockHeader{target979000: {Height: 979000, Confirmations: 473, PreviousBlockHash: parent}},
+	}
+
+	got, err := resolveResetTarget(context.Background(), core.start(t), strings.ToUpper(target979000))
+	if err != nil {
+		t.Fatalf("resolveResetTarget: %v", err)
+	}
+	if got.Hash != target979000 {
+		t.Errorf("hash = %s, want the lower case form %s", got.Hash, target979000)
+	}
+	if calls := strings.Join(core.methods, ","); calls != "getblockheader" {
+		t.Errorf("rpc calls = %s, want getblockheader only", calls)
+	}
+}
+
+func TestResolveResetTargetRefusesAHeightAboveTheTip(t *testing.T) {
+	core := &fakeCore{tips: []int64{979472}, hashes: map[int64]string{979472: tipHash}}
+
+	_, err := resolveResetTarget(context.Background(), core.start(t), "999999")
+	if err == nil {
+		t.Fatal("resolveResetTarget accepted a height above the tip")
+	}
+	if !strings.Contains(err.Error(), "979472") {
+		t.Errorf("error = %v, want the tip height in it", err)
+	}
+}
+
+// A block off the active chain has nothing above it to replay, and Core would
+// climb back to a tip the caller never named.
+func TestResolveResetTargetRefusesABlockOffTheChain(t *testing.T) {
+	core := &fakeCore{
+		tips:    []int64{979472},
+		headers: map[string]blockHeader{other: {Height: 979000, Confirmations: -1, PreviousBlockHash: parent}},
+	}
+
+	_, err := resolveResetTarget(context.Background(), core.start(t), other)
+	if err == nil {
+		t.Fatal("resolveResetTarget accepted a block off the active chain")
+	}
+}
+
+func TestResolveResetTargetRefusesJunk(t *testing.T) {
+	core := &fakeCore{tips: []int64{979472}, hashes: map[int64]string{979472: tipHash}}
+
+	for _, target := range []string{"", "   ", "abc", "-4", "0x10"} {
+		if _, err := resolveResetTarget(context.Background(), core.start(t), target); err == nil {
+			t.Errorf("resolveResetTarget accepted %q", target)
+		}
+	}
+}
+
+// The reset takes its own drop back at once. invalidateblock alone marks the
+// branch bad, so Core would park on the parent and never follow it again.
+func TestResetCoreToBlockReconsidersImmediately(t *testing.T) {
+	resetSyncPollInterval = time.Millisecond
+	t.Cleanup(func() { resetSyncPollInterval = time.Second })
+
+	core := &fakeCore{
+		tips:    []int64{978999, 979472},
+		hashes:  map[int64]string{978999: parent, 979472: tipHash},
+		headers: map[string]blockHeader{target979000: {Height: 979000, Confirmations: 473, PreviousBlockHash: parent}},
+	}
+
+	base := ResetProgress{TargetHeight: 979000, TargetHash: target979000, TipHeight: 979472, BlocksTotal: 473}
+	var steps []ResetProgress
+	final, err := resetCoreToBlock(context.Background(), core.start(t), base, func(p ResetProgress) {
+		steps = append(steps, p)
+	})
+	if err != nil {
+		t.Fatalf("resetCoreToBlock: %v", err)
+	}
+	if final != 979472 {
+		t.Errorf("final tip = %d, want 979472", final)
+	}
+
+	calls := strings.Join(core.methods, ",")
+	invalidate := strings.Index(calls, "invalidateblock")
+	reconsider := strings.Index(calls, "reconsiderblock")
+	if invalidate < 0 || reconsider < 0 {
+		t.Fatalf("rpc calls = %s, want both invalidateblock and reconsiderblock", calls)
+	}
+	if reconsider < invalidate {
+		t.Errorf("rpc calls = %s, want invalidateblock before reconsiderblock", calls)
+	}
+
+	if got := phases(steps); !hasPhase(got, ResetPhaseMoveBack) || !hasPhase(got, ResetPhaseSyncForward) {
+		t.Errorf("phases = %v, want a move back and a sync forward", got)
+	}
+}
+
+// The parked tip is the block below the target, and it is what the move back
+// reports.
+func TestResetCoreToBlockReportsTheParkedTip(t *testing.T) {
+	resetSyncPollInterval = time.Millisecond
+	t.Cleanup(func() { resetSyncPollInterval = time.Second })
+
+	core := &fakeCore{
+		tips:    []int64{978999, 979472},
+		hashes:  map[int64]string{978999: parent, 979472: tipHash},
+		headers: map[string]blockHeader{target979000: {Height: 979000, Confirmations: 473, PreviousBlockHash: parent}},
+	}
+
+	base := ResetProgress{TargetHeight: 979000, TargetHash: target979000, TipHeight: 979472, BlocksTotal: 473}
+	var moveBack *ResetProgress
+	if _, err := resetCoreToBlock(context.Background(), core.start(t), base, func(p ResetProgress) {
+		if p.Phase == ResetPhaseMoveBack {
+			step := p
+			moveBack = &step
+		}
+	}); err != nil {
+		t.Fatalf("resetCoreToBlock: %v", err)
+	}
+	if moveBack == nil {
+		t.Fatal("the reset reported no move back")
+	}
+	if moveBack.CoreHeight != 978999 {
+		t.Errorf("parked tip = %d, want 978999", moveBack.CoreHeight)
+	}
+}
+
+// The blocks the reset drops are the target and everything above it, so a
+// reset to the tip itself still replays one block.
+func TestNewResetProgressCountsTheDroppedBlocks(t *testing.T) {
+	core := &fakeCore{tips: []int64{979472, 979472}, hashes: map[int64]string{979472: tipHash}}
+	client := core.start(t)
+
+	got, err := newResetProgress(context.Background(), client, resetTarget{Hash: target979000, Height: 979000})
+	if err != nil {
+		t.Fatalf("newResetProgress: %v", err)
+	}
+	if got.BlocksTotal != 473 {
+		t.Errorf("BlocksTotal = %d, want 473", got.BlocksTotal)
+	}
+
+	tip, err := newResetProgress(context.Background(), client, resetTarget{Hash: tipHash, Height: 979472})
+	if err != nil {
+		t.Fatalf("newResetProgress at the tip: %v", err)
+	}
+	if tip.BlocksTotal != 1 {
+		t.Errorf("BlocksTotal at the tip = %d, want 1", tip.BlocksTotal)
+	}
+}
+
+func phases(steps []ResetProgress) []ResetPhase {
+	out := make([]ResetPhase, 0, len(steps))
+	for _, s := range steps {
+		out = append(out, s.Phase)
+	}
+	return out
+}
+
+func hasPhase(list []ResetPhase, want ResetPhase) bool {
+	for _, p := range list {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.connect.client.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.connect.client.dart
@@ -539,6 +539,26 @@ extension type OrchestratorServiceClient(connect.Transport _transport) {
     );
   }
 
+  /// Move the chain back to a block, then sync forward to the tip again. Core
+  /// drops the block and every block above it, then re-validates them from
+  /// disk. Streams one message per phase.
+  Stream<orchestratorv1orchestrator.ResetToBlockResponse> resetToBlock(
+    orchestratorv1orchestrator.ResetToBlockRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).server(
+      specs.OrchestratorService.resetToBlock,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
   /// Full bitcoind getmempoolinfo response. Distinct from getrawmempool.
   Future<orchestratorv1orchestrator.GetCoreMempoolInfoResponse> getCoreMempoolInfo(
     orchestratorv1orchestrator.GetCoreMempoolInfoRequest input, {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.connect.spec.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.connect.spec.dart
@@ -271,6 +271,16 @@ abstract final class OrchestratorService {
     orchestratorv1orchestrator.AcceptBlockResponse.new,
   );
 
+  /// Move the chain back to a block, then sync forward to the tip again. Core
+  /// drops the block and every block above it, then re-validates them from
+  /// disk. Streams one message per phase.
+  static const resetToBlock = connect.Spec(
+    '/$name/ResetToBlock',
+    connect.StreamType.server,
+    orchestratorv1orchestrator.ResetToBlockRequest.new,
+    orchestratorv1orchestrator.ResetToBlockResponse.new,
+  );
+
   /// Full bitcoind getmempoolinfo response. Distinct from getrawmempool.
   static const getCoreMempoolInfo = connect.Spec(
     '/$name/GetCoreMempoolInfo',

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -4966,6 +4966,359 @@ class AcceptBlockResponse extends $pb.GeneratedMessage {
   void clearEnforcerChecked() => clearField(6);
 }
 
+class ResetToBlockRequest extends $pb.GeneratedMessage {
+  factory ResetToBlockRequest({
+    $core.String? target,
+    $core.int? enforcerWaitSeconds,
+  }) {
+    final $result = create();
+    if (target != null) {
+      $result.target = target;
+    }
+    if (enforcerWaitSeconds != null) {
+      $result.enforcerWaitSeconds = enforcerWaitSeconds;
+    }
+    return $result;
+  }
+  ResetToBlockRequest._() : super();
+  factory ResetToBlockRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ResetToBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResetToBlockRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'target')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'enforcerWaitSeconds', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  ResetToBlockRequest clone() => ResetToBlockRequest()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ResetToBlockRequest copyWith(void Function(ResetToBlockRequest) updates) =>
+      super.copyWith((message) => updates(message as ResetToBlockRequest)) as ResetToBlockRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ResetToBlockRequest create() => ResetToBlockRequest._();
+  ResetToBlockRequest createEmptyInstance() => create();
+  static $pb.PbList<ResetToBlockRequest> createRepeated() => $pb.PbList<ResetToBlockRequest>();
+  @$core.pragma('dart2js:noInline')
+  static ResetToBlockRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResetToBlockRequest>(create);
+  static ResetToBlockRequest? _defaultInstance;
+
+  /// The block to move back to. A 64-character hash names one block. Anything
+  /// else reads as a decimal height, and a height resolves against the chain
+  /// this node follows today.
+  @$pb.TagNumber(1)
+  $core.String get target => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set target($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasTarget() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTarget() => clearField(1);
+
+  /// How long to wait for the enforcer to follow before its validator chain is
+  /// deleted. Zero picks the default.
+  @$pb.TagNumber(2)
+  $core.int get enforcerWaitSeconds => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set enforcerWaitSeconds($core.int v) {
+    $_setUnsignedInt32(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasEnforcerWaitSeconds() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearEnforcerWaitSeconds() => clearField(2);
+}
+
+class ResetToBlockResponse extends $pb.GeneratedMessage {
+  factory ResetToBlockResponse({
+    ResetPhase? phase,
+    $core.String? message,
+    $core.int? targetHeight,
+    $core.String? targetHash,
+    $core.int? coreHeight,
+    $core.int? tipHeight,
+    $core.int? blocksDone,
+    $core.int? blocksTotal,
+    $core.int? enforcerHeight,
+    $core.bool? enforcerChecked,
+    $core.bool? enforcerRebuilt,
+    $core.String? enforcerError,
+    $core.bool? done,
+  }) {
+    final $result = create();
+    if (phase != null) {
+      $result.phase = phase;
+    }
+    if (message != null) {
+      $result.message = message;
+    }
+    if (targetHeight != null) {
+      $result.targetHeight = targetHeight;
+    }
+    if (targetHash != null) {
+      $result.targetHash = targetHash;
+    }
+    if (coreHeight != null) {
+      $result.coreHeight = coreHeight;
+    }
+    if (tipHeight != null) {
+      $result.tipHeight = tipHeight;
+    }
+    if (blocksDone != null) {
+      $result.blocksDone = blocksDone;
+    }
+    if (blocksTotal != null) {
+      $result.blocksTotal = blocksTotal;
+    }
+    if (enforcerHeight != null) {
+      $result.enforcerHeight = enforcerHeight;
+    }
+    if (enforcerChecked != null) {
+      $result.enforcerChecked = enforcerChecked;
+    }
+    if (enforcerRebuilt != null) {
+      $result.enforcerRebuilt = enforcerRebuilt;
+    }
+    if (enforcerError != null) {
+      $result.enforcerError = enforcerError;
+    }
+    if (done != null) {
+      $result.done = done;
+    }
+    return $result;
+  }
+  ResetToBlockResponse._() : super();
+  factory ResetToBlockResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ResetToBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResetToBlockResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'orchestrator.v1'), createEmptyInstance: create)
+    ..e<ResetPhase>(1, _omitFieldNames ? '' : 'phase', $pb.PbFieldType.OE,
+        defaultOrMaker: ResetPhase.RESET_PHASE_UNSPECIFIED, valueOf: ResetPhase.valueOf, enumValues: ResetPhase.values)
+    ..aOS(2, _omitFieldNames ? '' : 'message')
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'targetHeight', $pb.PbFieldType.OU3)
+    ..aOS(4, _omitFieldNames ? '' : 'targetHash')
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'coreHeight', $pb.PbFieldType.OU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'tipHeight', $pb.PbFieldType.OU3)
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'blocksDone', $pb.PbFieldType.OU3)
+    ..a<$core.int>(8, _omitFieldNames ? '' : 'blocksTotal', $pb.PbFieldType.OU3)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'enforcerHeight', $pb.PbFieldType.OU3)
+    ..aOB(10, _omitFieldNames ? '' : 'enforcerChecked')
+    ..aOB(11, _omitFieldNames ? '' : 'enforcerRebuilt')
+    ..aOS(12, _omitFieldNames ? '' : 'enforcerError')
+    ..aOB(13, _omitFieldNames ? '' : 'done')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  ResetToBlockResponse clone() => ResetToBlockResponse()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ResetToBlockResponse copyWith(void Function(ResetToBlockResponse) updates) =>
+      super.copyWith((message) => updates(message as ResetToBlockResponse)) as ResetToBlockResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ResetToBlockResponse create() => ResetToBlockResponse._();
+  ResetToBlockResponse createEmptyInstance() => create();
+  static $pb.PbList<ResetToBlockResponse> createRepeated() => $pb.PbList<ResetToBlockResponse>();
+  @$core.pragma('dart2js:noInline')
+  static ResetToBlockResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResetToBlockResponse>(create);
+  static ResetToBlockResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  ResetPhase get phase => $_getN(0);
+  @$pb.TagNumber(1)
+  set phase(ResetPhase v) {
+    setField(1, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasPhase() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPhase() => clearField(1);
+
+  /// Human-readable status for the phase.
+  @$pb.TagNumber(2)
+  $core.String get message => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set message($core.String v) {
+    $_setString(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasMessage() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMessage() => clearField(2);
+
+  /// The block the reset moves back to.
+  @$pb.TagNumber(3)
+  $core.int get targetHeight => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set targetHeight($core.int v) {
+    $_setUnsignedInt32(2, v);
+  }
+
+  @$pb.TagNumber(3)
+  $core.bool hasTargetHeight() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearTargetHeight() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get targetHash => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set targetHash($core.String v) {
+    $_setString(3, v);
+  }
+
+  @$pb.TagNumber(4)
+  $core.bool hasTargetHash() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearTargetHash() => clearField(4);
+
+  /// Core's tip as the phase reports it. It falls to target_height - 1 on the
+  /// move back, then climbs again.
+  @$pb.TagNumber(5)
+  $core.int get coreHeight => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set coreHeight($core.int v) {
+    $_setUnsignedInt32(4, v);
+  }
+
+  @$pb.TagNumber(5)
+  $core.bool hasCoreHeight() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearCoreHeight() => clearField(5);
+
+  /// Core's tip before the reset. The replay ends here.
+  @$pb.TagNumber(6)
+  $core.int get tipHeight => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set tipHeight($core.int v) {
+    $_setUnsignedInt32(5, v);
+  }
+
+  @$pb.TagNumber(6)
+  $core.bool hasTipHeight() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearTipHeight() => clearField(6);
+
+  /// Blocks re-validated so far, out of the blocks the reset drops.
+  @$pb.TagNumber(7)
+  $core.int get blocksDone => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set blocksDone($core.int v) {
+    $_setUnsignedInt32(6, v);
+  }
+
+  @$pb.TagNumber(7)
+  $core.bool hasBlocksDone() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearBlocksDone() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.int get blocksTotal => $_getIZ(7);
+  @$pb.TagNumber(8)
+  set blocksTotal($core.int v) {
+    $_setUnsignedInt32(7, v);
+  }
+
+  @$pb.TagNumber(8)
+  $core.bool hasBlocksTotal() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearBlocksTotal() => clearField(8);
+
+  /// The enforcer's tip afterwards. Zero when the enforcer is stopped.
+  @$pb.TagNumber(9)
+  $core.int get enforcerHeight => $_getIZ(8);
+  @$pb.TagNumber(9)
+  set enforcerHeight($core.int v) {
+    $_setUnsignedInt32(8, v);
+  }
+
+  @$pb.TagNumber(9)
+  $core.bool hasEnforcerHeight() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearEnforcerHeight() => clearField(9);
+
+  /// False when the enforcer was never asked, so enforcer_height carries no
+  /// reading and must not be shown as one.
+  @$pb.TagNumber(10)
+  $core.bool get enforcerChecked => $_getBF(9);
+  @$pb.TagNumber(10)
+  set enforcerChecked($core.bool v) {
+    $_setBool(9, v);
+  }
+
+  @$pb.TagNumber(10)
+  $core.bool hasEnforcerChecked() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearEnforcerChecked() => clearField(10);
+
+  /// True when the enforcer did not follow, so its validator chain was deleted
+  /// and it rebuilds from the local Core.
+  @$pb.TagNumber(11)
+  $core.bool get enforcerRebuilt => $_getBF(10);
+  @$pb.TagNumber(11)
+  set enforcerRebuilt($core.bool v) {
+    $_setBool(10, v);
+  }
+
+  @$pb.TagNumber(11)
+  $core.bool hasEnforcerRebuilt() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearEnforcerRebuilt() => clearField(11);
+
+  /// Empty on success; otherwise why the enforcer could not be brought back
+  /// onto Core's chain.
+  @$pb.TagNumber(12)
+  $core.String get enforcerError => $_getSZ(11);
+  @$pb.TagNumber(12)
+  set enforcerError($core.String v) {
+    $_setString(11, v);
+  }
+
+  @$pb.TagNumber(12)
+  $core.bool hasEnforcerError() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearEnforcerError() => clearField(12);
+
+  /// Set on the last message.
+  @$pb.TagNumber(13)
+  $core.bool get done => $_getBF(12);
+  @$pb.TagNumber(13)
+  set done($core.bool v) {
+    $_setBool(12, v);
+  }
+
+  @$pb.TagNumber(13)
+  $core.bool hasDone() => $_has(12);
+  @$pb.TagNumber(13)
+  void clearDone() => clearField(13);
+}
+
 class GetCoreMempoolInfoRequest extends $pb.GeneratedMessage {
   factory GetCoreMempoolInfoRequest() => create();
   GetCoreMempoolInfoRequest._() : super();
@@ -6187,6 +6540,8 @@ class OrchestratorServiceApi {
       _client.invoke<RejectBlockResponse>(ctx, 'OrchestratorService', 'RejectBlock', request, RejectBlockResponse());
   $async.Future<AcceptBlockResponse> acceptBlock($pb.ClientContext? ctx, AcceptBlockRequest request) =>
       _client.invoke<AcceptBlockResponse>(ctx, 'OrchestratorService', 'AcceptBlock', request, AcceptBlockResponse());
+  $async.Future<ResetToBlockResponse> resetToBlock($pb.ClientContext? ctx, ResetToBlockRequest request) =>
+      _client.invoke<ResetToBlockResponse>(ctx, 'OrchestratorService', 'ResetToBlock', request, ResetToBlockResponse());
   $async.Future<GetCoreMempoolInfoResponse> getCoreMempoolInfo(
           $pb.ClientContext? ctx, GetCoreMempoolInfoRequest request) =>
       _client.invoke<GetCoreMempoolInfoResponse>(

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbenum.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbenum.dart
@@ -149,4 +149,28 @@ class RejectOutcome extends $pb.ProtobufEnum {
   const RejectOutcome._($core.int v, $core.String n) : super(v, n);
 }
 
+/// Which step of a reset a progress message reports.
+class ResetPhase extends $pb.ProtobufEnum {
+  static const ResetPhase RESET_PHASE_UNSPECIFIED = ResetPhase._(0, _omitEnumNames ? '' : 'RESET_PHASE_UNSPECIFIED');
+  static const ResetPhase RESET_PHASE_RESOLVE = ResetPhase._(1, _omitEnumNames ? '' : 'RESET_PHASE_RESOLVE');
+  static const ResetPhase RESET_PHASE_MOVE_BACK = ResetPhase._(2, _omitEnumNames ? '' : 'RESET_PHASE_MOVE_BACK');
+  static const ResetPhase RESET_PHASE_SYNC_FORWARD = ResetPhase._(3, _omitEnumNames ? '' : 'RESET_PHASE_SYNC_FORWARD');
+  static const ResetPhase RESET_PHASE_ENFORCER = ResetPhase._(4, _omitEnumNames ? '' : 'RESET_PHASE_ENFORCER');
+  static const ResetPhase RESET_PHASE_DONE = ResetPhase._(5, _omitEnumNames ? '' : 'RESET_PHASE_DONE');
+
+  static const $core.List<ResetPhase> values = <ResetPhase>[
+    RESET_PHASE_UNSPECIFIED,
+    RESET_PHASE_RESOLVE,
+    RESET_PHASE_MOVE_BACK,
+    RESET_PHASE_SYNC_FORWARD,
+    RESET_PHASE_ENFORCER,
+    RESET_PHASE_DONE,
+  ];
+
+  static final $core.Map<$core.int, ResetPhase> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static ResetPhase? valueOf($core.int value) => _byValue[value];
+
+  const ResetPhase._($core.int v, $core.String n) : super(v, n);
+}
+
 const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -107,6 +107,26 @@ final $typed_data.Uint8List rejectOutcomeDescriptor =
         'NUX09VVENPTUVfU1dJVENIRURfQlJBTkNIEAESIwofUkVKRUNUX09VVENPTUVfUEFSS0VEX09O'
         'X1BBUkVOVBACEiMKH1JFSkVDVF9PVVRDT01FX0FMUkVBRFlfSU5BQ1RJVkUQAw==');
 
+@$core.Deprecated('Use resetPhaseDescriptor instead')
+const ResetPhase$json = {
+  '1': 'ResetPhase',
+  '2': [
+    {'1': 'RESET_PHASE_UNSPECIFIED', '2': 0},
+    {'1': 'RESET_PHASE_RESOLVE', '2': 1},
+    {'1': 'RESET_PHASE_MOVE_BACK', '2': 2},
+    {'1': 'RESET_PHASE_SYNC_FORWARD', '2': 3},
+    {'1': 'RESET_PHASE_ENFORCER', '2': 4},
+    {'1': 'RESET_PHASE_DONE', '2': 5},
+  ],
+};
+
+/// Descriptor for `ResetPhase`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List resetPhaseDescriptor =
+    $convert.base64Decode('CgpSZXNldFBoYXNlEhsKF1JFU0VUX1BIQVNFX1VOU1BFQ0lGSUVEEAASFwoTUkVTRVRfUEhBU0'
+        'VfUkVTT0xWRRABEhkKFVJFU0VUX1BIQVNFX01PVkVfQkFDSxACEhwKGFJFU0VUX1BIQVNFX1NZ'
+        'TkNfRk9SV0FSRBADEhgKFFJFU0VUX1BIQVNFX0VORk9SQ0VSEAQSFAoQUkVTRVRfUEhBU0VfRE'
+        '9ORRAF');
+
 @$core.Deprecated('Use binaryStatusMsgDescriptor instead')
 const BinaryStatusMsg$json = {
   '1': 'BinaryStatusMsg',
@@ -1004,6 +1024,52 @@ final $typed_data.Uint8List acceptBlockResponseDescriptor =
         'JSZWJ1aWx0EiUKDmVuZm9yY2VyX2Vycm9yGAUgASgJUg1lbmZvcmNlckVycm9yEikKEGVuZm9y'
         'Y2VyX2NoZWNrZWQYBiABKAhSD2VuZm9yY2VyQ2hlY2tlZA==');
 
+@$core.Deprecated('Use resetToBlockRequestDescriptor instead')
+const ResetToBlockRequest$json = {
+  '1': 'ResetToBlockRequest',
+  '2': [
+    {'1': 'target', '3': 1, '4': 1, '5': 9, '10': 'target'},
+    {'1': 'enforcer_wait_seconds', '3': 2, '4': 1, '5': 13, '10': 'enforcerWaitSeconds'},
+  ],
+};
+
+/// Descriptor for `ResetToBlockRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List resetToBlockRequestDescriptor =
+    $convert.base64Decode('ChNSZXNldFRvQmxvY2tSZXF1ZXN0EhYKBnRhcmdldBgBIAEoCVIGdGFyZ2V0EjIKFWVuZm9yY2'
+        'VyX3dhaXRfc2Vjb25kcxgCIAEoDVITZW5mb3JjZXJXYWl0U2Vjb25kcw==');
+
+@$core.Deprecated('Use resetToBlockResponseDescriptor instead')
+const ResetToBlockResponse$json = {
+  '1': 'ResetToBlockResponse',
+  '2': [
+    {'1': 'phase', '3': 1, '4': 1, '5': 14, '6': '.orchestrator.v1.ResetPhase', '10': 'phase'},
+    {'1': 'message', '3': 2, '4': 1, '5': 9, '10': 'message'},
+    {'1': 'target_height', '3': 3, '4': 1, '5': 13, '10': 'targetHeight'},
+    {'1': 'target_hash', '3': 4, '4': 1, '5': 9, '10': 'targetHash'},
+    {'1': 'core_height', '3': 5, '4': 1, '5': 13, '10': 'coreHeight'},
+    {'1': 'tip_height', '3': 6, '4': 1, '5': 13, '10': 'tipHeight'},
+    {'1': 'blocks_done', '3': 7, '4': 1, '5': 13, '10': 'blocksDone'},
+    {'1': 'blocks_total', '3': 8, '4': 1, '5': 13, '10': 'blocksTotal'},
+    {'1': 'enforcer_height', '3': 9, '4': 1, '5': 13, '10': 'enforcerHeight'},
+    {'1': 'enforcer_checked', '3': 10, '4': 1, '5': 8, '10': 'enforcerChecked'},
+    {'1': 'enforcer_rebuilt', '3': 11, '4': 1, '5': 8, '10': 'enforcerRebuilt'},
+    {'1': 'enforcer_error', '3': 12, '4': 1, '5': 9, '10': 'enforcerError'},
+    {'1': 'done', '3': 13, '4': 1, '5': 8, '10': 'done'},
+  ],
+};
+
+/// Descriptor for `ResetToBlockResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List resetToBlockResponseDescriptor =
+    $convert.base64Decode('ChRSZXNldFRvQmxvY2tSZXNwb25zZRIxCgVwaGFzZRgBIAEoDjIbLm9yY2hlc3RyYXRvci52MS'
+        '5SZXNldFBoYXNlUgVwaGFzZRIYCgdtZXNzYWdlGAIgASgJUgdtZXNzYWdlEiMKDXRhcmdldF9o'
+        'ZWlnaHQYAyABKA1SDHRhcmdldEhlaWdodBIfCgt0YXJnZXRfaGFzaBgEIAEoCVIKdGFyZ2V0SG'
+        'FzaBIfCgtjb3JlX2hlaWdodBgFIAEoDVIKY29yZUhlaWdodBIdCgp0aXBfaGVpZ2h0GAYgASgN'
+        'Ugl0aXBIZWlnaHQSHwoLYmxvY2tzX2RvbmUYByABKA1SCmJsb2Nrc0RvbmUSIQoMYmxvY2tzX3'
+        'RvdGFsGAggASgNUgtibG9ja3NUb3RhbBInCg9lbmZvcmNlcl9oZWlnaHQYCSABKA1SDmVuZm9y'
+        'Y2VySGVpZ2h0EikKEGVuZm9yY2VyX2NoZWNrZWQYCiABKAhSD2VuZm9yY2VyQ2hlY2tlZBIpCh'
+        'BlbmZvcmNlcl9yZWJ1aWx0GAsgASgIUg9lbmZvcmNlclJlYnVpbHQSJQoOZW5mb3JjZXJfZXJy'
+        'b3IYDCABKAlSDWVuZm9yY2VyRXJyb3ISEgoEZG9uZRgNIAEoCFIEZG9uZQ==');
+
 @$core.Deprecated('Use getCoreMempoolInfoRequestDescriptor instead')
 const GetCoreMempoolInfoRequest$json = {
   '1': 'GetCoreMempoolInfoRequest',
@@ -1287,6 +1353,12 @@ const $core.Map<$core.String, $core.dynamic> OrchestratorServiceBase$json = {
     {'1': 'RejectBlock', '2': '.orchestrator.v1.RejectBlockRequest', '3': '.orchestrator.v1.RejectBlockResponse'},
     {'1': 'AcceptBlock', '2': '.orchestrator.v1.AcceptBlockRequest', '3': '.orchestrator.v1.AcceptBlockResponse'},
     {
+      '1': 'ResetToBlock',
+      '2': '.orchestrator.v1.ResetToBlockRequest',
+      '3': '.orchestrator.v1.ResetToBlockResponse',
+      '6': true
+    },
+    {
       '1': 'GetCoreMempoolInfo',
       '2': '.orchestrator.v1.GetCoreMempoolInfoRequest',
       '3': '.orchestrator.v1.GetCoreMempoolInfoResponse'
@@ -1362,6 +1434,8 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> Orchestrat
   '.orchestrator.v1.RejectBlockResponse': RejectBlockResponse$json,
   '.orchestrator.v1.AcceptBlockRequest': AcceptBlockRequest$json,
   '.orchestrator.v1.AcceptBlockResponse': AcceptBlockResponse$json,
+  '.orchestrator.v1.ResetToBlockRequest': ResetToBlockRequest$json,
+  '.orchestrator.v1.ResetToBlockResponse': ResetToBlockResponse$json,
   '.orchestrator.v1.GetCoreMempoolInfoRequest': GetCoreMempoolInfoRequest$json,
   '.orchestrator.v1.GetCoreMempoolInfoResponse': GetCoreMempoolInfoResponse$json,
   '.orchestrator.v1.GetBmmContextRequest': GetBmmContextRequest$json,
@@ -1426,11 +1500,13 @@ final $typed_data.Uint8List orchestratorServiceDescriptor =
         'IudjEuRGVsZXRlRmlsZXNSZXNwb25zZTABElgKC1JlamVjdEJsb2NrEiMub3JjaGVzdHJhdG9y'
         'LnYxLlJlamVjdEJsb2NrUmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5SZWplY3RCbG9ja1Jlc3'
         'BvbnNlElgKC0FjY2VwdEJsb2NrEiMub3JjaGVzdHJhdG9yLnYxLkFjY2VwdEJsb2NrUmVxdWVz'
-        'dBokLm9yY2hlc3RyYXRvci52MS5BY2NlcHRCbG9ja1Jlc3BvbnNlEm0KEkdldENvcmVNZW1wb2'
-        '9sSW5mbxIqLm9yY2hlc3RyYXRvci52MS5HZXRDb3JlTWVtcG9vbEluZm9SZXF1ZXN0Gisub3Jj'
-        'aGVzdHJhdG9yLnYxLkdldENvcmVNZW1wb29sSW5mb1Jlc3BvbnNlEl4KDUdldEJtbUNvbnRleH'
-        'QSJS5vcmNoZXN0cmF0b3IudjEuR2V0Qm1tQ29udGV4dFJlcXVlc3QaJi5vcmNoZXN0cmF0b3Iu'
-        'djEuR2V0Qm1tQ29udGV4dFJlc3BvbnNlElgKC0NvcmVSYXdDYWxsEiMub3JjaGVzdHJhdG9yLn'
-        'YxLkNvcmVSYXdDYWxsUmVxdWVzdBokLm9yY2hlc3RyYXRvci52MS5Db3JlUmF3Q2FsbFJlc3Bv'
-        'bnNlEl4KDUdldEZvcmtTdGF0dXMSJS5vcmNoZXN0cmF0b3IudjEuR2V0Rm9ya1N0YXR1c1JlcX'
-        'Vlc3QaJi5vcmNoZXN0cmF0b3IudjEuR2V0Rm9ya1N0YXR1c1Jlc3BvbnNl');
+        'dBokLm9yY2hlc3RyYXRvci52MS5BY2NlcHRCbG9ja1Jlc3BvbnNlEl0KDFJlc2V0VG9CbG9jax'
+        'IkLm9yY2hlc3RyYXRvci52MS5SZXNldFRvQmxvY2tSZXF1ZXN0GiUub3JjaGVzdHJhdG9yLnYx'
+        'LlJlc2V0VG9CbG9ja1Jlc3BvbnNlMAESbQoSR2V0Q29yZU1lbXBvb2xJbmZvEioub3JjaGVzdH'
+        'JhdG9yLnYxLkdldENvcmVNZW1wb29sSW5mb1JlcXVlc3QaKy5vcmNoZXN0cmF0b3IudjEuR2V0'
+        'Q29yZU1lbXBvb2xJbmZvUmVzcG9uc2USXgoNR2V0Qm1tQ29udGV4dBIlLm9yY2hlc3RyYXRvci'
+        '52MS5HZXRCbW1Db250ZXh0UmVxdWVzdBomLm9yY2hlc3RyYXRvci52MS5HZXRCbW1Db250ZXh0'
+        'UmVzcG9uc2USWAoLQ29yZVJhd0NhbGwSIy5vcmNoZXN0cmF0b3IudjEuQ29yZVJhd0NhbGxSZX'
+        'F1ZXN0GiQub3JjaGVzdHJhdG9yLnYxLkNvcmVSYXdDYWxsUmVzcG9uc2USXgoNR2V0Rm9ya1N0'
+        'YXR1cxIlLm9yY2hlc3RyYXRvci52MS5HZXRGb3JrU3RhdHVzUmVxdWVzdBomLm9yY2hlc3RyYX'
+        'Rvci52MS5HZXRGb3JrU3RhdHVzUmVzcG9uc2U=');

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbserver.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbserver.dart
@@ -59,6 +59,7 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
   $async.Future<$2.DeleteFilesResponse> deleteFiles($pb.ServerContext ctx, $2.DeleteFilesRequest request);
   $async.Future<$2.RejectBlockResponse> rejectBlock($pb.ServerContext ctx, $2.RejectBlockRequest request);
   $async.Future<$2.AcceptBlockResponse> acceptBlock($pb.ServerContext ctx, $2.AcceptBlockRequest request);
+  $async.Future<$2.ResetToBlockResponse> resetToBlock($pb.ServerContext ctx, $2.ResetToBlockRequest request);
   $async.Future<$2.GetCoreMempoolInfoResponse> getCoreMempoolInfo(
       $pb.ServerContext ctx, $2.GetCoreMempoolInfoRequest request);
   $async.Future<$2.GetBmmContextResponse> getBmmContext($pb.ServerContext ctx, $2.GetBmmContextRequest request);
@@ -121,6 +122,8 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
         return $2.RejectBlockRequest();
       case 'AcceptBlock':
         return $2.AcceptBlockRequest();
+      case 'ResetToBlock':
+        return $2.ResetToBlockRequest();
       case 'GetCoreMempoolInfo':
         return $2.GetCoreMempoolInfoRequest();
       case 'GetBmmContext':
@@ -191,6 +194,8 @@ abstract class OrchestratorServiceBase extends $pb.GeneratedService {
         return this.rejectBlock(ctx, request as $2.RejectBlockRequest);
       case 'AcceptBlock':
         return this.acceptBlock(ctx, request as $2.AcceptBlockRequest);
+      case 'ResetToBlock':
+        return this.resetToBlock(ctx, request as $2.ResetToBlockRequest);
       case 'GetCoreMempoolInfo':
         return this.getCoreMempoolInfo(ctx, request as $2.GetCoreMempoolInfoRequest);
       case 'GetBmmContext':

--- a/sidechain_core/lib/rpcs/orchestrator_rpc.dart
+++ b/sidechain_core/lib/rpcs/orchestrator_rpc.dart
@@ -139,6 +139,18 @@ class OrchestratorRPC {
     return _unaryClient.acceptBlock(AcceptBlockRequest(blockHash: blockHash));
   }
 
+  /// Move the chain back to a block, then sync forward to the tip again.
+  /// [target] takes a height or a 64-character hash. Emits one message per
+  /// phase, and the last message carries the enforcer result.
+  Stream<ResetToBlockResponse> resetToBlock({
+    required String target,
+    int enforcerWaitSeconds = 0,
+  }) {
+    return _streamClient.resetToBlock(
+      ResetToBlockRequest(target: target, enforcerWaitSeconds: enforcerWaitSeconds),
+    );
+  }
+
   Future<StartBinaryResponse> startBinary(
     String name, {
     List<String>? extraArgs,


### PR DESCRIPTION
One field takes a height or a hash. Core drops that block and everything above it, then reconsiderblock runs at once so Core replays them from disk.

invalidateblock alone marks the branch bad, so Core would park on the parent and never follow it again.

Design: Figma "Daemon settings", frames 5 to 10.