### PR TITLE
ci: do not upgrade every package on linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,7 +262,7 @@ jobs:
 
         # https://docs.flutter.dev/platform-integration/linux/building
       # prettier-ignore
-      - run:  sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get install -y curl git unzip xz-utils zip libglu1-mesa && sudo apt-get install clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev libcurl4-openssl-dev libusb-1.0-0-dev
+      - run:  sudo apt-get update -y && sudo apt-get install -y curl git unzip xz-utils zip libglu1-mesa && sudo apt-get install -y clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev libcurl4-openssl-dev libusb-1.0-0-dev
         if: runner.os == 'Linux'
 
       # Install FUSE and other dependencies for AppImage creation

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -886,7 +886,13 @@ func (s *Server) ListBlocks(ctx context.Context, c *connect.Request[pb.ListBlock
 			hash, err := s.data.BlockHash(ctx, &corepb.GetBlockHashRequest{
 				Height: uint32(height),
 			})
-			if err != nil {
+			switch {
+			// A reorg between the tip read and this call drops the height off
+			// the chain. Skip it, the next poll reads the shorter tip.
+			case err != nil && strings.Contains(err.Error(), "Block height out of range"):
+				return nil, nil
+
+			case err != nil:
 				return nil, fmt.Errorf("bitcoind: could not get block hash %d: %w", height, err)
 			}
 

--- a/bitwindow/server/api/bitwindowd/bitwindowd_test.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd_test.go
@@ -1387,6 +1387,61 @@ func TestService_ListBlocks(t *testing.T) {
 		assert.Len(t, resp.Msg.RecentBlocks, 5)
 	})
 
+	t.Run("a reorg below the tip drops the missing heights", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.Test(t)
+		ctrl := gomock.NewController(t)
+		mockBitcoind := mocks.NewMockBitcoinServiceClient(ctrl)
+		expectWatchWalletNoop(mockBitcoind)
+
+		mockBitcoind.EXPECT().
+			GetBlockchainInfo(gomock.Any(), gomock.Any()).
+			Return(&connect.Response[corepb.GetBlockchainInfoResponse]{
+				Msg: &corepb.GetBlockchainInfoResponse{Blocks: 10},
+			}, nil)
+
+		// Core drops to height 8 while the page is in flight, so 10 and 9 are
+		// off the chain by the time each height asks for its hash.
+		const tipAfterReorg = 8
+		mockBitcoind.EXPECT().
+			GetBlockHash(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *connect.Request[corepb.GetBlockHashRequest]) (*connect.Response[corepb.GetBlockHashResponse], error) {
+				if req.Msg.Height > tipAfterReorg {
+					return nil, fmt.Errorf("unknown: -8: Block height out of range")
+				}
+				return &connect.Response[corepb.GetBlockHashResponse]{
+					Msg: &corepb.GetBlockHashResponse{Hash: fmt.Sprintf("hash%d", req.Msg.Height)},
+				}, nil
+			}).Times(5)
+
+		mockBitcoind.EXPECT().
+			GetBlock(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *connect.Request[corepb.GetBlockRequest]) (*connect.Response[corepb.GetBlockResponse], error) {
+				var height uint32
+				if _, err := fmt.Sscanf(req.Msg.Hash, "hash%d", &height); err != nil {
+					return nil, err
+				}
+				return &connect.Response[corepb.GetBlockResponse]{
+					Msg: &corepb.GetBlockResponse{
+						Height: height,
+						Hash:   req.Msg.Hash,
+						Time:   timestamppb.Now(),
+					},
+				}, nil
+			}).Times(3)
+
+		cli := v1connect.NewBitwindowdServiceClient(apitests.API(t, db, apitests.WithBitcoind(mockBitcoind)))
+
+		resp, err := cli.ListBlocks(context.Background(), connect.NewRequest(&v1.ListBlocksRequest{
+			PageSize: 5,
+		}))
+		require.NoError(t, err)
+		require.Len(t, resp.Msg.RecentBlocks, 3)
+		assert.Equal(t, uint32(8), resp.Msg.RecentBlocks[0].Height)
+		assert.Equal(t, uint32(6), resp.Msg.RecentBlocks[2].Height)
+	})
+
 	t.Run("repeat call at the same tip is served from cache", func(t *testing.T) {
 		t.Parallel()
 

--- a/bitwindow/server/dial/dial.go
+++ b/bitwindow/server/dial/dial.go
@@ -254,8 +254,9 @@ func getSharedClient(ctx context.Context) *http.Client {
 		sharedClient = &http.Client{
 			Transport: &http2.Transport{
 				AllowHTTP: true,
-				DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
-					return net.Dial(network, addr)
+				DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+					var dialer net.Dialer
+					return dialer.DialContext(ctx, network, addr)
 				},
 				// Without explicit timeouts here, clients linger indefinitely
 				IdleConnTimeout:  15 * time.Second,


### PR DESCRIPTION
The linux build step ran apt-get upgrade -y, which upgrades the whole runner image. It stalled 44 minutes and someone cancelled the run, so the release upload never ran. The second apt-get install also missed -y.