### PR TITLE
sailui: rebuild the wallet picker once per refresh

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.303
+version: 1.0.304
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.303
+version: 1.0.304
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.168
+version: 0.2.169
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.176
+version: 1.0.177
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/widgets/from_wallet_field.dart
+++ b/sail_ui/lib/widgets/from_wallet_field.dart
@@ -60,6 +60,7 @@ class _WalletPickerState extends State<WalletPicker> {
       return;
     }
     final rpc = GetIt.I<OrchestratorRPC>().wallet;
+    final fresh = <String, int>{};
     for (final wallet in _wallets) {
       final int sats;
       try {
@@ -68,11 +69,21 @@ class _WalletPickerState extends State<WalletPicker> {
         // One unreadable wallet must not blank the balance of the others.
         continue;
       }
-      if (!mounted || _balanceSats[wallet.id] == sats) {
-        continue;
+      // The picker went away mid-read, so the rest of the wallets are nobody's
+      // to fetch. Carrying on keeps calling for a widget that is gone.
+      if (!mounted) {
+        return;
       }
-      setState(() => _balanceSats[wallet.id] = sats);
+      if (_balanceSats[wallet.id] != sats) {
+        fresh[wallet.id] = sats;
+      }
     }
+    if (fresh.isEmpty) {
+      return;
+    }
+    // One rebuild for the whole refresh. A setState per wallet rebuilt the
+    // picker once for every funding wallet, every fifteen seconds.
+    setState(() => _balanceSats.addAll(fresh));
   }
 
   @override

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.305
+version: 1.0.306
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.176
+version: 1.0.177
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.303
+version: 1.0.304
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The balance refresh called setState once per funding wallet, so the picker rebuilt N times every fifteen seconds. It now collects the changes and rebuilds once.

It also returns rather than continues once the widget unmounts, so a disposed picker stops issuing wallet RPCs.