### PR TITLE
multi: name the block the node refuses

### DIFF
--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -29,17 +29,19 @@ bool showDaemonCard({
   return walletNeedsBackends || connected || initializing;
 }
 
-/// Why Bitcoin Core sits still on a chain that moves, or null when it follows
-/// its peers. Both progress bars read 100% off the network, so only this
-/// message tells the user.
+/// Why the node sits still on a chain that moves, or null when it follows its
+/// peers. Both progress bars read 100% off the network, so only this message
+/// tells the user.
 String? offNetworkMessage(SyncInfo? syncInfo) {
   if (syncInfo == null || !syncInfo.offNetwork) {
     return null;
   }
-  if (syncInfo.behindPeers > 0) {
-    return 'Off the network chain: Core rejects a block its peers accept, ${syncInfo.behindPeers} blocks behind';
+  if (syncInfo.refusedBranchStart > 0) {
+    return 'Off the network chain: the node refuses the branch from block ${syncInfo.refusedBranchStart}, '
+        '${syncInfo.behindPeers} blocks behind its peers';
   }
-  return 'Core rejects a block at its own tip, so it can fall off the network chain';
+  return 'Off the network chain: the node refuses a block its peers accept, '
+      '${syncInfo.behindPeers} blocks behind';
 }
 
 class BottomNav extends StatelessWidget {

--- a/sail_ui/test/off_network_message_test.dart
+++ b/sail_ui/test/off_network_message_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+void main() {
+  // The drynet4 node of 2026-08-20: it holds 979995 and refuses the branch
+  // that starts at 979996.
+  test('the message names where the refused branch starts', () {
+    final message = offNetworkMessage(
+      SyncInfo(
+        progressCurrent: 979995,
+        progressGoal: 979995,
+        lastBlockAt: null,
+        peerBestHeight: 980185,
+        rejectedBranch: true,
+        refusedBranchStart: 979996,
+      ),
+    );
+
+    expect(message, contains('branch from block 979996'));
+    expect(message, contains('190 blocks behind'));
+    expect(message, isNot(contains('Core')));
+  });
+
+  // An older node reports no branch start, so the message drops the number.
+  test('the message works without a branch start', () {
+    final message = offNetworkMessage(
+      SyncInfo(
+        progressCurrent: 979995,
+        progressGoal: 979995,
+        lastBlockAt: null,
+        peerBestHeight: 980185,
+        rejectedBranch: true,
+      ),
+    );
+
+    expect(message, contains('190 blocks behind'));
+  });
+
+  // A node that follows its peers says nothing at all.
+  test('a node on the network chain shows no message', () {
+    expect(
+      offNetworkMessage(
+        SyncInfo(progressCurrent: 100, progressGoal: 100, lastBlockAt: null, peerBestHeight: 100),
+      ),
+      isNull,
+    );
+    expect(offNetworkMessage(null), isNull);
+  });
+}

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -495,12 +495,13 @@ func chainSyncToProto(s *orchestrator.ChainSyncResult) *pb.ChainSync {
 		return nil
 	}
 	return &pb.ChainSync{
-		Blocks:         int32(s.Blocks),
-		Headers:        int32(s.Headers),
-		Time:           s.Time,
-		Error:          s.Error,
-		PeerBestHeight: int32(s.PeerBestHeight),
-		RejectedBranch: s.RejectedBranch,
+		Blocks:             int32(s.Blocks),
+		Headers:            int32(s.Headers),
+		Time:               s.Time,
+		Error:              s.Error,
+		PeerBestHeight:     int32(s.PeerBestHeight),
+		RejectedBranch:     s.RejectedBranch,
+		RefusedBranchStart: int32(s.RefusedBranchStart),
 	}
 }
 

--- a/sidechain-orchestrator/chain_fork_test.go
+++ b/sidechain-orchestrator/chain_fork_test.go
@@ -47,3 +47,33 @@ func TestForkStateFromWithoutPeers(t *testing.T) {
 	assert.False(t, state.RejectedBranch)
 	assert.Zero(t, state.PeerBestHeight)
 }
+
+// The drynet4 node of 2026-08-20: it holds 979995 and refuses the branch that
+// starts at 979996, which its peers build on.
+func TestForkStateFromNamesTheRefusedBranchStart(t *testing.T) {
+	state := forkStateFrom(
+		[]coreChainTip{
+			{Height: 980185, Status: "invalid", BranchLen: 190},
+			{Height: 980014, Status: "invalid", BranchLen: 19},
+			{Height: 979995, Status: "active", BranchLen: 0},
+			{Height: 979059, Status: "invalid", BranchLen: 35},
+		},
+		[]corePeerTip{{SyncedHeaders: 980185}},
+	)
+
+	assert.True(t, state.RejectedBranch)
+	assert.Equal(t, int64(979996), state.RefusedBranchStart)
+}
+
+// An old fork below the tip is ordinary history, so it names no branch.
+func TestForkStateFromNamesNoBranchForAnOldFork(t *testing.T) {
+	state := forkStateFrom(
+		[]coreChainTip{
+			{Height: 500000, Status: "invalid", BranchLen: 1},
+			{Height: 979028, Status: "active", BranchLen: 0},
+		},
+		[]corePeerTip{{SyncedHeaders: 979028}},
+	)
+
+	assert.Zero(t, state.RefusedBranchStart)
+}

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -2805,8 +2805,11 @@ type ChainSync struct {
 	// With a higher peer_best_height it means the node left the network's
 	// chain, which blocks and headers alone never show. Mainchain only.
 	RejectedBranch bool `protobuf:"varint,6,opt,name=rejected_branch,json=rejectedBranch,proto3" json:"rejected_branch,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Where the refused branch leaves this node's chain, 0 when the node
+	// refuses none. The invalid block sits at or above it. Mainchain only.
+	RefusedBranchStart int32 `protobuf:"varint,7,opt,name=refused_branch_start,json=refusedBranchStart,proto3" json:"refused_branch_start,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *ChainSync) Reset() {
@@ -2879,6 +2882,13 @@ func (x *ChainSync) GetRejectedBranch() bool {
 		return x.RejectedBranch
 	}
 	return false
+}
+
+func (x *ChainSync) GetRefusedBranchStart() int32 {
+	if x != nil {
+		return x.RefusedBranchStart
+	}
+	return 0
 }
 
 type GetDownloadStatusRequest struct {
@@ -5029,14 +5039,15 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x0fenforcer_wallet\x18\x05 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\x0eenforcerWallet\"u\n" +
 	"\x0fSidechainStatus\x122\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x1e.orchestrator.v1.SidechainTypeR\x04type\x12.\n" +
-	"\x04sync\x18\x02 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\x04sync\"\xba\x01\n" +
+	"\x04sync\x18\x02 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\x04sync\"\xec\x01\n" +
 	"\tChainSync\x12\x16\n" +
 	"\x06blocks\x18\x01 \x01(\x05R\x06blocks\x12\x18\n" +
 	"\aheaders\x18\x02 \x01(\x05R\aheaders\x12\x12\n" +
 	"\x04time\x18\x03 \x01(\x03R\x04time\x12\x14\n" +
 	"\x05error\x18\x04 \x01(\tR\x05error\x12(\n" +
 	"\x10peer_best_height\x18\x05 \x01(\x05R\x0epeerBestHeight\x12'\n" +
-	"\x0frejected_branch\x18\x06 \x01(\bR\x0erejectedBranch\"\x1a\n" +
+	"\x0frejected_branch\x18\x06 \x01(\bR\x0erejectedBranch\x120\n" +
+	"\x14refused_branch_start\x18\a \x01(\x05R\x12refusedBranchStart\"\x1a\n" +
 	"\x18GetDownloadStatusRequest\"Z\n" +
 	"\x19GetDownloadStatusResponse\x12=\n" +
 	"\tdownloads\x18\x01 \x03(\v2\x1f.orchestrator.v1.DownloadStatusR\tdownloads\"\x9f\x01\n" +

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -2550,8 +2550,9 @@ func (c *bitcoindInfoConnection) Fetch(ctx context.Context) (*MainchainBlockchai
 // ChainForkState is what Core knows about branches it refuses and about the
 // tips its peers announce.
 type ChainForkState struct {
-	PeerBestHeight int64
-	RejectedBranch bool
+	PeerBestHeight     int64
+	RejectedBranch     bool
+	RefusedBranchStart int64
 }
 
 // chainForkConnection reads getchaintips and getpeerinfo. A sync bar that only
@@ -2595,6 +2596,14 @@ type coreChainTip struct {
 	BranchLen int64  `json:"branchlen"`
 }
 
+// forkHeight is where this branch leaves the node's own chain.
+func (t coreChainTip) forkHeight() int64 {
+	if t.BranchLen < 1 {
+		return t.Height
+	}
+	return t.Height - t.BranchLen + 1
+}
+
 // corePeerTip is what one peer announces. A fresh peer reports only
 // StartHeight until headers arrive.
 type corePeerTip struct {
@@ -2615,14 +2624,25 @@ func forkStateFrom(tips []coreChainTip, peers []corePeerTip) ChainForkState {
 		}
 	}
 
+	var refused int64
+	for _, tip := range tips {
+		if tip.Status != "invalid" || tip.Height < active {
+			continue
+		}
+		if fork := tip.forkHeight(); refused == 0 || fork < refused {
+			refused = fork
+		}
+	}
+
 	var best int64
 	for _, peer := range peers {
 		best = max(best, peer.SyncedHeaders, peer.StartHeight)
 	}
 
 	return ChainForkState{
-		PeerBestHeight: best,
-		RejectedBranch: rejected > 0 && rejected >= active,
+		PeerBestHeight:     best,
+		RejectedBranch:     rejected > 0 && rejected >= active,
+		RefusedBranchStart: refused,
 	}
 }
 
@@ -2814,6 +2834,9 @@ type ChainSyncResult struct {
 	// tip invalid. Together with a higher PeerBestHeight it means the node
 	// refuses the chain its peers follow.
 	RejectedBranch bool
+	// RefusedBranchStart is where the refused branch leaves this node's
+	// chain, zero when none. The invalid block sits at or above it.
+	RefusedBranchStart int64
 }
 
 // SyncStatus is the atomic snapshot returned by GetSyncStatus. Mainchain +
@@ -2981,6 +3004,7 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 	if fork != nil && out.Mainchain.Error == "" {
 		out.Mainchain.PeerBestHeight = fork.PeerBestHeight
 		out.Mainchain.RejectedBranch = fork.RejectedBranch
+		out.Mainchain.RefusedBranchStart = fork.RefusedBranchStart
 	}
 
 	// Headers fan-out: dependent chains measure progress against bitcoind's

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -540,6 +540,9 @@ message ChainSync {
   // With a higher peer_best_height it means the node left the network's
   // chain, which blocks and headers alone never show. Mainchain only.
   bool rejected_branch = 6;
+  // Where the refused branch leaves this node's chain, 0 when the node
+  // refuses none. The invalid block sits at or above it. Mainchain only.
+  int32 refused_branch_start = 7;
 }
 
 // GetDownloadStatus

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -3494,6 +3494,7 @@ class ChainSync extends $pb.GeneratedMessage {
     $core.String? error,
     $core.int? peerBestHeight,
     $core.bool? rejectedBranch,
+    $core.int? refusedBranchStart,
   }) {
     final $result = create();
     if (blocks != null) {
@@ -3514,6 +3515,9 @@ class ChainSync extends $pb.GeneratedMessage {
     if (rejectedBranch != null) {
       $result.rejectedBranch = rejectedBranch;
     }
+    if (refusedBranchStart != null) {
+      $result.refusedBranchStart = refusedBranchStart;
+    }
     return $result;
   }
   ChainSync._() : super();
@@ -3530,6 +3534,7 @@ class ChainSync extends $pb.GeneratedMessage {
     ..aOS(4, _omitFieldNames ? '' : 'error')
     ..a<$core.int>(5, _omitFieldNames ? '' : 'peerBestHeight', $pb.PbFieldType.O3)
     ..aOB(6, _omitFieldNames ? '' : 'rejectedBranch')
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'refusedBranchStart', $pb.PbFieldType.O3)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -3633,6 +3638,20 @@ class ChainSync extends $pb.GeneratedMessage {
   $core.bool hasRejectedBranch() => $_has(5);
   @$pb.TagNumber(6)
   void clearRejectedBranch() => clearField(6);
+
+  /// Where the refused branch leaves this node's chain, 0 when the node
+  /// refuses none. The invalid block sits at or above it. Mainchain only.
+  @$pb.TagNumber(7)
+  $core.int get refusedBranchStart => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set refusedBranchStart($core.int v) {
+    $_setSignedInt32(6, v);
+  }
+
+  @$pb.TagNumber(7)
+  $core.bool hasRefusedBranchStart() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearRefusedBranchStart() => clearField(7);
 }
 
 class GetDownloadStatusRequest extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -765,6 +765,7 @@ const ChainSync$json = {
     {'1': 'error', '3': 4, '4': 1, '5': 9, '10': 'error'},
     {'1': 'peer_best_height', '3': 5, '4': 1, '5': 5, '10': 'peerBestHeight'},
     {'1': 'rejected_branch', '3': 6, '4': 1, '5': 8, '10': 'rejectedBranch'},
+    {'1': 'refused_branch_start', '3': 7, '4': 1, '5': 5, '10': 'refusedBranchStart'},
   ],
 };
 
@@ -773,7 +774,8 @@ final $typed_data.Uint8List chainSyncDescriptor =
     $convert.base64Decode('CglDaGFpblN5bmMSFgoGYmxvY2tzGAEgASgFUgZibG9ja3MSGAoHaGVhZGVycxgCIAEoBVIHaG'
         'VhZGVycxISCgR0aW1lGAMgASgDUgR0aW1lEhQKBWVycm9yGAQgASgJUgVlcnJvchIoChBwZWVy'
         'X2Jlc3RfaGVpZ2h0GAUgASgFUg5wZWVyQmVzdEhlaWdodBInCg9yZWplY3RlZF9icmFuY2gYBi'
-        'ABKAhSDnJlamVjdGVkQnJhbmNo');
+        'ABKAhSDnJlamVjdGVkQnJhbmNoEjAKFHJlZnVzZWRfYnJhbmNoX3N0YXJ0GAcgASgFUhJyZWZ1'
+        'c2VkQnJhbmNoU3RhcnQ=');
 
 @$core.Deprecated('Use getDownloadStatusRequestDescriptor instead')
 const GetDownloadStatusRequest$json = {

--- a/sidechain_core/lib/providers/sync_provider.dart
+++ b/sidechain_core/lib/providers/sync_provider.dart
@@ -22,6 +22,10 @@ class SyncInfo {
   /// True when the node marked a branch at or above its own tip invalid.
   final bool rejectedBranch;
 
+  /// Where the refused branch leaves this node's chain, 0 when it refuses
+  /// none. The invalid block sits at or above it.
+  final int refusedBranchStart;
+
   double get progress => progressGoal == 0 ? 0 : progressCurrent / progressGoal;
   bool get isSynced => progressGoal > 0 && progressCurrent == progressGoal;
 
@@ -40,6 +44,7 @@ class SyncInfo {
     required this.lastBlockAt,
     this.peerBestHeight = 0,
     this.rejectedBranch = false,
+    this.refusedBranchStart = 0,
   });
 
   @override
@@ -52,11 +57,13 @@ class SyncInfo {
         other.progressGoal == progressGoal &&
         other.lastBlockAt == lastBlockAt &&
         other.peerBestHeight == peerBestHeight &&
-        other.rejectedBranch == rejectedBranch;
+        other.rejectedBranch == rejectedBranch &&
+        other.refusedBranchStart == refusedBranchStart;
   }
 
   @override
-  int get hashCode => Object.hash(progressCurrent, progressGoal, lastBlockAt, peerBestHeight, rejectedBranch);
+  int get hashCode =>
+      Object.hash(progressCurrent, progressGoal, lastBlockAt, peerBestHeight, rejectedBranch, refusedBranchStart);
 }
 
 /// Represents a binary that has some sort of sync-status
@@ -399,6 +406,7 @@ class SyncProvider extends ChangeNotifier implements NetworkScoped {
       lastBlockAt: (cs?.time ?? Int64(0)) != Int64(0) ? Timestamp(seconds: cs!.time) : null,
       peerBestHeight: cs?.peerBestHeight ?? 0,
       rejectedBranch: cs?.rejectedBranch ?? false,
+      refusedBranchStart: cs?.refusedBranchStart ?? 0,
     );
   }
 


### PR DESCRIPTION
The off-network message blamed Core. Core is not the actor — on drynet4 the enforcer calls invalidateblock, and Core unwinds.

The orchestrator now reads the first block of the refused branch from getchaintips and passes it to the frontend, so the message names that height instead of a daemon.