### PR TITLE
orchestrator: keep the eCash network from the conf

### DIFF
--- a/sidechain-orchestrator/network_catalog.go
+++ b/sidechain-orchestrator/network_catalog.go
@@ -41,7 +41,7 @@ func (o *Orchestrator) ResolveNetworkCatalog(ctx context.Context) {
 	}
 	// Reconcile installs whose cached catalog already lists the selected
 	// network, where no pending promotion fires.
-	ecashID := o.SelectedECashID(current)
+	ecashID := o.RunningECashID(current)
 	if !promoted && !o.wipeIfECashNetworkStale(ctx, ecashID) {
 		// Keep serving the network those blocks belong to, so the next start
 		// retries rather than opening them as the new fork.
@@ -63,11 +63,11 @@ func (o *Orchestrator) ResolveNetworkCatalog(ctx context.Context) {
 // pending one when it could be applied, otherwise the current one, so the
 // process never serves a generation whose data it has not cleared.
 func (o *Orchestrator) promotePendingCatalog(ctx context.Context, current, pending netcatalog.Catalog, fromDisk bool) netcatalog.Catalog {
-	// The selected network, not the catalog's first entry: a user pinned to a
-	// retained row keeps blocks from that row, and a refresh that drops it
+	// The network this install serves, not the catalog's first entry: a user on
+	// a retained row keeps blocks from that row, and a refresh that drops it
 	// leaves both documents naming the same first entry. An id-only compare
 	// reads that as no change and promotes over a chain it never cleared.
-	baseline := o.SelectedECashID(current)
+	baseline := o.RunningECashID(current)
 	if !fromDisk {
 		baseline = netcatalog.EmbeddedECashID()
 	}
@@ -166,11 +166,11 @@ func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
 	// Off eCash the retired chain is cold files that no start will revisit:
 	// the startup wipe only runs while eCash is active. Clear them here.
 	if config.NetworkFromString(o.Network) != config.NetworkECash {
-		// The pick on both sides, not each document's first row. A user pinned
-		// to a retained entry holds that chain on disk, and comparing first
-		// rows reads two identical ids while the blocks belong to a third.
+		// The pick on both sides, not each document's first row. A user on a
+		// retained entry holds that chain on disk, and comparing first rows
+		// reads two identical ids while the blocks belong to a third.
 		current, _ := netcatalog.Load(o.BitwindowDir)
-		if !o.wipeOnECashNetworkChange(ctx, o.SelectedECashID(current), o.SelectedECashID(pending)) {
+		if !o.wipeOnECashNetworkChange(ctx, o.RunningECashID(current), o.SelectedECashID(pending)) {
 			return fmt.Errorf("could not clear the retired eCash chain data")
 		}
 	}
@@ -338,18 +338,44 @@ func (o *Orchestrator) wipeIfECashNetworkStale(ctx context.Context, selected str
 	return o.wipeOnECashNetworkChange(ctx, o.installedECashNetwork(), selected)
 }
 
-// SelectedECashID returns the eCash network this install runs: the one the user
-// picked from the catalog while the catalog still lists it, otherwise the entry
-// the catalog lists first.
+// SelectedECashID returns the network a catalog resolves to: the one the user
+// picked while that catalog still lists it, otherwise the entry it lists first.
 func (o *Orchestrator) SelectedECashID(c netcatalog.Catalog) string {
-	if o.Settings != nil {
-		if picked := o.Settings.ECashNetworkID(); picked != "" {
-			if _, ok := c.ByID(picked); ok {
-				return picked
-			}
+	if picked := o.pinnedECashID(c); picked != "" {
+		return picked
+	}
+	return c.ECashID()
+}
+
+// RunningECashID returns the eCash network this install serves: the user's pick,
+// then the id its bitcoin.conf names, and only then the entry the catalog lists
+// first. The conf comes before document order because it names the fork whose
+// blocks are on disk.
+func (o *Orchestrator) RunningECashID(c netcatalog.Catalog) string {
+	if picked := o.pinnedECashID(c); picked != "" {
+		return picked
+	}
+	if installed := o.installedECashNetwork(); installed != "" {
+		if _, ok := c.ByID(installed); ok {
+			return installed
 		}
 	}
 	return c.ECashID()
+}
+
+// pinnedECashID returns the user's pick while the catalog still lists it.
+func (o *Orchestrator) pinnedECashID(c netcatalog.Catalog) string {
+	if o.Settings == nil {
+		return ""
+	}
+	picked := o.Settings.ECashNetworkID()
+	if picked == "" {
+		return ""
+	}
+	if _, ok := c.ByID(picked); !ok {
+		return ""
+	}
+	return picked
 }
 
 // SelectECashNetwork pins the eCash network the user picked. The switch itself

--- a/sidechain-orchestrator/network_catalog_pending_test.go
+++ b/sidechain-orchestrator/network_catalog_pending_test.go
@@ -260,3 +260,57 @@ func TestRolloverWritesThePublishedPeerAndRetargetsTheEnforcer(t *testing.T) {
 	require.Equal(t, "drynet9", o.EnforcerConf.Config.GetSetting("network-preset"))
 	require.Equal(t, "true", o.EnforcerConf.Config.GetSetting("enable-wallet"))
 }
+
+// catalogWithECashRows lists several eCash networks in the order given, each
+// with endpoints that match its id.
+func catalogWithECashRows(t *testing.T, ids ...string) netcatalog.Catalog {
+	t.Helper()
+	c := catalogWithECash(t, ids[0])
+	rows := make([]netcatalog.Network, 0, len(c.Networks)+len(ids))
+	for _, n := range c.Networks {
+		rows = append(rows, n)
+		if n.Family != netcatalog.FamilyECash {
+			continue
+		}
+		for _, id := range ids[1:] {
+			extra := n
+			extra.ID = id
+			extra.P2P.Address = id + ".example:8335"
+			extra.Backends = []netcatalog.Backend{{Kind: "esplora", URL: "https://esplora." + id + ".example"}}
+			rows = append(rows, extra)
+		}
+	}
+	c.Networks = rows
+	return c
+}
+
+// A cache written in another order lists the retired rows first, and a retired
+// row publishes no endpoints. Document order alone moves the install to that
+// row, and the wallet then has no chain source at all.
+func TestStartKeepsTheNetworkTheConfNames(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupDefault, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.coreReachable = func() bool { return false }
+	o.adoptCatalog(catalogWithECash(t, "drynet4"), "drynet4")
+	require.Equal(t, "drynet4", o.installedECashNetwork())
+
+	retiredFirst := catalogWithECashRows(t, "drynet2", "drynet4")
+	for i := range retiredFirst.Networks {
+		if retiredFirst.Networks[i].ID == "drynet2" {
+			retiredFirst.Networks[i].Backends = nil
+		}
+	}
+	require.NoError(t, netcatalog.Save(o.BitwindowDir, retiredFirst))
+
+	o.ResolveNetworkCatalog(context.Background())
+
+	require.Equal(t, "drynet4", config.ECashNetworkID())
+	require.Equal(t, "ecash-drynet4", o.BitcoinConf.Config.GetEffectiveSetting("uacomment", "main"))
+	require.Equal(t,
+		[]string{"https://esplora.drynet4.example"},
+		config.WalletChainSourceURLsForNetwork(config.NetworkECash),
+		"the wallet must keep reading the network whose blocks are on disk",
+	)
+}

--- a/sidechain-orchestrator/network_options_test.go
+++ b/sidechain-orchestrator/network_options_test.go
@@ -177,3 +177,55 @@ func TestECashPickSurvivesAnotherSettingChange(t *testing.T) {
 	require.Equal(t, "drynet4", reloaded.ECashNetworkID, "the pick must survive an unrelated save")
 	require.Equal(t, "https://esplora.example", reloaded.ElectrumServerURL)
 }
+
+// The conf names the fork whose blocks are on disk, so it outranks document
+// order. A cache that lists a retired row first must not move the install.
+func TestRunningECashIDKeepsTheNetworkTheConfNames(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+
+	retiredFirst := netcatalog.Catalog{Networks: []netcatalog.Network{
+		{ID: "drynet2", Family: netcatalog.FamilyECash},
+		{ID: "drynet3", Family: netcatalog.FamilyECash},
+		{ID: "drynet4", Family: netcatalog.FamilyECash},
+	}}
+	o.adoptCatalog(retiredFirst, "drynet4")
+	require.Equal(t, "drynet4", o.installedECashNetwork())
+
+	require.Equal(t, "drynet4", o.RunningECashID(retiredFirst))
+	require.Equal(t, "drynet2", o.SelectedECashID(retiredFirst), "the document still resolves to its first row")
+}
+
+// The user's pick is the last word, so it outranks the conf the previous
+// network wrote.
+func TestRunningECashIDPrefersTheUserPick(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+
+	cat := netcatalog.Catalog{Networks: []netcatalog.Network{
+		{ID: "alphanet", Family: netcatalog.FamilyECash},
+		{ID: "drynet4", Family: netcatalog.FamilyECash},
+	}}
+	o.adoptCatalog(cat, "drynet4")
+	require.NoError(t, o.SelectECashNetwork("alphanet"))
+
+	require.Equal(t, "alphanet", o.RunningECashID(cat))
+}
+
+// A conf that names a network the catalog dropped points nowhere, so the
+// document decides again.
+func TestRunningECashIDFallsBackWhenTheCatalogDropsTheConfNetwork(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.adoptCatalog(netcatalog.Catalog{Networks: []netcatalog.Network{
+		{ID: "drynet4", Family: netcatalog.FamilyECash},
+	}}, "drynet4")
+
+	trimmed := netcatalog.Catalog{Networks: []netcatalog.Network{
+		{ID: "alphanet", Family: netcatalog.FamilyECash},
+	}}
+	require.Equal(t, "alphanet", o.RunningECashID(trimmed))
+}


### PR DESCRIPTION
A cached catalog written in another order lists the retired eCash rows first, so document order alone moved a live install from drynet4 to drynet2. That row publishes no backends, so the wallet lost its chain source and every switch failed with a precondition error.

The conf names the fork whose blocks are on disk, so it now outranks document order. The user pick still comes first, and the upgrade prompt still reads the published document.