### PR TITLE
orchestrator: never wipe the ecash chain without asking

### DIFF
--- a/bitwindow/lib/pages/settings/settings_network.dart
+++ b/bitwindow/lib/pages/settings/settings_network.dart
@@ -585,8 +585,32 @@ Future<void> swapNetworkWithDatadirPrompt(
   if (!context.mounted) {
     return;
   }
-  if (network == BitcoinNetwork.BITCOIN_NETWORK_ECASH && !await confirmPendingECashUpgrade(context)) {
-    return;
+  var targetId = networkId;
+  if (network == BitcoinNetwork.BITCOIN_NETWORK_ECASH) {
+    final outcome = await confirmPendingECashUpgrade(context);
+    if (outcome == ECashUpgradeOutcome.cancelled) {
+      return;
+    }
+    // An applied upgrade is the switch itself only when eCash already ran.
+    // From another network it records the generation and leaves the active
+    // network alone, so the move below still has to happen — on the generation
+    // the user just confirmed, not the row they started from.
+    if (outcome == ECashUpgradeOutcome.applied) {
+      if (provider.network == BitcoinNetwork.BITCOIN_NETWORK_ECASH) {
+        return;
+      }
+      if (provider.ecashNetworkId.isNotEmpty) {
+        targetId = provider.ecashNetworkId;
+      }
+    }
+    if (!context.mounted) {
+      return;
+    }
+    // The pending prompt only fires for a published upgrade. A pick made from
+    // the dropdown moves the chain just as much, so it asks too.
+    if (!await confirmECashSwitch(context, targetId)) {
+      return;
+    }
   }
 
   if (!context.mounted) {
@@ -598,7 +622,7 @@ Future<void> swapNetworkWithDatadirPrompt(
         fromNetwork: provider.network,
         toNetwork: network,
         dataDir: dataDir,
-        networkId: networkId,
+        networkId: targetId,
       ),
     ),
   );

--- a/bitwindow/lib/widgets/ecash_upgrade_banner.dart
+++ b/bitwindow/lib/widgets/ecash_upgrade_banner.dart
@@ -6,6 +6,68 @@ import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:sail_ui/sail_ui.dart';
 
+/// What a move between two eCash networks does to the chain on disk. The
+/// backend rewinds to the fork when both networks publish one, so the blocks
+/// below it stay and only the new fork downloads.
+String ecashChainCostLine(PlanECashSwitchResponse? plan, String fromId, String toId, {bool manualConf = false}) {
+  // A manual switch has no backend to rewind for it: the steps below tell the
+  // user to delete blocks/ and chainstate/ by hand.
+  if (!manualConf && plan != null && plan.needsRollback && !plan.mustWipe) {
+    return '\u2022 The chain rewinds to block ${plan.rewindHeight}. Blocks below it are kept, '
+        'so only $toId\u2019s own blocks download.';
+  }
+  return '\u2022 The $fromId chain is deleted; $toId syncs from scratch.';
+}
+
+/// Asks before a move between two eCash networks and states what it costs.
+/// Returns false when the user backs out.
+Future<bool> confirmECashSwitch(BuildContext context, String toId) async {
+  if (toId.isEmpty) {
+    return true;
+  }
+  // A plan we could not read is not a plan we may skip: the switch itself still
+  // runs, and it can be the one that deletes the chain. Ask with the worst case
+  // named instead.
+  PlanECashSwitchResponse? plan;
+  try {
+    plan = await GetIt.I.get<BitcoinConfProvider>().planECashSwitch(toId);
+  } catch (e) {
+    plan = null;
+  }
+  if (plan != null && (plan.fromId.isEmpty || plan.fromId == plan.toId)) {
+    return true;
+  }
+  if (!context.mounted) {
+    return false;
+  }
+  final fromId = plan?.fromId ?? 'the current network';
+  final go = await showThemedDialog<bool>(
+    context: context,
+    builder: (context) => SailDialog(
+      title: 'Switch to $toId',
+      subtitle: '$toId is a separate chain, not a continuation of $fromId.',
+      actions: [
+        SailButton(
+          label: 'Cancel',
+          variant: ButtonVariant.secondary,
+          onPressed: () async => Navigator.of(context).pop(false),
+        ),
+        SailButton(label: 'Switch to $toId', onPressed: () async => Navigator.of(context).pop(true)),
+      ],
+      child: SailColumn(
+        spacing: SailStyleValues.padding12,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SailText.secondary13(ecashChainCostLine(plan, fromId, toId)),
+          SailText.secondary13('\u2022 Coins and transactions you had on $fromId are gone for good.'),
+          SailText.secondary13('\u2022 Your wallets, addresses and keys are kept.'),
+        ],
+      ),
+    ),
+  );
+  return go == true;
+}
+
 /// Action key the banner notification carries; see NotificationActions.
 const ecashUpgradeAction = 'ecash_upgrade';
 
@@ -105,26 +167,41 @@ Future<bool> openECashUpgrade(BuildContext context) async {
 
 /// Runs the upgrade flow when a newer network is published, so entering
 /// eCash never lands on a retired one. True means carry on with the swap.
-Future<bool> confirmPendingECashUpgrade(BuildContext context) async {
+/// What the pending-upgrade prompt did, which decides whether a pick the user
+/// started with is still the one to act on.
+enum ECashUpgradeOutcome {
+  /// Nothing was pending. The caller carries on with its own pick.
+  none,
+
+  /// The prompt switched networks. That move supersedes the caller's pick: the
+  /// row it started from is the one the user just left.
+  applied,
+
+  /// The user backed out.
+  cancelled,
+}
+
+Future<ECashUpgradeOutcome> confirmPendingECashUpgrade(BuildContext context) async {
   final GetPendingNetworkGenerationResponse pending;
   try {
     pending = await GetIt.I.get<OrchestratorRPC>().getPendingNetworkGeneration();
   } catch (e) {
-    return true; // Orchestrator not reachable; the swap itself will report it.
+    // Orchestrator not reachable; the swap itself will report it.
+    return ECashUpgradeOutcome.none;
   }
   if (pending.pendingNetworkId.isEmpty) {
-    return true;
+    return ECashUpgradeOutcome.none;
   }
 
   if (!context.mounted) {
-    return false;
+    return ECashUpgradeOutcome.cancelled;
   }
   final applied = await showThemedDialog<bool>(
     context: context,
     barrierDismissible: false,
     builder: (context) => ECashUpgradeDialog(pending: pending),
   );
-  return applied == true;
+  return applied == true ? ECashUpgradeOutcome.applied : ECashUpgradeOutcome.cancelled;
 }
 
 /// Spells out what switching networks costs before running it.
@@ -145,10 +222,33 @@ class _ECashUpgradeDialogState extends State<ECashUpgradeDialog> {
   String? _error;
   String _progress = '';
 
+  /// The backend's plan for this move, which says whether the chain rewinds to
+  /// the fork or resyncs. Null until it answers.
+  PlanECashSwitchResponse? _plan;
+
   @override
   void initState() {
     super.initState();
+    unawaited(_readPlan());
     _refresh = Timer.periodic(const Duration(seconds: 5), (_) => unawaited(_reload()));
+  }
+
+  Future<void> _readPlan() async {
+    final id = _pending.pendingNetworkId;
+    if (id.isEmpty) {
+      return;
+    }
+    try {
+      final plan = await GetIt.I.get<BitcoinConfProvider>().planECashSwitch(id);
+      // A refresh can publish another network while this is in flight. The
+      // late answer prices the network the dialog no longer names, and the
+      // user would confirm a resync after a rewind was promised.
+      if (mounted && id == _pending.pendingNetworkId) {
+        setState(() => _plan = plan);
+      }
+    } catch (e) {
+      _log.w('ECashUpgradeDialog: could not plan the switch: $e');
+    }
   }
 
   @override
@@ -176,7 +276,12 @@ class _ECashUpgradeDialogState extends State<ECashUpgradeDialog> {
       Navigator.of(context).pop(true);
       return;
     }
-    setState(() => _pending = fresh);
+    // The plan belongs to the network on screen, so it goes stale with it.
+    setState(() {
+      _pending = fresh;
+      _plan = null;
+    });
+    unawaited(_readPlan());
   }
 
   bool get _hasSnapshot => _pending.snapshotHeight > 0;
@@ -252,7 +357,7 @@ class _ECashUpgradeDialogState extends State<ECashUpgradeDialog> {
             '${p.currentNetworkId}. Switching means:',
           ),
           SailText.secondary13(
-            '• The ${p.currentNetworkId} chain is deleted; ${p.pendingNetworkId} syncs from scratch.',
+            ecashChainCostLine(_plan, p.currentNetworkId, p.pendingNetworkId, manualConf: p.userManagedConf),
           ),
           SailText.secondary13('• Coins and transactions you had on ${p.currentNetworkId} are gone for good.'),
           SailText.secondary13('• Your wallets, addresses and keys are kept.'),

--- a/bitwindow/server/database/migrations/046_bundle_status_stamped.sql
+++ b/bitwindow/server/database/migrations/046_bundle_status_stamped.sql
@@ -1,0 +1,6 @@
+-- Terminal transitions now record the height they happened at. Rows written
+-- before that carry only their last vote, so a fork purge cannot tell which
+-- branch ended them and has to take them conservatively. This marks the rows
+-- that do carry a real stamp, so the conservative path applies to legacy rows
+-- alone rather than to every terminal bundle forever.
+ALTER TABLE withdrawal_bundles ADD COLUMN status_stamped INTEGER NOT NULL DEFAULT 0;

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -131,22 +131,105 @@ type BlockResult struct {
 	Error  error
 }
 
-// resetProcessedChain drops processed blocks and everything derived from them;
-// the derived inserts ignore conflicts, so stale rows would survive the rescan.
+// resetProcessedChain drops every processed block and everything derived from
+// them; the derived inserts ignore conflicts, so stale rows would survive the
+// rescan.
 func (p *Parser) resetProcessedChain(ctx context.Context) error {
-	if err := blocks.WipeProcessedBlocks(ctx, p.db); err != nil {
-		return fmt.Errorf("wipe processed blocks: %w", err)
+	_, err := p.purgeAtOrAbove(ctx, 0)
+	return err
+}
+
+// purgeAtOrAbove drops every row derived from a block at height or above, so a
+// replay of that range rebuilds them against the chain Core now follows.
+//
+// One transaction. A partial purge would delete the processed markers that make
+// the fork detectable while orphan rows survive, and the first-wins inserts on
+// replay would then keep them for good.
+// It returns the height the replay has to start from, which the M4 purge can
+// take below height: a bundle whose score the orphan branch moved only rebuilds
+// by replaying the blocks that built it.
+func (p *Parser) purgeAtOrAbove(ctx context.Context, height uint32) (uint32, error) {
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("open the fork purge: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // committed on success
+
+	replayFrom, err := purgeM4AtOrAboveTx(ctx, tx, height)
+	if err != nil {
+		return 0, fmt.Errorf("purge m4 on fork: %w", err)
+	}
+	if err := blocks.DeleteProcessedBlocksAtOrAboveTx(ctx, tx, replayFrom); err != nil {
+		return 0, fmt.Errorf("delete processed blocks on fork: %w", err)
+	}
+	if err := purgeCoinNewsAtOrAboveTx(ctx, tx, height); err != nil {
+		return 0, fmt.Errorf("purge coinnews on fork: %w", err)
+	}
+	if err := purgeChainDerivedAtOrAboveTx(ctx, tx, height); err != nil {
+		return 0, fmt.Errorf("purge chain-derived rows on fork: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit the fork purge: %w", err)
+	}
+	return replayFrom, nil
+}
+
+// forkPoint returns the lowest processed height whose block Core no longer
+// holds, or 0 when Core still agrees with everything we processed.
+//
+// The common case costs one RPC: the processed tip usually still matches. A
+// mismatch then binary-searches the processed range for the first block the two
+// chains disagree on, which is where a replay has to start.
+func (p *Parser) forkPoint(ctx context.Context, processedTip uint32, processedHash string) (uint32, error) {
+	if processedTip == 0 || processedHash == "" {
+		return 0, nil
+	}
+	switch same, err := p.coreHoldsBlock(ctx, processedTip, processedHash); {
+	case err != nil:
+		return 0, err
+	case same:
+		return 0, nil
 	}
 
-	if err := p.purgeCoinNewsAtOrAbove(ctx, 0); err != nil {
-		return fmt.Errorf("purge coinnews: %w", err)
+	// Anchored at 0, a height nothing processes, so height 1 is searched like
+	// any other. A regenerated regtest datadir differs from block 1 up.
+	lo, hi := uint32(0), processedTip
+	for lo+1 < hi {
+		mid := lo + (hi-lo)/2
+		stored, err := blocks.GetProcessedBlock(ctx, p.db, mid)
+		if err != nil {
+			// A gap in the processed range tells us nothing about the fork.
+			// Treat everything above it as suspect.
+			hi = mid
+			continue
+		}
+		switch same, err := p.coreHoldsBlock(ctx, mid, stored.Hash.String()); {
+		case err != nil:
+			return 0, err
+		case same:
+			lo = mid
+		default:
+			hi = mid
+		}
 	}
+	return hi, nil
+}
 
-	if err := p.purgeM4AtOrAbove(ctx, 0); err != nil {
-		return fmt.Errorf("purge m4: %w", err)
+// coreHoldsBlock reports whether Core's block at height is the one we recorded.
+func (p *Parser) coreHoldsBlock(ctx context.Context, height uint32, hash string) (bool, error) {
+	bitcoind, err := p.bitcoind.Get(ctx)
+	if err != nil {
+		return false, err
 	}
-
-	return nil
+	res, err := bitcoind.GetBlockHash(ctx, connect.NewRequest(&corepb.GetBlockHashRequest{Height: height}))
+	if err != nil {
+		if strings.Contains(err.Error(), "out of range") {
+			// Core is shorter than we processed, so it holds no such block.
+			return false, nil
+		}
+		return false, fmt.Errorf("get block hash %d: %w", height, err)
+	}
+	return res.Msg.Hash == hash, nil
 }
 
 func (p *Parser) handleBlockTick(ctx context.Context) error {
@@ -196,13 +279,12 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 	}
 
 	// Get current blockchain height + IBD flag.
-	currentHeight, currentHash, inIBD, err := p.currentChainState(ctx)
+	currentHeight, _, inIBD, err := p.currentChainState(ctx)
 	if err != nil {
 		return fmt.Errorf("fetch current height: %w", err)
 	}
 
-	// A node shorter than our processed tip means the chain was wiped (or
-	// rolled back deeper than the rewind-20 path below handles). A healthy
+	// A node shorter than our processed tip means the chain was wiped. A healthy
 	// node — and a fresh install (processed tip 0) — is never shorter than
 	// what we've already processed, so this only fires on a real wipe, not on
 	// the pruning/reindex/restart blips that keep the tip high. Left stale,
@@ -219,6 +301,32 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 			return fmt.Errorf("reset processed chain on chain wipe: %w", err)
 		}
 		return nil
+	}
+
+	// Before the IBD guard below. A switch leaves the replacement fork in IBD
+	// while it downloads from the rewind point, and every tick that returns
+	// early keeps serving rows from the fork that went away. The purge is a few
+	// queries; only the replay under it is expensive, and that still waits.
+	//
+	// A height compare cannot see an eCash fork switch: both forks descend from
+	// mainnet, so the tip stays as high or higher. Only the hash at a height we
+	// already processed says the chain moved under us.
+	switch fork, err := p.forkPoint(ctx, lastProcessedHeight, lastProcessedHash.String()); {
+	case err != nil:
+		zerolog.Ctx(ctx).Warn().Err(err).
+			Msg("bitcoind_engine/parser: could not check for a fork, retrying next tick")
+		return nil
+
+	case fork > 0:
+		zerolog.Ctx(ctx).Warn().
+			Uint32("fork_height", fork).
+			Uint32("processed_tip", lastProcessedHeight).
+			Msg("bitcoind_engine/parser: the chain forked below our processed tip, replaying from there")
+		replayFrom, err := p.purgeAtOrAbove(ctx, fork)
+		if err != nil {
+			return err
+		}
+		lastProcessedHeight = replayFrom - 1
 	}
 
 	// While Core is still doing initial block download on a *full* chain
@@ -244,29 +352,6 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 
 	zerolog.Ctx(ctx).Trace().
 		Msgf("bitcoind_engine/parser: found current height: %d", currentHeight)
-
-	if lastProcessedHeight == currentHeight && lastProcessedHash != currentHash {
-		// probably some sort of reorg, process the last 20 blocks again!
-		// doesnt handle very deep reorgs, but thats okay
-		lastProcessedHeight -= 20
-		zerolog.Ctx(ctx).Trace().
-			Msgf("bitcoind_engine/parser: detected reorg, processing last 20 blocks")
-
-		// Wipe the CoinNews rows that came from blocks we're about to
-		// replay; otherwise the canonical first-wins rules see stale
-		// orphans from the pre-reorg chain and ignore the new winners.
-		if err := p.purgeCoinNewsAtOrAbove(ctx, lastProcessedHeight+1); err != nil {
-			return fmt.Errorf("purge coinnews on reorg: %w", err)
-		}
-
-		if err := p.purgeM4AtOrAbove(ctx, lastProcessedHeight+1); err != nil {
-			return fmt.Errorf("purge m4 on reorg: %w", err)
-		}
-
-		if err := p.purgeChainDerivedAtOrAbove(ctx, lastProcessedHeight+1); err != nil {
-			return fmt.Errorf("purge chain-derived rows on reorg: %w", err)
-		}
-	}
 
 	const batchSize = 30
 

--- a/bitwindow/server/engines/coinnews.go
+++ b/bitwindow/server/engines/coinnews.go
@@ -166,16 +166,84 @@ func dropMsg(ctx context.Context, pos cnstore.BlockPos, reason string, err error
 		Msg("coinnews: " + reason + ", dropping")
 }
 
-// purgeM4AtOrAbove deletes every M4/SCDB row originating from a block at or
-// above `fromHeight`. Called on the same reorg replay as purgeCoinNewsAtOrAbove
-// — without it, a bundle first seen in an orphaned block survives the replay
-// (its insert is ON CONFLICT DO NOTHING) and keeps voting.
+// purgeM4AtOrAbove runs the M4 purge in its own transaction.
 func (p *Parser) purgeM4AtOrAbove(ctx context.Context, fromHeight uint32) error {
+	return p.inTx(ctx, func(tx *sql.Tx) error {
+		_, err := purgeM4AtOrAboveTx(ctx, tx, fromHeight)
+		return err
+	})
+}
+
+// purgeChainDerivedAtOrAbove runs the op_returns purge in its own transaction.
+func (p *Parser) purgeChainDerivedAtOrAbove(ctx context.Context, fromHeight uint32) error {
+	return p.inTx(ctx, func(tx *sql.Tx) error {
+		return purgeChainDerivedAtOrAboveTx(ctx, tx, fromHeight)
+	})
+}
+
+// purgeCoinNewsAtOrAbove runs the coinnews purge in its own transaction.
+func (p *Parser) purgeCoinNewsAtOrAbove(ctx context.Context, fromHeight uint32) error {
+	return p.inTx(ctx, func(tx *sql.Tx) error {
+		return purgeCoinNewsAtOrAboveTx(ctx, tx, fromHeight)
+	})
+}
+
+// inTx runs fn in one transaction and commits when it returns nil.
+func (p *Parser) inTx(ctx context.Context, fn func(*sql.Tx) error) error {
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback() //nolint:errcheck // committed on success
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// purgeM4AtOrAbove deletes every M4/SCDB row originating from a block at or
+// above `fromHeight`. Called on the same reorg replay as purgeCoinNewsAtOrAbove
+// — without it, a bundle first seen in an orphaned block survives the replay
+// (its insert is ON CONFLICT DO NOTHING) and keeps voting.
+// It returns the height a replay has to start from to rebuild what survives.
+// A bundle the orphan branch scored carries a work_score, status and
+// last_updated_height that no query rebuilds: the score is a running count with
+// a floor. Only a replay of the blocks does. So the bundle goes, and the
+// returned height takes the replay back to its first block.
+func purgeM4AtOrAboveTx(ctx context.Context, tx *sql.Tx, fromHeight uint32) (uint32, error) {
+	// Widening the window drags in more bundles, and each of those has to be
+	// replayed from its own first block too. Repeat until it stops moving, or a
+	// bundle ends up cleared with part of its history never replayed.
+	replayFrom := fromHeight
+	for {
+		var lowest sql.NullInt64
+		// A terminal bundle written before the transitions stamped their height
+		// carries only its last vote, so last_updated_height cannot say whether
+		// the branch that went away is what ended it.
+		//
+		// Only a legacy row is ambiguous, and a legacy row is one whose stamp
+		// still sits at the vote that ended it — status_stamped marks the rest.
+		// Without that guard every approved bundle would pull the window back
+		// to the oldest one, so a one-block reorg rescans years of blocks.
+		//
+		// failed and expired both need blocks_left = 0, which cannot happen
+		// before first_seen_height + max_age, so one that aged out below the
+		// window stays. approved needs only a score, which any block can reach.
+		if err := tx.QueryRowContext(ctx, `
+			SELECT MIN(first_seen_height) FROM withdrawal_bundles
+			WHERE last_updated_height >= ?
+			   OR (status_stamped = 0 AND status = 'approved' AND first_seen_height < ?)
+			   OR (status_stamped = 0 AND status IN ('failed', 'expired')
+			       AND first_seen_height + max_age >= ?)`,
+			replayFrom, replayFrom, replayFrom,
+		).Scan(&lowest); err != nil {
+			return 0, err
+		}
+		if !lowest.Valid || lowest.Int64 < 0 || uint32(lowest.Int64) >= replayFrom {
+			break
+		}
+		replayFrom = uint32(lowest.Int64)
+	}
 
 	stmts := []string{
 		`DELETE FROM m4_votes           WHERE m4_message_id IN (SELECT id FROM m4_messages WHERE block_height >= ?)`,
@@ -184,11 +252,14 @@ func (p *Parser) purgeM4AtOrAbove(ctx context.Context, fromHeight uint32) error 
 		`DELETE FROM withdrawal_bundles WHERE first_seen_height >= ?`,
 	}
 	for _, q := range stmts {
-		if _, err := tx.ExecContext(ctx, q, fromHeight); err != nil {
-			return err
+		if _, err := tx.ExecContext(ctx, q, replayFrom); err != nil {
+			return 0, err
 		}
 	}
-	return tx.Commit()
+
+	// No reset is left to make: at the fixed point every bundle the replay
+	// re-scores was first seen at or above replayFrom, so the delete took it.
+	return replayFrom, nil
 }
 
 // purgeChainDerivedAtOrAbove drops the block-derived op_returns and
@@ -198,12 +269,7 @@ func (p *Parser) purgeM4AtOrAbove(ctx context.Context, fromHeight uint32) error 
 // timestamp is never re-examined. Mempool OP_RETURNs have a NULL height
 // and are left alone; reset timestamps go back through the confirming
 // loop, which re-confirms them against the new chain or fails them.
-func (p *Parser) purgeChainDerivedAtOrAbove(ctx context.Context, fromHeight uint32) error {
-	tx, err := p.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback() //nolint:errcheck // committed on success
+func purgeChainDerivedAtOrAboveTx(ctx context.Context, tx *sql.Tx, fromHeight uint32) error {
 
 	if _, err := tx.ExecContext(ctx,
 		`DELETE FROM op_returns WHERE height >= ?`, fromHeight,
@@ -218,7 +284,7 @@ func (p *Parser) purgeChainDerivedAtOrAbove(ctx context.Context, fromHeight uint
 	); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return nil
 }
 
 // purgeCoinNewsAtOrAbove deletes every cn_* row originating from a
@@ -226,19 +292,16 @@ func (p *Parser) purgeChainDerivedAtOrAbove(ctx context.Context, fromHeight uint
 // reorg and replays a height range — without it, `INSERT OR IGNORE`
 // during the replay would silently keep orphaned rows from the
 // pre-reorg chain, breaking the determinism budget.
-func (p *Parser) purgeCoinNewsAtOrAbove(ctx context.Context, fromHeight uint32) error {
-	tx, err := p.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback() //nolint:errcheck // committed on success
+func purgeCoinNewsAtOrAboveTx(ctx context.Context, tx *sql.Tx, fromHeight uint32) error {
 
 	stmts := []string{
 		`DELETE FROM cn_stories       WHERE item_id IN (SELECT item_id FROM cn_items WHERE block_height >= ?)`,
 		`DELETE FROM cn_comments      WHERE item_id IN (SELECT item_id FROM cn_items WHERE block_height >= ?)`,
 		`DELETE FROM cn_votes         WHERE block_height >= ?`,
 		`DELETE FROM cn_continuations WHERE block_height >= ?`,
-		`DELETE FROM cn_topics        WHERE created_height >= ?`,
+		// An empty txid marks a local bootstrap row, not a creation on chain.
+		// No block replays it, so a delete here loses it for good.
+		`DELETE FROM cn_topics        WHERE created_height >= ? AND txid != ''`,
 		`DELETE FROM cn_items         WHERE block_height >= ?`,
 	}
 	for _, q := range stmts {
@@ -246,5 +309,5 @@ func (p *Parser) purgeCoinNewsAtOrAbove(ctx context.Context, fromHeight uint32) 
 			return err
 		}
 	}
-	return tx.Commit()
+	return nil
 }

--- a/bitwindow/server/engines/fork_point_test.go
+++ b/bitwindow/server/engines/fork_point_test.go
@@ -1,0 +1,107 @@
+package engines
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	service "github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// hashAt is a distinct block hash per height and chain.
+func hashAt(height uint32, chain byte) chainhash.Hash {
+	var h chainhash.Hash
+	h[0] = chain
+	h[1] = byte(height)
+	h[2] = byte(height >> 8)
+	return h
+}
+
+// forkParser wires a Parser to a Core that serves `chain` at every height.
+func forkParser(t *testing.T, chain byte) *Parser {
+	t.Helper()
+	core := mocks.NewMockBitcoinServiceClient(gomock.NewController(t))
+	p := &Parser{
+		db: database.Test(t),
+		bitcoind: service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+			return core, nil
+		}),
+	}
+	core.EXPECT().
+		GetBlockHash(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *connect.Request[corepb.GetBlockHashRequest]) (*connect.Response[corepb.GetBlockHashResponse], error) {
+			return connect.NewResponse(&corepb.GetBlockHashResponse{Hash: hashAt(req.Msg.Height, chain).String()}), nil
+		}).
+		AnyTimes()
+	return p
+}
+
+// seedProcessed records a contiguous processed chain on `chain`.
+func seedProcessed(t *testing.T, ctx context.Context, p *Parser, tip uint32, chain byte) {
+	t.Helper()
+	for h := uint32(1); h <= tip; h++ {
+		_, err := p.db.ExecContext(ctx, `
+			INSERT INTO processed_blocks (height, block_hash, txids, block_time)
+			VALUES (?, ?, '[]', 0)`, h, hashAt(h, chain).String())
+		require.NoError(t, err)
+	}
+}
+
+// A datadir regenerated from scratch differs from block 1 up. Anchoring the
+// search at height 1 would assume it matches and keep that marker for good.
+func TestForkPointFindsADivergenceAtBlockOne(t *testing.T) {
+	ctx := context.Background()
+	p := forkParser(t, 'b')
+	seedProcessed(t, ctx, p, 10, 'a')
+
+	fork, err := p.forkPoint(ctx, 10, hashAt(10, 'a').String())
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), fork, "the whole processed chain belongs to another datadir")
+}
+
+// The ordinary case: the chains agree below the fork and part above it.
+func TestForkPointFindsTheFirstDivergentBlock(t *testing.T) {
+	ctx := context.Background()
+	core := mocks.NewMockBitcoinServiceClient(gomock.NewController(t))
+	p := &Parser{
+		db: database.Test(t),
+		bitcoind: service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+			return core, nil
+		}),
+	}
+	// Core keeps chain 'a' up to 6, then follows chain 'b'.
+	core.EXPECT().
+		GetBlockHash(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *connect.Request[corepb.GetBlockHashRequest]) (*connect.Response[corepb.GetBlockHashResponse], error) {
+			chain := byte('a')
+			if req.Msg.Height > 6 {
+				chain = 'b'
+			}
+			return connect.NewResponse(&corepb.GetBlockHashResponse{Hash: hashAt(req.Msg.Height, chain).String()}), nil
+		}).
+		AnyTimes()
+	seedProcessed(t, ctx, p, 10, 'a')
+
+	fork, err := p.forkPoint(ctx, 10, hashAt(10, 'a').String())
+	require.NoError(t, err)
+	require.Equal(t, uint32(7), fork)
+}
+
+// Core still holds everything we processed, so there is no fork and no purge.
+func TestForkPointReportsNoneWhenTheChainsAgree(t *testing.T) {
+	ctx := context.Background()
+	p := forkParser(t, 'a')
+	seedProcessed(t, ctx, p, 10, 'a')
+
+	fork, err := p.forkPoint(ctx, 10, hashAt(10, 'a').String())
+	require.NoError(t, err)
+	require.Zero(t, fork)
+}

--- a/bitwindow/server/engines/m4_engine.go
+++ b/bitwindow/server/engines/m4_engine.go
@@ -443,13 +443,20 @@ func (e *M4Engine) updateBundleStates(ctx context.Context, height uint32) error 
 		return fmt.Errorf("recompute blocks_left: %w", err)
 	}
 
+	// Each transition stamps the height it happened at. A terminal bundle takes
+	// no more votes, so this changes nothing for scoring — but a fork purge
+	// keys on last_updated_height, and without it a bundle that went terminal
+	// on the branch that went away keeps that state for good.
+	//
 	// Mark bundles as approved if work_score >= 13150
 	_, err = e.db.ExecContext(ctx, `
 		UPDATE withdrawal_bundles
-		SET status = 'approved'
+		SET status = 'approved',
+		    last_updated_height = ?,
+		    status_stamped = 1
 		WHERE status = 'pending'
 		  AND work_score >= ?
-	`, m4.MinWorkScore)
+	`, height, m4.MinWorkScore)
 	if err != nil {
 		return fmt.Errorf("mark approved bundles: %w", err)
 	}
@@ -457,11 +464,13 @@ func (e *M4Engine) updateBundleStates(ctx context.Context, height uint32) error 
 	// Mark bundles as failed if blocks_left = 0 and work_score < 13150
 	_, err = e.db.ExecContext(ctx, `
 		UPDATE withdrawal_bundles
-		SET status = 'failed'
+		SET status = 'failed',
+		    last_updated_height = ?,
+		    status_stamped = 1
 		WHERE status = 'pending'
 		  AND blocks_left = 0
 		  AND work_score < ?
-	`, m4.MinWorkScore)
+	`, height, m4.MinWorkScore)
 	if err != nil {
 		return fmt.Errorf("mark failed bundles: %w", err)
 	}
@@ -469,10 +478,12 @@ func (e *M4Engine) updateBundleStates(ctx context.Context, height uint32) error 
 	// Mark bundles as expired if blocks_left = 0 (regardless of score)
 	_, err = e.db.ExecContext(ctx, `
 		UPDATE withdrawal_bundles
-		SET status = 'expired'
+		SET status = 'expired',
+		    last_updated_height = ?,
+		    status_stamped = 1
 		WHERE status = 'pending'
 		  AND blocks_left = 0
-	`)
+	`, height)
 	if err != nil {
 		return fmt.Errorf("mark expired bundles: %w", err)
 	}

--- a/bitwindow/server/engines/reset_processed_chain_test.go
+++ b/bitwindow/server/engines/reset_processed_chain_test.go
@@ -1,0 +1,258 @@
+package engines
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/stretchr/testify/require"
+)
+
+// The chain reset replaces a delete of bitwindow.db, so it has to clear every
+// block-derived row. op_returns keeps its old height on re-insert, so a row
+// left behind names a block the new chain never had.
+func TestResetProcessedChainClearsOPReturns(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	p := &Parser{db: db, m4Engine: NewM4Engine(db)}
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO op_returns (txid, vout, op_return_data, fee_sats, height)
+		VALUES ('confirmed', 0, 'from the retired fork', 100, 963700),
+		       ('mempool', 0, 'still unconfirmed', 100, NULL)`)
+	require.NoError(t, err)
+
+	require.NoError(t, p.resetProcessedChain(ctx))
+
+	var confirmed, mempool int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM op_returns WHERE height IS NOT NULL`).Scan(&confirmed))
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM op_returns WHERE height IS NULL`).Scan(&mempool))
+
+	require.Zero(t, confirmed, "confirmed op_returns belong to the chain that went away")
+	require.Equal(t, 1, mempool, "mempool op_returns are not block-derived")
+}
+
+// The user's own rows are not chain data. The reset that a network change now
+// relies on must leave every one of them in place.
+func TestResetProcessedChainKeepsTheUsersRows(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	p := &Parser{db: db, m4Engine: NewM4Engine(db)}
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO address_book (wallet_id, label, address, direction) VALUES ('w1', 'mum', 'bc1qexample', 'receive')`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO transaction_notes (wallet_id, txid, note) VALUES ('w1', 'deadbeef', 'rent')`)
+	require.NoError(t, err)
+
+	require.NoError(t, p.resetProcessedChain(ctx))
+
+	var addresses, notes int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM address_book`).Scan(&addresses))
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM transaction_notes`).Scan(&notes))
+	require.Equal(t, 1, addresses, "the address book is the user's, not the chain's")
+	require.Equal(t, 1, notes, "transaction notes are the user's, not the chain's")
+}
+
+// seedBundleRow inserts a bundle with a chosen aggregate.
+func seedBundleRow(t *testing.T, ctx context.Context, db *sql.DB, hash string, firstSeen, lastUpdated, score uint32) {
+	t.Helper()
+	_, err := db.ExecContext(ctx, `INSERT OR IGNORE INTO sidechains (slot, name) VALUES (0, 'test')`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO withdrawal_bundles (sidechain_slot, bundle_hash, work_score, blocks_left,
+			first_seen_height, last_updated_height, status)
+		VALUES (0, ?, ?, 100, ?, ?, 'pending')`, hash, score, firstSeen, lastUpdated)
+	require.NoError(t, err)
+}
+
+func bundleAggregate(t *testing.T, ctx context.Context, db *sql.DB, hash string) (score, lastUpdated uint32, found bool) {
+	t.Helper()
+	err := db.QueryRowContext(ctx,
+		`SELECT work_score, last_updated_height FROM withdrawal_bundles WHERE bundle_hash = ?`,
+		hash).Scan(&score, &lastUpdated)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, 0, false
+	}
+	require.NoError(t, err)
+	return score, lastUpdated, true
+}
+
+// A bundle whose score the orphan branch moved cannot be rebuilt by a query:
+// the score is a running count with a floor. The purge takes the replay back to
+// the bundle's own first block instead, and clears what the branch left.
+func TestForkPurgeReplaysFromABundleTheOrphanBranchScored(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	p := &Parser{db: db, m4Engine: NewM4Engine(db)}
+
+	// Scored at 1000, above the fork at 950, so the branch that went away
+	// touched it.
+	seedBundleRow(t, ctx, db, "scored-above-the-fork", 900, 1000, 42)
+	// Not touched by the fork itself, but the widened window reaches it, so its
+	// own history has to be replayed too.
+	seedBundleRow(t, ctx, db, "inside-the-window", 880, 920, 7)
+	// Settled below the window. Nothing replays it, so nothing may touch it.
+	seedBundleRow(t, ctx, db, "below-the-window", 800, 850, 5)
+
+	replayFrom, err := p.purgeAtOrAbove(ctx, 950)
+	require.NoError(t, err)
+	// 950 drags in the bundle first seen at 900, which drags in the one first
+	// seen at 880. Stopping at 900 would clear that one with blocks 880-899
+	// never replayed.
+	require.Equal(t, uint32(880), replayFrom, "the window widens until it stops moving")
+
+	_, _, found := bundleAggregate(t, ctx, db, "scored-above-the-fork")
+	require.False(t, found, "the replay rebuilds it from its own first block")
+
+	_, _, found = bundleAggregate(t, ctx, db, "inside-the-window")
+	require.False(t, found, "the widened window rebuilds it too")
+
+	score, lastUpdated, found := bundleAggregate(t, ctx, db, "below-the-window")
+	require.True(t, found)
+	require.Equal(t, uint32(5), score, "nothing replays it, so nothing may touch it")
+	require.Equal(t, uint32(850), lastUpdated)
+}
+
+// With no bundle for the orphan branch to have scored, the replay starts at the
+// fork and no aggregate moves.
+func TestForkPurgeStaysAtTheForkWithNoTouchedBundle(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	p := &Parser{db: db, m4Engine: NewM4Engine(db)}
+
+	seedBundleRow(t, ctx, db, "settled-below-the-fork", 900, 940, 42)
+
+	replayFrom, err := p.purgeAtOrAbove(ctx, 950)
+	require.NoError(t, err)
+	require.Equal(t, uint32(950), replayFrom)
+
+	score, _, found := bundleAggregate(t, ctx, db, "settled-below-the-fork")
+	require.True(t, found)
+	require.Equal(t, uint32(42), score, "a bundle the fork never reached keeps its score")
+}
+
+// The default topics are seeded by a migration at height 0 with an empty txid.
+// No block replays them, so a purge that takes them loses them for good — the
+// migration is already recorded and never runs again.
+func TestForkPurgeKeepsTheBootstrapTopics(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	p := &Parser{db: db, m4Engine: NewM4Engine(db)}
+
+	// A topic created on chain, which a replay rebuilds.
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO cn_topics (topic, name, retention_days, created_height, txid)
+		 VALUES (x'b1b1b1b1', 'On Chain', 30, 900, 'deadbeef')`)
+	require.NoError(t, err)
+
+	_, err = p.purgeAtOrAbove(ctx, 0)
+	require.NoError(t, err)
+
+	var bootstrap, onChain int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM cn_topics WHERE txid = ''`).Scan(&bootstrap))
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM cn_topics WHERE txid != ''`).Scan(&onChain))
+
+	require.Equal(t, 2, bootstrap, "the seeded default topics must survive")
+	require.Zero(t, onChain, "a topic a replay rebuilds must go")
+}
+
+// A bundle can go terminal without a vote: updateBundleStates ages it out. That
+// transition has to stamp its height, or the purge cannot tell a bundle that
+// failed on the branch that went away from one that failed below the fork.
+func TestBundleAgeingStampsTheHeightSoAForkPurgeSeesIt(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	p := &Parser{db: db, m4Engine: NewM4Engine(db)}
+
+	// Last voted at 900, so no vote moves it. It ages out at 1000, above the
+	// fork at 950.
+	seedBundleRow(t, ctx, db, "aged-out-above-the-fork", 880, 900, 0)
+	_, err := db.ExecContext(ctx, `UPDATE withdrawal_bundles SET max_age = 0, blocks_left = 0`)
+	require.NoError(t, err)
+
+	require.NoError(t, p.m4Engine.updateBundleStates(ctx, 1000))
+
+	_, lastUpdated, found := bundleAggregate(t, ctx, db, "aged-out-above-the-fork")
+	require.True(t, found)
+	require.Equal(t, uint32(1000), lastUpdated, "the transition must stamp its height")
+
+	replayFrom, err := p.purgeAtOrAbove(ctx, 950)
+	require.NoError(t, err)
+	require.Equal(t, uint32(880), replayFrom, "the replay must rebuild it from its first block")
+
+	_, _, found = bundleAggregate(t, ctx, db, "aged-out-above-the-fork")
+	require.False(t, found, "the orphan branch's terminal state must not survive")
+}
+
+// A terminal bundle written before the transitions stamped their height carries
+// only its last vote. The replay cannot repair it — every update guards on
+// status = 'pending' — so the purge has to take it.
+func TestForkPurgeTakesLegacyTerminalBundles(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	p := &Parser{db: db, m4Engine: NewM4Engine(db)}
+
+	// Last vote at 900, below the fork, and no stamp. max_age reaches past the
+	// fork, so it could only have aged out on the branch that went away.
+	seedBundleRow(t, ctx, db, "legacy-expired", 900, 900, 3)
+	_, err := db.ExecContext(ctx,
+		`UPDATE withdrawal_bundles SET status = 'expired', max_age = 100, blocks_left = 0`)
+	require.NoError(t, err)
+
+	replayFrom, err := p.purgeAtOrAbove(ctx, 950)
+	require.NoError(t, err)
+	require.Equal(t, uint32(900), replayFrom, "the replay must rebuild it from its first block")
+
+	_, _, found := bundleAggregate(t, ctx, db, "legacy-expired")
+	require.False(t, found, "a terminal state the replay cannot repair must go")
+}
+
+// One that aged out below the window stays: blocks_left reaches 0 only at
+// first_seen_height + max_age, and that is under the fork.
+func TestForkPurgeKeepsABundleThatAgedOutBelowTheWindow(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	p := &Parser{db: db, m4Engine: NewM4Engine(db)}
+
+	seedBundleRow(t, ctx, db, "expired-long-ago", 800, 800, 3)
+	_, err := db.ExecContext(ctx,
+		`UPDATE withdrawal_bundles SET status = 'expired', max_age = 10, blocks_left = 0`)
+	require.NoError(t, err)
+
+	replayFrom, err := p.purgeAtOrAbove(ctx, 950)
+	require.NoError(t, err)
+	require.Equal(t, uint32(950), replayFrom, "nothing below the fork had to move")
+
+	_, _, found := bundleAggregate(t, ctx, db, "expired-long-ago")
+	require.True(t, found, "a bundle the fork never reached keeps its state")
+}
+
+// A stamped terminal bundle carries the height its transition happened at, so
+// the conservative fallback must not reach it. Without that guard every
+// approved bundle pulls the window back and a one-block reorg rescans years.
+func TestForkPurgeLeavesStampedTerminalBundlesAlone(t *testing.T) {
+	ctx := context.Background()
+	db := database.Test(t)
+	p := &Parser{db: db, m4Engine: NewM4Engine(db)}
+
+	seedBundleRow(t, ctx, db, "approved-long-ago", 800, 850, 20000)
+	_, err := db.ExecContext(ctx,
+		`UPDATE withdrawal_bundles SET status = 'approved', status_stamped = 1`)
+	require.NoError(t, err)
+
+	replayFrom, err := p.purgeAtOrAbove(ctx, 950)
+	require.NoError(t, err)
+	require.Equal(t, uint32(950), replayFrom, "a stamped bundle says it ended below the fork")
+
+	score, _, found := bundleAggregate(t, ctx, db, "approved-long-ago")
+	require.True(t, found)
+	require.Equal(t, uint32(20000), score, "nothing replays it, so nothing may touch it")
+}

--- a/bitwindow/server/models/blocks/processed_blocks.go
+++ b/bitwindow/server/models/blocks/processed_blocks.go
@@ -96,18 +96,12 @@ func MarkBlocksProcessed(ctx context.Context, db *sql.DB, blocks []ProcessedBloc
 	return nil
 }
 
-func WipeProcessedBlocks(ctx context.Context, db *sql.DB) error {
-	start := time.Now()
-	tag, err := db.ExecContext(ctx, `DELETE FROM processed_blocks`)
-	if err != nil {
-		return fmt.Errorf("wipe processed blocks: %w", err)
+// DeleteProcessedBlocksAtOrAboveTx drops every processed block from height up,
+// so a chain that forked below it is re-scanned from the last common block.
+func DeleteProcessedBlocksAtOrAboveTx(ctx context.Context, tx *sql.Tx, height uint32) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM processed_blocks WHERE height >= ?`, height); err != nil {
+		return fmt.Errorf("delete processed blocks at or above %d: %w", height, err)
 	}
-
-	if rows, _ := tag.RowsAffected(); rows > 0 {
-		zerolog.Ctx(ctx).Debug().
-			Msgf("blocks: wiped %d processed blocks in %s", rows, time.Since(start))
-	}
-
 	return nil
 }
 

--- a/sidechain-orchestrator/api/bitcoin_conf_handler.go
+++ b/sidechain-orchestrator/api/bitcoin_conf_handler.go
@@ -135,6 +135,7 @@ func (h *BitcoinConfHandler) PlanECashSwitch(ctx context.Context, req *connect.R
 		ToId:          plan.ToID,
 		RewindHeight:  plan.RewindHeight,
 		NeedsRollback: plan.NeedsRollback,
+		MustWipe:      plan.MustWipe,
 	}), nil
 }
 

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -271,6 +271,31 @@ func run(cctx *cli.Context) error {
 	// generation is settled before anything can be served.
 	orch.ResolveNetworkCatalog(ctx)
 
+	// A swap that died between the park and the conf write left this network's
+	// state parked. Bring it back before anything opens the datadir.
+	//
+	// Fatal: the listener and the --binary auto-boot both start daemons, and a
+	// daemon over an absent path builds fresh state that hides the real one.
+	if err := orch.RestoreParkedSwapState(); err != nil {
+		return fmt.Errorf("restore parked network-swap state: %w", err)
+	}
+
+	// A switch that journalled a wipe and died before making it. Here, because
+	// the delete renames Core's blocks aside and nothing has started yet.
+	if err := orch.ApplyPendingECashWipe(ctx); err != nil {
+		return fmt.Errorf("apply the eCash wipe a switch left behind: %w", err)
+	}
+	if err := orch.ApplyPendingEnforcerWipe(); err != nil {
+		return fmt.Errorf("apply the enforcer cleanup a switch left behind: %w", err)
+	}
+
+	// A Core adopted from the previous run answers already, so the drop can be
+	// made here. Before the listener binds: serving the target generation over
+	// the retired fork is what the drop exists to stop.
+	if err := orch.ApplyPendingRewindToAdoptedCore(ctx); err != nil {
+		return fmt.Errorf("apply the eCash rewind a switch left behind: %w", err)
+	}
+
 	// Set up gRPC/ConnectRPC server
 	handler := api.NewHandler(orch)
 	mux := http.NewServeMux()

--- a/sidechain-orchestrator/config/binaries.go
+++ b/sidechain-orchestrator/config/binaries.go
@@ -364,11 +364,7 @@ func DeleteFilesWithRetry(paths []string, log zerolog.Logger) {
 func (b BinaryDirConfig) GetBlockchainDataPaths(networkDir string, network Network, log zerolog.Logger) []string {
 	switch b.layoutKey() {
 	case "bitcoind":
-		paths := GetExistingFilesInDir(networkDir, []string{
-			".lock", "anchors.dat", "banlist.json", "bitcoin.pid", "bitcoind.pid",
-			"blocks", "chainstate", "debug.log", "fee_estimates.dat", "indexes",
-			"mempool.dat", "peers.dat", "settings.json",
-		}, log)
+		paths := GetExistingFilesInDir(networkDir, coreChainDataNames, log)
 		// assumeutxo snapshots are named for the height they commit to, so a
 		// fixed filename can't catch them. They are large and re-downloadable.
 		return append(paths, GetMatchingFilesInDir(networkDir, utxoSnapshotPattern, log)...)
@@ -381,7 +377,7 @@ func (b BinaryDirConfig) GetBlockchainDataPaths(networkDir string, network Netwo
 		return GetExistingFilesInDir(networkDir, []string{"bitdrive", "bitwindow.db"}, log)
 
 	case "thunder", "bitnames", "bitassets", "thunder-orchard", "truthcoin", "photon", "coinshift":
-		return GetExistingFilesInDir(networkDir, []string{"data.mdb", "lock.mdb", "logs"}, log)
+		return GetExistingFilesInDir(networkDir, SidechainChainDataNames, log)
 
 	default:
 		return nil
@@ -409,54 +405,72 @@ func WipeChainData(network Network, bitcoinDatadirOverride string, log zerolog.L
 	go WipeChainDataSync(network, bitcoinDatadirOverride, log)
 }
 
-// WipeNetworkScopedChainDataSync wipes only the binaries whose data is
-// actually partitioned by network: bitcoind (eCash has its own datadir group)
-// and bitwindowd (per-network subdir). Sidechains keep a flat datadir shared
-// across networks, and the enforcer maps both eCash and mainnet onto
-// validator/bitcoin, so wiping those for one network destroys another's state.
+// SidechainChainDataNames are the entries a sidechain keeps its chain in. The
+// datadir is flat across every network, so a swap has to move them.
+var SidechainChainDataNames = []string{"data.mdb", "lock.mdb", "logs"}
+
+// coreChainDataNames are the entries a Core datadir keeps its chain in. Kept
+// beside GetBlockchainDataPaths, which lists the same set.
+var coreChainDataNames = []string{
+	".lock", "anchors.dat", "banlist.json", "bitcoin.pid", "bitcoind.pid",
+	"blocks", "chainstate", "debug.log", "fee_estimates.dat", "indexes",
+	"mempool.dat", "peers.dat", "settings.json",
+}
+
+// unreadableChainPaths returns the chain paths os.Stat refuses for a reason
+// other than "not there".
+func unreadableChainPaths(dir string) []string {
+	var unreadable []string
+	for _, name := range coreChainDataNames {
+		p := filepath.Join(dir, name)
+		if _, err := os.Stat(p); err != nil && !os.IsNotExist(err) {
+			unreadable = append(unreadable, p)
+		}
+	}
+	return unreadable
+}
+
+// WipeNetworkScopedChainDataSync wipes Bitcoin Core's blocks for network.
 //
-// Used by the eCash network rollover, which can fire while the user is on
-// a different network entirely. A network swap purges enforcer and sidechain
-// state separately.
-func WipeNetworkScopedChainDataSync(network Network, bitcoinDatadirOverride string, log zerolog.Logger) {
+// Core only: sidechains share one flat datadir across networks, the enforcer
+// maps eCash and mainnet onto the same validator dir, and bitwindow.db holds
+// the address book, notes, labels and multisig records that no chain rebuilds.
+// bitwindowd drops its own block-derived rows when the tip falls below them.
+// It reports whether every path left the live layout. A rename that could not
+// run falls back to an in-place delete on a goroutine, and a caller that records
+// the wipe as done would leave a live Core over blocks that are still there.
+func WipeNetworkScopedChainDataSync(network Network, bitcoinDatadirOverride string, log zerolog.Logger) error {
 	var doomed []string
+	var stuck []string
 	for _, dc := range AllDirConfigs() {
-		if dc.BinaryName != "bitcoind" && dc.BinaryName != "bitwindowd" {
+		if dc.BinaryName != "bitcoind" {
 			continue
 		}
 		networkDir := dc.DatadirNetwork(network, bitcoinDatadirOverride)
+		// A path that exists but cannot be read is omitted from the list below,
+		// so without this a wipe over an unreadable volume reads as done and
+		// the blocks stay live with no record left to retry them.
+		if unreadable := unreadableChainPaths(networkDir); len(unreadable) > 0 {
+			return fmt.Errorf("could not read: %s", strings.Join(unreadable, ", "))
+		}
 		for _, p := range dc.GetBlockchainDataPaths(networkDir, network, log) {
 			orphans, _ := filepath.Glob(p + wipingSuffix + "*")
 			doomed = append(doomed, orphans...)
-			if aside := renameAside(p, log); aside != "" {
+			aside := renameAside(p, log)
+			if aside == p {
+				// renameAside returns the live path when it could not move it.
+				stuck = append(stuck, p)
+			}
+			if aside != "" {
 				doomed = append(doomed, aside)
 			}
 		}
 	}
 	go DeleteFilesWithRetry(doomed, log)
-}
-
-// WipeBitwindowChainDataSync clears bitwindowd's chain-derived rows for
-// network, leaving Bitcoin Core's blocks alone. An eCash switch that rewinds
-// Core keeps its blocks, but bitwindowd indexes the fork it left — OP_RETURNs
-// and timestamps from a chain this node no longer follows — and its runtime
-// recycle is keyed on the network, which does not change across the switch.
-func WipeBitwindowChainDataSync(network Network, log zerolog.Logger) {
-	var doomed []string
-	for _, dc := range AllDirConfigs() {
-		if dc.BinaryName != "bitwindowd" {
-			continue
-		}
-		networkDir := dc.DatadirNetwork(network, "")
-		for _, p := range dc.GetBlockchainDataPaths(networkDir, network, log) {
-			orphans, _ := filepath.Glob(p + wipingSuffix + "*")
-			doomed = append(doomed, orphans...)
-			if aside := renameAside(p, log); aside != "" {
-				doomed = append(doomed, aside)
-			}
-		}
+	if len(stuck) > 0 {
+		return fmt.Errorf("could not move aside: %s", strings.Join(stuck, ", "))
 	}
-	go DeleteFilesWithRetry(doomed, log)
+	return nil
 }
 
 // WipeEnforcerChainDataSync wipes the enforcer's validator and block state for
@@ -465,22 +479,41 @@ func WipeBitwindowChainDataSync(network Network, log zerolog.Logger) {
 // so fires no network swap — must clear it here or the new generation inherits
 // the old one's validator chain. Renames aside synchronously like
 // WipeChainDataSync so a caller recording the wipe can trust it happened.
-func WipeEnforcerChainDataSync(network Network, log zerolog.Logger) {
+// It reports whether every path left the live layout, for the same reason
+// WipeNetworkScopedChainDataSync does: a caller that records the wipe as done
+// would start the enforcer on the retired generation's validator chain.
+func WipeEnforcerChainDataSync(network Network, log zerolog.Logger) error {
 	var doomed []string
+	var stuck []string
 	for _, dc := range AllDirConfigs() {
 		if dc.BinaryName != "bip300301-enforcer" {
 			continue
 		}
-		networkDir := dc.DatadirNetwork(network, "")
-		for _, p := range dc.GetBlockchainDataPaths(networkDir, network, log) {
+		networkName := EnforcerNetworkName(network)
+		for _, name := range []string{filepath.Join("validator", networkName), networkName} {
+			p := filepath.Join(dc.RootDir(), name)
+			if _, err := os.Stat(p); err != nil {
+				if !os.IsNotExist(err) {
+					stuck = append(stuck, p)
+				}
+				continue
+			}
 			orphans, _ := filepath.Glob(p + wipingSuffix + "*")
 			doomed = append(doomed, orphans...)
-			if aside := renameAside(p, log); aside != "" {
+			aside := renameAside(p, log)
+			if aside == p {
+				stuck = append(stuck, p)
+			}
+			if aside != "" {
 				doomed = append(doomed, aside)
 			}
 		}
 	}
 	go DeleteFilesWithRetry(doomed, log)
+	if len(stuck) > 0 {
+		return fmt.Errorf("could not move aside: %s", strings.Join(stuck, ", "))
+	}
+	return nil
 }
 
 // WipeChainDataSync renames the doomed paths aside before returning, then

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -21,6 +21,14 @@ const (
 	NetworkTestnet Network = "testnet"
 )
 
+// AllNetworks lists every network the app can run.
+func AllNetworks() []Network {
+	return []Network{
+		NetworkMainnet, NetworkForknet, NetworkECash,
+		NetworkSignet, NetworkRegtest, NetworkTestnet,
+	}
+}
+
 // DatadirGroup partitions networks by which folder bitcoind writes to.
 // Forknet and eCash both run on chain=main and write to the root of datadir,
 // colliding with mainnet and each other — so each needs its own group. The four

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -31,13 +31,16 @@ type ECashSwitchPlan struct {
 // fork height is shared history: a rewind to that height keeps it and drops
 // only what the retired fork added. MustWipe says no published fork height
 // tells the two apart, so the old blocks cannot stay.
+//
+// It prices the move from another network too. The chain is cold there and no
+// Core answers, but the drop is recorded rather than made, so the blocks below
+// the fork stay either way and the caller must not name a resync.
 func (o *Orchestrator) PlanECashSwitch(toID string) (ECashSwitchPlan, error) {
 	o.mu.RLock()
-	cat := o.Catalog
 	fromID := o.ecashID
 	o.mu.RUnlock()
 
-	to, ok := cat.ByID(toID)
+	to, ok := o.ecashEntry(toID)
 	if !ok {
 		return ECashSwitchPlan{}, fmt.Errorf("no network %q in the catalog", toID)
 	}
@@ -48,12 +51,7 @@ func (o *Orchestrator) PlanECashSwitch(toID string) (ECashSwitchPlan, error) {
 	if fromID == "" || fromID == toID {
 		return plan, nil
 	}
-	// Off eCash the old chain is cold files that no reset can reach, and there
-	// is no Core on that chain to talk to.
-	if config.NetworkFromString(o.Network) != config.NetworkECash {
-		return plan, nil
-	}
-	from, ok := cat.ByID(fromID)
+	from, ok := o.ecashEntry(fromID)
 	if !ok || from.ForkHeight <= 0 || to.ForkHeight <= 0 {
 		// The blocks on disk belong to another fork and nothing says where the
 		// chains part, so they cannot stay.
@@ -73,6 +71,22 @@ func (o *Orchestrator) PlanECashSwitch(toID string) (ECashSwitchPlan, error) {
 	plan.RewindHeight = uint32(shared - 1)
 	plan.NeedsRollback = true
 	return plan, nil
+}
+
+// ecashEntry finds a published eCash network by id: the catalog this process
+// serves, then the pending document a refresh left. A confirmed upgrade targets
+// a network the served catalog does not list yet.
+func (o *Orchestrator) ecashEntry(id string) (netcatalog.Network, bool) {
+	o.mu.RLock()
+	cat := o.Catalog
+	o.mu.RUnlock()
+	if n, ok := cat.ByID(id); ok {
+		return n, true
+	}
+	if pending, ok := netcatalog.LoadPending(o.BitwindowDir); ok {
+		return pending.ByID(id)
+	}
+	return netcatalog.Network{}, false
 }
 
 // RetargetECashEnforcerConf moves a persisted enforcer preset onto the eCash
@@ -178,12 +192,41 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 		case err == nil:
 			dropped = hash
 		case errors.Is(err, errNoLiveCore):
+			// Deleting here would cost every block below the fork, which both
+			// networks still agree on. Leave the drop for the first boot that
+			// has a Core to make it with.
+			if o.Settings == nil {
+				o.restartAfterAbort(ctx, restartL1, stoppedL2)
+				return fmt.Errorf("no bitcoin core to rewind to block %d and nowhere to record it", plan.RewindHeight)
+			}
+			if err := o.recordPendingRewind(plan.FromID, toID); err != nil {
+				o.restartAfterAbort(ctx, restartL1, stoppedL2)
+				return fmt.Errorf("record the deferred rewind to block %d: %w", plan.RewindHeight, err)
+			}
 			o.log.Warn().Uint32("rewind_height", plan.RewindHeight).
-				Msg("no live bitcoin core to rewind, clearing the old eCash chain instead")
-			wipe = true
+				Msg("no live bitcoin core to rewind, the next boot drops the retired branch")
 		default:
 			o.restartAfterAbort(ctx, restartL1, stoppedL2)
 			return fmt.Errorf("rewind to block %d: %w", plan.RewindHeight, err)
+		}
+	}
+
+	// A mandatory wipe is journalled before the target is committed. Past that
+	// point a retry reads FromID == ToID, skips this call, and would start Core
+	// over the retired chain with the work forgotten.
+	if o.Settings != nil {
+		if wipe {
+			if err := o.recordPendingRewind(plan.FromID, toID); err != nil {
+				o.restartAfterAbort(ctx, restartL1, stoppedL2)
+				return fmt.Errorf("journal the wipe for %s: %w", toID, err)
+			}
+		}
+		// The enforcer chain goes on every switch, rewind or wipe. Journalled
+		// for the same reason: past the commit below a retry reads
+		// FromID == ToID and skips this call.
+		if err := o.Settings.SetPendingEnforcerWipe(toID); err != nil {
+			o.restartAfterAbort(ctx, restartL1, stoppedL2)
+			return fmt.Errorf("journal the enforcer cleanup for %s: %w", toID, err)
 		}
 	}
 
@@ -212,7 +255,6 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 	}
 
 	o.mu.Lock()
-	cat := o.Catalog
 	o.ecashID = toID
 	for name, raw := range o.rawConfigs {
 		o.configs[name] = expandECashPlaceholder(raw, toID)
@@ -220,7 +262,7 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 	o.mu.Unlock()
 
 	config.SetECashNetworkID(toID)
-	if entry, ok := cat.ByID(toID); ok {
+	if entry, ok := o.ecashEntry(toID); ok {
 		config.SetForkHeight(config.NetworkECash, entry.ForkHeight)
 		config.SetNetworkDisplayName(config.NetworkECash, entry.DisplayName)
 		config.SetECashEndpoints(entry)
@@ -248,13 +290,23 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 		o.WalletSvc.ClearNetworkScans(string(config.NetworkECash))
 	}
 	if wipe {
-		config.WipeNetworkScopedChainDataSync(config.NetworkECash, o.ecashDatadir(), o.log)
-	} else {
-		// The rewind keeps Core's blocks, so nothing else clears what bitwindowd
-		// indexed for the fork this switch leaves.
-		config.WipeBitwindowChainDataSync(config.NetworkECash, o.log)
+		// Both failures below stop the switch before the stack comes back up.
+		// A Core started over the retired chain is what the wipe exists to
+		// stop, and a journal left behind makes the next start wipe the chain
+		// this one downloads. The record survives either way, so a retry or the
+		// next start finishes the job.
+		if err := config.WipeNetworkScopedChainDataSync(config.NetworkECash, o.ecashDatadir(), o.log); err != nil {
+			return fmt.Errorf("clear the retired %s chain: %w", plan.FromID, err)
+		}
+		if o.Settings != nil {
+			if err := o.Settings.SetPendingRewind(nil); err != nil {
+				return fmt.Errorf("clear the journalled eCash wipe: %w", err)
+			}
+		}
 	}
-	config.WipeEnforcerChainDataSync(config.NetworkECash, o.log)
+	if err := o.ApplyPendingEnforcerWipe(); err != nil {
+		return err
+	}
 	o.clearNetworkSwapCaches()
 
 	o.log.Info().
@@ -264,6 +316,183 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 		Msg("switched eCash network")
 
 	return o.finishNetworkSwap(config.NetworkECash, restartL1)
+}
+
+// recordPendingRewind stores a drop for the next live Core, or clears one that
+// the move makes moot.
+//
+// FromID always names the network the blocks on disk belong to, which the first
+// record fixes. A later switch changes only the target: the chain has not moved
+// while no Core ran, so a record that took its source from the last pick would
+// aim the drop at the very fork it lands on.
+func (o *Orchestrator) recordPendingRewind(fromID, toID string) error {
+	if existing := o.Settings.PendingRewind(); existing != nil && existing.FromID != "" {
+		fromID = existing.FromID
+	}
+	// Back to the chain on disk: nothing to drop.
+	if fromID == toID {
+		return o.Settings.SetPendingRewind(nil)
+	}
+	height, ok := o.sharedECashHeight(fromID, toID)
+	if !ok {
+		// Nothing says where the two forks part, so the old chain cannot stay.
+		// It is still journalled: a crash before the delete would otherwise
+		// leave the target's conf over the source fork.
+		return o.Settings.SetPendingRewind(&PendingRewind{FromID: fromID, ToID: toID, Wipe: true})
+	}
+	return o.Settings.SetPendingRewind(&PendingRewind{FromID: fromID, ToID: toID, Height: height})
+}
+
+// applyPendingEnforcerWipe clears the enforcer chain a switch journalled, and
+// keeps the record until it is gone. The enforcer keeps one validator chain per
+// network, not per fork, so a leftover serves the retired generation.
+func (o *Orchestrator) ApplyPendingEnforcerWipe() error {
+	if o.Settings == nil {
+		return nil
+	}
+	recorded := o.Settings.PendingEnforcerWipe()
+	if recorded == "" {
+		return nil
+	}
+	// eCash shares validator/bitcoin with mainnet and forknet, so off eCash
+	// this would delete the active network's chain — possibly under a daemon
+	// that holds it open. The record waits for the swap that brings eCash back.
+	if config.NetworkFromString(o.Network) != config.NetworkECash {
+		return nil
+	}
+	o.mu.RLock()
+	running := o.ecashID
+	o.mu.RUnlock()
+
+	// The record goes in before the switch commits, so an abort leaves one for
+	// a move that never happened. Applying that would delete the validator
+	// chain of the generation this install still runs.
+	if running != recorded {
+		o.log.Info().
+			Str("recorded_for", recorded).
+			Str("running", running).
+			Msg("the eCash selection never moved, dropping the enforcer cleanup")
+		return o.Settings.SetPendingEnforcerWipe("")
+	}
+	if err := config.WipeEnforcerChainDataSync(config.NetworkECash, o.log); err != nil {
+		return fmt.Errorf("clear the retired enforcer chain: %w", err)
+	}
+	if err := o.Settings.SetPendingEnforcerWipe(""); err != nil {
+		return fmt.Errorf("clear the journalled enforcer cleanup: %w", err)
+	}
+	return nil
+}
+
+// ApplyPendingRewindToAdoptedCore makes a journalled drop against a Core that
+// outlived the previous run, and stops that Core when it cannot.
+//
+// A switch that died between its journal and its Core stop leaves exactly that:
+// a live Core on the retired fork under a conf naming the target. Nothing else
+// reaches it, because the deferred hook only rides a start this process makes.
+func (o *Orchestrator) ApplyPendingRewindToAdoptedCore(ctx context.Context) error {
+	if o.Settings == nil {
+		return nil
+	}
+	record := o.Settings.PendingRewind()
+	if record == nil || record.Wipe || record.Height == 0 {
+		return nil
+	}
+	if !o.process.IsRunning("bitcoind") && !o.coreRPCReachable() {
+		return nil
+	}
+	if err := o.ApplyPendingECashRewind(ctx); err != nil {
+		if stopErr := o.process.Stop(ctx, "bitcoind", true); stopErr != nil {
+			o.log.Error().Err(stopErr).Msg("could not stop the adopted bitcoind after the rewind failed")
+		}
+		return err
+	}
+	return nil
+}
+
+// ApplyPendingECashWipe deletes a chain a switch journalled but never got to.
+// It runs before any binary starts: the delete renames Core's blocks aside, and
+// a live Core over that is a corrupt datadir.
+func (o *Orchestrator) ApplyPendingECashWipe(ctx context.Context) error {
+	if o.Settings == nil {
+		return nil
+	}
+	record := o.Settings.PendingRewind()
+	if record == nil || !record.Wipe {
+		return nil
+	}
+	if config.NetworkFromString(o.Network) != config.NetworkECash {
+		return nil
+	}
+	o.mu.RLock()
+	running := o.ecashID
+	o.mu.RUnlock()
+	if running != record.ToID {
+		o.log.Info().
+			Str("recorded_for", record.ToID).
+			Str("running", running).
+			Msg("the eCash selection moved on, dropping the wipe a switch left behind")
+		return o.Settings.SetPendingRewind(nil)
+	}
+	if o.coreRPCReachable() {
+		return fmt.Errorf("a bitcoin core is running over the retired %s chain — stop it first", record.FromID)
+	}
+	if err := config.WipeNetworkScopedChainDataSync(config.NetworkECash, o.ecashDatadir(), o.log); err != nil {
+		// Keep the record and stop the boot. Clearing it would let Core open
+		// the retired chain under the target's conf with nothing left to retry.
+		return fmt.Errorf("clear the retired %s chain: %w", record.FromID, err)
+	}
+	if err := o.ApplyPendingEnforcerWipe(); err != nil {
+		return err
+	}
+	if err := o.Settings.SetPendingRewind(nil); err != nil {
+		return fmt.Errorf("clear the journalled eCash wipe: %w", err)
+	}
+	o.log.Info().Str("previous", record.FromID).Str("current", record.ToID).
+		Msg("cleared the eCash chain a switch left behind")
+	return nil
+}
+
+// ApplyPendingECashRewind makes the drop a switch could not make itself.// ApplyPendingECashRewind makes the drop a switch could not make itself. It runs
+// once Core answers and before the enforcer starts, so nothing indexes the
+// branch this leaves.
+func (o *Orchestrator) ApplyPendingECashRewind(ctx context.Context) error {
+	if o.Settings == nil {
+		return nil
+	}
+	record := o.Settings.PendingRewind()
+	// A journalled wipe belongs to ApplyPendingECashWipe, which runs before
+	// Core does. By here Core holds the datadir open.
+	if record == nil || record.Wipe || record.Height == 0 {
+		return nil
+	}
+	if config.NetworkFromString(o.Network) != config.NetworkECash {
+		return nil
+	}
+	o.mu.RLock()
+	running := o.ecashID
+	o.mu.RUnlock()
+
+	// A selection that went back to where it started leaves this drop pointed
+	// at the fork now on disk. Making it would bar that fork's own first block
+	// and park Core below it for good.
+	if running != record.ToID {
+		o.log.Info().
+			Str("recorded_for", record.ToID).
+			Str("running", running).
+			Msg("the eCash selection moved on, dropping the rewind a switch left behind")
+		return o.Settings.SetPendingRewind(nil)
+	}
+
+	if _, err := o.rewindBelowTheFork(ctx, record.Height); err != nil {
+		// Keep the record: the next boot tries again rather than opening the
+		// retired branch as the network the conf names.
+		return fmt.Errorf("apply the deferred rewind to block %d: %w", record.Height, err)
+	}
+	// The rewind cleared the record in the same write that recorded its outcome,
+	// so a crash here leaves nothing to retry.
+	o.log.Info().Uint32("height", record.Height).Str("network", record.ToID).
+		Msg("applied the eCash rewind a switch left behind")
+	return nil
 }
 
 // errNoLiveCore says the rollback found no Bitcoin Core to talk to.
@@ -307,8 +536,12 @@ func (o *Orchestrator) rewindBelowTheFork(ctx context.Context, height uint32) (s
 
 	// A drop nobody recorded cannot be taken back, and the next switch would bar
 	// this branch too — leaving Core under the fork with neither to follow.
-	if o.Settings != nil && hash != "" {
-		if err := o.Settings.SetRewoundBlockHash(hash); err != nil {
+	//
+	// It runs for an empty hash too. A chain already below the fork bars
+	// nothing, and this write is what clears the drop waiting on it; without it
+	// Core syncs past the fork and the next boot bars the target's own block.
+	if o.Settings != nil {
+		if err := o.Settings.CommitRewind(hash); err != nil {
 			o.restoreRewind(ctx, hash)
 			return "", fmt.Errorf("record the dropped block %s: %w", hash, err)
 		}

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -16,6 +16,7 @@ func ecashCatalog() netcatalog.Catalog {
 	return netcatalog.Catalog{Networks: []netcatalog.Network{
 		{ID: "alphanet", Family: netcatalog.FamilyECash, DisplayName: "Alphanet", ForkHeight: 963648},
 		{ID: "drynet4", Family: netcatalog.FamilyECash, DisplayName: "Drynet 4", ForkHeight: 961632},
+		{ID: "alphanet2", Family: netcatalog.FamilyECash, DisplayName: "Alphanet 2", ForkHeight: 970000},
 	}}
 }
 
@@ -39,16 +40,19 @@ func TestPlanECashSwitchTargetsTheSharedBlock(t *testing.T) {
 	require.EqualValues(t, 961631, plan.RewindHeight)
 }
 
-// The reset needs a live Core on the old chain. Off eCash there is none, and
-// the retired blocks are cold files, so the move carries no rollback.
-func TestPlanECashSwitchNeedsNoRollbackOffECash(t *testing.T) {
+// Off eCash no Core answers, so the drop is recorded rather than made. The
+// blocks below the fork stay either way, and a plan that reported none would
+// make the dialog name a resync that never happens.
+func TestPlanECashSwitchPricesTheColdChainRewind(t *testing.T) {
 	o := newTestOrchestrator(t)
 	o.adoptCatalog(ecashCatalog(), "drynet4")
+	require.NotEqual(t, string(config.NetworkECash), o.Network)
 
 	plan, err := o.PlanECashSwitch("alphanet")
 	require.NoError(t, err)
-	require.False(t, plan.NeedsRollback)
-	require.Zero(t, plan.RewindHeight)
+	require.True(t, plan.NeedsRollback)
+	require.False(t, plan.MustWipe)
+	require.EqualValues(t, 961631, plan.RewindHeight)
 }
 
 // Staying put costs nothing, so the plan must not ask for a reset.
@@ -87,9 +91,9 @@ func TestApplyECashSwitchRewritesTheConfSentinel(t *testing.T) {
 	require.Equal(t, "alphanet", config.ECashNetworkID())
 }
 
-// A Core that is down leaves nothing to rewind, so the old chain has to go.
-// Switching without either would run alphanet on drynet4 blocks.
-func TestApplyECashSwitchWipesWhenNoCoreAnswers(t *testing.T) {
+// A Core that is down cannot rewind, but deleting would cost every block below
+// the fork that both networks keep. The drop waits for the next live Core.
+func TestApplyECashSwitchDefersTheRewindWhenNoCoreAnswers(t *testing.T) {
 	o := newTestOrchestrator(t)
 	datadir := t.TempDir()
 	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, datadir)
@@ -102,13 +106,36 @@ func TestApplyECashSwitchWipesWhenNoCoreAnswers(t *testing.T) {
 
 	require.NoError(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
 
-	require.NoDirExists(t, blocks, "the retired chain must go when it cannot be rewound")
+	require.DirExists(t, blocks, "the blocks below the fork must survive the switch")
+	require.Equal(t, &PendingRewind{FromID: "drynet4", ToID: "alphanet", Height: 961631}, o.Settings.PendingRewind())
 	require.Equal(t, "alphanet", o.installedECashNetwork())
 }
 
-// Off eCash the retired chain is cold files that no start revisits, so the pick
-// has to clear them. Keeping them would boot the new fork on the old chainstate.
-func TestSelectECashNetworkClearsTheColdChain(t *testing.T) {
+// No published fork height leaves nothing to rewind to, so the old blocks
+// cannot stay. This is the one delete, and a user confirms it.
+func TestApplyECashSwitchWipesWithNoPublishedForkHeight(t *testing.T) {
+	o := newTestOrchestrator(t)
+	datadir := t.TempDir()
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, datadir)
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.coreReachable = func() bool { return false }
+	o.adoptCatalog(netcatalog.Catalog{Networks: []netcatalog.Network{
+		{ID: "alphanet", Family: netcatalog.FamilyECash},
+		{ID: "drynet4", Family: netcatalog.FamilyECash},
+	}}, "drynet4")
+
+	blocks := filepath.Join(datadir, "blocks")
+	require.NoError(t, os.MkdirAll(blocks, 0o755))
+
+	require.NoError(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
+
+	require.NoDirExists(t, blocks, "with no fork height the old chain cannot stay")
+	require.Nil(t, o.Settings.PendingRewind())
+}
+
+// Off eCash there is no Core on that chain to rewind, so the pick records the
+// drop. Deleting would cost blocks both networks keep.
+func TestSelectECashNetworkDefersTheColdChainRewind(t *testing.T) {
 	o := newTestOrchestrator(t)
 	datadir := t.TempDir()
 	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, datadir)
@@ -120,7 +147,8 @@ func TestSelectECashNetworkClearsTheColdChain(t *testing.T) {
 
 	require.NoError(t, o.SelectECashNetwork("alphanet"))
 
-	require.NoDirExists(t, blocks, "the retired chain must go with the pick")
+	require.DirExists(t, blocks, "the blocks below the fork must survive the pick")
+	require.Equal(t, &PendingRewind{FromID: "drynet4", ToID: "alphanet", Height: 961631}, o.Settings.PendingRewind())
 	require.Equal(t, "alphanet", o.SelectedECashID(ecashCatalog()))
 }
 

--- a/sidechain-orchestrator/ecash_upgrade_keeps_blocks_test.go
+++ b/sidechain-orchestrator/ecash_upgrade_keeps_blocks_test.go
@@ -1,0 +1,493 @@
+package orchestrator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// ecashInstall puts a test orchestrator on eCash with both datadir slots set.
+func ecashInstall(t *testing.T) *Orchestrator {
+	t.Helper()
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupDefault, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.coreReachable = func() bool { return false }
+	o.log = zerolog.Nop()
+	return o
+}
+
+// seedCoreChainData writes the block store an eCash install carries.
+func seedCoreChainData(t *testing.T, datadir string) {
+	t.Helper()
+	for _, d := range []string{"blocks", "chainstate"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(datadir, d), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(datadir, d, "data"), []byte("chain"), 0o644))
+	}
+}
+
+// An app update must never resync the chain. drynet4 -> alphanet is an offer,
+// so startup serves the network the blocks belong to and leaves the move to
+// the user.
+func TestStartupKeepsTheChainWhenTheCatalogMovesOn(t *testing.T) {
+	o := ecashInstall(t)
+	datadir := o.ecashDatadir()
+	require.NotEmpty(t, datadir)
+	seedCoreChainData(t, datadir)
+
+	// The install the user updated: blocks from drynet4, catalog on alphanet.
+	o.BitcoinConf.Config.SetSetting("uacomment", config.ECashUAComment("drynet4"), "main")
+	require.Equal(t, "drynet4", o.installedECashNetwork())
+	require.NoError(t, netcatalog.Save(o.BitwindowDir, catalogWithECash(t, "alphanet")))
+
+	o.ResolveNetworkCatalog(context.Background())
+
+	require.Equal(t, "drynet4", config.ECashNetworkID(), "startup must serve the network the blocks belong to")
+	for _, d := range []string{"blocks", "chainstate"} {
+		_, err := os.Stat(filepath.Join(datadir, d, "data"))
+		require.NoErrorf(t, err, "%s must survive a start that sees a newer eCash network", d)
+	}
+	require.Equal(t, "alphanet", o.Catalog.ECashID(), "the offer still reaches the user")
+}
+
+// No blocks on disk, nothing to hold back: a fresh install takes what the
+// catalog publishes.
+func TestStartupTakesThePublishedNetworkWithNoChainOnDisk(t *testing.T) {
+	o := ecashInstall(t)
+	o.BitcoinConf.Config.SetSetting("uacomment", config.ECashUAComment("drynet4"), "main")
+	require.NoError(t, netcatalog.Save(o.BitwindowDir, catalogWithECash(t, "alphanet")))
+
+	o.ResolveNetworkCatalog(context.Background())
+
+	require.Equal(t, "alphanet", config.ECashNetworkID())
+}
+
+// A network the user picked is not an offer. Startup applies it.
+func TestStartupAppliesTheNetworkTheUserPicked(t *testing.T) {
+	o := ecashInstall(t)
+	seedCoreChainData(t, o.ecashDatadir())
+	o.BitcoinConf.Config.SetSetting("uacomment", config.ECashUAComment("drynet4"), "main")
+	require.NoError(t, netcatalog.Save(o.BitwindowDir, catalogWithECash(t, "alphanet")))
+	_, err := o.Settings.SetECashNetworkID("alphanet")
+	require.NoError(t, err)
+
+	o.ResolveNetworkCatalog(context.Background())
+
+	require.Equal(t, "alphanet", config.ECashNetworkID())
+}
+
+// A confirmed upgrade must leave the chain matching the network the conf names.
+// Recording the pick alone would park Core on the retired fork for good.
+func TestConfirmMovesTheChainToMatchTheConf(t *testing.T) {
+	o := ecashOnPendingNetwork(t)
+	o.ResolveNetworkCatalog(context.Background())
+	datadir := o.ecashDatadir()
+	require.NotEmpty(t, datadir)
+	seedCoreChainData(t, datadir)
+
+	require.NoError(t, o.ConfirmPendingECashNetwork(context.Background()))
+
+	require.Equal(t, "drynet3", config.ECashNetworkID())
+	// No live Core answers in a test, so the drop waits for the next boot. The
+	// blocks stay either way: both networks keep everything below the fork.
+	_, err := os.Stat(filepath.Join(datadir, "blocks", "data"))
+	require.NoError(t, err, "the blocks below the fork must survive the switch")
+	require.NotNil(t, o.Settings.PendingRewind(), "the drop must be recorded")
+}
+
+// The published network lives only in the pending document until a confirm
+// promotes it. A plan that reads the served catalog alone cannot price the
+// move, and the dialog then names a resync the switch never does.
+func TestPlanReadsANetworkFromThePendingCatalog(t *testing.T) {
+	o := ecashOnPendingNetwork(t)
+	o.ResolveNetworkCatalog(context.Background())
+
+	_, served := o.Catalog.ByID("drynet3")
+	require.False(t, served, "drynet3 must still be pending only")
+
+	plan, err := o.PlanECashSwitch("drynet3")
+	require.NoError(t, err)
+	require.Equal(t, "drynet2", plan.FromID)
+	require.Equal(t, "drynet3", plan.ToID)
+}
+
+// A selection that goes back where it started leaves the recorded drop pointed
+// at the fork now on disk. Making it would bar that fork's own first block.
+func TestDeferredRewindIsDroppedWhenTheSelectionReverses(t *testing.T) {
+	o := ecashInstall(t)
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	require.NoError(t, o.Settings.SetPendingRewind(
+		&PendingRewind{FromID: "drynet4", ToID: "alphanet", Height: 961631}))
+
+	require.NoError(t, o.ApplyPendingECashRewind(context.Background()))
+
+	require.Nil(t, o.Settings.PendingRewind(), "a drop for a network we no longer run must go")
+}
+
+// The drop still runs when the selection stands.
+func TestDeferredRewindRunsForTheSelectedNetwork(t *testing.T) {
+	o := ecashInstall(t)
+	o.adoptCatalog(ecashCatalog(), "alphanet")
+	require.NoError(t, o.Settings.SetPendingRewind(
+		&PendingRewind{FromID: "drynet4", ToID: "alphanet", Height: 961631}))
+
+	// No Core answers, so the drop cannot be made and the record must survive
+	// for the next boot.
+	require.Error(t, o.ApplyPendingECashRewind(context.Background()))
+	require.NotNil(t, o.Settings.PendingRewind(), "an unmade drop must outlive the boot")
+}
+
+// Two switches with no Core between them: A -> B, then B -> A. The blocks are
+// still A's, so the record must go. Taking the source from the last pick would
+// aim the drop at A's own first fork block.
+func TestTwoDeferredSwitchesBackToTheChainOnDiskClearTheRecord(t *testing.T) {
+	o := ecashInstall(t)
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+
+	require.NoError(t, o.recordPendingRewind("drynet4", "alphanet"))
+	require.Equal(t,
+		&PendingRewind{FromID: "drynet4", ToID: "alphanet", Height: 961631},
+		o.Settings.PendingRewind())
+
+	require.NoError(t, o.recordPendingRewind("alphanet", "drynet4"))
+
+	require.Nil(t, o.Settings.PendingRewind(), "back on the chain on disk, so nothing to drop")
+}
+
+// A third network keeps the original source: the blocks never moved.
+func TestDeferredSwitchesKeepTheNetworkTheBlocksBelongTo(t *testing.T) {
+	o := ecashInstall(t)
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+
+	require.NoError(t, o.recordPendingRewind("drynet4", "alphanet"))
+	require.NoError(t, o.recordPendingRewind("alphanet", "alphanet2"))
+
+	record := o.Settings.PendingRewind()
+	require.NotNil(t, record)
+	require.Equal(t, "drynet4", record.FromID, "the source is what is on disk, not the last pick")
+	require.Equal(t, "alphanet2", record.ToID)
+}
+
+// The pick is durable before the drop is. Leaving it while the drop went
+// unrecorded lets a later boot serve the target over the source fork with
+// nothing to invalidate it.
+func TestSelectECashNetworkPutsThePickBackWhenTheDropCannotBeRecorded(t *testing.T) {
+	o := ecashInstall(t)
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkSignet))
+	// No fork height tells the two apart, so the drop cannot be recorded; and
+	// with no bitcoin config the delete that would replace it cannot run.
+	o.adoptCatalog(catalogWithECash(t, "alphanet"), "drynet4")
+	o.Catalog.Networks = append(o.Catalog.Networks, netcatalog.Network{
+		ID: "drynet4", Family: netcatalog.FamilyECash,
+	})
+	for i := range o.Catalog.Networks {
+		if o.Catalog.Networks[i].Family == netcatalog.FamilyECash {
+			o.Catalog.Networks[i].ForkHeight = 0
+		}
+	}
+	o.BitcoinConf = nil
+	_, err := o.Settings.SetECashNetworkID("drynet4")
+	require.NoError(t, err)
+
+	require.Error(t, o.SelectECashNetwork("alphanet"))
+
+	require.Equal(t, "drynet4", o.Settings.ECashNetworkID(),
+		"an unrecorded drop must leave the pick where it was")
+}
+
+// A rewind that committed records its outcome and clears the drop in one write. Two writes
+// leave a crash window where the next boot retries, and a retry reconsiders the
+// block it just barred.
+func TestRecordingARewindClearsThePendingDropInOneWrite(t *testing.T) {
+	o := ecashInstall(t)
+	require.NoError(t, o.Settings.SetPendingRewind(
+		&PendingRewind{FromID: "drynet4", ToID: "alphanet", Height: 961631}))
+
+	require.NoError(t, o.Settings.CommitRewind("00deadbeef"))
+
+	require.Nil(t, o.Settings.PendingRewind(), "the drop must go with the outcome")
+	require.Equal(t, "00deadbeef", o.Settings.RewoundBlockHash())
+}
+
+// A chain already below the fork bars nothing, so the rewind reports an empty
+// hash. That write still has to clear the drop, or Core syncs past the fork and
+// the next boot bars the target's own first block.
+func TestRecordingAnEmptyRewindStillClearsThePendingDrop(t *testing.T) {
+	o := ecashInstall(t)
+	require.NoError(t, o.Settings.SetPendingRewind(
+		&PendingRewind{FromID: "drynet4", ToID: "alphanet", Height: 961631}))
+
+	require.NoError(t, o.Settings.CommitRewind(""))
+
+	require.Nil(t, o.Settings.PendingRewind())
+}
+
+// No published fork height leaves nothing to rewind to, but the switch is still
+// journalled: a crash before the delete would leave the target's conf over the
+// source fork with nothing to clear it.
+func TestASwitchWithNoForkHeightJournalsAWipe(t *testing.T) {
+	o := ecashInstall(t)
+	o.adoptCatalog(netcatalog.Catalog{Networks: []netcatalog.Network{
+		{ID: "alphanet", Family: netcatalog.FamilyECash},
+		{ID: "drynet4", Family: netcatalog.FamilyECash},
+	}}, "drynet4")
+
+	require.NoError(t, o.recordPendingRewind("drynet4", "alphanet"))
+
+	record := o.Settings.PendingRewind()
+	require.NotNil(t, record)
+	require.True(t, record.Wipe, "with no fork height the old chain cannot stay")
+	require.Zero(t, record.Height)
+}
+
+// The journalled wipe runs before Core opens the datadir, and clears itself.
+func TestStartupMakesAJournalledWipe(t *testing.T) {
+	o := ecashInstall(t)
+	o.adoptCatalog(ecashCatalog(), "alphanet")
+	datadir := o.ecashDatadir()
+	require.NotEmpty(t, datadir)
+	seedCoreChainData(t, datadir)
+	require.NoError(t, o.Settings.SetPendingRewind(
+		&PendingRewind{FromID: "drynet4", ToID: "alphanet", Wipe: true}))
+
+	require.NoError(t, o.ApplyPendingECashWipe(context.Background()))
+
+	require.NoDirExists(t, filepath.Join(datadir, "blocks"), "the retired chain must go")
+	require.Nil(t, o.Settings.PendingRewind(), "a wipe that ran must not run again")
+}
+
+// A selection that moved on makes the journalled wipe moot. Making it anyway
+// would delete the chain the install now runs.
+func TestAJournalledWipeIsDroppedWhenTheSelectionMovesOn(t *testing.T) {
+	o := ecashInstall(t)
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	datadir := o.ecashDatadir()
+	seedCoreChainData(t, datadir)
+	require.NoError(t, o.Settings.SetPendingRewind(
+		&PendingRewind{FromID: "drynet4", ToID: "alphanet", Wipe: true}))
+
+	require.NoError(t, o.ApplyPendingECashWipe(context.Background()))
+
+	require.DirExists(t, filepath.Join(datadir, "blocks"), "the chain we run must survive")
+	require.Nil(t, o.Settings.PendingRewind())
+}
+
+// A wipe that fails leaves the target committed, so a retry reads FromID ==
+// ToID and skips the switch. The journal is what carries the work across.
+func TestAMandatorySwitchJournalsItsWipeBeforeCommitting(t *testing.T) {
+	o := ecashInstall(t)
+	datadir := o.ecashDatadir()
+	require.NotEmpty(t, datadir)
+	seedCoreChainData(t, datadir)
+	o.adoptCatalog(netcatalog.Catalog{Networks: []netcatalog.Network{
+		{ID: "alphanet", Family: netcatalog.FamilyECash},
+		{ID: "drynet4", Family: netcatalog.FamilyECash},
+	}}, "drynet4")
+
+	require.NoError(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
+
+	// The switch made the wipe itself, so the journal is spent.
+	require.NoDirExists(t, filepath.Join(datadir, "blocks"))
+	require.Nil(t, o.Settings.PendingRewind(), "a wipe that ran clears its journal")
+	require.Equal(t, "alphanet", o.installedECashNetwork())
+}
+
+// The failure the journal exists for: the wipe cannot run, the target is
+// already committed, and a retry reads FromID == ToID and skips the switch.
+// Only the record carries the work to the next start.
+func TestAFailedMandatoryWipeLeavesItsJournal(t *testing.T) {
+	o := ecashInstall(t)
+	datadir := o.ecashDatadir()
+	require.NotEmpty(t, datadir)
+	seedCoreChainData(t, datadir)
+	o.adoptCatalog(netcatalog.Catalog{Networks: []netcatalog.Network{
+		{ID: "alphanet", Family: netcatalog.FamilyECash},
+		{ID: "drynet4", Family: netcatalog.FamilyECash},
+	}}, "drynet4")
+
+	// An unreadable datadir makes the wipe refuse rather than report success.
+	require.NoError(t, os.Chmod(datadir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(datadir, 0o755) })
+
+	err := o.ApplyECashSwitch(context.Background(), "alphanet")
+	if err == nil {
+		t.Skip("this filesystem reads the datadir anyway, so the failure cannot be staged")
+	}
+
+	record := o.Settings.PendingRewind()
+	require.NotNil(t, record, "a wipe that never ran must leave its journal")
+	require.True(t, record.Wipe)
+	require.Equal(t, "alphanet", record.ToID)
+}
+
+// The enforcer keeps one validator chain per network, not per fork, so every
+// switch clears it. That work is journalled too: past the commit a retry reads
+// FromID == ToID and skips the switch entirely.
+func TestASwitchJournalsItsEnforcerCleanup(t *testing.T) {
+	o := ecashInstall(t)
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	require.NoError(t, o.Settings.SetPendingEnforcerWipe("alphanet"))
+
+	require.NoError(t, o.ApplyPendingEnforcerWipe())
+
+	require.Empty(t, o.Settings.PendingEnforcerWipe(), "cleanup that ran clears its journal")
+}
+
+// A cleanup that cannot run keeps its record, so the next enforcer start
+// retries rather than serving the retired generation's validator chain.
+func TestAFailedEnforcerCleanupKeepsItsJournal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	o := ecashInstall(t)
+	require.NoError(t, o.Settings.SetPendingEnforcerWipe("alphanet"))
+
+	validator := filepath.Join(config.EnforcerDirs.RootDir(), "validator")
+	require.NoError(t, os.MkdirAll(filepath.Join(validator, "bitcoin"), 0o755))
+	require.NoError(t, os.Chmod(validator, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(validator, 0o755) })
+
+	if err := o.ApplyPendingEnforcerWipe(); err == nil {
+		t.Skip("this filesystem reads the path anyway, so the failure cannot be staged")
+	}
+
+	require.Equal(t, "alphanet", o.Settings.PendingEnforcerWipe(),
+		"cleanup that never ran must leave its journal")
+}
+
+// The record goes in before the switch commits, so an abort leaves one for a
+// move that never happened. Applying it would delete the validator chain of the
+// generation this install still runs.
+func TestAnEnforcerCleanupForAnAbortedSwitchIsDropped(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	o := ecashInstall(t)
+	// The install still runs drynet4: the switch to alphanet never committed.
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	require.NoError(t, o.Settings.SetPendingEnforcerWipe("alphanet"))
+
+	chain := filepath.Join(config.EnforcerDirs.RootDir(), "validator", "bitcoin")
+	require.NoError(t, os.MkdirAll(chain, 0o755))
+
+	require.NoError(t, o.ApplyPendingEnforcerWipe())
+
+	require.DirExists(t, chain, "the running generation's validator chain must survive")
+	require.Empty(t, o.Settings.PendingEnforcerWipe(),
+		"a cleanup for a network we never moved to must go")
+}
+
+// A pick made from another network reaches eCash through SwapNetwork, not
+// ApplyECashSwitch, so the cold path has to record the enforcer cleanup itself.
+func TestAColdPickRecordsTheEnforcerCleanup(t *testing.T) {
+	o := ecashInstall(t)
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkSignet))
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+
+	require.NoError(t, o.SelectECashNetwork("alphanet"))
+
+	require.Equal(t, "alphanet", o.Settings.PendingEnforcerWipe(),
+		"the enforcer chain must be cleared before the new generation runs")
+}
+
+// eCash shares validator/bitcoin with mainnet and forknet. Off eCash the
+// cleanup has to wait, or it deletes the chain the active network is using.
+func TestTheEnforcerCleanupWaitsUntilECashIsActive(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	o := ecashInstall(t)
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
+	o.adoptCatalog(ecashCatalog(), "alphanet")
+	require.NoError(t, o.Settings.SetPendingEnforcerWipe("alphanet"))
+
+	chain := filepath.Join(config.EnforcerDirs.RootDir(), "validator", "bitcoin")
+	require.NoError(t, os.MkdirAll(chain, 0o755))
+
+	require.NoError(t, o.ApplyPendingEnforcerWipe())
+
+	require.DirExists(t, chain, "mainnet shares this chain, so it must survive")
+	require.Equal(t, "alphanet", o.Settings.PendingEnforcerWipe(),
+		"the cleanup waits for the swap that brings eCash back")
+}
+
+// The cold path with no fork height wipes Core, so the enforcer chain has to go
+// too — and off eCash that work is journalled rather than made.
+func TestAColdMandatoryWipeJournalsTheEnforcerCleanup(t *testing.T) {
+	o := ecashInstall(t)
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkSignet))
+	o.adoptCatalog(netcatalog.Catalog{Networks: []netcatalog.Network{
+		{ID: "alphanet", Family: netcatalog.FamilyECash},
+		{ID: "drynet4", Family: netcatalog.FamilyECash},
+	}}, "drynet4")
+
+	require.True(t, o.wipeOnECashNetworkChange(context.Background(), "drynet4", "alphanet"))
+
+	require.Equal(t, "alphanet", o.Settings.PendingEnforcerWipe(),
+		"a wiped Core leaves an enforcer chain that has to go with it")
+}
+
+// An empty datadir override means Core's platform default, which is a
+// supported setup. Reading it as "nothing on disk" lets a start adopt the
+// published fork over blocks that are still there.
+func TestTheDefaultDatadirCountsAsChainOnDisk(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	o := newTestOrchestrator(t)
+	// No datadir slot and no datadir= line: Core falls back to its own default.
+	o.setNetwork(string(config.NetworkECash))
+	require.Empty(t, o.ecashDatadir(), "this install runs on the platform default")
+
+	defaultDir := config.BitcoinCoreDirs.DatadirNetwork(config.NetworkECash, "")
+	require.NoError(t, os.MkdirAll(filepath.Join(defaultDir, "blocks"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(defaultDir, "blocks", "blk00000.dat"), []byte("chain"), 0o644))
+
+	require.True(t, o.ecashChainDataOnDisk(), "the default datadir holds the chain too")
+}
+
+// Only "not there" says the chain is gone. Any other refusal leaves blocks that
+// may exist, and adopting the published fork over them needs the user first.
+func TestAnUnreadableBlocksDirCountsAsChainOnDisk(t *testing.T) {
+	o := ecashInstall(t)
+	datadir := o.ecashDatadir()
+	require.NotEmpty(t, datadir)
+	seedCoreChainData(t, datadir)
+
+	require.NoError(t, os.Chmod(filepath.Join(datadir, "blocks"), 0o000))
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(datadir, "blocks"), 0o755) })
+
+	if entries, err := os.ReadDir(filepath.Join(datadir, "blocks")); err == nil {
+		_ = entries
+		t.Skip("this filesystem reads the directory anyway, so the failure cannot be staged")
+	}
+
+	require.True(t, o.ecashChainDataOnDisk(), "a chain we cannot read is still a chain")
+}
+
+// A switch that died between its journal and its Core stop leaves a live Core
+// on the retired fork under a conf naming the target. Only startup reaches it,
+// and it has to before the listener binds.
+func TestStartupMakesTheDropAgainstAnAdoptedCore(t *testing.T) {
+	o := ecashInstall(t)
+	o.adoptCatalog(ecashCatalog(), "alphanet")
+	require.NoError(t, o.Settings.SetPendingRewind(
+		&PendingRewind{FromID: "drynet4", ToID: "alphanet", Height: 961631}))
+
+	// No Core answers, so there is nothing adopted and nothing to drop yet.
+	o.coreReachable = func() bool { return false }
+	require.NoError(t, o.ApplyPendingRewindToAdoptedCore(context.Background()))
+	require.NotNil(t, o.Settings.PendingRewind(), "the drop waits for a Core that answers")
+
+	// One that answers but refuses the RPC must not leave the boot running.
+	o.coreReachable = func() bool { return true }
+	require.Error(t, o.ApplyPendingRewindToAdoptedCore(context.Background()))
+	require.NotNil(t, o.Settings.PendingRewind(), "an unmade drop must outlive the start")
+}

--- a/sidechain-orchestrator/gen/orchestrator/v1/bitcoin_conf.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/bitcoin_conf.pb.go
@@ -500,6 +500,8 @@ type PlanECashSwitchResponse struct {
 	// it and follows the new network from there. Zero when nothing is dropped.
 	RewindHeight  uint32 `protobuf:"varint,3,opt,name=rewind_height,json=rewindHeight,proto3" json:"rewind_height,omitempty"`
 	NeedsRollback bool   `protobuf:"varint,4,opt,name=needs_rollback,json=needsRollback,proto3" json:"needs_rollback,omitempty"`
+	// True when the old blocks cannot stay and the switch resyncs the chain.
+	MustWipe      bool `protobuf:"varint,5,opt,name=must_wipe,json=mustWipe,proto3" json:"must_wipe,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -558,6 +560,13 @@ func (x *PlanECashSwitchResponse) GetRewindHeight() uint32 {
 func (x *PlanECashSwitchResponse) GetNeedsRollback() bool {
 	if x != nil {
 		return x.NeedsRollback
+	}
+	return false
+}
+
+func (x *PlanECashSwitchResponse) GetMustWipe() bool {
+	if x != nil {
+		return x.MustWipe
 	}
 	return false
 }
@@ -1122,12 +1131,13 @@ const file_orchestrator_v1_bitcoin_conf_proto_rawDesc = "" +
 	"\bnetworks\x18\x01 \x03(\v2\x1e.orchestrator.v1.NetworkOptionR\bnetworks\"7\n" +
 	"\x16PlanECashSwitchRequest\x12\x1d\n" +
 	"\n" +
-	"network_id\x18\x01 \x01(\tR\tnetworkId\"\x93\x01\n" +
+	"network_id\x18\x01 \x01(\tR\tnetworkId\"\xb0\x01\n" +
 	"\x17PlanECashSwitchResponse\x12\x17\n" +
 	"\afrom_id\x18\x01 \x01(\tR\x06fromId\x12\x13\n" +
 	"\x05to_id\x18\x02 \x01(\tR\x04toId\x12#\n" +
 	"\rrewind_height\x18\x03 \x01(\rR\frewindHeight\x12%\n" +
-	"\x0eneeds_rollback\x18\x04 \x01(\bR\rneedsRollback\"\x18\n" +
+	"\x0eneeds_rollback\x18\x04 \x01(\bR\rneedsRollback\x12\x1b\n" +
+	"\tmust_wipe\x18\x05 \x01(\bR\bmustWipe\"\x18\n" +
 	"\x16TakeNewNetworksRequest\"U\n" +
 	"\x17TakeNewNetworksResponse\x12:\n" +
 	"\bnetworks\x18\x01 \x03(\v2\x1e.orchestrator.v1.NetworkOptionR\bnetworks\"\x9b\x01\n" +

--- a/sidechain-orchestrator/network_catalog.go
+++ b/sidechain-orchestrator/network_catalog.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -39,17 +41,17 @@ func (o *Orchestrator) ResolveNetworkCatalog(ctx context.Context) {
 		current = o.promotePendingCatalog(ctx, current, pending, fromDisk)
 		promoted = true
 	}
-	// Reconcile installs whose cached catalog already lists the selected
-	// network, where no pending promotion fires.
+	// RunningECashID already keeps a network the catalog still lists, so this
+	// only fires once the catalog drops the one the blocks belong to. Serving
+	// it with no endpoints beats opening its blocks as another fork: the user
+	// switches from Settings, which states the resync before it runs.
 	ecashID := o.RunningECashID(current)
-	if !promoted && !o.wipeIfECashNetworkStale(ctx, ecashID) {
-		// Keep serving the network those blocks belong to, so the next start
-		// retries rather than opening them as the new fork.
-		o.log.Error().
-			Str("retained", o.installedECashNetwork()).
+	if installed := o.installedECashNetwork(); !promoted && o.ecashNetworkMoved(installed, ecashID) {
+		o.log.Warn().
+			Str("installed", installed).
 			Str("published", ecashID).
-			Msg("eCash chain data could not be cleared, staying on the installed network")
-		ecashID = o.installedECashNetwork()
+			Msg("the catalog dropped the installed eCash network, switch from Settings to move")
+		ecashID = installed
 	}
 	o.adoptCatalog(current, ecashID)
 
@@ -58,11 +60,11 @@ func (o *Orchestrator) ResolveNetworkCatalog(ctx context.Context) {
 	go o.refreshNetworkCatalog(ctx, current)
 }
 
-// promotePendingCatalog applies a catalog left by a previous refresh, wiping
-// the stale eCash chain data first. Returns the catalog to actually use: the
-// pending one when it could be applied, otherwise the current one, so the
-// process never serves a generation whose data it has not cleared.
-func (o *Orchestrator) promotePendingCatalog(ctx context.Context, current, pending netcatalog.Catalog, fromDisk bool) netcatalog.Catalog {
+// promotePendingCatalog applies a catalog left by a previous refresh. Returns
+// the catalog to actually use: the pending one when it names the same eCash
+// network, otherwise the current one, so a move between networks stays the
+// user's to make.
+func (o *Orchestrator) promotePendingCatalog(_ context.Context, current, pending netcatalog.Catalog, fromDisk bool) netcatalog.Catalog {
 	// The network this install serves, not the catalog's first entry: a user on
 	// a retained row keeps blocks from that row, and a refresh that drops it
 	// leaves both documents naming the same first entry. An id-only compare
@@ -85,14 +87,6 @@ func (o *Orchestrator) promotePendingCatalog(ctx context.Context, current, pendi
 		return current
 	}
 
-	if !o.wipeOnECashNetworkChange(ctx, baseline, target) {
-		// Leave the pending file in place; the next start tries again.
-		o.log.Warn().Msg("could not apply the pending network catalog, keeping the current one")
-		return current
-	}
-	// Cache and pending are only reconciled once the stale data is gone, so an
-	// interrupted promotion repeats rather than recording a wipe that did not
-	// happen.
 	if err := netcatalog.Save(o.BitwindowDir, pending); err != nil {
 		o.log.Warn().Err(err).Msg("could not persist the promoted network catalog")
 		return current
@@ -147,8 +141,8 @@ func (o *Orchestrator) ecashSwitchIsManual() bool {
 	return o.BitcoinConf != nil && o.BitcoinConf.HasPrivateConf
 }
 
-// ConfirmPendingECashNetwork records the user's go-ahead by promoting the
-// published catalog to the cache. The switch itself runs on the next start.
+// ConfirmPendingECashNetwork applies the user's go-ahead: it moves the chain
+// onto the published network, then promotes that catalog to the cache.
 func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
 	pending, ok := netcatalog.LoadPending(o.BitwindowDir)
 	if !ok {
@@ -157,23 +151,35 @@ func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
 	if o.ecashSwitchIsManual() {
 		return fmt.Errorf("your own bitcoin.conf decides which eCash network this node runs, so the switch has to be made there")
 	}
-	// The next start must be free to wipe, and it cannot stop a Core we did not
-	// launch. Promoting the cache first would leave nothing to fall back to.
+	// The switch below stops the daemons, and it cannot stop a Core we did not
+	// launch.
 	if config.NetworkFromString(o.Network) == config.NetworkECash &&
 		!o.process.IsRunning("bitcoind") && o.coreRPCReachable() {
 		return fmt.Errorf("a bitcoin core this app did not start is running — stop it first")
 	}
-	// Off eCash the retired chain is cold files that no start will revisit:
-	// the startup wipe only runs while eCash is active. Clear them here.
-	if config.NetworkFromString(o.Network) != config.NetworkECash {
-		// The pick on both sides, not each document's first row. A user on a
-		// retained entry holds that chain on disk, and comparing first rows
-		// reads two identical ids while the blocks belong to a third.
-		current, _ := netcatalog.Load(o.BitwindowDir)
-		if !o.wipeOnECashNetworkChange(ctx, o.RunningECashID(current), o.SelectedECashID(pending)) {
-			return fmt.Errorf("could not clear the retired eCash chain data")
+	current, _ := netcatalog.Load(o.BitwindowDir)
+	previousPick := ""
+	if o.Settings != nil {
+		previousPick = o.Settings.ECashNetworkID()
+	}
+
+	// The journal goes first. Between the writes below and the switch there is a
+	// window where the record names the target while the chain is still the
+	// source; a crash there would let the next start adopt the target with no
+	// drop to make. This record is what that start finds instead.
+	//
+	// A move with no published fork height journals a wipe instead, so every
+	// switch leaves something the next start can finish.
+	if id := o.SelectedECashID(pending); id != "" && config.NetworkFromString(o.Network) == config.NetworkECash {
+		if err := o.recordPendingRewind(o.RunningECashID(current), id); err != nil {
+			return fmt.Errorf("journal the switch to %s: %w", id, err)
 		}
 	}
+
+	// Every durable write goes before the switch. A volume that refuses them
+	// after the chain moved would leave the record naming a network the blocks
+	// no longer belong to, and the next start would act on that record.
+	//
 	// The pick goes before the catalog it belongs to. A catalog promoted without
 	// it reads as current on the next start: the pending file gets cleared, the
 	// old pick still resolves, and the prompt never returns to say so.
@@ -190,14 +196,66 @@ func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
 		}
 	}
 	if err := netcatalog.Save(o.BitwindowDir, pending); err != nil {
+		o.restoreConfirmRecord(previousPick, current, pending)
 		return fmt.Errorf("persist network catalog: %w", err)
 	}
+
+	if config.NetworkFromString(o.Network) == config.NetworkECash {
+		// Here, not on the next start: this is the one moment a live Core can
+		// rewind to the fork. A start has none and could only delete the chain.
+		if id := o.SelectedECashID(pending); id != "" {
+			if err := o.ApplyECashSwitch(ctx, id); err != nil {
+				// Only when the switch never committed. Past that point the
+				// chain and the conf already name the target, and putting the
+				// record back would send the next start after the branch this
+				// switch invalidated.
+				o.mu.RLock()
+				running := o.ecashID
+				o.mu.RUnlock()
+				if running != id {
+					o.restoreConfirmRecord(previousPick, current, pending)
+				}
+				return fmt.Errorf("switch to %s: %w", id, err)
+			}
+		}
+	} else {
+		// Off eCash the retired chain is cold files that no start will revisit,
+		// and there is no Core on that chain to rewind. Clear them here.
+		//
+		// The pick on both sides, not each document's first row. A user on a
+		// retained entry holds that chain on disk, and comparing first rows
+		// reads two identical ids while the blocks belong to a third.
+		if !o.wipeOnECashNetworkChange(ctx, o.RunningECashID(current), o.SelectedECashID(pending)) {
+			o.restoreConfirmRecord(previousPick, current, pending)
+			return fmt.Errorf("could not clear the retired eCash chain data")
+		}
+	}
+	// Last: the switch reads the pending document to resolve a network the
+	// served catalog does not list yet. A file left behind by a crash names the
+	// same network as the cache, which the next start promotes with no work.
 	netcatalog.ClearPending(o.BitwindowDir)
 	o.log.Info().
 		Str("current", config.ECashNetworkID()).
 		Str("confirmed", pending.ECashID()).
-		Msg("eCash network switch confirmed, applying on the next start")
+		Msg("eCash network switch confirmed")
 	return nil
+}
+
+// restoreConfirmRecord puts back the pick, the cache and the pending file a
+// failed confirm already wrote, so the prompt returns and the record keeps
+// describing the chain on disk.
+func (o *Orchestrator) restoreConfirmRecord(pick string, current, pending netcatalog.Catalog) {
+	if o.Settings != nil {
+		if _, err := o.Settings.SetECashNetworkID(pick); err != nil {
+			o.log.Error().Err(err).Msg("could not put the eCash network pick back after a failed confirm")
+		}
+	}
+	if err := netcatalog.Save(o.BitwindowDir, current); err != nil {
+		o.log.Error().Err(err).Msg("could not put the network catalog back after a failed confirm")
+	}
+	if err := netcatalog.SavePending(o.BitwindowDir, pending); err != nil {
+		o.log.Error().Err(err).Msg("could not put the pending network catalog back after a failed confirm")
+	}
 }
 
 // refreshNetworkCatalog fetches the published catalog and, when it differs from
@@ -329,13 +387,38 @@ func expandECashPlaceholder(cfg BinaryConfig, id string) BinaryConfig {
 	return cfg
 }
 
-// wipeIfECashNetworkStale clears eCash chain data when the on-disk conf was
-// written for a different eCash network than the one this start serves.
-func (o *Orchestrator) wipeIfECashNetworkStale(ctx context.Context, selected string) bool {
-	if config.NetworkFromString(o.Network) != config.NetworkECash {
-		return true
+// ecashNetworkMoved reports whether startup must hold back the published eCash
+// network: it differs from the one the blocks on disk belong to, the user never
+// asked to move, and there are blocks to lose.
+func (o *Orchestrator) ecashNetworkMoved(installed, published string) bool {
+	if installed == "" || published == "" || installed == published {
+		return false
 	}
-	return o.wipeOnECashNetworkChange(ctx, o.installedECashNetwork(), selected)
+	if config.NetworkFromString(o.Network) != config.NetworkECash {
+		return false
+	}
+	// A move the user already picked is not an offer.
+	if o.Settings != nil && o.Settings.ECashNetworkID() == published {
+		return false
+	}
+	return o.ecashChainDataOnDisk()
+}
+
+// ecashChainDataOnDisk reports whether Core holds eCash blocks worth keeping.
+func (o *Orchestrator) ecashChainDataOnDisk() bool {
+	// An empty override means Core's platform default, which is a supported
+	// setup — not an install with nothing on disk.
+	datadir := config.BitcoinCoreDirs.DatadirNetwork(config.NetworkECash, o.ecashDatadir())
+	if datadir == "" {
+		return false
+	}
+	entries, err := os.ReadDir(filepath.Join(datadir, "blocks"))
+	if err != nil {
+		// Only "not there" says there is nothing to keep. Any other refusal
+		// leaves a chain that may exist, and adopting over it needs the user.
+		return !os.IsNotExist(err)
+	}
+	return len(entries) > 0
 }
 
 // SelectedECashID returns the network a catalog resolves to: the one the user
@@ -406,12 +489,18 @@ func (o *Orchestrator) SelectECashNetwork(id string) error {
 	if _, err := o.Settings.SetECashNetworkID(id); err != nil {
 		return err
 	}
-	// Off eCash the retired chain is cold files that no start revisits: the
-	// startup wipe only runs while eCash is active, and by the time it is the
-	// conf already names the new network. Clear them here.
+	// Off eCash there is no Core on that chain to rewind, so the drop is
+	// recorded for the boot that brings one up.
 	if config.NetworkFromString(o.Network) != config.NetworkECash {
 		if !o.wipeOnECashNetworkChange(context.Background(), previous, id) {
-			return fmt.Errorf("could not clear the retired eCash chain data")
+			// The pick is already durable. Leaving it while the drop is not
+			// recorded lets a later boot serve the target over the source fork
+			// with nothing to invalidate it.
+			if _, err := o.Settings.SetECashNetworkID(previous); err != nil {
+				o.log.Error().Err(err).Str("previous", previous).
+					Msg("could not put the eCash network pick back")
+			}
+			return fmt.Errorf("could not record the move off the retired eCash chain")
 		}
 	}
 	return nil
@@ -426,12 +515,29 @@ func (o *Orchestrator) installedECashNetwork() string {
 	return config.ECashIDFromUAComment(o.BitcoinConf.Config.GetEffectiveSetting("uacomment", "main"))
 }
 
-// wipeOnECashNetworkChange deletes eCash chain state when the published
-// network moves on (drynet4 -> alphanet). The networks are separate forks
-// that share one datadir, so the previous blocks and chainstate are invalid for
-// the new chain. Wallets survive — see WipeChainData.
-// It reports whether the catalog may move on: true when nothing needed wiping
-// or the wipe was started, false when the stale data is still there.
+// sharedECashHeight returns the last block two eCash networks agree on: one
+// below the lower published fork height. Both fork mainnet, so everything under
+// it is valid on either. false means one of them publishes no fork height, and
+// nothing says where the two part.
+func (o *Orchestrator) sharedECashHeight(fromID, toID string) (uint32, bool) {
+	from, okFrom := o.ecashEntry(fromID)
+	to, okTo := o.ecashEntry(toID)
+	if !okFrom || !okTo || from.ForkHeight <= 1 || to.ForkHeight <= 1 {
+		return 0, false
+	}
+	shared := from.ForkHeight
+	if to.ForkHeight < shared {
+		shared = to.ForkHeight
+	}
+	return uint32(shared - 1), true
+}
+
+// wipeOnECashNetworkChange makes the chain on disk match a new eCash network.
+// It records a rewind to the block both networks share whenever the catalog
+// publishes one, and only deletes when nothing says where the two forks part.
+// Wallets survive either way — see WipeChainData.
+// It reports whether the catalog may move on: true when nothing had to happen
+// or the work was started, false when the stale data is still there.
 func (o *Orchestrator) wipeOnECashNetworkChange(ctx context.Context, oldID, newID string) bool {
 	if oldID == "" || newID == "" || oldID == newID {
 		return true
@@ -439,6 +545,26 @@ func (o *Orchestrator) wipeOnECashNetworkChange(ctx context.Context, oldID, newI
 	if o.BitcoinConf == nil || o.BitcoinConf.Config == nil {
 		o.log.Warn().Msg("eCash network changed but bitcoin config is unavailable, skipping wipe")
 		return false
+	}
+	// A delete would cost every block below the fork, which both networks keep.
+	// Record the drop for the first boot with a Core to make it.
+	if _, ok := o.sharedECashHeight(oldID, newID); ok && o.Settings != nil {
+		if err := o.recordPendingRewind(oldID, newID); err != nil {
+			o.log.Warn().Err(err).Msg("could not record the deferred eCash rewind")
+			return false
+		}
+		// The move back to eCash goes through SwapNetwork, not ApplyECashSwitch,
+		// so nothing else records this. Without it the enforcer comes up on the
+		// retired generation's validator chain.
+		if err := o.Settings.SetPendingEnforcerWipe(newID); err != nil {
+			o.log.Warn().Err(err).Msg("could not record the deferred enforcer cleanup")
+			return false
+		}
+		o.log.Info().
+			Str("previous", oldID).
+			Str("current", newID).
+			Msg("eCash network changed, the next boot drops the retired branch")
+		return true
 	}
 	if o.BitcoinConf.HasPrivateConf {
 		// That user's chain data follows their own bitcoin.conf, not ours.
@@ -478,11 +604,26 @@ func (o *Orchestrator) wipeOnECashNetworkChange(ctx context.Context, oldID, newI
 	// Synchronous: the caller persists the new generation next, and recording
 	// a wipe that has not happened is worse than not wiping at all. Runs on
 	// the refresh goroutine, so a slow volume cannot delay startup.
-	config.WipeNetworkScopedChainDataSync(config.NetworkECash, o.ecashDatadir(), o.log)
-	// The enforcer's validator chain is per-network, not per-generation, so on
-	// eCash it must be cleared here too; other networks' swap into eCash does it.
-	if config.NetworkFromString(o.Network) == config.NetworkECash {
-		config.WipeEnforcerChainDataSync(config.NetworkECash, o.log)
+	if err := config.WipeNetworkScopedChainDataSync(config.NetworkECash, o.ecashDatadir(), o.log); err != nil {
+		o.log.Warn().Err(err).Msg("could not clear the retired eCash chain")
+		return false
+	}
+	// The enforcer's validator chain is per-network, not per-generation, so it
+	// goes too. Off eCash it shares validator/bitcoin with the active network,
+	// so the work is journalled for the swap that brings eCash back.
+	if config.NetworkFromString(o.Network) != config.NetworkECash {
+		if o.Settings == nil {
+			return false
+		}
+		if err := o.Settings.SetPendingEnforcerWipe(newID); err != nil {
+			o.log.Warn().Err(err).Msg("could not record the deferred enforcer cleanup")
+			return false
+		}
+		return true
+	}
+	if err := config.WipeEnforcerChainDataSync(config.NetworkECash, o.log); err != nil {
+		o.log.Warn().Err(err).Msg("could not clear the retired enforcer chain")
+		return false
 	}
 	return true
 }

--- a/sidechain-orchestrator/network_catalog_pending_test.go
+++ b/sidechain-orchestrator/network_catalog_pending_test.go
@@ -94,9 +94,9 @@ func TestNewGenerationIsNotAppliedWithoutConsent(t *testing.T) {
 	require.True(t, stillPending, "pending file must survive so the prompt persists")
 }
 
-// Confirming records the choice on disk and nothing else: wiping the chain
-// under the running daemons is what the next start is for.
-func TestConfirmPromotesTheCacheWithoutSwitchingLive(t *testing.T) {
+// Confirming is the one moment a live Core can rewind to the fork, so the
+// switch happens here. A start has no Core and could only delete the chain.
+func TestConfirmMovesTheChainOnTheSpot(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
 	o.ResolveNetworkCatalog(context.Background())
 
@@ -107,8 +107,8 @@ func TestConfirmPromotesTheCacheWithoutSwitchingLive(t *testing.T) {
 	require.Equal(t, "drynet3", cached.ECashID())
 	_, stillPending := netcatalog.LoadPending(o.BitwindowDir)
 	require.False(t, stillPending, "the prompt must clear once confirmed")
-	require.Equal(t, "drynet2", config.ECashNetworkID(), "this process keeps serving the retired generation")
-	require.Equal(t, "ecash-drynet2", o.BitcoinConf.Config.GetEffectiveSetting("uacomment", "main"))
+	require.Equal(t, "drynet3", config.ECashNetworkID(), "this process moves onto the confirmed network")
+	require.Equal(t, "ecash-drynet3", o.BitcoinConf.Config.GetEffectiveSetting("uacomment", "main"))
 }
 
 // The enforcer's esplora host comes from the catalog, so a switch that updates
@@ -127,8 +127,8 @@ func TestConfirmedGenerationLandsOnTheNextStart(t *testing.T) {
 	require.Empty(t, o.PendingECashUpgrade().ID)
 }
 
-// Confirming off eCash must clear the retired chain itself: the startup wipe
-// only runs while eCash is active, and by then the conf names the new one.
+// Confirming off eCash reaches no Core on that chain, so it records the drop
+// rather than deleting blocks both networks keep.
 func TestConfirmWorksFromAnotherNetwork(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
 	ecashDir := o.BitcoinConf.Config.GetGroupDatadir(config.DatadirGroupECash)
@@ -141,7 +141,8 @@ func TestConfirmWorksFromAnotherNetwork(t *testing.T) {
 
 	require.NoError(t, o.ConfirmPendingECashNetwork(context.Background()))
 
-	require.NoDirExists(t, blocks, "the retired generation's blocks must be cleared")
+	require.DirExists(t, blocks, "the blocks below the fork must survive the confirm")
+	require.NotNil(t, o.Settings.PendingRewind(), "the drop waits for the next live Core")
 	require.Empty(t, o.PendingECashUpgrade().ID)
 	require.Equal(t, string(config.NetworkMainnet), o.Network, "the active network must be left alone")
 }
@@ -205,11 +206,10 @@ func TestSwappingNetworksResolvesTheIncomingBuild(t *testing.T) {
 func TestGenerationChangeResolvesANewCoreBinary(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
 	o.ResolveNetworkCatalog(context.Background())
-	require.NoError(t, o.ConfirmPendingECashNetwork(context.Background()))
 
 	stale := writeResolvedCoreBinary(t, o, "drynet2 build")
 
-	o.ResolveNetworkCatalog(context.Background())
+	require.NoError(t, o.ConfirmPendingECashNetwork(context.Background()))
 
 	fresh := resolvedCoreBinaryPath(t, o)
 	require.NotEqual(t, stale, fresh, "the retired generation's build must not resolve")

--- a/sidechain-orchestrator/network_swap_park_test.go
+++ b/sidechain-orchestrator/network_swap_park_test.go
@@ -1,0 +1,198 @@
+package orchestrator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/stretchr/testify/require"
+)
+
+// thunderChainPath is the flat store a sidechain keeps across every network.
+func thunderChainPath(t *testing.T) string {
+	t.Helper()
+	dc, ok := config.DirConfigByName("thunder")
+	require.True(t, ok)
+	datadir := dc.DatadirNetwork(config.NetworkSignet, "")
+	require.NoError(t, os.MkdirAll(datadir, 0o755))
+	return filepath.Join(datadir, "data.mdb")
+}
+
+func parkInstall(t *testing.T) *Orchestrator {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupDefault, t.TempDir())
+	o.coreReachable = func() bool { return false }
+	return o
+}
+
+// Sidechains keep one flat datadir across every network, so a swap used to
+// delete the only copy. The state is parked under the network it belongs to and
+// comes back on the swap home.
+func TestNetworkSwapParksSidechainStateAndBringsItBack(t *testing.T) {
+	o := parkInstall(t)
+	require.Equal(t, string(config.NetworkSignet), o.Network)
+	chain := thunderChainPath(t)
+	require.NoError(t, os.WriteFile(chain, []byte("signet sidechain state"), 0o644))
+
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+
+	require.NoFileExists(t, chain, "the outgoing state must move out of the way")
+	parked, err := os.ReadFile(chain + ".network-signet")
+	require.NoError(t, err, "the outgoing state must be parked, never deleted")
+	require.Equal(t, "signet sidechain state", string(parked))
+
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkSignet))
+
+	back, err := os.ReadFile(chain)
+	require.NoError(t, err, "the swap home must bring the state back")
+	require.Equal(t, "signet sidechain state", string(back))
+}
+
+// A swap that dies between the park and the conf write leaves the state parked
+// under a network the conf no longer names. The next start brings it back.
+func TestStartRestoresStateAnInterruptedSwapParked(t *testing.T) {
+	o := parkInstall(t)
+	chain := thunderChainPath(t)
+	require.NoError(t, os.WriteFile(chain+".network-signet", []byte("stranded"), 0o644))
+
+	require.NoError(t, o.RestoreParkedSwapState())
+
+	back, err := os.ReadFile(chain)
+	require.NoError(t, err, "a start must bring back what the conf's network parked")
+	require.Equal(t, "stranded", string(back))
+}
+
+// A live path is the newer state by definition. Restoring over it would swap in
+// a copy the user already moved past.
+func TestRestoreNeverOverwritesLiveState(t *testing.T) {
+	o := parkInstall(t)
+	chain := thunderChainPath(t)
+	require.NoError(t, os.WriteFile(chain, []byte("live"), 0o644))
+	require.NoError(t, os.WriteFile(chain+".network-signet", []byte("older"), 0o644))
+
+	require.NoError(t, o.RestoreParkedSwapState())
+
+	live, err := os.ReadFile(chain)
+	require.NoError(t, err)
+	require.Equal(t, "live", string(live))
+	require.FileExists(t, chain+".network-signet", "the parked copy stays on disk")
+}
+
+// An interrupted swap leaves a parked copy behind. Parking again must not
+// overwrite it: that copy is the only one of its network.
+func TestParkNeverOverwritesAnEarlierPark(t *testing.T) {
+	o := parkInstall(t)
+	chain := thunderChainPath(t)
+	require.NoError(t, os.WriteFile(chain, []byte("live"), 0o644))
+	require.NoError(t, os.WriteFile(chain+".network-signet", []byte("stranded"), 0o644))
+
+	require.NoError(t, o.parkOutgoingSwapState())
+
+	stranded, err := os.ReadFile(chain + ".network-signet")
+	require.NoError(t, err)
+	require.Equal(t, "stranded", string(stranded), "the earlier park must survive untouched")
+	live, err := os.ReadFile(chain + ".network-signet.1")
+	require.NoError(t, err)
+	require.Equal(t, "live", string(live))
+}
+
+// The newest park is the state that was live, so that is the one to bring back.
+func TestRestoreTakesTheNewestSlot(t *testing.T) {
+	o := parkInstall(t)
+	chain := thunderChainPath(t)
+	require.NoError(t, os.WriteFile(chain+".network-signet", []byte("older"), 0o644))
+	require.NoError(t, os.WriteFile(chain+".network-signet.1", []byte("newest"), 0o644))
+
+	require.NoError(t, o.RestoreParkedSwapState())
+
+	live, err := os.ReadFile(chain)
+	require.NoError(t, err)
+	require.Equal(t, "newest", string(live))
+	require.FileExists(t, chain+".network-signet", "the older copy stays on disk")
+}
+
+// parkedPathsFor drives the restore, so a numbered slot it cannot see is a
+// numbered slot nothing ever brings back.
+func TestParkedPathsForFindsNumberedSlots(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "data.mdb.network-signet.1"), []byte("x"), 0o644))
+
+	require.Equal(t, []string{filepath.Join(dir, "data.mdb")}, parkedPathsFor(dir, config.NetworkSignet))
+}
+
+// A restore that fails leaves the network durable but the state parked. The
+// retry must resume there, not read the network as swapped and report success.
+func TestSwapKeepsRetryStateWhenTheRestoreFails(t *testing.T) {
+	o := parkInstall(t)
+	chain := thunderChainPath(t)
+	require.NoError(t, os.WriteFile(chain, []byte("signet sidechain state"), 0o644))
+
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	require.Nil(t, o.pendingSwap, "a swap that finished leaves nothing to resume")
+
+	// Back home, but the parked copy is unreadable, so the restore fails.
+	parked := chain + ".network-signet"
+	require.NoError(t, os.Remove(parked))
+	require.NoError(t, os.MkdirAll(parked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(parked, 0o755) })
+
+	err := o.SwapNetwork(context.Background(), config.NetworkSignet)
+	if err == nil {
+		t.Skip("this filesystem allows the rename, so the failure cannot be staged")
+	}
+	require.Contains(t, err.Error(), "restore the state", "the swap must fail on the restore, not elsewhere")
+	require.NotNil(t, o.pendingSwap, "a failed tail must leave a swap to resume")
+	require.Equal(t, config.NetworkSignet, o.pendingSwap.network)
+}
+
+// A swap that could not bring its state back leaves the live path absent.
+// Starting a daemon there builds fresh state, and the restore then refuses to
+// overwrite it — so the real copy strands. The start refuses instead.
+func TestDaemonStartsRefuseWhileStateIsParked(t *testing.T) {
+	o := parkInstall(t)
+	chain := thunderChainPath(t)
+	require.NoError(t, os.WriteFile(chain+".network-signet", []byte("parked"), 0o644))
+
+	_, err := o.StartWithL1(context.Background(), "bitcoind", StartOpts{})
+	require.Error(t, err, "a start over an absent live path must refuse")
+	require.Contains(t, err.Error(), "restart BitWindow")
+
+	_, err = o.RestartDaemon(context.Background(), "bitcoind")
+	require.Error(t, err, "the restart button must refuse too")
+}
+
+// Once the state is back, starts go through again.
+func TestDaemonStartsResumeOnceTheStateIsBack(t *testing.T) {
+	o := parkInstall(t)
+	chain := thunderChainPath(t)
+	require.NoError(t, os.WriteFile(chain+".network-signet", []byte("parked"), 0o644))
+
+	require.NoError(t, o.RestoreParkedSwapState())
+
+	require.Empty(t, o.parkedStateOutstanding(), "nothing is aside any more")
+}
+
+// GetBlockchainDataPaths omits a path it cannot read, and an omitted path never
+// reaches the fail-closed check. The swap has to see it and refuse.
+func TestASwapRefusesAnUnreadableSidechainPath(t *testing.T) {
+	o := parkInstall(t)
+	chain := thunderChainPath(t)
+	require.NoError(t, os.WriteFile(chain, []byte("signet sidechain state"), 0o644))
+	require.NoError(t, os.Chmod(filepath.Dir(chain), 0o000))
+	t.Cleanup(func() { _ = os.Chmod(filepath.Dir(chain), 0o755) })
+
+	if _, err := os.Stat(chain); err == nil {
+		t.Skip("this filesystem reads the path anyway, so the failure cannot be staged")
+	}
+
+	err := o.SwapNetwork(context.Background(), config.NetworkECash)
+	require.Error(t, err, "a swap that cannot see the outgoing state must refuse")
+	require.Contains(t, err.Error(), "before parking it")
+}

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -829,6 +829,9 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 	if err != nil {
 		return nil, err
 	}
+	if err := o.refuseWhileParked(); err != nil {
+		return nil, err
+	}
 
 	ch := make(chan StartupProgress, 100)
 
@@ -1064,7 +1067,71 @@ func (o *Orchestrator) injectHeadlessForForcedBackend(config BinaryConfig, opts 
 // Returns true on success (or already-running), false on fatal failure
 // (failBoot has already surfaced the error to the UI in that case).
 //
-// Dart parity: rpc_connection.dart L197-232 initBinary pattern.
+// parkedStateOutstanding names a live path a swap moved aside and never brought
+// back. A daemon started over one builds fresh state, and the restore then
+// refuses to overwrite it — so the real copy strands.
+//
+// It reports the paths rather than restoring them: a conf write that failed
+// half way makes o.Network stale, and restoring on a stale network puts the
+// outgoing state where the incoming one looks. Only a start reads the conf
+// again, so recovery belongs there.
+func (o *Orchestrator) parkedStateOutstanding() []string {
+	var outstanding []string
+	active := config.Network(o.Network)
+	for path := range o.swapStatePaths(active) {
+		if _, err := os.Stat(path); err == nil {
+			continue
+		}
+		if _, ok := latestParkedPath(path, active); ok {
+			outstanding = append(outstanding, path)
+		}
+	}
+	return outstanding
+}
+
+// refuseWhileParked stops a daemon start while a swap's state is still aside.
+func (o *Orchestrator) refuseWhileParked() error {
+	outstanding := o.parkedStateOutstanding()
+	if len(outstanding) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"a network change left state aside and could not bring it back — restart BitWindow to finish it (%s)",
+		strings.Join(outstanding, ", "),
+	)
+}
+
+// applyPendingECashRewindAfterCore makes a drop a switch left for the next live// applyPendingECashRewindAfterCore makes a drop a switch left for the next live
+// Core, and stops Core when it cannot. Every path that brings Core up calls it:
+// a flag saying the boot failed does not take a running daemon off the fork the
+// drop exists to leave.
+func (o *Orchestrator) applyPendingECashRewindAfterCore(ctx context.Context, ch chan<- StartupProgress) error {
+	err := o.ApplyPendingECashRewind(ctx)
+	if err == nil {
+		return nil
+	}
+	o.log.Error().Err(err).Msg("could not apply the eCash rewind a switch left behind")
+	if stopErr := o.process.Stop(ctx, "bitcoind", true); stopErr != nil {
+		o.log.Error().Err(stopErr).Msg("could not stop bitcoind after the deferred rewind failed")
+	}
+	ch <- StartupProgress{Error: fmt.Errorf("apply the deferred eCash rewind: %w", err)}
+	return err
+}
+
+// applyPendingECashWipeBeforeCore makes a journalled wipe and reports it on ch.// applyPendingECashWipeBeforeCore makes a journalled wipe and reports it on ch.
+// Every path that brings Core up calls it: the wipe renames Core's blocks
+// aside, so it only works while nothing holds the datadir open.
+func (o *Orchestrator) applyPendingECashWipeBeforeCore(ctx context.Context, ch chan<- StartupProgress) error {
+	err := o.ApplyPendingECashWipe(ctx)
+	if err == nil {
+		return nil
+	}
+	o.log.Error().Err(err).Msg("could not clear the eCash chain a switch left behind")
+	ch <- StartupProgress{Error: fmt.Errorf("apply the deferred eCash wipe: %w", err)}
+	return err
+}
+
+// Dart parity: rpc_connection.dart L197-232 initBinary pattern.// Dart parity: rpc_connection.dart L197-232 initBinary pattern.
 //  1. startConnectionTimer() — pings once, then starts 1s timer
 //  2. if (connected) → "already running, not booting" → return
 //  3. else → bootProcess() → wait for connection
@@ -1072,11 +1139,26 @@ func (o *Orchestrator) startBitcoindOnly(ctx context.Context, opts StartOpts, ch
 	// A UTXO snapshot can only be loaded against a live, RPC-reachable node, so
 	// every path that brings bitcoind up gets the apply for free rather than
 	// each caller having to remember it.
+	//
+	// The deferred rewind rides here for the same reason: the daemon card's
+	// restart button reaches Core through this function alone, and a Core up on
+	// the target conf over the retired fork is what the drop exists to stop.
 	defer func() {
-		if started {
-			o.maybeApplySnapshot(ctx, ch)
+		if !started {
+			return
 		}
+		if err := o.applyPendingECashRewindAfterCore(ctx, ch); err != nil {
+			started = false
+			return
+		}
+		o.maybeApplySnapshot(ctx, ch)
 	}()
+
+	// Before Core opens the datadir: a journalled wipe renames its blocks
+	// aside, and a retry that skipped it would start over the retired chain.
+	if err := o.applyPendingECashWipeBeforeCore(ctx, ch); err != nil {
+		return false
+	}
 
 	coreCfg := o.configs["bitcoind"]
 	var coreHealthOpts HealthCheckOpts
@@ -1194,6 +1276,9 @@ func (o *Orchestrator) RestartDaemon(ctx context.Context, name string, options .
 	if err != nil {
 		return nil, err
 	}
+	if err := o.refuseWhileParked(); err != nil {
+		return nil, err
+	}
 
 	ch := make(chan StartupProgress, 100)
 
@@ -1256,6 +1341,16 @@ func (o *Orchestrator) exitedFunc(name string) func() (int, bool) {
 // If prefetched is non-nil, the enforcer binary is already being downloaded
 // in parallel and we wait on its completion instead of starting a new download.
 func (o *Orchestrator) startEnforcerWhenReady(ctx context.Context, opts StartOpts, prefetched <-chan error) {
+	// A switch that could not finish its enforcer cleanup journalled it. Here,
+	// because a leftover validator chain serves the retired generation.
+	if err := o.ApplyPendingEnforcerWipe(); err != nil {
+		o.log.Error().Err(err).Msg("could not clear the enforcer chain a switch left behind")
+		mon := o.getOrCreateMonitor("enforcer", NewHealthChecker(o.configs["enforcer"]), enforcerStartupPatterns)
+		mon.SetConnectionError(err.Error())
+		mon.SetInitializing(false)
+		return
+	}
+
 	// A boot that is not the swap's own would write a starter file from the
 	// wallet as it stands mid-swap and leave the daemon's state derived from a
 	// seed that is about to be replaced. Refuse rather than race.
@@ -1463,6 +1558,14 @@ func enforcerEnv() map[string]string {
 // If prefetched is non-nil, the target binary is already being downloaded in
 // parallel and we wait on its completion instead of starting a new download.
 func (o *Orchestrator) startTargetOnly(ctx context.Context, config BinaryConfig, opts StartOpts, ch chan<- StartupProgress, prefetched <-chan error) {
+	// An immediate start reaches Core through here rather than
+	// startBitcoindOnly, so the journalled wipe has to run on both paths.
+	if config.IsMainchainCore() {
+		if err := o.applyPendingECashWipeBeforeCore(ctx, ch); err != nil {
+			return
+		}
+	}
+
 	var startupPatterns []string
 	var healthOpts HealthCheckOpts
 	if config.IsMainchainCore() && o.BitcoinConf != nil {
@@ -1482,6 +1585,16 @@ func (o *Orchestrator) startTargetOnly(ctx context.Context, config BinaryConfig,
 	// Keep the target monitor alive even if the frontend asked us to start
 	// the chain before the target RPC is reachable.
 	targetMon.StartConnectionTimer(ctx)
+
+	// An immediate start reaches Core through here, and the drop needs a Core
+	// that answers — so it rides every way out of this function.
+	if config.IsMainchainCore() {
+		defer func() {
+			if targetMon.Connected() {
+				_ = o.applyPendingECashRewindAfterCore(ctx, ch)
+			}
+		}()
+	}
 
 	// A call that opens the frontend must reach the launch below even when the
 	// backend already answers: a backend that outlived its window would
@@ -2052,19 +2165,31 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 		}
 	}
 
-	if err := o.purgeNetworkSwapState(n); err != nil {
+	if err := o.parkOutgoingSwapState(); err != nil {
 		return err
 	}
 
+	// Both failures leave the state parked on purpose. A write that got as far
+	// as naming n makes o.Network stale, and restoring on that would put the
+	// outgoing state at the live paths for a conf that names the target — which
+	// then opens the previous network's database. The next start reads the conf
+	// and restores whatever it names, whichever way the write landed.
 	if err := o.BitcoinConf.UpdateNetwork(n); err != nil {
+		o.log.Warn().Err(err).Str("network", string(n)).
+			Msg("network-swap state stays parked, the next start restores what the conf names")
 		return fmt.Errorf("persist network: %w", err)
 	}
 	if err := o.BitcoinConf.LoadConfig(false); err != nil {
+		o.log.Warn().Err(err).Str("network", string(n)).
+			Msg("network-swap state stays parked, the next start restores what the conf names")
 		return fmt.Errorf("reload config: %w", err)
 	}
 	o.setNetwork(string(n))
 	o.clearNetworkSwapCaches()
 
+	// Installed before the tail below, which can fail. Without it a retry reads
+	// the network as already swapped, takes the no-op path and reports success
+	// while the state is still parked and the daemons are still down.
 	o.pendingSwap = &pendingNetworkSwap{network: n, restartL1: bitcoindWasRunning || enforcerWasRunning}
 	return o.finishNetworkSwap(n, o.pendingSwap.restartL1)
 }
@@ -2078,6 +2203,13 @@ type pendingNetworkSwap struct {
 // finishNetworkSwap rebinds wallet state and restarts L1. Everything here is
 // retryable: the caller keeps pendingSwap until it returns nil.
 func (o *Orchestrator) finishNetworkSwap(n config.Network, restartL1 bool) error {
+	// First, and on every retry: the network is durable by now, so this brings
+	// back whatever it parked on its way out. A daemon started over an absent
+	// path builds fresh state that a later park files above the real one.
+	if err := o.RestoreParkedSwapState(); err != nil {
+		return fmt.Errorf("restore the state %s parked: %w", n, err)
+	}
+
 	// Eager, before anything can read: wallet state derived from the outgoing
 	// network must not outlive the swap.
 	if o.walletEngine != nil {
@@ -2111,11 +2243,96 @@ func (o *Orchestrator) finishNetworkSwap(n config.Network, restartL1 bool) error
 	return nil
 }
 
-func (o *Orchestrator) purgeNetworkSwapState(target config.Network) error {
-	paths := make(map[string]bool)
+// parkOutgoingSwapState moves the state a swap would otherwise destroy out of
+// the way, filed under the network leaving. Its other half is
+// RestoreParkedSwapState, which runs once the new network is durable.
+//
+// Sidechains keep one flat datadir and the enforcer shares directories between
+// colliding networks, so both networks want the same paths. A delete would cost
+// the user a full sidechain resync — and the enforcer's keys — every swap.
+func (o *Orchestrator) parkOutgoingSwapState() error {
+	from := config.Network(o.Network)
+	moved := make(map[string]string)
+	for path := range o.swapStatePaths(from) {
+		switch _, err := os.Stat(path); {
+		case os.IsNotExist(err):
+			continue
+		case err != nil:
+			// Skipping on an unreadable path leaves the outgoing state in the
+			// shared live path. Once access recovers the target opens it, and
+			// its own parked copy stays ignored.
+			o.unparkPartialMove(moved)
+			return fmt.Errorf("read %s before parking it: %w", path, err)
+		}
+		outgoing, err := freeParkedPath(path, from)
+		if err != nil {
+			o.unparkPartialMove(moved)
+			return err
+		}
+		if err := os.Rename(path, outgoing); err != nil {
+			// Half a park is worse than none: the conf still names this
+			// network while some of its state is gone from the live paths.
+			o.unparkPartialMove(moved)
+			return fmt.Errorf("park %s under %s: %w", path, from, err)
+		}
+		moved[path] = outgoing
+		o.log.Info().Str("path", path).Str("parked_under", string(from)).
+			Msg("parked network-swap state")
+	}
+	return nil
+}
 
-	for _, path := range enforcerNetworkSwapStatePaths(config.Network(o.Network), target) {
-		paths[path] = true
+// unparkPartialMove puts back what a failed park already moved.
+func (o *Orchestrator) unparkPartialMove(moved map[string]string) {
+	for path, parked := range moved {
+		if err := os.Rename(parked, path); err != nil {
+			o.log.Error().Err(err).Str("path", path).Str("parked", parked).
+				Msg("could not put back state a failed park moved")
+		}
+	}
+}
+
+// RestoreParkedSwapState brings back what the active network parked on its way
+// out. It runs after a swap and at every start, so a crash between the park and
+// the conf write costs nothing: the next start restores whatever the conf names.
+//
+// It never overwrites. A live path is the newer state by definition, and the
+// parked copy under it stays on disk.
+func (o *Orchestrator) RestoreParkedSwapState() error {
+	active := config.Network(o.Network)
+	for path := range o.swapStatePaths(active) {
+		switch _, err := os.Stat(path); {
+		case err == nil:
+			continue
+		case !os.IsNotExist(err):
+			// A path we cannot read may hold live state. Restoring over it
+			// would bury that; leaving it costs a retry.
+			return fmt.Errorf("read %s before restoring it: %w", path, err)
+		}
+		incoming, ok := latestParkedPath(path, active)
+		if !ok {
+			continue
+		}
+		if err := os.Rename(incoming, path); err != nil {
+			// Starting a daemon over an absent path builds fresh state, which a
+			// later park files as the newest slot and hides the real one.
+			return fmt.Errorf("restore %s from %s: %w", path, incoming, err)
+		}
+		o.log.Info().Str("path", path).Str("network", string(active)).
+			Msg("restored parked network-swap state")
+	}
+	return nil
+}
+
+// swapStatePaths lists the live paths a swap has to move for network n: the
+// sidechain stores it shares with every other network, the enforcer state that
+// collides, and any path a park left behind.
+func (o *Orchestrator) swapStatePaths(n config.Network) map[string]bool {
+	paths := make(map[string]bool)
+	for _, other := range config.AllNetworks() {
+		for _, path := range enforcerNetworkSwapStatePaths(n, other) {
+			paths[path] = true
+		}
 	}
 
 	bitcoinOverride := ""
@@ -2130,28 +2347,91 @@ func (o *Orchestrator) purgeNetworkSwapState(target config.Network) error {
 		if !ok {
 			continue
 		}
-		for _, network := range []config.Network{config.Network(o.Network), target} {
-			networkDir := dc.DatadirNetwork(network, bitcoinOverride)
-			for _, path := range dc.GetBlockchainDataPaths(networkDir, network, o.log) {
-				paths[path] = true
-			}
+		networkDir := dc.DatadirNetwork(n, bitcoinOverride)
+		// The names, not what stat can see: GetBlockchainDataPaths omits a path
+		// it cannot read, and an omitted path never reaches the fail-closed
+		// check in parkOutgoingSwapState.
+		for _, name := range config.SidechainChainDataNames {
+			paths[filepath.Join(networkDir, name)] = true
+		}
+		// The list above only reports files that exist, and a parked one does
+		// not — so without this the swap home never finds its own state.
+		for _, path := range parkedPathsFor(networkDir, n) {
+			paths[path] = true
 		}
 	}
+	return paths
+}
 
-	for path := range paths {
-		if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("wipe network-swap state %s: %w", path, err)
+// parkedPathsFor returns the live paths whose state n parked in dir, numbered
+// slots included: an interrupted swap parks under a numbered one, and skipping
+// those would leave that state stranded for good.
+func parkedPathsFor(dir string, n config.Network) []string {
+	suffix := ".network-" + string(n)
+	seen := make(map[string]bool)
+	var paths []string
+	for _, pattern := range []string{"*" + suffix, "*" + suffix + ".*"} {
+		matches, err := filepath.Glob(filepath.Join(dir, pattern))
+		if err != nil {
+			continue
 		}
-		o.log.Info().Str("path", path).Msg("wiped network-swap state")
+		for _, m := range matches {
+			live := m[:strings.LastIndex(m, suffix)]
+			if live == "" || seen[live] {
+				continue
+			}
+			seen[live] = true
+			paths = append(paths, live)
+		}
 	}
-	return nil
+	return paths
+}
+
+// latestParkedPath returns the newest slot n parked, which is the highest
+// numbered one. An interrupted swap parks the live state above an older copy
+// nothing restored, so the number orders them.
+func latestParkedPath(path string, n config.Network) (string, bool) {
+	base := parkedPath(path, n)
+	newest := ""
+	for i := 0; i < 20; i++ {
+		candidate := base
+		if i > 0 {
+			candidate = fmt.Sprintf("%s.%d", base, i)
+		}
+		if _, err := os.Stat(candidate); err == nil {
+			newest = candidate
+		}
+	}
+	return newest, newest != ""
+}
+
+// parkedPath is where path lives while another network runs.
+func parkedPath(path string, n config.Network) string {
+	return path + ".network-" + string(n)
+}
+
+// freeParkedPath returns a parked name nothing occupies. A swap interrupted
+// before its restore leaves one behind, and overwriting it would delete the
+// very state parking exists to keep.
+func freeParkedPath(path string, n config.Network) (string, error) {
+	base := parkedPath(path, n)
+	for i := 0; i < 20; i++ {
+		candidate := base
+		if i > 0 {
+			candidate = fmt.Sprintf("%s.%d", base, i)
+		}
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("no free parking slot for %s under %s", path, n)
 }
 
 // enforcerNetworkSwapStatePaths returns the enforcer state a swap from -> to
-// must drop. The enforcer files its validator chain and wallet per network, so
-// both survive a swap and are still valid on the way back; state only has to go
-// when the two networks share those directories, leaving the outgoing chain
-// where the incoming one will look for its own.
+// must move. The enforcer files its validator chain and wallet per network, so
+// both survive a swap untouched; state only has to move when the two networks
+// share those directories, leaving the outgoing chain where the incoming one
+// will look for its own.
 func enforcerNetworkSwapStatePaths(from, to config.Network) []string {
 	if !config.EnforcerNetworksCollide(from, to) {
 		return nil

--- a/sidechain-orchestrator/orchestrator_settings.go
+++ b/sidechain-orchestrator/orchestrator_settings.go
@@ -29,6 +29,14 @@ type OrchestratorSettings struct {
 	// branch for good, so a move back to the network it dropped must clear the
 	// mark first.
 	RewoundBlockHash string `json:"rewound_block_hash"`
+	// PendingRewind is a drop an eCash switch could not make because no Core
+	// answered. The first boot that has one makes it, so the blocks below the
+	// fork stay instead of being deleted.
+	PendingRewind *PendingRewind `json:"pending_rewind,omitempty"`
+	// PendingEnforcerWipe is the eCash network whose enforcer validator chain a
+	// switch left behind. The enforcer keeps one chain per network, not per
+	// fork, so it has to go before the enforcer runs on the new one.
+	PendingEnforcerWipe string `json:"pending_enforcer_wipe,omitempty"`
 	// ElectrumServerURL overrides the network's default Esplora endpoint for
 	// electrum wallets. Empty means "use the network default".
 	ElectrumServerURL string `json:"electrum_server_url"`
@@ -271,17 +279,87 @@ func (s *SettingsStore) SetSeenNetworkIDs(ids []string) error {
 	return nil
 }
 
+// PendingRewind is a drop waiting for a live Core, and the move it belongs to.
+// The ids matter: a selection that reverses before the drop runs would
+// otherwise invalidate the first block of the very fork it lands on.
+type PendingRewind struct {
+	FromID string `json:"from_id"`
+	ToID   string `json:"to_id"`
+	Height uint32 `json:"height"`
+	// Wipe means no published fork height tells the two networks apart, so the
+	// old chain has to go rather than rewind. It runs before Core starts.
+	Wipe bool `json:"wipe,omitempty"`
+}
+
+// PendingEnforcerWipe returns the network whose enforcer chain still has to go,
+// empty when none does.
+func (s *SettingsStore) PendingEnforcerWipe() string {
+	return s.Get().PendingEnforcerWipe
+}
+
+// SetPendingEnforcerWipe persists enforcer cleanup a switch could not finish.
+// An empty id clears it.
+func (s *SettingsStore) SetPendingEnforcerWipe(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	next := s.current
+	next.PendingEnforcerWipe = id
+	if err := SaveSettings(s.bitwindowDir, next); err != nil {
+		return err
+	}
+	s.current = next
+	return nil
+}
+
+// PendingRewind returns the drop a switch left for the next live Core, nil when
+// none waits.
+func (s *SettingsStore) PendingRewind() *PendingRewind {
+	return s.Get().PendingRewind
+}
+
+// SetPendingRewind persists a drop for the next live Core. A nil record clears
+// it.
+func (s *SettingsStore) SetPendingRewind(rewind *PendingRewind) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	next := s.current
+	next.PendingRewind = rewind
+	if err := SaveSettings(s.bitwindowDir, next); err != nil {
+		return err
+	}
+	s.current = next
+	return nil
+}
+
 // RewoundBlockHash returns the block an eCash switch dropped, empty when none.
 func (s *SettingsStore) RewoundBlockHash() string {
 	return s.Get().RewoundBlockHash
 }
 
-// SetRewoundBlockHash persists the block an eCash switch dropped.
+// SetRewoundBlockHash persists the block an eCash switch dropped. A rollback
+// uses it to put the previous mark back, so it leaves any drop still waiting
+// alone — that work outlives the switch that failed.
 func (s *SettingsStore) SetRewoundBlockHash(hash string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	next := s.current
 	next.RewoundBlockHash = hash
+	if err := SaveSettings(s.bitwindowDir, next); err != nil {
+		return err
+	}
+	s.current = next
+	return nil
+}
+
+// CommitRewind records a drop that succeeded and clears the one that was
+// waiting, in one write. Two writes leave a window where a crash repeats the
+// work, and a repeat reconsiders the block it just barred.
+func (s *SettingsStore) CommitRewind(hash string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	next := s.current
+	next.RewoundBlockHash = hash
+	next.PendingRewind = nil
 	if err := SaveSettings(s.bitwindowDir, next); err != nil {
 		return err
 	}

--- a/sidechain-orchestrator/proto/orchestrator/v1/bitcoin_conf.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/bitcoin_conf.proto
@@ -104,6 +104,8 @@ message PlanECashSwitchResponse {
   // it and follows the new network from there. Zero when nothing is dropped.
   uint32 rewind_height = 3;
   bool needs_rollback = 4;
+  // True when the old blocks cannot stay and the switch resyncs the chain.
+  bool must_wipe = 5;
 }
 
 // TakeNewNetworks

--- a/sidechain-orchestrator/reject_block.go
+++ b/sidechain-orchestrator/reject_block.go
@@ -328,7 +328,12 @@ func (o *Orchestrator) rebuildEnforcerChain(ctx context.Context) error {
 		return fmt.Errorf("stop the enforcer: %w", err)
 	}
 
-	config.WipeEnforcerChainDataSync(config.NetworkFromString(o.Network), o.log)
+	// Leave it stopped rather than report a rebuild it never made: a restart
+	// here reopens the very chain that failed to follow Core's branch.
+	if err := config.WipeEnforcerChainDataSync(config.NetworkFromString(o.Network), o.log); err != nil {
+		release()
+		return fmt.Errorf("clear the enforcer chain: %w", err)
+	}
 
 	// RestartDaemon starts the one daemon whatever the active wallet is. The
 	// L1 boot path serves an electrum wallet no local backends, so it would

--- a/sidechain-orchestrator/wipe_scope_test.go
+++ b/sidechain-orchestrator/wipe_scope_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -27,7 +28,9 @@ func TestRolloverWipeLeavesSidechainDataAlone(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config.WipeNetworkScopedChainDataSync(config.NetworkECash, datadir, zerolog.Nop())
+	if err := config.WipeNetworkScopedChainDataSync(config.NetworkECash, datadir, zerolog.Nop()); err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := os.Stat(blocks); err == nil {
 		t.Error("eCash blocks should have been renamed aside")
@@ -55,12 +58,75 @@ func TestRolloverWipesEnforcerChainButKeepsWallet(t *testing.T) {
 		}
 	}
 
-	config.WipeEnforcerChainDataSync(config.NetworkECash, zerolog.Nop())
+	if err := config.WipeEnforcerChainDataSync(config.NetworkECash, zerolog.Nop()); err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := os.Stat(chain); err == nil {
 		t.Error("enforcer validator chain should have been renamed aside")
 	}
 	if _, err := os.Stat(wallet); err != nil {
 		t.Errorf("enforcer wallet must survive a eCash network change: %v", err)
+	}
+}
+
+// bitwindow.db holds the address book, transaction notes, UTXO labels and
+// multisig records, and bitdrive holds the user's files. No chain rebuilds
+// any of it, so an eCash network change must leave both alone.
+func TestRolloverKeepsTheUsersBitwindowData(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	dc, ok := config.DirConfigByName("bitwindow")
+	if !ok {
+		t.Fatal("no dir config for bitwindow")
+	}
+	datadir := dc.DatadirNetwork(config.NetworkECash, "")
+	bitdrive := filepath.Join(datadir, "bitdrive")
+	if err := os.MkdirAll(bitdrive, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db := filepath.Join(datadir, "bitwindow.db")
+	if err := os.WriteFile(db, []byte("address book, notes, labels"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := config.WipeNetworkScopedChainDataSync(config.NetworkECash, t.TempDir(), zerolog.Nop()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(db); err != nil {
+		t.Errorf("bitwindow.db must survive an eCash network change: %v", err)
+	}
+	if _, err := os.Stat(bitdrive); err != nil {
+		t.Errorf("bitdrive files must survive an eCash network change: %v", err)
+	}
+}
+
+// The enforcer wipe has to say whether the validator chain actually left the
+// live layout. A caller that records it as done would start the enforcer on the
+// retired generation's chain with nothing left to retry.
+func TestEnforcerWipeReportsAPathItCouldNotRead(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	root := config.EnforcerDirs.RootDir()
+	validator := filepath.Join(root, "validator")
+	if err := os.MkdirAll(filepath.Join(validator, "bitcoin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(validator, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(validator, 0o755) })
+
+	err := config.WipeEnforcerChainDataSync(config.NetworkECash, zerolog.Nop())
+	if err == nil {
+		t.Skip("this filesystem reads the path anyway, so the failure cannot be staged")
+	}
+	if !strings.Contains(err.Error(), "validator") {
+		t.Errorf("the error must name the path it could not clear: %v", err)
 	}
 }

--- a/sidechain_core/lib/gen/orchestrator/v1/bitcoin_conf.pb.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/bitcoin_conf.pb.dart
@@ -648,6 +648,7 @@ class PlanECashSwitchResponse extends $pb.GeneratedMessage {
     $core.String? toId,
     $core.int? rewindHeight,
     $core.bool? needsRollback,
+    $core.bool? mustWipe,
   }) {
     final $result = create();
     if (fromId != null) {
@@ -661,6 +662,9 @@ class PlanECashSwitchResponse extends $pb.GeneratedMessage {
     }
     if (needsRollback != null) {
       $result.needsRollback = needsRollback;
+    }
+    if (mustWipe != null) {
+      $result.mustWipe = mustWipe;
     }
     return $result;
   }
@@ -677,6 +681,7 @@ class PlanECashSwitchResponse extends $pb.GeneratedMessage {
     ..aOS(2, _omitFieldNames ? '' : 'toId')
     ..a<$core.int>(3, _omitFieldNames ? '' : 'rewindHeight', $pb.PbFieldType.OU3)
     ..aOB(4, _omitFieldNames ? '' : 'needsRollback')
+    ..aOB(5, _omitFieldNames ? '' : 'mustWipe')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -749,6 +754,19 @@ class PlanECashSwitchResponse extends $pb.GeneratedMessage {
   $core.bool hasNeedsRollback() => $_has(3);
   @$pb.TagNumber(4)
   void clearNeedsRollback() => clearField(4);
+
+  /// True when the old blocks cannot stay and the switch resyncs the chain.
+  @$pb.TagNumber(5)
+  $core.bool get mustWipe => $_getBF(4);
+  @$pb.TagNumber(5)
+  set mustWipe($core.bool v) {
+    $_setBool(4, v);
+  }
+
+  @$pb.TagNumber(5)
+  $core.bool hasMustWipe() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearMustWipe() => clearField(5);
 }
 
 class TakeNewNetworksRequest extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/orchestrator/v1/bitcoin_conf.pbjson.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/bitcoin_conf.pbjson.dart
@@ -138,6 +138,7 @@ const PlanECashSwitchResponse$json = {
     {'1': 'to_id', '3': 2, '4': 1, '5': 9, '10': 'toId'},
     {'1': 'rewind_height', '3': 3, '4': 1, '5': 13, '10': 'rewindHeight'},
     {'1': 'needs_rollback', '3': 4, '4': 1, '5': 8, '10': 'needsRollback'},
+    {'1': 'must_wipe', '3': 5, '4': 1, '5': 8, '10': 'mustWipe'},
   ],
 };
 
@@ -145,7 +146,8 @@ const PlanECashSwitchResponse$json = {
 final $typed_data.Uint8List planECashSwitchResponseDescriptor =
     $convert.base64Decode('ChdQbGFuRUNhc2hTd2l0Y2hSZXNwb25zZRIXCgdmcm9tX2lkGAEgASgJUgZmcm9tSWQSEwoFdG'
         '9faWQYAiABKAlSBHRvSWQSIwoNcmV3aW5kX2hlaWdodBgDIAEoDVIMcmV3aW5kSGVpZ2h0EiUK'
-        'Dm5lZWRzX3JvbGxiYWNrGAQgASgIUg1uZWVkc1JvbGxiYWNr');
+        'Dm5lZWRzX3JvbGxiYWNrGAQgASgIUg1uZWVkc1JvbGxiYWNrEhsKCW11c3Rfd2lwZRgFIAEoCF'
+        'IIbXVzdFdpcGU=');
 
 @$core.Deprecated('Use takeNewNetworksRequestDescriptor instead')
 const TakeNewNetworksRequest$json = {


### PR DESCRIPTION
Startup deleted Core's blocks, `bitwindow.db` and `bitdrive` when the catalog moved from drynet4 to alphanet. Nobody asked the user.

Startup now serves the network the blocks belong to. A switch the user picks rewinds to the shared fork block, and the dialog states the cost first.