### PR TITLE
orchestrator: read the tip from the chain source

### DIFF
--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -44,6 +44,16 @@ String? offNetworkMessage(SyncInfo? syncInfo) {
       '${syncInfo.behindPeers} blocks behind';
 }
 
+/// The block count an electrum wallet shows, or null when the chain source
+/// reports no height yet. A wallet with no local node has only this one.
+String? chainSourceBlocks(SyncInfo? syncInfo) {
+  final height = syncInfo?.progressCurrent.toInt() ?? 0;
+  if (height <= 0) {
+    return null;
+  }
+  return '${formatWithThousandSpacers(height)} blocks';
+}
+
 class BottomNav extends StatelessWidget {
   final List<Widget> endWidgets;
   final List<Widget> balanceEndWidgets;
@@ -617,9 +627,13 @@ class ChainLoaders extends ViewModelWidget<BottomNavViewModel> {
   @override
   Widget build(BuildContext context, BottomNavViewModel viewModel) {
     // Electrum wallets run no L1 daemons, so there are no block-sync bars to
-    // show — the electrum scan status is rendered separately.
+    // show — the chain source reports the only height they have.
     if (!viewModel.needsBackends) {
-      return const SizedBox.shrink();
+      final blocks = chainSourceBlocks(viewModel.syncProvider.chainSourceSyncInfo);
+      if (blocks == null) {
+        return const SizedBox.shrink();
+      }
+      return SailText.secondary12(blocks);
     }
     final mainchainConnected = viewModel.syncProvider.mainchainSyncInfo != null;
     final enforcerConnected = viewModel.syncProvider.enforcerSyncInfo != null;

--- a/sail_ui/test/chain_source_blocks_test.dart
+++ b/sail_ui/test/chain_source_blocks_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+SyncInfo _at(int height) => SyncInfo(
+  progressCurrent: height.toDouble(),
+  progressGoal: height.toDouble(),
+  lastBlockAt: null,
+);
+
+void main() {
+  // An electrum wallet runs no local node, so the chain source height is the
+  // only block count the bottom nav can show.
+  test('the nav shows the chain source height', () {
+    expect(chainSourceBlocks(_at(963476)), '963 476 blocks');
+  });
+
+  // A chain source that answered nothing yet must draw no label at all — a
+  // "0 blocks" reads as a chain at genesis.
+  test('no height draws nothing', () {
+    expect(chainSourceBlocks(_at(0)), isNull);
+    expect(chainSourceBlocks(null), isNull);
+  });
+}

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -472,6 +472,7 @@ func (h *Handler) GetSyncStatus(ctx context.Context, req *connect.Request[pb.Get
 		Mainchain:        chainSyncToProto(s.Mainchain),
 		Enforcer:         chainSyncToProto(s.Enforcer),
 		EnforcerWallet:   chainSyncToProto(s.EnforcerWallet),
+		ChainSource:      chainSyncToProto(s.ChainSource),
 		Sidechains:       sidechains,
 		WalletSyncStatus: walletSyncStatus,
 	}), nil

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -418,6 +418,7 @@ func run(cctx *cli.Context) error {
 		}
 		log.Info().Str("tor_proxy", torProxy).Msg("electrum wallet routing through tor proxy")
 	}
+	orch.SetChainTipSource(chainSource)
 	electrumBackend := wallet.NewElectrumBackend(walletSvc, chainSource, netParams, log)
 	log.Info().Strs("chain_source_urls", resolveChainTarget().URLs).Msg("electrum wallet provider initialized")
 

--- a/sidechain-orchestrator/fork.go
+++ b/sidechain-orchestrator/fork.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"connectrpc.com/connect"
@@ -43,19 +44,86 @@ func (o *Orchestrator) ForkState(ctx context.Context) (*fork.ForkState, error) {
 	return o.forkEngine.State(ctx)
 }
 
-// ForkTip implements fork.TipSource off the cached getblockchaininfo.
+// ChainTipSource reads the mainchain height from the wallet chain source.
+// Both the esplora and the electrum client satisfy it.
+type ChainTipSource interface {
+	TipHeight(ctx context.Context) (int, error)
+}
+
+// SetChainTipSource hands the orchestrator the chain source it reads the
+// height from when no local Core answers.
+func (o *Orchestrator) SetChainTipSource(src ChainTipSource) {
+	o.mu.Lock()
+	o.chainTip = src
+	o.mu.Unlock()
+}
+
+func (o *Orchestrator) chainTipSource() ChainTipSource {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.chainTip
+}
+
+// chainSourceHeightConnection reads the tip from the wallet chain source.
+type chainSourceHeightConnection struct{ o *Orchestrator }
+
+func (c *chainSourceHeightConnection) Fetch(ctx context.Context) (int, error) {
+	src := c.o.chainTipSource()
+	if src == nil {
+		return 0, fmt.Errorf("no wallet chain source")
+	}
+	rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	return src.TipHeight(rpcCtx)
+}
+
+// chainSourceHeightCached returns the single cached connection every
+// chain-source height read goes through, so one poll per TTL reaches the
+// server no matter how many callers ask.
+func (o *Orchestrator) chainSourceHeightCached() *CachedConnection[int] {
+	o.syncConnMu.Lock()
+	defer o.syncConnMu.Unlock()
+	if o.chainSourceHeight == nil {
+		o.chainSourceHeight = &CachedConnection[int]{
+			inner: &chainSourceHeightConnection{o: o},
+			ttl:   chainSyncCacheTTL,
+		}
+	}
+	return o.chainSourceHeight
+}
+
+// ChainSourceHeight returns the tip the wallet chain source reports. An
+// electrum wallet runs no local node, so this is the only height it has.
+func (o *Orchestrator) ChainSourceHeight(ctx context.Context) (int, error) {
+	return o.chainSourceHeightCached().Fetch(ctx)
+}
+
+// ForkTip implements fork.TipSource off the cached getblockchaininfo, and off
+// the wallet chain source when no local Core runs.
 func (o *Orchestrator) ForkTip(ctx context.Context) (fork.Tip, error) {
+	network := config.NetworkFromString(o.Network)
+	tip := fork.Tip{
+		Network:     o.Network,
+		ForkHeight:  config.PublishedForkHeight(network),
+		DisplayName: config.PublishedDisplayName(network),
+	}
+
 	info, err := o.GetMainchainBlockchainInfo(ctx)
-	if err != nil {
+	if err == nil {
+		tip.Blocks, tip.Headers = info.Blocks, info.Headers
+		return tip, nil
+	}
+	if o.chainTipSource() == nil {
 		return fork.Tip{}, err
 	}
-	return fork.Tip{
-		Network:     o.Network,
-		Blocks:      info.Blocks,
-		Headers:     info.Headers,
-		ForkHeight:  config.PublishedForkHeight(config.NetworkFromString(o.Network)),
-		DisplayName: config.PublishedDisplayName(config.NetworkFromString(o.Network)),
-	}, nil
+	// One height, so blocks and headers are the same: the server serves a
+	// synced chain, and a claim scan reads that same server.
+	height, chainErr := o.ChainSourceHeight(ctx)
+	if chainErr != nil {
+		return fork.Tip{}, err
+	}
+	tip.Blocks, tip.Headers = height, height
+	return tip, nil
 }
 
 // forkWalletScanner adapts wallet.Service + wallet.WalletEngine + the enforcer

--- a/sidechain-orchestrator/fork_tip_test.go
+++ b/sidechain-orchestrator/fork_tip_test.go
@@ -1,0 +1,102 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubChainTip struct {
+	height int
+	err    error
+	calls  int
+}
+
+func (s *stubChainTip) TipHeight(context.Context) (int, error) {
+	s.calls++
+	return s.height, s.err
+}
+
+// An electrum wallet runs no local Core, so the countdown and the block count
+// both come from the chain source. Without the fallback they stay empty.
+func TestForkTipFallsBackToTheChainSource(t *testing.T) {
+	o := newTestOrchestrator(t)
+	tip := &stubChainTip{height: 963476}
+	o.SetChainTipSource(tip)
+
+	got, err := o.ForkTip(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, 963476, got.Blocks)
+	require.Equal(t, 963476, got.Headers)
+	require.Equal(t, o.Network, got.Network)
+}
+
+// A chain source that cannot answer leaves the caller with Core's error, which
+// names the daemon that is actually down.
+func TestForkTipReportsCoreErrorWhenTheChainSourceFailsToo(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.SetChainTipSource(&stubChainTip{err: fmt.Errorf("esplora unreachable")})
+
+	_, err := o.ForkTip(context.Background())
+
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "esplora unreachable")
+}
+
+// Without a chain source there is nothing to fall back to.
+func TestForkTipWithoutAChainSourceFails(t *testing.T) {
+	o := newTestOrchestrator(t)
+
+	_, err := o.ForkTip(context.Background())
+
+	require.Error(t, err)
+}
+
+// The bottom nav reads this slot, so an electrum wallet shows a block count
+// with no local daemon running.
+func TestSyncStatusCarriesTheChainSourceHeight(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.SetChainTipSource(&stubChainTip{height: 963476})
+
+	status, err := o.GetSyncStatus(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, int64(963476), status.ChainSource.Blocks)
+	require.Empty(t, status.ChainSource.Error)
+}
+
+// One cached read per TTL, however many callers ask: the height goes over the
+// network, and the nav polls once a second.
+func TestChainSourceHeightReadsOncePerTTL(t *testing.T) {
+	o := newTestOrchestrator(t)
+	tip := &stubChainTip{height: 963476}
+	o.SetChainTipSource(tip)
+
+	for range 5 {
+		_, err := o.ChainSourceHeight(context.Background())
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 1, tip.calls)
+}
+
+// A network swap throws the cache away, so the new network's height never
+// reads as the old one's.
+func TestChainSourceHeightResetsOnANetworkSwap(t *testing.T) {
+	o := newTestOrchestrator(t)
+	tip := &stubChainTip{height: 963476}
+	o.SetChainTipSource(tip)
+	_, err := o.ChainSourceHeight(context.Background())
+	require.NoError(t, err)
+
+	o.clearNetworkSwapCaches()
+	tip.height = 200
+	got, err := o.ChainSourceHeight(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, 200, got)
+	require.Equal(t, 2, tip.calls)
+}

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -2666,8 +2666,11 @@ type GetSyncStatusResponse struct {
 	// Tip the enforcer's own wallet is synced to. The wallet scans esplora
 	// separately from the validator, so it can lag behind `enforcer`.
 	EnforcerWallet *ChainSync `protobuf:"bytes,5,opt,name=enforcer_wallet,json=enforcerWallet,proto3" json:"enforcer_wallet,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Tip the wallet chain source reports (esplora or electrum). An electrum
+	// wallet runs no local node, so this is the only height it has.
+	ChainSource   *ChainSync `protobuf:"bytes,6,opt,name=chain_source,json=chainSource,proto3" json:"chain_source,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetSyncStatusResponse) Reset() {
@@ -2731,6 +2734,13 @@ func (x *GetSyncStatusResponse) GetWalletSyncStatus() string {
 func (x *GetSyncStatusResponse) GetEnforcerWallet() *ChainSync {
 	if x != nil {
 		return x.EnforcerWallet
+	}
+	return nil
+}
+
+func (x *GetSyncStatusResponse) GetChainSource() *ChainSync {
+	if x != nil {
+		return x.ChainSource
 	}
 	return nil
 }
@@ -5047,7 +5057,7 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x06blocks\x18\x01 \x01(\x05R\x06blocks\x12\x18\n" +
 	"\aheaders\x18\x02 \x01(\x05R\aheaders\x12\x12\n" +
 	"\x04time\x18\x03 \x01(\x03R\x04time\"\x16\n" +
-	"\x14GetSyncStatusRequest\"\xbe\x02\n" +
+	"\x14GetSyncStatusRequest\"\xfd\x02\n" +
 	"\x15GetSyncStatusResponse\x128\n" +
 	"\tmainchain\x18\x01 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\tmainchain\x126\n" +
 	"\benforcer\x18\x02 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\benforcer\x12@\n" +
@@ -5055,7 +5065,8 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"sidechains\x18\x03 \x03(\v2 .orchestrator.v1.SidechainStatusR\n" +
 	"sidechains\x12,\n" +
 	"\x12wallet_sync_status\x18\x04 \x01(\tR\x10walletSyncStatus\x12C\n" +
-	"\x0fenforcer_wallet\x18\x05 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\x0eenforcerWallet\"u\n" +
+	"\x0fenforcer_wallet\x18\x05 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\x0eenforcerWallet\x12=\n" +
+	"\fchain_source\x18\x06 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\vchainSource\"u\n" +
 	"\x0fSidechainStatus\x122\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x1e.orchestrator.v1.SidechainTypeR\x04type\x12.\n" +
 	"\x04sync\x18\x02 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\x04sync\"\xec\x01\n" +
@@ -5406,91 +5417,92 @@ var file_orchestrator_v1_orchestrator_proto_depIdxs = []int32{
 	46, // 6: orchestrator.v1.GetSyncStatusResponse.enforcer:type_name -> orchestrator.v1.ChainSync
 	45, // 7: orchestrator.v1.GetSyncStatusResponse.sidechains:type_name -> orchestrator.v1.SidechainStatus
 	46, // 8: orchestrator.v1.GetSyncStatusResponse.enforcer_wallet:type_name -> orchestrator.v1.ChainSync
-	0,  // 9: orchestrator.v1.SidechainStatus.type:type_name -> orchestrator.v1.SidechainType
-	46, // 10: orchestrator.v1.SidechainStatus.sync:type_name -> orchestrator.v1.ChainSync
-	49, // 11: orchestrator.v1.GetDownloadStatusResponse.downloads:type_name -> orchestrator.v1.DownloadStatus
-	1,  // 12: orchestrator.v1.DownloadStatus.binary:type_name -> orchestrator.v1.BinaryType
-	1,  // 13: orchestrator.v1.GetSidechainBalanceRequest.sidechain:type_name -> orchestrator.v1.BinaryType
-	1,  // 14: orchestrator.v1.SingleDeletion.binary:type_name -> orchestrator.v1.BinaryType
-	2,  // 15: orchestrator.v1.SingleDeletion.deletions:type_name -> orchestrator.v1.DeletionType
-	54, // 16: orchestrator.v1.GatherFilesToDeleteRequest.items:type_name -> orchestrator.v1.SingleDeletion
-	57, // 17: orchestrator.v1.GatherFilesToDeleteResponse.files:type_name -> orchestrator.v1.ResetFileInfo
-	2,  // 18: orchestrator.v1.ResetFileInfo.deletion_type:type_name -> orchestrator.v1.DeletionType
-	1,  // 19: orchestrator.v1.ResetFileInfo.binary:type_name -> orchestrator.v1.BinaryType
-	54, // 20: orchestrator.v1.DeleteFilesRequest.items:type_name -> orchestrator.v1.SingleDeletion
-	3,  // 21: orchestrator.v1.RejectBlockResponse.outcome:type_name -> orchestrator.v1.RejectOutcome
-	4,  // 22: orchestrator.v1.ResetToBlockResponse.phase:type_name -> orchestrator.v1.ResetPhase
-	74, // 23: orchestrator.v1.GetForkStatusResponse.claims:type_name -> orchestrator.v1.ForkWalletClaim
-	75, // 24: orchestrator.v1.ForkWalletClaim.utxos:type_name -> orchestrator.v1.ForkClaimUtxo
-	7,  // 25: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
-	9,  // 26: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
-	11, // 27: orchestrator.v1.OrchestratorService.GetBinaryVersion:input_type -> orchestrator.v1.GetBinaryVersionRequest
-	13, // 28: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
-	15, // 29: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
-	17, // 30: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
-	19, // 31: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
-	21, // 32: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
-	23, // 33: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
-	25, // 34: orchestrator.v1.OrchestratorService.RestartL1:input_type -> orchestrator.v1.RestartL1Request
-	27, // 35: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:input_type -> orchestrator.v1.ApplyUTXOSnapshotRequest
-	29, // 36: orchestrator.v1.OrchestratorService.GetSnapshotStatus:input_type -> orchestrator.v1.GetSnapshotStatusRequest
-	31, // 37: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:input_type -> orchestrator.v1.GetPendingNetworkGenerationRequest
-	33, // 38: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:input_type -> orchestrator.v1.ConfirmPendingNetworkGenerationRequest
-	35, // 39: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
-	76, // 40: orchestrator.v1.OrchestratorService.Shutdown:input_type -> orchestrator.v1.ShutdownRequest
-	37, // 41: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
-	39, // 42: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
-	41, // 43: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
-	43, // 44: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
-	47, // 45: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
-	50, // 46: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
-	52, // 47: orchestrator.v1.OrchestratorService.GetSidechainBalance:input_type -> orchestrator.v1.GetSidechainBalanceRequest
-	55, // 48: orchestrator.v1.OrchestratorService.GatherFilesToDelete:input_type -> orchestrator.v1.GatherFilesToDeleteRequest
-	58, // 49: orchestrator.v1.OrchestratorService.DeleteFiles:input_type -> orchestrator.v1.DeleteFilesRequest
-	60, // 50: orchestrator.v1.OrchestratorService.RejectBlock:input_type -> orchestrator.v1.RejectBlockRequest
-	62, // 51: orchestrator.v1.OrchestratorService.AcceptBlock:input_type -> orchestrator.v1.AcceptBlockRequest
-	64, // 52: orchestrator.v1.OrchestratorService.ResetToBlock:input_type -> orchestrator.v1.ResetToBlockRequest
-	66, // 53: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
-	68, // 54: orchestrator.v1.OrchestratorService.GetBmmContext:input_type -> orchestrator.v1.GetBmmContextRequest
-	70, // 55: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
-	72, // 56: orchestrator.v1.OrchestratorService.GetForkStatus:input_type -> orchestrator.v1.GetForkStatusRequest
-	8,  // 57: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
-	10, // 58: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
-	12, // 59: orchestrator.v1.OrchestratorService.GetBinaryVersion:output_type -> orchestrator.v1.GetBinaryVersionResponse
-	14, // 60: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
-	16, // 61: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
-	18, // 62: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
-	20, // 63: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
-	22, // 64: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
-	24, // 65: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
-	26, // 66: orchestrator.v1.OrchestratorService.RestartL1:output_type -> orchestrator.v1.RestartL1Response
-	28, // 67: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:output_type -> orchestrator.v1.ApplyUTXOSnapshotResponse
-	30, // 68: orchestrator.v1.OrchestratorService.GetSnapshotStatus:output_type -> orchestrator.v1.GetSnapshotStatusResponse
-	32, // 69: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:output_type -> orchestrator.v1.GetPendingNetworkGenerationResponse
-	34, // 70: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:output_type -> orchestrator.v1.ConfirmPendingNetworkGenerationResponse
-	36, // 71: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
-	77, // 72: orchestrator.v1.OrchestratorService.Shutdown:output_type -> orchestrator.v1.ShutdownResponse
-	38, // 73: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
-	40, // 74: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
-	42, // 75: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
-	44, // 76: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
-	48, // 77: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
-	51, // 78: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
-	53, // 79: orchestrator.v1.OrchestratorService.GetSidechainBalance:output_type -> orchestrator.v1.GetSidechainBalanceResponse
-	56, // 80: orchestrator.v1.OrchestratorService.GatherFilesToDelete:output_type -> orchestrator.v1.GatherFilesToDeleteResponse
-	59, // 81: orchestrator.v1.OrchestratorService.DeleteFiles:output_type -> orchestrator.v1.DeleteFilesResponse
-	61, // 82: orchestrator.v1.OrchestratorService.RejectBlock:output_type -> orchestrator.v1.RejectBlockResponse
-	63, // 83: orchestrator.v1.OrchestratorService.AcceptBlock:output_type -> orchestrator.v1.AcceptBlockResponse
-	65, // 84: orchestrator.v1.OrchestratorService.ResetToBlock:output_type -> orchestrator.v1.ResetToBlockResponse
-	67, // 85: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
-	69, // 86: orchestrator.v1.OrchestratorService.GetBmmContext:output_type -> orchestrator.v1.GetBmmContextResponse
-	71, // 87: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
-	73, // 88: orchestrator.v1.OrchestratorService.GetForkStatus:output_type -> orchestrator.v1.GetForkStatusResponse
-	57, // [57:89] is the sub-list for method output_type
-	25, // [25:57] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	46, // 9: orchestrator.v1.GetSyncStatusResponse.chain_source:type_name -> orchestrator.v1.ChainSync
+	0,  // 10: orchestrator.v1.SidechainStatus.type:type_name -> orchestrator.v1.SidechainType
+	46, // 11: orchestrator.v1.SidechainStatus.sync:type_name -> orchestrator.v1.ChainSync
+	49, // 12: orchestrator.v1.GetDownloadStatusResponse.downloads:type_name -> orchestrator.v1.DownloadStatus
+	1,  // 13: orchestrator.v1.DownloadStatus.binary:type_name -> orchestrator.v1.BinaryType
+	1,  // 14: orchestrator.v1.GetSidechainBalanceRequest.sidechain:type_name -> orchestrator.v1.BinaryType
+	1,  // 15: orchestrator.v1.SingleDeletion.binary:type_name -> orchestrator.v1.BinaryType
+	2,  // 16: orchestrator.v1.SingleDeletion.deletions:type_name -> orchestrator.v1.DeletionType
+	54, // 17: orchestrator.v1.GatherFilesToDeleteRequest.items:type_name -> orchestrator.v1.SingleDeletion
+	57, // 18: orchestrator.v1.GatherFilesToDeleteResponse.files:type_name -> orchestrator.v1.ResetFileInfo
+	2,  // 19: orchestrator.v1.ResetFileInfo.deletion_type:type_name -> orchestrator.v1.DeletionType
+	1,  // 20: orchestrator.v1.ResetFileInfo.binary:type_name -> orchestrator.v1.BinaryType
+	54, // 21: orchestrator.v1.DeleteFilesRequest.items:type_name -> orchestrator.v1.SingleDeletion
+	3,  // 22: orchestrator.v1.RejectBlockResponse.outcome:type_name -> orchestrator.v1.RejectOutcome
+	4,  // 23: orchestrator.v1.ResetToBlockResponse.phase:type_name -> orchestrator.v1.ResetPhase
+	74, // 24: orchestrator.v1.GetForkStatusResponse.claims:type_name -> orchestrator.v1.ForkWalletClaim
+	75, // 25: orchestrator.v1.ForkWalletClaim.utxos:type_name -> orchestrator.v1.ForkClaimUtxo
+	7,  // 26: orchestrator.v1.OrchestratorService.ListBinaries:input_type -> orchestrator.v1.ListBinariesRequest
+	9,  // 27: orchestrator.v1.OrchestratorService.GetBinaryStatus:input_type -> orchestrator.v1.GetBinaryStatusRequest
+	11, // 28: orchestrator.v1.OrchestratorService.GetBinaryVersion:input_type -> orchestrator.v1.GetBinaryVersionRequest
+	13, // 29: orchestrator.v1.OrchestratorService.DownloadBinary:input_type -> orchestrator.v1.DownloadBinaryRequest
+	15, // 30: orchestrator.v1.OrchestratorService.StartBinary:input_type -> orchestrator.v1.StartBinaryRequest
+	17, // 31: orchestrator.v1.OrchestratorService.StopBinary:input_type -> orchestrator.v1.StopBinaryRequest
+	19, // 32: orchestrator.v1.OrchestratorService.StreamLogs:input_type -> orchestrator.v1.StreamLogsRequest
+	21, // 33: orchestrator.v1.OrchestratorService.StartWithL1:input_type -> orchestrator.v1.StartWithL1Request
+	23, // 34: orchestrator.v1.OrchestratorService.RestartDaemon:input_type -> orchestrator.v1.RestartDaemonRequest
+	25, // 35: orchestrator.v1.OrchestratorService.RestartL1:input_type -> orchestrator.v1.RestartL1Request
+	27, // 36: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:input_type -> orchestrator.v1.ApplyUTXOSnapshotRequest
+	29, // 37: orchestrator.v1.OrchestratorService.GetSnapshotStatus:input_type -> orchestrator.v1.GetSnapshotStatusRequest
+	31, // 38: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:input_type -> orchestrator.v1.GetPendingNetworkGenerationRequest
+	33, // 39: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:input_type -> orchestrator.v1.ConfirmPendingNetworkGenerationRequest
+	35, // 40: orchestrator.v1.OrchestratorService.ShutdownAll:input_type -> orchestrator.v1.ShutdownAllRequest
+	76, // 41: orchestrator.v1.OrchestratorService.Shutdown:input_type -> orchestrator.v1.ShutdownRequest
+	37, // 42: orchestrator.v1.OrchestratorService.GetBTCPrice:input_type -> orchestrator.v1.GetBTCPriceRequest
+	39, // 43: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:input_type -> orchestrator.v1.GetMainchainBlockchainInfoRequest
+	41, // 44: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:input_type -> orchestrator.v1.GetEnforcerBlockchainInfoRequest
+	43, // 45: orchestrator.v1.OrchestratorService.GetSyncStatus:input_type -> orchestrator.v1.GetSyncStatusRequest
+	47, // 46: orchestrator.v1.OrchestratorService.GetDownloadStatus:input_type -> orchestrator.v1.GetDownloadStatusRequest
+	50, // 47: orchestrator.v1.OrchestratorService.GetMainchainBalance:input_type -> orchestrator.v1.GetMainchainBalanceRequest
+	52, // 48: orchestrator.v1.OrchestratorService.GetSidechainBalance:input_type -> orchestrator.v1.GetSidechainBalanceRequest
+	55, // 49: orchestrator.v1.OrchestratorService.GatherFilesToDelete:input_type -> orchestrator.v1.GatherFilesToDeleteRequest
+	58, // 50: orchestrator.v1.OrchestratorService.DeleteFiles:input_type -> orchestrator.v1.DeleteFilesRequest
+	60, // 51: orchestrator.v1.OrchestratorService.RejectBlock:input_type -> orchestrator.v1.RejectBlockRequest
+	62, // 52: orchestrator.v1.OrchestratorService.AcceptBlock:input_type -> orchestrator.v1.AcceptBlockRequest
+	64, // 53: orchestrator.v1.OrchestratorService.ResetToBlock:input_type -> orchestrator.v1.ResetToBlockRequest
+	66, // 54: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:input_type -> orchestrator.v1.GetCoreMempoolInfoRequest
+	68, // 55: orchestrator.v1.OrchestratorService.GetBmmContext:input_type -> orchestrator.v1.GetBmmContextRequest
+	70, // 56: orchestrator.v1.OrchestratorService.CoreRawCall:input_type -> orchestrator.v1.CoreRawCallRequest
+	72, // 57: orchestrator.v1.OrchestratorService.GetForkStatus:input_type -> orchestrator.v1.GetForkStatusRequest
+	8,  // 58: orchestrator.v1.OrchestratorService.ListBinaries:output_type -> orchestrator.v1.ListBinariesResponse
+	10, // 59: orchestrator.v1.OrchestratorService.GetBinaryStatus:output_type -> orchestrator.v1.GetBinaryStatusResponse
+	12, // 60: orchestrator.v1.OrchestratorService.GetBinaryVersion:output_type -> orchestrator.v1.GetBinaryVersionResponse
+	14, // 61: orchestrator.v1.OrchestratorService.DownloadBinary:output_type -> orchestrator.v1.DownloadBinaryResponse
+	16, // 62: orchestrator.v1.OrchestratorService.StartBinary:output_type -> orchestrator.v1.StartBinaryResponse
+	18, // 63: orchestrator.v1.OrchestratorService.StopBinary:output_type -> orchestrator.v1.StopBinaryResponse
+	20, // 64: orchestrator.v1.OrchestratorService.StreamLogs:output_type -> orchestrator.v1.StreamLogsResponse
+	22, // 65: orchestrator.v1.OrchestratorService.StartWithL1:output_type -> orchestrator.v1.StartWithL1Response
+	24, // 66: orchestrator.v1.OrchestratorService.RestartDaemon:output_type -> orchestrator.v1.RestartDaemonResponse
+	26, // 67: orchestrator.v1.OrchestratorService.RestartL1:output_type -> orchestrator.v1.RestartL1Response
+	28, // 68: orchestrator.v1.OrchestratorService.ApplyUTXOSnapshot:output_type -> orchestrator.v1.ApplyUTXOSnapshotResponse
+	30, // 69: orchestrator.v1.OrchestratorService.GetSnapshotStatus:output_type -> orchestrator.v1.GetSnapshotStatusResponse
+	32, // 70: orchestrator.v1.OrchestratorService.GetPendingNetworkGeneration:output_type -> orchestrator.v1.GetPendingNetworkGenerationResponse
+	34, // 71: orchestrator.v1.OrchestratorService.ConfirmPendingNetworkGeneration:output_type -> orchestrator.v1.ConfirmPendingNetworkGenerationResponse
+	36, // 72: orchestrator.v1.OrchestratorService.ShutdownAll:output_type -> orchestrator.v1.ShutdownAllResponse
+	77, // 73: orchestrator.v1.OrchestratorService.Shutdown:output_type -> orchestrator.v1.ShutdownResponse
+	38, // 74: orchestrator.v1.OrchestratorService.GetBTCPrice:output_type -> orchestrator.v1.GetBTCPriceResponse
+	40, // 75: orchestrator.v1.OrchestratorService.GetMainchainBlockchainInfo:output_type -> orchestrator.v1.GetMainchainBlockchainInfoResponse
+	42, // 76: orchestrator.v1.OrchestratorService.GetEnforcerBlockchainInfo:output_type -> orchestrator.v1.GetEnforcerBlockchainInfoResponse
+	44, // 77: orchestrator.v1.OrchestratorService.GetSyncStatus:output_type -> orchestrator.v1.GetSyncStatusResponse
+	48, // 78: orchestrator.v1.OrchestratorService.GetDownloadStatus:output_type -> orchestrator.v1.GetDownloadStatusResponse
+	51, // 79: orchestrator.v1.OrchestratorService.GetMainchainBalance:output_type -> orchestrator.v1.GetMainchainBalanceResponse
+	53, // 80: orchestrator.v1.OrchestratorService.GetSidechainBalance:output_type -> orchestrator.v1.GetSidechainBalanceResponse
+	56, // 81: orchestrator.v1.OrchestratorService.GatherFilesToDelete:output_type -> orchestrator.v1.GatherFilesToDeleteResponse
+	59, // 82: orchestrator.v1.OrchestratorService.DeleteFiles:output_type -> orchestrator.v1.DeleteFilesResponse
+	61, // 83: orchestrator.v1.OrchestratorService.RejectBlock:output_type -> orchestrator.v1.RejectBlockResponse
+	63, // 84: orchestrator.v1.OrchestratorService.AcceptBlock:output_type -> orchestrator.v1.AcceptBlockResponse
+	65, // 85: orchestrator.v1.OrchestratorService.ResetToBlock:output_type -> orchestrator.v1.ResetToBlockResponse
+	67, // 86: orchestrator.v1.OrchestratorService.GetCoreMempoolInfo:output_type -> orchestrator.v1.GetCoreMempoolInfoResponse
+	69, // 87: orchestrator.v1.OrchestratorService.GetBmmContext:output_type -> orchestrator.v1.GetBmmContextResponse
+	71, // 88: orchestrator.v1.OrchestratorService.CoreRawCall:output_type -> orchestrator.v1.CoreRawCallResponse
+	73, // 89: orchestrator.v1.OrchestratorService.GetForkStatus:output_type -> orchestrator.v1.GetForkStatusResponse
+	58, // [58:90] is the sub-list for method output_type
+	26, // [26:58] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_orchestrator_v1_orchestrator_proto_init() }

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -158,6 +158,10 @@ type Orchestrator struct {
 	forkEngine         *fork.Engine
 	forkEnforcerWallet enforcerrpc.WalletServiceClient
 
+	// chainTip reads the height from the wallet chain source (esplora or
+	// electrum), so an electrum wallet gets a tip with no local Core.
+	chainTip ChainTipSource
+
 	// clearedMark is the block an eCash rewind lifted the bar from, kept so a
 	// rollback can put that bar back. Guarded by swapNetworkMu, which every
 	// eCash switch holds.
@@ -238,6 +242,7 @@ type Orchestrator struct {
 	enforcerWalletSync *CachedConnection[*ChainSyncResult]
 	sidechainSyncs     map[string]*CachedConnection[*ChainSyncResult]
 	chainFork          *CachedConnection[*ChainForkState]
+	chainSourceHeight  *CachedConnection[int]
 
 	// httpClientsMu guards the lazy HTTP-client singletons used by the
 	// chatty pollers (CoreStatusClient, GetSyncStatus). Each client is built
@@ -2180,6 +2185,7 @@ func (o *Orchestrator) clearNetworkSwapCaches() {
 	o.enforcerWalletSync = nil
 	o.sidechainSyncs = nil
 	o.chainFork = nil
+	o.chainSourceHeight = nil
 	o.syncConnMu.Unlock()
 
 	o.httpClientsMu.Lock()
@@ -2849,6 +2855,9 @@ type SyncStatus struct {
 	Enforcer       *ChainSyncResult
 	EnforcerWallet *ChainSyncResult
 	Sidechains     map[string]*ChainSyncResult
+	// ChainSource is the tip the wallet chain source reports. An electrum
+	// wallet runs no local node, so this is the only height it has.
+	ChainSource *ChainSyncResult
 }
 
 // GetSyncStatus fans out concurrent probes — mainchain bitcoind, enforcer
@@ -2866,6 +2875,7 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 		Enforcer:       &ChainSyncResult{},
 		EnforcerWallet: &ChainSyncResult{},
 		Sidechains:     make(map[string]*ChainSyncResult),
+		ChainSource:    &ChainSyncResult{},
 	}
 
 	// Pre-populate sidechain map with one slot per L2 sidechain. The
@@ -2956,6 +2966,17 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 	go func() {
 		defer wg.Done()
 		heights = o.fetchExplorerHeights(ctx)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		height, err := o.ChainSourceHeight(ctx)
+		if err != nil {
+			out.ChainSource.Error = err.Error()
+			return
+		}
+		out.ChainSource.Blocks, out.ChainSource.Headers = int64(height), int64(height)
 	}()
 
 	var fork *ChainForkState

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -477,6 +477,9 @@ message GetSyncStatusResponse {
   // Tip the enforcer's own wallet is synced to. The wallet scans esplora
   // separately from the validator, so it can lag behind `enforcer`.
   ChainSync enforcer_wallet = 5;
+  // Tip the wallet chain source reports (esplora or electrum). An electrum
+  // wallet runs no local node, so this is the only height it has.
+  ChainSync chain_source = 6;
 }
 
 // SidechainType keeps the response strongly-typed so callers don't have to

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -3283,6 +3283,7 @@ class GetSyncStatusResponse extends $pb.GeneratedMessage {
     $core.Iterable<SidechainStatus>? sidechains,
     $core.String? walletSyncStatus,
     ChainSync? enforcerWallet,
+    ChainSync? chainSource,
   }) {
     final $result = create();
     if (mainchain != null) {
@@ -3299,6 +3300,9 @@ class GetSyncStatusResponse extends $pb.GeneratedMessage {
     }
     if (enforcerWallet != null) {
       $result.enforcerWallet = enforcerWallet;
+    }
+    if (chainSource != null) {
+      $result.chainSource = chainSource;
     }
     return $result;
   }
@@ -3317,6 +3321,7 @@ class GetSyncStatusResponse extends $pb.GeneratedMessage {
         subBuilder: SidechainStatus.create)
     ..aOS(4, _omitFieldNames ? '' : 'walletSyncStatus')
     ..aOM<ChainSync>(5, _omitFieldNames ? '' : 'enforcerWallet', subBuilder: ChainSync.create)
+    ..aOM<ChainSync>(6, _omitFieldNames ? '' : 'chainSource', subBuilder: ChainSync.create)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -3406,6 +3411,22 @@ class GetSyncStatusResponse extends $pb.GeneratedMessage {
   void clearEnforcerWallet() => clearField(5);
   @$pb.TagNumber(5)
   ChainSync ensureEnforcerWallet() => $_ensure(4);
+
+  /// Tip the wallet chain source reports (esplora or electrum). An electrum
+  /// wallet runs no local node, so this is the only height it has.
+  @$pb.TagNumber(6)
+  ChainSync get chainSource => $_getN(5);
+  @$pb.TagNumber(6)
+  set chainSource(ChainSync v) {
+    setField(6, v);
+  }
+
+  @$pb.TagNumber(6)
+  $core.bool hasChainSource() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearChainSource() => clearField(6);
+  @$pb.TagNumber(6)
+  ChainSync ensureChainSource() => $_ensure(5);
 }
 
 class SidechainStatus extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -728,6 +728,7 @@ const GetSyncStatusResponse$json = {
     {'1': 'sidechains', '3': 3, '4': 3, '5': 11, '6': '.orchestrator.v1.SidechainStatus', '10': 'sidechains'},
     {'1': 'wallet_sync_status', '3': 4, '4': 1, '5': 9, '10': 'walletSyncStatus'},
     {'1': 'enforcer_wallet', '3': 5, '4': 1, '5': 11, '6': '.orchestrator.v1.ChainSync', '10': 'enforcerWallet'},
+    {'1': 'chain_source', '3': 6, '4': 1, '5': 11, '6': '.orchestrator.v1.ChainSync', '10': 'chainSource'},
   ],
 };
 
@@ -738,7 +739,8 @@ final $typed_data.Uint8List getSyncStatusResponseDescriptor =
         'dG9yLnYxLkNoYWluU3luY1IIZW5mb3JjZXISQAoKc2lkZWNoYWlucxgDIAMoCzIgLm9yY2hlc3'
         'RyYXRvci52MS5TaWRlY2hhaW5TdGF0dXNSCnNpZGVjaGFpbnMSLAoSd2FsbGV0X3N5bmNfc3Rh'
         'dHVzGAQgASgJUhB3YWxsZXRTeW5jU3RhdHVzEkMKD2VuZm9yY2VyX3dhbGxldBgFIAEoCzIaLm'
-        '9yY2hlc3RyYXRvci52MS5DaGFpblN5bmNSDmVuZm9yY2VyV2FsbGV0');
+        '9yY2hlc3RyYXRvci52MS5DaGFpblN5bmNSDmVuZm9yY2VyV2FsbGV0Ej0KDGNoYWluX3NvdXJj'
+        'ZRgGIAEoCzIaLm9yY2hlc3RyYXRvci52MS5DaGFpblN5bmNSC2NoYWluU291cmNl');
 
 @$core.Deprecated('Use sidechainStatusDescriptor instead')
 const SidechainStatus$json = {

--- a/sidechain_core/lib/mocks/mocks.dart
+++ b/sidechain_core/lib/mocks/mocks.dart
@@ -1812,6 +1812,12 @@ class MockSyncProvider implements SyncProvider {
   SyncInfo? mainchainSyncInfo;
 
   @override
+  String? chainSourceError;
+
+  @override
+  SyncInfo? chainSourceSyncInfo;
+
+  @override
   Map<SidechainType, SyncInfo> sidechains = const {};
 
   @override

--- a/sidechain_core/lib/providers/sync_provider.dart
+++ b/sidechain_core/lib/providers/sync_provider.dart
@@ -165,6 +165,11 @@ class SyncProvider extends ChangeNotifier implements NetworkScoped {
   SyncInfo? enforcerWalletSyncInfo;
   String? enforcerWalletError;
 
+  /// Tip the wallet chain source reports (esplora or electrum). An electrum
+  /// wallet runs no local node, so this is the only height it has.
+  SyncInfo? chainSourceSyncInfo;
+  String? chainSourceError;
+
   /// Per-sidechain sync state, keyed by [SidechainType]. Populated from
   /// `GetSyncStatusResponse.sidechains` on every poll. Includes every L2
   /// chain the orchestrator manages — entries that aren't running yet
@@ -234,6 +239,8 @@ class SyncProvider extends ChangeNotifier implements NetworkScoped {
   void reset() {
     mainchainSyncInfo = null;
     mainchainError = null;
+    chainSourceSyncInfo = null;
+    chainSourceError = null;
     enforcerSyncInfo = null;
     enforcerError = null;
     sidechains = const {};
@@ -330,6 +337,13 @@ class SyncProvider extends ChangeNotifier implements NetworkScoped {
       if (_diff(enforcerWalletSyncInfo, newEnforcerWallet) || enforcerWalletError != _errOrNull(resp.enforcerWallet)) {
         enforcerWalletSyncInfo = newEnforcerWallet;
         enforcerWalletError = _errOrNull(resp.enforcerWallet);
+        changed = true;
+      }
+
+      final newChainSource = _toSyncInfo(resp.chainSource);
+      if (_diff(chainSourceSyncInfo, newChainSource) || chainSourceError != _errOrNull(resp.chainSource)) {
+        chainSourceSyncInfo = newChainSource;
+        chainSourceError = _errOrNull(resp.chainSource);
         changed = true;
       }
 
@@ -451,6 +465,8 @@ class SyncProvider extends ChangeNotifier implements NetworkScoped {
   void clearState() {
     mainchainSyncInfo = null;
     mainchainError = null;
+    chainSourceSyncInfo = null;
+    chainSourceError = null;
     enforcerSyncInfo = null;
     enforcerError = null;
     bitwindowdSyncInfo = null;


### PR DESCRIPTION
An electrum wallet runs no local node, so every height read failed and the fork countdown and the bottom-nav block count both stayed empty. The chain source already answers the question through TipHeight.

ForkTip now falls back to it when no Core answers, GetSyncStatus carries it as its own slot, and the bottom nav draws the block count for a wallet with no daemons. One cached read per TTL keeps the poll off the server.