### PR TITLE
bitwindow: release new version

### DIFF
--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.170
+version: 0.2.171
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
ghm skipped the version bump on #2070: it gates on the repo name in the path, and the PR was merged from a worktree under ~/code/wt/.