### PR TITLE
multi: stop the bitcoind pollers in light mode

### DIFF
--- a/bitwindow/lib/providers/network_provider.dart
+++ b/bitwindow/lib/providers/network_provider.dart
@@ -29,8 +29,16 @@ class NetworkProvider extends ChangeNotifier {
   }
 
   Future<void> fetch() async {
-    // Light mode runs no local Bitcoin Core, and these stats read it.
+    // Light mode runs no local Bitcoin Core, and these stats read it. Drop the
+    // last reading too: the cards and the traffic graph would else hold
+    // full-mode numbers that no longer move.
     if (!NodeModeProvider.runsLocalBackends) {
+      if (stats != null || error != null || bandwidthHistory.isNotEmpty) {
+        stats = null;
+        error = null;
+        bandwidthHistory = [];
+        notifyListeners();
+      }
       return;
     }
     if (!bitwindowd.connected || _isFetching) {

--- a/bitwindow/lib/providers/network_provider.dart
+++ b/bitwindow/lib/providers/network_provider.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:sidechain_core/env.dart';
+import 'package:sidechain_core/sidechain_core.dart';
 import 'package:sail_ui/sail_ui.dart';
 
 class NetworkProvider extends ChangeNotifier {
@@ -28,6 +29,10 @@ class NetworkProvider extends ChangeNotifier {
   }
 
   Future<void> fetch() async {
+    // Light mode runs no local Bitcoin Core, and these stats read it.
+    if (!NodeModeProvider.runsLocalBackends) {
+      return;
+    }
     if (!bitwindowd.connected || _isFetching) {
       return;
     }

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -1310,6 +1310,13 @@ func (s *Server) GetMiningStatus(ctx context.Context, req *connect.Request[empty
 }
 
 func (s *Server) GetNetworkStats(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[pb.GetNetworkStatsResponse], error) {
+	// Light mode runs no local Bitcoin Core. Answer before the dial, so the
+	// caller gets one clear reason instead of a connection error each tick.
+	if !s.walletEngine.NodeMode().RunsLocalNode(ctx) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("network stats need full mode, which runs a local Bitcoin node"))
+	}
+
 	// Fetch blockchain info
 	blockchainInfo, err := s.data.BlockchainInfo(ctx, &corepb.GetBlockchainInfoRequest{})
 	if err != nil {

--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -192,12 +192,14 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 	rt.timestampEngine = engines.NewTimestampEngine(rt.db, timestampLogger, walletAdapter, s.Bitcoind)
 	rt.m4Engine = engines.NewM4Engine(rt.db)
 	rt.notificationEngine = engines.NewNotificationEngine(rt.db, s.Bitcoind)
+	rt.notificationEngine.SetNodeMode(rt.walletEngine.NodeMode())
 	rt.bitdriveEngine = engines.NewBitDriveEngine(rt.db, rt.walletEngine, conf.Datadir, rt.chainParams)
 	rt.sidechainMonitor = engines.NewSidechainMonitorEngine(
 		s.Thunder, s.BitNames, s.BitAssets, s.Truthcoin, s.Photon, s.CoinShift,
 		rt.notificationEngine,
 	)
 	rt.bitcoinEngine = engines.NewBitcoind(s.Bitcoind, rt.db, conf)
+	rt.bitcoinEngine.SetNodeMode(rt.walletEngine.NodeMode())
 
 	// Coinnews dedicated log lives next to the main server log. Path is
 	// derived from conf.LogPath which is also network-scoped (Finalize
@@ -408,9 +410,22 @@ func (rt *Runtime) runZMQ(ctx context.Context, log *zerolog.Logger) {
 	const maxAttempts = 20
 	var zmqEngine *engines.ZMQ
 
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	for attempt := 0; attempt < maxAttempts; {
+		// Light mode runs no local Bitcoin Core, so there is no ZMQ endpoint
+		// to dial. Wait for a switch to full mode instead of spending the
+		// attempts on a daemon that is not there.
+		if !rt.walletEngine.NodeMode().RunsLocalNode(ctx) {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
+			}
+			continue
+		}
+
 		eng, err := dialZmqEngine(ctx, rt.conf)
 		if err != nil {
+			attempt++
 			if connect.CodeOf(err) == connect.CodeUnavailable || strings.Contains(err.Error(), "connection refused") {
 				log.Debug().Msg("ZMQ engine: waiting for Bitcoin Core connection")
 			} else {

--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -190,6 +190,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 	walletAdapter := engines.NewWalletAdapter(rt.walletEngine)
 	timestampLogger := log.With().Str("component", "timestamp").Logger()
 	rt.timestampEngine = engines.NewTimestampEngine(rt.db, timestampLogger, walletAdapter, s.Bitcoind)
+	rt.timestampEngine.SetNodeMode(rt.walletEngine.NodeMode())
 	rt.m4Engine = engines.NewM4Engine(rt.db)
 	rt.notificationEngine = engines.NewNotificationEngine(rt.db, s.Bitcoind)
 	rt.notificationEngine.SetNodeMode(rt.walletEngine.NodeMode())

--- a/bitwindow/server/api/wallet/cheque_funding_test.go
+++ b/bitwindow/server/api/wallet/cheque_funding_test.go
@@ -31,6 +31,16 @@ type fakeOrchestrator struct {
 	calls   atomic.Int32
 }
 
+// The pollers ask before each tick. A full-mode answer keeps them running,
+// which is what these tests exercise.
+func (f *fakeOrchestrator) GetNodeMode(
+	_ context.Context, _ *connect.Request[orchpb.GetNodeModeRequest],
+) (*connect.Response[orchpb.GetNodeModeResponse], error) {
+	return connect.NewResponse(&orchpb.GetNodeModeResponse{
+		Mode: orchpb.NodeMode_NODE_MODE_FULL,
+	}), nil
+}
+
 // Seeds come from the local wallet file in tests, so refuse here and let the
 // engine fall through.
 func (f *fakeOrchestrator) GetWalletSeed(

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -93,7 +93,7 @@ func (p *Parser) Run(ctx context.Context) error {
 
 		case <-reapTicker.C:
 			if p.nodeMode.RunsLocalNode(ctx) {
-				p.reapExpiredMempool(ctx)
+				p.sweepMempool(ctx)
 			}
 
 		case <-alertTicker.C:
@@ -101,8 +101,9 @@ func (p *Parser) Run(ctx context.Context) error {
 				continue
 			}
 			if !sweptOnStart {
-				sweptOnStart = true
-				p.reapExpiredMempool(ctx)
+				// Bitcoin Core can still boot when the mode reads full. Mark
+				// the sweep done only once it reaches the mempool.
+				sweptOnStart = p.sweepMempool(ctx)
 			}
 
 			zerolog.Ctx(ctx).Trace().
@@ -123,9 +124,19 @@ func (p *Parser) Run(ctx context.Context) error {
 	}
 }
 
-// reapExpiredMempool drops unconfirmed OP_RETURNs that can no longer
-// confirm. Best-effort: a failed sweep is retried on the next tick.
-func (p *Parser) reapExpiredMempool(ctx context.Context) {
+// sweepMempool drops expired unconfirmed OP_RETURNs and reports whether it
+// finished, so the caller can try again. A failure means Bitcoin Core is
+// unreachable, which the block tick reports on the same cadence.
+func (p *Parser) sweepMempool(ctx context.Context) bool {
+	if err := p.reapExpiredMempool(ctx); err != nil {
+		zerolog.Ctx(ctx).Debug().Err(err).Msg("could not reap expired mempool OP_RETURNs")
+		return false
+	}
+	return true
+}
+
+// reapExpiredMempool drops unconfirmed OP_RETURNs that can no longer confirm.
+func (p *Parser) reapExpiredMempool(ctx context.Context) error {
 	mempoolTxIDs := func() ([]string, error) {
 		bitcoind, err := p.bitcoind.Get(ctx)
 		if err != nil {
@@ -137,9 +148,7 @@ func (p *Parser) reapExpiredMempool(ctx context.Context) {
 		}
 		return res.Msg.Txids, nil
 	}
-	if err := opreturns.ReapExpiredMempool(ctx, p.db, mempoolTxIDs); err != nil {
-		zerolog.Ctx(ctx).Err(err).Msgf("unable to reap expired mempool OP_RETURNs")
-	}
+	return opreturns.ReapExpiredMempool(ctx, p.db, mempoolTxIDs)
 }
 
 // BlockResult represents the result of processing a single block

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -48,9 +48,16 @@ type Parser struct {
 	conf     config.Config
 
 	m4Engine *M4Engine
+	nodeMode *NodeMode
 
 	// Dedicated sink for coinnews sync events. Nil => logging disabled.
 	coinnewsLog *zerolog.Logger
+}
+
+// SetNodeMode gates the block tick on the node mode. Light mode runs no local
+// Bitcoin Core, so there is nothing to parse.
+func (p *Parser) SetNodeMode(nodeMode *NodeMode) {
+	p.nodeMode = nodeMode
 }
 
 // SetCoinnewsLogger attaches a dedicated logger for coinnews sync events.
@@ -71,7 +78,9 @@ func (p *Parser) Run(ctx context.Context) error {
 	// sessions are often shorter than the tick — and hourly after that.
 	reapTicker := time.NewTicker(time.Hour)
 	defer reapTicker.Stop()
-	p.reapExpiredMempool(ctx)
+	if p.nodeMode.RunsLocalNode(ctx) {
+		p.reapExpiredMempool(ctx)
+	}
 
 	zerolog.Ctx(ctx).Info().
 		Msgf("bitcoind_engine/parser: started parser ticker")
@@ -84,9 +93,14 @@ func (p *Parser) Run(ctx context.Context) error {
 			return nil
 
 		case <-reapTicker.C:
-			p.reapExpiredMempool(ctx)
+			if p.nodeMode.RunsLocalNode(ctx) {
+				p.reapExpiredMempool(ctx)
+			}
 
 		case <-alertTicker.C:
+			if !p.nodeMode.RunsLocalNode(ctx) {
+				continue
+			}
 
 			zerolog.Ctx(ctx).Trace().
 				Msgf("bitcoind_engine/parser: processing block tick")

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -74,13 +74,12 @@ func (p *Parser) Run(ctx context.Context) error {
 	alertTicker := time.NewTicker(2 * time.Second)
 	defer alertTicker.Stop()
 
-	// Unconfirmed OP_RETURNs never expire on their own. Sweep on start —
-	// sessions are often shorter than the tick — and hourly after that.
+	// Unconfirmed OP_RETURNs never expire on their own. Sweep on the first
+	// tick that reads full mode — sessions are often shorter than the hourly
+	// tick, and the orchestrator answers the mode a moment after boot.
 	reapTicker := time.NewTicker(time.Hour)
 	defer reapTicker.Stop()
-	if p.nodeMode.RunsLocalNode(ctx) {
-		p.reapExpiredMempool(ctx)
-	}
+	sweptOnStart := false
 
 	zerolog.Ctx(ctx).Info().
 		Msgf("bitcoind_engine/parser: started parser ticker")
@@ -100,6 +99,10 @@ func (p *Parser) Run(ctx context.Context) error {
 		case <-alertTicker.C:
 			if !p.nodeMode.RunsLocalNode(ctx) {
 				continue
+			}
+			if !sweptOnStart {
+				sweptOnStart = true
+				p.reapExpiredMempool(ctx)
 			}
 
 			zerolog.Ctx(ctx).Trace().

--- a/bitwindow/server/engines/export_test.go
+++ b/bitwindow/server/engines/export_test.go
@@ -1,0 +1,7 @@
+package engines
+
+// ExpireNodeModeCache drops the cached mode, so the next read reaches the
+// orchestrator. Tests use it in place of a clock.
+func ExpireNodeModeCache(n *NodeMode) {
+	n.expire()
+}

--- a/bitwindow/server/engines/light_mode_pollers_test.go
+++ b/bitwindow/server/engines/light_mode_pollers_test.go
@@ -74,3 +74,34 @@ func TestParserDoesNotDialBitcoinCoreInLightMode(t *testing.T) {
 func TestParserDialsBitcoinCoreInFullMode(t *testing.T) {
 	require.Positive(t, runParserFor(t, orchpb.NodeMode_NODE_MODE_FULL, 3*time.Second))
 }
+
+// Both notification watchers tick at ten seconds and both reach Bitcoin Core.
+// The two modes run at the same time, so the test costs one window.
+func TestNotificationEngineWatchesOnlyInFullMode(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		mode      orchpb.NodeMode
+		wantDials bool
+	}{
+		{name: "light mode dials nothing", mode: orchpb.NodeMode_NODE_MODE_LIGHT},
+		{name: "full mode still dials", mode: orchpb.NodeMode_NODE_MODE_FULL, wantDials: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var dials atomic.Int64
+			engine := engines.NewNotificationEngine(database.Test(t), countingBitcoind(&dials))
+			engine.SetNodeMode(nodeModeSource(t, tc.mode))
+
+			ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+			defer cancel()
+			_ = engine.Run(ctx)
+
+			if tc.wantDials {
+				require.Positive(t, dials.Load())
+			} else {
+				require.Zero(t, dials.Load())
+			}
+		})
+	}
+}

--- a/bitwindow/server/engines/light_mode_pollers_test.go
+++ b/bitwindow/server/engines/light_mode_pollers_test.go
@@ -1,0 +1,76 @@
+package engines_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/config"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// countingBitcoind reports how many times an engine reached for Bitcoin Core.
+func countingBitcoind(dials *atomic.Int64) *service.Service[corerpc.BitcoinServiceClient] {
+	return service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+		dials.Add(1)
+		return nil, context.Canceled
+	})
+}
+
+func nodeModeSource(t *testing.T, mode orchpb.NodeMode) *engines.NodeMode {
+	t.Helper()
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	client.EXPECT().
+		GetNodeMode(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Return(&connect.Response[orchpb.GetNodeModeResponse]{
+			Msg: &orchpb.GetNodeModeResponse{Mode: mode},
+		}, nil)
+
+	nodeMode := engines.NewNodeMode()
+	nodeMode.SetClient(client)
+	return nodeMode
+}
+
+func runParserFor(t *testing.T, mode orchpb.NodeMode, window time.Duration) int64 {
+	t.Helper()
+
+	var dials atomic.Int64
+	parser := engines.NewBitcoind(countingBitcoind(&dials), database.Test(t), config.Config{})
+	parser.SetNodeMode(nodeModeSource(t, mode))
+
+	ctx, cancel := context.WithTimeout(context.Background(), window)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- parser.Run(ctx) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(window + 5*time.Second):
+		t.Fatal("Run did not return after its context ended")
+	}
+	return dials.Load()
+}
+
+// A light-mode install runs no Bitcoin Core. Every tick that dialled one wrote
+// a "unable to handle block tick" error, twice a second, for the whole session.
+func TestParserDoesNotDialBitcoinCoreInLightMode(t *testing.T) {
+	require.Zero(t, runParserFor(t, orchpb.NodeMode_NODE_MODE_LIGHT, 3*time.Second))
+}
+
+// The same loop must still run in full mode. A gate that stops both modes
+// stops the block parser.
+func TestParserDialsBitcoinCoreInFullMode(t *testing.T) {
+	require.Positive(t, runParserFor(t, orchpb.NodeMode_NODE_MODE_FULL, 3*time.Second))
+}

--- a/bitwindow/server/engines/light_mode_pollers_test.go
+++ b/bitwindow/server/engines/light_mode_pollers_test.go
@@ -109,15 +109,18 @@ func TestNotificationEngineWatchesOnlyInFullMode(t *testing.T) {
 }
 
 // bitcoindWithMempool answers the reap and refuses the block tick, so only the
-// mempool sweep counts.
-func bitcoindWithMempool(t *testing.T, sweeps *atomic.Int64) *service.Service[corerpc.BitcoinServiceClient] {
+// mempool sweep counts. failFirst refuses the first sweep, the way Bitcoin Core
+// refuses every RPC while it loads its block index.
+func bitcoindWithMempool(t *testing.T, sweeps *atomic.Int64, failFirst bool) *service.Service[corerpc.BitcoinServiceClient] {
 	t.Helper()
 	client := mocks.NewMockBitcoinServiceClient(gomock.NewController(t))
 	client.EXPECT().
 		GetRawMempool(gomock.Any(), gomock.Any()).
 		AnyTimes().
 		DoAndReturn(func(context.Context, *connect.Request[corepb.GetRawMempoolRequest]) (*connect.Response[corepb.GetRawMempoolResponse], error) {
-			sweeps.Add(1)
+			if sweeps.Add(1) == 1 && failFirst {
+				return nil, errors.New("-28: Loading block index")
+			}
 			return connect.NewResponse(&corepb.GetRawMempoolResponse{}), nil
 		})
 	client.EXPECT().
@@ -159,7 +162,7 @@ func TestParserSweepsTheMempoolAfterTheModeRecovers(t *testing.T) {
 	require.NoError(t, err)
 
 	var sweeps atomic.Int64
-	parser := engines.NewBitcoind(bitcoindWithMempool(t, &sweeps), db, config.Config{})
+	parser := engines.NewBitcoind(bitcoindWithMempool(t, &sweeps, false), db, config.Config{})
 	parser.SetNodeMode(nodeMode)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
@@ -168,6 +171,32 @@ func TestParserSweepsTheMempoolAfterTheModeRecovers(t *testing.T) {
 
 	// Once, and once only — the hourly ticker never fires in this window.
 	require.Equal(t, int64(1), sweeps.Load())
+
+	var left int
+	require.NoError(t, db.QueryRow(`SELECT count(*) FROM op_returns`).Scan(&left))
+	require.Zero(t, left)
+}
+
+// Bitcoin Core can still load its block index when the mode reads full. A flag
+// set before the sweep marks it done, and the rows then wait an hour.
+func TestParserRetriesTheStartupSweepAfterCoreIsReady(t *testing.T) {
+	db := database.Test(t)
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO op_returns (txid, vout, op_return_data, fee_sats, height, created_at)
+		VALUES ('dead', 0, 'beef', 1, NULL, datetime('now', '-30 days'))
+	`)
+	require.NoError(t, err)
+
+	var sweeps atomic.Int64
+	parser := engines.NewBitcoind(bitcoindWithMempool(t, &sweeps, true), db, config.Config{})
+	parser.SetNodeMode(nodeModeSource(t, orchpb.NodeMode_NODE_MODE_FULL))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	defer cancel()
+	require.NoError(t, parser.Run(ctx))
+
+	// The first sweep fails, the next tick sweeps again, and the row goes.
+	require.Equal(t, int64(2), sweeps.Load())
 
 	var left int
 	require.NoError(t, db.QueryRow(`SELECT count(*) FROM op_returns`).Scan(&left))

--- a/bitwindow/server/engines/light_mode_pollers_test.go
+++ b/bitwindow/server/engines/light_mode_pollers_test.go
@@ -16,6 +16,7 @@ import (
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -201,4 +202,43 @@ func TestParserRetriesTheStartupSweepAfterCoreIsReady(t *testing.T) {
 	var left int
 	require.NoError(t, db.QueryRow(`SELECT count(*) FROM op_returns`).Scan(&left))
 	require.Zero(t, left)
+}
+
+// A light-mode user can still stamp a file through the Electrum wallet, and
+// the row then waits at "confirming". This watcher read Bitcoin Core for it
+// every ten seconds, and warned each time.
+func TestTimestampEngineWatchesOnlyInFullMode(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		mode      orchpb.NodeMode
+		wantDials bool
+	}{
+		{name: "light mode dials nothing", mode: orchpb.NodeMode_NODE_MODE_LIGHT},
+		{name: "full mode still dials", mode: orchpb.NodeMode_NODE_MODE_FULL, wantDials: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			db := database.Test(t)
+			_, err := db.ExecContext(context.Background(), `
+				INSERT INTO file_timestamps (filename, file_hash, txid, status)
+				VALUES ('note.txt', 'abc', 'dead', 'confirming')
+			`)
+			require.NoError(t, err)
+
+			var dials atomic.Int64
+			engine := engines.NewTimestampEngine(db, zerolog.Nop(), nil, countingBitcoind(&dials))
+			engine.SetNodeMode(nodeModeSource(t, tc.mode))
+
+			ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+			defer cancel()
+			_ = engine.Run(ctx)
+
+			if tc.wantDials {
+				require.Positive(t, dials.Load())
+			} else {
+				require.Zero(t, dials.Load())
+			}
+		})
+	}
 }

--- a/bitwindow/server/engines/light_mode_pollers_test.go
+++ b/bitwindow/server/engines/light_mode_pollers_test.go
@@ -2,6 +2,7 @@ package engines_test
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	corepb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
 	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -104,4 +106,70 @@ func TestNotificationEngineWatchesOnlyInFullMode(t *testing.T) {
 			}
 		})
 	}
+}
+
+// bitcoindWithMempool answers the reap and refuses the block tick, so only the
+// mempool sweep counts.
+func bitcoindWithMempool(t *testing.T, sweeps *atomic.Int64) *service.Service[corerpc.BitcoinServiceClient] {
+	t.Helper()
+	client := mocks.NewMockBitcoinServiceClient(gomock.NewController(t))
+	client.EXPECT().
+		GetRawMempool(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(context.Context, *connect.Request[corepb.GetRawMempoolRequest]) (*connect.Response[corepb.GetRawMempoolResponse], error) {
+			sweeps.Add(1)
+			return connect.NewResponse(&corepb.GetRawMempoolResponse{}), nil
+		})
+	client.EXPECT().
+		GetBlockHash(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Return(nil, errors.New("no chain in this test"))
+
+	return service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+		return client, nil
+	})
+}
+
+// bitwindowd starts the orchestrator, so the first mode read of a full-mode
+// install often fails. A sweep tied to that read waits a whole hour, and the
+// expired rows it drops sit in the table meanwhile.
+func TestParserSweepsTheMempoolAfterTheModeRecovers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	orch := mocks.NewMockWalletManagerServiceClient(ctrl)
+	gomock.InOrder(
+		orch.EXPECT().
+			GetNodeMode(gomock.Any(), gomock.Any()).
+			Return(nil, errors.New("orchestrator is starting")),
+		orch.EXPECT().
+			GetNodeMode(gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(&connect.Response[orchpb.GetNodeModeResponse]{
+				Msg: &orchpb.GetNodeModeResponse{Mode: orchpb.NodeMode_NODE_MODE_FULL},
+			}, nil),
+	)
+	nodeMode := engines.NewNodeMode()
+	nodeMode.SetClient(orch)
+
+	// The sweep reads the mempool only when an expired row waits for it.
+	db := database.Test(t)
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO op_returns (txid, vout, op_return_data, fee_sats, height, created_at)
+		VALUES ('dead', 0, 'beef', 1, NULL, datetime('now', '-30 days'))
+	`)
+	require.NoError(t, err)
+
+	var sweeps atomic.Int64
+	parser := engines.NewBitcoind(bitcoindWithMempool(t, &sweeps), db, config.Config{})
+	parser.SetNodeMode(nodeMode)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	defer cancel()
+	require.NoError(t, parser.Run(ctx))
+
+	// Once, and once only — the hourly ticker never fires in this window.
+	require.Equal(t, int64(1), sweeps.Load())
+
+	var left int
+	require.NoError(t, db.QueryRow(`SELECT count(*) FROM op_returns`).Scan(&left))
+	require.Zero(t, left)
 }

--- a/bitwindow/server/engines/node_mode.go
+++ b/bitwindow/server/engines/node_mode.go
@@ -63,21 +63,34 @@ func (n *NodeMode) Mode(ctx context.Context) (orchpb.NodeMode, error) {
 	return resp.Msg.Mode, nil
 }
 
-// RunsLocalNode reports whether a poller may talk to Bitcoin Core. Only a mode
-// that reads light stops it: an unreadable mode keeps the last known answer,
-// and an engine with no source has no mode to obey.
+// hasClient reports whether this source can reach the orchestrator at all.
+func (n *NodeMode) hasClient() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.client != nil
+}
+
+// lastKnown gives the mode of the last successful read.
+func (n *NodeMode) lastKnown() orchpb.NodeMode {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.cached
+}
+
+// RunsLocalNode reports whether a poller may talk to Bitcoin Core. Full mode
+// is the only mode that runs one: light mode starts no daemon, and an unpicked
+// mode starts nothing either while the welcome prompt waits for the user. An
+// unreadable mode keeps the last known answer, and an engine with no source
+// has no mode to obey.
 func (n *NodeMode) RunsLocalNode(ctx context.Context) bool {
-	if n == nil {
+	if n == nil || !n.hasClient() {
 		return true
 	}
 	mode, err := n.Mode(ctx)
-	if err == nil {
-		return mode != orchpb.NodeMode_NODE_MODE_LIGHT
+	if err != nil {
+		mode = n.lastKnown()
 	}
-
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	return n.cached != orchpb.NodeMode_NODE_MODE_LIGHT
+	return mode == orchpb.NodeMode_NODE_MODE_FULL
 }
 
 // expire drops the cached mode, so the next read reaches the orchestrator.

--- a/bitwindow/server/engines/node_mode.go
+++ b/bitwindow/server/engines/node_mode.go
@@ -1,0 +1,106 @@
+package engines
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"connectrpc.com/connect"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
+)
+
+// nodeModeTTL keeps a per-tick gate off the orchestrator. Engines tick each
+// second; the mode changes when the user picks a new one.
+const nodeModeTTL = 5 * time.Second
+
+// NodeMode answers one question for the whole server: does this install run a
+// local Bitcoin node? Every backend-dependent engine and RPC reads it here.
+type NodeMode struct {
+	client orchrpc.WalletManagerServiceClient
+
+	mu     sync.Mutex
+	cached orchpb.NodeMode
+	readAt time.Time
+}
+
+func NewNodeMode() *NodeMode {
+	return &NodeMode{}
+}
+
+func (n *NodeMode) SetClient(client orchrpc.WalletManagerServiceClient) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.client = client
+	n.cached = orchpb.NodeMode_NODE_MODE_UNSPECIFIED
+	n.readAt = time.Time{}
+}
+
+// Mode reads the mode the user picked. Repeat calls inside the TTL get the
+// cached answer.
+func (n *NodeMode) Mode(ctx context.Context) (orchpb.NodeMode, error) {
+	n.mu.Lock()
+	client := n.client
+	cached, readAt := n.cached, n.readAt
+	n.mu.Unlock()
+
+	if client == nil {
+		return orchpb.NodeMode_NODE_MODE_UNSPECIFIED, fmt.Errorf("orchestrator wallet client not connected")
+	}
+	if !readAt.IsZero() && time.Since(readAt) < nodeModeTTL {
+		return cached, nil
+	}
+
+	resp, err := client.GetNodeMode(ctx, connect.NewRequest(&orchpb.GetNodeModeRequest{}))
+	if err != nil {
+		return orchpb.NodeMode_NODE_MODE_UNSPECIFIED, err
+	}
+
+	n.mu.Lock()
+	n.cached, n.readAt = resp.Msg.Mode, time.Now()
+	n.mu.Unlock()
+	return resp.Msg.Mode, nil
+}
+
+// RunsLocalNode reports whether a poller may talk to Bitcoin Core. Only a mode
+// that reads light stops it: an unreadable mode keeps the last known answer,
+// and an engine with no source has no mode to obey.
+func (n *NodeMode) RunsLocalNode(ctx context.Context) bool {
+	if n == nil {
+		return true
+	}
+	mode, err := n.Mode(ctx)
+	if err == nil {
+		return mode != orchpb.NodeMode_NODE_MODE_LIGHT
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.cached != orchpb.NodeMode_NODE_MODE_LIGHT
+}
+
+// expire drops the cached mode, so the next read reaches the orchestrator.
+func (n *NodeMode) expire() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.readAt = time.Time{}
+}
+
+// RequireFullNode refuses an operation that needs a local Bitcoin node or the
+// BIP300/301 enforcer. Strict where RunsLocalNode is lenient: a caller that
+// cannot read the mode gets an error, not a guess. It also reads fresh — a
+// user who just picked full mode must not meet a cached refusal.
+func (n *NodeMode) RequireFullNode(ctx context.Context, op string) error {
+	n.expire()
+	mode, err := n.Mode(ctx)
+	if err != nil {
+		return connect.NewError(connect.CodeUnavailable,
+			fmt.Errorf("%s: could not read the node mode: %w", op, err))
+	}
+	if mode == orchpb.NodeMode_NODE_MODE_LIGHT {
+		return connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("%s needs full mode, which runs a local Bitcoin node and the enforcer", op))
+	}
+	return nil
+}

--- a/bitwindow/server/engines/node_mode.go
+++ b/bitwindow/server/engines/node_mode.go
@@ -9,6 +9,7 @@ import (
 	"connectrpc.com/connect"
 	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect"
+	"golang.org/x/sync/singleflight"
 )
 
 // nodeModeTTL keeps a per-tick gate off the orchestrator. Engines tick each
@@ -19,6 +20,10 @@ const nodeModeTTL = 5 * time.Second
 // local Bitcoin node? Every backend-dependent engine and RPC reads it here.
 type NodeMode struct {
 	client orchrpc.WalletManagerServiceClient
+
+	// One read at a time. Four pollers expire the cache together, and an
+	// older answer that lands last would else overwrite a newer one.
+	reads singleflight.Group
 
 	mu     sync.Mutex
 	cached orchpb.NodeMode
@@ -52,15 +57,21 @@ func (n *NodeMode) Mode(ctx context.Context) (orchpb.NodeMode, error) {
 		return cached, nil
 	}
 
-	resp, err := client.GetNodeMode(ctx, connect.NewRequest(&orchpb.GetNodeModeRequest{}))
+	read, err, _ := n.reads.Do("mode", func() (any, error) {
+		resp, err := client.GetNodeMode(ctx, connect.NewRequest(&orchpb.GetNodeModeRequest{}))
+		if err != nil {
+			return orchpb.NodeMode_NODE_MODE_UNSPECIFIED, err
+		}
+
+		n.mu.Lock()
+		n.cached, n.readAt = resp.Msg.Mode, time.Now()
+		n.mu.Unlock()
+		return resp.Msg.Mode, nil
+	})
 	if err != nil {
 		return orchpb.NodeMode_NODE_MODE_UNSPECIFIED, err
 	}
-
-	n.mu.Lock()
-	n.cached, n.readAt = resp.Msg.Mode, time.Now()
-	n.mu.Unlock()
-	return resp.Msg.Mode, nil
+	return read.(orchpb.NodeMode), nil
 }
 
 // hasClient reports whether this source can reach the orchestrator at all.

--- a/bitwindow/server/engines/node_mode_test.go
+++ b/bitwindow/server/engines/node_mode_test.go
@@ -1,0 +1,116 @@
+package engines_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	orchpb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func nodeModeWith(t *testing.T, mode orchpb.NodeMode, err error) *engines.NodeMode {
+	t.Helper()
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	client.EXPECT().
+		GetNodeMode(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Return(&connect.Response[orchpb.GetNodeModeResponse]{
+			Msg: &orchpb.GetNodeModeResponse{Mode: mode},
+		}, err)
+
+	nodeMode := engines.NewNodeMode()
+	nodeMode.SetClient(client)
+	return nodeMode
+}
+
+// The whole point of the gate: a light-mode install runs no Bitcoin Core, so
+// every poller must stop before it dials one.
+func TestRunsLocalNodeStopsOnLightMode(t *testing.T) {
+	nodeMode := nodeModeWith(t, orchpb.NodeMode_NODE_MODE_LIGHT, nil)
+	require.False(t, nodeMode.RunsLocalNode(context.Background()))
+}
+
+func TestRunsLocalNodeAllowsFullMode(t *testing.T) {
+	nodeMode := nodeModeWith(t, orchpb.NodeMode_NODE_MODE_FULL, nil)
+	require.True(t, nodeMode.RunsLocalNode(context.Background()))
+}
+
+// An engine with no source has no mode to obey. It keeps its old behaviour.
+func TestRunsLocalNodeAllowsANilSource(t *testing.T) {
+	var nodeMode *engines.NodeMode
+	require.True(t, nodeMode.RunsLocalNode(context.Background()))
+}
+
+// An orchestrator restart must not restart the pollers a light-mode user
+// stopped. The last known answer stands until a read succeeds.
+func TestRunsLocalNodeKeepsTheLastAnswer(t *testing.T) {
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	nodeMode := engines.NewNodeMode()
+	nodeMode.SetClient(client)
+
+	client.EXPECT().
+		GetNodeMode(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[orchpb.GetNodeModeResponse]{
+			Msg: &orchpb.GetNodeModeResponse{Mode: orchpb.NodeMode_NODE_MODE_LIGHT},
+		}, nil)
+	require.False(t, nodeMode.RunsLocalNode(context.Background()))
+
+	engines.ExpireNodeModeCache(nodeMode)
+	client.EXPECT().
+		GetNodeMode(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("orchestrator is restarting"))
+	require.False(t, nodeMode.RunsLocalNode(context.Background()))
+}
+
+// One read per TTL. Every engine ticks each second, and each tick asks.
+func TestModeCachesTheRead(t *testing.T) {
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	nodeMode := engines.NewNodeMode()
+	nodeMode.SetClient(client)
+
+	client.EXPECT().
+		GetNodeMode(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(&connect.Response[orchpb.GetNodeModeResponse]{
+			Msg: &orchpb.GetNodeModeResponse{Mode: orchpb.NodeMode_NODE_MODE_FULL},
+		}, nil)
+
+	for range 5 {
+		require.True(t, nodeMode.RunsLocalNode(context.Background()))
+	}
+}
+
+// A user who switches to full mode gets the pollers back without a restart.
+func TestModeReReadsAfterTheCacheExpires(t *testing.T) {
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	nodeMode := engines.NewNodeMode()
+	nodeMode.SetClient(client)
+
+	client.EXPECT().
+		GetNodeMode(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[orchpb.GetNodeModeResponse]{
+			Msg: &orchpb.GetNodeModeResponse{Mode: orchpb.NodeMode_NODE_MODE_LIGHT},
+		}, nil)
+	require.False(t, nodeMode.RunsLocalNode(context.Background()))
+
+	engines.ExpireNodeModeCache(nodeMode)
+	client.EXPECT().
+		GetNodeMode(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[orchpb.GetNodeModeResponse]{
+			Msg: &orchpb.GetNodeModeResponse{Mode: orchpb.NodeMode_NODE_MODE_FULL},
+		}, nil)
+	require.True(t, nodeMode.RunsLocalNode(context.Background()))
+}
+
+// A source with no client cannot answer, so a gated RPC must refuse.
+func TestRequireFullNodeNeedsAClient(t *testing.T) {
+	nodeMode := engines.NewNodeMode()
+	err := nodeMode.RequireFullNode(context.Background(), "proposing a sidechain")
+	require.Error(t, err)
+	require.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+}

--- a/bitwindow/server/engines/node_mode_test.go
+++ b/bitwindow/server/engines/node_mode_test.go
@@ -3,7 +3,9 @@ package engines_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/engines"
@@ -140,4 +142,37 @@ func TestRequireFullNodeNeedsAClient(t *testing.T) {
 	err := nodeMode.RequireFullNode(context.Background(), "proposing a sidechain")
 	require.Error(t, err)
 	require.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+}
+
+// Four pollers expire the cache together. One read serves them all, and an
+// older answer cannot land last and overwrite a newer one.
+func TestModeCollapsesConcurrentReads(t *testing.T) {
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	nodeMode := engines.NewNodeMode()
+	nodeMode.SetClient(client)
+
+	client.EXPECT().
+		GetNodeMode(gomock.Any(), gomock.Any()).
+		Times(1).
+		DoAndReturn(func(context.Context, *connect.Request[orchpb.GetNodeModeRequest]) (*connect.Response[orchpb.GetNodeModeResponse], error) {
+			time.Sleep(100 * time.Millisecond)
+			return &connect.Response[orchpb.GetNodeModeResponse]{
+				Msg: &orchpb.GetNodeModeResponse{Mode: orchpb.NodeMode_NODE_MODE_FULL},
+			}, nil
+		})
+
+	var wg sync.WaitGroup
+	answers := make([]bool, 4)
+	for i := range answers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			answers[i] = nodeMode.RunsLocalNode(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	for i, answer := range answers {
+		require.Truef(t, answer, "reader %d read the wrong mode", i)
+	}
 }

--- a/bitwindow/server/engines/node_mode_test.go
+++ b/bitwindow/server/engines/node_mode_test.go
@@ -40,6 +40,13 @@ func TestRunsLocalNodeAllowsFullMode(t *testing.T) {
 	require.True(t, nodeMode.RunsLocalNode(context.Background()))
 }
 
+// A fresh install reads an unpicked mode until the user chooses, and it starts
+// no daemon meanwhile. Polling there dials a Bitcoin Core that is not there.
+func TestRunsLocalNodeStopsOnAnUnpickedMode(t *testing.T) {
+	nodeMode := nodeModeWith(t, orchpb.NodeMode_NODE_MODE_UNSPECIFIED, nil)
+	require.False(t, nodeMode.RunsLocalNode(context.Background()))
+}
+
 // An engine with no source has no mode to obey. It keeps its old behaviour.
 func TestRunsLocalNodeAllowsANilSource(t *testing.T) {
 	var nodeMode *engines.NodeMode
@@ -65,6 +72,26 @@ func TestRunsLocalNodeKeepsTheLastAnswer(t *testing.T) {
 		GetNodeMode(gomock.Any(), gomock.Any()).
 		Return(nil, errors.New("orchestrator is restarting"))
 	require.False(t, nodeMode.RunsLocalNode(context.Background()))
+}
+
+// A full-mode install keeps its pollers through an orchestrator restart.
+func TestRunsLocalNodeKeepsAFullAnswer(t *testing.T) {
+	client := mocks.NewMockWalletManagerServiceClient(gomock.NewController(t))
+	nodeMode := engines.NewNodeMode()
+	nodeMode.SetClient(client)
+
+	client.EXPECT().
+		GetNodeMode(gomock.Any(), gomock.Any()).
+		Return(&connect.Response[orchpb.GetNodeModeResponse]{
+			Msg: &orchpb.GetNodeModeResponse{Mode: orchpb.NodeMode_NODE_MODE_FULL},
+		}, nil)
+	require.True(t, nodeMode.RunsLocalNode(context.Background()))
+
+	engines.ExpireNodeModeCache(nodeMode)
+	client.EXPECT().
+		GetNodeMode(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("orchestrator is restarting"))
+	require.True(t, nodeMode.RunsLocalNode(context.Background()))
 }
 
 // One read per TTL. Every engine ticks each second, and each tick asks.

--- a/bitwindow/server/engines/notification_engine.go
+++ b/bitwindow/server/engines/notification_engine.go
@@ -35,8 +35,8 @@ type NotificationEngine struct {
 	subscribers []chan *notificationv1.WatchResponse
 }
 
-// SetNodeMode gates the wallet-transaction watch on the node mode. Light mode
-// runs no local Bitcoin Core, so there are no core wallets to read.
+// SetNodeMode gates both watches on the node mode. Light mode runs no local
+// Bitcoin Core, so there are no core wallets and no confirmations to read.
 func (e *NotificationEngine) SetNodeMode(nodeMode *NodeMode) {
 	e.nodeMode = nodeMode
 }
@@ -77,6 +77,9 @@ func (e *NotificationEngine) watchTimestamps(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			if !e.nodeMode.RunsLocalNode(ctx) {
+				continue
+			}
 			if err := e.checkTimestampConfirmations(ctx); err != nil {
 				log.Warn().Err(err).Msg("check timestamp confirmations")
 			}

--- a/bitwindow/server/engines/notification_engine.go
+++ b/bitwindow/server/engines/notification_engine.go
@@ -29,9 +29,16 @@ const notificationBacklog = 24 * time.Hour
 type NotificationEngine struct {
 	db       *sql.DB
 	bitcoind *service.Service[corerpc.BitcoinServiceClient]
+	nodeMode *NodeMode
 
 	mu          sync.RWMutex
 	subscribers []chan *notificationv1.WatchResponse
+}
+
+// SetNodeMode gates the wallet-transaction watch on the node mode. Light mode
+// runs no local Bitcoin Core, so there are no core wallets to read.
+func (e *NotificationEngine) SetNodeMode(nodeMode *NodeMode) {
+	e.nodeMode = nodeMode
 }
 
 func NewNotificationEngine(
@@ -174,6 +181,9 @@ func (e *NotificationEngine) watchWalletTransactions(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			if !e.nodeMode.RunsLocalNode(ctx) {
+				continue
+			}
 			if err := e.checkWalletTransactions(ctx); err != nil {
 				// Connection errors during startup are expected, log at debug level
 				if connect.CodeOf(err) == connect.CodeUnavailable || strings.Contains(err.Error(), "connection refused") {

--- a/bitwindow/server/engines/timestamp_engine.go
+++ b/bitwindow/server/engines/timestamp_engine.go
@@ -61,6 +61,13 @@ type TimestampEngine struct {
 	log      zerolog.Logger
 	wallet   WalletService
 	bitcoind *service.Service[corerpc.BitcoinServiceClient]
+	nodeMode *NodeMode
+}
+
+// SetNodeMode gates the confirmation watch on the node mode. Light mode runs no
+// local Bitcoin Core, so it holds no confirmations to read.
+func (e *TimestampEngine) SetNodeMode(nodeMode *NodeMode) {
+	e.nodeMode = nodeMode
 }
 
 // WalletService interface for sending transactions
@@ -94,6 +101,9 @@ func (e *TimestampEngine) Run(ctx context.Context) error {
 			e.log.Info().Msg("timestamp engine stopped")
 			return ctx.Err()
 		case <-ticker.C:
+			if !e.nodeMode.RunsLocalNode(ctx) {
+				continue
+			}
 			if err := e.checkConfirmations(ctx); err != nil {
 				e.log.Warn().Err(err).Msg("check confirmations")
 			}

--- a/bitwindow/server/engines/wallet_engine.go
+++ b/bitwindow/server/engines/wallet_engine.go
@@ -78,6 +78,9 @@ type WalletEngine struct {
 	// Orchestrator client — when set, core wallet operations delegate here
 	orchClient orchrpc.WalletManagerServiceClient
 
+	// The one node-mode source every poller and gated RPC reads.
+	nodeMode *NodeMode
+
 	// Unlocked wallet state (in memory)
 	mu             sync.RWMutex
 	seedHex        string
@@ -120,6 +123,7 @@ func NewWalletEngine(
 		isUnlocked:        false,
 		coreWallets:       make(map[string]string),
 		walletCache:       make(map[string]*WalletInfo),
+		nodeMode:          NewNodeMode(),
 	}
 	e.unlockCond = sync.NewCond(&e.mu)
 
@@ -142,6 +146,12 @@ func NewWalletEngine(
 // When set, core wallet operations delegate to the orchestrator.
 func (e *WalletEngine) SetOrchestratorClient(client orchrpc.WalletManagerServiceClient) {
 	e.orchClient = client
+	e.nodeMode.SetClient(client)
+}
+
+// NodeMode hands out the shared node-mode source.
+func (e *WalletEngine) NodeMode() *NodeMode {
+	return e.nodeMode
 }
 
 // ============================================================================
@@ -843,20 +853,7 @@ func (e *WalletEngine) FinalizePsbt(ctx context.Context, psbtBase64 string) (str
 // RequireFullNode refuses an operation that needs a local BIP300/301 enforcer.
 // Light mode runs no daemon, so the operation cannot work there.
 func (e *WalletEngine) RequireFullNode(ctx context.Context, op string) error {
-	if e.orchClient == nil {
-		return connect.NewError(connect.CodeUnavailable,
-			fmt.Errorf("%s: orchestrator wallet client not connected", op))
-	}
-	resp, err := e.orchClient.GetNodeMode(ctx, connect.NewRequest(&orchpb.GetNodeModeRequest{}))
-	if err != nil {
-		return connect.NewError(connect.CodeUnavailable,
-			fmt.Errorf("%s: could not read the node mode: %w", op, err))
-	}
-	if resp.Msg.Mode == orchpb.NodeMode_NODE_MODE_LIGHT {
-		return connect.NewError(connect.CodeFailedPrecondition,
-			fmt.Errorf("%s needs full mode, which runs a local Bitcoin node and the enforcer", op))
-	}
-	return nil
+	return e.nodeMode.RequireFullNode(ctx, op)
 }
 
 // BroadcastOpReturn publishes raw OP_RETURN data through the active wallet's

--- a/bitwindow/test/light_mode_polling_test.dart
+++ b/bitwindow/test/light_mode_polling_test.dart
@@ -1,0 +1,65 @@
+import 'package:bitwindow/providers/network_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+import 'package:sidechain_core/sidechain_core.dart';
+
+import 'mocks/api_mock.dart';
+
+class _CountingBitwindowdAPI extends MockBitwindowdAPI {
+  int statsCalls = 0;
+
+  @override
+  Future<GetNetworkStatsResponse> getNetworkStats() async {
+    statsCalls++;
+    return GetNetworkStatsResponse();
+  }
+}
+
+class _CountingAPI extends MockAPI {
+  _CountingAPI() : super(binaryType: BinaryType.BINARY_TYPE_BITWINDOWD);
+
+  final _CountingBitwindowdAPI api = _CountingBitwindowdAPI();
+
+  @override
+  BitwindowAPI get bitwindowd => api;
+}
+
+void main() {
+  late _CountingAPI rpc;
+
+  Future<void> boot(wmpb.NodeMode mode) async {
+    await GetIt.I.reset();
+    GetIt.I.registerSingleton<Logger>(Logger(level: Level.off));
+    rpc = _CountingAPI();
+    rpc.connected = true;
+    GetIt.I.registerSingleton<BitwindowRPC>(rpc);
+    GetIt.I.registerSingleton<NodeModeProvider>(NodeModeProvider()..mode = mode);
+  }
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  // Network stats read Bitcoin Core. A light-mode install runs none, so each
+  // poll wrote an error to both logs every five seconds.
+  test('network stats do not poll in light mode', () async {
+    await boot(wmpb.NodeMode.NODE_MODE_LIGHT);
+
+    final provider = NetworkProvider();
+    await provider.fetch();
+
+    expect(rpc.api.statsCalls, 0);
+    expect(provider.error, isNull);
+  });
+
+  test('network stats poll in full mode', () async {
+    await boot(wmpb.NodeMode.NODE_MODE_FULL);
+
+    final provider = NetworkProvider();
+    await provider.fetch();
+
+    expect(rpc.api.statsCalls, greaterThan(0));
+  });
+}

--- a/bitwindow/test/light_mode_polling_test.dart
+++ b/bitwindow/test/light_mode_polling_test.dart
@@ -54,6 +54,22 @@ void main() {
     expect(provider.error, isNull);
   });
 
+  // A switch to light mode leaves the last reading on the cards and in the
+  // traffic graph, where the numbers no longer move.
+  test('a skipped poll drops the old network stats', () async {
+    await boot(wmpb.NodeMode.NODE_MODE_FULL);
+    final provider = NetworkProvider();
+    await provider.fetch();
+    expect(provider.stats, isNotNull);
+
+    GetIt.I.get<NodeModeProvider>().mode = wmpb.NodeMode.NODE_MODE_LIGHT;
+    await provider.fetch();
+
+    expect(provider.stats, isNull);
+    expect(provider.error, isNull);
+    expect(provider.bandwidthHistory, isEmpty);
+  });
+
   test('network stats poll in full mode', () async {
     await boot(wmpb.NodeMode.NODE_MODE_FULL);
 

--- a/sidechain_core/lib/providers/sync_provider.dart
+++ b/sidechain_core/lib/providers/sync_provider.dart
@@ -381,7 +381,16 @@ class SyncProvider extends ChangeNotifier implements NetworkScoped {
       }
     }
 
-    if (bitwindowFuture != null) {
+    if (bitwindowFuture == null) {
+      // A skipped poll leaves the last snapshot behind. An unsynced one holds
+      // the aggressive cadence at 100 ms for the rest of the session, and the
+      // daemon card keeps full-mode progress that no longer moves.
+      if (bitwindowdSyncInfo != null || bitwindowdError != null) {
+        bitwindowdSyncInfo = null;
+        bitwindowdError = null;
+        changed = true;
+      }
+    } else {
       final result = await bitwindowFuture;
       final info = result.info;
       if (info != null) {

--- a/sidechain_core/lib/providers/sync_provider.dart
+++ b/sidechain_core/lib/providers/sync_provider.dart
@@ -9,6 +9,9 @@ import 'package:sidechain_core/gen/google/protobuf/timestamp.pb.dart';
 import 'package:sidechain_core/gen/orchestrator/v1/orchestrator.pb.dart' as orch_pb;
 import 'package:sidechain_core/sidechain_core.dart';
 
+/// One bitwindowd sync poll: the reply, or the reason it failed.
+typedef _BitwindowSync = ({GetSyncInfoResponse? info, String? error});
+
 /// Detailed sync info for one chain. progressCurrent / progressGoal are
 /// chain heights — download progress lives in [DownloadProvider], not here.
 class SyncInfo {
@@ -294,9 +297,20 @@ class SyncProvider extends ChangeNotifier implements NetworkScoped {
     // GetSyncStatus skips it and we hit bitwindowd ourselves. The check is
     // by GetIt registration — every non-bitwindow app skips the second
     // poll automatically because BitwindowRPC isn't wired in.
+    //
+    // Light mode runs no local Bitcoin Core, so the bitwindowd card reads a
+    // daemon that is not there. Skip the second poll there.
     final orchFuture = _orchestrator.getSyncStatus();
-    final BitwindowRPC? bitwindowRpc = GetIt.I.isRegistered<BitwindowRPC>() ? GetIt.I.get<BitwindowRPC>() : null;
-    final bitwindowFuture = bitwindowRpc?.bitwindowd.getSyncInfo();
+    final bitwindowRpc = GetIt.I.isRegistered<BitwindowRPC>() && NodeModeProvider.runsLocalBackends
+        ? GetIt.I.get<BitwindowRPC>()
+        : null;
+    // The handler goes on at creation. Attaching it after the orchestrator
+    // await lets a failure land while nothing listens, and the zone then
+    // reports it as an unhandled error.
+    final bitwindowFuture = bitwindowRpc?.bitwindowd.getSyncInfo().then<_BitwindowSync>(
+      (info) => (info: info, error: null),
+      onError: (Object e) => (info: null, error: extractConnectException(e)),
+    );
 
     orch_pb.GetSyncStatusResponse? resp;
     String? orchErr;
@@ -368,8 +382,9 @@ class SyncProvider extends ChangeNotifier implements NetworkScoped {
     }
 
     if (bitwindowFuture != null) {
-      try {
-        final info = await bitwindowFuture;
+      final result = await bitwindowFuture;
+      final info = result.info;
+      if (info != null) {
         final next = SyncInfo(
           progressCurrent: info.tipBlockHeight.toDouble(),
           progressGoal: info.headerHeight.toDouble(),
@@ -380,12 +395,9 @@ class SyncProvider extends ChangeNotifier implements NetworkScoped {
           bitwindowdError = null;
           changed = true;
         }
-      } catch (e) {
-        final err = extractConnectException(e);
-        if (bitwindowdError != err) {
-          bitwindowdError = err;
-          changed = true;
-        }
+      } else if (bitwindowdError != result.error) {
+        bitwindowdError = result.error;
+        changed = true;
       }
     }
 

--- a/sidechain_core/test/sync_provider_light_mode_test.dart
+++ b/sidechain_core/test/sync_provider_light_mode_test.dart
@@ -1,0 +1,92 @@
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sidechain_core/gen/orchestrator/v1/orchestrator.pb.dart' as orch_pb;
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+import 'package:sidechain_core/sidechain_core.dart';
+
+class _FakeOrchestrator implements OrchestratorRPC {
+  @override
+  Future<orch_pb.GetSyncStatusResponse> getSyncStatus() async => orch_pb.GetSyncStatusResponse();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeBitwindow implements BitwindowRPC {
+  int syncInfoCalls = 0;
+
+  @override
+  BitwindowAPI get bitwindowd => _FakeBitwindowd(this);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeBitwindowd implements BitwindowAPI {
+  _FakeBitwindowd(this.parent);
+
+  final _FakeBitwindow parent;
+
+  @override
+  Future<GetSyncInfoResponse> getSyncInfo() async {
+    parent.syncInfoCalls++;
+    return GetSyncInfoResponse(tipBlockHeight: Int64(1), headerHeight: Int64(10));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late _FakeBitwindow bitwindow;
+
+  Future<SyncProvider> boot(wmpb.NodeMode mode) async {
+    await GetIt.I.reset();
+    GetIt.I.registerSingleton<Logger>(Logger(level: Level.off));
+    GetIt.I.registerSingleton<OrchestratorRPC>(_FakeOrchestrator());
+    bitwindow = _FakeBitwindow();
+    GetIt.I.registerSingleton<BitwindowRPC>(bitwindow);
+    GetIt.I.registerSingleton<NodeModeProvider>(NodeModeProvider()..mode = mode);
+    return SyncProvider(startTimer: false);
+  }
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  // The bitwindowd card reads Bitcoin Core through bitwindowd, and light mode
+  // runs neither. Each poll wrote an error to both logs.
+  test('the bitwindowd poll stops in light mode', () async {
+    final provider = await boot(wmpb.NodeMode.NODE_MODE_LIGHT);
+
+    await provider.fetch();
+
+    expect(bitwindow.syncInfoCalls, 0);
+  });
+
+  // A switch to light mode leaves the last snapshot behind. An unsynced one
+  // holds the poll at 100 ms for the rest of the session.
+  test('a skipped poll drops the old bitwindowd snapshot', () async {
+    final provider = await boot(wmpb.NodeMode.NODE_MODE_LIGHT);
+    provider.bitwindowdSyncInfo = SyncInfo(progressCurrent: 1, progressGoal: 10, lastBlockAt: null);
+    provider.bitwindowdError = 'stale';
+
+    expect(SyncProvider.connectionWantsAggressivePoll(provider.bitwindowdSyncInfo, null), isTrue);
+
+    await provider.fetch();
+
+    expect(provider.bitwindowdSyncInfo, isNull);
+    expect(provider.bitwindowdError, isNull);
+  });
+
+  test('the bitwindowd poll runs in full mode', () async {
+    final provider = await boot(wmpb.NodeMode.NODE_MODE_FULL);
+
+    await provider.fetch();
+
+    expect(bitwindow.syncInfoCalls, 1);
+    expect(provider.bitwindowdSyncInfo, isNotNull);
+  });
+}


### PR DESCRIPTION
Light mode runs no local Bitcoin Core, but the block parser, the notification watcher, the ZMQ dialer and the network-stats poll kept dialing one. Each tick wrote an error, twice a second, for the whole session.

One node-mode source now answers for the whole server, and every poller reads it before it dials. The Flutter side reads the mode it already has, and the sync poll attaches its error handler at creation so a failure no longer lands as an unhandled error.