### PR TITLE
Address book layout and a collapsible fee graph

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -25,7 +25,7 @@ jobs:
     name: ${{ matrix.package }}
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: true
       matrix:

--- a/bitwindow/lib/pages/wallet/wallet_send.dart
+++ b/bitwindow/lib/pages/wallet/wallet_send.dart
@@ -383,8 +383,17 @@ class FeeCard extends ViewModelWidget<SendPageViewModel> {
 
   @override
   Widget build(BuildContext context, SendPageViewModel viewModel) {
+    final hasGraph = viewModel.feeRatePoints.isNotEmpty || viewModel.loadingFeeRates;
+
     return SailCard(
       title: 'Fee',
+      widgetHeaderEnd: hasGraph
+          ? SailButton(
+              label: viewModel.showFeeGraph ? 'Hide graph' : 'Show graph',
+              variant: ButtonVariant.ghost,
+              onPressed: () async => viewModel.toggleFeeGraph(),
+            )
+          : null,
       child: SailColumn(
         spacing: SailStyleValues.padding12,
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -414,19 +423,20 @@ class FeeCard extends ViewModelWidget<SendPageViewModel> {
               ],
             ),
           ),
-          if (viewModel.feeRatePoints.isNotEmpty)
-            FeeRateChart(
-              points: viewModel.feeRatePoints,
-              selectedConfTarget: viewModel.selectedConfTarget,
-              onSelected: viewModel.selectFeeRatePoint,
-            )
-          else if (viewModel.loadingFeeRates)
-            SizedBox(
-              height: 180,
-              child: Center(
-                child: SailCircularProgressIndicator(color: context.sailTheme.colors.text),
+          if (viewModel.showFeeGraph)
+            if (viewModel.feeRatePoints.isNotEmpty)
+              FeeRateChart(
+                points: viewModel.feeRatePoints,
+                selectedConfTarget: viewModel.selectedConfTarget,
+                onSelected: viewModel.selectFeeRatePoint,
+              )
+            else if (viewModel.loadingFeeRates)
+              SizedBox(
+                height: feeRateChartHeight,
+                child: Center(
+                  child: SailCircularProgressIndicator(color: context.sailTheme.colors.text),
+                ),
               ),
-            ),
           SailColumn(
             spacing: SailStyleValues.padding04,
             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -560,6 +570,12 @@ class SendPageViewModel extends BaseViewModel {
   List<FeeRatePoint> feeRatePoints = [];
   int? selectedConfTarget;
   bool loadingFeeRates = false;
+  bool showFeeGraph = false;
+
+  void toggleFeeGraph() {
+    showFeeGraph = !showFeeGraph;
+    notifyListeners();
+  }
 
   void _onRecipientChanged() {
     notifyListeners();

--- a/bitwindow/lib/pages/wallet/widgets/fee_rate_chart.dart
+++ b/bitwindow/lib/pages/wallet/widgets/fee_rate_chart.dart
@@ -4,6 +4,8 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/widgets.dart';
 import 'package:sail_ui/sail_ui.dart';
 
+const double feeRateChartHeight = 140;
+
 class FeeRateChart extends StatelessWidget {
   final List<FeeRatePoint> points;
   final int? selectedConfTarget;
@@ -38,7 +40,7 @@ class FeeRateChart extends StatelessWidget {
         : points.indexWhere((p) => p.confTarget == selectedConfTarget);
 
     return SizedBox(
-      height: 180,
+      height: feeRateChartHeight,
       child: LineChart(
         LineChartData(
           gridData: FlGridData(

--- a/bitwindow/lib/widgets/address_list.dart
+++ b/bitwindow/lib/widgets/address_list.dart
@@ -11,6 +11,8 @@ import 'package:intl/intl.dart';
 import 'package:sail_ui/sail_ui.dart';
 import 'package:stacked/stacked.dart';
 
+const double actionsColumnWidth = 96;
+
 class AddressBookViewModel extends BaseViewModel {
   final AddressBookProvider _provider = GetIt.I.get<AddressBookProvider>();
   final TextEditingController labelController = TextEditingController();
@@ -293,28 +295,25 @@ class _AddressBookContentState extends State<AddressBookContent> {
       key: Key('address-book-$direction'),
       title: direction == Direction.DIRECTION_SEND ? 'Sending Addresses' : 'Receiving Addresses',
       subtitle: widget.viewModel.error('create') ?? widget.viewModel.error('edit') ?? widget.viewModel.error('delete'),
-      widgetHeaderEnd: Padding(
-        padding: const EdgeInsets.only(bottom: SailStyleValues.padding16),
-        child: SailRow(
-          spacing: SailStyleValues.padding08,
-          children: [
-            if (direction == Direction.DIRECTION_SEND)
-              SailButton(
-                label: 'Add New Sending Address',
-                onPressed: () async => _showCreateDialog(context),
-              ),
+      widgetHeaderEnd: SailRow(
+        spacing: SailStyleValues.padding08,
+        children: [
+          if (direction == Direction.DIRECTION_SEND)
             SailButton(
-              label: 'Import Labels',
-              variant: ButtonVariant.secondary,
-              onPressed: () async => widget.viewModel.importLabels(context),
+              label: 'Add Address',
+              onPressed: () async => _showCreateDialog(context),
             ),
-            SailButton(
-              label: 'Export Labels',
-              variant: ButtonVariant.secondary,
-              onPressed: () async => widget.viewModel.exportLabels(context),
-            ),
-          ],
-        ),
+          SailButton(
+            label: 'Import',
+            variant: ButtonVariant.outline,
+            onPressed: () async => widget.viewModel.importLabels(context),
+          ),
+          SailButton(
+            label: 'Export',
+            variant: ButtonVariant.outline,
+            onPressed: () async => widget.viewModel.exportLabels(context),
+          ),
+        ],
       ),
       bottomPadding: false,
       child: SailTable(
@@ -328,7 +327,10 @@ class _AddressBookContentState extends State<AddressBookContent> {
             name: 'Address',
             onSort: () => onSort('address'),
           ),
-          const SailTableHeaderCell(name: 'Actions'),
+          const SailTableHeaderCell(
+            name: 'Actions',
+            alignment: Alignment.centerRight,
+          ),
         ],
         rowBuilder: (context, row, selected) {
           final entry = widget.viewModel.entries[row];
@@ -346,20 +348,28 @@ class _AddressBookContentState extends State<AddressBookContent> {
             ),
             SailTableCell(
               value: 'Actions',
+              width: actionsColumnWidth,
+              alignment: Alignment.centerRight,
               child: SailRow(
-                spacing: SailStyleValues.padding08,
+                spacing: SailStyleValues.padding04,
                 children: [
-                  SailButton(
-                    label: 'Edit Label',
-                    variant: ButtonVariant.ghost,
-                    onPressed: () async => _showEditDialog(context, entry),
-                    insideTable: true,
+                  SailTooltip(
+                    message: 'Edit label',
+                    child: SailButton(
+                      variant: ButtonVariant.icon,
+                      icon: SailSVGAsset.iconPen,
+                      onPressed: () async => _showEditDialog(context, entry),
+                      insideTable: true,
+                    ),
                   ),
-                  SailButton(
-                    label: 'Delete',
-                    variant: ButtonVariant.destructive,
-                    onPressed: () async => _showDeleteConfirmation(context, entry),
-                    insideTable: true,
+                  SailTooltip(
+                    message: 'Delete address',
+                    child: SailButton(
+                      variant: ButtonVariant.icon,
+                      icon: SailSVGAsset.iconDelete,
+                      onPressed: () async => _showDeleteConfirmation(context, entry),
+                      insideTable: true,
+                    ),
                   ),
                 ],
               ),
@@ -367,7 +377,7 @@ class _AddressBookContentState extends State<AddressBookContent> {
           ];
         },
         rowCount: widget.viewModel.entries.length,
-        emptyPlaceholder: 'No addresses in address book',
+        emptyPlaceholder: 'No addresses yet',
         drawGrid: true,
         sortColumnIndex: ['label', 'address', 'actions'].indexOf(sortColumn),
         sortAscending: sortAscending,

--- a/bitwindow/test/address_book_table_test.dart
+++ b/bitwindow/test/address_book_table_test.dart
@@ -1,0 +1,97 @@
+import 'package:bitwindow/widgets/address_list.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized({
+    'flutter.test.automatic_wait_for_timers': 'false',
+  });
+
+  const entries = [
+    ['bb privat', 'bc1qjyeu20wv7yrwj6q96h5k7ewcc5v474n7yqv023'],
+    ['bb jalborgs', 'bc1qcq7hfsfal7alfyfhe04jcy3avyt2j8e988zdh0'],
+  ];
+
+  Widget addressTable({required double width}) {
+    return Center(
+      child: SizedBox(
+        width: width,
+        height: 300,
+        child: SailTable(
+          getRowId: (index) => '$index',
+          drawGrid: true,
+          headerBuilder: (context) => const [
+            SailTableHeaderCell(name: 'Label'),
+            SailTableHeaderCell(name: 'Address'),
+            SailTableHeaderCell(name: 'Actions', alignment: Alignment.centerRight),
+          ],
+          rowBuilder: (context, row, selected) => [
+            SailTableCell(value: entries[row][0], monospace: true),
+            SailTableCell(value: entries[row][1], monospace: true),
+            SailTableCell(
+              value: 'Actions',
+              width: actionsColumnWidth,
+              alignment: Alignment.centerRight,
+              child: SailRow(
+                spacing: SailStyleValues.padding04,
+                children: [
+                  SailButton(
+                    variant: ButtonVariant.icon,
+                    icon: SailSVGAsset.iconPen,
+                    onPressed: () async {},
+                    insideTable: true,
+                  ),
+                  SailButton(
+                    variant: ButtonVariant.icon,
+                    icon: SailSVGAsset.iconDelete,
+                    onPressed: () async {},
+                    insideTable: true,
+                  ),
+                ],
+              ),
+            ),
+          ],
+          rowCount: entries.length,
+        ),
+      ),
+    );
+  }
+
+  double renderedTableWidth(WidgetTester tester) {
+    final box = find
+        .descendant(
+          of: find.byType(SingleChildScrollView),
+          matching: find.byType(SizedBox),
+        )
+        .first;
+    return tester.getSize(box).width;
+  }
+
+  group('address book table', () {
+    testWidgets('fills its width and keeps the actions in their column', (tester) async {
+      await tester.pumpSailPage(addressTable(width: 900));
+      await tester.pumpAndSettle();
+
+      final actions = find
+          .descendant(
+            of: find.byType(SailTableCell).at(2),
+            matching: find.byType(SailRow),
+          )
+          .first;
+
+      expect(renderedTableWidth(tester), 900);
+      expect(tester.getSize(actions).width, lessThanOrEqualTo(actionsColumnWidth));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('does not stretch past the content when the box is narrow', (tester) async {
+      await tester.pumpSailPage(addressTable(width: 240));
+      await tester.pumpAndSettle();
+
+      expect(renderedTableWidth(tester), greaterThan(240));
+    });
+  });
+}

--- a/bitwindow/test/fee_graph_toggle_test.dart
+++ b/bitwindow/test/fee_graph_toggle_test.dart
@@ -1,0 +1,38 @@
+import 'package:bitwindow/pages/wallet/widgets/fee_rate_chart.dart';
+import 'package:bitwindow/utils/fee_estimation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized({
+    'flutter.test.automatic_wait_for_timers': 'false',
+  });
+
+  group('fee graph', () {
+    testWidgets('draws at the compact height', (tester) async {
+      final points = [
+        FeeRatePoint(confTarget: 1, satPerVByte: 1.2),
+        FeeRatePoint(confTarget: 6, satPerVByte: 1.0),
+        FeeRatePoint(confTarget: 144, satPerVByte: 0.3),
+      ];
+
+      await tester.pumpSailPage(
+        Center(
+          child: SizedBox(
+            width: 900,
+            child: FeeRateChart(
+              points: points,
+              selectedConfTarget: 1,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.getSize(find.byType(FeeRateChart)).height, feeRateChartHeight);
+    });
+  });
+}

--- a/sail_ui/lib/widgets/components/table.dart
+++ b/sail_ui/lib/widgets/components/table.dart
@@ -157,11 +157,7 @@ class _SailTableState extends State<SailTable> {
             constraints.maxWidth > 0 &&
             constraints.maxWidth != double.infinity) {
           _currentConstraints = constraints;
-          if (mounted) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              _resizeColumns(constraints.maxWidth, force: true);
-            });
-          }
+          _autoSizeColumns(constraints.maxWidth);
         }
 
         // Calculate total width including resize handles
@@ -334,6 +330,7 @@ class _SailTableState extends State<SailTable> {
     _widths.clear();
 
     final columnWidths = List<double>.filled(_numColumns!, 0);
+    final fixedColumns = List<bool>.filled(_numColumns!, false);
 
     final headers = widget.headerBuilder(context);
     for (int col = 0; col < headers.length; col++) {
@@ -352,7 +349,11 @@ class _SailTableState extends State<SailTable> {
     for (int row in rowsToSample) {
       final cells = widget.rowBuilder(context, row, false);
       for (int col = 0; col < cells.length && col < _numColumns!; col++) {
-        final cellWidth = _calculateColumnWidth(cells[col]);
+        final cell = cells[col];
+        if (cell is SailTableCell && cell.width != null) {
+          fixedColumns[col] = true;
+        }
+        final cellWidth = _calculateColumnWidth(cell);
         columnWidths[col] = max(columnWidths[col], cellWidth);
       }
     }
@@ -361,7 +362,37 @@ class _SailTableState extends State<SailTable> {
       columnWidths[i] = max(columnWidths[i], defaultMinColumnWidth);
     }
 
+    _stretchToFill(columnWidths, fixedColumns, availableWidth);
+
     _widths.addAll(columnWidths);
+  }
+
+  void _stretchToFill(
+    List<double> columnWidths,
+    List<bool> fixedColumns,
+    double availableWidth,
+  ) {
+    final handleWidth = widget.resizableColumns ? (_numColumns! - 1) * 8.0 : 0.0;
+    final contentWidth = columnWidths.fold<double>(0, (prev, e) => prev + e);
+    final slack = availableWidth - handleWidth - contentWidth;
+    if (slack <= 0) {
+      return;
+    }
+
+    final growable = <int>[];
+    for (int i = 0; i < _numColumns!; i++) {
+      if (!fixedColumns[i]) {
+        growable.add(i);
+      }
+    }
+    if (growable.isEmpty) {
+      return;
+    }
+
+    final share = slack / growable.length;
+    for (final i in growable) {
+      columnWidths[i] += share;
+    }
   }
 
   double _calculateColumnWidth(Widget widget) {
@@ -739,7 +770,7 @@ class SailTableHeaderCell extends StatelessWidget {
       child: Container(
         width: double.infinity,
         padding: padding,
-        alignment: Alignment.centerLeft,
+        alignment: alignment,
         child: Row(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.center,


### PR DESCRIPTION
Address book: the actions column had a fixed 55px overflow and the table left half the card empty. Columns now stretch to fill, and the row actions are icon buttons in a sized column.

Fee section: the graph is hidden by default behind a Show graph / Hide graph toggle in the card header, and it draws at 140px instead of 180px.