### PR TITLE
Split coins from a multisig wallet

### DIFF
--- a/bitwindow/lib/pages/wallet/wallet_send.dart
+++ b/bitwindow/lib/pages/wallet/wallet_send.dart
@@ -5,6 +5,7 @@ import 'package:bitwindow/env.dart';
 import 'package:bitwindow/main.dart';
 import 'package:bitwindow/providers/address_book_provider.dart';
 import 'package:bitwindow/providers/blockchain_provider.dart';
+import 'package:bitwindow/providers/fork_provider.dart';
 import 'package:bitwindow/providers/transactions_provider.dart';
 import 'package:bitwindow/providers/coin_selection_provider.dart';
 import 'package:bitwindow/pages/wallet/widgets/fee_rate_chart.dart';
@@ -13,6 +14,7 @@ import 'package:bitwindow/utils/bitcoin_uri.dart';
 import 'package:bitwindow/signing/psbt_signer.dart';
 import 'package:bitwindow/signing/sign_and_broadcast.dart';
 import 'package:bitwindow/widgets/multisig_sign_panel.dart';
+import 'package:bitwindow/widgets/replay_protection_dialog.dart';
 import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
 import 'package:sidechain_core/gen/walletpsbt/v1/walletpsbt.pb.dart';
 import 'package:bitwindow/utils/coin_selection.dart';
@@ -130,7 +132,11 @@ class SendTab extends ViewModelWidget<SendPageViewModel> {
     if (walletId == null) {
       return;
     }
-    final psbt = await viewModel.buildUnsignedPsbtForAirgap(context);
+    final plan = await viewModel.askReplayProtect(context);
+    if (plan == null || !context.mounted) {
+      return;
+    }
+    final psbt = await viewModel.buildUnsignedPsbtForAirgap(context, replayProtect: plan.protect);
     if (psbt == null || !context.mounted) {
       return;
     }
@@ -141,7 +147,13 @@ class SendTab extends ViewModelWidget<SendPageViewModel> {
         unsignedPsbtBase64: psbt,
         signer: signer,
       );
-      if (txid == null || !context.mounted) {
+      if (txid == null) {
+        return;
+      }
+      if (plan.risky && !plan.protect) {
+        GetIt.I<ForkProvider>().rememberUnprotectedSend(txid);
+      }
+      if (!context.mounted) {
         return;
       }
       showSailToast(context, 'Transaction broadcast', variant: SailToastVariant.success);
@@ -739,12 +751,98 @@ class SendPageViewModel extends BaseViewModel {
     notifyListeners();
   }
 
+  /// Coins this send may spend that also exist unspent on the other chain, so
+  /// spending them here replays the same transaction there.
+  /// The backend funds from every coin the wallet holds. A frozen coin is
+  /// bitwindow's own mark, so the backend can still spend it.
+  List<UnspentOutput> get splittableInputs => splittableAmong(
+    selectedUtxos,
+    allUtxos,
+    requiredSats: _sendTotalSats,
+    preForkOutpoints: GetIt.I<ForkProvider>().claimOutpoints,
+    preForkKnown: GetIt.I<ForkProvider>().claimsLoaded,
+    replayedTxids: GetIt.I<ForkProvider>().replayedTxids,
+  );
+
+  /// The sats the send pays out, plus the fee the wallet adds on top.
+  int get _sendTotalSats {
+    final amounts = recipients.fold<int>(
+      0,
+      (sum, r) =>
+          sum + parseAmountToSatoshis(r.amountController.text.isEmpty ? '0' : r.amountController.text, currentUnit),
+    );
+    if (_subtractFeeFromAmount) {
+      return amounts;
+    }
+    return amounts + parseAmountToSatoshis(feeController.text.isEmpty ? '0' : feeController.text, currentUnit);
+  }
+
+  /// The coins of a send that exist on both chains. A selection that cannot pay
+  /// the send is not the whole input set: the backend adds more coins from the
+  /// wallet, so every available coin counts. A pre-fork coin the split engine
+  /// did not check yet counts too, because it can still exist on both chains.
+  static List<UnspentOutput> splittableAmong(
+    List<UnspentOutput> selected,
+    List<UnspentOutput> available, {
+    int requiredSats = 0,
+    Set<String> preForkOutpoints = const {},
+    bool preForkKnown = true,
+    Set<String> replayedTxids = const {},
+  }) {
+    final selectedSats = selected.fold<int>(0, (sum, u) => sum + u.valueSats.toInt());
+    final source = selected.isNotEmpty && selectedSats >= requiredSats ? selected : available;
+    return source.where((u) {
+      // An unprotected send replays, so its own outputs land on both chains.
+      if (replayedTxids.contains(u.output.split(':').first)) {
+        return true;
+      }
+      if (u.hasSplittable()) {
+        return u.splittable;
+      }
+      // The pre-fork set is unread, so an unchecked coin can still be on both.
+      return !preForkKnown || preForkOutpoints.contains(u.output);
+    }).toList();
+  }
+
+  /// Asks about replay protection when the send spends a coin that exists on
+  /// both chains. Returns null when the user cancels. `risky` stays false for a
+  /// send whose coins live on one chain, so its own outputs raise no warning.
+  Future<({bool protect, bool risky})?> askReplayProtect(BuildContext context) async {
+    const safe = (protect: false, risky: false);
+    // A chain whose nodes reject the magic locktime has no protection to offer.
+    if (!GetIt.I<ForkProvider>().replayProtectionAvailable) {
+      return safe;
+    }
+    final splittable = splittableInputs;
+    // An empty coin list means the wallet did not report its coins yet. The
+    // backend still funds from its own pool, so the send stays a risk.
+    final coinsKnown = allUtxos.isNotEmpty;
+    if (splittable.isEmpty && coinsKnown) {
+      return safe;
+    }
+    final choice = await askReplayProtection(context, coins: splittable, coinsKnown: coinsKnown);
+    switch (choice) {
+      case ReplayChoice.cancel:
+        return null;
+      case ReplayChoice.sendPlain:
+        return (protect: false, risky: true);
+      case ReplayChoice.sendProtected:
+        return (protect: true, risky: true);
+    }
+  }
+
   Future<void> sendTransaction(BuildContext context) async {
+    final plan = await askReplayProtect(context);
+    if (plan == null || !context.mounted) {
+      return;
+    }
+    final replayProtect = plan.protect;
+
     // Multisig never auto-signs: save the PSBT as a draft and open its tab,
     // where each keystore signs explicitly and broadcast happens once the
     // threshold is met.
     if (isMultisig) {
-      await _createMultisigDraft(context);
+      await _createMultisigDraft(context, replayProtect: replayProtect);
       return;
     }
 
@@ -796,7 +894,11 @@ class SendPageViewModel extends BaseViewModel {
         fixedFeeSats: feeSats,
         subtractFeeFromAmount: _subtractFeeFromAmount,
         requiredInputs: selectedUtxos,
+        replayProtect: replayProtect,
       )).txid;
+      if (plan.risky && !replayProtect) {
+        GetIt.I<ForkProvider>().rememberUnprotectedSend(txid);
+      }
       await clearAll();
       log.d('Sent transaction: txid=$txid');
       final network = GetIt.I.get<BitcoinConfProvider>().network;
@@ -823,13 +925,13 @@ class SendPageViewModel extends BaseViewModel {
   /// Build the PSBT for a multisig send, save it as a draft, and switch to
   /// its tab at once. Reuses the airgap PSBT builder (validates
   /// recipients/fee and calls createPsbt).
-  Future<void> _createMultisigDraft(BuildContext context) async {
+  Future<void> _createMultisigDraft(BuildContext context, {bool replayProtect = false}) async {
     final walletId = activeWalletId;
     if (walletId == null) {
       return;
     }
     final generation = draftProvider.generation;
-    final psbt = await buildUnsignedPsbtForAirgap(context);
+    final psbt = await buildUnsignedPsbtForAirgap(context, replayProtect: replayProtect);
     if (psbt == null) {
       return;
     }
@@ -863,7 +965,7 @@ class SendPageViewModel extends BaseViewModel {
   /// Build an unsigned PSBT from the current recipients/fee/coin-selection for
   /// an external (airgap) signer. Returns base64, or null after surfacing an
   /// error toast.
-  Future<String?> buildUnsignedPsbtForAirgap(BuildContext context) async {
+  Future<String?> buildUnsignedPsbtForAirgap(BuildContext context, {bool replayProtect = false}) async {
     final missingAddress = recipients.indexWhere((r) => r.addressController.text.trim().isEmpty);
     if (missingAddress != -1) {
       showSailToast(context, 'Please enter an address for all recipients.');
@@ -899,6 +1001,7 @@ class SendPageViewModel extends BaseViewModel {
         fixedFeeSats: feeSats,
         subtractFeeFromAmount: _subtractFeeFromAmount,
         requiredInputs: selectedUtxos,
+        replayProtect: replayProtect,
       );
     } catch (error) {
       log.e('Error building unsigned PSBT: $error');

--- a/bitwindow/lib/providers/fork_provider.dart
+++ b/bitwindow/lib/providers/fork_provider.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
 
+import 'package:bitwindow/providers/psbt_draft_provider.dart';
 import 'package:bitwindow/providers/transactions_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart' as bwpb;
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+import 'package:sidechain_core/gen/walletpsbt/v1/walletpsbt.pb.dart' as wppb;
 import 'package:sail_ui/sail_ui.dart';
 
 /// One wallet's claimable pre-fork coins, with the exact UTXOs the sweep spends.
@@ -16,7 +19,17 @@ class WalletClaim {
   /// False for wallets whose claim can't be replay-protected (the enforcer
   /// wallet) — shown for awareness, but not swept.
   final bool replayProtectable;
+
+  /// Multisig policy of the wallet that holds the coins, null for single-sig.
+  /// A multisig claim builds a PSBT its cosigners sign, not a broadcast.
+  final wmpb.MultisigInfo? multisig;
+
+  /// False while the wallet list holds no record of this wallet. Its policy is
+  /// unknown, so the claim offers no action until the record arrives.
+  final bool walletResolved;
   final List<bwpb.UnspentOutput> utxos;
+
+  bool get isMultisig => multisig != null;
 
   WalletClaim({
     required this.walletId,
@@ -24,7 +37,23 @@ class WalletClaim {
     required this.claimableSats,
     required this.replayProtectable,
     required this.utxos,
+    this.multisig,
+    this.walletResolved = true,
   });
+}
+
+/// The magic nLockTime a replay-protected transaction carries. A patched node
+/// treats it as final; stock Bitcoin Core rejects it as non-final.
+const int replayLockTime = 499999999;
+
+/// One split draft that waits for signatures, and the coins it spends. A
+/// second split of the same coins would make a conflicting draft.
+class PendingSplit {
+  final String walletId;
+  final String draftId;
+  final Set<String> outpoints;
+
+  PendingSplit({required this.walletId, required this.draftId, required this.outpoints});
 }
 
 /// Thin consumer of the orchestrator's ForkEngine — the single source of truth
@@ -41,6 +70,9 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
   OrchestratorRPC get _orchestrator => GetIt.I<OrchestratorRPC>();
   OrchestratorWalletRPC get _wallet => _orchestrator.wallet;
   TransactionProvider get _transactions => GetIt.I<TransactionProvider>();
+  WalletReaderProvider get _walletReader => GetIt.I<WalletReaderProvider>();
+  PsbtDraftProvider get _drafts => GetIt.I<PsbtDraftProvider>();
+  WalletPsbtAPI get _draftApi => GetIt.I<BitwindowRPC>().walletpsbt;
   BalanceProvider get _balance => GetIt.I<BalanceProvider>();
   Logger get _log => GetIt.I<Logger>();
 
@@ -68,6 +100,16 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
   bool showCountdown = false;
   List<WalletClaim> claims = [];
 
+  /// False until one fork status read succeeds. A coin the split engine did
+  /// not report yet cannot be cleared while this is false.
+  bool claimsLoaded = false;
+
+  /// True only where a node accepts the magic locktime. Stock Bitcoin Core
+  /// reads such a transaction as non-final and rejects it, so a split there
+  /// stays a plain transaction.
+  bool get replayProtectionAvailable =>
+      GetIt.I.get<BitcoinConfProvider>().network == BitcoinNetwork.BITCOIN_NETWORK_ECASH;
+
   /// Estimated wall-clock instant of the next fork. Held stable between
   /// re-anchors; the timer widget ticks the local clock down to it.
   DateTime? forkTargetDate;
@@ -76,16 +118,67 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
 
   Timer? _timer;
   bool _fetching = false;
+  bool _syncingSplits = false;
+  bool _resyncQueued = false;
+  bool _disposed = false;
+
+  /// Unsigned drafts that hold coins, with the coins each one spends. Read
+  /// back from the saved drafts, so a restart keeps holding them.
+  List<PendingSplit> pendingSplits = [];
+
+  /// The PSBT of each draft already read, so one draft is read one time.
+  final Map<String, String> _readPsbtByDraft = {};
+
+  /// Coins of a split this session still builds. They hold from the click, so
+  /// a second click cannot build a conflicting draft of the same coins.
+  final Set<String> _splitsInFlight = {};
+
+  /// Transactions this session sent without protection. Their outputs exist on
+  /// both chains, so spending one replays again.
+  final Set<String> replayedTxids = {};
+
+  /// Wallets whose drafts the last read did not reach. Their saved drafts can
+  /// hold coins, so the claim card offers none of their coins until a read
+  /// succeeds.
+  Set<String> walletsWithUnreadDrafts = {};
+
+  /// Every pre-fork coin the engine reports, whatever its BTC status. A coin
+  /// outside this set came after the fork, so it exists on one chain only.
+  Set<String> get claimOutpoints => claims.expand((c) => c.utxos).map((u) => u.output).toSet();
+
+  /// Every coin a pending split holds.
+  Set<String> get pendingSplitOutpoints => {...pendingSplits.expand((p) => p.outpoints), ..._splitsInFlight};
+
+  /// True when this coin can exist on both chains: a pre-fork coin, or an
+  /// output of a transaction this session sent without protection.
+  bool isReplayRisk(String outpoint) =>
+      claimOutpoints.contains(outpoint) || replayedTxids.contains(outpoint.split(':').first);
+
+  /// Records a transaction this session broadcast without replay protection.
+  /// Its outputs land on both chains.
+  void rememberUnprotectedSend(String txid) {
+    if (txid.isEmpty) {
+      return;
+    }
+    replayedTxids.add(txid);
+    notifyListeners();
+  }
 
   /// Claims that can actually be swept (replay-protected). Excludes the
-  /// enforcer wallet, which is detected but not safely claimable.
-  List<WalletClaim> get sweepableClaims => claims.where((c) => c.replayProtectable).toList();
+  /// enforcer wallet, which is detected but not safely claimable, and a wallet
+  /// whose record has not arrived: a multisig claim must never sweep.
+  List<WalletClaim> get sweepableClaims => claims.where((c) => c.replayProtectable && c.walletResolved).toList();
 
   /// Blocks left until the next fork, by header height.
   int get blocksUntilFork => (forkHeight - currentHeaders).clamp(0, forkHeight == 0 ? 0 : forkHeight);
 
   void init() {
     fetch();
+    // The wallet list carries each claim's policy, so a late list must not wait
+    // out the poll.
+    _walletReader.addListener(fetch);
+    // Any draft can hold a claimable coin, so a save must hold it at once.
+    _drafts.addListener(_onDraftsChanged);
     _timer = Timer.periodic(const Duration(seconds: 10), (_) => fetch());
   }
 
@@ -101,17 +194,36 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
     hasFundsToClaim = false;
     showCountdown = false;
     claims = [];
+    claimsLoaded = false;
     forkTargetDate = null;
     _anchorBucket = -1;
     _anchorForkHeight = -1;
+    pendingSplits = [];
+    _readPsbtByDraft.clear();
+    _splitsInFlight.clear();
+    replayedTxids.clear();
+    walletsWithUnreadDrafts = {};
     notifyListeners();
     fetch();
   }
 
   @override
   void dispose() {
+    _disposed = true;
     _timer?.cancel();
+    _walletReader.removeListener(fetch);
+    _drafts.removeListener(_onDraftsChanged);
     super.dispose();
+  }
+
+  void _onDraftsChanged() {
+    unawaited(
+      _syncPendingSplits().then((_) {
+        if (!_disposed) {
+          notifyListeners();
+        }
+      }),
+    );
   }
 
   Future<void> fetch() async {
@@ -139,6 +251,8 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
               walletName: c.walletName,
               claimableSats: c.claimableSats.toInt(),
               replayProtectable: c.replayProtectable,
+              multisig: _walletReader.wallets.where((w) => w.id == c.walletId).firstOrNull?.multisig,
+              walletResolved: _walletReader.wallets.any((w) => w.id == c.walletId),
               utxos: c.utxos
                   .map(
                     (u) => bwpb.UnspentOutput(
@@ -155,12 +269,89 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
           )
           .toList();
 
+      claimsLoaded = true;
+      await _syncPendingSplits();
       _updateForkTarget();
       notifyListeners();
     } catch (e) {
       _log.e('ForkProvider.fetch failed: $e');
     } finally {
       _fetching = false;
+    }
+  }
+
+  /// The splits that still hold their coins: one whose draft is still on the
+  /// send tab, one whose wallet answered nothing, or one this read never saw
+  /// because a split saved it while the read ran.
+  static List<PendingSplit> keepLivePendingSplits(
+    List<PendingSplit> pending,
+    Set<String> liveDraftIds,
+    Set<String> unreadableWallets,
+    Set<String> knownBeforeRead,
+  ) => pending
+      .where(
+        (p) =>
+            liveDraftIds.contains(p.draftId) ||
+            unreadableWallets.contains(p.walletId) ||
+            !knownBeforeRead.contains(p.draftId),
+      )
+      .toList();
+
+  /// Read the coins each unsigned draft holds, across every wallet with a
+  /// claim. A draft that is gone releases the coins it held.
+  Future<void> _syncPendingSplits() async {
+    if (_syncingSplits) {
+      // A draft saved during the read is missing from its listing, so the read
+      // runs again after this one.
+      _resyncQueued = true;
+      return;
+    }
+    _syncingSplits = true;
+    try {
+      do {
+        _resyncQueued = false;
+        await _readPendingSplits();
+      } while (_resyncQueued);
+    } finally {
+      _syncingSplits = false;
+    }
+  }
+
+  Future<void> _readPendingSplits() async {
+    final knownBeforeRead = pendingSplits.map((p) => p.draftId).toSet();
+    final listed = <wppb.PsbtDraft>[];
+    final unreadable = <String>{};
+    for (final walletId in claims.map((c) => c.walletId).toSet()) {
+      try {
+        listed.addAll(await _draftApi.listDrafts(walletId));
+      } catch (e) {
+        unreadable.add(walletId);
+        _log.e('ForkProvider: could not list the drafts of wallet $walletId: $e');
+      }
+    }
+    walletsWithUnreadDrafts = unreadable;
+    final unsigned = listed.where((d) => d.txid.isEmpty).toList();
+    final liveIds = unsigned.map((d) => d.id).toSet();
+    pendingSplits = keepLivePendingSplits(pendingSplits, liveIds, unreadable, knownBeforeRead);
+    _readPsbtByDraft.removeWhere((id, _) => !liveIds.contains(id) && knownBeforeRead.contains(id));
+
+    for (final draft in unsigned) {
+      if (_readPsbtByDraft[draft.id] == draft.psbtBase64) {
+        continue;
+      }
+      try {
+        final decoded = await _wallet.decodeTransaction(input: draft.psbtBase64, walletId: draft.walletId);
+        final outpoints = decoded.details.inputs.map((i) => '${i.prevTxid}:${i.prevVout}').toSet();
+        pendingSplits = [
+          ...pendingSplits.where((p) => p.draftId != draft.id),
+          PendingSplit(walletId: draft.walletId, draftId: draft.id, outpoints: outpoints),
+        ];
+        _readPsbtByDraft[draft.id] = draft.psbtBase64;
+      } catch (e) {
+        // The draft holds coins this read did not name, so the wallet stays shut.
+        walletsWithUnreadDrafts = {...walletsWithUnreadDrafts, draft.walletId};
+        _log.e('ForkProvider: could not read the coins of draft ${draft.id}: $e');
+      }
     }
   }
 
@@ -192,22 +383,34 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
   /// selectable set below the unchecked coins.
   static bool isSelectable(bwpb.UnspentOutput u) => !u.hasSplittable() || u.splittable;
 
+  /// True when every claim in the selection needs cosigner signatures, so the
+  /// split ends in a PSBT instead of a broadcast.
+  static bool splitNeedsSignatures(Iterable<WalletClaim> selected) =>
+      selected.isNotEmpty && selected.every((c) => c.isMultisig);
+
   /// The coins a claim spends when the user picks none.
   static List<bwpb.UnspentOutput> defaultClaimInputs(WalletClaim claim) => claim.utxos.where(isSelectable).toList();
+
+  /// True while the user can still pick this coin: the BTC side allows it, no
+  /// draft of it waits for signatures, and this wallet's drafts are readable.
+  bool canSelect(WalletClaim claim, bwpb.UnspentOutput u) =>
+      isSelectable(u) && !pendingSplitOutpoints.contains(u.output) && !walletsWithUnreadDrafts.contains(claim.walletId);
+
+  /// The coins of one claim the user can still pick.
+  List<bwpb.UnspentOutput> selectableInputs(WalletClaim claim) =>
+      claim.utxos.where((u) => canSelect(claim, u)).toList();
 
   /// True while at least one sweepable wallet holds a selectable coin. The
   /// claim card hides without one — a card with every coin disabled offers
   /// no action.
-  bool get hasSelectableCoins => sweepableClaims.any((c) => defaultClaimInputs(c).isNotEmpty);
+  bool get hasSelectableCoins => sweepableClaims.any((c) => selectableInputs(c).isNotEmpty);
 
   /// Smallest selected sum a sweep can pay: the post-fee output must stay
   /// above dust. Generous estimate at the 1 sat/vB sweep rate.
   static int minClaimSats(int inputCount) => 546 + 150 + 70 * inputCount;
 
-  /// Sweep one wallet's pre-fork coins (from the engine's UTXO list) to a fresh
-  /// address it controls — one sendTransaction, exactly like a send. Returns txid.
-  Future<String> claim(String walletId, {Set<String>? outpoints}) async {
-    final claim = claims.firstWhere((c) => c.walletId == walletId);
+  /// The coins one claim spends, from the user's selection or the default set.
+  List<bwpb.UnspentOutput> _claimInputs(WalletClaim claim, Set<String>? outpoints) {
     final inputs = outpoints == null
         ? defaultClaimInputs(claim)
         : claim.utxos.where((u) => outpoints.contains(u.output)).toList();
@@ -218,6 +421,69 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
     if (amountSats < minClaimSats(inputs.length)) {
       throw Exception('selected amount is too small to pay the sweep fee');
     }
+    return inputs;
+  }
+
+  /// Build the split of one multisig wallet's pre-fork coins and file it as a
+  /// draft. The cosigners sign it on the send tab; nothing is broadcast here.
+  /// Returns the draft id.
+  Future<String> createSplitDraft(String walletId, {Set<String>? outpoints}) async {
+    final claim = claims.firstWhere((c) => c.walletId == walletId);
+    final inputs = _claimInputs(claim, outpoints);
+    final reserved = inputs.map((u) => u.output).toSet();
+    if (reserved.any(pendingSplitOutpoints.contains)) {
+      throw Exception('a split of these coins is already under way');
+    }
+    // Hold the coins from here, so a second click builds nothing.
+    _splitsInFlight.addAll(reserved);
+    notifyListeners();
+    try {
+      return await _buildSplitDraft(claim, inputs);
+    } finally {
+      _splitsInFlight.removeAll(reserved);
+      notifyListeners();
+    }
+  }
+
+  Future<String> _buildSplitDraft(WalletClaim claim, List<bwpb.UnspentOutput> inputs) async {
+    final walletId = claim.walletId;
+    final amountSats = inputs.fold<int>(0, (sum, u) => sum + u.valueSats.toInt());
+    final generation = _drafts.generation;
+    final address = (await _wallet.getNewAddress(walletId)).address;
+
+    _log.i(
+      'Splitting eCash in multisig: wallet="${claim.walletName}" id=$walletId '
+      'amount=$amountSats sats inputs=${inputs.length} -> $address',
+    );
+
+    final psbt = await _wallet.createPsbt(
+      walletId: walletId,
+      destinations: {address: amountSats},
+      requiredInputs: inputs,
+      subtractFeeFromAmount: true,
+      feeRateSatPerVbyte: _sweepFeeRateSatPerVbyte,
+      replayProtect: replayProtectionAvailable,
+    );
+    if (_drafts.generation != generation) {
+      throw Exception('The network changed during the build. Create the split transaction again.');
+    }
+    final draft = await _drafts.create(psbt, walletId: walletId);
+    pendingSplits = [
+      ...pendingSplits,
+      PendingSplit(walletId: walletId, draftId: draft.id, outpoints: inputs.map((u) => u.output).toSet()),
+    ];
+    _readPsbtByDraft[draft.id] = psbt;
+    notifyListeners();
+    _log.i('Split draft created: wallet="${claim.walletName}" id=$walletId draft=${draft.id}');
+    return draft.id;
+  }
+
+  /// Sweep one wallet's pre-fork coins (from the engine's UTXO list) to a fresh
+  /// address it controls — one sendTransaction, exactly like a send. Returns txid.
+  Future<String> claim(String walletId, {Set<String>? outpoints}) async {
+    final claim = claims.firstWhere((c) => c.walletId == walletId);
+    final inputs = _claimInputs(claim, outpoints);
+    final amountSats = inputs.fold<int>(0, (sum, u) => sum + u.valueSats.toInt());
     final address = (await _wallet.getNewAddress(walletId)).address;
 
     _log.i(
@@ -231,10 +497,7 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
       requiredInputs: inputs,
       subtractFeeFromAmount: true,
       feeRateSatPerVbyte: _sweepFeeRateSatPerVbyte,
-      // Replay protection is off for now — a plain sweep so the claim flow is
-      // testable end-to-end on stock Core (signet/regtest). The replay-protect
-      // path (magic version + byte) stays wired behind this flag for later.
-      replayProtect: false,
+      replayProtect: replayProtectionAvailable,
     )).txid;
 
     _log.i('Claimed eCash: wallet="${claim.walletName}" id=$walletId txid=$txid -> $address');

--- a/bitwindow/lib/widgets/fork_mode_banner.dart
+++ b/bitwindow/lib/widgets/fork_mode_banner.dart
@@ -58,7 +58,7 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
       final selected = _selected.putIfAbsent(claim.walletId, () => {});
       final selectable = <String>{};
       for (final u in claim.utxos) {
-        if (ForkProvider.isSelectable(u)) {
+        if (widget.fork.canSelect(claim, u)) {
           selectable.add(u.output);
           if (seen.add(u.output)) {
             selected.add(u.output);
@@ -109,7 +109,7 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
     _syncSelection();
     final selectedSats = _selectedSats;
     // A wallet with no selectable coin gets no picker — it offers no action.
-    final claims = widget.fork.sweepableClaims.where((c) => ForkProvider.defaultClaimInputs(c).isNotEmpty).toList();
+    final claims = widget.fork.sweepableClaims.where((c) => widget.fork.selectableInputs(c).isNotEmpty).toList();
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
@@ -142,9 +142,7 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
                       const SizedBox(height: 8),
                       if (_selectionValid)
                         SailButton(
-                          label: claims.length > 1
-                              ? 'Split ${formatter.formatSats(selectedSats)} from all wallets'
-                              : 'Split ${formatter.formatSats(selectedSats)}',
+                          label: _buttonLabel(formatter, selectedSats, claims),
                           icon: SailSVGAsset.iconCoins,
                           onPressed: () => _claim(context),
                         ),
@@ -159,6 +157,19 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
         ),
       ),
     );
+  }
+
+  /// A multisig split ends in a PSBT its cosigners still have to sign, so the
+  /// button never promises a finished split.
+  String _buttonLabel(FormatterProvider formatter, int selectedSats, List<WalletClaim> claims) {
+    final selectedClaims = claims.where((c) => (_selected[c.walletId] ?? {}).isNotEmpty).toList();
+    if (ForkProvider.splitNeedsSignatures(selectedClaims)) {
+      return 'Create split transaction';
+    }
+    if (claims.length > 1) {
+      return 'Split ${formatter.formatSats(selectedSats)} from all wallets';
+    }
+    return 'Split ${formatter.formatSats(selectedSats)}';
   }
 
   Widget _coinPicker(BuildContext context, WalletClaim claim, FormatterProvider formatter) {
@@ -187,7 +198,7 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
             ),
             const SizedBox(height: 8),
             ...claim.utxos.map((u) {
-              final selectable = ForkProvider.isSelectable(u);
+              final selectable = widget.fork.canSelect(claim, u);
               final isSelected = selected.contains(u.output);
               return Padding(
                 padding: const EdgeInsets.only(bottom: 8),
@@ -242,10 +253,28 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
                 SailText.primary13(formatter.formatSats(selectedClaimSats), bold: true, monospace: true),
               ],
             ),
+            if (claim.isMultisig) ...[
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  SailText.secondary13('Signatures'),
+                  const Spacer(),
+                  SailText.primary13(
+                    '${claim.multisig!.m} of ${claim.multisig!.n} keys',
+                    bold: true,
+                    monospace: true,
+                  ),
+                ],
+              ),
+            ],
             const SizedBox(height: 12),
             SailText.secondary12('SENDS JUST ECX TO'),
             const SizedBox(height: 2),
-            SailText.secondary13('A fresh address in ${claim.walletName}'),
+            SailText.secondary13(
+              claim.isMultisig
+                  ? 'A fresh address in ${claim.walletName} · ${claim.multisig!.m}-of-${claim.multisig!.n} multisig'
+                  : 'A fresh address in ${claim.walletName}',
+            ),
           ],
         ),
       ),
@@ -265,10 +294,12 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
   }
 
   Widget _whyThisIsNecessary() {
-    const paragraphs = [
+    final paragraphs = [
       'You have coins on both BTC and ECX. We recommend splitting your coins to not lose any ECX or BTC you currently own.',
       'By default, a transaction valid on bitcoin is also valid on eCash. Therefore, by spending your bitcoin, you will make that same transaction on eCash. If you do not control the receiving eCash wallet, you will lose your eCash.',
       'Claiming sweeps the selected coins to a fresh address in the same wallet.',
+      if (widget.fork.sweepableClaims.any((c) => c.isMultisig))
+        'A multisig wallet holds some of these coins. BitWindow builds a PSBT instead of a finished transaction, and nothing is broadcast until the cosigners sign it on the send tab.',
     ];
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -289,15 +320,28 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
     // Snapshot the plan first — claim() refetches and replaces the claims,
     // so one wallet's failure must not misreport the wallets already swept.
     final planned = widget.fork.sweepableClaims
-        .map((c) => (walletId: c.walletId, outpoints: Set<String>.of(_selected[c.walletId] ?? {})))
+        .map(
+          (c) => (
+            walletId: c.walletId,
+            multisig: c.isMultisig,
+            outpoints: Set<String>.of(_selected[c.walletId] ?? {}),
+          ),
+        )
         .where((p) => p.outpoints.isNotEmpty)
         .toList();
 
-    final txids = <String>[];
+    var broadcast = 0;
+    var drafted = 0;
     Object? firstError;
     for (final p in planned) {
       try {
-        txids.add(await widget.fork.claim(p.walletId, outpoints: p.outpoints));
+        if (p.multisig) {
+          await widget.fork.createSplitDraft(p.walletId, outpoints: p.outpoints);
+          drafted++;
+        } else {
+          await widget.fork.claim(p.walletId, outpoints: p.outpoints);
+          broadcast++;
+        }
       } catch (e) {
         firstError ??= e;
       }
@@ -305,14 +349,31 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
     if (!context.mounted) {
       return;
     }
-    if (firstError == null) {
-      showSailToast(context, 'Claimed eCash in ${txids.length} transaction(s).');
-    } else {
+    if (firstError != null) {
       showSailToast(
         context,
-        'Claimed ${txids.length} of ${planned.length} wallet(s). First error: $firstError',
+        'Claimed ${broadcast + drafted} of ${planned.length} wallet(s). First error: $firstError',
         duration: const Duration(seconds: 5),
       );
+      return;
     }
+    if (drafted > 0 && broadcast == 0) {
+      showSailToast(
+        context,
+        'Split transaction created. Sign it on the send tab.',
+        duration: const Duration(seconds: 5),
+      );
+      return;
+    }
+    if (drafted > 0) {
+      showSailToast(
+        context,
+        'Claimed eCash in $broadcast transaction(s). '
+        '$drafted split transaction(s) wait for signatures on the send tab.',
+        duration: const Duration(seconds: 5),
+      );
+      return;
+    }
+    showSailToast(context, 'Claimed eCash in $broadcast transaction(s).');
   }
 }

--- a/bitwindow/lib/widgets/multisig_sign_panel.dart
+++ b/bitwindow/lib/widgets/multisig_sign_panel.dart
@@ -1,4 +1,5 @@
 import 'package:bitwindow/providers/address_book_provider.dart';
+import 'package:bitwindow/providers/fork_provider.dart';
 import 'package:bitwindow/providers/psbt_draft_provider.dart';
 import 'package:bitwindow/providers/transactions_provider.dart';
 import 'package:bitwindow/utils/explorer_url.dart';
@@ -235,6 +236,16 @@ class _MultisigSignPanelState extends State<MultisigSignPanel> {
     try {
       final hex = await _wallet.finalizePsbt(psbtBase64: draft.psbtBase64);
       final txid = await _wallet.broadcastTransaction(walletId: widget.walletId, txHex: hex);
+      final fork = GetIt.I.get<ForkProvider>();
+      final decoded = _decoded;
+      // An undecoded transaction can hold a coin from both chains, so it counts
+      // as one until the decode says otherwise.
+      final spendsRisk =
+          decoded == null || decoded.details.inputs.any((i) => fork.isReplayRisk('${i.prevTxid}:${i.prevVout}'));
+      final protected = decoded != null && decoded.details.locktime == replayLockTime;
+      if (spendsRisk && !protected) {
+        fork.rememberUnprotectedSend(txid);
+      }
 
       // The transaction is on the network from here on. A failure below is
       // bookkeeping only and must never read as a broadcast failure.

--- a/bitwindow/lib/widgets/replay_protection_dialog.dart
+++ b/bitwindow/lib/widgets/replay_protection_dialog.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/widgets.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart';
+
+/// What the user chose when a send would spend coins that exist on both chains.
+enum ReplayChoice { cancel, sendPlain, sendProtected }
+
+/// Asks before a send spends coins that exist on both chains, and offers
+/// replay protection for that one transaction.
+Future<ReplayChoice> askReplayProtection(
+  BuildContext context, {
+  required List<UnspentOutput> coins,
+  bool coinsKnown = true,
+}) async {
+  final choice = await showThemedDialog<ReplayChoice>(
+    context: context,
+    builder: (context) => SailModal(
+      constraints: const BoxConstraints(maxWidth: 720),
+      child: SailCard(
+        title: coinsKnown && coins.length == 1 ? 'This coin exists on both chains' : 'These coins exist on both chains',
+        subtitle: coinsKnown
+            ? 'Spending them makes the same transaction on the other chain.'
+            : 'The wallet did not report its coins yet, so this send can spend one that exists on both chains.',
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (coinsKnown) ...[
+              SailText.primary15('Coins on both chains', bold: true),
+              const SizedBox(height: SailStyleValues.padding08),
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 240),
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: coins.map((c) => _CoinRow(coin: c)).toList(),
+                  ),
+                ),
+              ),
+              const SizedBox(height: SailStyleValues.padding16),
+            ],
+            SailText.secondary13(
+              'Replay protection keeps this transaction on this chain only. The other chain rejects it.',
+            ),
+            const SizedBox(height: SailStyleValues.padding16),
+            Wrap(
+              alignment: WrapAlignment.end,
+              spacing: SailStyleValues.padding08,
+              runSpacing: SailStyleValues.padding08,
+              children: [
+                SailButton(
+                  label: 'Cancel',
+                  variant: ButtonVariant.ghost,
+                  onPressed: () async => Navigator.of(context).pop(ReplayChoice.cancel),
+                ),
+                SailButton(
+                  label: 'Send without protection',
+                  variant: ButtonVariant.secondary,
+                  onPressed: () async => Navigator.of(context).pop(ReplayChoice.sendPlain),
+                ),
+                SailButton(
+                  label: 'Enable replay protection',
+                  onPressed: () async => Navigator.of(context).pop(ReplayChoice.sendProtected),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  return choice ?? ReplayChoice.cancel;
+}
+
+class _CoinRow extends StatelessWidget {
+  final UnspentOutput coin;
+
+  const _CoinRow({required this.coin});
+
+  @override
+  Widget build(BuildContext context) {
+    final formatter = GetIt.I.get<FormatterProvider>();
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SailStyleValues.padding04),
+      child: Row(
+        children: [
+          SailText.secondary13(formatter.formatSats(coin.valueSats.toInt()), monospace: true),
+          const Spacer(),
+          SailText.secondary13(_shortAddress(coin.address), monospace: true),
+        ],
+      ),
+    );
+  }
+}
+
+String _shortAddress(String address) {
+  if (address.length <= 14) {
+    return address;
+  }
+  return '${address.substring(0, 6)}…${address.substring(address.length - 4)}';
+}

--- a/bitwindow/test/fork_claim_replay_test.dart
+++ b/bitwindow/test/fork_claim_replay_test.dart
@@ -1,0 +1,136 @@
+import 'package:bitwindow/providers/fork_provider.dart';
+import 'package:bitwindow/providers/transactions_provider.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart' as bwpb;
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+import 'package:sail_ui/sail_ui.dart';
+
+import 'test_utils.dart';
+
+class _FakeWallet implements OrchestratorWalletRPC {
+  bool? sentReplayProtect;
+
+  @override
+  Future<wmpb.GetNewAddressResponse> getNewAddress(String walletId, {wmpb.AddressType? addressType}) async =>
+      wmpb.GetNewAddressResponse(address: 'bcrt1qsweep');
+
+  @override
+  Future<wmpb.SendTransactionResponse> sendTransaction({
+    required String walletId,
+    required Map<String, int> destinations,
+    int? feeRateSatPerVbyte,
+    int? fixedFeeSats,
+    bool subtractFeeFromAmount = false,
+    String? opReturnMessage,
+    String? opReturnHex,
+    List<bwpb.UnspentOutput>? requiredInputs,
+    bool replayProtect = false,
+  }) async {
+    sentReplayProtect = replayProtect;
+    return wmpb.SendTransactionResponse(txid: 'aa' * 32);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeOrchestrator implements OrchestratorRPC {
+  _FakeOrchestrator(this.wallet);
+
+  @override
+  final OrchestratorWalletRPC wallet;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeConf implements BitcoinConfProvider {
+  _FakeConf(this.network);
+
+  @override
+  final BitcoinNetwork network;
+
+  @override
+  bool get drivechainFeaturesAvailable => false;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeTransactions implements TransactionProvider {
+  @override
+  Future<void> fetch() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeBalance implements BalanceProvider {
+  @override
+  Future<void> fetch() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<void> replace<T extends Object>(T instance) async {
+  if (GetIt.I.isRegistered<T>()) {
+    await GetIt.I.unregister<T>();
+  }
+  GetIt.I.registerSingleton<T>(instance);
+}
+
+void main() {
+  late _FakeWallet wallet;
+
+  setUp(() async {
+    await GetIt.I.reset();
+    await registerTestDependencies();
+    wallet = _FakeWallet();
+    await replace<OrchestratorRPC>(_FakeOrchestrator(wallet));
+    await replace<BitcoinConfProvider>(_FakeConf(BitcoinNetwork.BITCOIN_NETWORK_ECASH));
+    await replace<TransactionProvider>(_FakeTransactions());
+    await replace<BalanceProvider>(_FakeBalance());
+  });
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  test('the sweep of a single-sig claim carries replay protection', () async {
+    final provider = ForkProvider();
+    provider.claims = [
+      WalletClaim(
+        walletId: 'w1',
+        walletName: 'Main wallet',
+        claimableSats: 100000,
+        replayProtectable: true,
+        utxos: [bwpb.UnspentOutput(output: 'aa:0', valueSats: Int64(100000))],
+      ),
+    ];
+
+    await provider.claim('w1');
+
+    expect(wallet.sentReplayProtect, isTrue, reason: 'a plain sweep replays onto the other chain');
+  });
+
+  test('the sweep stays plain where the node rejects the magic locktime', () async {
+    await replace<BitcoinConfProvider>(_FakeConf(BitcoinNetwork.BITCOIN_NETWORK_SIGNET));
+    final provider = ForkProvider();
+    provider.claims = [
+      WalletClaim(
+        walletId: 'w1',
+        walletName: 'Main wallet',
+        claimableSats: 100000,
+        replayProtectable: true,
+        utxos: [bwpb.UnspentOutput(output: 'aa:0', valueSats: Int64(100000))],
+      ),
+    ];
+
+    await provider.claim('w1');
+
+    expect(wallet.sentReplayProtect, isFalse, reason: 'stock Core rejects a non-final transaction');
+  });
+}

--- a/bitwindow/test/fork_provider_test.dart
+++ b/bitwindow/test/fork_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:bitwindow/providers/fork_provider.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart' as bwpb;
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
 
 bwpb.UnspentOutput utxo(String output, {bool? splittable}) {
   final u = bwpb.UnspentOutput(output: output, valueSats: Int64(100));
@@ -11,15 +12,18 @@ bwpb.UnspentOutput utxo(String output, {bool? splittable}) {
   return u;
 }
 
-WalletClaim claimWith(List<bwpb.UnspentOutput> utxos) {
+WalletClaim claimWith(List<bwpb.UnspentOutput> utxos, {wmpb.MultisigInfo? multisig}) {
   return WalletClaim(
     walletId: 'w1',
     walletName: 'Main wallet',
     claimableSats: 300,
     replayProtectable: true,
+    multisig: multisig,
     utxos: utxos,
   );
 }
+
+wmpb.MultisigInfo policy(int m, int n) => wmpb.MultisigInfo(m: m, n: n);
 
 void main() {
   test('a coin with unknown BTC status stays selectable', () {
@@ -65,5 +69,108 @@ void main() {
       claimWith([utxo('aa:0', splittable: false), utxo('bb:1')]),
     ];
     expect(provider.hasSelectableCoins, isTrue);
+  });
+
+  test('a claim without a policy is single-sig', () {
+    expect(claimWith([utxo('aa:0')]).isMultisig, isFalse);
+  });
+
+  test('a claim with a policy needs cosigner signatures', () {
+    final claim = claimWith([utxo('aa:0')], multisig: policy(2, 3));
+    expect(claim.isMultisig, isTrue);
+    expect(claim.multisig!.m, 2);
+    expect(claim.multisig!.n, 3);
+  });
+
+  test('a split needs signatures only when every selected claim is multisig', () {
+    final single = claimWith([utxo('aa:0')]);
+    final multi = claimWith([utxo('bb:0')], multisig: policy(2, 3));
+    expect(ForkProvider.splitNeedsSignatures([multi]), isTrue);
+    expect(ForkProvider.splitNeedsSignatures([multi, single]), isFalse);
+    expect(ForkProvider.splitNeedsSignatures([single]), isFalse);
+  });
+
+  test('an empty selection never needs signatures', () {
+    expect(ForkProvider.splitNeedsSignatures([]), isFalse);
+  });
+
+  test('a coin inside a pending split draft leaves the selection', () {
+    final provider = ForkProvider();
+    final claim = claimWith([utxo('aa:0'), utxo('bb:1')], multisig: policy(2, 3));
+    provider.claims = [claim];
+    expect(provider.selectableInputs(claim).length, 2);
+
+    provider.pendingSplits = [
+      PendingSplit(walletId: 'w1', draftId: 'd1', outpoints: {'aa:0'}),
+    ];
+    expect(provider.canSelect(claim, utxo('aa:0')), isFalse);
+    expect(provider.selectableInputs(claim).map((u) => u.output), ['bb:1']);
+  });
+
+  test('a wallet whose coins all wait for signatures offers no claim', () {
+    final provider = ForkProvider();
+    provider.claims = [
+      claimWith([utxo('aa:0')], multisig: policy(2, 3)),
+    ];
+    expect(provider.hasSelectableCoins, isTrue);
+
+    provider.pendingSplits = [
+      PendingSplit(walletId: 'w1', draftId: 'd1', outpoints: {'aa:0'}),
+    ];
+    expect(provider.hasSelectableCoins, isFalse);
+  });
+
+  test('a live draft keeps holding the coins it spends', () {
+    final pending = [
+      PendingSplit(walletId: 'w1', draftId: 'd1', outpoints: {'aa:0'}),
+    ];
+    expect(ForkProvider.keepLivePendingSplits(pending, {'d1'}, {}, {'d1'}).length, 1);
+  });
+
+  test('a discarded draft releases the coins it held', () {
+    final pending = [
+      PendingSplit(walletId: 'w1', draftId: 'd1', outpoints: {'aa:0'}),
+    ];
+    expect(ForkProvider.keepLivePendingSplits(pending, {}, {}, {'d1'}), isEmpty);
+  });
+
+  test('a wallet that answers nothing keeps its coins held', () {
+    final pending = [
+      PendingSplit(walletId: 'w2', draftId: 'd2', outpoints: {'bb:1'}),
+    ];
+    expect(ForkProvider.keepLivePendingSplits(pending, {}, {'w2'}, {'d2'}).length, 1);
+  });
+
+  test('a wallet with unread drafts offers no coin', () {
+    final provider = ForkProvider();
+    final claim = claimWith([utxo('aa:0')], multisig: policy(2, 3));
+    provider.claims = [claim];
+    expect(provider.hasSelectableCoins, isTrue);
+
+    provider.walletsWithUnreadDrafts = {'w1'};
+    expect(provider.canSelect(claim, utxo('aa:0')), isFalse);
+    expect(provider.hasSelectableCoins, isFalse);
+  });
+
+  test('a claim whose wallet record is missing offers no sweep', () {
+    final provider = ForkProvider();
+    provider.claims = [
+      WalletClaim(
+        walletId: 'w1',
+        walletName: 'Main wallet',
+        claimableSats: 300,
+        replayProtectable: true,
+        walletResolved: false,
+        utxos: [utxo('aa:0')],
+      ),
+    ];
+    expect(provider.sweepableClaims, isEmpty);
+  });
+
+  test('a split saved while the read ran keeps its coins', () {
+    final pending = [
+      PendingSplit(walletId: 'w1', draftId: 'new', outpoints: {'aa:0'}),
+    ];
+    expect(ForkProvider.keepLivePendingSplits(pending, {}, {}, {}).length, 1);
   });
 }

--- a/bitwindow/test/replay_protection_dialog_test.dart
+++ b/bitwindow/test/replay_protection_dialog_test.dart
@@ -1,0 +1,74 @@
+import 'package:bitwindow/widgets/replay_protection_dialog.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart';
+
+import 'test_utils.dart';
+
+UnspentOutput coin(String address, int sats) =>
+    UnspentOutput(output: '$address:0', address: address, valueSats: Int64(sats));
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized({
+    'flutter.test.automatic_wait_for_timers': 'false',
+  });
+
+  setUp(() async {
+    await GetIt.I.reset();
+    await registerTestDependencies();
+  });
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  Future<ReplayChoice?> openDialog(WidgetTester tester, List<UnspentOutput> coins, {bool coinsKnown = true}) async {
+    ReplayChoice? choice;
+    await tester.pumpSailPage(
+      Builder(
+        builder: (context) => TextButton(
+          onPressed: () async => choice = await askReplayProtection(context, coins: coins, coinsKnown: coinsKnown),
+          child: const Text('open'),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    return choice;
+  }
+
+  testWidgets('the dialog names every coin that exists on both chains', (tester) async {
+    await openDialog(tester, [
+      coin('tb1qm4v000000000000000008xr2', 30000000),
+      coin('tb1qk9d000000000000000003ptu', 10000000),
+    ]);
+
+    expect(find.text('These coins exist on both chains'), findsOneWidget);
+    expect(find.text('tb1qm4…8xr2'), findsOneWidget);
+    expect(find.text('tb1qk9…3ptu'), findsOneWidget);
+  });
+
+  testWidgets('one coin reads in the singular', (tester) async {
+    await openDialog(tester, [coin('tb1qm4v000000000000000008xr2', 30000000)]);
+
+    expect(find.text('This coin exists on both chains'), findsOneWidget);
+  });
+
+  testWidgets('the protected send is the primary action', (tester) async {
+    await openDialog(tester, [coin('tb1qm4v000000000000000008xr2', 30000000)]);
+
+    expect(find.text('Cancel'), findsWidgets);
+    expect(find.text('Send without protection'), findsWidgets);
+    expect(find.text('Enable replay protection'), findsWidgets);
+  });
+
+  testWidgets('an unread wallet raises the prompt without a coin list', (tester) async {
+    await openDialog(tester, [], coinsKnown: false);
+
+    expect(find.text('These coins exist on both chains'), findsOneWidget);
+    expect(find.text('Coins on both chains'), findsNothing);
+    expect(find.text('Enable replay protection'), findsWidgets);
+  });
+}

--- a/bitwindow/test/replay_protection_prompt_test.dart
+++ b/bitwindow/test/replay_protection_prompt_test.dart
@@ -1,0 +1,87 @@
+import 'package:bitwindow/pages/wallet/wallet_send.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart';
+
+UnspentOutput coin(String output, {bool? splittable}) {
+  final u = UnspentOutput(output: output, valueSats: Int64(100_000));
+  if (splittable != null) {
+    u.splittable = splittable;
+  }
+  return u;
+}
+
+void main() {
+  test('a coin that came after the fork raises no prompt', () {
+    expect(SendPageViewModel.splittableAmong([], [coin('aa:0')]), isEmpty);
+  });
+
+  test('an unchecked pre-fork coin raises the prompt', () {
+    final unchecked = coin('aa:0');
+    expect(
+      SendPageViewModel.splittableAmong([], [unchecked], preForkOutpoints: {'aa:0'}),
+      [unchecked],
+    );
+  });
+
+  test('a pre-fork coin the engine cleared raises no prompt', () {
+    expect(
+      SendPageViewModel.splittableAmong([], [coin('aa:0', splittable: false)], preForkOutpoints: {'aa:0'}),
+      isEmpty,
+    );
+  });
+
+  test('a coin that exists on both chains raises the prompt', () {
+    final both = coin('aa:0', splittable: true);
+    expect(SendPageViewModel.splittableAmong([], [both]), [both]);
+  });
+
+  test('a coin that exists on one chain only raises no prompt', () {
+    expect(SendPageViewModel.splittableAmong([], [coin('aa:0', splittable: false)]), isEmpty);
+  });
+
+  test('a selection hides the coins it leaves behind', () {
+    final picked = coin('aa:0');
+    final other = coin('bb:0', splittable: true);
+    expect(SendPageViewModel.splittableAmong([picked], [picked, other]), isEmpty);
+  });
+
+  test('a selection of both-chain coins raises the prompt', () {
+    final picked = coin('aa:0', splittable: true);
+    expect(SendPageViewModel.splittableAmong([picked], [picked, coin('bb:0')]), [picked]);
+  });
+
+  test('a selection that cannot pay the send widens the check', () {
+    final picked = coin('aa:0');
+    final other = coin('bb:0', splittable: true);
+    expect(
+      SendPageViewModel.splittableAmong([picked], [picked, other], requiredSats: 500_000),
+      [other],
+    );
+  });
+
+  test('a selection that pays the send hides the rest', () {
+    final picked = coin('aa:0');
+    final other = coin('bb:0', splittable: true);
+    expect(
+      SendPageViewModel.splittableAmong([picked], [picked, other], requiredSats: 50_000),
+      isEmpty,
+    );
+  });
+
+  test('an unchecked coin raises the prompt while the fork set is unread', () {
+    final unchecked = coin('aa:0');
+    expect(
+      SendPageViewModel.splittableAmong([], [unchecked], preForkKnown: false),
+      [unchecked],
+    );
+  });
+
+  test('the change of an unprotected send raises the prompt', () {
+    final change = coin('bb:1');
+    expect(
+      SendPageViewModel.splittableAmong([], [change], replayedTxids: {'bb'}),
+      [change],
+    );
+  });
+}

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -1911,6 +1911,7 @@ func (h *WalletHandler) CreatePsbt(ctx context.Context, req *connect.Request[pb.
 		FixedFeeSats:          req.Msg.FixedFeeSats,
 		OpReturnHex:           req.Msg.OpReturnHex,
 		SubtractFeeFromAmount: req.Msg.SubtractFeeFromAmount,
+		ReplayProtect:         req.Msg.ReplayProtect,
 	}
 	sendReq.RequiredInputs = lo.Map(req.Msg.RequiredInputs, func(u *pb.UnspentOutput, _ int) wallet.RequiredInput {
 		return wallet.RequiredInput{

--- a/sidechain-orchestrator/fork.go
+++ b/sidechain-orchestrator/fork.go
@@ -127,11 +127,8 @@ func (s *forkWalletScanner) Wallets() []fork.WalletMeta {
 	if s.o.WalletSvc == nil {
 		return nil
 	}
-	// Watch-only has no key, so it can't be swept. Core and enforcer
-	// wallets both hold spendable L1 BTC, but only Core claims can be
-	// replay-protected (the custom-serialized tx path is Core-only).
 	return lo.FilterMap(s.o.WalletSvc.GetAllWallets(), func(w wallet.WalletData, _ int) (fork.WalletMeta, bool) {
-		if w.IsWatchOnly() {
+		if !forkScannable(w) {
 			return fork.WalletMeta{}, false
 		}
 		return fork.WalletMeta{
@@ -140,6 +137,21 @@ func (s *forkWalletScanner) Wallets() []fork.WalletMeta {
 			ReplayProtectable: true,
 		}, true
 	})
+}
+
+// forkScannable reports whether a wallet's coins can reach a claim. A
+// single-sig watch-only wallet holds no key, so its coins can never move. A
+// multisig wallet always can: its split leaves as a PSBT, and the cosigners
+// sign it on a device or elsewhere.
+func forkScannable(w wallet.WalletData) bool {
+	return !w.IsWatchOnly() || w.Multisig != nil
+}
+
+// forkSpendable reports whether a coin can still move. A watch-only scan of a
+// multisig wallet marks every coin unspendable, but a psbt its cosigners sign
+// moves it, so the claim keeps it.
+func forkSpendable(spendable, multisig bool) bool {
+	return spendable || multisig
 }
 
 func (s *forkWalletScanner) Unspent(ctx context.Context, walletID string, tipHeight int) ([]fork.Utxo, error) {
@@ -156,6 +168,12 @@ func (s *forkWalletScanner) coreUnspent(ctx context.Context, walletID string, ti
 	if err != nil {
 		return nil, err
 	}
+	multisig := false
+	if s.o.WalletSvc != nil {
+		if w := s.o.WalletSvc.GetWalletByID(walletID); w != nil {
+			multisig = w.Multisig != nil
+		}
+	}
 	return lo.Map(coreUTXOs, func(u wallet.UTXO, _ int) fork.Utxo {
 		height := 0
 		if u.Confirmations > 0 {
@@ -167,7 +185,7 @@ func (s *forkWalletScanner) coreUnspent(ctx context.Context, walletID string, ti
 			Label:     u.Label,
 			Sats:      fork.BTCToSats(u.Amount),
 			Height:    height,
-			Spendable: u.Spendable,
+			Spendable: forkSpendable(u.Spendable, multisig),
 		}
 	}), nil
 }

--- a/sidechain-orchestrator/fork_tip_test.go
+++ b/sidechain-orchestrator/fork_tip_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 )
 
 type stubChainTip struct {
@@ -99,4 +101,29 @@ func TestChainSourceHeightResetsOnANetworkSwap(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, got)
 	require.Equal(t, 2, tip.calls)
+}
+
+// A multisig wallet whose cosigners all sign elsewhere still reaches a claim:
+// the split leaves as a PSBT for those signers.
+func TestForkScannableWallets(t *testing.T) {
+	held := wallet.WalletData{Master: wallet.MasterWallet{}}
+	require.True(t, forkScannable(held), "a wallet with a seed holds a key")
+
+	watchOnly := wallet.WalletData{WatchOnly: []byte(`{"xpub":"xpub661"}`)}
+	require.False(t, forkScannable(watchOnly), "a watch-only wallet can never sign")
+
+	externalMultisig := wallet.WalletData{
+		Multisig: &wallet.MultisigWalletData{
+			M: 2, N: 3,
+			Cosigners: []wallet.MultisigCosigner{{Xpub: "xpub1"}, {Xpub: "xpub2"}, {Xpub: "xpub3"}},
+		},
+	}
+	require.True(t, externalMultisig.IsWatchOnly())
+	require.True(t, forkScannable(externalMultisig), "the cosigners sign the psbt elsewhere")
+}
+
+func TestForkSpendableCoins(t *testing.T) {
+	require.True(t, forkSpendable(true, false), "a wallet key signs it")
+	require.False(t, forkSpendable(false, false), "no key, no signature")
+	require.True(t, forkSpendable(false, true), "the cosigners sign the psbt")
 }

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -4606,8 +4606,12 @@ type CreatePsbtRequest struct {
 	RequiredInputs        []*UnspentOutput       `protobuf:"bytes,7,rep,name=required_inputs,json=requiredInputs,proto3" json:"required_inputs,omitempty"`
 	RawOutputs            []*RawOutput           `protobuf:"bytes,8,rep,name=raw_outputs,json=rawOutputs,proto3" json:"raw_outputs,omitempty"`
 	ExternalInputs        []*ExternalInput       `protobuf:"bytes,9,rep,name=external_inputs,json=externalInputs,proto3" json:"external_inputs,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// Stamp the magic nLockTime (499999999) and non-final input sequences before
+	// the PSBT goes out for signatures, so the signed transaction is valid on
+	// eCash only. Electrum wallets only.
+	ReplayProtect bool `protobuf:"varint,10,opt,name=replay_protect,json=replayProtect,proto3" json:"replay_protect,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreatePsbtRequest) Reset() {
@@ -4701,6 +4705,13 @@ func (x *CreatePsbtRequest) GetExternalInputs() []*ExternalInput {
 		return x.ExternalInputs
 	}
 	return nil
+}
+
+func (x *CreatePsbtRequest) GetReplayProtect() bool {
+	if x != nil {
+		return x.ReplayProtect
+	}
+	return false
 }
 
 type CreatePsbtResponse struct {
@@ -9673,7 +9684,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x04vout\x18\x02 \x01(\x05R\x04vout\x12\x1d\n" +
 	"\n" +
 	"value_sats\x18\x03 \x01(\x03R\tvalueSats\x12*\n" +
-	"\x11script_pubkey_hex\x18\x04 \x01(\tR\x0fscriptPubkeyHex\"\xd5\x04\n" +
+	"\x11script_pubkey_hex\x18\x04 \x01(\tR\x0fscriptPubkeyHex\"\xfc\x04\n" +
 	"\x11CreatePsbtRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12Y\n" +
 	"\fdestinations\x18\x02 \x03(\v25.walletmanager.v1.CreatePsbtRequest.DestinationsEntryR\fdestinations\x122\n" +
@@ -9684,7 +9695,9 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x0frequired_inputs\x18\a \x03(\v2\x1f.walletmanager.v1.UnspentOutputR\x0erequiredInputs\x12<\n" +
 	"\vraw_outputs\x18\b \x03(\v2\x1b.walletmanager.v1.RawOutputR\n" +
 	"rawOutputs\x12H\n" +
-	"\x0fexternal_inputs\x18\t \x03(\v2\x1f.walletmanager.v1.ExternalInputR\x0eexternalInputs\x1a?\n" +
+	"\x0fexternal_inputs\x18\t \x03(\v2\x1f.walletmanager.v1.ExternalInputR\x0eexternalInputs\x12%\n" +
+	"\x0ereplay_protect\x18\n" +
+	" \x01(\bR\rreplayProtect\x1a?\n" +
 	"\x11DestinationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"5\n" +

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -693,6 +693,10 @@ message CreatePsbtRequest {
   repeated UnspentOutput required_inputs = 7;
   repeated RawOutput raw_outputs = 8;
   repeated ExternalInput external_inputs = 9;
+  // Stamp the magic nLockTime (499999999) and non-final input sequences before
+  // the PSBT goes out for signatures, so the signed transaction is valid on
+  // eCash only. Electrum wallets only.
+  bool replay_protect = 10;
 }
 
 message CreatePsbtResponse {

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -988,6 +988,9 @@ func (p *ElectrumBackend) CreatePSBT(ctx context.Context, walletID string, req S
 	if err != nil {
 		return "", err
 	}
+	if req.ReplayProtect {
+		replay.ApplyLockTime(packet.UnsignedTx)
+	}
 	return packet.B64Encode()
 }
 

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -2086,3 +2086,75 @@ func TestElectrumTaprootReceivePathUsesBIP86(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "m/84'/1'/0'/0/0", segwit.HDPath)
 }
+
+// A replay-protected PSBT must carry the magic locktime and non-final
+// sequences BEFORE it goes out for signatures, so every signature commits to
+// them and the finalized transaction still holds them.
+func TestElectrumCreatePSBTReplayProtect(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	ctx := context.Background()
+
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 200_000, TxCount: 1},
+	}
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID: "4444444444444444444444444444444444444444444444444444444444444444",
+		Vout: 0, Value: 200_000,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}
+
+	req := SendRequest{
+		DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000},
+		FeeRateSatPerVB:  2,
+		ReplayProtect:    true,
+	}
+
+	unsigned, err := p.CreatePSBT(ctx, w.ID, req)
+	require.NoError(t, err)
+
+	packet, err := decodePSBTBase64(unsigned)
+	require.NoError(t, err)
+	require.Equal(t, replay.ReplayLockTime, packet.UnsignedTx.LockTime)
+	for _, in := range packet.UnsignedTx.TxIn {
+		require.Less(t, in.Sequence, wire.MaxTxInSequenceNum, "locktime only applies to a non-final input")
+	}
+
+	signed, err := p.SignPSBT(ctx, w.ID, unsigned)
+	require.NoError(t, err)
+	rawHex, err := p.FinalizePSBT(signed)
+	require.NoError(t, err)
+
+	var tx wire.MsgTx
+	raw, err := hex.DecodeString(rawHex)
+	require.NoError(t, err)
+	require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+	require.Equal(t, replay.ReplayLockTime, tx.LockTime)
+	require.NotEmpty(t, tx.TxIn[0].Witness)
+}
+
+// Without the flag the PSBT stays a plain transaction.
+func TestElectrumCreatePSBTNoReplayProtect(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	ctx := context.Background()
+
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 200_000, TxCount: 1},
+	}
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID: "4444444444444444444444444444444444444444444444444444444444444444",
+		Vout: 0, Value: 200_000,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}
+
+	unsigned, err := p.CreatePSBT(ctx, w.ID, SendRequest{
+		DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000},
+		FeeRateSatPerVB:  2,
+	})
+	require.NoError(t, err)
+
+	packet, err := decodePSBTBase64(unsigned)
+	require.NoError(t, err)
+	require.NotEqual(t, replay.ReplayLockTime, packet.UnsignedTx.LockTime)
+}

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -15,9 +15,9 @@ import 'dart:core' as $core;
 import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
-import '../../google/protobuf/empty.pb.dart' as $2;
-import '../../google/protobuf/timestamp.pb.dart' as $1;
-import '../../orchestrator/v1/orchestrator.pbenum.dart' as $0;
+import '../../google/protobuf/empty.pb.dart' as $16;
+import '../../google/protobuf/timestamp.pb.dart' as $15;
+import '../../orchestrator/v1/orchestrator.pbenum.dart' as $2;
 import 'walletmanager.pbenum.dart';
 
 export 'walletmanager.pbenum.dart';
@@ -2101,11 +2101,11 @@ class DeleteAllWalletsResponse extends $pb.GeneratedMessage {
 
 class BalanceSnapshot extends $pb.GeneratedMessage {
   factory BalanceSnapshot({
-    $0.BinaryType? binary,
+    $2.BinaryType? binary,
     $core.String? displayName,
     $fixnum.Int64? confirmedSats,
     $fixnum.Int64? pendingSats,
-    $1.Timestamp? updatedAt,
+    $15.Timestamp? updatedAt,
   }) {
     final $result = create();
     if (binary != null) {
@@ -2130,11 +2130,11 @@ class BalanceSnapshot extends $pb.GeneratedMessage {
   factory BalanceSnapshot.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BalanceSnapshot', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
-    ..e<$0.BinaryType>(1, _omitFieldNames ? '' : 'binary', $pb.PbFieldType.OE, defaultOrMaker: $0.BinaryType.BINARY_TYPE_UNSPECIFIED, valueOf: $0.BinaryType.valueOf, enumValues: $0.BinaryType.values)
+    ..e<$2.BinaryType>(1, _omitFieldNames ? '' : 'binary', $pb.PbFieldType.OE, defaultOrMaker: $2.BinaryType.BINARY_TYPE_UNSPECIFIED, valueOf: $2.BinaryType.valueOf, enumValues: $2.BinaryType.values)
     ..aOS(2, _omitFieldNames ? '' : 'displayName')
     ..a<$fixnum.Int64>(3, _omitFieldNames ? '' : 'confirmedSats', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
     ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'pendingSats', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
-    ..aOM<$1.Timestamp>(5, _omitFieldNames ? '' : 'updatedAt', subBuilder: $1.Timestamp.create)
+    ..aOM<$15.Timestamp>(5, _omitFieldNames ? '' : 'updatedAt', subBuilder: $15.Timestamp.create)
     ..hasRequiredFields = false
   ;
 
@@ -2160,9 +2160,9 @@ class BalanceSnapshot extends $pb.GeneratedMessage {
   static BalanceSnapshot? _defaultInstance;
 
   @$pb.TagNumber(1)
-  $0.BinaryType get binary => $_getN(0);
+  $2.BinaryType get binary => $_getN(0);
   @$pb.TagNumber(1)
-  set binary($0.BinaryType v) { setField(1, v); }
+  set binary($2.BinaryType v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasBinary() => $_has(0);
   @$pb.TagNumber(1)
@@ -2196,15 +2196,15 @@ class BalanceSnapshot extends $pb.GeneratedMessage {
   void clearPendingSats() => clearField(4);
 
   @$pb.TagNumber(5)
-  $1.Timestamp get updatedAt => $_getN(4);
+  $15.Timestamp get updatedAt => $_getN(4);
   @$pb.TagNumber(5)
-  set updatedAt($1.Timestamp v) { setField(5, v); }
+  set updatedAt($15.Timestamp v) { setField(5, v); }
   @$pb.TagNumber(5)
   $core.bool hasUpdatedAt() => $_has(4);
   @$pb.TagNumber(5)
   void clearUpdatedAt() => clearField(5);
   @$pb.TagNumber(5)
-  $1.Timestamp ensureUpdatedAt() => $_ensure(4);
+  $15.Timestamp ensureUpdatedAt() => $_ensure(4);
 }
 
 class BackupWalletSummary extends $pb.GeneratedMessage {
@@ -2288,7 +2288,7 @@ class BackupWalletSummary extends $pb.GeneratedMessage {
 class WalletBackup extends $pb.GeneratedMessage {
   factory WalletBackup({
     $core.String? backupId,
-    $1.Timestamp? createdAt,
+    $15.Timestamp? createdAt,
     $core.String? sourceName,
     $core.bool? encrypted,
     $core.bool? hasMetadata,
@@ -2337,7 +2337,7 @@ class WalletBackup extends $pb.GeneratedMessage {
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WalletBackup', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'backupId')
-    ..aOM<$1.Timestamp>(2, _omitFieldNames ? '' : 'createdAt', subBuilder: $1.Timestamp.create)
+    ..aOM<$15.Timestamp>(2, _omitFieldNames ? '' : 'createdAt', subBuilder: $15.Timestamp.create)
     ..aOS(3, _omitFieldNames ? '' : 'sourceName')
     ..aOB(4, _omitFieldNames ? '' : 'encrypted')
     ..aOB(5, _omitFieldNames ? '' : 'hasMetadata')
@@ -2380,15 +2380,15 @@ class WalletBackup extends $pb.GeneratedMessage {
   void clearBackupId() => clearField(1);
 
   @$pb.TagNumber(2)
-  $1.Timestamp get createdAt => $_getN(1);
+  $15.Timestamp get createdAt => $_getN(1);
   @$pb.TagNumber(2)
-  set createdAt($1.Timestamp v) { setField(2, v); }
+  set createdAt($15.Timestamp v) { setField(2, v); }
   @$pb.TagNumber(2)
   $core.bool hasCreatedAt() => $_has(1);
   @$pb.TagNumber(2)
   void clearCreatedAt() => clearField(2);
   @$pb.TagNumber(2)
-  $1.Timestamp ensureCreatedAt() => $_ensure(1);
+  $15.Timestamp ensureCreatedAt() => $_ensure(1);
 
   @$pb.TagNumber(3)
   $core.String get sourceName => $_getSZ(2);
@@ -5241,6 +5241,7 @@ class CreatePsbtRequest extends $pb.GeneratedMessage {
     $core.Iterable<UnspentOutput>? requiredInputs,
     $core.Iterable<RawOutput>? rawOutputs,
     $core.Iterable<ExternalInput>? externalInputs,
+    $core.bool? replayProtect,
   }) {
     final $result = create();
     if (walletId != null) {
@@ -5270,6 +5271,9 @@ class CreatePsbtRequest extends $pb.GeneratedMessage {
     if (externalInputs != null) {
       $result.externalInputs.addAll(externalInputs);
     }
+    if (replayProtect != null) {
+      $result.replayProtect = replayProtect;
+    }
     return $result;
   }
   CreatePsbtRequest._() : super();
@@ -5286,6 +5290,7 @@ class CreatePsbtRequest extends $pb.GeneratedMessage {
     ..pc<UnspentOutput>(7, _omitFieldNames ? '' : 'requiredInputs', $pb.PbFieldType.PM, subBuilder: UnspentOutput.create)
     ..pc<RawOutput>(8, _omitFieldNames ? '' : 'rawOutputs', $pb.PbFieldType.PM, subBuilder: RawOutput.create)
     ..pc<ExternalInput>(9, _omitFieldNames ? '' : 'externalInputs', $pb.PbFieldType.PM, subBuilder: ExternalInput.create)
+    ..aOB(10, _omitFieldNames ? '' : 'replayProtect')
     ..hasRequiredFields = false
   ;
 
@@ -5366,6 +5371,18 @@ class CreatePsbtRequest extends $pb.GeneratedMessage {
 
   @$pb.TagNumber(9)
   $core.List<ExternalInput> get externalInputs => $_getList(8);
+
+  /// Stamp the magic nLockTime (499999999) and non-final input sequences before
+  /// the PSBT goes out for signatures, so the signed transaction is valid on
+  /// eCash only. Electrum wallets only.
+  @$pb.TagNumber(10)
+  $core.bool get replayProtect => $_getBF(9);
+  @$pb.TagNumber(10)
+  set replayProtect($core.bool v) { $_setBool(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasReplayProtect() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearReplayProtect() => clearField(10);
 }
 
 class CreatePsbtResponse extends $pb.GeneratedMessage {
@@ -7919,7 +7936,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
     $core.bool? spendable,
     $core.bool? solvable,
     $core.String? walletId,
-    $1.Timestamp? receivedAt,
+    $15.Timestamp? receivedAt,
     $core.String? derivationPath,
     $core.bool? splittable,
   }) {
@@ -7980,7 +7997,7 @@ class UnspentOutput extends $pb.GeneratedMessage {
     ..aOB(8, _omitFieldNames ? '' : 'spendable')
     ..aOB(9, _omitFieldNames ? '' : 'solvable')
     ..aOS(10, _omitFieldNames ? '' : 'walletId')
-    ..aOM<$1.Timestamp>(11, _omitFieldNames ? '' : 'receivedAt', subBuilder: $1.Timestamp.create)
+    ..aOM<$15.Timestamp>(11, _omitFieldNames ? '' : 'receivedAt', subBuilder: $15.Timestamp.create)
     ..aOS(12, _omitFieldNames ? '' : 'derivationPath')
     ..aOB(13, _omitFieldNames ? '' : 'splittable')
     ..hasRequiredFields = false
@@ -8100,15 +8117,15 @@ class UnspentOutput extends $pb.GeneratedMessage {
   /// Wallet's first-seen mempool timestamp when available, otherwise the
   /// confirming block's time. Unset if neither is known.
   @$pb.TagNumber(11)
-  $1.Timestamp get receivedAt => $_getN(10);
+  $15.Timestamp get receivedAt => $_getN(10);
   @$pb.TagNumber(11)
-  set receivedAt($1.Timestamp v) { setField(11, v); }
+  set receivedAt($15.Timestamp v) { setField(11, v); }
   @$pb.TagNumber(11)
   $core.bool hasReceivedAt() => $_has(10);
   @$pb.TagNumber(11)
   void clearReceivedAt() => clearField(11);
   @$pb.TagNumber(11)
-  $1.Timestamp ensureReceivedAt() => $_ensure(10);
+  $15.Timestamp ensureReceivedAt() => $_ensure(10);
 
   /// BIP32 path of the address that owns this output. Empty when the backend
   /// cannot report one (Bitcoin Core bulk lists, the enforcer).
@@ -11495,7 +11512,7 @@ class WalletManagerServiceApi {
   $async.Future<SetTorConfigResponse> setTorConfig($pb.ClientContext? ctx, SetTorConfigRequest request) =>
     _client.invoke<SetTorConfigResponse>(ctx, 'WalletManagerService', 'SetTorConfig', request, SetTorConfigResponse())
   ;
-  $async.Future<WatchWalletDataResponse> watchWalletData($pb.ClientContext? ctx, $2.Empty request) =>
+  $async.Future<WatchWalletDataResponse> watchWalletData($pb.ClientContext? ctx, $16.Empty request) =>
     _client.invoke<WatchWalletDataResponse>(ctx, 'WalletManagerService', 'WatchWalletData', request, WatchWalletDataResponse())
   ;
 }

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -13,8 +13,8 @@ import 'dart:convert' as $convert;
 import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 
-import '../../google/protobuf/empty.pbjson.dart' as $2;
-import '../../google/protobuf/timestamp.pbjson.dart' as $1;
+import '../../google/protobuf/empty.pbjson.dart' as $16;
+import '../../google/protobuf/timestamp.pbjson.dart' as $15;
 
 @$core.Deprecated('Use nodeModeDescriptor instead')
 const NodeMode$json = {
@@ -1238,6 +1238,7 @@ const CreatePsbtRequest$json = {
     {'1': 'required_inputs', '3': 7, '4': 3, '5': 11, '6': '.walletmanager.v1.UnspentOutput', '10': 'requiredInputs'},
     {'1': 'raw_outputs', '3': 8, '4': 3, '5': 11, '6': '.walletmanager.v1.RawOutput', '10': 'rawOutputs'},
     {'1': 'external_inputs', '3': 9, '4': 3, '5': 11, '6': '.walletmanager.v1.ExternalInput', '10': 'externalInputs'},
+    {'1': 'replay_protect', '3': 10, '4': 1, '5': 8, '10': 'replayProtect'},
   ],
   '3': [CreatePsbtRequest_DestinationsEntry$json],
 };
@@ -1263,8 +1264,9 @@ final $typed_data.Uint8List createPsbtRequestDescriptor = $convert.base64Decode(
     'ZF9pbnB1dHMYByADKAsyHy53YWxsZXRtYW5hZ2VyLnYxLlVuc3BlbnRPdXRwdXRSDnJlcXVpcm'
     'VkSW5wdXRzEjwKC3Jhd19vdXRwdXRzGAggAygLMhsud2FsbGV0bWFuYWdlci52MS5SYXdPdXRw'
     'dXRSCnJhd091dHB1dHMSSAoPZXh0ZXJuYWxfaW5wdXRzGAkgAygLMh8ud2FsbGV0bWFuYWdlci'
-    '52MS5FeHRlcm5hbElucHV0Ug5leHRlcm5hbElucHV0cxo/ChFEZXN0aW5hdGlvbnNFbnRyeRIQ'
-    'CgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoA1IFdmFsdWU6AjgB');
+    '52MS5FeHRlcm5hbElucHV0Ug5leHRlcm5hbElucHV0cxIlCg5yZXBsYXlfcHJvdGVjdBgKIAEo'
+    'CFINcmVwbGF5UHJvdGVjdBo/ChFEZXN0aW5hdGlvbnNFbnRyeRIQCgNrZXkYASABKAlSA2tleR'
+    'IUCgV2YWx1ZRgCIAEoA1IFdmFsdWU6AjgB');
 
 @$core.Deprecated('Use createPsbtResponseDescriptor instead')
 const CreatePsbtResponse$json = {
@@ -2563,7 +2565,7 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> WalletMana
   '.walletmanager.v1.ListWalletBackupsRequest': ListWalletBackupsRequest$json,
   '.walletmanager.v1.ListWalletBackupsResponse': ListWalletBackupsResponse$json,
   '.walletmanager.v1.WalletBackup': WalletBackup$json,
-  '.google.protobuf.Timestamp': $1.Timestamp$json,
+  '.google.protobuf.Timestamp': $15.Timestamp$json,
   '.walletmanager.v1.BackupWalletSummary': BackupWalletSummary$json,
   '.walletmanager.v1.BalanceSnapshot': BalanceSnapshot$json,
   '.walletmanager.v1.RestoreWalletBackupRequest': RestoreWalletBackupRequest$json,
@@ -2683,7 +2685,7 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> WalletMana
   '.walletmanager.v1.GetTorConfigResponse': GetTorConfigResponse$json,
   '.walletmanager.v1.SetTorConfigRequest': SetTorConfigRequest$json,
   '.walletmanager.v1.SetTorConfigResponse': SetTorConfigResponse$json,
-  '.google.protobuf.Empty': $2.Empty$json,
+  '.google.protobuf.Empty': $16.Empty$json,
   '.walletmanager.v1.WatchWalletDataResponse': WatchWalletDataResponse$json,
 };
 

--- a/sidechain_core/lib/rpcs/orchestrator_wallet_rpc.dart
+++ b/sidechain_core/lib/rpcs/orchestrator_wallet_rpc.dart
@@ -35,11 +35,15 @@ class OrchestratorWalletRPC {
   }
 
   Future<void> rescanWallet({String? walletId}) async {
-    await _unaryClient.rescanWallet(wmpb.RescanWalletRequest(walletId: walletId ?? ''));
+    await _unaryClient.rescanWallet(
+      wmpb.RescanWalletRequest(walletId: walletId ?? ''),
+    );
   }
 
   Future<double?> estimateFee(int confTarget) async {
-    final r = await _unaryClient.estimateFee(wmpb.EstimateFeeRequest(confTarget: confTarget));
+    final r = await _unaryClient.estimateFee(
+      wmpb.EstimateFeeRequest(confTarget: confTarget),
+    );
     return r.satPerVbyte > 0 ? r.satPerVbyte : null;
   }
 
@@ -74,7 +78,9 @@ class OrchestratorWalletRPC {
   }
 
   Future<wmpb.UnlockWalletResponse> unlockWallet(String password) {
-    return _unaryClient.unlockWallet(wmpb.UnlockWalletRequest(password: password));
+    return _unaryClient.unlockWallet(
+      wmpb.UnlockWalletRequest(password: password),
+    );
   }
 
   Future<wmpb.LockWalletResponse> lockWallet() {
@@ -82,7 +88,9 @@ class OrchestratorWalletRPC {
   }
 
   Future<wmpb.EncryptWalletResponse> encryptWallet(String password) {
-    return _unaryClient.encryptWallet(wmpb.EncryptWalletRequest(password: password));
+    return _unaryClient.encryptWallet(
+      wmpb.EncryptWalletRequest(password: password),
+    );
   }
 
   Future<wmpb.ChangePasswordResponse> changePassword(
@@ -176,17 +184,28 @@ class OrchestratorWalletRPC {
   /// Parses a descriptor or wallet-config file into a multisig policy +
   /// cosigners, for the editable-descriptor and import-config flows.
   Future<wmpb.ParseMultisigConfigResponse> parseMultisigConfig(String content) {
-    return _unaryClient.parseMultisigConfig(wmpb.ParseMultisigConfigRequest(content: content));
+    return _unaryClient.parseMultisigConfig(
+      wmpb.ParseMultisigConfigRequest(content: content),
+    );
   }
 
   /// Reads an output descriptor into the script policy it encodes. Throws if
   /// the descriptor is incomplete or unsupported.
-  Future<wmpb.ValidateDescriptorResponse> validateDescriptor(String descriptor) {
-    return _unaryClient.validateDescriptor(wmpb.ValidateDescriptorRequest(descriptor: descriptor));
+  Future<wmpb.ValidateDescriptorResponse> validateDescriptor(
+    String descriptor,
+  ) {
+    return _unaryClient.validateDescriptor(
+      wmpb.ValidateDescriptorRequest(descriptor: descriptor),
+    );
   }
 
-  Future<wmpb.SwitchWalletResponse> switchWallet(String walletId, {String dataDir = ''}) {
-    return _unaryClient.switchWallet(wmpb.SwitchWalletRequest(walletId: walletId, dataDir: dataDir));
+  Future<wmpb.SwitchWalletResponse> switchWallet(
+    String walletId, {
+    String dataDir = '',
+  }) {
+    return _unaryClient.switchWallet(
+      wmpb.SwitchWalletRequest(walletId: walletId, dataDir: dataDir),
+    );
   }
 
   Future<wmpb.UpdateWalletMetadataResponse> updateWalletMetadata({
@@ -204,7 +223,9 @@ class OrchestratorWalletRPC {
   }
 
   Future<wmpb.DeleteWalletResponse> deleteWallet(String walletId) {
-    return _unaryClient.deleteWallet(wmpb.DeleteWalletRequest(walletId: walletId));
+    return _unaryClient.deleteWallet(
+      wmpb.DeleteWalletRequest(walletId: walletId),
+    );
   }
 
   Future<wmpb.DeleteAllWalletsResponse> deleteAllWallets() {
@@ -220,10 +241,7 @@ class OrchestratorWalletRPC {
     String password = '',
   }) {
     return _unaryClient.restoreWalletBackup(
-      wmpb.RestoreWalletBackupRequest(
-        backupId: backupId,
-        password: password,
-      ),
+      wmpb.RestoreWalletBackupRequest(backupId: backupId, password: password),
     );
   }
 
@@ -232,10 +250,7 @@ class OrchestratorWalletRPC {
     String password = '',
   }) {
     return _streamClient.restoreWalletBackupStream(
-      wmpb.RestoreWalletBackupRequest(
-        backupId: backupId,
-        password: password,
-      ),
+      wmpb.RestoreWalletBackupRequest(backupId: backupId, password: password),
     );
   }
 
@@ -269,7 +284,9 @@ class OrchestratorWalletRPC {
     return _unaryClient.sendTransaction(
       wmpb.SendTransactionRequest(
         walletId: walletId,
-        destinations: destinations.map((key, value) => MapEntry(key, Int64(value))),
+        destinations: destinations.map(
+          (key, value) => MapEntry(key, Int64(value)),
+        ),
         feeRateSatPerVbyte: Int64(feeRateSatPerVbyte ?? 0),
         subtractFeeFromAmount: subtractFeeFromAmount,
         opReturnHex: resolvedOpReturnHex ?? '',
@@ -291,6 +308,7 @@ class OrchestratorWalletRPC {
     String? opReturnMessage,
     String? opReturnHex,
     List<bwpb.UnspentOutput>? requiredInputs,
+    bool replayProtect = false,
   }) async {
     final resolvedOpReturnHex =
         opReturnHex ?? (opReturnMessage == null ? null : _bytesToHex(utf8.encode(opReturnMessage)));
@@ -298,19 +316,25 @@ class OrchestratorWalletRPC {
     final response = await _unaryClient.createPsbt(
       wmpb.CreatePsbtRequest(
         walletId: walletId,
-        destinations: destinations.map((key, value) => MapEntry(key, Int64(value))),
+        destinations: destinations.map(
+          (key, value) => MapEntry(key, Int64(value)),
+        ),
         feeRateSatPerVbyte: Int64(feeRateSatPerVbyte ?? 0),
         subtractFeeFromAmount: subtractFeeFromAmount,
         opReturnHex: resolvedOpReturnHex ?? '',
         fixedFeeSats: Int64(fixedFeeSats ?? 0),
         requiredInputs: requiredInputs?.map(_mapRequiredInput).toList() ?? [],
+        replayProtect: replayProtect,
       ),
     );
     return response.psbtBase64;
   }
 
   /// Sign a PSBT with the active (hot) wallet, returning the updated PSBT.
-  Future<String> signPsbt({required String walletId, required String psbtBase64}) async {
+  Future<String> signPsbt({
+    required String walletId,
+    required String psbtBase64,
+  }) async {
     final response = await _unaryClient.signPsbt(
       wmpb.SignPsbtRequest(walletId: walletId, psbtBase64: psbtBase64),
     );
@@ -357,12 +381,18 @@ class OrchestratorWalletRPC {
     required String psbtBase64,
   }) {
     return _unaryClient.multisigPsbtStatus(
-      wmpb.MultisigPsbtStatusRequest(walletId: walletId, psbtBase64: psbtBase64),
+      wmpb.MultisigPsbtStatusRequest(
+        walletId: walletId,
+        psbtBase64: psbtBase64,
+      ),
     );
   }
 
   /// Broadcasts a finalized raw transaction over the wallet's chain.
-  Future<String> broadcastTransaction({required String walletId, required String txHex}) async {
+  Future<String> broadcastTransaction({
+    required String walletId,
+    required String txHex,
+  }) async {
     final response = await _unaryClient.broadcastTransaction(
       wmpb.BroadcastTransactionRequest(walletId: walletId, txHex: txHex),
     );
@@ -371,7 +401,9 @@ class OrchestratorWalletRPC {
 
   /// Lists connected USB hardware wallets. A passphrase makes a
   /// passphrase-protected device report its passphrase-wallet fingerprint.
-  Future<List<wmpb.HardwareDevice>> enumerateHardwareDevices({String? passphrase}) async {
+  Future<List<wmpb.HardwareDevice>> enumerateHardwareDevices({
+    String? passphrase,
+  }) async {
     final response = await _unaryClient.enumerateHardwareDevices(
       wmpb.EnumerateHardwareDevicesRequest(passphrase: passphrase ?? ''),
     );
@@ -384,7 +416,10 @@ class OrchestratorWalletRPC {
     required String derivationPath,
   }) async {
     final response = await _unaryClient.getHardwareXpub(
-      wmpb.GetHardwareXpubRequest(device: device, derivationPath: derivationPath),
+      wmpb.GetHardwareXpubRequest(
+        device: device,
+        derivationPath: derivationPath,
+      ),
     );
     return response.xpub;
   }
@@ -401,17 +436,28 @@ class OrchestratorWalletRPC {
   }
 
   /// Makes a locked device show its scrambled PIN matrix.
-  Future<void> promptDevicePin({required wmpb.HardwareDeviceSelector device}) async {
-    await _unaryClient.promptDevicePin(wmpb.PromptDevicePinRequest(device: device));
+  Future<void> promptDevicePin({
+    required wmpb.HardwareDeviceSelector device,
+  }) async {
+    await _unaryClient.promptDevicePin(
+      wmpb.PromptDevicePinRequest(device: device),
+    );
   }
 
   /// Unlocks a device with the matrix positions the user picked.
-  Future<void> sendDevicePin({required wmpb.HardwareDeviceSelector device, required String pin}) async {
-    await _unaryClient.sendDevicePin(wmpb.SendDevicePinRequest(device: device, pin: pin));
+  Future<void> sendDevicePin({
+    required wmpb.HardwareDeviceSelector device,
+    required String pin,
+  }) async {
+    await _unaryClient.sendDevicePin(
+      wmpb.SendDevicePinRequest(device: device, pin: pin),
+    );
   }
 
   /// Releases a device session (e.g. after cancelling a PIN prompt).
-  Future<void> closeDevice({required wmpb.HardwareDeviceSelector device}) async {
+  Future<void> closeDevice({
+    required wmpb.HardwareDeviceSelector device,
+  }) async {
     await _unaryClient.closeDevice(wmpb.CloseDeviceRequest(device: device));
   }
 
@@ -460,7 +506,10 @@ class OrchestratorWalletRPC {
 
   /// Canonicalises a derivation path and reports the script type it is the
   /// standard path for. Throws with the reason it is unusable.
-  Future<wmpb.ValidateDerivationPathResponse> validateDerivationPath(String path, {bool multisig = false}) {
+  Future<wmpb.ValidateDerivationPathResponse> validateDerivationPath(
+    String path, {
+    bool multisig = false,
+  }) {
     return _unaryClient.validateDerivationPath(
       wmpb.ValidateDerivationPathRequest(path: path, multisig: multisig),
     );
@@ -473,7 +522,11 @@ class OrchestratorWalletRPC {
     int account = 0,
   }) {
     return _unaryClient.listDerivationPaths(
-      wmpb.ListDerivationPathsRequest(scriptType: scriptType, multisig: multisig, account: account),
+      wmpb.ListDerivationPathsRequest(
+        scriptType: scriptType,
+        multisig: multisig,
+        account: account,
+      ),
     );
   }
 
@@ -487,10 +540,14 @@ class OrchestratorWalletRPC {
   }
 
   Future<wmpb.ListUnspentResponse> listUnspent(String walletId) {
-    return _unaryClient.listUnspent(wmpb.ListUnspentRequest(walletId: walletId));
+    return _unaryClient.listUnspent(
+      wmpb.ListUnspentRequest(walletId: walletId),
+    );
   }
 
-  Future<wmpb.ListReceiveAddressesResponse> listReceiveAddresses(String walletId) {
+  Future<wmpb.ListReceiveAddressesResponse> listReceiveAddresses(
+    String walletId,
+  ) {
     return _unaryClient.listReceiveAddresses(
       wmpb.ListReceiveAddressesRequest(walletId: walletId),
     );
@@ -611,7 +668,9 @@ class OrchestratorWalletRPC {
   /// to the network default. Validates connectivity server-side and keeps the
   /// previous endpoint on failure.
   Future<wmpb.SetElectrumServerResponse> setElectrumServer(String url) {
-    return _unaryClient.setElectrumServer(wmpb.SetElectrumServerRequest(url: url));
+    return _unaryClient.setElectrumServer(
+      wmpb.SetElectrumServerRequest(url: url),
+    );
   }
 
   Future<wmpb.GetTorConfigResponse> getTorConfig() {
@@ -622,7 +681,9 @@ class OrchestratorWalletRPC {
   /// SOCKS5 proxy. When enabling, an empty proxy uses the network default.
   /// Validates connectivity server-side and keeps the previous config on failure.
   Future<wmpb.SetTorConfigResponse> setTorConfig(bool enabled, String proxy) {
-    return _unaryClient.setTorConfig(wmpb.SetTorConfigRequest(enabled: enabled, proxy: proxy));
+    return _unaryClient.setTorConfig(
+      wmpb.SetTorConfigRequest(enabled: enabled, proxy: proxy),
+    );
   }
 
   String _bytesToHex(List<int> bytes) {


### PR DESCRIPTION
A multisig wallet cannot sign its own eCash claim, so the claim card now builds a replay-protected PSBT and files it as a draft that the cosigners sign on the send tab.

Any send that spends a coin the split engine found on both chains asks first, and offers replay protection for that one transaction.

Design: https://www.figma.com/design/Uvj2xZiMJsOt3nDaSxDGLQ/drivechain-frontends?node-id=584-433