### PR TITLE
orchestrator: set dbcache from host memory

### DIFF
--- a/sidechain-orchestrator/config/bitcoin_conf.go
+++ b/sidechain-orchestrator/config/bitcoin_conf.go
@@ -335,6 +335,7 @@ zmqpubrawblock=tcp://127.0.0.1:29003
 zmqpubrawtx=tcp://127.0.0.1:29004
 rpcthreads=10
 rpcworkqueue=50
+dbcache=%s
 rest=1
 uacomment=BitWindow-0.2
 chain=%s # current network
@@ -364,7 +365,7 @@ fallbackfee=0.00021
 # Regtest-specific settings
 [regtest]
 fallbackfee=0.00021
-`, bitcoinConfVersionCommentPrefix, BitcoinConfMigrationsVersion, currentNetwork, mainSection)
+`, bitcoinConfVersionCommentPrefix, BitcoinConfMigrationsVersion, defaultDBCacheSetting(), currentNetwork, mainSection)
 }
 
 // SaveConfig writes the current config to disk.

--- a/sidechain-orchestrator/config/bitcoin_config_syncer.go
+++ b/sidechain-orchestrator/config/bitcoin_config_syncer.go
@@ -20,6 +20,9 @@ type BitcoinConfMigration struct {
 	// invalidates (e.g. a signetchallenge change). Wiped only when the
 	// migration actually changes a value in an existing config.
 	WipeChainData []Network
+	// SkipIfSet leaves a key that the config already carries alone, so a
+	// migration that only backfills a default never overwrites a user's value.
+	SkipIfSet bool
 }
 
 var bitcoinConfMigrations = []BitcoinConfMigration{
@@ -146,10 +149,21 @@ var bitcoinConfMigrations = []BitcoinConfMigration{
 		},
 		WipeChainData: []Network{NetworkSignet},
 	},
+	{
+		// Core's default caches under 1 GiB of the UTXO set, so a large
+		// initial block download spends most of its time in chainstate reads.
+		Version:   11,
+		SkipIfSet: true,
+		Changes: map[string]map[string]string{
+			"": {
+				"dbcache": defaultDBCacheSetting(),
+			},
+		},
+	},
 }
 
 // BitcoinConfMigrationsVersion is the highest migration version.
-var BitcoinConfMigrationsVersion = 10
+var BitcoinConfMigrationsVersion = 11
 
 // RunBitcoinConfMigrations applies pending migrations to a BitcoinConfig.
 // Returns whether any migration was applied, plus the networks whose chain
@@ -166,6 +180,9 @@ func RunBitcoinConfMigrations(config *BitcoinConfig) (bool, []Network) {
 		changed := false
 		for section, settings := range m.Changes {
 			for key, value := range settings {
+				if m.SkipIfSet && config.GetSetting(key, section) != "" {
+					continue
+				}
 				if config.GetSetting(key, section) != value {
 					changed = true
 				}

--- a/sidechain-orchestrator/config/dbcache.go
+++ b/sidechain-orchestrator/config/dbcache.go
@@ -1,0 +1,29 @@
+package config
+
+import "strconv"
+
+const (
+	minDBCacheMiB = 450
+	maxDBCacheMiB = 16384
+)
+
+// DefaultDBCacheMiB is the -dbcache value for bitcoin.conf: a quarter of host
+// memory, clamped to [450, 16384].
+func DefaultDBCacheMiB() int {
+	total := totalMemoryBytes()
+	if total == 0 {
+		return minDBCacheMiB
+	}
+	cache := int(total / 4 / (1024 * 1024))
+	if cache < minDBCacheMiB {
+		return minDBCacheMiB
+	}
+	if cache > maxDBCacheMiB {
+		return maxDBCacheMiB
+	}
+	return cache
+}
+
+func defaultDBCacheSetting() string {
+	return strconv.Itoa(DefaultDBCacheMiB())
+}

--- a/sidechain-orchestrator/config/dbcache_darwin.go
+++ b/sidechain-orchestrator/config/dbcache_darwin.go
@@ -1,0 +1,11 @@
+package config
+
+import "golang.org/x/sys/unix"
+
+func totalMemoryBytes() uint64 {
+	total, err := unix.SysctlUint64("hw.memsize")
+	if err != nil {
+		return 0
+	}
+	return total
+}

--- a/sidechain-orchestrator/config/dbcache_integration_test.go
+++ b/sidechain-orchestrator/config/dbcache_integration_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// An old conf on disk gets dbcache written into the file itself.
+func TestLoadOrCreate_BackfillsDBCacheOnDisk(t *testing.T) {
+	m := newTestConfManager(t)
+	confPath := m.getBitWindowConfigPath()
+
+	old := "# bitwindow-bitcoin-conf-version=10\n\nserver=1\ndatadir=/Volumes/LaCie/Bitcoin\nchain=main\n"
+	if err := os.WriteFile(confPath, []byte(old), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := m.loadOrCreateConfigContent(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	onDisk, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	written := ParseBitcoinConfig(string(onDisk))
+	if got := written.GetSetting("dbcache"); got != defaultDBCacheSetting() {
+		t.Errorf("dbcache = %q, want %q:\n%s", got, defaultDBCacheSetting(), onDisk)
+	}
+	if written.ConfigVersion != BitcoinConfMigrationsVersion {
+		t.Errorf("version = %d, want %d", written.ConfigVersion, BitcoinConfMigrationsVersion)
+	}
+	if got := written.GetSetting("datadir"); got != "/Volumes/LaCie/Bitcoin" {
+		t.Errorf("datadir = %q, want /Volumes/LaCie/Bitcoin", got)
+	}
+}
+
+// A hand-set dbcache survives the migration on disk.
+func TestLoadOrCreate_KeepsUserDBCacheOnDisk(t *testing.T) {
+	m := newTestConfManager(t)
+	confPath := m.getBitWindowConfigPath()
+
+	old := "# bitwindow-bitcoin-conf-version=10\n\ndbcache=100\nchain=main\n"
+	if err := os.WriteFile(confPath, []byte(old), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := m.loadOrCreateConfigContent(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	onDisk, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ParseBitcoinConfig(string(onDisk)).GetSetting("dbcache"); got != "100" {
+		t.Errorf("dbcache = %q, want 100:\n%s", got, onDisk)
+	}
+}
+
+// A first run writes dbcache, and a second load leaves it alone.
+func TestLoadOrCreate_DBCacheIsIdempotent(t *testing.T) {
+	m := newTestConfManager(t)
+	confPath := m.getBitWindowConfigPath()
+
+	if _, err := m.loadOrCreateConfigContent(); err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	first, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "dbcache=" + strconv.Itoa(DefaultDBCacheMiB())
+	if !strings.Contains(string(first), want) {
+		t.Fatalf("first run misses %q:\n%s", want, first)
+	}
+
+	if _, err := m.loadOrCreateConfigContent(); err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	second, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(second) != string(first) {
+		t.Errorf("second load changed the file:\n%s\n---\n%s", first, second)
+	}
+	if n := strings.Count(string(second), "dbcache="); n != 1 {
+		t.Errorf("dbcache lines = %d, want 1:\n%s", n, second)
+	}
+}

--- a/sidechain-orchestrator/config/dbcache_linux.go
+++ b/sidechain-orchestrator/config/dbcache_linux.go
@@ -1,0 +1,11 @@
+package config
+
+import "golang.org/x/sys/unix"
+
+func totalMemoryBytes() uint64 {
+	var info unix.Sysinfo_t
+	if err := unix.Sysinfo(&info); err != nil {
+		return 0
+	}
+	return uint64(info.Totalram) * uint64(info.Unit)
+}

--- a/sidechain-orchestrator/config/dbcache_other.go
+++ b/sidechain-orchestrator/config/dbcache_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux && !windows
+
+package config
+
+func totalMemoryBytes() uint64 {
+	return 0
+}

--- a/sidechain-orchestrator/config/dbcache_test.go
+++ b/sidechain-orchestrator/config/dbcache_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestDefaultDBCacheMiBStaysInRange(t *testing.T) {
+	got := DefaultDBCacheMiB()
+	if got < minDBCacheMiB || got > maxDBCacheMiB {
+		t.Fatalf("dbcache %d outside [%d, %d]", got, minDBCacheMiB, maxDBCacheMiB)
+	}
+}
+
+func TestDefaultConfigCarriesDBCache(t *testing.T) {
+	m := &BitcoinConfManager{Network: NetworkECash}
+	want := "dbcache=" + strconv.Itoa(DefaultDBCacheMiB())
+	if !strings.Contains(m.GetDefaultConfig(), want) {
+		t.Fatalf("default config misses %q", want)
+	}
+}
+
+func TestMigrationBackfillsDBCache(t *testing.T) {
+	config := ParseBitcoinConfig("# bitwindow-bitcoin-conf-version=10\nserver=1\n")
+	migrated, _ := RunBitcoinConfMigrations(config)
+	if !migrated {
+		t.Fatal("no migration ran")
+	}
+	if got := config.GetSetting("dbcache"); got != defaultDBCacheSetting() {
+		t.Fatalf("dbcache = %q, want %q", got, defaultDBCacheSetting())
+	}
+	if config.ConfigVersion != BitcoinConfMigrationsVersion {
+		t.Fatalf("version = %d, want %d", config.ConfigVersion, BitcoinConfMigrationsVersion)
+	}
+}
+
+func TestMigrationKeepsUserDBCache(t *testing.T) {
+	config := ParseBitcoinConfig("# bitwindow-bitcoin-conf-version=10\ndbcache=100\n")
+	if _, _ = RunBitcoinConfMigrations(config); config.GetSetting("dbcache") != "100" {
+		t.Fatalf("dbcache = %q, want 100", config.GetSetting("dbcache"))
+	}
+}

--- a/sidechain-orchestrator/config/dbcache_windows.go
+++ b/sidechain-orchestrator/config/dbcache_windows.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type memoryStatusEx struct {
+	length               uint32
+	memoryLoad           uint32
+	totalPhys            uint64
+	availPhys            uint64
+	totalPageFile        uint64
+	availPageFile        uint64
+	totalVirtual         uint64
+	availVirtual         uint64
+	availExtendedVirtual uint64
+}
+
+func totalMemoryBytes() uint64 {
+	proc := windows.NewLazySystemDLL("kernel32.dll").NewProc("GlobalMemoryStatusEx")
+	if err := proc.Find(); err != nil {
+		return 0
+	}
+	status := memoryStatusEx{}
+	status.length = uint32(unsafe.Sizeof(status))
+	ret, _, _ := proc.Call(uintptr(unsafe.Pointer(&status)))
+	if ret == 0 {
+		return 0
+	}
+	return status.totalPhys
+}

--- a/sidechain-orchestrator/go.mod
+++ b/sidechain-orchestrator/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
-	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/sys v0.46.0
 	golang.org/x/text v0.38.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Core ran the alphanet initial block download with its default cache, which holds under 1 GiB of the UTXO set. A profile of the validation thread put 86% of its samples in chainstate LevelDB reads, while the 13 script threads sat 91% idle.

bitcoin.conf now carries dbcache at a quarter of host memory, clamped to 450-16384 MiB. A migration backfills it and leaves a hand-set value alone.