### PR TITLE
coinnews: re-read the bitcoind cookie per call

### DIFF
--- a/coinnews/server/main.go
+++ b/coinnews/server/main.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -51,17 +50,12 @@ func main() {
 
 	// A cookie file lets us share Bitcoin Core's auto-generated
 	// `__cookie__:<pass>` credentials (e.g. a mounted Docker secret)
-	// instead of hardcoding a static rpcauth user/pass.
+	// instead of hardcoding a static rpcauth user/pass. Read it here only to
+	// fail fast on a bad path; the client re-reads it per call.
 	if *bitcoindCookie != "" {
-		raw, err := os.ReadFile(*bitcoindCookie)
-		if err != nil {
+		if _, _, err := scanner.ReadCookie(*bitcoindCookie); err != nil {
 			log.Fatal().Err(err).Str("file", *bitcoindCookie).Msg("read bitcoind cookie file")
 		}
-		user, pass, ok := strings.Cut(strings.TrimSpace(string(raw)), ":")
-		if !ok {
-			log.Fatal().Str("file", *bitcoindCookie).Msg("malformed bitcoind cookie file: expected user:password")
-		}
-		*bitcoindUser, *bitcoindPass = user, pass
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -77,10 +71,11 @@ func main() {
 		go func() {
 			s := &scanner.Scanner{
 				Client: &scanner.Client{
-					URL:  *bitcoindURL,
-					User: *bitcoindUser,
-					Pass: *bitcoindPass,
-					HTTP: &http.Client{Timeout: 30 * time.Second},
+					URL:        *bitcoindURL,
+					User:       *bitcoindUser,
+					Pass:       *bitcoindPass,
+					CookiePath: *bitcoindCookie,
+					HTTP:       &http.Client{Timeout: 30 * time.Second},
 				},
 				DB:           db,
 				Log:          log.With().Str("component", "scanner").Logger(),

--- a/coinnews/server/scanner/client.go
+++ b/coinnews/server/scanner/client.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 	"sync/atomic"
 )
 
@@ -18,8 +20,32 @@ type Client struct {
 	User string
 	Pass string
 
+	// CookiePath, when set, wins over User/Pass. Bitcoin Core writes a new
+	// password into this file on every start, so each call re-reads it.
+	CookiePath string
+
 	HTTP *http.Client
 	id   atomic.Uint64
+}
+
+// ReadCookie returns the user and password from a Bitcoin Core .cookie file.
+func ReadCookie(path string) (string, string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", fmt.Errorf("read cookie %s: %w", path, err)
+	}
+	user, pass, ok := strings.Cut(strings.TrimSpace(string(raw)), ":")
+	if !ok {
+		return "", "", fmt.Errorf("malformed cookie %s: expected user:password", path)
+	}
+	return user, pass, nil
+}
+
+func (c *Client) credentials() (string, string, error) {
+	if c.CookiePath == "" {
+		return c.User, c.Pass, nil
+	}
+	return ReadCookie(c.CookiePath)
 }
 
 type rpcRequest struct {
@@ -51,7 +77,11 @@ func (c *Client) call(ctx context.Context, method string, params any, out any) e
 	if err != nil {
 		return err
 	}
-	req.SetBasicAuth(c.User, c.Pass)
+	user, pass, err := c.credentials()
+	if err != nil {
+		return fmt.Errorf("rpc %s: %w", method, err)
+	}
+	req.SetBasicAuth(user, pass)
 	req.Header.Set("content-type", "application/json")
 
 	httpClient := c.HTTP
@@ -63,6 +93,12 @@ func (c *Client) call(ctx context.Context, method string, params any, out any) e
 		return fmt.Errorf("rpc %s: %w", method, err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
+
+	// Core answers a bad password with 401 and an empty body, which decodes
+	// as a bare EOF and hides the cause.
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("rpc %s: unauthorized (status %d)", method, resp.StatusCode)
+	}
 
 	var r rpcResponse
 	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {

--- a/coinnews/server/scanner/client_test.go
+++ b/coinnews/server/scanner/client_test.go
@@ -1,0 +1,114 @@
+package scanner
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// authRecorder answers getblockcount and records the password it received.
+func authRecorder(t *testing.T) (*httptest.Server, func() string) {
+	t.Helper()
+	var mu sync.Mutex
+	var lastPass string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, pass, _ := r.BasicAuth()
+		mu.Lock()
+		lastPass = pass
+		mu.Unlock()
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"result":42,"error":null}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return lastPass
+	}
+}
+
+func TestClientRereadsCookiePerCall(t *testing.T) {
+	t.Parallel()
+	srv, lastPass := authRecorder(t)
+
+	path := filepath.Join(t.TempDir(), ".cookie")
+	require.NoError(t, os.WriteFile(path, []byte("__cookie__:first"), 0o600))
+
+	c := &Client{URL: srv.URL, CookiePath: path, HTTP: srv.Client()}
+
+	_, err := c.GetBlockCount(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "first", lastPass())
+
+	// Core writes a new password every time it starts.
+	require.NoError(t, os.WriteFile(path, []byte("__cookie__:second"), 0o600))
+
+	_, err = c.GetBlockCount(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "second", lastPass())
+}
+
+func TestClientUsesStaticCredentialsWithoutCookie(t *testing.T) {
+	t.Parallel()
+	srv, lastPass := authRecorder(t)
+
+	c := &Client{URL: srv.URL, User: "user", Pass: "static", HTTP: srv.Client()}
+
+	_, err := c.GetBlockCount(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "static", lastPass())
+}
+
+func TestClientReportsUnauthorized(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &Client{URL: srv.URL, User: "user", Pass: "wrong", HTTP: srv.Client()}
+
+	_, err := c.GetBlockCount(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unauthorized")
+	assert.NotContains(t, err.Error(), "EOF")
+}
+
+func TestClientReportsMissingCookie(t *testing.T) {
+	t.Parallel()
+	srv, _ := authRecorder(t)
+
+	c := &Client{URL: srv.URL, CookiePath: filepath.Join(t.TempDir(), "absent"), HTTP: srv.Client()}
+
+	_, err := c.GetBlockCount(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read cookie")
+}
+
+func TestReadCookieRejectsMalformedFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), ".cookie")
+	require.NoError(t, os.WriteFile(path, []byte("no-colon-here"), 0o600))
+
+	_, _, err := ReadCookie(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected user:password")
+}
+
+func TestReadCookieTrimsWhitespace(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), ".cookie")
+	require.NoError(t, os.WriteFile(path, []byte("  __cookie__:pass\n"), 0o600))
+
+	user, pass, err := ReadCookie(path)
+	require.NoError(t, err)
+	assert.Equal(t, "__cookie__", user)
+	assert.Equal(t, "pass", pass)
+}


### PR DESCRIPTION
coinnewsd read the cookie file once at startup and kept the password. Bitcoin Core writes a new one every time it starts, so any Core restart left the scanner stuck on a dead credential until someone restarted coinnewsd. A bad password also came back as `decode: EOF`, which hid the cause.

The client now holds the cookie path and reads it per call, the way the orchestrator does. A 401 reports itself as unauthorized.