### PR TITLE
bitwindow: make the About settings section open

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.307
+version: 1.0.308
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.307
+version: 1.0.308
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/lib/pages/settings_page.dart
+++ b/bitwindow/lib/pages/settings_page.dart
@@ -25,13 +25,30 @@ class SettingsPage extends StatefulWidget {
     }
   }
 
+  static final List<SailSettingsSection> sections = [
+    SailSettingsSection(label: 'Node mode', builder: (_) => const SettingsNodeMode()),
+    SailSettingsSection(label: 'Network', builder: (_) => const SettingsNetwork()),
+    SailSettingsSection(label: 'Wallet', builder: (_) => const SettingsWallet()),
+    SailSettingsSection(label: 'Appearance', builder: (_) => const SettingsAppearance()),
+    SailSettingsSection(label: 'Advanced', builder: (_) => const SettingsAdvanced()),
+    SailSettingsSection(label: 'Reset', builder: (_) => const SettingsReset()),
+    SailSettingsSection(
+      label: 'About',
+      builder: (_) => SettingsInfo(
+        appName: 'BitWindow',
+        versionString: AppVersion.versionString,
+        buildDate: AppVersion.buildDate,
+        commitFull: AppVersion.commitFull,
+        applicationName: AppVersion.appName,
+      ),
+    ),
+  ];
+
   @override
   State<SettingsPage> createState() => SettingsPageState();
 }
 
 class SettingsPageState extends State<SettingsPage> {
-  static const _sectionCount = 6;
-
   late int _selectedIndex;
 
   @override
@@ -40,7 +57,7 @@ class SettingsPageState extends State<SettingsPage> {
     SettingsPage._currentState = this;
     final pending = SettingsPage._pendingSection;
     SettingsPage._pendingSection = null;
-    _selectedIndex = (pending ?? widget.initialSection).clamp(0, _sectionCount - 1);
+    _selectedIndex = (pending ?? widget.initialSection).clamp(0, SettingsPage.sections.length - 1);
   }
 
   @override
@@ -52,7 +69,7 @@ class SettingsPageState extends State<SettingsPage> {
   }
 
   void setSelectedIndex(int index) {
-    if (index >= 0 && index < _sectionCount) {
+    if (index >= 0 && index < SettingsPage.sections.length) {
       setState(() {
         _selectedIndex = index;
       });
@@ -65,24 +82,7 @@ class SettingsPageState extends State<SettingsPage> {
       subtitle: 'Manage your BitWindow settings',
       selectedIndex: _selectedIndex,
       onSectionSelected: setSelectedIndex,
-      sections: [
-        SailSettingsSection(label: 'Node mode', builder: (_) => const SettingsNodeMode()),
-        SailSettingsSection(label: 'Network', builder: (_) => const SettingsNetwork()),
-        SailSettingsSection(label: 'Wallet', builder: (_) => const SettingsWallet()),
-        SailSettingsSection(label: 'Appearance', builder: (_) => const SettingsAppearance()),
-        SailSettingsSection(label: 'Advanced', builder: (_) => const SettingsAdvanced()),
-        SailSettingsSection(label: 'Reset', builder: (_) => const SettingsReset()),
-        SailSettingsSection(
-          label: 'About',
-          builder: (_) => SettingsInfo(
-            appName: 'BitWindow',
-            versionString: AppVersion.versionString,
-            buildDate: AppVersion.buildDate,
-            commitFull: AppVersion.commitFull,
-            applicationName: AppVersion.appName,
-          ),
-        ),
-      ],
+      sections: SettingsPage.sections,
     );
   }
 }

--- a/bitwindow/lib/pages/sidechains_page.dart
+++ b/bitwindow/lib/pages/sidechains_page.dart
@@ -147,7 +147,8 @@ class _L1RequiredCard extends ViewModelWidget<SidechainsViewModel> {
                     'Deposits, withdrawals and the slot list are read from BIP300 state, which only a local '
                         'Bitcoin Core plus the enforcer can produce. Both must be running and fully synced '
                         'before this tab can do anything.',
-                  L1Gate.starting => 'Both daemons are coming up. The slot list appears once they are synced.',
+                  // One string for both: the enforcer drops in and out while it
+                  // catches up, and a per-state string reflows the page each time.
                   _ =>
                     'The slot list and balances stay empty until Core and the enforcer have caught up with '
                         'the chain tip. You can leave this tab — syncing carries on.',
@@ -173,25 +174,21 @@ class _L1RequiredCard extends ViewModelWidget<SidechainsViewModel> {
               stopDaemon: () => viewModel.stopDaemon(Enforcer()),
               navigateToLogs: viewModel.navigateToLogs,
             ),
-            const SailSpacing(SailStyleValues.padding16),
-            Row(
-              children: [
-                if (gate == L1Gate.stopped)
+            if (gate == L1Gate.stopped) ...[
+              const SailSpacing(SailStyleValues.padding16),
+              Row(
+                children: [
                   SailButton(
                     label: 'Start Bitcoin Core + Enforcer',
                     onPressed: viewModel.startL1,
                   ),
-                if (gate == L1Gate.stopped) const SizedBox(width: SailStyleValues.padding12),
-                Flexible(
-                  child: SailText.secondary12(
-                    switch (gate) {
-                      L1Gate.stopped => 'Takes a while on first run — the chain has to download and verify.',
-                      _ => 'Progress also shows in the status bar below.',
-                    },
+                  const SizedBox(width: SailStyleValues.padding12),
+                  Flexible(
+                    child: SailText.secondary12('Takes a while on first run — the chain has to download and verify.'),
                   ),
-                ),
-              ],
-            ),
+                ],
+              ),
+            ],
           ],
         ),
       ),

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.174
+version: 0.2.175
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/test/settings_sections_test.dart
+++ b/bitwindow/test/settings_sections_test.dart
@@ -1,0 +1,37 @@
+import 'package:bitwindow/gen/version.dart';
+import 'package:bitwindow/pages/settings_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized({
+    'flutter.test.automatic_wait_for_timers': 'false',
+  });
+
+  setUpAll(() async {
+    await registerTestDependencies();
+    if (!GetIt.I.isRegistered<UpdateProvider>()) {
+      GetIt.I.registerSingleton<UpdateProvider>(
+        UpdateProvider(
+          log: GetIt.I.get<Logger>(),
+          binaryType: BinaryType.BINARY_TYPE_BITWINDOWD,
+          currentVersion: AppVersion.version,
+        ),
+      );
+    }
+  });
+
+  testWidgets('the About section stays selectable', (tester) async {
+    final last = SettingsPage.sections.length - 1;
+    expect(SettingsPage.sections[last].label, 'About');
+
+    await tester.pumpSailPage(SettingsPage(initialSection: last));
+
+    expect(find.text('Build date'), findsOneWidget);
+    expect(find.text('Commit'), findsOneWidget);
+  });
+}

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.180
+version: 1.0.181
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/widgets/components/daemon_connection_card.dart
+++ b/sail_ui/lib/widgets/components/daemon_connection_card.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
@@ -103,6 +104,14 @@ class DaemonConnectionCard extends StatelessWidget {
                   );
                 },
               ),
+              _StartStopButton(
+                binaryName: connection.binary.name,
+                isInitializing: connection.initializingBinary || isDownloading,
+                isConnected: connection.connected,
+                isStopping: connection.stoppingBinary,
+                onStart: restartDaemon,
+                onStop: stopDaemon,
+              ),
               SailButton(
                 variant: ButtonVariant.icon,
                 onPressed: () async {
@@ -116,15 +125,6 @@ class DaemonConnectionCard extends StatelessWidget {
                 },
                 icon: SailSVGAsset.tabSettings,
               ),
-              _RestartStopButton(
-                binaryName: connection.binary.name,
-                isInitializing: connection.initializingBinary || isDownloading,
-                isConnected: connection.connected,
-                isStopping: connection.stoppingBinary,
-                onRestart: restartDaemon,
-                onStop: stopDaemon,
-                errorColor: theme.colors.error,
-              ),
               if (deleteFunction != null)
                 SailButton(
                   variant: ButtonVariant.icon,
@@ -133,38 +133,39 @@ class DaemonConnectionCard extends StatelessWidget {
                 ),
             ],
           ),
-          if (downloadProgress != null)
-            SizedBox(
-              width: 350,
-              child: DownloadStatusRow(
-                name: connection.binary.name,
-                download: downloadProgress,
-              ),
-            )
-          else if (syncInfo != null)
-            SizedBox(
-              width: 350,
-              child: BlockStatus(
-                name: connection.binary.name,
-                syncInfo: syncInfo!,
-              ),
+          // The row stays even with nothing to report, so a card that gains
+          // sync info or a download does not grow.
+          SizedBox(
+            width: 350,
+            height: progressRowHeight(context),
+            child: downloadProgress != null
+                ? DownloadStatusRow(
+                    name: connection.binary.name,
+                    download: downloadProgress,
+                  )
+                : syncInfo != null
+                ? BlockStatus(
+                    name: connection.binary.name,
+                    syncInfo: syncInfo!,
+                  )
+                : null,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: SailStyleValues.padding04),
+            child: DaemonStatusBlock(
+              message: infoMessage != null || connection.connectionError != null || !connection.connected
+                  ? prettifyLogMessage(
+                      resolveDaemonStatusMessage(
+                        connectionError: connection.connectionError,
+                        startupError: connection.startupError,
+                        infoMessage: infoMessage,
+                        initializingBinary: connection.initializingBinary,
+                        initializingFallback: providerBinary?.startupLogs.lastOrNull?.message,
+                      ),
+                    )
+                  : '',
             ),
-          if (infoMessage != null || connection.connectionError != null || !connection.connected)
-            Padding(
-              padding: const EdgeInsets.only(top: SailStyleValues.padding04),
-              child: SailText.secondary12(
-                prettifyLogMessage(
-                  resolveDaemonStatusMessage(
-                    connectionError: connection.connectionError,
-                    startupError: connection.startupError,
-                    infoMessage: infoMessage,
-                    initializingBinary: connection.initializingBinary,
-                    initializingFallback: providerBinary?.startupLogs.lastOrNull?.message,
-                  ),
-                ),
-                monospace: true,
-              ),
-            ),
+          ),
         ],
       ),
     );
@@ -179,6 +180,113 @@ class DaemonConnectionCard extends StatelessWidget {
     isDownloading: isDownloading,
     hasInfoMessage: infoMessage != null,
   );
+}
+
+/// Height of the progress bar itself.
+const double progressBarHeight = 16;
+
+/// The style the daemon status text renders in. One style measures and renders,
+/// or a block reserves a height the reader never gets.
+TextStyle daemonStatusStyle(BuildContext context) {
+  final theme = SailTheme.of(context);
+  return SailStyleValues.twelve.copyWith(
+    color: theme.colors.textSecondary,
+    fontFamily: theme.chrome.fontFamily ?? 'IBMPlexMono',
+  );
+}
+
+/// One rendered row of daemon status text, at the reader's text scale.
+double daemonStatusRowHeight(BuildContext context) {
+  final painter = TextPainter(
+    text: TextSpan(text: ' ', style: daemonStatusStyle(context)),
+    textDirection: Directionality.of(context),
+    textScaler: MediaQuery.of(context).textScaler.clamp(maxScaleFactor: 2),
+  )..layout();
+  return painter.preferredLineHeight;
+}
+
+/// Height the progress row holds whether or not a daemon reports progress. A
+/// synced daemon puts text there instead of a bar, so the row fits both.
+double progressRowHeight(BuildContext context) => math.max(progressBarHeight, daemonStatusRowHeight(context));
+
+/// Daemon status in a block that always holds the same height, so a card never
+/// resizes as errors come and go. A message taller than the block hides behind
+/// "Show more", which the reader opens.
+class DaemonStatusBlock extends StatefulWidget {
+  /// Rows the block reserves. Three fits the enforcer's error and its two
+  /// causes, which is the tallest message the daemons produce.
+  static const int rows = 3;
+
+  /// Width the toggle holds. The slot stays even with nothing to open, so the
+  /// text wraps at the same point whether or not the toggle is there.
+  static const double toggleWidth = 96;
+
+  final String message;
+
+  const DaemonStatusBlock({super.key, required this.message});
+
+  @override
+  State<DaemonStatusBlock> createState() => _DaemonStatusBlockState();
+}
+
+class _DaemonStatusBlockState extends State<DaemonStatusBlock> {
+  bool _open = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = daemonStatusStyle(context);
+    final scaler = MediaQuery.of(context).textScaler.clamp(maxScaleFactor: 2);
+    final body = widget.message.trim().isEmpty ? null : widget.message.trimRight();
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final textWidth = (constraints.maxWidth - DaemonStatusBlock.toggleWidth).clamp(1.0, double.infinity);
+        final painter = TextPainter(
+          text: TextSpan(text: body ?? ' ', style: style),
+          maxLines: DaemonStatusBlock.rows,
+          textDirection: Directionality.of(context),
+          textScaler: scaler,
+        )..layout(maxWidth: textWidth);
+
+        final hasMore = body != null && painter.didExceedMaxLines;
+        final open = hasMore && _open;
+        final text = Text(
+          body ?? ' ',
+          style: style,
+          textScaler: scaler,
+          maxLines: open ? null : DaemonStatusBlock.rows,
+          overflow: open ? TextOverflow.clip : TextOverflow.ellipsis,
+        );
+
+        return SizedBox(
+          height: open ? null : daemonStatusRowHeight(context) * DaemonStatusBlock.rows,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: body == null ? text : Tooltip(message: body, child: text),
+              ),
+              SizedBox(
+                width: DaemonStatusBlock.toggleWidth,
+                child: hasMore
+                    ? Align(
+                        alignment: Alignment.topRight,
+                        child: SailButton(
+                          variant: ButtonVariant.ghost,
+                          small: true,
+                          padding: EdgeInsets.zero,
+                          label: open ? 'Show less' : 'Show more',
+                          onPressed: () async => setState(() => _open = !_open),
+                        ),
+                      )
+                    : null,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
 }
 
 /// Renders the in-flight download progress for a daemon. Shown by the
@@ -359,80 +467,47 @@ String formatProgress(double progress, bool withDecimal) {
   return progress.toStringAsFixed(withDecimal ? 1 : 0);
 }
 
-class _RestartStopButton extends StatefulWidget {
+/// Start or stop one daemon. A reader who wants to bounce a daemon stops it and
+/// starts it again, so the head holds one button, not two.
+class _StartStopButton extends StatefulWidget {
   final String binaryName;
   final bool isInitializing;
   final bool isConnected;
   final bool isStopping;
-  final Future<void> Function() onRestart;
+  final Future<void> Function() onStart;
   final Future<void> Function() onStop;
-  final Color errorColor;
 
-  const _RestartStopButton({
+  const _StartStopButton({
     required this.binaryName,
     required this.isInitializing,
     required this.isConnected,
     required this.isStopping,
-    required this.onRestart,
+    required this.onStart,
     required this.onStop,
-    required this.errorColor,
   });
 
   @override
-  State<_RestartStopButton> createState() => _RestartStopButtonState();
+  State<_StartStopButton> createState() => _StartStopButtonState();
 }
 
-class _RestartStopButtonState extends State<_RestartStopButton> {
-  bool _isHovering = false;
+class _StartStopButtonState extends State<_StartStopButton> {
+  bool _hovering = false;
 
   @override
   Widget build(BuildContext context) {
-    // When initializing and hovering, show stop button instead of spinner
-    final showStopOnHover = widget.isInitializing && _isHovering;
+    // A daemon that boots offers a way out, so hover swaps the spinner for stop.
+    final stops = widget.isConnected || (widget.isInitializing && _hovering);
 
     return MouseRegion(
-      onEnter: (_) => setState(() => _isHovering = true),
-      onExit: (_) => setState(() => _isHovering = false),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (showStopOnHover)
-            // Show stop button when hovering during initialization
-            Tooltip(
-              message: 'Stop ${widget.binaryName}',
-              child: SailButton(
-                variant: ButtonVariant.icon,
-                onPressed: widget.onStop,
-                loading: widget.isStopping,
-                icon: SailSVGAsset.square,
-                textColor: widget.errorColor,
-              ),
-            )
-          else ...[
-            // Normal restart button
-            Tooltip(
-              message: 'Restart ${widget.binaryName}',
-              child: SailButton(
-                variant: ButtonVariant.icon,
-                onPressed: widget.onRestart,
-                loading: widget.isInitializing,
-                icon: SailSVGAsset.iconRestart,
-              ),
-            ),
-            // Show stop button when connected (and not initializing)
-            if (widget.isConnected && !widget.isInitializing)
-              Tooltip(
-                message: 'Stop ${widget.binaryName}',
-                child: SailButton(
-                  variant: ButtonVariant.icon,
-                  onPressed: widget.onStop,
-                  loading: widget.isStopping,
-                  icon: SailSVGAsset.square,
-                  textColor: widget.errorColor,
-                ),
-              ),
-          ],
-        ],
+      onEnter: (_) => setState(() => _hovering = true),
+      onExit: (_) => setState(() => _hovering = false),
+      child: Tooltip(
+        message: stops ? 'Stop ${widget.binaryName}' : 'Start ${widget.binaryName}',
+        child: SailButton(
+          label: stops ? 'Stop' : 'Start',
+          loading: stops ? widget.isStopping : widget.isInitializing,
+          onPressed: stops ? widget.onStop : widget.onStart,
+        ),
       ),
     );
   }

--- a/sail_ui/test/widgets/daemon_connection_card_build_test.dart
+++ b/sail_ui/test/widgets/daemon_connection_card_build_test.dart
@@ -1,0 +1,144 @@
+// The card asserts its way out of a debug build when a button carries an icon
+// on a variant that demands a label. Nothing built the card before, so that
+// crash reached review instead of the suite.
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+class _FakeConnection extends RPCConnection {
+  _FakeConnection({required super.binaryType});
+
+  @override
+  Future<List<String>> binaryArgs() async => [];
+
+  @override
+  Future<void> stopRPC() async {}
+
+  @override
+  Future<(double, double)> balance() async => (0.0, 0.0);
+
+  @override
+  Future<BlockchainInfo> getBlockchainInfo() async => BlockchainInfo(
+    chain: 'signet',
+    blocks: 0,
+    headers: 0,
+    bestBlockHash: '',
+    difficulty: 0,
+    time: 0,
+    medianTime: 0,
+    verificationProgress: 0,
+    initialBlockDownload: false,
+    chainWork: '',
+    sizeOnDisk: 0,
+    pruned: false,
+    warnings: const [],
+  );
+}
+
+class _FakeConf extends ChangeNotifier implements BitcoinConfProvider {
+  @override
+  BitcoinNetwork network = BitcoinNetwork.BITCOIN_NETWORK_SIGNET;
+
+  @override
+  Future<void> loadConfig({bool isFirst = false, bool userInitiated = false}) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _Store implements KeyValueStore {
+  final _db = <String, String>{};
+
+  @override
+  Future<String?> getString(String key) async => _db[key];
+
+  @override
+  Future<void> setString(String key, String value) async => _db[key] = value;
+
+  @override
+  Future<void> delete(String key) async => _db.remove(key);
+}
+
+void main() {
+  late _FakeConnection connection;
+
+  setUpAll(() => TestWidgetsFlutterBinding.ensureInitialized());
+
+  setUp(() async {
+    final getIt = GetIt.instance;
+    await getIt.reset();
+
+    final log = Logger(level: Level.off);
+    getIt.registerSingleton<Logger>(log);
+    getIt.registerSingleton<ClientSettings>(ClientSettings(store: _Store(), log: log));
+    getIt.registerSingleton<BitwindowClientSettings>(BitwindowClientSettings(store: _Store(), log: log));
+    getIt.registerSingleton<SettingsProvider>(await SettingsProvider.create());
+    getIt.registerSingleton<BinaryProvider>(
+      BinaryProvider.test(appDir: Directory.systemTemp, binaries: [BitcoinCore(), Enforcer()]),
+    );
+    getIt.registerSingleton<LogProvider>(LogProvider());
+    getIt.registerSingleton<BitcoinConfProvider>(_FakeConf());
+
+    connection = _FakeConnection(binaryType: BinaryType.BINARY_TYPE_BITCOIND);
+  });
+
+  tearDown(() async => GetIt.instance.reset());
+
+  Widget wrap(Widget child) => MaterialApp(
+    home: SailTheme(
+      data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+      child: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(width: 900, child: child),
+        ),
+      ),
+    ),
+  );
+
+  Widget card() => DaemonConnectionCard(
+    connection: connection,
+    syncInfo: null,
+    infoMessage: null,
+    restartDaemon: () async {},
+    stopDaemon: () async {},
+    navigateToLogs: (_, _, _) {},
+  );
+
+  testWidgets('a stopped daemon builds with no assert', (tester) async {
+    await tester.pumpWidget(wrap(card()));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Start'), findsWidgets);
+  });
+
+  testWidgets('a connected daemon builds and offers Stop', (tester) async {
+    connection.connected = true;
+
+    await tester.pumpWidget(wrap(card()));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Stop'), findsWidgets);
+  });
+
+  testWidgets('a daemon that errors builds and keeps its height', (tester) async {
+    await tester.pumpWidget(wrap(card()));
+    await tester.pump();
+    final quiet = tester.getSize(find.byType(DaemonConnectionCard));
+
+    connection.connectionError = 'Error:  × block producer mempool task failed\n  └─▶ mempool initial sync error';
+    connection.markStateChanged();
+    await tester.pumpWidget(wrap(card()));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(tester.getSize(find.byType(DaemonConnectionCard)).height, quiet.height);
+  });
+}

--- a/sail_ui/test/widgets/daemon_status_block_test.dart
+++ b/sail_ui/test/widgets/daemon_status_block_test.dart
@@ -1,0 +1,128 @@
+// The daemon cards resize whenever an error comes and goes, which makes the
+// page jump. DaemonStatusBlock holds the same height either way, and puts a
+// taller message behind a toggle the reader opens.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+void main() {
+  Widget wrap(String message) => MaterialApp(
+    home: SailTheme(
+      data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+      child: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(width: 900, child: DaemonStatusBlock(message: message)),
+        ),
+      ),
+    ),
+  );
+
+  Finder toggle(String label) => find.byWidgetPredicate((w) => w is SailButton && w.label == label);
+
+  const threeLines =
+      'Error:  × block producer mempool task failed\n'
+      '  ├─▶ mempool initial sync error\n'
+      '  └─▶ Batch JSON RPC error: Block not found on disk';
+
+  const sixLines =
+      '$threeLines\n'
+      '  └─▶ chain state is behind the header tip\n'
+      '  └─▶ retry scheduled\n'
+      '  └─▶ giving the node more time';
+
+  testWidgets('an empty message holds the same height as a real one', (tester) async {
+    await tester.pumpWidget(wrap(''));
+    final empty = tester.getSize(find.byType(DaemonStatusBlock));
+
+    await tester.pumpWidget(wrap('Initializing...'));
+    final short = tester.getSize(find.byType(DaemonStatusBlock));
+
+    await tester.pumpWidget(wrap(threeLines));
+    final long = tester.getSize(find.byType(DaemonStatusBlock));
+
+    expect(empty.height, short.height);
+    expect(empty.height, long.height);
+  });
+
+  testWidgets('a message that fits offers no toggle', (tester) async {
+    await tester.pumpWidget(wrap(threeLines));
+    expect(toggle('Show more'), findsNothing);
+  });
+
+  testWidgets('a taller message keeps the height and offers a toggle', (tester) async {
+    await tester.pumpWidget(wrap(''));
+    final closed = tester.getSize(find.byType(DaemonStatusBlock));
+
+    await tester.pumpWidget(wrap(sixLines));
+    expect(tester.getSize(find.byType(DaemonStatusBlock)).height, closed.height);
+    expect(toggle('Show more'), findsOneWidget);
+  });
+
+  testWidgets('the toggle opens the whole message and closes it again', (tester) async {
+    await tester.pumpWidget(wrap(sixLines));
+    final closed = tester.getSize(find.byType(DaemonStatusBlock));
+
+    await tester.tap(toggle('Show more'));
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(find.byType(DaemonStatusBlock)).height, greaterThan(closed.height));
+    expect(toggle('Show less'), findsOneWidget);
+
+    await tester.tap(toggle('Show less'));
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(find.byType(DaemonStatusBlock)).height, closed.height);
+    expect(toggle('Show more'), findsOneWidget);
+  });
+
+  testWidgets('every line of the error stays readable', (tester) async {
+    await tester.pumpWidget(wrap(threeLines));
+
+    final texts = tester.widgetList<Text>(find.byType(Text)).map((t) => t.data).toList();
+    expect(texts, contains(threeLines));
+  });
+
+  testWidgets('the tooltip carries the whole message', (tester) async {
+    await tester.pumpWidget(wrap(threeLines));
+
+    final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+    expect(tooltip.message, threeLines);
+  });
+
+  testWidgets('an empty message gets no tooltip', (tester) async {
+    await tester.pumpWidget(wrap(''));
+    expect(find.byType(Tooltip), findsNothing);
+  });
+
+  test('the block reserves three rows', () {
+    expect(DaemonStatusBlock.rows, 3);
+  });
+
+  testWidgets("the progress row grows with the reader's text scale", (tester) async {
+    late double plain;
+    late double scaled;
+
+    Widget probe(double scale, void Function(double) sink) => MediaQuery(
+      data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+      child: MaterialApp(
+        home: SailTheme(
+          data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+          child: Builder(
+            builder: (context) {
+              sink(progressRowHeight(context));
+              return const SizedBox();
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(probe(1, (v) => plain = v));
+    await tester.pumpWidget(probe(2, (v) => scaled = v));
+
+    expect(plain, greaterThanOrEqualTo(progressBarHeight));
+    expect(scaled, greaterThan(plain));
+  });
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.309
+version: 1.0.310
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.180
+version: 1.0.181
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.307
+version: 1.0.308
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The settings page listed 7 sections but guarded the index with a hand-written count of 6, so a click on About did nothing. The count now comes from the section list.