### PR TITLE
coinnews: add a scan start height

### DIFF
--- a/coinnews/README.md
+++ b/coinnews/README.md
@@ -20,6 +20,9 @@ just test         # codec + server tests
   defaults — if your Core works for bitwindow it works for coinnews).
 - Override with `COINNEWS_BITCOIND_URL`, `COINNEWS_BITCOIND_USER`,
   `COINNEWS_BITCOIND_PASS`, `COINNEWS_NETWORK`.
+- `COINNEWS_SCAN_FROM_HEIGHT` (or `-scan-from-height`) sets the first block to
+  index. Point it at a chain's fork height to skip blocks that carry no
+  CoinNews. It moves a lagging cursor forward, and never rewinds one.
 
 Ports:
 

--- a/coinnews/server/main.go
+++ b/coinnews/server/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -33,6 +34,8 @@ func h2cProtocols() *http.Protocols {
 }
 
 func main() {
+	scanFromEnv, scanFromErr := envUint("COINNEWS_SCAN_FROM_HEIGHT", 0)
+
 	var (
 		listen         = flag.String("listen", envOr("COINNEWS_LISTEN", "0.0.0.0:8080"), "HTTP listen address")
 		dbPath         = flag.String("db", envOr("COINNEWS_DB", "./coinnews.db"), "SQLite path")
@@ -42,11 +45,16 @@ func main() {
 		bitcoindCookie = flag.String("bitcoind-cookie", envOr("COINNEWS_BITCOIND_COOKIE", ""), "Path to a Bitcoin Core .cookie file (contents: user:password); overrides -bitcoind-user/-bitcoind-pass when set")
 		network        = flag.String("network", envOr("COINNEWS_NETWORK", "signet"), "Network label (mainnet/signet/testnet/regtest) — informational")
 		scan           = flag.Bool("scan", envBool("COINNEWS_SCAN", true), "Run the block scanner; set false for read-only API mode")
+		scanFrom       = flag.Uint("scan-from-height", uint(scanFromEnv), "First block to index; moves a lagging cursor forward, never rewinds. Use a chain's fork height to skip blocks that carry no CoinNews")
 	)
 	flag.Parse()
 
 	log := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}).
 		With().Timestamp().Str("network", *network).Logger()
+
+	if scanFromErr != nil {
+		log.Fatal().Err(scanFromErr).Msg("COINNEWS_SCAN_FROM_HEIGHT")
+	}
 
 	// A cookie file lets us share Bitcoin Core's auto-generated
 	// `__cookie__:<pass>` credentials (e.g. a mounted Docker secret)
@@ -80,6 +88,7 @@ func main() {
 				DB:           db,
 				Log:          log.With().Str("component", "scanner").Logger(),
 				PollInterval: 5 * time.Second,
+				FromHeight:   uint32(*scanFrom),
 			}
 			if err := s.Run(ctx); err != nil {
 				log.Error().Err(err).Msg("scanner exited")
@@ -144,6 +153,21 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// envUint reads a uint32-ranged value. A set-but-unparsable value is an
+// error, never the fallback: a silent 0 here sends the scanner back to
+// genesis, which is the cost the setting exists to avoid.
+func envUint(key string, fallback uint64) (uint64, error) {
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback, nil
+	}
+	n, err := strconv.ParseUint(v, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%s=%q: want a whole number that fits in 32 bits", key, v)
+	}
+	return n, nil
 }
 
 func envBool(key string, fallback bool) bool {

--- a/coinnews/server/main_test.go
+++ b/coinnews/server/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvUintUnsetReturnsFallback(t *testing.T) {
+	n, err := envUint("COINNEWS_TEST_HEIGHT", 963648)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(963648), n)
+}
+
+func TestEnvUintReadsValue(t *testing.T) {
+	t.Setenv("COINNEWS_TEST_HEIGHT", "963648")
+	n, err := envUint("COINNEWS_TEST_HEIGHT", 0)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(963648), n)
+}
+
+// A set-but-unparsable value must never fall back to 0 — that silently sends
+// the scanner to genesis, which is what the setting exists to avoid.
+func TestEnvUintRejectsInvalidValues(t *testing.T) {
+	for _, v := range []string{"96364a", "-1", "4294967296", "", " 963648", "963_648", "1.5"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("COINNEWS_TEST_HEIGHT", v)
+			_, err := envUint("COINNEWS_TEST_HEIGHT", 963648)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "COINNEWS_TEST_HEIGHT")
+		})
+	}
+}
+
+func TestEnvUintAcceptsMaxUint32(t *testing.T) {
+	t.Setenv("COINNEWS_TEST_HEIGHT", "4294967295")
+	n, err := envUint("COINNEWS_TEST_HEIGHT", 0)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(4294967295), n)
+}

--- a/coinnews/server/scanner/from_height_test.go
+++ b/coinnews/server/scanner/from_height_test.go
@@ -1,0 +1,133 @@
+package scanner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/coinnews/server/store"
+)
+
+// fakeCore answers the three RPCs the scanner uses and records every height
+// it was asked to fetch. Blocks carry no transactions, so nothing is indexed.
+type fakeCore struct {
+	tip uint32
+
+	mu     sync.Mutex
+	served []uint32
+}
+
+func (f *fakeCore) heights() []uint32 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]uint32(nil), f.served...)
+}
+
+func (f *fakeCore) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string            `json:"method"`
+			Params []json.RawMessage `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		w.Header().Set("content-type", "application/json")
+
+		switch req.Method {
+		case "getblockcount":
+			_, _ = fmt.Fprintf(w, `{"result":%d,"error":null}`, f.tip)
+		case "getblockhash":
+			var h uint32
+			require.NoError(t, json.Unmarshal(req.Params[0], &h))
+			f.mu.Lock()
+			f.served = append(f.served, h)
+			f.mu.Unlock()
+			// A hash the scanner can decode: 32 bytes, height in the low byte.
+			_, _ = fmt.Fprintf(w, `{"result":"%064x","error":null}`, h)
+		case "getblock":
+			_, _ = fmt.Fprint(w, `{"result":{"hash":"00","height":0,"time":1,"mediantime":1,"tx":[]},"error":null}`)
+		default:
+			t.Errorf("unexpected method %q", req.Method)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func runScanner(t *testing.T, core *fakeCore, from uint32) {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := store.Open(ctx, t.TempDir()+"/coinnews.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	srv := core.start(t)
+	s := &Scanner{
+		Client:     &Client{URL: srv.URL, HTTP: srv.Client()},
+		DB:         db,
+		Log:        zerolog.Nop(),
+		FromHeight: from,
+	}
+	require.NoError(t, s.catchUp(ctx))
+}
+
+func TestScannerStartsAtFromHeight(t *testing.T) {
+	t.Parallel()
+	core := &fakeCore{tip: 1000}
+	runScanner(t, core, 900)
+
+	served := core.heights()
+	require.NotEmpty(t, served)
+	assert.Equal(t, uint32(900), served[0], "first block fetched")
+	assert.Equal(t, uint32(1000), served[len(served)-1], "last block fetched")
+	assert.Len(t, served, 101, "900..1000 inclusive")
+}
+
+func TestScannerWithoutFromHeightStartsAtGenesis(t *testing.T) {
+	t.Parallel()
+	core := &fakeCore{tip: 10}
+	runScanner(t, core, 0)
+
+	assert.Equal(t, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, core.heights())
+}
+
+func TestScannerFromHeightNeverRewindsCursor(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db, err := store.Open(ctx, t.TempDir()+"/coinnews.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// A cursor already past the configured start height.
+	require.NoError(t, store.SaveCursor(ctx, db, 500, [32]byte{}))
+
+	core := &fakeCore{tip: 503}
+	srv := core.start(t)
+	s := &Scanner{
+		Client:     &Client{URL: srv.URL, HTTP: srv.Client()},
+		DB:         db,
+		Log:        zerolog.Nop(),
+		FromHeight: 100,
+	}
+	require.NoError(t, s.catchUp(ctx))
+
+	assert.Equal(t, []uint32{501, 502, 503}, core.heights(), "resumes at the cursor, not at FromHeight")
+}
+
+func TestScannerFromHeightAboveTipIndexesNothing(t *testing.T) {
+	t.Parallel()
+	core := &fakeCore{tip: 50}
+	runScanner(t, core, 900)
+
+	assert.Empty(t, core.heights())
+}

--- a/coinnews/server/scanner/scanner.go
+++ b/coinnews/server/scanner/scanner.go
@@ -24,6 +24,11 @@ type Scanner struct {
 
 	// PollInterval is how often we re-check the tip after catching up.
 	PollInterval time.Duration
+
+	// FromHeight is the first block to index. A chain that starts at a fork
+	// carries no CoinNews below it, so scanning from genesis only costs time.
+	// It moves a lagging cursor forward, and never rewinds one.
+	FromHeight uint32
 }
 
 // Run blocks until ctx is cancelled. Catches up to the tip, then
@@ -57,6 +62,11 @@ func (s *Scanner) catchUp(ctx context.Context) error {
 	cursor, _, err := store.LoadCursor(ctx, s.DB)
 	if err != nil {
 		return fmt.Errorf("load cursor: %w", err)
+	}
+	if s.FromHeight > 0 && cursor+1 < s.FromHeight {
+		s.Log.Info().Uint32("cursor", cursor).Uint32("from_height", s.FromHeight).
+			Msg("coinnews-scanner: skipping ahead to the configured start height")
+		cursor = s.FromHeight - 1
 	}
 	if cursor >= tip {
 		return nil


### PR DESCRIPTION
A chain that starts at a fork carries no CoinNews below that height, so the scanner spends hours on blocks that can hold nothing. On the eCash alphanet it walked from block 1 at 9 blocks per second, which is about 20 hours before it reaches the tip.

`-scan-from-height`, or `COINNEWS_SCAN_FROM_HEIGHT`, sets the first block to index. It moves a lagging cursor forward and never rewinds one, so a node already past that height keeps its place.