### PR TITLE
bitwindow: start the block scan a week back

### DIFF
--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -386,7 +386,17 @@ func (p *Parser) handleBlockTick(ctx context.Context) error {
 		Uint32("batch-size", batchSize).
 		Msgf("bitcoind_engine/parser: processing blocks")
 
-	for batchStart := lastProcessedHeight + 1; batchStart <= currentHeight; batchStart += batchSize {
+	batchStart := lastProcessedHeight + 1
+	if floor := p.scanFloor(currentHeight); floor > batchStart {
+		zerolog.Ctx(ctx).Info().
+			Uint32("scan_floor", floor).
+			Uint32("processed", lastProcessedHeight).
+			Uint32("tip", currentHeight).
+			Msg("bitcoind_engine/parser: skipping ahead to the scan floor")
+		batchStart = floor
+	}
+
+	for ; batchStart <= currentHeight; batchStart += batchSize {
 		batchEnd := min(batchStart+batchSize-1, currentHeight)
 		if p.conf.SyncToHeight > 0 {
 			batchEnd = min(batchEnd, p.conf.SyncToHeight)
@@ -827,6 +837,32 @@ func (p *Parser) handleOpReturns(
 	}
 
 	return opReturns, nil
+}
+
+// recentScanWindow is how far back a lagging scan reaches: about a week at ten
+// minutes a block.
+const recentScanWindow uint32 = 144 * 7
+
+// scanFloor is the first block worth scanning. The feed shows recent posts, so
+// a lagging scan on a populated chain starts a week back instead of at genesis.
+// Signet, testnet and regtest blocks are small or empty, so those scan whole.
+// Zero scans from the start.
+//
+// The loop also feeds M4Engine, so a fresh install holds no withdrawal-vote
+// history below the floor. Votes still read as they appeared on chain.
+func (p *Parser) scanFloor(currentHeight uint32) uint32 {
+	// An explicit target asks for history, and a floor above it would leave
+	// every batch empty while the run still reports the goal as reached.
+	if p.conf.SyncToHeight > 0 {
+		return 0
+	}
+	if !config.IsFullChainNetwork(p.conf.BitcoinCoreNetwork) {
+		return 0
+	}
+	if currentHeight <= recentScanWindow {
+		return 0
+	}
+	return currentHeight - recentScanWindow
 }
 
 // logCoinnews emits a detailed line to the dedicated coinnews-sync log when

--- a/bitwindow/server/engines/scan_floor_test.go
+++ b/bitwindow/server/engines/scan_floor_test.go
@@ -1,0 +1,62 @@
+package engines
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/config"
+)
+
+func parserOn(network config.Network) *Parser {
+	return &Parser{conf: config.Config{BitcoinCoreNetwork: network}}
+}
+
+// An explicit historical target must fetch the blocks it names. A floor above
+// it leaves every batch empty while the run still reports the goal as reached.
+func TestScanFloorIsZeroUnderASyncTarget(t *testing.T) {
+	p := &Parser{conf: config.Config{
+		BitcoinCoreNetwork: config.NetworkMainnet,
+		SyncToHeight:       500000,
+	}}
+	assert.Zero(t, p.scanFloor(900000))
+}
+
+func TestScanFloorStartsOneWindowBack(t *testing.T) {
+	for _, network := range []config.Network{
+		config.NetworkMainnet, config.NetworkForknet, config.NetworkECash,
+	} {
+		t.Run(string(network), func(t *testing.T) {
+			assert.Equal(t, 900000-recentScanWindow, parserOn(network).scanFloor(900000))
+		})
+	}
+}
+
+// Signet, testnet and regtest blocks are small or empty, so those scan whole.
+func TestScanFloorIsZeroOnSmallChains(t *testing.T) {
+	for _, network := range []config.Network{
+		config.NetworkSignet, config.NetworkRegtest, config.Network("testnet"),
+	} {
+		t.Run(string(network), func(t *testing.T) {
+			assert.Zero(t, parserOn(network).scanFloor(900000))
+		})
+	}
+}
+
+// A short chain must not wrap around on the unsigned subtraction.
+func TestScanFloorIsZeroOnAChainShorterThanTheWindow(t *testing.T) {
+	p := parserOn(config.NetworkMainnet)
+
+	for _, tip := range []uint32{0, 1, 200, recentScanWindow} {
+		assert.Zero(t, p.scanFloor(tip), "tip %d", tip)
+	}
+}
+
+// One block past a full window is the first tip that moves the floor.
+func TestScanFloorMovesOneBlockPastTheWindow(t *testing.T) {
+	assert.Equal(t, uint32(1), parserOn(config.NetworkMainnet).scanFloor(recentScanWindow+1))
+}
+
+func TestScanFloorWindowIsAboutAWeek(t *testing.T) {
+	assert.Equal(t, uint32(1008), recentScanWindow)
+}


### PR DESCRIPTION
The OP_RETURN scan walked from block 1 on every network. On eCash that is 963648 blocks of mainnet history before the fork, each one a fetch that yields nothing.

A lagging scan on mainnet, forknet and eCash now starts one week back, 144*7 blocks. Signet, testnet and regtest scan whole, because their blocks are small or empty. A chain shorter than a window still scans from the start, and an explicit --sync-to-height target turns the floor off, so the run fetches the blocks it names. The floor only moves the start forward and never rewinds a processed tip, so fork detection still reads the real one. The tip it measures from is the synced tip: on those three networks the scan already waits for Core to leave IBD.

Two accepted trades on a fresh install. The loop also feeds M4Engine, so no withdrawal-vote history exists below the floor; a bundle stays votable for 26300 blocks, so covering it would mean a six-month floor. And coinnews.go drops a comment or a vote whose parent sits below the floor, so engagement on older stories does not appear.