### PR TITLE
orchestrator: ship the published network catalog

### DIFF
--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.175
+version: 0.2.176
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/server/api/misc/misc.go
+++ b/bitwindow/server/api/misc/misc.go
@@ -340,7 +340,11 @@ func (s *Server) ListCoinNews(ctx context.Context, req *connect.Request[miscv1.L
 		}
 	}
 	if s.remoteCoinNews != nil {
-		return s.listRemoteCoinNews(ctx, req.Msg.Topic)
+		res, err := s.listRemoteCoinNews(ctx, req.Msg.Topic)
+		// No published indexer for this network, so the local index answers.
+		if !errors.Is(err, engines.ErrNoIndexer) {
+			return res, err
+		}
 	}
 
 	news, err := opreturns.ListCoinNews(ctx, s.database)

--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -275,7 +275,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 	}
 	{
 		miscSvc := api_misc.New(rt.db, rt.timestampEngine, s.Bitcoind, rt.walletEngine,
-			engines.NewRemoteCoinNews(ctx, string(conf.BitcoinCoreNetwork)))
+			engines.NewRemoteCoinNews(string(conf.BitcoinCoreNetwork)))
 		path, h := miscv1connect.NewMiscServiceHandler(miscSvc, stdOpts...)
 		register(path, h)
 	}

--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -275,7 +275,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 	}
 	{
 		miscSvc := api_misc.New(rt.db, rt.timestampEngine, s.Bitcoind, rt.walletEngine,
-			engines.NewRemoteCoinNews(s.svcs.BitwindowDir, string(conf.BitcoinCoreNetwork)))
+			engines.NewRemoteCoinNews(ctx, string(conf.BitcoinCoreNetwork)))
 		path, h := miscv1connect.NewMiscServiceHandler(miscSvc, stdOpts...)
 		register(path, h)
 	}

--- a/bitwindow/server/engines/coinnews_remote.go
+++ b/bitwindow/server/engines/coinnews_remote.go
@@ -42,10 +42,12 @@ type connectRemote struct {
 }
 
 // NewRemoteCoinNews returns a reader for the network's published CoinNews
-// indexer, or nil when the network publishes none.
-func NewRemoteCoinNews(bitwindowDir, network string) RemoteCoinNews {
-	catalog, _ := netcatalog.Load(bitwindowDir)
-	net, ok := catalog.ForNetwork(network)
+// indexer, or nil when the network publishes none. The bound is short: a slow
+// document must not hold up the API handlers this runs from.
+func NewRemoteCoinNews(ctx context.Context, network string) RemoteCoinNews {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	net, ok := netcatalog.Resolve(ctx).ForNetwork(network)
 	if !ok || net.Services.CoinNews.URL == "" {
 		return nil
 	}

--- a/bitwindow/server/engines/coinnews_remote.go
+++ b/bitwindow/server/engines/coinnews_remote.go
@@ -2,7 +2,9 @@ package engines
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"sync"
 	"time"
 
 	coinnewsv1 "github.com/LayerTwo-Labs/sidesail/coinnews/server/gen/coinnews/v1"
@@ -12,9 +14,14 @@ import (
 	"connectrpc.com/connect"
 )
 
+// ErrNoIndexer means the network publishes no CoinNews indexer, so the caller
+// reads its own database instead.
+var ErrNoIndexer = errors.New("this network publishes no coin news indexer")
+
 // RemoteCoinNews reads a published CoinNews indexer.
 type RemoteCoinNews interface {
-	// ListFrontPage returns items ranked by score, newest-first on ties.
+	// ListFrontPage returns items ranked by score, newest-first on ties. It
+	// returns ErrNoIndexer when the network publishes none.
 	ListFrontPage(ctx context.Context, topicHex string, limit uint32) ([]RemoteItem, error)
 }
 
@@ -38,33 +45,43 @@ type RemoteItem struct {
 
 // connectRemote reads a coinnewsd deployment over ConnectRPC.
 type connectRemote struct {
-	client coinnewsv1connect.CoinNewsServiceClient
+	network string
+	once    sync.Once
+	client  coinnewsv1connect.CoinNewsServiceClient
 }
 
 // NewRemoteCoinNews returns a reader for the network's published CoinNews
-// indexer, or nil when the network publishes none. The bound is short: a slow
-// document must not hold up the API handlers this runs from.
-func NewRemoteCoinNews(ctx context.Context, network string) RemoteCoinNews {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	net, ok := netcatalog.Resolve(ctx).ForNetwork(network)
-	if !ok || net.Services.CoinNews.URL == "" {
-		return nil
-	}
-	return &connectRemote{
-		client: coinnewsv1connect.NewCoinNewsServiceClient(
+// indexer. It reads the document on the first call, not here: the API handlers
+// this runs from must not wait on a slow endpoint.
+func NewRemoteCoinNews(network string) RemoteCoinNews {
+	return &connectRemote{network: network}
+}
+
+// resolve reads the indexer URL the network publishes, once.
+func (r *connectRemote) resolve(ctx context.Context) coinnewsv1connect.CoinNewsServiceClient {
+	r.once.Do(func() {
+		net, ok := netcatalog.Resolve(ctx).ForNetwork(r.network)
+		if !ok || net.Services.CoinNews.URL == "" {
+			return
+		}
+		r.client = coinnewsv1connect.NewCoinNewsServiceClient(
 			&http.Client{Timeout: 30 * time.Second},
 			net.Services.CoinNews.URL,
-		),
-	}
+		)
+	})
+	return r.client
 }
 
 func (r *connectRemote) ListFrontPage(ctx context.Context, topicHex string, limit uint32) ([]RemoteItem, error) {
+	client := r.resolve(ctx)
+	if client == nil {
+		return nil, ErrNoIndexer
+	}
 	req := &coinnewsv1.ListFrontPageRequest{Limit: limit}
 	if topicHex != "" {
 		req.TopicHex = &topicHex
 	}
-	res, err := r.client.ListFrontPage(ctx, connect.NewRequest(req))
+	res, err := client.ListFrontPage(ctx, connect.NewRequest(req))
 	if err != nil {
 		return nil, err
 	}

--- a/sidechain-orchestrator/api/bitcoin_conf_handler_extra_test.go
+++ b/sidechain-orchestrator/api/bitcoin_conf_handler_extra_test.go
@@ -126,7 +126,7 @@ func TestSetBitcoinConfigNetwork_RefusesBeforeMovingTheECashPick(t *testing.T) {
 		{ID: "alphanet", Family: netcatalog.FamilyECash, ForkHeight: 963648},
 	}}
 	require.NoError(t, orch.SelectECashNetwork("drynet4"))
-	require.Equal(t, "drynet4", orch.SelectedECashID(orch.Catalog))
+	require.Equal(t, "drynet4", orch.RunningECashID(orch.Catalog))
 
 	h := NewBitcoinConfHandler(orch)
 	_, err := h.SetBitcoinConfigNetwork(context.Background(), connect.NewRequest(&pb.SetBitcoinConfigNetworkRequest{
@@ -135,6 +135,6 @@ func TestSetBitcoinConfigNetwork_RefusesBeforeMovingTheECashPick(t *testing.T) {
 	}))
 	require.Error(t, err, "an unwritable datadir must be refused")
 
-	assert.Equal(t, "drynet4", orch.SelectedECashID(orch.Catalog),
+	assert.Equal(t, "drynet4", orch.RunningECashID(orch.Catalog),
 		"a refused request must not move the pick")
 }

--- a/sidechain-orchestrator/commands/commands.go
+++ b/sidechain-orchestrator/commands/commands.go
@@ -725,10 +725,10 @@ func binaryPathFor(cctx *cli.Context, dataDir, name string) string {
 	)
 }
 
-// servedECashNetwork returns the eCash network the daemon runs. Do not
-// read the catalog cache instead: the confirm writes a new generation there
-// before the restart that starts to use it, so a path from the cache names a
-// build no process runs, and `wipe` deletes that one while the live build stays.
+// servedECashNetwork returns the eCash network the daemon runs. Do not read the
+// published document instead: it names the newest network, and a path from that
+// document names a build no process runs — `wipe` then deletes that one while
+// the live build stays.
 func servedECashNetwork(cctx *cli.Context, bitwindowDir string) string {
 	// A path lookup must not wait forever on an address that never answers.
 	ctx, cancel := context.WithTimeout(cctx.Context, 2*time.Second)
@@ -740,10 +740,12 @@ func servedECashNetwork(cctx *cli.Context, bitwindowDir string) string {
 	if err == nil {
 		return resp.Msg.CurrentNetworkId
 	}
-	// No daemon answers, so no process serves an older generation. The cached
-	// one is what the next start uses.
-	c, _ := netcatalog.Load(bitwindowDir)
-	return c.ECashID()
+	// No daemon answers. The next start serves the network this install records,
+	// and only then the one compiled into the binary.
+	if s, err := orchestrator.LoadSettings(bitwindowDir); err == nil && s.ECashChainID != "" {
+		return s.ECashChainID
+	}
+	return netcatalog.EmbeddedECashID()
 }
 
 func extractVersion(s string) string {

--- a/sidechain-orchestrator/config/netcatalog/catalog.go
+++ b/sidechain-orchestrator/config/netcatalog/catalog.go
@@ -216,28 +216,36 @@ func (n Network) BackendURL(kind string) string {
 	return best.URL
 }
 
-// CachePath is where the last known good catalog is persisted.
-func CachePath(bitwindowDir string) string {
-	return filepath.Join(bitwindowDir, cacheFilename)
-}
-
-// Load returns the catalog persisted by a previous run. fromDisk is false when
-// no usable cache exists, in which case the embedded copy is returned — that
-// distinction matters to callers comparing generations, since only a cache
-// written by a previous run describes the state actually on disk.
-func Load(bitwindowDir string) (c Catalog, fromDisk bool) {
-	if raw, err := os.ReadFile(CachePath(bitwindowDir)); err == nil {
-		if parsed, err := parse(raw); err == nil {
-			return parsed, true
-		}
-	}
+// Embedded is the catalog compiled into the binary. It is what every reader
+// falls back to when the published document cannot be fetched.
+func Embedded() Catalog {
 	// The embedded copy is compiled in and always parses; a failure here is a
 	// build problem, not a runtime one.
 	parsed, err := parse(embedded)
 	if err != nil {
 		panic(fmt.Sprintf("netcatalog: embedded networks.json is invalid: %v", err))
 	}
-	return parsed, false
+	return parsed
+}
+
+// Resolve returns the published document, or the embedded copy when the fetch
+// fails. The catalog is a document rather than state, so no process keeps a
+// copy of it on disk.
+func Resolve(ctx context.Context) Catalog {
+	c, err := Fetch(ctx, DefaultURL)
+	if err != nil {
+		return Embedded()
+	}
+	return c
+}
+
+// RemoveLegacyFiles deletes the catalog copies an older build kept in the data
+// directory. That build served a cached document, and held a refresh back in a
+// second file until a start applied it.
+func RemoveLegacyFiles(bitwindowDir string) {
+	for _, name := range []string{cacheFilename, pendingFilename} {
+		_ = os.Remove(filepath.Join(bitwindowDir, name))
+	}
 }
 
 // EmbeddedECashID is the eCash network id compiled into the binary. It is the
@@ -250,22 +258,14 @@ func EmbeddedECashID() string {
 // EmbeddedECash is the eCash entry compiled into the binary, zero when it
 // carries none. Endpoint helpers fall back to it before the catalog resolves.
 func EmbeddedECash() Network {
-	c, err := parse(embedded)
-	if err != nil {
-		return Network{}
-	}
-	n, _ := c.CurrentECash()
+	n, _ := Embedded().CurrentECash()
 	return n
 }
 
 // EmbeddedPeer is the seed address the compiled-in catalog publishes for a
 // network id, empty when it lists none.
 func EmbeddedPeer(id string) string {
-	c, err := parse(embedded)
-	if err != nil {
-		return ""
-	}
-	n, ok := c.ByID(id)
+	n, ok := Embedded().ByID(id)
 	if !ok {
 		return ""
 	}
@@ -295,37 +295,6 @@ func Fetch(ctx context.Context, url string) (Catalog, error) {
 		return Catalog{}, fmt.Errorf("read catalog body: %w", err)
 	}
 	return parse(body)
-}
-
-// Save persists the newest document this install knows, which is what a start
-// reads when the fetch fails. The write is tmp-then-rename but deliberately
-// skips fsync: this is a cache, and a torn write simply fails to parse on the
-// next boot and falls back to the embedded copy.
-func Save(bitwindowDir string, c Catalog) error {
-	if err := os.MkdirAll(bitwindowDir, 0o755); err != nil {
-		return fmt.Errorf("mkdir bitwindow dir: %w", err)
-	}
-	data, err := json.MarshalIndent(c, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal catalog: %w", err)
-	}
-	path := CachePath(bitwindowDir)
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return fmt.Errorf("write catalog cache: %w", err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("rename catalog cache: %w", err)
-	}
-	return nil
-}
-
-// RemoveLegacyPending removes the second document an older build left on disk. That
-// build held a refresh back in its own file until a start applied it; a start
-// now takes the newest document as it stands.
-func RemoveLegacyPending(bitwindowDir string) {
-	_ = os.Remove(filepath.Join(bitwindowDir, pendingFilename))
 }
 
 // parse decodes a catalog document and rejects one that carries no networks or

--- a/sidechain-orchestrator/config/netcatalog/catalog.go
+++ b/sidechain-orchestrator/config/netcatalog/catalog.go
@@ -297,15 +297,11 @@ func Fetch(ctx context.Context, url string) (Catalog, error) {
 	return parse(body)
 }
 
-// Save persists a catalog as the baseline for the next run. The write is
-// tmp-then-rename but deliberately skips fsync: this is a cache, and a torn
-// write simply fails to parse on the next boot and falls back to the embedded
-// copy.
+// Save persists the newest document this install knows, which is what a start
+// reads when the fetch fails. The write is tmp-then-rename but deliberately
+// skips fsync: this is a cache, and a torn write simply fails to parse on the
+// next boot and falls back to the embedded copy.
 func Save(bitwindowDir string, c Catalog) error {
-	return writeCatalog(CachePath(bitwindowDir), bitwindowDir, c)
-}
-
-func writeCatalog(path, bitwindowDir string, c Catalog) error {
 	if err := os.MkdirAll(bitwindowDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir bitwindow dir: %w", err)
 	}
@@ -313,6 +309,7 @@ func writeCatalog(path, bitwindowDir string, c Catalog) error {
 	if err != nil {
 		return fmt.Errorf("marshal catalog: %w", err)
 	}
+	path := CachePath(bitwindowDir)
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o644); err != nil {
 		return fmt.Errorf("write catalog cache: %w", err)
@@ -324,35 +321,11 @@ func writeCatalog(path, bitwindowDir string, c Catalog) error {
 	return nil
 }
 
-// PendingPath is where a refreshed catalog waits to be applied.
-func PendingPath(bitwindowDir string) string {
-	return filepath.Join(bitwindowDir, pendingFilename)
-}
-
-// SavePending records a freshly fetched catalog for the next start to apply.
-// The running process keeps serving whatever it loaded, so the cache — which
-// must always describe the data on disk — is left alone until startup promotes
-// this.
-func SavePending(bitwindowDir string, c Catalog) error {
-	return writeCatalog(PendingPath(bitwindowDir), bitwindowDir, c)
-}
-
-// LoadPending returns a catalog left by a previous run's refresh, if any.
-func LoadPending(bitwindowDir string) (Catalog, bool) {
-	raw, err := os.ReadFile(PendingPath(bitwindowDir))
-	if err != nil {
-		return Catalog{}, false
-	}
-	parsed, err := parse(raw)
-	if err != nil {
-		return Catalog{}, false
-	}
-	return parsed, true
-}
-
-// ClearPending removes a promoted or unusable pending catalog.
-func ClearPending(bitwindowDir string) {
-	_ = os.Remove(PendingPath(bitwindowDir))
+// RemoveLegacyPending removes the second document an older build left on disk. That
+// build held a refresh back in its own file until a start applied it; a start
+// now takes the newest document as it stands.
+func RemoveLegacyPending(bitwindowDir string) {
+	_ = os.Remove(filepath.Join(bitwindowDir, pendingFilename))
 }
 
 // parse decodes a catalog document and rejects one that carries no networks or

--- a/sidechain-orchestrator/config/netcatalog/catalog_test.go
+++ b/sidechain-orchestrator/config/netcatalog/catalog_test.go
@@ -11,10 +11,7 @@ import (
 const embeddedGeneration = "alphanet"
 
 func TestEmbeddedCatalogParses(t *testing.T) {
-	c, fromDisk := Load(t.TempDir())
-	if fromDisk {
-		t.Fatal("empty dir must not report a cached catalog")
-	}
+	c := Embedded()
 	if got := c.ECashID(); got != embeddedGeneration {
 		t.Errorf("embedded ECashID() = %q, want %s", got, embeddedGeneration)
 	}
@@ -66,44 +63,22 @@ func TestECashIDEmptyWithoutECash(t *testing.T) {
 	}
 }
 
-// The cache is the baseline for detecting a generation change, so a round trip
-// must preserve the id and report that it came from disk.
-func TestSaveThenLoadReportsFromDisk(t *testing.T) {
+// An older build kept the document on disk. Those files decide nothing now, so
+// a start deletes them rather than leaving a stale document to read.
+func TestRemoveLegacyFilesClearsBothCopies(t *testing.T) {
 	dir := t.TempDir()
-	saved, _ := Load(dir)
-	for i, n := range saved.Networks {
-		if n.Family == FamilyECash {
-			saved.Networks[i].ID = "betanet"
-			break
+	for _, name := range []string{cacheFilename, pendingFilename} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
 		}
 	}
-	if err := Save(dir, saved); err != nil {
-		t.Fatalf("Save: %v", err)
-	}
 
-	got, fromDisk := Load(dir)
-	if !fromDisk {
-		t.Fatal("Load must report a catalog written by Save as coming from disk")
-	}
-	if got.ECashID() != "betanet" {
-		t.Errorf("ECashID() = %q, want betanet", got.ECashID())
-	}
-}
+	RemoveLegacyFiles(dir)
 
-// A corrupt cache must fall back to the embedded copy rather than surfacing a
-// half-written file — and must not claim to be from disk, which would let it
-// act as a wipe baseline.
-func TestCorruptCacheFallsBackToEmbedded(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, cacheFilename), []byte("{not json"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	c, fromDisk := Load(dir)
-	if fromDisk {
-		t.Error("corrupt cache must not report as from disk")
-	}
-	if c.ECashID() != embeddedGeneration {
-		t.Errorf("ECashID() = %q, want the embedded %s", c.ECashID(), embeddedGeneration)
+	for _, name := range []string{cacheFilename, pendingFilename} {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Errorf("%s must be gone, stat returned %v", name, err)
+		}
 	}
 }
 

--- a/sidechain-orchestrator/config/netcatalog/catalog_test.go
+++ b/sidechain-orchestrator/config/netcatalog/catalog_test.go
@@ -71,7 +71,12 @@ func TestECashIDEmptyWithoutECash(t *testing.T) {
 func TestSaveThenLoadReportsFromDisk(t *testing.T) {
 	dir := t.TempDir()
 	saved, _ := Load(dir)
-	saved.Networks[len(saved.Networks)-1].ID = "betanet"
+	for i, n := range saved.Networks {
+		if n.Family == FamilyECash {
+			saved.Networks[i].ID = "betanet"
+			break
+		}
+	}
 	if err := Save(dir, saved); err != nil {
 		t.Fatalf("Save: %v", err)
 	}

--- a/sidechain-orchestrator/config/netcatalog/networks.json
+++ b/sidechain-orchestrator/config/netcatalog/networks.json
@@ -19,12 +19,6 @@
           "url": "https://esplora.mainnet.drivechain.info",
           "tls": true,
           "label": "L2L Esplora"
-        },
-        {
-          "kind": "electrum",
-          "url": "ssl://explorer.mainnet.drivechain.info:50002",
-          "tls": true,
-          "label": "L2L electrs"
         }
       ],
       "explorer_tx_template": "https://explorer.mainnet.drivechain.info/tx/{txid}",
@@ -77,7 +71,7 @@
           "kind": "electrum",
           "url": "ssl://node.signet.drivechain.info:50002",
           "tls": true,
-          "label": "L2L electrs"
+          "label": "Fulcrum"
         }
       ],
       "explorer_tx_template": "https://explorer.signet.drivechain.info/tx/{txid}",
@@ -118,7 +112,8 @@
           "p2p": {
             "address": "node.signet.drivechain.info:4002",
             "transport": "quic"
-          }
+          },
+          "network_magic": null
         },
         {
           "slot": 4,
@@ -129,7 +124,8 @@
           "p2p": {
             "address": "node.signet.drivechain.info:4004",
             "transport": "quic"
-          }
+          },
+          "network_magic": null
         },
         {
           "slot": 9,
@@ -140,7 +136,8 @@
           "p2p": {
             "address": "node.signet.drivechain.info:4009",
             "transport": "quic"
-          }
+          },
+          "network_magic": null
         },
         {
           "slot": 13,
@@ -151,7 +148,8 @@
           "p2p": {
             "address": "node.signet.drivechain.info:4013",
             "transport": "quic"
-          }
+          },
+          "network_magic": null
         },
         {
           "slot": 98,
@@ -162,7 +160,8 @@
           "p2p": {
             "address": "node.signet.drivechain.info:4098",
             "transport": "quic"
-          }
+          },
+          "network_magic": null
         },
         {
           "slot": 99,
@@ -173,7 +172,8 @@
           "p2p": {
             "address": "node.signet.drivechain.info:4099",
             "transport": "quic"
-          }
+          },
+          "network_magic": null
         },
         {
           "slot": 255,
@@ -184,7 +184,8 @@
           "p2p": {
             "address": "node.signet.drivechain.info:4255",
             "transport": "quic"
-          }
+          },
+          "network_magic": null
         }
       ],
       "assumeutxo": null
@@ -207,6 +208,12 @@
           "url": "https://esplora.alpha.ecash.ninja",
           "tls": true,
           "label": "L2L Esplora"
+        },
+        {
+          "kind": "electrum",
+          "url": "ssl://explorer.alpha.ecash.ninja:50002",
+          "tls": true,
+          "label": "Fulcrum"
         }
       ],
       "explorer_tx_template": "https://explorer.alpha.ecash.ninja/tx/{txid}",
@@ -225,8 +232,8 @@
           "url": null
         },
         "mining_pool": {
-          "url": null,
-          "stratum": null
+          "url": "https://pool.alpha.avonpool.xyz",
+          "stratum": "stratum+tcp://pool.alpha.avonpool.xyz:3334"
         },
         "fast_withdrawal": []
       },
@@ -234,7 +241,143 @@
         "address": "seed.alpha.ecash.ninja:8533"
       },
       "sidechains": [],
-      "assumeutxo": null
+      "assumeutxo": {
+        "url": "https://data.drivechain.dev/alphanet/utxo-935000.dat",
+        "height": 935000,
+        "sha256": "922ccc7ae0ebf23fbff674e12e295265c9958ecfb0a5da729341b50319ae73cc",
+        "size_bytes": 9387990306
+      }
+    },
+    {
+      "id": "drynet4",
+      "family": "ecash",
+      "display_name": "Drynet 4",
+      "description": "Fork of mainnet with PoW difficulty reset",
+      "chain": "main",
+      "currency": {
+        "name": "eCash",
+        "ticker": "ECX"
+      },
+      "network_magic": "eca5d404",
+      "fork_height": 961632,
+      "backends": [
+        {
+          "kind": "esplora",
+          "url": "https://esplora.drynet4.drivechain.dev",
+          "tls": true,
+          "label": "L2L Esplora"
+        },
+        {
+          "kind": "electrum",
+          "url": "ssl://drynet4.drivechain.dev:50002",
+          "tls": true,
+          "label": "mempool/electrs"
+        }
+      ],
+      "explorer_tx_template": "https://explorer.drynet4.drivechain.dev/tx/{txid}",
+      "explorer_address_template": "https://explorer.drynet4.drivechain.dev/address/{address}",
+      "explorer_block_template": "https://explorer.drynet4.drivechain.dev/block/{hash}",
+      "services": {
+        "faucet": {
+          "url": null,
+          "amount": null,
+          "cooldown_seconds": null
+        },
+        "coinnews": {
+          "url": null
+        },
+        "blockbook": {
+          "url": null
+        },
+        "mining_pool": {
+          "url": "https://pool.drynet4.drivechain.dev",
+          "stratum": "stratum+tcp://pool.drynet4.drivechain.dev:3333"
+        },
+        "fast_withdrawal": []
+      },
+      "p2p": {
+        "address": "drynet4.drivechain.dev:8533"
+      },
+      "sidechains": [
+        {
+          "slot": 2,
+          "title": "BitNames",
+          "description": "A variant of Namecoin/BitDNS that aims to replace ICANN",
+          "image": "ghcr.io/layertwo-labs/bitnames:sha-2a9fd14",
+          "version": "v0.14.0",
+          "p2p": {
+            "address": "drynet4.drivechain.dev:4002",
+            "transport": "quic"
+          },
+          "network_magic": null
+        },
+        {
+          "slot": 4,
+          "title": "BitAssets",
+          "description": "A sidechain for digital assets",
+          "image": "ghcr.io/layertwo-labs/bitassets:sha-8f8a627",
+          "version": "v0.13.1",
+          "p2p": {
+            "address": "drynet4.drivechain.dev:4004",
+            "transport": "quic"
+          },
+          "network_magic": null
+        },
+        {
+          "slot": 9,
+          "title": "Thunder",
+          "description": "A sidechain with a large & growing blocksize, plus fraud proofs",
+          "image": "ghcr.io/layertwo-labs/thunder:sha-7541701",
+          "version": "v0.17.1",
+          "p2p": {
+            "address": "drynet4.drivechain.dev:4009",
+            "transport": "quic"
+          },
+          "network_magic": "37d05667"
+        },
+        {
+          "slot": 13,
+          "title": "Truthcoin",
+          "description": "A sidechain for decentralized prediction markets and oracle data",
+          "image": "ghcr.io/layertwo-labs/truthcoin:sha-de1aa6f",
+          "version": "sha-de1aa6f",
+          "p2p": {
+            "address": "drynet4.drivechain.dev:4013",
+            "transport": "quic"
+          },
+          "network_magic": null
+        },
+        {
+          "slot": 98,
+          "title": "zSide",
+          "description": "Sidechain with private transactions",
+          "image": "ghcr.io/iwakura-rein/thunder-orchard:sha-7e34625",
+          "version": "v0.14.0",
+          "p2p": {
+            "address": "drynet4.drivechain.dev:4098",
+            "transport": "quic"
+          },
+          "network_magic": null
+        },
+        {
+          "slot": 99,
+          "title": "Photon",
+          "description": "Sidechain using post-quantum cryptography",
+          "image": "ghcr.io/layertwo-labs/photon:sha-13ba3e4",
+          "version": "v0.14.0",
+          "p2p": {
+            "address": "drynet4.drivechain.dev:4099",
+            "transport": "quic"
+          },
+          "network_magic": null
+        }
+      ],
+      "assumeutxo": {
+        "url": "https://data.drivechain.dev/drynet4/utxo-961632.dat",
+        "height": 961632,
+        "sha256": "750067d5da800f64c39d2ac424a38d51e236740921f670abaea5c3cd2b1b7c69",
+        "size_bytes": 9471810879
+      }
     }
   ]
 }

--- a/sidechain-orchestrator/core_variants_integration_test.go
+++ b/sidechain-orchestrator/core_variants_integration_test.go
@@ -567,10 +567,9 @@ func TestIntegration_ActiveCoreBinaryPath_ExpandsECashPlaceholder(t *testing.T) 
 	assert.Equal(t, filepath.Join(BinDir(dataDir), "drynet4", "bitcoind"),
 		ActiveCoreBinaryPath(dataDir, bwDir, []BinaryConfig{cfg}, "bitcoind", "ecash", "drynet4"))
 
-	// The daemon keeps its generation until it restarts, and the confirm
-	// writes the next one to the cache at once. The path must follow the
-	// daemon, or `wipe bitcoind` deletes a build no process runs.
-	require.NoError(t, netcatalog.Save(bwDir, catalogWithECash(t, "drynet5")))
+	// The daemon keeps its generation until it restarts, so the path must follow
+	// the daemon, not the published document, or `wipe bitcoind` deletes a build
+	// no process runs.
 	assert.Equal(t, filepath.Join(BinDir(dataDir), "drynet4", "bitcoind"),
 		ActiveCoreBinaryPath(dataDir, bwDir, []BinaryConfig{cfg}, "bitcoind", "ecash", "drynet4"))
 

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -74,18 +74,13 @@ func (o *Orchestrator) PlanECashSwitch(toID string) (ECashSwitchPlan, error) {
 	return plan, nil
 }
 
-// ecashEntry finds a published eCash network by id: the catalog this process
-// serves, then the newest document on disk. A confirmed upgrade targets a
-// network the served catalog does not list yet.
+// ecashEntry finds a published eCash network by id in the catalog this process
+// serves.
 func (o *Orchestrator) ecashEntry(id string) (netcatalog.Network, bool) {
 	o.mu.RLock()
 	cat := o.Catalog
 	o.mu.RUnlock()
-	if n, ok := cat.ByID(id); ok {
-		return n, true
-	}
-	published, _ := netcatalog.Load(o.BitwindowDir)
-	return published.ByID(id)
+	return cat.ByID(id)
 }
 
 // RetargetECashEnforcerConf moves a persisted enforcer preset onto the eCash

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -75,8 +75,8 @@ func (o *Orchestrator) PlanECashSwitch(toID string) (ECashSwitchPlan, error) {
 }
 
 // ecashEntry finds a published eCash network by id: the catalog this process
-// serves, then the pending document a refresh left. A confirmed upgrade targets
-// a network the served catalog does not list yet.
+// serves, then the newest document on disk. A confirmed upgrade targets a
+// network the served catalog does not list yet.
 func (o *Orchestrator) ecashEntry(id string) (netcatalog.Network, bool) {
 	o.mu.RLock()
 	cat := o.Catalog
@@ -84,10 +84,8 @@ func (o *Orchestrator) ecashEntry(id string) (netcatalog.Network, bool) {
 	if n, ok := cat.ByID(id); ok {
 		return n, true
 	}
-	if pending, ok := netcatalog.LoadPending(o.BitwindowDir); ok {
-		return pending.ByID(id)
-	}
-	return netcatalog.Network{}, false
+	published, _ := netcatalog.Load(o.BitwindowDir)
+	return published.ByID(id)
 }
 
 // RetargetECashEnforcerConf moves a persisted enforcer preset onto the eCash
@@ -119,6 +117,8 @@ func (o *Orchestrator) RetargetECashEnforcerConf(previousID string) {
 // follows writes bitcoin.conf and starts binaries, and both read the id from
 // here, so a stale one boots the network the user just left.
 func (o *Orchestrator) AdoptECashID(id string) {
+	o.recordECashChain(id)
+
 	o.mu.Lock()
 	cat := o.Catalog
 	o.ecashID = id

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -136,14 +136,11 @@ func TestApplyECashSwitchKeepsTheChainWithNoPublishedForkHeight(t *testing.T) {
 // with nothing left to ask.
 func TestConfirmPendingECashNetworkRepinsTheSelection(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
-	o.ResolveNetworkCatalog(context.Background())
 	require.NoError(t, o.SelectECashNetwork("drynet2"))
 
 	require.NoError(t, o.ConfirmPendingECashNetwork(context.Background()))
 
-	cached, _ := netcatalog.Load(o.BitwindowDir)
-	require.Equal(t, "drynet3", cached.ECashID())
-	require.Equal(t, "drynet3", o.RunningECashID(cached), "the pick must move with the confirmation")
+	require.Equal(t, "drynet3", o.Settings.ECashNetworkID(), "the pick must move with the confirmation")
 }
 
 // The pending catalog is the one that names the confirmed network, and the
@@ -151,8 +148,7 @@ func TestConfirmPendingECashNetworkRepinsTheSelection(t *testing.T) {
 // document drops the pick and the next start boots the old network again.
 func TestConfirmPendingECashNetworkRepinsAnUnlistedID(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
-	o.ResolveNetworkCatalog(context.Background())
-	require.Equal(t, "drynet2", o.ecashID, "the process still serves the old catalog")
+	require.Equal(t, "drynet2", o.ecashID, "the process runs the network the conf names")
 
 	require.NoError(t, o.ConfirmPendingECashNetwork(context.Background()))
 

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -87,7 +87,7 @@ func TestApplyECashSwitchRewritesTheConfSentinel(t *testing.T) {
 	require.NoError(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
 
 	require.Equal(t, "alphanet", o.installedECashNetwork())
-	require.Equal(t, "alphanet", o.SelectedECashID(ecashCatalog()))
+	require.Equal(t, "alphanet", o.RunningECashID(ecashCatalog()))
 	require.Equal(t, "alphanet", config.ECashNetworkID())
 }
 
@@ -143,7 +143,7 @@ func TestConfirmPendingECashNetworkRepinsTheSelection(t *testing.T) {
 
 	cached, _ := netcatalog.Load(o.BitwindowDir)
 	require.Equal(t, "drynet3", cached.ECashID())
-	require.Equal(t, "drynet3", o.SelectedECashID(cached), "the pick must move with the confirmation")
+	require.Equal(t, "drynet3", o.RunningECashID(cached), "the pick must move with the confirmation")
 }
 
 // The pending catalog is the one that names the confirmed network, and the
@@ -362,7 +362,7 @@ func TestApplyECashSwitchRewindsAndLandsTheTarget(t *testing.T) {
 	require.Equal(t, []string{"invalidateblock"}, marks(core))
 	require.Equal(t, []string{"bitcoind"}, stopped, "core stops only after the rewind reads it")
 	require.Equal(t, "alphanet", o.installedECashNetwork())
-	require.Equal(t, "alphanet", o.SelectedECashID(ecashCatalog()))
+	require.Equal(t, "alphanet", o.RunningECashID(ecashCatalog()))
 	require.Equal(t, forkBlock, o.Settings.RewoundBlockHash())
 	require.Nil(t, o.pendingSwap, "a tail that lands leaves nothing pending")
 }

--- a/sidechain-orchestrator/ecash_upgrade_keeps_blocks_test.go
+++ b/sidechain-orchestrator/ecash_upgrade_keeps_blocks_test.go
@@ -101,15 +101,14 @@ func TestConfirmMovesTheChainToMatchTheConf(t *testing.T) {
 	require.NoError(t, err, "the blocks below the fork must survive the switch")
 }
 
-// The published network lives only in the pending document until a confirm
-// promotes it. A plan that reads the served catalog alone cannot price the
-// move, and the dialog then names a resync the switch never does.
-func TestPlanReadsANetworkFromThePendingCatalog(t *testing.T) {
+// A start adopts the newest document, so a process that started before the
+// refresh serves an older one. A plan that reads the served catalog alone
+// cannot price the move, and the dialog then names a resync the switch never does.
+func TestPlanReadsANetworkFromTheNewestDocument(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
-	o.ResolveNetworkCatalog(context.Background())
 
 	_, served := o.Catalog.ByID("drynet3")
-	require.False(t, served, "drynet3 must still be pending only")
+	require.False(t, served, "this process still serves the document it started with")
 
 	plan, err := o.PlanECashSwitch("drynet3")
 	require.NoError(t, err)

--- a/sidechain-orchestrator/ecash_upgrade_keeps_blocks_test.go
+++ b/sidechain-orchestrator/ecash_upgrade_keeps_blocks_test.go
@@ -45,9 +45,10 @@ func TestStartupKeepsTheChainWhenTheCatalogMovesOn(t *testing.T) {
 	// The install the user updated: blocks from drynet4, catalog on alphanet.
 	o.BitcoinConf.Config.SetSetting("uacomment", config.ECashUAComment("drynet4"), "main")
 	require.Equal(t, "drynet4", o.installedECashNetwork())
-	require.NoError(t, netcatalog.Save(o.BitwindowDir, catalogWithECash(t, "alphanet")))
+	publish(t, o, catalogWithECash(t, "alphanet"))
 
 	o.ResolveNetworkCatalog(context.Background())
+	awaitRefresh(t, o, "alphanet")
 
 	require.Equal(t, "drynet4", config.ECashNetworkID(), "startup must serve the network the blocks belong to")
 	for _, d := range []string{"blocks", "chainstate"} {
@@ -57,28 +58,17 @@ func TestStartupKeepsTheChainWhenTheCatalogMovesOn(t *testing.T) {
 	require.Equal(t, "alphanet", o.Catalog.ECashID(), "the offer still reaches the user")
 }
 
-// No blocks on disk, nothing to hold back: a fresh install takes what the
-// catalog publishes.
-func TestStartupTakesThePublishedNetworkWithNoChainOnDisk(t *testing.T) {
-	o := ecashInstall(t)
-	o.BitcoinConf.Config.SetSetting("uacomment", config.ECashUAComment("drynet4"), "main")
-	require.NoError(t, netcatalog.Save(o.BitwindowDir, catalogWithECash(t, "alphanet")))
-
-	o.ResolveNetworkCatalog(context.Background())
-
-	require.Equal(t, "alphanet", config.ECashNetworkID())
-}
-
 // A network the user picked is not an offer. Startup applies it.
 func TestStartupAppliesTheNetworkTheUserPicked(t *testing.T) {
 	o := ecashInstall(t)
 	seedCoreChainData(t, o.ecashDatadir())
 	o.BitcoinConf.Config.SetSetting("uacomment", config.ECashUAComment("drynet4"), "main")
-	require.NoError(t, netcatalog.Save(o.BitwindowDir, catalogWithECash(t, "alphanet")))
+	publish(t, o, catalogWithECash(t, "alphanet"))
 	_, err := o.Settings.SetECashNetworkID("alphanet")
 	require.NoError(t, err)
 
 	o.ResolveNetworkCatalog(context.Background())
+	awaitRefresh(t, o, "alphanet")
 
 	require.Equal(t, "alphanet", config.ECashNetworkID())
 }
@@ -87,7 +77,6 @@ func TestStartupAppliesTheNetworkTheUserPicked(t *testing.T) {
 // Recording the pick alone would park Core on the retired fork for good.
 func TestConfirmMovesTheChainToMatchTheConf(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
-	o.ResolveNetworkCatalog(context.Background())
 	datadir := o.ecashDatadir()
 	require.NotEmpty(t, datadir)
 	seedCoreChainData(t, datadir)
@@ -101,14 +90,10 @@ func TestConfirmMovesTheChainToMatchTheConf(t *testing.T) {
 	require.NoError(t, err, "the blocks below the fork must survive the switch")
 }
 
-// A start adopts the newest document, so a process that started before the
-// refresh serves an older one. A plan that reads the served catalog alone
-// cannot price the move, and the dialog then names a resync the switch never does.
-func TestPlanReadsANetworkFromTheNewestDocument(t *testing.T) {
+// The dialog states what the move costs, so the plan reads both networks out of
+// the document this process serves.
+func TestPlanPricesThePublishedNetwork(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
-
-	_, served := o.Catalog.ByID("drynet3")
-	require.False(t, served, "this process still serves the document it started with")
 
 	plan, err := o.PlanECashSwitch("drynet3")
 	require.NoError(t, err)
@@ -239,42 +224,4 @@ func TestAChangeWithNoForkHeightHoldsTheCatalogBack(t *testing.T) {
 	require.False(t, o.ecashChangeHasASharedBlock("drynet4", "alphanet"))
 
 	require.Empty(t, o.Settings.PendingEnforcerWipe(), "a change that cannot run journals nothing")
-}
-
-// An empty datadir override means Core's platform default, which is a
-// supported setup. Reading it as "nothing on disk" lets a start adopt the
-// published fork over blocks that are still there.
-func TestTheDefaultDatadirCountsAsChainOnDisk(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-	o := newTestOrchestrator(t)
-	// No datadir slot and no datadir= line: Core falls back to its own default.
-	o.setNetwork(string(config.NetworkECash))
-	require.Empty(t, o.ecashDatadir(), "this install runs on the platform default")
-
-	defaultDir := config.BitcoinCoreDirs.DatadirNetwork(config.NetworkECash, "")
-	require.NoError(t, os.MkdirAll(filepath.Join(defaultDir, "blocks"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(defaultDir, "blocks", "blk00000.dat"), []byte("chain"), 0o644))
-
-	require.True(t, o.ecashChainDataOnDisk(), "the default datadir holds the chain too")
-}
-
-// Only "not there" says the chain is gone. Any other refusal leaves blocks that
-// may exist, and adopting the published fork over them needs the user first.
-func TestAnUnreadableBlocksDirCountsAsChainOnDisk(t *testing.T) {
-	o := ecashInstall(t)
-	datadir := o.ecashDatadir()
-	require.NotEmpty(t, datadir)
-	seedCoreChainData(t, datadir)
-
-	require.NoError(t, os.Chmod(filepath.Join(datadir, "blocks"), 0o000))
-	t.Cleanup(func() { _ = os.Chmod(filepath.Join(datadir, "blocks"), 0o755) })
-
-	if entries, err := os.ReadDir(filepath.Join(datadir, "blocks")); err == nil {
-		_ = entries
-		t.Skip("this filesystem reads the directory anyway, so the failure cannot be staged")
-	}
-
-	require.True(t, o.ecashChainDataOnDisk(), "a chain we cannot read is still a chain")
 }

--- a/sidechain-orchestrator/network_catalog.go
+++ b/sidechain-orchestrator/network_catalog.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -18,39 +16,48 @@ import (
 // appears in chains_config.json, so a new generation needs no config edit.
 const ecashPlaceholder = "{ecash}"
 
-// ResolveNetworkCatalog adopts the newest catalog document this install holds,
-// then refreshes it from the published one. The published document is always
-// the correct one; the copy on disk is what a start reads when the fetch fails.
+// firstRunFetchTimeout bounds the one fetch a start waits for. It only applies
+// to an install that has no eCash network of its own yet.
+const firstRunFetchTimeout = 3 * time.Second
+
+// ResolveNetworkCatalog adopts the catalog compiled into this build, then
+// refreshes it from the published document. The published document is always
+// the correct one; the compiled-in copy is what a start reads until the fetch
+// lands, and what an offline start keeps. Neither one is held on disk.
+//
 // A refresh moves no chain: it changes the rows the picker lists and the
-// endpoints they publish, and the eCash network this install runs stays the
+// endpoints they publish. The eCash network this install runs stays the
 // user's to change.
 func (o *Orchestrator) ResolveNetworkCatalog(ctx context.Context) {
-	// Disk first, and synchronously: this runs before the RPC listener binds,
-	// so anything slow here delays every caller, including the wallet list the
-	// UI needs to draw. A local read is microseconds.
-	current, _ := netcatalog.Load(o.BitwindowDir)
+	// The compiled-in document first, and with no I/O: this runs before the RPC
+	// listener binds, so anything slow here delays every caller, including the
+	// wallet list the UI needs to draw.
+	current := netcatalog.Embedded()
+	// An install with no eCash network of its own has no chain to keep, so the
+	// live document decides which one it starts on. One short wait beats an
+	// upgrade prompt on the first run, and the record below makes it the last.
+	if !o.hasOwnECashNetwork() {
+		fetchCtx, cancel := context.WithTimeout(ctx, firstRunFetchTimeout)
+		if fetched, err := netcatalog.Fetch(fetchCtx, o.publishedCatalogURL()); err == nil {
+			current = fetched
+		}
+		cancel()
+	}
 	o.seedToldNetworks(current)
-	netcatalog.RemoveLegacyPending(o.BitwindowDir)
+	netcatalog.RemoveLegacyFiles(o.BitwindowDir)
 
 	// The network this install serves, not the document's first row: the blocks
 	// on disk belong to one network, and only the user moves them to another.
 	ecashID := o.RunningECashID(current)
-	// RunningECashID already keeps a network the catalog still lists, so this
-	// only fires once the catalog drops the one the blocks belong to. Serving
-	// it with no endpoints beats opening its blocks as another fork: the user
-	// switches from Settings, which states the resync before it runs.
-	if installed := o.installedECashNetwork(); o.ecashNetworkMoved(installed, ecashID) {
+	if _, listed := current.ByID(ecashID); ecashID != "" && !listed {
 		o.log.Warn().
-			Str("installed", installed).
-			Str("published", ecashID).
-			Msg("the catalog dropped the installed eCash network, switch from Settings to move")
-		ecashID = installed
+			Str("network", ecashID).
+			Msg("the catalog does not list the eCash network this install runs, switch from Settings to move")
 	}
 	o.adoptCatalog(current, ecashID)
 
-	// The refresh is network I/O and must never gate startup. It runs detached
-	// and only writes the document to disk.
-	go o.refreshNetworkCatalog(ctx, current)
+	// The fetch is network I/O and must never gate startup, so it runs detached.
+	go o.refreshNetworkCatalog(ctx)
 }
 
 // PendingECashUpgrade is a published generation this install has not switched
@@ -66,10 +73,10 @@ type PendingECashUpgrade struct {
 }
 
 // PendingECashUpgrade reports the generation waiting for the user's go-ahead.
-// It reads the newest document on disk, not the one this process serves: the
-// refresh writes that document, and a start adopts it without moving a chain.
 func (o *Orchestrator) PendingECashUpgrade() PendingECashUpgrade {
-	published, _ := netcatalog.Load(o.BitwindowDir)
+	o.mu.RLock()
+	published := o.Catalog
+	o.mu.RUnlock()
 	// The document's first row against the network this install runs. A pick
 	// says which network runs, not that the user heard about the newer one, and
 	// the document keeps their row so its endpoints stay reachable.
@@ -102,7 +109,9 @@ func (o *Orchestrator) ecashSwitchIsManual() bool {
 // ConfirmPendingECashNetwork applies the user's go-ahead: it records the
 // published network as the pick, then moves the chain onto it.
 func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
-	published, _ := netcatalog.Load(o.BitwindowDir)
+	o.mu.RLock()
+	published := o.Catalog
+	o.mu.RUnlock()
 	target := published.ECashID()
 	if target == "" || target == o.RunningECashID(published) {
 		return fmt.Errorf("no new eCash network to switch to")
@@ -137,7 +146,7 @@ func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
 
 	if config.NetworkFromString(o.Network) == config.NetworkECash {
 		// Here, not on the next start: this is the one moment a live Core can
-		// rewind to the fork. A start has none and could only delete the chain.
+		// rewind to the fork. A start has none, so it would leave Core above it.
 		if err := o.ApplyECashSwitch(ctx, target); err != nil {
 			// Only when the switch never committed. Past that point the
 			// chain and the conf already name the target, and putting the
@@ -152,18 +161,19 @@ func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
 			return fmt.Errorf("switch to %s: %w", target, err)
 		}
 	} else {
-		// Off eCash the retired chain is cold files that no start will revisit,
-		// and there is no Core on that chain to rewind. Clear them here.
+		// Off eCash no Core answers on that chain, so nothing rewinds here. The
+		// blocks stay either way: both networks hold everything below the fork,
+		// and Core reorganises onto the confirmed one when it next runs.
 		//
-		// The pick on both sides, not each document's first row. A user on a
-		// retained entry holds that chain on disk, and comparing first rows
-		// reads two identical ids while the blocks belong to a third.
+		// The network this install runs, not the document's first row. A user on
+		// a retained entry holds that chain, and comparing first rows reads two
+		// identical ids while the blocks belong to a third.
 		o.mu.RLock()
 		served := o.Catalog
 		o.mu.RUnlock()
 		if !o.ecashChangeHasASharedBlock(o.RunningECashID(served), target) {
 			o.restoreECashPick(previousPick)
-			return fmt.Errorf("could not clear the retired eCash chain data")
+			return fmt.Errorf("no fork height says where the two eCash chains part")
 		}
 	}
 	o.log.Info().
@@ -184,34 +194,53 @@ func (o *Orchestrator) restoreECashPick(pick string) {
 	}
 }
 
-// refreshNetworkCatalog fetches the published catalog and records it as the
-// newest document this install knows. The next start adopts it.
-//
-// It deliberately mutates nothing in memory. This runs after the RPC server is
-// accepting requests, and the orchestrator's shared state — binary configs,
-// monitors, catalog, the bitcoin.conf manager — is read by those handlers
-// without a common lock.
-func (o *Orchestrator) refreshNetworkCatalog(ctx context.Context, current netcatalog.Catalog) {
-	fetched, err := netcatalog.Fetch(ctx, netcatalog.DefaultURL)
+// refreshNetworkCatalog fetches the published document and takes it in memory.
+// A failed fetch is never fatal: the compiled-in document stays in force.
+func (o *Orchestrator) refreshNetworkCatalog(ctx context.Context) {
+	fetched, err := netcatalog.Fetch(ctx, o.publishedCatalogURL())
 	if err != nil {
-		o.log.Warn().Err(err).Msg("network catalog refresh failed, using last known values")
+		o.log.Warn().Err(err).Msg("network catalog refresh failed, using the compiled-in document")
 		return
 	}
-	next := retainRunningECash(fetched, current, o.RunningECashID(current))
+	o.mu.RLock()
+	current := o.Catalog
+	running := o.ecashID
+	o.mu.RUnlock()
+
+	next := retainRunningECash(fetched, current, running)
 	// Every entry matters, not just the eCash one: the picker lists them all and
 	// the endpoints come from their backends. An id-only compare threw away a
 	// refresh that added a network, so it never reached the picker.
 	if next.SameAs(current) {
 		return
 	}
-	if err := netcatalog.Save(o.BitwindowDir, next); err != nil {
-		o.log.Warn().Err(err).Msg("could not record the refreshed network catalog")
-		return
-	}
+	// The rows only. The chain this install runs is the user's to change, and a
+	// conf rewrite under the running daemons is not this call's to make.
+	o.adoptCatalogRows(next, running)
 	o.log.Info().
-		Str("current", current.ECashID()).
+		Str("current", running).
 		Str("published", next.ECashID()).
-		Msg("the network catalog changed, restart to apply it")
+		Msg("took the published network catalog")
+}
+
+// publishedCatalogURL is where the document is fetched from.
+func (o *Orchestrator) publishedCatalogURL() string {
+	if o.catalogURL == "" {
+		return netcatalog.DefaultURL
+	}
+	return o.catalogURL
+}
+
+// hasOwnECashNetwork reports whether this install already runs an eCash network:
+// the user picked one, its conf names one, or a previous start recorded one.
+func (o *Orchestrator) hasOwnECashNetwork() bool {
+	if o.installedECashNetwork() != "" {
+		return true
+	}
+	if o.Settings == nil {
+		return false
+	}
+	return o.Settings.ECashNetworkID() != "" || o.Settings.ECashChainID() != ""
 }
 
 // retainRunningECash appends the entry for the eCash network this install runs
@@ -244,46 +273,15 @@ func (o *Orchestrator) adoptCatalog(c netcatalog.Catalog, id string) {
 	}
 
 	o.recordECashChain(id)
+	o.adoptCatalogRows(c, id)
 
-	o.mu.Lock()
-	o.Catalog = c
-	o.ecashID = id
-	// Always expand from the pristine configs: a previous adopt already
-	// replaced the placeholder, so re-expanding those would leave the old
-	// network pinned forever.
-	for name, raw := range o.rawConfigs {
-		o.configs[name] = expandECashPlaceholder(raw, id)
-	}
+	o.mu.RLock()
 	conf := o.BitcoinConf
 	enforcerConf := o.EnforcerConf
-	o.mu.Unlock()
+	o.mu.RUnlock()
 
 	if id == "" {
 		return
-	}
-	// The URL helpers and the conf writer both key off the eCash id, so both
-	// need the resolved one.
-	config.SetECashNetworkID(id)
-
-	// Fork heights ride along in the catalog, so a new eCash network — and the
-	// real fork — activate without a release.
-	for _, n := range c.Networks {
-		// An eCash id names no network, so writing it as one would stamp its
-		// values onto signet, which is what NetworkFromString falls back to.
-		if net, ok := config.LookupNetwork(n.ID); ok {
-			config.SetForkHeight(net, n.ForkHeight)
-			config.SetNetworkDisplayName(net, n.DisplayName)
-		}
-		if n.Family == netcatalog.FamilyECash {
-			config.SetECashPeer(n.ID, n.P2P.Address)
-		}
-	}
-	// The eCash slot takes the resolved entry's values, not the last listed
-	// one: the catalog keeps the retired networks after the live one.
-	if ecash, ok := c.ByID(id); ok {
-		config.SetForkHeight(config.NetworkECash, ecash.ForkHeight)
-		config.SetNetworkDisplayName(config.NetworkECash, ecash.DisplayName)
-		config.SetECashEndpoints(ecash)
 	}
 
 	// The esplora host and network preset name the eCash network, so a rollover
@@ -321,6 +319,50 @@ func (o *Orchestrator) recordECashChain(id string) {
 	}
 }
 
+// adoptCatalogRows takes a document in memory: the rows the picker lists, the
+// endpoints they publish and the fork heights they carry. It writes no conf, so
+// a refresh can call it while the daemons run.
+func (o *Orchestrator) adoptCatalogRows(c netcatalog.Catalog, id string) {
+	o.mu.Lock()
+	o.Catalog = c
+	o.ecashID = id
+	// Always expand from the pristine configs: a previous adopt already
+	// replaced the placeholder, so re-expanding those would leave the old
+	// network pinned forever.
+	for name, raw := range o.rawConfigs {
+		o.configs[name] = expandECashPlaceholder(raw, id)
+	}
+	o.mu.Unlock()
+
+	if id == "" {
+		return
+	}
+	// The URL helpers and the conf writer both key off the eCash id, so both
+	// need the resolved one.
+	config.SetECashNetworkID(id)
+
+	// Fork heights ride along in the catalog, so a new eCash network — and the
+	// real fork — activate without a release.
+	for _, n := range c.Networks {
+		// An eCash id names no network, so writing it as one would stamp its
+		// values onto signet, which is what NetworkFromString falls back to.
+		if net, ok := config.LookupNetwork(n.ID); ok {
+			config.SetForkHeight(net, n.ForkHeight)
+			config.SetNetworkDisplayName(net, n.DisplayName)
+		}
+		if n.Family == netcatalog.FamilyECash {
+			config.SetECashPeer(n.ID, n.P2P.Address)
+		}
+	}
+	// The eCash slot takes the resolved entry's values, not the last listed
+	// one: the catalog keeps the retired networks after the live one.
+	if ecash, ok := c.ByID(id); ok {
+		config.SetForkHeight(config.NetworkECash, ecash.ForkHeight)
+		config.SetNetworkDisplayName(config.NetworkECash, ecash.DisplayName)
+		config.SetECashEndpoints(ecash)
+	}
+}
+
 // expandECashPlaceholder replaces the eCash placeholder throughout a binary's
 // Core variants. It is applied on every path that installs configs — including
 // the chains_config.json watcher — because a reload otherwise reinstates the
@@ -344,66 +386,33 @@ func expandECashPlaceholder(cfg BinaryConfig, id string) BinaryConfig {
 	return cfg
 }
 
-// ecashNetworkMoved reports whether startup must hold back the published eCash
-// network: it differs from the one the blocks on disk belong to, the user never
-// asked to move, and there are blocks to lose.
-func (o *Orchestrator) ecashNetworkMoved(installed, published string) bool {
-	if installed == "" || published == "" || installed == published {
-		return false
-	}
-	if config.NetworkFromString(o.Network) != config.NetworkECash {
-		return false
-	}
-	// A move the user already picked is not an offer.
-	if o.Settings != nil && o.Settings.ECashNetworkID() == published {
-		return false
-	}
-	return o.ecashChainDataOnDisk()
-}
-
-// ecashChainDataOnDisk reports whether Core holds eCash blocks worth keeping.
-func (o *Orchestrator) ecashChainDataOnDisk() bool {
-	// An empty override means Core's platform default, which is a supported
-	// setup — not an install with nothing on disk.
-	datadir := config.BitcoinCoreDirs.DatadirNetwork(config.NetworkECash, o.ecashDatadir())
-	if datadir == "" {
-		return false
-	}
-	entries, err := os.ReadDir(filepath.Join(datadir, "blocks"))
-	if err != nil {
-		// Only "not there" says there is nothing to keep. Any other refusal
-		// leaves a chain that may exist, and adopting over it needs the user.
-		return !os.IsNotExist(err)
-	}
-	return len(entries) > 0
-}
-
 // RunningECashID returns the eCash network this install serves: the user's pick,
 // then the id its bitcoin.conf names, then the recorded chain, and only then
-// the entry the catalog lists first. The conf and the record come before
-// document order because they name the fork whose blocks are on disk.
+// the entry the catalog lists first.
+//
+// The conf and the record win even when the document drops their network. They
+// name the fork whose blocks are on disk, and serving it with no endpoints
+// beats opening those blocks as another fork.
 func (o *Orchestrator) RunningECashID(c netcatalog.Catalog) string {
 	if picked := o.pinnedECashID(c); picked != "" {
 		return picked
 	}
 	if installed := o.installedECashNetwork(); installed != "" {
-		if _, ok := c.ByID(installed); ok {
-			return installed
-		}
+		return installed
 	}
 	// A swap to another network strips the conf sentinel, so off eCash this
 	// record is the only thing that still names the blocks on disk.
 	if o.Settings != nil {
 		if recorded := o.Settings.ECashChainID(); recorded != "" {
-			if _, ok := c.ByID(recorded); ok {
-				return recorded
-			}
+			return recorded
 		}
 	}
 	return c.ECashID()
 }
 
-// pinnedECashID returns the user's pick while the catalog still lists it.
+// pinnedECashID returns the user's pick while the catalog still lists it. A
+// pick the document dropped is a network the user left long ago, and the conf
+// then names the one whose blocks are on disk.
 func (o *Orchestrator) pinnedECashID(c netcatalog.Catalog) string {
 	if o.Settings == nil {
 		return ""
@@ -419,9 +428,8 @@ func (o *Orchestrator) pinnedECashID(c netcatalog.Catalog) string {
 }
 
 // SelectECashNetwork pins the eCash network the user picked. The switch itself
-// runs on the next start, which is the only place the stale chain can be wiped.
-// An id the catalog does not list is ignored: a caller that sends the bare slot
-// name keeps whatever the catalog resolves.
+// runs on the next start. An id the catalog does not list is ignored: a caller
+// that sends the bare slot name keeps whatever the catalog resolves.
 func (o *Orchestrator) SelectECashNetwork(id string) error {
 	o.mu.RLock()
 	cat := o.Catalog
@@ -459,7 +467,8 @@ func (o *Orchestrator) SelectECashNetwork(id string) error {
 		return fmt.Errorf("no fork height says where %s and %s part", previous, id)
 	}
 	// The enforcer keeps one validator chain per network, not per fork, so the
-	// new generation cannot inherit the old one's. Off eCash that directory
+	// new generation cannot inherit the old one's. That chain rebuilds from the
+	// blocks; Core's own block store is never touched. Off eCash the directory
 	// belongs to the running network, so the work waits for the swap back.
 	if err := o.Settings.SetPendingEnforcerWipe(id); err != nil {
 		o.log.Warn().Err(err).Msg("could not record the enforcer cleanup")

--- a/sidechain-orchestrator/network_catalog.go
+++ b/sidechain-orchestrator/network_catalog.go
@@ -16,33 +16,13 @@ import (
 // appears in chains_config.json, so a new generation needs no config edit.
 const ecashPlaceholder = "{ecash}"
 
-// firstRunFetchTimeout bounds the one fetch a start waits for. It only applies
-// to an install that has no eCash network of its own yet.
-const firstRunFetchTimeout = 3 * time.Second
-
-// ResolveNetworkCatalog adopts the catalog compiled into this build, then
-// refreshes it from the published document. The published document is always
-// the correct one; the compiled-in copy is what a start reads until the fetch
-// lands, and what an offline start keeps. Neither one is held on disk.
-//
-// A refresh moves no chain: it changes the rows the picker lists and the
-// endpoints they publish. The eCash network this install runs stays the
-// user's to change.
+// ResolveNetworkCatalog adopts the compiled-in catalog, then refreshes it from
+// the published document. Neither copy is held on disk, and no start waits on
+// the endpoint. A refresh moves no chain: only the user changes that.
 func (o *Orchestrator) ResolveNetworkCatalog(ctx context.Context) {
-	// The compiled-in document first, and with no I/O: this runs before the RPC
-	// listener binds, so anything slow here delays every caller, including the
-	// wallet list the UI needs to draw.
+	// No I/O: this runs before the RPC listener binds, so anything slow here
+	// delays every caller.
 	current := netcatalog.Embedded()
-	// An install with no eCash network of its own has no chain to keep, so the
-	// live document decides which one it starts on. One short wait beats an
-	// upgrade prompt on the first run, and the record below makes it the last.
-	if !o.hasOwnECashNetwork() {
-		fetchCtx, cancel := context.WithTimeout(ctx, firstRunFetchTimeout)
-		if fetched, err := netcatalog.Fetch(fetchCtx, o.publishedCatalogURL()); err == nil {
-			current = fetched
-		}
-		cancel()
-	}
 	o.seedToldNetworks(current)
 	netcatalog.RemoveLegacyFiles(o.BitwindowDir)
 
@@ -78,8 +58,7 @@ func (o *Orchestrator) PendingECashUpgrade() PendingECashUpgrade {
 	published := o.Catalog
 	o.mu.RUnlock()
 	// The document's first row against the network this install runs. A pick
-	// says which network runs, not that the user heard about the newer one, and
-	// the document keeps their row so its endpoints stay reachable.
+	// says which network runs, not that the user heard about the newer one.
 	id := published.ECashID()
 	if id == "" || id == o.RunningECashID(published) {
 		return PendingECashUpgrade{}
@@ -161,13 +140,9 @@ func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
 			return fmt.Errorf("switch to %s: %w", target, err)
 		}
 	} else {
-		// Off eCash no Core answers on that chain, so nothing rewinds here. The
-		// blocks stay either way: both networks hold everything below the fork,
-		// and Core reorganises onto the confirmed one when it next runs.
-		//
-		// The network this install runs, not the document's first row. A user on
-		// a retained entry holds that chain, and comparing first rows reads two
-		// identical ids while the blocks belong to a third.
+		// Off eCash no Core answers, so nothing rewinds and the blocks stay.
+		// The network this install runs, not the document's first row: a user on
+		// a retained entry holds that chain.
 		o.mu.RLock()
 		served := o.Catalog
 		o.mu.RUnlock()
@@ -214,8 +189,7 @@ func (o *Orchestrator) refreshNetworkCatalog(ctx context.Context) {
 	if next.SameAs(current) {
 		return
 	}
-	// The rows only. The chain this install runs is the user's to change, and a
-	// conf rewrite under the running daemons is not this call's to make.
+	// Rows only: the chain this install runs is the user's to change.
 	o.adoptCatalogRows(next, running)
 	o.log.Info().
 		Str("current", running).
@@ -231,22 +205,8 @@ func (o *Orchestrator) publishedCatalogURL() string {
 	return o.catalogURL
 }
 
-// hasOwnECashNetwork reports whether this install already runs an eCash network:
-// the user picked one, its conf names one, or a previous start recorded one.
-func (o *Orchestrator) hasOwnECashNetwork() bool {
-	if o.installedECashNetwork() != "" {
-		return true
-	}
-	if o.Settings == nil {
-		return false
-	}
-	return o.Settings.ECashNetworkID() != "" || o.Settings.ECashChainID() != ""
-}
-
-// retainRunningECash appends the entry for the eCash network this install runs
-// when the published document drops it. Its backends are the only ones that
-// reach the blocks on disk, and the user keeps that chain until they confirm a
-// switch. It goes last, so the published network still leads the document.
+// retainRunningECash keeps the entry for the network this install runs when the
+// published document drops it. It goes last, so the live network still leads.
 func retainRunningECash(fetched, current netcatalog.Catalog, id string) netcatalog.Catalog {
 	if id == "" {
 		return fetched
@@ -308,8 +268,8 @@ func (o *Orchestrator) adoptCatalog(c netcatalog.Catalog, id string) {
 	}
 }
 
-// recordECashChain persists the eCash network this install serves, so a start
-// on another network still knows which fork the blocks belong to.
+// recordECashChain persists the network this install serves, so a start off
+// eCash still knows which fork the blocks belong to.
 func (o *Orchestrator) recordECashChain(id string) {
 	if id == "" || o.Settings == nil {
 		return
@@ -319,9 +279,8 @@ func (o *Orchestrator) recordECashChain(id string) {
 	}
 }
 
-// adoptCatalogRows takes a document in memory: the rows the picker lists, the
-// endpoints they publish and the fork heights they carry. It writes no conf, so
-// a refresh can call it while the daemons run.
+// adoptCatalogRows takes a document in memory: the picker rows, their endpoints
+// and their fork heights. It writes no conf, so a refresh can call it live.
 func (o *Orchestrator) adoptCatalogRows(c netcatalog.Catalog, id string) {
 	o.mu.Lock()
 	o.Catalog = c
@@ -386,13 +345,10 @@ func expandECashPlaceholder(cfg BinaryConfig, id string) BinaryConfig {
 	return cfg
 }
 
-// RunningECashID returns the eCash network this install serves: the user's pick,
-// then the id its bitcoin.conf names, then the recorded chain, and only then
-// the entry the catalog lists first.
-//
-// The conf and the record win even when the document drops their network. They
-// name the fork whose blocks are on disk, and serving it with no endpoints
-// beats opening those blocks as another fork.
+// RunningECashID returns the eCash network this install serves: the pick, then
+// the conf, then the record, and only then the document's first row. The conf
+// and the record win even when the document drops their network: the blocks
+// belong to it.
 func (o *Orchestrator) RunningECashID(c netcatalog.Catalog) string {
 	if picked := o.pinnedECashID(c); picked != "" {
 		return picked

--- a/sidechain-orchestrator/network_catalog.go
+++ b/sidechain-orchestrator/network_catalog.go
@@ -18,35 +18,28 @@ import (
 // appears in chains_config.json, so a new generation needs no config edit.
 const ecashPlaceholder = "{ecash}"
 
-// ResolveNetworkCatalog loads the catalog persisted by the previous run, then
-// refreshes it from the published document. A failed refresh is never fatal:
-// the persisted copy stays in force, which is also what makes it a safe
-// baseline for spotting a eCash network change — an offline boot compares
-// the old values against themselves and so can never wipe anything.
+// ResolveNetworkCatalog adopts the newest catalog document this install holds,
+// then refreshes it from the published one. The published document is always
+// the correct one; the copy on disk is what a start reads when the fetch fails.
+// A refresh moves no chain: it changes the rows the picker lists and the
+// endpoints they publish, and the eCash network this install runs stays the
+// user's to change.
 func (o *Orchestrator) ResolveNetworkCatalog(ctx context.Context) {
 	// Disk first, and synchronously: this runs before the RPC listener binds,
 	// so anything slow here delays every caller, including the wallet list the
 	// UI needs to draw. A local read is microseconds.
-	current, fromDisk := netcatalog.Load(o.BitwindowDir)
-	// Before the promotion below rewrites the cache: what this document lists is
-	// what the previous run knew, and the notice compares against exactly that.
+	current, _ := netcatalog.Load(o.BitwindowDir)
 	o.seedToldNetworks(current)
+	netcatalog.RemoveLegacyPending(o.BitwindowDir)
 
-	// A previous run's refresh may have left a newer catalog waiting. Startup
-	// is the only place it can be applied: the generation decides which chain
-	// data is valid, and swapping that under a running process is what caused
-	// the wipe and cache to disagree.
-	promoted := false
-	if pending, ok := netcatalog.LoadPending(o.BitwindowDir); ok {
-		current = o.promotePendingCatalog(ctx, current, pending, fromDisk)
-		promoted = true
-	}
+	// The network this install serves, not the document's first row: the blocks
+	// on disk belong to one network, and only the user moves them to another.
+	ecashID := o.RunningECashID(current)
 	// RunningECashID already keeps a network the catalog still lists, so this
 	// only fires once the catalog drops the one the blocks belong to. Serving
 	// it with no endpoints beats opening its blocks as another fork: the user
 	// switches from Settings, which states the resync before it runs.
-	ecashID := o.RunningECashID(current)
-	if installed := o.installedECashNetwork(); !promoted && o.ecashNetworkMoved(installed, ecashID) {
+	if installed := o.installedECashNetwork(); o.ecashNetworkMoved(installed, ecashID) {
 		o.log.Warn().
 			Str("installed", installed).
 			Str("published", ecashID).
@@ -56,43 +49,8 @@ func (o *Orchestrator) ResolveNetworkCatalog(ctx context.Context) {
 	o.adoptCatalog(current, ecashID)
 
 	// The refresh is network I/O and must never gate startup. It runs detached
-	// and only writes the pending slot.
+	// and only writes the document to disk.
 	go o.refreshNetworkCatalog(ctx, current)
-}
-
-// promotePendingCatalog applies a catalog left by a previous refresh. Returns
-// the catalog to actually use: the pending one when it names the same eCash
-// network, otherwise the current one, so a move between networks stays the
-// user's to make.
-func (o *Orchestrator) promotePendingCatalog(_ context.Context, current, pending netcatalog.Catalog, fromDisk bool) netcatalog.Catalog {
-	// The network this install serves, not the catalog's first entry: a user on
-	// a retained row keeps blocks from that row, and a refresh that drops it
-	// leaves both documents naming the same first entry. An id-only compare
-	// reads that as no change and promotes over a chain it never cleared.
-	baseline := o.RunningECashID(current)
-	if !fromDisk {
-		baseline = netcatalog.EmbeddedECashID()
-	}
-	// What the pending document resolves to for this install, which is the pick
-	// while the pick survives the refresh.
-	target := o.SelectedECashID(pending)
-
-	// Switching networks throws away the old chain, so it is the user's call
-	// to make. The pending file is what the upgrade prompt reads.
-	if baseline != "" && target != "" && baseline != target {
-		o.log.Info().
-			Str("current", baseline).
-			Str("published", target).
-			Msg("a new eCash network is available, waiting for the user to confirm the resync")
-		return current
-	}
-
-	if err := netcatalog.Save(o.BitwindowDir, pending); err != nil {
-		o.log.Warn().Err(err).Msg("could not persist the promoted network catalog")
-		return current
-	}
-	netcatalog.ClearPending(o.BitwindowDir)
-	return pending
 }
 
 // PendingECashUpgrade is a published generation this install has not switched
@@ -108,18 +66,18 @@ type PendingECashUpgrade struct {
 }
 
 // PendingECashUpgrade reports the generation waiting for the user's go-ahead.
+// It reads the newest document on disk, not the one this process serves: the
+// refresh writes that document, and a start adopts it without moving a chain.
 func (o *Orchestrator) PendingECashUpgrade() PendingECashUpgrade {
-	pending, ok := netcatalog.LoadPending(o.BitwindowDir)
-	if !ok {
+	published, _ := netcatalog.Load(o.BitwindowDir)
+	// The document's first row against the network this install runs. A pick
+	// says which network runs, not that the user heard about the newer one, and
+	// the document keeps their row so its endpoints stay reachable.
+	id := published.ECashID()
+	if id == "" || id == o.RunningECashID(published) {
 		return PendingECashUpgrade{}
 	}
-	// The pick, not the document's first row: a user pinned to a retained entry
-	// is on no upgrade path just because another row sits above theirs.
-	id := o.SelectedECashID(pending)
-	if id == "" || id == config.ECashNetworkID() {
-		return PendingECashUpgrade{}
-	}
-	entry, _ := pending.ByID(id)
+	entry, _ := published.ByID(id)
 	peer := entry.P2P.Address
 	if peer == "" {
 		peer = config.ECashPeerFor(id)
@@ -141,11 +99,12 @@ func (o *Orchestrator) ecashSwitchIsManual() bool {
 	return o.BitcoinConf != nil && o.BitcoinConf.HasPrivateConf
 }
 
-// ConfirmPendingECashNetwork applies the user's go-ahead: it moves the chain
-// onto the published network, then promotes that catalog to the cache.
+// ConfirmPendingECashNetwork applies the user's go-ahead: it records the
+// published network as the pick, then moves the chain onto it.
 func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
-	pending, ok := netcatalog.LoadPending(o.BitwindowDir)
-	if !ok {
+	published, _ := netcatalog.Load(o.BitwindowDir)
+	target := published.ECashID()
+	if target == "" || target == o.RunningECashID(published) {
 		return fmt.Errorf("no new eCash network to switch to")
 	}
 	if o.ecashSwitchIsManual() {
@@ -157,53 +116,40 @@ func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
 		!o.process.IsRunning("bitcoind") && o.coreRPCReachable() {
 		return fmt.Errorf("a bitcoin core this app did not start is running — stop it first")
 	}
-	current, _ := netcatalog.Load(o.BitwindowDir)
 	previousPick := ""
 	if o.Settings != nil {
 		previousPick = o.Settings.ECashNetworkID()
 	}
 
-	// Every durable write goes before the switch. A volume that refuses them
-	// after the chain moved would leave the record naming a network the blocks
-	// no longer belong to, and the next start would act on that record.
-	//
-	// The pick goes before the catalog it belongs to. A catalog promoted without
-	// it reads as current on the next start: the pending file gets cleared, the
-	// old pick still resolves, and the prompt never returns to say so.
+	// The pick goes before the switch. A volume that refuses the write after the
+	// chain moved would leave the record naming a network the blocks no longer
+	// belong to, and the next start would act on that record.
 	//
 	// Written straight, not through SelectECashNetwork: that one checks the id
 	// against the catalog this process still serves, which is the one the
-	// pending document supersedes.
-	if id := pending.ECashID(); id != "" {
-		if o.Settings == nil {
-			return fmt.Errorf("orchestrator settings are unavailable")
-		}
-		if _, err := o.Settings.SetECashNetworkID(id); err != nil {
-			return fmt.Errorf("record the confirmed network: %w", err)
-		}
+	// published document supersedes.
+	if o.Settings == nil {
+		return fmt.Errorf("orchestrator settings are unavailable")
 	}
-	if err := netcatalog.Save(o.BitwindowDir, pending); err != nil {
-		o.restoreConfirmRecord(previousPick, current, pending)
-		return fmt.Errorf("persist network catalog: %w", err)
+	if _, err := o.Settings.SetECashNetworkID(target); err != nil {
+		return fmt.Errorf("record the confirmed network: %w", err)
 	}
 
 	if config.NetworkFromString(o.Network) == config.NetworkECash {
 		// Here, not on the next start: this is the one moment a live Core can
 		// rewind to the fork. A start has none and could only delete the chain.
-		if id := o.SelectedECashID(pending); id != "" {
-			if err := o.ApplyECashSwitch(ctx, id); err != nil {
-				// Only when the switch never committed. Past that point the
-				// chain and the conf already name the target, and putting the
-				// record back would send the next start after the branch this
-				// switch invalidated.
-				o.mu.RLock()
-				running := o.ecashID
-				o.mu.RUnlock()
-				if running != id {
-					o.restoreConfirmRecord(previousPick, current, pending)
-				}
-				return fmt.Errorf("switch to %s: %w", id, err)
+		if err := o.ApplyECashSwitch(ctx, target); err != nil {
+			// Only when the switch never committed. Past that point the
+			// chain and the conf already name the target, and putting the
+			// record back would send the next start after the branch this
+			// switch invalidated.
+			o.mu.RLock()
+			running := o.ecashID
+			o.mu.RUnlock()
+			if running != target {
+				o.restoreECashPick(previousPick)
 			}
+			return fmt.Errorf("switch to %s: %w", target, err)
 		}
 	} else {
 		// Off eCash the retired chain is cold files that no start will revisit,
@@ -212,69 +158,80 @@ func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
 		// The pick on both sides, not each document's first row. A user on a
 		// retained entry holds that chain on disk, and comparing first rows
 		// reads two identical ids while the blocks belong to a third.
-		if !o.ecashChangeHasASharedBlock(o.RunningECashID(current), o.SelectedECashID(pending)) {
-			o.restoreConfirmRecord(previousPick, current, pending)
+		o.mu.RLock()
+		served := o.Catalog
+		o.mu.RUnlock()
+		if !o.ecashChangeHasASharedBlock(o.RunningECashID(served), target) {
+			o.restoreECashPick(previousPick)
 			return fmt.Errorf("could not clear the retired eCash chain data")
 		}
 	}
-	// Last: the switch reads the pending document to resolve a network the
-	// served catalog does not list yet. A file left behind by a crash names the
-	// same network as the cache, which the next start promotes with no work.
-	netcatalog.ClearPending(o.BitwindowDir)
 	o.log.Info().
 		Str("current", config.ECashNetworkID()).
-		Str("confirmed", pending.ECashID()).
+		Str("confirmed", target).
 		Msg("eCash network switch confirmed")
 	return nil
 }
 
-// restoreConfirmRecord puts back the pick, the cache and the pending file a
-// failed confirm already wrote, so the prompt returns and the record keeps
-// describing the chain on disk.
-func (o *Orchestrator) restoreConfirmRecord(pick string, current, pending netcatalog.Catalog) {
-	if o.Settings != nil {
-		if _, err := o.Settings.SetECashNetworkID(pick); err != nil {
-			o.log.Error().Err(err).Msg("could not put the eCash network pick back after a failed confirm")
-		}
+// restoreECashPick puts back the pick a failed confirm already wrote, so the
+// prompt returns and the record keeps describing the chain on disk.
+func (o *Orchestrator) restoreECashPick(pick string) {
+	if o.Settings == nil {
+		return
 	}
-	if err := netcatalog.Save(o.BitwindowDir, current); err != nil {
-		o.log.Error().Err(err).Msg("could not put the network catalog back after a failed confirm")
-	}
-	if err := netcatalog.SavePending(o.BitwindowDir, pending); err != nil {
-		o.log.Error().Err(err).Msg("could not put the pending network catalog back after a failed confirm")
+	if _, err := o.Settings.SetECashNetworkID(pick); err != nil {
+		o.log.Error().Err(err).Msg("could not put the eCash network pick back after a failed confirm")
 	}
 }
 
-// refreshNetworkCatalog fetches the published catalog and, when it differs from
-// what this process is serving, leaves it for the next start to apply.
+// refreshNetworkCatalog fetches the published catalog and records it as the
+// newest document this install knows. The next start adopts it.
 //
-// It deliberately mutates nothing in memory and does not touch the cache. This
-// runs after the RPC server is accepting requests, and the orchestrator's
-// shared state — binary configs, monitors, catalog, the bitcoin.conf manager —
-// is read by those handlers without a common lock. The cache must also keep
-// describing the data actually on disk, which is the generation this process
-// is still serving.
+// It deliberately mutates nothing in memory. This runs after the RPC server is
+// accepting requests, and the orchestrator's shared state — binary configs,
+// monitors, catalog, the bitcoin.conf manager — is read by those handlers
+// without a common lock.
 func (o *Orchestrator) refreshNetworkCatalog(ctx context.Context, current netcatalog.Catalog) {
 	fetched, err := netcatalog.Fetch(ctx, netcatalog.DefaultURL)
 	if err != nil {
 		o.log.Warn().Err(err).Msg("network catalog refresh failed, using last known values")
 		return
 	}
+	next := retainRunningECash(fetched, current, o.RunningECashID(current))
 	// Every entry matters, not just the eCash one: the picker lists them all and
 	// the endpoints come from their backends. An id-only compare threw away a
 	// refresh that added a network, so it never reached the picker.
-	if fetched.SameAs(current) {
-		netcatalog.ClearPending(o.BitwindowDir)
+	if next.SameAs(current) {
 		return
 	}
-	if err := netcatalog.SavePending(o.BitwindowDir, fetched); err != nil {
+	if err := netcatalog.Save(o.BitwindowDir, next); err != nil {
 		o.log.Warn().Err(err).Msg("could not record the refreshed network catalog")
 		return
 	}
 	o.log.Info().
 		Str("current", current.ECashID()).
-		Str("published", fetched.ECashID()).
+		Str("published", next.ECashID()).
 		Msg("the network catalog changed, restart to apply it")
+}
+
+// retainRunningECash appends the entry for the eCash network this install runs
+// when the published document drops it. Its backends are the only ones that
+// reach the blocks on disk, and the user keeps that chain until they confirm a
+// switch. It goes last, so the published network still leads the document.
+func retainRunningECash(fetched, current netcatalog.Catalog, id string) netcatalog.Catalog {
+	if id == "" {
+		return fetched
+	}
+	if _, ok := fetched.ByID(id); ok {
+		return fetched
+	}
+	running, ok := current.ByID(id)
+	if !ok {
+		return fetched
+	}
+	rows := make([]netcatalog.Network, 0, len(fetched.Networks)+1)
+	fetched.Networks = append(append(rows, fetched.Networks...), running)
+	return fetched
 }
 
 // adoptCatalog stores the catalog and expands the eCash placeholder across
@@ -285,6 +242,8 @@ func (o *Orchestrator) adoptCatalog(c netcatalog.Catalog, id string) {
 	if id == "" {
 		o.log.Warn().Msg("network catalog carries no eCash network, eCash downloads will not resolve")
 	}
+
+	o.recordECashChain(id)
 
 	o.mu.Lock()
 	o.Catalog = c
@@ -351,6 +310,17 @@ func (o *Orchestrator) adoptCatalog(c netcatalog.Catalog, id string) {
 	}
 }
 
+// recordECashChain persists the eCash network this install serves, so a start
+// on another network still knows which fork the blocks belong to.
+func (o *Orchestrator) recordECashChain(id string) {
+	if id == "" || o.Settings == nil {
+		return
+	}
+	if err := o.Settings.SetECashChainID(id); err != nil {
+		o.log.Warn().Err(err).Str("network", id).Msg("could not record the eCash network this install runs")
+	}
+}
+
 // expandECashPlaceholder replaces the eCash placeholder throughout a binary's
 // Core variants. It is applied on every path that installs configs — including
 // the chains_config.json watcher — because a reload otherwise reinstates the
@@ -408,19 +378,10 @@ func (o *Orchestrator) ecashChainDataOnDisk() bool {
 	return len(entries) > 0
 }
 
-// SelectedECashID returns the network a catalog resolves to: the one the user
-// picked while that catalog still lists it, otherwise the entry it lists first.
-func (o *Orchestrator) SelectedECashID(c netcatalog.Catalog) string {
-	if picked := o.pinnedECashID(c); picked != "" {
-		return picked
-	}
-	return c.ECashID()
-}
-
 // RunningECashID returns the eCash network this install serves: the user's pick,
-// then the id its bitcoin.conf names, and only then the entry the catalog lists
-// first. The conf comes before document order because it names the fork whose
-// blocks are on disk.
+// then the id its bitcoin.conf names, then the recorded chain, and only then
+// the entry the catalog lists first. The conf and the record come before
+// document order because they name the fork whose blocks are on disk.
 func (o *Orchestrator) RunningECashID(c netcatalog.Catalog) string {
 	if picked := o.pinnedECashID(c); picked != "" {
 		return picked
@@ -428,6 +389,15 @@ func (o *Orchestrator) RunningECashID(c netcatalog.Catalog) string {
 	if installed := o.installedECashNetwork(); installed != "" {
 		if _, ok := c.ByID(installed); ok {
 			return installed
+		}
+	}
+	// A swap to another network strips the conf sentinel, so off eCash this
+	// record is the only thing that still names the blocks on disk.
+	if o.Settings != nil {
+		if recorded := o.Settings.ECashChainID(); recorded != "" {
+			if _, ok := c.ByID(recorded); ok {
+				return recorded
+			}
 		}
 	}
 	return c.ECashID()
@@ -634,9 +604,8 @@ func (o *Orchestrator) NetworkForOption(id string) (config.Network, bool) {
 }
 
 // seedToldNetworks records what this install already knew, once, from the
-// catalog it booted with. It runs before a pending catalog is promoted, so the
-// baseline is the previous run's document — an upgrade from an older build
-// therefore reads every network published since as new, and says so.
+// catalog it booted with — an upgrade from an older build therefore reads every
+// network published since as new, and says so.
 func (o *Orchestrator) seedToldNetworks(booted netcatalog.Catalog) {
 	if o.Settings == nil || o.Settings.SeenNetworkIDs() != nil {
 		return

--- a/sidechain-orchestrator/network_catalog_pending_test.go
+++ b/sidechain-orchestrator/network_catalog_pending_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,34 +36,8 @@ func catalogWithECash(t *testing.T, id string) netcatalog.Catalog {
 	return c
 }
 
-// The cache must always describe the data on disk. A promotion that cannot
-// wipe has to leave both the cache and the served generation alone, or the
-// next start trusts a rollover that never happened.
-func TestPendingNotPromotedWhenWipeCannotRun(t *testing.T) {
-	dir := t.TempDir()
-	current := catalogWithECash(t, "drynet2")
-	pending := catalogWithECash(t, "drynet3")
-	if err := netcatalog.SavePending(dir, pending); err != nil {
-		t.Fatal(err)
-	}
-
-	// No BitcoinConf, so the wipe cannot run.
-	o := &Orchestrator{BitwindowDir: dir, log: zerolog.Nop()}
-	got := o.promotePendingCatalog(context.Background(), current, pending, true)
-
-	if got.ECashID() != "drynet2" {
-		t.Errorf("served generation = %q, want the unchanged drynet2", got.ECashID())
-	}
-	if _, ok := netcatalog.LoadPending(dir); !ok {
-		t.Error("pending catalog must survive so the next start retries")
-	}
-	if cached, fromDisk := netcatalog.Load(dir); fromDisk && cached.ECashID() == "drynet3" {
-		t.Error("cache must not record a generation whose data was never wiped")
-	}
-}
-
-// ecashOnPendingNetwork puts a eCash install on drynet2 with drynet3
-// published but not applied.
+// ecashOnPendingNetwork puts a eCash install on drynet2 with a published
+// document that leads with drynet3 and keeps the drynet2 row.
 func ecashOnPendingNetwork(t *testing.T) *Orchestrator {
 	t.Helper()
 	o := newTestOrchestrator(t)
@@ -76,8 +49,9 @@ func ecashOnPendingNetwork(t *testing.T) *Orchestrator {
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
 	// Don't let the unmanaged-Core guard find a real node on this machine.
 	o.coreReachable = func() bool { return false }
-	require.NoError(t, netcatalog.Save(o.BitwindowDir, catalogWithECash(t, "drynet2")))
-	require.NoError(t, netcatalog.SavePending(o.BitwindowDir, catalogWithECash(t, "drynet3")))
+	o.adoptCatalog(catalogWithECash(t, "drynet2"), "drynet2")
+	require.Equal(t, "drynet2", o.installedECashNetwork())
+	require.NoError(t, netcatalog.Save(o.BitwindowDir, catalogWithECashRows(t, "drynet3", "drynet2")))
 	return o
 }
 
@@ -90,8 +64,50 @@ func TestNewGenerationIsNotAppliedWithoutConsent(t *testing.T) {
 
 	require.Equal(t, "drynet2", config.ECashNetworkID())
 	require.Equal(t, "drynet3", o.PendingECashUpgrade().ID, "the upgrade prompt must still see it")
-	_, stillPending := netcatalog.LoadPending(o.BitwindowDir)
-	require.True(t, stillPending, "pending file must survive so the prompt persists")
+}
+
+// The picker draws the adopted document, so a start that holds the published
+// one back leaves the user no row to switch to.
+func TestPublishedNetworkReachesThePicker(t *testing.T) {
+	o := ecashOnPendingNetwork(t)
+
+	o.ResolveNetworkCatalog(context.Background())
+
+	var ids []string
+	for _, n := range o.ListNetworks() {
+		ids = append(ids, n.ID)
+	}
+	require.Contains(t, ids, "drynet3", "the published network must be listed")
+	require.Contains(t, ids, "drynet2", "the network this install runs must stay listed")
+	require.Equal(t, "drynet2", config.ECashNetworkID(), "the chain stays where it is")
+}
+
+// The published document drops a network once it retires, and its backends are
+// the only ones that reach the blocks this install holds.
+func TestRefreshKeepsTheRowThisInstallRuns(t *testing.T) {
+	current := catalogWithECashRows(t, "drynet2", "drynet3")
+	fetched := catalogWithECash(t, "drynet4")
+
+	next := retainRunningECash(fetched, current, "drynet3")
+
+	require.Equal(t, "drynet4", next.ECashID(), "the published network still leads")
+	kept, ok := next.ByID("drynet3")
+	require.True(t, ok, "the row this install runs must survive the refresh")
+	require.Equal(t, "https://esplora.drynet3.example", kept.BackendURL("esplora"))
+}
+
+// A swap to another network strips the conf sentinel. Without the record, the
+// next start reads the published document as the chain on disk.
+func TestStartOffECashKeepsTheRecordedChain(t *testing.T) {
+	o := ecashOnPendingNetwork(t)
+	o.ResolveNetworkCatalog(context.Background())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
+	require.Empty(t, o.installedECashNetwork(), "the swap strips the eCash sentinel")
+
+	o.ResolveNetworkCatalog(context.Background())
+
+	require.Equal(t, "drynet2", config.ECashNetworkID())
+	require.Equal(t, "drynet3", o.PendingECashUpgrade().ID)
 }
 
 // Confirming is the one moment a live Core can rewind to the fork, so the
@@ -102,11 +118,7 @@ func TestConfirmMovesTheChainOnTheSpot(t *testing.T) {
 
 	require.NoError(t, o.ConfirmPendingECashNetwork(context.Background()))
 
-	cached, fromDisk := netcatalog.Load(o.BitwindowDir)
-	require.True(t, fromDisk)
-	require.Equal(t, "drynet3", cached.ECashID())
-	_, stillPending := netcatalog.LoadPending(o.BitwindowDir)
-	require.False(t, stillPending, "the prompt must clear once confirmed")
+	require.Empty(t, o.PendingECashUpgrade().ID, "the prompt must clear once confirmed")
 	require.Equal(t, "drynet3", config.ECashNetworkID(), "this process moves onto the confirmed network")
 	require.Equal(t, "ecash-drynet3", o.BitcoinConf.Config.GetEffectiveSetting("uacomment", "main"))
 }
@@ -156,8 +168,8 @@ func TestConfirmRefusedForAUserManagedConf(t *testing.T) {
 	require.True(t, o.PendingECashUpgrade().UserManagedConf)
 	require.Error(t, o.ConfirmPendingECashNetwork(context.Background()))
 
-	_, stillPending := netcatalog.LoadPending(o.BitwindowDir)
-	require.True(t, stillPending, "the prompt must persist so they know the chain is retired")
+	require.Equal(t, "drynet3", o.PendingECashUpgrade().ID,
+		"the prompt must persist so they know the chain is retired")
 }
 
 // Entering eCash must not silently switch generation: the retired chain is
@@ -171,19 +183,6 @@ func TestSwappingToECashKeepsTheGenerationPrompt(t *testing.T) {
 
 	require.Equal(t, "drynet2", config.ECashNetworkID())
 	require.Equal(t, "drynet3", o.PendingECashUpgrade().ID)
-}
-
-// An unchanged generation clears any stale pending file rather than leaving it
-// to be re-applied forever.
-func TestPromotionIsANoOpForTheSameGeneration(t *testing.T) {
-	dir := t.TempDir()
-	same := catalogWithECash(t, "drynet2")
-
-	o := &Orchestrator{BitwindowDir: dir, log: zerolog.Nop()}
-	got := o.promotePendingCatalog(context.Background(), same, same, true)
-	if got.ECashID() != "drynet2" {
-		t.Errorf("generation = %q, want drynet2", got.ECashID())
-	}
 }
 
 // Core is per-chain and every variant shares one path, so a build left by the

--- a/sidechain-orchestrator/network_catalog_pending_test.go
+++ b/sidechain-orchestrator/network_catalog_pending_test.go
@@ -2,9 +2,13 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
@@ -13,7 +17,7 @@ import (
 
 func catalogWithECash(t *testing.T, id string) netcatalog.Catalog {
 	t.Helper()
-	c, _ := netcatalog.Load(t.TempDir())
+	c := netcatalog.Embedded()
 	// One eCash entry only, with endpoints that match its id: the published
 	// document is what the app reads them from.
 	networks := make([]netcatalog.Network, 0, len(c.Networks))
@@ -36,7 +40,52 @@ func catalogWithECash(t *testing.T, id string) netcatalog.Catalog {
 	return c
 }
 
-// ecashOnPendingNetwork puts a eCash install on drynet2 with a published
+// catalogWithECashRows lists several eCash networks in the order given, each
+// with endpoints that match its id.
+func catalogWithECashRows(t *testing.T, ids ...string) netcatalog.Catalog {
+	t.Helper()
+	c := catalogWithECash(t, ids[0])
+	rows := make([]netcatalog.Network, 0, len(c.Networks)+len(ids))
+	for _, n := range c.Networks {
+		rows = append(rows, n)
+		if n.Family != netcatalog.FamilyECash {
+			continue
+		}
+		for _, id := range ids[1:] {
+			extra := n
+			extra.ID = id
+			extra.P2P.Address = id + ".example:8335"
+			extra.Backends = []netcatalog.Backend{{Kind: "esplora", URL: "https://esplora." + id + ".example"}}
+			rows = append(rows, extra)
+		}
+	}
+	c.Networks = rows
+	return c
+}
+
+// publish serves a document to this orchestrator, as drivechain.dev does.
+func publish(t *testing.T, o *Orchestrator, c netcatalog.Catalog) {
+	t.Helper()
+	body, err := json.Marshal(c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	o.catalogURL = srv.URL
+}
+
+// awaitRefresh waits for the detached fetch to take the published document.
+func awaitRefresh(t *testing.T, o *Orchestrator, id string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		o.mu.RLock()
+		defer o.mu.RUnlock()
+		return o.Catalog.ECashID() == id
+	}, 5*time.Second, 10*time.Millisecond, "the published document must reach the process")
+}
+
+// ecashOnPendingNetwork puts a eCash install on drynet2, with a published
 // document that leads with drynet3 and keeps the drynet2 row.
 func ecashOnPendingNetwork(t *testing.T) *Orchestrator {
 	t.Helper()
@@ -51,27 +100,24 @@ func ecashOnPendingNetwork(t *testing.T) *Orchestrator {
 	o.coreReachable = func() bool { return false }
 	o.adoptCatalog(catalogWithECash(t, "drynet2"), "drynet2")
 	require.Equal(t, "drynet2", o.installedECashNetwork())
-	require.NoError(t, netcatalog.Save(o.BitwindowDir, catalogWithECashRows(t, "drynet3", "drynet2")))
+	// What a refresh takes: the live network first, the row this install runs
+	// kept, and the chain left where it is.
+	o.adoptCatalogRows(catalogWithECashRows(t, "drynet3", "drynet2"), "drynet2")
 	return o
 }
 
-// Switching generations destroys the old chain, so startup must leave it for
-// the user to confirm rather than wiping behind their back.
-func TestNewGenerationIsNotAppliedWithoutConsent(t *testing.T) {
-	o := ecashOnPendingNetwork(t)
+// The bug the picker had: a start held the published document back, so the
+// network the user was told about was never a row they could pick.
+func TestARefreshReachesThePickerWithoutMovingTheChain(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.coreReachable = func() bool { return false }
+	o.adoptCatalog(catalogWithECash(t, "drynet2"), "drynet2")
+	publish(t, o, catalogWithECashRows(t, "drynet3", "drynet2"))
 
 	o.ResolveNetworkCatalog(context.Background())
-
-	require.Equal(t, "drynet2", config.ECashNetworkID())
-	require.Equal(t, "drynet3", o.PendingECashUpgrade().ID, "the upgrade prompt must still see it")
-}
-
-// The picker draws the adopted document, so a start that holds the published
-// one back leaves the user no row to switch to.
-func TestPublishedNetworkReachesThePicker(t *testing.T) {
-	o := ecashOnPendingNetwork(t)
-
-	o.ResolveNetworkCatalog(context.Background())
+	awaitRefresh(t, o, "drynet3")
 
 	var ids []string
 	for _, n := range o.ListNetworks() {
@@ -80,6 +126,16 @@ func TestPublishedNetworkReachesThePicker(t *testing.T) {
 	require.Contains(t, ids, "drynet3", "the published network must be listed")
 	require.Contains(t, ids, "drynet2", "the network this install runs must stay listed")
 	require.Equal(t, "drynet2", config.ECashNetworkID(), "the chain stays where it is")
+	require.Equal(t, "drynet3", o.PendingECashUpgrade().ID, "and the move is offered")
+}
+
+// Switching generations rewinds the chain, so startup must leave it for the
+// user to confirm rather than moving them behind their back.
+func TestNewGenerationIsNotAppliedWithoutConsent(t *testing.T) {
+	o := ecashOnPendingNetwork(t)
+
+	require.Equal(t, "drynet2", config.ECashNetworkID())
+	require.Equal(t, "drynet3", o.PendingECashUpgrade().ID, "the upgrade prompt must still see it")
 }
 
 // The published document drops a network once it retires, and its backends are
@@ -96,25 +152,34 @@ func TestRefreshKeepsTheRowThisInstallRuns(t *testing.T) {
 	require.Equal(t, "https://esplora.drynet3.example", kept.BackendURL("esplora"))
 }
 
-// A swap to another network strips the conf sentinel. Without the record, the
-// next start reads the published document as the chain on disk.
+// A swap to another network strips the conf sentinel. Without the record, a
+// start reads the published document as the chain on disk.
 func TestStartOffECashKeepsTheRecordedChain(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
-	o.ResolveNetworkCatalog(context.Background())
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
 	require.Empty(t, o.installedECashNetwork(), "the swap strips the eCash sentinel")
 
 	o.ResolveNetworkCatalog(context.Background())
 
 	require.Equal(t, "drynet2", config.ECashNetworkID())
-	require.Equal(t, "drynet3", o.PendingECashUpgrade().ID)
+}
+
+// A fresh install holds no chain, so it takes the published network at once
+// rather than starting on the compiled-in one and asking to move.
+func TestFreshInstallTakesThePublishedNetwork(t *testing.T) {
+	o := newTestOrchestrator(t)
+	publish(t, o, catalogWithECash(t, "drynet7"))
+
+	o.ResolveNetworkCatalog(context.Background())
+
+	require.Equal(t, "drynet7", config.ECashNetworkID())
+	require.Empty(t, o.PendingECashUpgrade().ID, "a fresh install has nothing to confirm")
 }
 
 // Confirming is the one moment a live Core can rewind to the fork, so the
-// switch happens here. A start has no Core and could only delete the chain.
+// switch happens here. A start has no Core and could only leave the two apart.
 func TestConfirmMovesTheChainOnTheSpot(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
-	o.ResolveNetworkCatalog(context.Background())
 
 	require.NoError(t, o.ConfirmPendingECashNetwork(context.Background()))
 
@@ -127,10 +192,11 @@ func TestConfirmMovesTheChainOnTheSpot(t *testing.T) {
 // only bitcoin.conf leaves it retrying a retired endpoint forever.
 func TestConfirmedGenerationLandsOnTheNextStart(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
-	o.ResolveNetworkCatalog(context.Background())
 	require.NoError(t, o.ConfirmPendingECashNetwork(context.Background()))
+	publish(t, o, catalogWithECashRows(t, "drynet3", "drynet2"))
 
 	o.ResolveNetworkCatalog(context.Background())
+	awaitRefresh(t, o, "drynet3")
 
 	require.Equal(t, "drynet3", config.ECashNetworkID())
 	require.Equal(t, "ecash-drynet3", o.BitcoinConf.Config.GetEffectiveSetting("uacomment", "main"))
@@ -139,13 +205,12 @@ func TestConfirmedGenerationLandsOnTheNextStart(t *testing.T) {
 	require.Empty(t, o.PendingECashUpgrade().ID)
 }
 
-// Confirming off eCash reaches no Core on that chain, so it records the drop
-// rather than deleting blocks both networks keep.
+// Confirming off eCash reaches no Core on that chain, so it records the move
+// rather than touching blocks both networks keep.
 func TestConfirmWorksFromAnotherNetwork(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
 	ecashDir := o.BitcoinConf.Config.GetGroupDatadir(config.DatadirGroupECash)
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
-	o.ResolveNetworkCatalog(context.Background())
 	require.Equal(t, "drynet3", o.PendingECashUpgrade().ID)
 
 	blocks := filepath.Join(ecashDir, "blocks")
@@ -162,7 +227,6 @@ func TestConfirmWorksFromAnotherNetwork(t *testing.T) {
 // Reporting success would clear the prompt and strand them on the retired chain.
 func TestConfirmRefusedForAUserManagedConf(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
-	o.ResolveNetworkCatalog(context.Background())
 	o.BitcoinConf.HasPrivateConf = true
 
 	require.True(t, o.PendingECashUpgrade().UserManagedConf)
@@ -172,12 +236,11 @@ func TestConfirmRefusedForAUserManagedConf(t *testing.T) {
 		"the prompt must persist so they know the chain is retired")
 }
 
-// Entering eCash must not silently switch generation: the retired chain is
-// only deleted with the user's go-ahead, which the prompt collects.
+// Entering eCash must not silently switch generation: the chain moves only with
+// the user's go-ahead, which the prompt collects.
 func TestSwappingToECashKeepsTheGenerationPrompt(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
-	o.ResolveNetworkCatalog(context.Background())
 
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
 
@@ -203,8 +266,6 @@ func TestSwappingNetworksResolvesTheIncomingBuild(t *testing.T) {
 // The generation rides in the subfolder, so a rollover resolves to a new path.
 func TestGenerationChangeResolvesANewCoreBinary(t *testing.T) {
 	o := ecashOnPendingNetwork(t)
-	o.ResolveNetworkCatalog(context.Background())
-
 	stale := writeResolvedCoreBinary(t, o, "drynet2 build")
 
 	require.NoError(t, o.ConfirmPendingECashNetwork(context.Background()))
@@ -234,24 +295,17 @@ func writeResolvedCoreBinary(t *testing.T, o *Orchestrator, body string) string 
 // Generations publish their own seed port — drynet4 answers on 8533 — so a
 // built name sends bitcoind somewhere nothing listens.
 func TestRolloverWritesThePublishedPeerAndRetargetsTheEnforcer(t *testing.T) {
-	o := newTestOrchestrator(t)
-	require.NotNil(t, o.BitcoinConf)
-	require.NotNil(t, o.EnforcerConf)
-
-	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
-	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
-	o.coreReachable = func() bool { return false }
+	o := ecashOnPendingNetwork(t)
 	require.NoError(t, o.EnforcerConf.WriteConfig("network-preset=drynet2\nenable-block-template-server=true"))
-
-	published := catalogWithECash(t, "drynet9")
+	published := catalogWithECashRows(t, "drynet9", "drynet2")
 	for i := range published.Networks {
-		if published.Networks[i].Family == netcatalog.FamilyECash {
+		if published.Networks[i].ID == "drynet9" {
 			published.Networks[i].P2P.Address = "drynet9.drivechain.dev:8533"
 		}
 	}
-	require.NoError(t, netcatalog.Save(o.BitwindowDir, published))
+	o.adoptCatalogRows(published, "drynet2")
 
-	o.ResolveNetworkCatalog(context.Background())
+	require.NoError(t, o.ConfirmPendingECashNetwork(context.Background()))
 
 	require.Equal(t, "drynet9", config.ECashNetworkID())
 	require.Equal(t, "drynet9.drivechain.dev:8533", o.BitcoinConf.Config.GetEffectiveSetting("addnode", "main"))
@@ -259,32 +313,8 @@ func TestRolloverWritesThePublishedPeerAndRetargetsTheEnforcer(t *testing.T) {
 	require.Equal(t, "true", o.EnforcerConf.Config.GetSetting("enable-block-template-server"))
 }
 
-// catalogWithECashRows lists several eCash networks in the order given, each
-// with endpoints that match its id.
-func catalogWithECashRows(t *testing.T, ids ...string) netcatalog.Catalog {
-	t.Helper()
-	c := catalogWithECash(t, ids[0])
-	rows := make([]netcatalog.Network, 0, len(c.Networks)+len(ids))
-	for _, n := range c.Networks {
-		rows = append(rows, n)
-		if n.Family != netcatalog.FamilyECash {
-			continue
-		}
-		for _, id := range ids[1:] {
-			extra := n
-			extra.ID = id
-			extra.P2P.Address = id + ".example:8335"
-			extra.Backends = []netcatalog.Backend{{Kind: "esplora", URL: "https://esplora." + id + ".example"}}
-			rows = append(rows, extra)
-		}
-	}
-	c.Networks = rows
-	return c
-}
-
-// A cache written in another order lists the retired rows first, and a retired
-// row publishes no endpoints. Document order alone moves the install to that
-// row, and the wallet then has no chain source at all.
+// A document that lists a retired row first must not move the install onto it.
+// A retired row publishes no endpoints, and the wallet then has no chain source.
 func TestStartKeepsTheNetworkTheConfNames(t *testing.T) {
 	o := newTestOrchestrator(t)
 	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
@@ -300,9 +330,10 @@ func TestStartKeepsTheNetworkTheConfNames(t *testing.T) {
 			retiredFirst.Networks[i].Backends = nil
 		}
 	}
-	require.NoError(t, netcatalog.Save(o.BitwindowDir, retiredFirst))
+	publish(t, o, retiredFirst)
 
 	o.ResolveNetworkCatalog(context.Background())
+	awaitRefresh(t, o, "drynet2")
 
 	require.Equal(t, "drynet4", config.ECashNetworkID())
 	require.Equal(t, "ecash-drynet4", o.BitcoinConf.Config.GetEffectiveSetting("uacomment", "main"))

--- a/sidechain-orchestrator/network_catalog_pending_test.go
+++ b/sidechain-orchestrator/network_catalog_pending_test.go
@@ -164,16 +164,33 @@ func TestStartOffECashKeepsTheRecordedChain(t *testing.T) {
 	require.Equal(t, "drynet2", config.ECashNetworkID())
 }
 
-// A fresh install holds no chain, so it takes the published network at once
-// rather than starting on the compiled-in one and asking to move.
-func TestFreshInstallTakesThePublishedNetwork(t *testing.T) {
+// The document is fetched, so the endpoint can be slow or down. A start takes
+// the compiled-in document at once and never waits for the answer.
+func TestAStartNeverWaitsOnTheEndpoint(t *testing.T) {
 	o := newTestOrchestrator(t)
-	publish(t, o, catalogWithECash(t, "drynet7"))
+	held := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-held
+	}))
+	t.Cleanup(func() {
+		close(held)
+		srv.Close()
+	})
+	o.catalogURL = srv.URL
 
-	o.ResolveNetworkCatalog(context.Background())
+	done := make(chan struct{})
+	go func() {
+		o.ResolveNetworkCatalog(context.Background())
+		close(done)
+	}()
 
-	require.Equal(t, "drynet7", config.ECashNetworkID())
-	require.Empty(t, o.PendingECashUpgrade().ID, "a fresh install has nothing to confirm")
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a start must not wait on the catalog endpoint")
+	}
+	require.Equal(t, netcatalog.EmbeddedECashID(), config.ECashNetworkID(),
+		"the compiled-in document carries the start")
 }
 
 // Confirming is the one moment a live Core can rewind to the fork, so the

--- a/sidechain-orchestrator/network_options_test.go
+++ b/sidechain-orchestrator/network_options_test.go
@@ -68,9 +68,9 @@ func TestSelectECashNetworkPinsTheID(t *testing.T) {
 	require.Equal(t, "drynet4", o.RunningECashID(cat))
 }
 
-// A pinned network the catalog drops is gone, so the boot has to fall back
-// rather than ask for a fork nothing publishes.
-func TestSelectedECashIDFallsBackWhenTheCatalogDropsIt(t *testing.T) {
+// A pick the catalog drops is a network the user left long ago, and no conf
+// names it, so the record this install keeps decides instead.
+func TestRunningECashIDFallsBackWhenThePickIsDropped(t *testing.T) {
 	o := newTestOrchestrator(t)
 	cat := netcatalog.Catalog{Networks: []netcatalog.Network{
 		{ID: "alphanet", Family: netcatalog.FamilyECash, ForkHeight: 963648},
@@ -214,9 +214,10 @@ func TestRunningECashIDPrefersTheUserPick(t *testing.T) {
 	require.Equal(t, "alphanet", o.RunningECashID(cat))
 }
 
-// A conf that names a network the catalog dropped points nowhere, so the
-// document decides again.
-func TestRunningECashIDFallsBackWhenTheCatalogDropsTheConfNetwork(t *testing.T) {
+// A conf that names a network the document dropped still names the fork whose
+// blocks are on disk. Reading the document instead would open those blocks as
+// another fork, so the install keeps its own network until the user moves it.
+func TestRunningECashIDKeepsAConfNetworkTheCatalogDropped(t *testing.T) {
 	o := newTestOrchestrator(t)
 	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
@@ -227,5 +228,5 @@ func TestRunningECashIDFallsBackWhenTheCatalogDropsTheConfNetwork(t *testing.T) 
 	trimmed := netcatalog.Catalog{Networks: []netcatalog.Network{
 		{ID: "alphanet", Family: netcatalog.FamilyECash, ForkHeight: 963648},
 	}}
-	require.Equal(t, "alphanet", o.RunningECashID(trimmed))
+	require.Equal(t, "drynet4", o.RunningECashID(trimmed))
 }

--- a/sidechain-orchestrator/network_options_test.go
+++ b/sidechain-orchestrator/network_options_test.go
@@ -58,14 +58,14 @@ func TestSelectECashNetworkPinsTheID(t *testing.T) {
 		{ID: "drynet4", Family: netcatalog.FamilyECash, ForkHeight: 961632},
 	}}
 	o.adoptCatalog(cat, "alphanet")
-	require.Equal(t, "alphanet", o.SelectedECashID(cat))
+	require.Equal(t, "alphanet", o.RunningECashID(cat))
 
 	require.NoError(t, o.SelectECashNetwork("drynet4"))
-	require.Equal(t, "drynet4", o.SelectedECashID(cat))
+	require.Equal(t, "drynet4", o.RunningECashID(cat))
 
 	// A bare slot name is not an id, so it must leave the pick alone.
 	require.NoError(t, o.SelectECashNetwork("ecash"))
-	require.Equal(t, "drynet4", o.SelectedECashID(cat))
+	require.Equal(t, "drynet4", o.RunningECashID(cat))
 }
 
 // A pinned network the catalog drops is gone, so the boot has to fall back
@@ -82,7 +82,7 @@ func TestSelectedECashIDFallsBackWhenTheCatalogDropsIt(t *testing.T) {
 	trimmed := netcatalog.Catalog{Networks: []netcatalog.Network{
 		{ID: "alphanet", Family: netcatalog.FamilyECash, ForkHeight: 963648},
 	}}
-	require.Equal(t, "alphanet", o.SelectedECashID(trimmed))
+	require.Equal(t, "alphanet", o.RunningECashID(trimmed))
 }
 
 // The refresh reports what appeared, so the app can name the network in the
@@ -194,7 +194,7 @@ func TestRunningECashIDKeepsTheNetworkTheConfNames(t *testing.T) {
 	require.Equal(t, "drynet4", o.installedECashNetwork())
 
 	require.Equal(t, "drynet4", o.RunningECashID(retiredFirst))
-	require.Equal(t, "drynet2", o.SelectedECashID(retiredFirst), "the document still resolves to its first row")
+	require.Equal(t, "drynet2", retiredFirst.ECashID(), "the document still resolves to its first row")
 }
 
 // The user's pick is the last word, so it outranks the conf the previous

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -248,6 +248,10 @@ type Orchestrator struct {
 	// the real boot helper; tests override it to bypass process spawning.
 	bootBitcoindForVariantSwap func(ctx context.Context) <-chan StartupProgress
 
+	// catalogURL is where the published network catalog is fetched from. Tests
+	// point it at their own server.
+	catalogURL string
+
 	// coreReachable reports whether something answers on Core's RPC port.
 	// Overridable so tests don't depend on what is listening on this machine.
 	coreReachable func() bool
@@ -350,6 +354,7 @@ func New(dataDir, network, bitwindowDir string, configs []BinaryConfig, log zero
 	orch.stopBinary = orch.Stop
 	orch.bootBitcoindForVariantSwap = orch.defaultBootBitcoindForVariantSwap
 	orch.coreReachable = orch.dialCoreRPC
+	orch.catalogURL = netcatalog.DefaultURL
 
 	// Wire process exit events to ConnectionMonitor state.
 	// When a process crashes, its stderr error message becomes the monitor's

--- a/sidechain-orchestrator/orchestrator_settings.go
+++ b/sidechain-orchestrator/orchestrator_settings.go
@@ -22,6 +22,10 @@ type OrchestratorSettings struct {
 	// ("alphanet"). Empty means "whichever one the catalog lists first", which
 	// is what a fresh install and every non-eCash network use.
 	ECashNetworkID string `json:"ecash_network_id"`
+	// ECashChainID is the eCash network whose blocks this install holds. The
+	// pick above is the user's choice; this is the record of what runs, and it
+	// outlives the conf sentinel, which a swap to another network strips.
+	ECashChainID string `json:"ecash_chain_id,omitempty"`
 	// SeenNetworkIDs are the catalog ids this install already told the user
 	// about. TakeNewNetworks reports the rest once, then adds them here.
 	SeenNetworkIDs []string `json:"seen_network_ids"`
@@ -254,6 +258,28 @@ func (s *SettingsStore) SetECashNetworkID(id string) (string, error) {
 	}
 	s.current = next
 	return prev, nil
+}
+
+// ECashChainID returns the eCash network whose blocks this install holds,
+// empty when it holds none.
+func (s *SettingsStore) ECashChainID() string {
+	return s.Get().ECashChainID
+}
+
+// SetECashChainID persists the eCash network this install runs.
+func (s *SettingsStore) SetECashChainID(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current.ECashChainID == id {
+		return nil
+	}
+	next := s.current
+	next.ECashChainID = id
+	if err := SaveSettings(s.bitwindowDir, next); err != nil {
+		return err
+	}
+	s.current = next
+	return nil
 }
 
 // SeenNetworkIDs returns the catalog ids this install already told the user


### PR DESCRIPTION
Copies the current https://drivechain.dev/config document into the embedded networks.json.

Adds drynet4 after alphanet, so the live eCash network does not change. Also brings the alphanet electrum backend, the mining pool URLs and both assumeutxo snapshots.