### PR TITLE
orchestrator: record the chain a switch moved to

### DIFF
--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -242,6 +242,9 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 	o.mu.Unlock()
 
 	config.SetECashNetworkID(toID)
+	// The blocks are on the new fork from here, and a swap to another network
+	// strips the conf sentinel that says so.
+	o.recordECashChain(toID)
 	if entry, ok := o.ecashEntry(toID); ok {
 		config.SetForkHeight(config.NetworkECash, entry.ForkHeight)
 		config.SetNetworkDisplayName(config.NetworkECash, entry.DisplayName)

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -91,6 +91,26 @@ func TestApplyECashSwitchRewritesTheConfSentinel(t *testing.T) {
 	require.Equal(t, "alphanet", config.ECashNetworkID())
 }
 
+// A swap to another network strips the conf sentinel, so the record is what
+// names the fork the blocks belong to. Left on the outgoing network, a later
+// boot serves that one against blocks this switch already moved.
+func TestApplyECashSwitchRecordsTheChainItMovedTo(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupDefault, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	require.Equal(t, "drynet4", o.Settings.ECashChainID())
+
+	require.NoError(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
+
+	require.Equal(t, "alphanet", o.Settings.ECashChainID())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
+	require.Empty(t, o.installedECashNetwork(), "the swap strips the eCash sentinel")
+	require.Equal(t, "alphanet", o.RunningECashID(netcatalog.Catalog{}),
+		"a document that lists neither network must not send the boot back")
+}
+
 // A Core that is down cannot rewind, and nothing is recorded for later. The
 // chain stays as it is: every block below the fork is shared either way.
 func TestApplyECashSwitchKeepsTheChainWhenNoCoreAnswers(t *testing.T) {


### PR DESCRIPTION
ApplyECashSwitch moved the chain but left the durable record on the outgoing network.

A later swap strips the conf sentinel, and an offline start then serves the outgoing generation against blocks the switch already moved. Follow-up to #2087.