### PR TITLE
orchestrator: fail the switch when the record cannot be written

### DIFF
--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -112,7 +112,11 @@ func (o *Orchestrator) RetargetECashEnforcerConf(previousID string) {
 // follows writes bitcoin.conf and starts binaries, and both read the id from
 // here, so a stale one boots the network the user just left.
 func (o *Orchestrator) AdoptECashID(id string) {
-	o.recordECashChain(id)
+	// Logged, not returned: the swap that follows writes the conf sentinel, and
+	// that sentinel names the network this install runs.
+	if err := o.recordECashChain(id); err != nil {
+		o.log.Warn().Err(err).Msg("could not record the eCash network this install runs")
+	}
 
 	o.mu.Lock()
 	cat := o.Catalog
@@ -243,8 +247,11 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 
 	config.SetECashNetworkID(toID)
 	// The blocks are on the new fork from here, and a swap to another network
-	// strips the conf sentinel that says so.
-	o.recordECashChain(toID)
+	// strips the conf sentinel that says so. A record that stays on the outgoing
+	// fork sends a later start after blocks this switch already moved.
+	if err := o.recordECashChain(toID); err != nil {
+		return err
+	}
 	if entry, ok := o.ecashEntry(toID); ok {
 		config.SetForkHeight(config.NetworkECash, entry.ForkHeight)
 		config.SetNetworkDisplayName(config.NetworkECash, entry.DisplayName)

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -142,20 +142,61 @@ func (o *Orchestrator) AdoptECashID(id string) {
 // serves is that retry, and it does nothing when there is nothing left to do.
 //
 // Call it with swapNetworkMu held.
-func (o *Orchestrator) resumeECashSwitch(ctx context.Context, toID string) error {
+func (o *Orchestrator) resumeECashSwitch(toID string) error {
+	if o.pendingSwap != nil && o.pendingSwap.network == config.NetworkECash {
+		return o.finishECashSwitch(o.pendingSwap.fromECashID, toID, o.pendingSwap.restartL1)
+	}
+	// No tail, so the records are all an earlier run can still owe. Both skip an
+	// unchanged value, which is what an ordinary same-target request finds.
 	if err := o.recordECashChain(toID); err != nil {
 		return err
 	}
 	if err := o.SelectECashNetwork(toID); err != nil {
 		return fmt.Errorf("record the network pick: %w", err)
 	}
-	if o.pendingSwap == nil || o.pendingSwap.network != config.NetworkECash {
-		return nil
+	return nil
+}
+
+// finishECashSwitch runs everything a switch owes once the chain and the conf
+// both moved: the two records, the enforcer conf, the wallet scans, the
+// enforcer chain, the caches and the restart. A retry runs the same steps.
+//
+// Call it with swapNetworkMu held.
+func (o *Orchestrator) finishECashSwitch(fromID, toID string, restartL1 bool) error {
+	// The blocks are on the new fork from here, and a swap to another network
+	// strips the conf sentinel that says so. A record that stays on the outgoing
+	// fork sends a later start after blocks this switch already moved.
+	if err := o.recordECashChain(toID); err != nil {
+		return err
+	}
+	// Only once the chain and the conf both moved. A pick recorded ahead of a
+	// failed switch would make the next boot read the old sentinel as stale and
+	// clear a chain this run still holds.
+	if err := o.SelectECashNetwork(toID); err != nil {
+		return fmt.Errorf("record the network pick: %w", err)
+	}
+	if o.EnforcerConf != nil {
+		if _, err := o.EnforcerConf.RetargetECashNetwork(fromID, toID); err != nil {
+			o.log.Warn().Err(err).Msg("could not rewrite bitwindow-enforcer.conf for the new eCash network")
+		}
+	}
+	// The wallet keys its cached scan on the network, and that key does not move
+	// between two eCash forks. A cold read would serve the retired fork's
+	// balances, transactions and UTXOs with no chain call to correct them.
+	if o.WalletSvc != nil {
+		o.WalletSvc.ClearNetworkScans(string(config.NetworkECash))
 	}
 	if err := o.ApplyPendingEnforcerWipe(); err != nil {
 		return err
 	}
-	return o.finishNetworkSwap(config.NetworkECash, o.pendingSwap.restartL1)
+	o.clearNetworkSwapCaches()
+
+	o.log.Info().
+		Str("previous", fromID).
+		Str("current", toID).
+		Msg("switched eCash network")
+
+	return o.finishNetworkSwap(config.NetworkECash, restartL1)
 }
 
 // pendingECashSwap reports whether a switch left work for a retry to finish.
@@ -181,7 +222,7 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 		return err
 	}
 	if plan.FromID == toID {
-		return o.resumeECashSwitch(ctx, toID)
+		return o.resumeECashSwitch(toID)
 	}
 	if plan.Blocked {
 		return fmt.Errorf(
@@ -282,43 +323,13 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 	// Installed before both records below, so a write that fails still leaves
 	// the ordinary same-network retry a tail to resume. Without it that retry
 	// reads FromID == ToID, takes the no-op path, and the stack stays stopped.
-	o.pendingSwap = &pendingNetworkSwap{network: config.NetworkECash, restartL1: restartL1}
+	o.pendingSwap = &pendingNetworkSwap{
+		network:     config.NetworkECash,
+		restartL1:   restartL1,
+		fromECashID: plan.FromID,
+	}
 
-	// The blocks are on the new fork from here, and a swap to another network
-	// strips the conf sentinel that says so. A record that stays on the outgoing
-	// fork sends a later start after blocks this switch already moved.
-	if err := o.recordECashChain(toID); err != nil {
-		return err
-	}
-	// Last, and only once the chain and the conf both moved. A pick recorded
-	// ahead of a failed switch would make the next boot read the old sentinel as
-	// stale and clear a chain this run still holds.
-	if err := o.SelectECashNetwork(toID); err != nil {
-		return fmt.Errorf("record the network pick: %w", err)
-	}
-	if o.EnforcerConf != nil {
-		if _, err := o.EnforcerConf.RetargetECashNetwork(plan.FromID, toID); err != nil {
-			o.log.Warn().Err(err).Msg("could not rewrite bitwindow-enforcer.conf for the new eCash network")
-		}
-	}
-	// The wallet keys its cached scan on the network, and that key does not move
-	// between two eCash forks. A cold read would serve the retired fork's
-	// balances, transactions and UTXOs with no chain call to correct them.
-	if o.WalletSvc != nil {
-		o.WalletSvc.ClearNetworkScans(string(config.NetworkECash))
-	}
-	if err := o.ApplyPendingEnforcerWipe(); err != nil {
-		return err
-	}
-	o.clearNetworkSwapCaches()
-
-	o.log.Info().
-		Str("previous", plan.FromID).
-		Str("current", toID).
-		Uint32("rewind_height", plan.RewindHeight).
-		Msg("switched eCash network")
-
-	return o.finishNetworkSwap(config.NetworkECash, restartL1)
+	return o.finishECashSwitch(plan.FromID, toID, restartL1)
 }
 
 // applyPendingEnforcerWipe clears the enforcer chain a switch journalled, and

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -137,6 +137,34 @@ func (o *Orchestrator) AdoptECashID(id string) {
 	}
 }
 
+// resumeECashSwitch finishes a switch that moved the chain but stopped before
+// its records or its restart. A request for the network this install already
+// serves is that retry, and it does nothing when there is nothing left to do.
+//
+// Call it with swapNetworkMu held.
+func (o *Orchestrator) resumeECashSwitch(ctx context.Context, toID string) error {
+	if err := o.recordECashChain(toID); err != nil {
+		return err
+	}
+	if err := o.SelectECashNetwork(toID); err != nil {
+		return fmt.Errorf("record the network pick: %w", err)
+	}
+	if o.pendingSwap == nil || o.pendingSwap.network != config.NetworkECash {
+		return nil
+	}
+	if err := o.ApplyPendingEnforcerWipe(); err != nil {
+		return err
+	}
+	return o.finishNetworkSwap(config.NetworkECash, o.pendingSwap.restartL1)
+}
+
+// pendingECashSwap reports whether a switch left work for a retry to finish.
+func (o *Orchestrator) pendingECashSwap() bool {
+	o.swapNetworkMu.Lock()
+	defer o.swapNetworkMu.Unlock()
+	return o.pendingSwap != nil && o.pendingSwap.network == config.NetworkECash
+}
+
 // ApplyECashSwitch moves this install onto another eCash network: it rewinds
 // the chain to the last block the two share, stops the daemons, rewrites the
 // confs and starts the stack again. The enforcer's validator chain is
@@ -153,7 +181,7 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 		return err
 	}
 	if plan.FromID == toID {
-		return nil
+		return o.resumeECashSwitch(ctx, toID)
 	}
 	if plan.Blocked {
 		return fmt.Errorf(

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -210,6 +210,20 @@ func (o *Orchestrator) recordECashSwitch(fromID, toID string) error {
 	return nil
 }
 
+// drainECashTail lands the records a previous eCash switch left. The note itself
+// stays: it is what says the stack owes a restart.
+//
+// Call it with swapNetworkMu held.
+func (o *Orchestrator) drainECashTail() error {
+	if o.pendingSwap == nil || o.pendingSwap.fromECashID == "" {
+		return nil
+	}
+	o.mu.RLock()
+	toID := o.ecashID
+	o.mu.RUnlock()
+	return o.recordECashSwitch(o.pendingSwap.fromECashID, toID)
+}
+
 // pendingECashSwap reports whether a switch left work for a retry to finish.
 func (o *Orchestrator) pendingECashSwap() bool {
 	o.swapNetworkMu.Lock()
@@ -227,6 +241,12 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 	// first just moved to.
 	o.swapNetworkMu.Lock()
 	defer o.swapNetworkMu.Unlock()
+
+	// A tail an earlier switch left lands first. Its records still name the fork
+	// that switch moved from, and every path below can consume the note.
+	if err := o.drainECashTail(); err != nil {
+		return err
+	}
 
 	plan, err := o.PlanECashSwitch(toID)
 	if err != nil {

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -246,22 +246,22 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 	o.mu.Unlock()
 
 	config.SetECashNetworkID(toID)
+	if entry, ok := o.ecashEntry(toID); ok {
+		config.SetForkHeight(config.NetworkECash, entry.ForkHeight)
+		config.SetNetworkDisplayName(config.NetworkECash, entry.DisplayName)
+		config.SetECashEndpoints(entry)
+	}
+	// Installed before both records below, so a write that fails still leaves
+	// the ordinary same-network retry a tail to resume. Without it that retry
+	// reads FromID == ToID, takes the no-op path, and the stack stays stopped.
+	o.pendingSwap = &pendingNetworkSwap{network: config.NetworkECash, restartL1: restartL1}
+
 	// The blocks are on the new fork from here, and a swap to another network
 	// strips the conf sentinel that says so. A record that stays on the outgoing
 	// fork sends a later start after blocks this switch already moved.
 	if err := o.recordECashChain(toID); err != nil {
 		return err
 	}
-	if entry, ok := o.ecashEntry(toID); ok {
-		config.SetForkHeight(config.NetworkECash, entry.ForkHeight)
-		config.SetNetworkDisplayName(config.NetworkECash, entry.DisplayName)
-		config.SetECashEndpoints(entry)
-	}
-	// Installed before the pick, so a pick that cannot be written still leaves
-	// the ordinary same-network retry a tail to resume. Without it that retry
-	// reads FromID == ToID, takes the no-op path, and the stack stays stopped.
-	o.pendingSwap = &pendingNetworkSwap{network: config.NetworkECash, restartL1: restartL1}
-
 	// Last, and only once the chain and the conf both moved. A pick recorded
 	// ahead of a failed switch would make the next boot read the old sentinel as
 	// stale and clear a chain this run still holds.

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -243,14 +243,8 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 		)
 	}
 
-	bitcoindWasRunning := o.process.IsRunning("bitcoind")
-	enforcerWasRunning := o.process.IsRunning("enforcer")
-	restartL1 := bitcoindWasRunning || enforcerWasRunning
-	// A tail an earlier switch left stopped the stack it owed a restart, so both
-	// daemons read as stopped above. This switch takes that obligation over.
-	if o.pendingSwap != nil && o.pendingSwap.network == config.NetworkECash {
-		restartL1 = restartL1 || o.pendingSwap.restartL1
-	}
+	// Read before the stops below, which make both daemons read as stopped.
+	restartL1 := o.owedRestartL1()
 
 	// Everything that can fail stops while Core still answers. A rewind before
 	// these would leave Core parked under the fork with the old network still

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -158,11 +158,28 @@ func (o *Orchestrator) resumeECashSwitch(toID string) error {
 }
 
 // finishECashSwitch runs everything a switch owes once the chain and the conf
-// both moved: the two records, the enforcer conf, the wallet scans, the
-// enforcer chain, the caches and the restart. A retry runs the same steps.
+// both moved, and then restarts the stack. A retry runs the same steps.
 //
 // Call it with swapNetworkMu held.
 func (o *Orchestrator) finishECashSwitch(fromID, toID string, restartL1 bool) error {
+	if err := o.recordECashSwitch(fromID, toID); err != nil {
+		return err
+	}
+	o.log.Info().
+		Str("previous", fromID).
+		Str("current", toID).
+		Msg("switched eCash network")
+
+	return o.finishNetworkSwap(config.NetworkECash, restartL1)
+}
+
+// recordECashSwitch is everything a switch owes apart from the restart: the two
+// records, the enforcer conf, the wallet scans, the enforcer chain and the
+// caches. A swap to another network drains a tail through this, because that
+// swap starts its own stack.
+//
+// Call it with swapNetworkMu held.
+func (o *Orchestrator) recordECashSwitch(fromID, toID string) error {
 	// The blocks are on the new fork from here, and a swap to another network
 	// strips the conf sentinel that says so. A record that stays on the outgoing
 	// fork sends a later start after blocks this switch already moved.
@@ -190,13 +207,7 @@ func (o *Orchestrator) finishECashSwitch(fromID, toID string, restartL1 bool) er
 		return err
 	}
 	o.clearNetworkSwapCaches()
-
-	o.log.Info().
-		Str("previous", fromID).
-		Str("current", toID).
-		Msg("switched eCash network")
-
-	return o.finishNetworkSwap(config.NetworkECash, restartL1)
+	return nil
 }
 
 // pendingECashSwap reports whether a switch left work for a retry to finish.

--- a/sidechain-orchestrator/ecash_switch.go
+++ b/sidechain-orchestrator/ecash_switch.go
@@ -246,6 +246,11 @@ func (o *Orchestrator) ApplyECashSwitch(ctx context.Context, toID string) error 
 	bitcoindWasRunning := o.process.IsRunning("bitcoind")
 	enforcerWasRunning := o.process.IsRunning("enforcer")
 	restartL1 := bitcoindWasRunning || enforcerWasRunning
+	// A tail an earlier switch left stopped the stack it owed a restart, so both
+	// daemons read as stopped above. This switch takes that obligation over.
+	if o.pendingSwap != nil && o.pendingSwap.network == config.NetworkECash {
+		restartL1 = restartL1 || o.pendingSwap.restartL1
+	}
 
 	// Everything that can fail stops while Core still answers. A rewind before
 	// these would leave Core parked under the fork with the old network still

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -165,6 +165,30 @@ func TestSwapNetworkFinishesAnECashTail(t *testing.T) {
 	require.Nil(t, o.pendingSwap, "the resumed tail leaves nothing behind")
 }
 
+// A swap to another network replaces the tail, so the tail has to land first.
+// Its record still names the outgoing fork, and the swap strips the sentinel
+// that says otherwise, so a return to eCash would serve the fork it left.
+func TestSwapToAnotherNetworkDrainsTheECashTail(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupDefault, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	require.NoError(t, o.EnforcerConf.WriteConfig("network-preset=drynet4"))
+	require.NoError(t, o.Settings.SetPendingEnforcerWipe("alphanet"))
+	blocked := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blocked, nil, 0o644))
+	o.Settings.bitwindowDir = blocked
+	require.Error(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
+	o.Settings.bitwindowDir = t.TempDir()
+
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
+
+	require.Equal(t, "alphanet", o.Settings.ECashChainID(),
+		"the record must name the fork the blocks are on")
+	require.Equal(t, "alphanet", o.EnforcerConf.Config.GetSetting("network-preset"))
+}
+
 // A Core that is down cannot rewind, and nothing is recorded for later. The
 // chain stays as it is: every block below the fork is shared either way.
 func TestApplyECashSwitchKeepsTheChainWhenNoCoreAnswers(t *testing.T) {

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -189,6 +189,35 @@ func TestSwapToAnotherNetworkDrainsTheECashTail(t *testing.T) {
 	require.Equal(t, "alphanet", o.EnforcerConf.Config.GetSetting("network-preset"))
 }
 
+// The tail that a swap drains stopped the stack it owed a restart, so both
+// daemons read as stopped. The obligation has to ride on the swap that replaces
+// the tail, or the stack stays down.
+func TestSwapCarriesTheRestartTheDrainedTailOwed(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupDefault, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.adoptCatalog(ecashCatalog(), "alphanet")
+	// What a switch leaves when it stops a running stack and then fails.
+	o.pendingSwap = &pendingNetworkSwap{
+		network:     config.NetworkECash,
+		restartL1:   true,
+		fromECashID: "drynet4",
+	}
+
+	// With no bitcoind config the restart refuses at once, which is the only
+	// place this swap can report the obligation it carries.
+	o.mu.Lock()
+	delete(o.configs, "bitcoind")
+	o.mu.Unlock()
+
+	err := o.SwapNetwork(context.Background(), config.NetworkMainnet)
+
+	require.Error(t, err, "the swap owes a restart it cannot run")
+	require.NotNil(t, o.pendingSwap, "a restart that cannot run stays retryable")
+	require.True(t, o.pendingSwap.restartL1, "the drained restart must ride on")
+}
+
 // A Core that is down cannot rewind, and nothing is recorded for later. The
 // chain stays as it is: every block below the fork is shared either way.
 func TestApplyECashSwitchKeepsTheChainWhenNoCoreAnswers(t *testing.T) {

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -111,6 +111,23 @@ func TestApplyECashSwitchRecordsTheChainItMovedTo(t *testing.T) {
 		"a document that lists neither network must not send the boot back")
 }
 
+// A record that cannot be written is a failed switch, not a warning. Reporting
+// success would leave the record on the outgoing fork, which is the state this
+// record exists to rule out.
+func TestApplyECashSwitchFailsWhenTheChainRecordCannotBeWritten(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+
+	// A file where the settings directory belongs, so every write refuses.
+	blocked := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blocked, nil, 0o644))
+	o.Settings.bitwindowDir = blocked
+
+	require.Error(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
+}
+
 // A Core that is down cannot rewind, and nothing is recorded for later. The
 // chain stays as it is: every block below the fork is shared either way.
 func TestApplyECashSwitchKeepsTheChainWhenNoCoreAnswers(t *testing.T) {

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -120,6 +120,7 @@ func TestApplyECashSwitchFailsWhenTheChainRecordCannotBeWritten(t *testing.T) {
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
 	o.adoptCatalog(ecashCatalog(), "drynet4")
 
+	require.NoError(t, o.EnforcerConf.WriteConfig("network-preset=drynet4"))
 	// The enforcer cleanup this switch journals is already recorded, so it
 	// writes nothing and the chain record is the first write to refuse.
 	require.NoError(t, o.Settings.SetPendingEnforcerWipe("alphanet"))
@@ -135,6 +136,8 @@ func TestApplyECashSwitchFailsWhenTheChainRecordCannotBeWritten(t *testing.T) {
 	o.Settings.bitwindowDir = t.TempDir()
 	require.NoError(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
 	require.Equal(t, "alphanet", o.Settings.ECashChainID())
+	require.Equal(t, "alphanet", o.EnforcerConf.Config.GetSetting("network-preset"),
+		"the retry owes the whole tail, not the records alone")
 	require.Nil(t, o.pendingSwap, "the resumed switch leaves nothing behind")
 }
 

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -239,6 +239,33 @@ func TestARefusedSwapKeepsTheECashTail(t *testing.T) {
 	require.Equal(t, "drynet4", o.pendingSwap.fromECashID)
 }
 
+// A second switch replaces the tail of the first, so it takes over what that
+// tail owed. The daemons the first switch stopped read as stopped here.
+func TestASecondSwitchTakesOverTheRestart(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.coreReachable = func() bool { return false }
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	o.pendingSwap = &pendingNetworkSwap{
+		network:     config.NetworkECash,
+		restartL1:   true,
+		fromECashID: "drynet4",
+	}
+	// With no bitcoind config the restart refuses at once, which is the only
+	// place this switch can report the obligation it carries. The raw copy goes
+	// too, because the switch re-expands the configs from it.
+	o.mu.Lock()
+	delete(o.configs, "bitcoind")
+	delete(o.rawConfigs, "bitcoind")
+	o.mu.Unlock()
+
+	require.Error(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
+
+	require.NotNil(t, o.pendingSwap, "a restart that cannot run stays retryable")
+	require.True(t, o.pendingSwap.restartL1, "the first tail's restart must ride on")
+}
+
 // A Core that is down cannot rewind, and nothing is recorded for later. The
 // chain stays as it is: every block below the fork is shared either way.
 func TestApplyECashSwitchKeepsTheChainWhenNoCoreAnswers(t *testing.T) {

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -120,12 +120,16 @@ func TestApplyECashSwitchFailsWhenTheChainRecordCannotBeWritten(t *testing.T) {
 	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
 	o.adoptCatalog(ecashCatalog(), "drynet4")
 
+	// The enforcer cleanup this switch journals is already recorded, so it
+	// writes nothing and the chain record is the first write to refuse.
+	require.NoError(t, o.Settings.SetPendingEnforcerWipe("alphanet"))
 	// A file where the settings directory belongs, so every write refuses.
 	blocked := filepath.Join(t.TempDir(), "not-a-directory")
 	require.NoError(t, os.WriteFile(blocked, nil, 0o644))
 	o.Settings.bitwindowDir = blocked
 
 	require.Error(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
+	require.NotNil(t, o.pendingSwap, "the retry must find a tail to resume")
 }
 
 // A Core that is down cannot rewind, and nothing is recorded for later. The

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -130,6 +130,12 @@ func TestApplyECashSwitchFailsWhenTheChainRecordCannotBeWritten(t *testing.T) {
 
 	require.Error(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
 	require.NotNil(t, o.pendingSwap, "the retry must find a tail to resume")
+
+	// The same target is the retry: it writes the record and finishes the swap.
+	o.Settings.bitwindowDir = t.TempDir()
+	require.NoError(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
+	require.Equal(t, "alphanet", o.Settings.ECashChainID())
+	require.Nil(t, o.pendingSwap, "the resumed switch leaves nothing behind")
 }
 
 // A Core that is down cannot rewind, and nothing is recorded for later. The

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -141,6 +141,30 @@ func TestApplyECashSwitchFailsWhenTheChainRecordCannotBeWritten(t *testing.T) {
 	require.Nil(t, o.pendingSwap, "the resumed switch leaves nothing behind")
 }
 
+// The network picker resumes a tail through SwapNetwork, not through the switch.
+// That door owes the same work: a restart alone leaves the enforcer conf, the
+// wallet scans and the clients on the retired fork.
+func TestSwapNetworkFinishesAnECashTail(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.adoptCatalog(ecashCatalog(), "drynet4")
+	require.NoError(t, o.EnforcerConf.WriteConfig("network-preset=drynet4"))
+	require.NoError(t, o.Settings.SetPendingEnforcerWipe("alphanet"))
+	blocked := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blocked, nil, 0o644))
+	o.Settings.bitwindowDir = blocked
+	require.Error(t, o.ApplyECashSwitch(context.Background(), "alphanet"))
+	require.NotNil(t, o.pendingSwap)
+
+	o.Settings.bitwindowDir = t.TempDir()
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+
+	require.Equal(t, "alphanet", o.Settings.ECashChainID())
+	require.Equal(t, "alphanet", o.EnforcerConf.Config.GetSetting("network-preset"))
+	require.Nil(t, o.pendingSwap, "the resumed tail leaves nothing behind")
+}
+
 // A Core that is down cannot rewind, and nothing is recorded for later. The
 // chain stays as it is: every block below the fork is shared either way.
 func TestApplyECashSwitchKeepsTheChainWhenNoCoreAnswers(t *testing.T) {

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -266,6 +266,30 @@ func TestASecondSwitchTakesOverTheRestart(t *testing.T) {
 	require.True(t, o.pendingSwap.restartL1, "the first tail's restart must ride on")
 }
 
+// Every path in a second switch can consume the note the first one left, and
+// the abort path restarts the stack. The first switch's records land first, or
+// that stack comes back up with the record naming the fork it left.
+func TestASecondSwitchLandsTheFirstRecords(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.coreReachable = func() bool { return false }
+	o.adoptCatalog(ecashCatalog(), "alphanet")
+	// What a switch to alphanet leaves when its records refuse to write.
+	require.NoError(t, o.Settings.SetECashChainID("drynet4"))
+	o.pendingSwap = &pendingNetworkSwap{
+		network:     config.NetworkECash,
+		restartL1:   true,
+		fromECashID: "drynet4",
+	}
+
+	// The catalog lists no betanet, so this switch fails before it commits.
+	require.Error(t, o.ApplyECashSwitch(context.Background(), "betanet"))
+
+	require.Equal(t, "alphanet", o.Settings.ECashChainID(),
+		"the first switch's record must land before the second one runs")
+}
+
 // A Core that is down cannot rewind, and nothing is recorded for later. The
 // chain stays as it is: every block below the fork is shared either way.
 func TestApplyECashSwitchKeepsTheChainWhenNoCoreAnswers(t *testing.T) {

--- a/sidechain-orchestrator/ecash_switch_test.go
+++ b/sidechain-orchestrator/ecash_switch_test.go
@@ -218,6 +218,27 @@ func TestSwapCarriesTheRestartTheDrainedTailOwed(t *testing.T) {
 	require.True(t, o.pendingSwap.restartL1, "the drained restart must ride on")
 }
 
+// A swap that never commits must leave the tail it drained records from. The
+// stack is down, and that tail is the only thing that says it owes a restart.
+func TestARefusedSwapKeepsTheECashTail(t *testing.T) {
+	o := newTestOrchestrator(t)
+	o.BitcoinConf.Config.SetGroupDatadir(config.DatadirGroupECash, t.TempDir())
+	require.NoError(t, o.SwapNetwork(context.Background(), config.NetworkECash))
+	o.adoptCatalog(ecashCatalog(), "alphanet")
+	o.pendingSwap = &pendingNetworkSwap{
+		network:     config.NetworkECash,
+		restartL1:   true,
+		fromECashID: "drynet4",
+	}
+
+	// Mainnet has no datadir here, so the swap refuses before it commits.
+	require.Error(t, o.SwapNetwork(context.Background(), config.NetworkMainnet))
+
+	require.NotNil(t, o.pendingSwap, "the tail must outlive a swap that never lands")
+	require.True(t, o.pendingSwap.restartL1)
+	require.Equal(t, "drynet4", o.pendingSwap.fromECashID)
+}
+
 // A Core that is down cannot rewind, and nothing is recorded for later. The
 // chain stays as it is: every block below the fork is shared either way.
 func TestApplyECashSwitchKeepsTheChainWhenNoCoreAnswers(t *testing.T) {

--- a/sidechain-orchestrator/network_catalog.go
+++ b/sidechain-orchestrator/network_catalog.go
@@ -93,6 +93,11 @@ func (o *Orchestrator) ConfirmPendingECashNetwork(ctx context.Context) error {
 	o.mu.RUnlock()
 	target := published.ECashID()
 	if target == "" || target == o.RunningECashID(published) {
+		// A previous confirm moved the chain but stopped before it finished. The
+		// same target is that retry, not a request for work already done.
+		if target != "" && o.pendingECashSwap() {
+			return o.ApplyECashSwitch(ctx, target)
+		}
 		return fmt.Errorf("no new eCash network to switch to")
 	}
 	if o.ecashSwitchIsManual() {

--- a/sidechain-orchestrator/network_catalog.go
+++ b/sidechain-orchestrator/network_catalog.go
@@ -232,7 +232,11 @@ func (o *Orchestrator) adoptCatalog(c netcatalog.Catalog, id string) {
 		o.log.Warn().Msg("network catalog carries no eCash network, eCash downloads will not resolve")
 	}
 
-	o.recordECashChain(id)
+	// Logged, not returned: a start moves no chain, and the conf sentinel the
+	// swap writes still names the network this install runs.
+	if err := o.recordECashChain(id); err != nil {
+		o.log.Warn().Err(err).Msg("could not record the eCash network this install runs")
+	}
 	o.adoptCatalogRows(c, id)
 
 	o.mu.RLock()
@@ -270,13 +274,14 @@ func (o *Orchestrator) adoptCatalog(c netcatalog.Catalog, id string) {
 
 // recordECashChain persists the network this install serves, so a start off
 // eCash still knows which fork the blocks belong to.
-func (o *Orchestrator) recordECashChain(id string) {
+func (o *Orchestrator) recordECashChain(id string) error {
 	if id == "" || o.Settings == nil {
-		return
+		return nil
 	}
 	if err := o.Settings.SetECashChainID(id); err != nil {
-		o.log.Warn().Err(err).Str("network", id).Msg("could not record the eCash network this install runs")
+		return fmt.Errorf("record the eCash chain %s: %w", id, err)
 	}
+	return nil
 }
 
 // adoptCatalogRows takes a document in memory: the picker rows, their endpoints

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -2018,6 +2018,14 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 		if o.pendingSwap == nil || o.pendingSwap.network != n {
 			return nil
 		}
+		// A tail an eCash fork switch left owes more than the restart: the two
+		// records, the enforcer conf, the wallet scans and the caches.
+		if o.pendingSwap.fromECashID != "" {
+			o.mu.RLock()
+			toID := o.ecashID
+			o.mu.RUnlock()
+			return o.finishECashSwitch(o.pendingSwap.fromECashID, toID, o.pendingSwap.restartL1)
+		}
 		return o.finishNetworkSwap(n, o.pendingSwap.restartL1)
 	}
 	plan := o.PlanNetworkChange(NetworkChangeRequest{Network: string(n)})

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -2039,8 +2039,10 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 		if err := o.recordECashSwitch(o.pendingSwap.fromECashID, toID); err != nil {
 			return err
 		}
+		// The tail stays until the replacement below takes its place. An error on
+		// the way there would otherwise leave the stack down with nothing left
+		// to say it owes a restart.
 		drainedRestartL1 = o.pendingSwap.restartL1
-		o.pendingSwap = nil
 	}
 
 	plan := o.PlanNetworkChange(NetworkChangeRequest{Network: string(n)})

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -2028,6 +2028,19 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 		}
 		return o.finishNetworkSwap(n, o.pendingSwap.restartL1)
 	}
+	// A tail an eCash switch left must not outlive the swap that replaces it:
+	// the record still names the outgoing fork, and this swap strips the conf
+	// sentinel that says otherwise. The restart waits for the swap below.
+	if o.pendingSwap != nil && o.pendingSwap.fromECashID != "" {
+		o.mu.RLock()
+		toID := o.ecashID
+		o.mu.RUnlock()
+		if err := o.recordECashSwitch(o.pendingSwap.fromECashID, toID); err != nil {
+			return err
+		}
+		o.pendingSwap = nil
+	}
+
 	plan := o.PlanNetworkChange(NetworkChangeRequest{Network: string(n)})
 	if plan.MustSelectDatadir {
 		return fmt.Errorf("datadir not configured for %s", n)

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -2030,8 +2030,8 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 	}
 	// A tail an eCash switch left must not outlive the swap that replaces it:
 	// the record still names the outgoing fork, and this swap strips the conf
-	// sentinel that says otherwise. The restart waits for the swap below.
-	drainedRestartL1 := false
+	// sentinel that says otherwise. The tail itself stays until the replacement
+	// below takes its place, so an error on the way there keeps the restart.
 	if o.pendingSwap != nil && o.pendingSwap.fromECashID != "" {
 		o.mu.RLock()
 		toID := o.ecashID
@@ -2039,10 +2039,6 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 		if err := o.recordECashSwitch(o.pendingSwap.fromECashID, toID); err != nil {
 			return err
 		}
-		// The tail stays until the replacement below takes its place. An error on
-		// the way there would otherwise leave the stack down with nothing left
-		// to say it owes a restart.
-		drainedRestartL1 = o.pendingSwap.restartL1
 	}
 
 	plan := o.PlanNetworkChange(NetworkChangeRequest{Network: string(n)})
@@ -2055,6 +2051,8 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 
 	bitcoindWasRunning := o.process.IsRunning("bitcoind")
 	enforcerWasRunning := o.process.IsRunning("enforcer")
+	// Read before the stops below, which make both daemons read as stopped.
+	restartL1 := o.owedRestartL1()
 
 	var runningL2 []string
 	for _, c := range o.Configs() {
@@ -2104,13 +2102,8 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 	// Installed before the tail below, which can fail. Without it a retry reads
 	// the network as already swapped, takes the no-op path and reports success
 	// while the state is still parked and the daemons are still down.
-	// The drained tail stopped the stack it owed a restart, so both daemons read
-	// as stopped above. Its obligation rides on, or this swap leaves them down.
-	o.pendingSwap = &pendingNetworkSwap{
-		network:   n,
-		restartL1: bitcoindWasRunning || enforcerWasRunning || drainedRestartL1,
-	}
-	return o.finishNetworkSwap(n, o.pendingSwap.restartL1)
+	o.pendingSwap = &pendingNetworkSwap{network: n, restartL1: restartL1}
+	return o.finishNetworkSwap(n, restartL1)
 }
 
 // pendingNetworkSwap is the tail of a swap whose network is already committed.
@@ -2120,6 +2113,18 @@ type pendingNetworkSwap struct {
 	// fromECashID is the network an eCash switch left. The retry rewrites the
 	// enforcer conf with it, which is where the retired endpoint still sits.
 	fromECashID string
+}
+
+// owedRestartL1 reports whether the L1 stack has to come back up: it runs now,
+// or a switch that stopped it left the note that says so. Read it before any
+// stop, which makes a running daemon read as stopped.
+//
+// Call it with swapNetworkMu held.
+func (o *Orchestrator) owedRestartL1() bool {
+	if o.process.IsRunning("bitcoind") || o.process.IsRunning("enforcer") {
+		return true
+	}
+	return o.pendingSwap != nil && o.pendingSwap.restartL1
 }
 
 // finishNetworkSwap rebinds wallet state and restarts L1. Everything here is

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -2031,6 +2031,7 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 	// A tail an eCash switch left must not outlive the swap that replaces it:
 	// the record still names the outgoing fork, and this swap strips the conf
 	// sentinel that says otherwise. The restart waits for the swap below.
+	drainedRestartL1 := false
 	if o.pendingSwap != nil && o.pendingSwap.fromECashID != "" {
 		o.mu.RLock()
 		toID := o.ecashID
@@ -2038,6 +2039,7 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 		if err := o.recordECashSwitch(o.pendingSwap.fromECashID, toID); err != nil {
 			return err
 		}
+		drainedRestartL1 = o.pendingSwap.restartL1
 		o.pendingSwap = nil
 	}
 
@@ -2100,7 +2102,12 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 	// Installed before the tail below, which can fail. Without it a retry reads
 	// the network as already swapped, takes the no-op path and reports success
 	// while the state is still parked and the daemons are still down.
-	o.pendingSwap = &pendingNetworkSwap{network: n, restartL1: bitcoindWasRunning || enforcerWasRunning}
+	// The drained tail stopped the stack it owed a restart, so both daemons read
+	// as stopped above. Its obligation rides on, or this swap leaves them down.
+	o.pendingSwap = &pendingNetworkSwap{
+		network:   n,
+		restartL1: bitcoindWasRunning || enforcerWasRunning || drainedRestartL1,
+	}
 	return o.finishNetworkSwap(n, o.pendingSwap.restartL1)
 }
 

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -2087,6 +2087,9 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 type pendingNetworkSwap struct {
 	network   config.Network
 	restartL1 bool
+	// fromECashID is the network an eCash switch left. The retry rewrites the
+	// enforcer conf with it, which is where the retired endpoint still sits.
+	fromECashID string
 }
 
 // finishNetworkSwap rebinds wallet state and restarts L1. Everything here is

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -2029,16 +2029,10 @@ func (o *Orchestrator) SwapNetwork(ctx context.Context, n config.Network) error 
 		return o.finishNetworkSwap(n, o.pendingSwap.restartL1)
 	}
 	// A tail an eCash switch left must not outlive the swap that replaces it:
-	// the record still names the outgoing fork, and this swap strips the conf
-	// sentinel that says otherwise. The tail itself stays until the replacement
-	// below takes its place, so an error on the way there keeps the restart.
-	if o.pendingSwap != nil && o.pendingSwap.fromECashID != "" {
-		o.mu.RLock()
-		toID := o.ecashID
-		o.mu.RUnlock()
-		if err := o.recordECashSwitch(o.pendingSwap.fromECashID, toID); err != nil {
-			return err
-		}
+	// its records still name the outgoing fork, and this swap strips the conf
+	// sentinel that says otherwise.
+	if err := o.drainECashTail(); err != nil {
+		return err
 	}
 
 	plan := o.PlanNetworkChange(NetworkChangeRequest{Network: string(n)})

--- a/sidechain-orchestrator/orchestrator_settings.go
+++ b/sidechain-orchestrator/orchestrator_settings.go
@@ -312,6 +312,9 @@ func (s *SettingsStore) PendingEnforcerWipe() string {
 func (s *SettingsStore) SetPendingEnforcerWipe(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.current.PendingEnforcerWipe == id {
+		return nil
+	}
 	next := s.current
 	next.PendingEnforcerWipe = id
 	if err := SaveSettings(s.bitwindowDir, next); err != nil {


### PR DESCRIPTION
recordECashChain only logged a failed write, so a switch could report success with the record still on the outgoing fork.

The switch now returns that error. The two start paths keep logging it: they move no chain, and the conf sentinel names the network. Follow-up to #2088.