### PR TITLE
Show the eCash claim card and protect every send

### DIFF
--- a/bitwindow/lib/pages/wallet/wallet_send.dart
+++ b/bitwindow/lib/pages/wallet/wallet_send.dart
@@ -136,7 +136,7 @@ class SendTab extends ViewModelWidget<SendPageViewModel> {
     if (plan == null || !context.mounted) {
       return;
     }
-    final psbt = await viewModel.buildUnsignedPsbtForAirgap(context, replayProtect: plan.protect);
+    final psbt = await viewModel.buildUnsignedPsbtForAirgap(context, allowReplay: plan.allowReplay);
     if (psbt == null || !context.mounted) {
       return;
     }
@@ -150,7 +150,7 @@ class SendTab extends ViewModelWidget<SendPageViewModel> {
       if (txid == null) {
         return;
       }
-      if (plan.risky && !plan.protect) {
+      if (plan.risky && plan.allowReplay) {
         GetIt.I<ForkProvider>().rememberUnprotectedSend(txid);
       }
       if (!context.mounted) {
@@ -807,8 +807,8 @@ class SendPageViewModel extends BaseViewModel {
   /// Asks about replay protection when the send spends a coin that exists on
   /// both chains. Returns null when the user cancels. `risky` stays false for a
   /// send whose coins live on one chain, so its own outputs raise no warning.
-  Future<({bool protect, bool risky})?> askReplayProtect(BuildContext context) async {
-    const safe = (protect: false, risky: false);
+  Future<({bool allowReplay, bool risky})?> askReplayProtect(BuildContext context) async {
+    const safe = (allowReplay: false, risky: false);
     // A chain whose nodes reject the magic locktime has no protection to offer.
     if (!GetIt.I<ForkProvider>().replayProtectionAvailable) {
       return safe;
@@ -825,9 +825,9 @@ class SendPageViewModel extends BaseViewModel {
       case ReplayChoice.cancel:
         return null;
       case ReplayChoice.sendPlain:
-        return (protect: false, risky: true);
+        return (allowReplay: true, risky: true);
       case ReplayChoice.sendProtected:
-        return (protect: true, risky: true);
+        return (allowReplay: false, risky: true);
     }
   }
 
@@ -836,13 +836,13 @@ class SendPageViewModel extends BaseViewModel {
     if (plan == null || !context.mounted) {
       return;
     }
-    final replayProtect = plan.protect;
+    final allowReplay = plan.allowReplay;
 
     // Multisig never auto-signs: save the PSBT as a draft and open its tab,
     // where each keystore signs explicitly and broadcast happens once the
     // threshold is met.
     if (isMultisig) {
-      await _createMultisigDraft(context, replayProtect: replayProtect);
+      await _createMultisigDraft(context, allowReplay: allowReplay);
       return;
     }
 
@@ -894,9 +894,9 @@ class SendPageViewModel extends BaseViewModel {
         fixedFeeSats: feeSats,
         subtractFeeFromAmount: _subtractFeeFromAmount,
         requiredInputs: selectedUtxos,
-        replayProtect: replayProtect,
+        allowReplay: allowReplay,
       )).txid;
-      if (plan.risky && !replayProtect) {
+      if (plan.risky && allowReplay) {
         GetIt.I<ForkProvider>().rememberUnprotectedSend(txid);
       }
       await clearAll();
@@ -925,13 +925,13 @@ class SendPageViewModel extends BaseViewModel {
   /// Build the PSBT for a multisig send, save it as a draft, and switch to
   /// its tab at once. Reuses the airgap PSBT builder (validates
   /// recipients/fee and calls createPsbt).
-  Future<void> _createMultisigDraft(BuildContext context, {bool replayProtect = false}) async {
+  Future<void> _createMultisigDraft(BuildContext context, {bool allowReplay = false}) async {
     final walletId = activeWalletId;
     if (walletId == null) {
       return;
     }
     final generation = draftProvider.generation;
-    final psbt = await buildUnsignedPsbtForAirgap(context, replayProtect: replayProtect);
+    final psbt = await buildUnsignedPsbtForAirgap(context, allowReplay: allowReplay);
     if (psbt == null) {
       return;
     }
@@ -965,7 +965,7 @@ class SendPageViewModel extends BaseViewModel {
   /// Build an unsigned PSBT from the current recipients/fee/coin-selection for
   /// an external (airgap) signer. Returns base64, or null after surfacing an
   /// error toast.
-  Future<String?> buildUnsignedPsbtForAirgap(BuildContext context, {bool replayProtect = false}) async {
+  Future<String?> buildUnsignedPsbtForAirgap(BuildContext context, {bool allowReplay = false}) async {
     final missingAddress = recipients.indexWhere((r) => r.addressController.text.trim().isEmpty);
     if (missingAddress != -1) {
       showSailToast(context, 'Please enter an address for all recipients.');
@@ -1001,7 +1001,7 @@ class SendPageViewModel extends BaseViewModel {
         fixedFeeSats: feeSats,
         subtractFeeFromAmount: _subtractFeeFromAmount,
         requiredInputs: selectedUtxos,
-        replayProtect: replayProtect,
+        allowReplay: allowReplay,
       );
     } catch (error) {
       log.e('Error building unsigned PSBT: $error');

--- a/bitwindow/lib/providers/fork_provider.dart
+++ b/bitwindow/lib/providers/fork_provider.dart
@@ -141,6 +141,20 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
   /// outside this set came after the fork, so it exists on one chain only.
   Set<String> get claimOutpoints => claims.expand((c) => c.utxos).map((u) => u.output).toSet();
 
+  /// The coins the user hid the claim card for. A new claimable coin brings
+  /// the card back.
+  Set<String> _dismissedClaimOutpoints = {};
+
+  /// True while the user hid the card and no new claimable coin arrived.
+  bool get claimCardDismissed =>
+      claimOutpoints.isNotEmpty && claimOutpoints.difference(_dismissedClaimOutpoints).isEmpty;
+
+  /// Hides the claim card until a new claimable coin arrives.
+  void dismissClaimCard() {
+    _dismissedClaimOutpoints = claimOutpoints;
+    notifyListeners();
+  }
+
   /// Every coin a pending split holds.
   Set<String> get pendingSplitOutpoints => {...pendingSplits.expand((p) => p.outpoints), ..._splitsInFlight};
 
@@ -196,6 +210,7 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
     _readPsbtByDraft.clear();
     _splitsInFlight.clear();
     replayedTxids.clear();
+    _dismissedClaimOutpoints = {};
     walletsWithUnreadDrafts = {};
     notifyListeners();
     fetch();

--- a/bitwindow/lib/providers/fork_provider.dart
+++ b/bitwindow/lib/providers/fork_provider.dart
@@ -455,7 +455,6 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
       requiredInputs: inputs,
       subtractFeeFromAmount: true,
       feeRateSatPerVbyte: _sweepFeeRateSatPerVbyte,
-      replayProtect: replayProtectionAvailable,
     );
     if (_drafts.generation != generation) {
       throw Exception('The network changed during the build. Create the split transaction again.');
@@ -490,7 +489,6 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
       requiredInputs: inputs,
       subtractFeeFromAmount: true,
       feeRateSatPerVbyte: _sweepFeeRateSatPerVbyte,
-      replayProtect: replayProtectionAvailable,
     )).txid;
 
     _log.i('Claimed eCash: wallet="${claim.walletName}" id=$walletId txid=$txid -> $address');

--- a/bitwindow/lib/widgets/fork_mode_banner.dart
+++ b/bitwindow/lib/widgets/fork_mode_banner.dart
@@ -22,7 +22,7 @@ class ForkModeBanner extends StatelessWidget {
         // Claim card only — the countdown is handled globally by
         // ForkCountdownTimer, and is hidden by the engine while coins are
         // unclaimed, so the two never overlap.
-        if (!_fork.hasFundsToClaim || !_fork.hasSelectableCoins) {
+        if (!_fork.hasFundsToClaim || !_fork.hasSelectableCoins || _fork.claimCardDismissed) {
           return const SizedBox.shrink();
         }
         return _ClaimEcashCard(fork: _fork);
@@ -128,6 +128,12 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
                 ),
                 const SizedBox(width: 8),
                 SailText.primary15('You have eCash to claim', bold: true),
+                const Spacer(),
+                SailButton(
+                  variant: ButtonVariant.icon,
+                  icon: SailSVGAsset.iconClose,
+                  onPressed: () async => widget.fork.dismissClaimCard(),
+                ),
               ],
             ),
             const SizedBox(height: 16),

--- a/bitwindow/lib/widgets/replay_protection_dialog.dart
+++ b/bitwindow/lib/widgets/replay_protection_dialog.dart
@@ -16,7 +16,7 @@ Future<ReplayChoice> askReplayProtection(
   final choice = await showThemedDialog<ReplayChoice>(
     context: context,
     builder: (context) => SailModal(
-      constraints: const BoxConstraints(maxWidth: 720),
+      constraints: const BoxConstraints(maxWidth: 560),
       child: SailCard(
         title: coinsKnown && coins.length == 1 ? 'This coin exists on both chains' : 'These coins exist on both chains',
         subtitle: coinsKnown
@@ -24,19 +24,10 @@ Future<ReplayChoice> askReplayProtection(
             : 'The wallet did not report its coins yet, so this send can spend one that exists on both chains.',
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
           children: [
             if (coinsKnown) ...[
-              SailText.primary15('Coins on both chains', bold: true),
-              const SizedBox(height: SailStyleValues.padding08),
-              ConstrainedBox(
-                constraints: const BoxConstraints(maxHeight: 240),
-                child: SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: coins.map((c) => _CoinRow(coin: c)).toList(),
-                  ),
-                ),
-              ),
+              _CoinList(coins: coins),
               const SizedBox(height: SailStyleValues.padding16),
             ],
             SailText.secondary13(
@@ -72,21 +63,71 @@ Future<ReplayChoice> askReplayProtection(
   return choice ?? ReplayChoice.cancel;
 }
 
-class _CoinRow extends StatelessWidget {
-  final UnspentOutput coin;
+/// The coins of the send, with their count and total on top. Scrolls once the
+/// list passes five rows, so a big send keeps the dialog short.
+class _CoinList extends StatelessWidget {
+  final List<UnspentOutput> coins;
 
-  const _CoinRow({required this.coin});
+  const _CoinList({required this.coins});
 
   @override
   Widget build(BuildContext context) {
     final formatter = GetIt.I.get<FormatterProvider>();
+    final total = coins.fold<int>(0, (sum, c) => sum + c.valueSats.toInt());
+
+    return SailCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _Row(
+            left: coins.length == 1 ? '1 coin' : '${coins.length} coins',
+            right: formatter.formatSats(total),
+            muted: true,
+          ),
+          const SizedBox(height: SailStyleValues.padding08),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 110),
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: coins
+                    .map(
+                      (c) => _Row(
+                        left: formatter.formatSats(c.valueSats.toInt()),
+                        right: _shortAddress(c.address),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Row extends StatelessWidget {
+  final String left;
+  final String right;
+  final bool muted;
+
+  const _Row({required this.left, required this.right, this.muted = false});
+
+  @override
+  Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(bottom: SailStyleValues.padding04),
       child: Row(
         children: [
-          SailText.secondary13(formatter.formatSats(coin.valueSats.toInt()), monospace: true),
+          if (muted) SailText.secondary12(left, bold: true) else SailText.primary13(left, monospace: true),
           const Spacer(),
-          SailText.secondary13(_shortAddress(coin.address), monospace: true),
+          if (muted)
+            SailText.secondary12(right, bold: true, monospace: true)
+          else
+            SailText.secondary13(right, monospace: true),
         ],
       ),
     );

--- a/bitwindow/test/fork_claim_replay_test.dart
+++ b/bitwindow/test/fork_claim_replay_test.dart
@@ -10,7 +10,7 @@ import 'package:sail_ui/sail_ui.dart';
 import 'test_utils.dart';
 
 class _FakeWallet implements OrchestratorWalletRPC {
-  bool? sentReplayProtect;
+  bool? sentAllowReplay;
 
   @override
   Future<wmpb.GetNewAddressResponse> getNewAddress(String walletId, {wmpb.AddressType? addressType}) async =>
@@ -26,9 +26,9 @@ class _FakeWallet implements OrchestratorWalletRPC {
     String? opReturnMessage,
     String? opReturnHex,
     List<bwpb.UnspentOutput>? requiredInputs,
-    bool replayProtect = false,
+    bool allowReplay = false,
   }) async {
-    sentReplayProtect = replayProtect;
+    sentAllowReplay = allowReplay;
     return wmpb.SendTransactionResponse(txid: 'aa' * 32);
   }
 
@@ -99,7 +99,7 @@ void main() {
     await GetIt.I.reset();
   });
 
-  test('the sweep of a single-sig claim carries replay protection', () async {
+  test('the sweep never allows a replay', () async {
     final provider = ForkProvider();
     provider.claims = [
       WalletClaim(
@@ -112,23 +112,6 @@ void main() {
 
     await provider.claim('w1');
 
-    expect(wallet.sentReplayProtect, isTrue, reason: 'a plain sweep replays onto the other chain');
-  });
-
-  test('the sweep stays plain where the node rejects the magic locktime', () async {
-    await replace<BitcoinConfProvider>(_FakeConf(BitcoinNetwork.BITCOIN_NETWORK_SIGNET));
-    final provider = ForkProvider();
-    provider.claims = [
-      WalletClaim(
-        walletId: 'w1',
-        walletName: 'Main wallet',
-        claimableSats: 100000,
-        utxos: [bwpb.UnspentOutput(output: 'aa:0', valueSats: Int64(100000))],
-      ),
-    ];
-
-    await provider.claim('w1');
-
-    expect(wallet.sentReplayProtect, isFalse, reason: 'stock Core rejects a non-final transaction');
+    expect(wallet.sentAllowReplay, isFalse, reason: 'a swept coin must stay on this chain');
   });
 }

--- a/bitwindow/test/replay_protection_dialog_test.dart
+++ b/bitwindow/test/replay_protection_dialog_test.dart
@@ -3,6 +3,7 @@ import 'package:fixnum/fixnum.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
+import 'package:sail_ui/sail_ui.dart';
 import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart';
 
 import 'test_utils.dart';
@@ -70,5 +71,13 @@ void main() {
     expect(find.text('These coins exist on both chains'), findsOneWidget);
     expect(find.text('Coins on both chains'), findsNothing);
     expect(find.text('Enable replay protection'), findsWidgets);
+  });
+
+  testWidgets('the dialog hugs its content instead of filling the screen', (tester) async {
+    await openDialog(tester, [coin('tb1qm4v000000000000000008xr2', 30000000)]);
+
+    final card = tester.getSize(find.byType(SailCard).first);
+    final screen = tester.view.physicalSize / tester.view.devicePixelRatio;
+    expect(card.height, lessThan(screen.height * 0.7));
   });
 }

--- a/sidechain-orchestrator/api/bip47_send.go
+++ b/sidechain-orchestrator/api/bip47_send.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/replay"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47send"
@@ -223,7 +224,16 @@ func (h *WalletHandler) buildBip47NotificationTx(
 // broadcastBip47Notification signs and broadcasts the notification tx through
 // the wallet's Core RPC, then marks the recipient as notified. Returns the
 // notification txid.
-func (h *WalletHandler) broadcastBip47Notification(ctx context.Context, walletID, recipientCode, rawHex string) (string, error) {
+func (h *WalletHandler) broadcastBip47Notification(ctx context.Context, walletID, recipientCode, rawHex string, allowReplay bool) (string, error) {
+	// The notification tx spends a real coin, so it takes the same locktime as
+	// the payment it precedes.
+	if wallet.ReplayProtect(h.svc.Network(), allowReplay) {
+		protectedHex, err := replay.ApplyLockTimeHex(rawHex)
+		if err != nil {
+			return "", connect.NewError(connect.CodeInternal, err)
+		}
+		rawHex = protectedHex
+	}
 	signed, err := h.engine.Backend().SignTransaction(ctx, walletID, rawHex)
 	if err != nil {
 		return "", fmt.Errorf("sign notification tx: %w", err)

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -836,7 +836,7 @@ func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Reques
 	}
 
 	if expansion.notificationTxHex != "" {
-		notifTxID, err := h.broadcastBip47Notification(ctx, walletID, expansion.recipientCode, expansion.notificationTxHex)
+		notifTxID, err := h.broadcastBip47Notification(ctx, walletID, expansion.recipientCode, expansion.notificationTxHex, req.Msg.AllowReplay)
 		if err != nil {
 			// The payment never went out, so its index is still free.
 			h.releaseBip47Index(walletID, expansion)
@@ -851,7 +851,7 @@ func (h *WalletHandler) SendTransaction(ctx context.Context, req *connect.Reques
 		FixedFeeSats:          req.Msg.FixedFeeSats,
 		OpReturnHex:           req.Msg.OpReturnHex,
 		SubtractFeeFromAmount: req.Msg.SubtractFeeFromAmount,
-		ReplayProtect:         req.Msg.ReplayProtect,
+		AllowReplay:           req.Msg.AllowReplay,
 		Replaceable:           req.Msg.Replaceable,
 	}
 	sendReq.RequiredInputs = lo.Map(req.Msg.RequiredInputs, func(u *pb.UnspentOutput, _ int) wallet.RequiredInput {
@@ -1911,7 +1911,7 @@ func (h *WalletHandler) CreatePsbt(ctx context.Context, req *connect.Request[pb.
 		FixedFeeSats:          req.Msg.FixedFeeSats,
 		OpReturnHex:           req.Msg.OpReturnHex,
 		SubtractFeeFromAmount: req.Msg.SubtractFeeFromAmount,
-		ReplayProtect:         req.Msg.ReplayProtect,
+		AllowReplay:           req.Msg.AllowReplay,
 	}
 	sendReq.RequiredInputs = lo.Map(req.Msg.RequiredInputs, func(u *pb.UnspentOutput, _ int) wallet.RequiredInput {
 		return wallet.RequiredInput{

--- a/sidechain-orchestrator/api/wallet_handler_routing_test.go
+++ b/sidechain-orchestrator/api/wallet_handler_routing_test.go
@@ -102,13 +102,13 @@ func TestSendTransactionPassesThroughConnectCodes(t *testing.T) {
 	// the handler must not rewrap it as internal.
 	elecFake.sendErr = connect.NewError(
 		connect.CodeInvalidArgument,
-		errors.New("replay protection is only supported for Bitcoin Core wallets"),
+		errors.New("this wallet cannot allow a replay"),
 	)
 
 	_, err := h.SendTransaction(context.Background(), connect.NewRequest(&pb.SendTransactionRequest{
-		WalletId:      elecID,
-		Destinations:  map[string]int64{"addr": 10_000},
-		ReplayProtect: true,
+		WalletId:     elecID,
+		Destinations: map[string]int64{"addr": 10_000},
+		AllowReplay:  true,
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -442,7 +442,7 @@ func run(cctx *cli.Context) error {
 		if electrumBackend != nil {
 			electrumBackend.OnProxyChange(splitClient.SetProxy)
 		}
-		splitEngine := engines.NewSplitEngine(log, orch, splitClient, walletSvc, currentNetwork)
+		splitEngine := engines.NewSplitEngine(log, orch, orch, splitClient, walletSvc, currentNetwork)
 		walletEngine.OnNetworkReset(splitEngine.ResetForNetwork)
 		go func() {
 			if err := splitEngine.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {

--- a/sidechain-orchestrator/engines/split_engine.go
+++ b/sidechain-orchestrator/engines/split_engine.go
@@ -17,9 +17,21 @@ import (
 // scan, so a slow tick is sufficient.
 const splitTickInterval = 2 * time.Minute
 
+// absentRecheckInterval is how long a coin Bitcoin does not know waits for the
+// next lookup. A replay-protected send makes change no other chain ever holds,
+// so most coins answer absent forever; without this they cost a request per
+// tick each.
+const absentRecheckInterval = 6 * time.Hour
+
 // ForkStateSource yields the fork snapshot. The orchestrator satisfies this.
 type ForkStateSource interface {
 	ForkState(ctx context.Context) (*fork.ForkState, error)
+}
+
+// UnspentSource lists every coin the wallets hold. The orchestrator satisfies
+// this.
+type UnspentSource interface {
+	WalletUnspent(ctx context.Context) ([]fork.Utxo, error)
 }
 
 // OutspendSource answers BTC-mainnet spend status per output.
@@ -33,26 +45,36 @@ type SplitStore interface {
 	SaveSplitStatus(ctx context.Context, outpoint string, splittable bool) error
 }
 
-// SplitEngine finds which claimable pre-fork UTXOs are splittable: the same
-// outpoint exists unspent on BTC mainnet. Each outpoint gets one lookup ever;
-// the fork scan gates the lookups so rate-limited servers see few requests.
+// SplitEngine asks BTC mainnet about every coin the wallets hold. A pre-fork
+// coin lives on both chains because they share its history; a post-fork coin
+// lives on both when its transaction went out without replay protection. Each
+// outpoint gets one lookup ever, so rate-limited servers see few requests.
 type SplitEngine struct {
 	log     zerolog.Logger
 	fork    ForkStateSource
+	coins   UnspentSource
 	btc     OutspendSource
 	store   SplitStore
 	network func() string
+	now     func() time.Time
+
+	// absent holds when a lookup last reported that Bitcoin does not know a
+	// coin. Such an answer expires, so it gates the next lookup, not the coin.
+	absent map[string]time.Time
 
 	wake chan struct{}
 }
 
-func NewSplitEngine(log zerolog.Logger, forkState ForkStateSource, btc OutspendSource, store SplitStore, network func() string) *SplitEngine {
+func NewSplitEngine(log zerolog.Logger, forkState ForkStateSource, coins UnspentSource, btc OutspendSource, store SplitStore, network func() string) *SplitEngine {
 	return &SplitEngine{
 		log:     log.With().Str("component", "split-engine").Logger(),
 		fork:    forkState,
+		coins:   coins,
 		btc:     btc,
 		store:   store,
 		network: network,
+		now:     time.Now,
+		absent:  map[string]time.Time{},
 		wake:    make(chan struct{}, 1),
 	}
 }
@@ -95,55 +117,105 @@ func (e *SplitEngine) tick(ctx context.Context) {
 	if st.Simulated {
 		return
 	}
-
+	coins, err := e.coins.WalletUnspent(ctx)
+	if err != nil {
+		e.log.Warn().Err(err).Msg("split: coin list unavailable")
+		return
+	}
 	cached, err := e.store.SplitStatuses(ctx)
 	if err != nil {
 		e.log.Warn().Err(err).Msg("split: cache unavailable")
 		return
 	}
+	e.absent = keepLiveAbsences(e.absent, coins)
 
-	for _, claim := range st.Claims {
-		for _, u := range claim.UTXOs {
-			if ctx.Err() != nil {
-				return
-			}
-			if _, ok := cached[u.Outpoint]; ok {
-				continue
-			}
-			// A failed lookup stops the pass — one dead provider must not
-			// cost a request per outpoint per tick. A later tick retries.
-			if err := e.check(ctx, u.Outpoint); err != nil {
-				e.log.Warn().Err(err).Str("outpoint", u.Outpoint).Msg("split: pass stopped")
-				return
-			}
+	for _, u := range coins {
+		if ctx.Err() != nil {
+			return
 		}
+		if _, done := cached[u.Outpoint]; done {
+			continue
+		}
+		if !dueForRecheck(e.absent[u.Outpoint], e.now()) {
+			continue
+		}
+		status, err := checkReplayStatus(ctx, e.btc, u.Outpoint)
+		if err != nil {
+			// One dead provider must not cost a request per coin per tick.
+			e.log.Warn().Err(err).Str("outpoint", u.Outpoint).Msg("split: pass stopped")
+			return
+		}
+		switch status {
+		case btcUnknown:
+			// Bitcoin holds no such coin, which this chain's own coins answer
+			// forever. The next lookup waits.
+			e.absent[u.Outpoint] = e.now()
+			continue
+		case btcPending:
+			// A block settles this, so the next tick asks again.
+			continue
+		}
+		delete(e.absent, u.Outpoint)
+		if err := e.store.SaveSplitStatus(ctx, u.Outpoint, status == btcUnspent); err != nil {
+			e.log.Warn().Err(err).Str("outpoint", u.Outpoint).Msg("split: pass stopped")
+			return
+		}
+		e.log.Info().Str("outpoint", u.Outpoint).Bool("splittable", status == btcUnspent).Msg("split: outpoint checked")
 	}
 }
 
-// check does the single BTC-side lookup for one outpoint. An error caches
-// nothing, so a later tick retries.
-func (e *SplitEngine) check(ctx context.Context, outpoint string) error {
+// keepLiveAbsences drops the records of coins the wallet no longer holds, so a
+// spent coin costs no memory.
+func keepLiveAbsences(absent map[string]time.Time, coins []fork.Utxo) map[string]time.Time {
+	live := make(map[string]time.Time, len(absent))
+	for _, u := range coins {
+		if t, ok := absent[u.Outpoint]; ok {
+			live[u.Outpoint] = t
+		}
+	}
+	return live
+}
+
+// dueForRecheck reports whether a coin gets a lookup on this pass. A coin no
+// lookup reported absent yet carries the zero time and always qualifies.
+func dueForRecheck(lastAbsent, now time.Time) bool {
+	return lastAbsent.IsZero() || now.Sub(lastAbsent) >= absentRecheckInterval
+}
+
+// btcStatus is what Bitcoin says about one coin.
+type btcStatus int
+
+const (
+	// btcUnknown: no server holds the coin. A coin this chain alone made
+	// answers this forever, and a replay can still land much later.
+	btcUnknown btcStatus = iota
+	// btcPending: a spend sits in the mempool and can drop out again.
+	btcPending
+	// btcSpent: a confirmed spend, so nothing replays.
+	btcSpent
+	// btcUnspent: the coin exists on Bitcoin, so a spend here replays there.
+	btcUnspent
+)
+
+// checkReplayStatus asks Bitcoin about one coin. The caller acts on the answer.
+func checkReplayStatus(ctx context.Context, btc OutspendSource, outpoint string) (btcStatus, error) {
 	txid, vout, ok := parseOutpoint(outpoint)
 	if !ok {
-		e.log.Warn().Str("outpoint", outpoint).Msg("split: malformed outpoint")
-		return nil
+		return btcUnknown, nil
 	}
-	out, found, err := e.btc.Outspend(ctx, txid, vout)
-	if err != nil {
-		return err
+	out, found, err := btc.Outspend(ctx, txid, vout)
+	switch {
+	case err != nil:
+		return btcUnknown, err
+	case !found:
+		return btcUnknown, nil
+	case out.Spent && !out.Status.Confirmed:
+		return btcPending, nil
+	case out.Spent:
+		return btcSpent, nil
+	default:
+		return btcUnspent, nil
 	}
-	// A mempool spend can drop out again — cache only stable states: unspent,
-	// spent with confirmation, or absent from the chain. A reorg of a
-	// confirmed spend is accepted as final.
-	if found && out.Spent && !out.Status.Confirmed {
-		return nil
-	}
-	splittable := found && !out.Spent
-	if err := e.store.SaveSplitStatus(ctx, outpoint, splittable); err != nil {
-		return err
-	}
-	e.log.Info().Str("outpoint", outpoint).Bool("splittable", splittable).Msg("split: outpoint checked")
-	return nil
 }
 
 func parseOutpoint(outpoint string) (string, int, bool) {

--- a/sidechain-orchestrator/engines/split_engine_test.go
+++ b/sidechain-orchestrator/engines/split_engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -67,25 +68,46 @@ func (f *fakeSplitStore) SaveSplitStatus(_ context.Context, outpoint string, spl
 	return nil
 }
 
-func forkStateWith(outpoints ...string) *fork.ForkState {
-	utxos := make([]fork.ClaimUTXO, 0, len(outpoints))
-	for _, op := range outpoints {
-		utxos = append(utxos, fork.ClaimUTXO{Outpoint: op, Sats: 100})
-	}
-	return &fork.ForkState{
-		HasFundsToClaim: true,
-		Claims:          []fork.WalletClaim{{WalletID: "w1", UTXOs: utxos}},
-	}
+type fakeCoins struct {
+	utxos []fork.Utxo
+	err   error
 }
 
-func newTestSplitEngine(st *fork.ForkState, btc *fakeOutspend, store *fakeSplitStore, network string) *SplitEngine {
-	return NewSplitEngine(zerolog.Nop(), &fakeForkState{st: st}, btc, store, func() string { return network })
+func (f *fakeCoins) WalletUnspent(context.Context) ([]fork.Utxo, error) { return f.utxos, f.err }
+
+// claimBoundary every test shares; a coin below it is pre-fork.
+const testBoundary = 1000
+
+func forkStateWith(outpoints ...string) *fork.ForkState {
+	return &fork.ForkState{HasFundsToClaim: true, ClaimBoundary: testBoundary}
+}
+
+// preFork lists coins confirmed before the fork — both chains share them.
+func preFork(outpoints ...string) *fakeCoins {
+	c := &fakeCoins{}
+	for _, op := range outpoints {
+		c.utxos = append(c.utxos, fork.Utxo{Outpoint: op, Sats: 100, Height: testBoundary - 1, Spendable: true})
+	}
+	return c
+}
+
+// postFork lists coins confirmed after the fork — this chain alone made them.
+func postFork(outpoints ...string) *fakeCoins {
+	c := &fakeCoins{}
+	for _, op := range outpoints {
+		c.utxos = append(c.utxos, fork.Utxo{Outpoint: op, Sats: 100, Height: testBoundary + 1, Spendable: true})
+	}
+	return c
+}
+
+func newTestSplitEngine(st *fork.ForkState, coins *fakeCoins, btc *fakeOutspend, store *fakeSplitStore, network string) *SplitEngine {
+	return NewSplitEngine(zerolog.Nop(), &fakeForkState{st: st}, coins, btc, store, func() string { return network })
 }
 
 func TestSplitEngineChecksEachOutpointOnce(t *testing.T) {
 	btc := newFakeOutspend()
 	store := &fakeSplitStore{statuses: map[string]bool{}}
-	e := newTestSplitEngine(forkStateWith("aa:0", "bb:1"), btc, store, "ecash")
+	e := newTestSplitEngine(forkStateWith(), preFork("aa:0", "bb:1"), btc, store, "ecash")
 
 	e.tick(context.Background())
 	e.tick(context.Background())
@@ -98,7 +120,7 @@ func TestSplitEngineChecksEachOutpointOnce(t *testing.T) {
 func TestSplitEngineSkipsCachedOutpoints(t *testing.T) {
 	btc := newFakeOutspend()
 	store := &fakeSplitStore{statuses: map[string]bool{"aa:0": false}}
-	e := newTestSplitEngine(forkStateWith("aa:0", "bb:1"), btc, store, "ecash")
+	e := newTestSplitEngine(forkStateWith(), preFork("aa:0", "bb:1"), btc, store, "ecash")
 
 	e.tick(context.Background())
 
@@ -109,7 +131,7 @@ func TestSplitEngineSkipsCachedOutpoints(t *testing.T) {
 func TestSplitEngineSkipsNonEcashNetwork(t *testing.T) {
 	btc := newFakeOutspend()
 	store := &fakeSplitStore{statuses: map[string]bool{}}
-	e := newTestSplitEngine(forkStateWith("aa:0"), btc, store, "signet")
+	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "signet")
 
 	e.tick(context.Background())
 
@@ -120,9 +142,9 @@ func TestSplitEngineSkipsNonEcashNetwork(t *testing.T) {
 func TestSplitEngineSkipsSimulatedFork(t *testing.T) {
 	btc := newFakeOutspend()
 	store := &fakeSplitStore{statuses: map[string]bool{}}
-	st := forkStateWith("aa:0")
+	st := forkStateWith()
 	st.Simulated = true
-	e := newTestSplitEngine(st, btc, store, "ecash")
+	e := newTestSplitEngine(st, preFork("aa:0"), btc, store, "ecash")
 
 	e.tick(context.Background())
 
@@ -133,7 +155,7 @@ func TestSplitEngineRetriesAfterLookupError(t *testing.T) {
 	btc := newFakeOutspend()
 	btc.fail["aa:0"] = true
 	store := &fakeSplitStore{statuses: map[string]bool{}}
-	e := newTestSplitEngine(forkStateWith("aa:0"), btc, store, "ecash")
+	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "ecash")
 
 	e.tick(context.Background())
 	require.Empty(t, store.statuses)
@@ -149,7 +171,7 @@ func TestSplitEngineDoesNotCacheMempoolSpend(t *testing.T) {
 	btc := newFakeOutspend()
 	btc.mempoolSpent["aa:0"] = true
 	store := &fakeSplitStore{statuses: map[string]bool{}}
-	e := newTestSplitEngine(forkStateWith("aa:0"), btc, store, "ecash")
+	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "ecash")
 
 	e.tick(context.Background())
 	require.Empty(t, store.statuses)
@@ -164,15 +186,162 @@ func TestSplitEngineDoesNotCacheMempoolSpend(t *testing.T) {
 func TestSplitEngineStatusMapping(t *testing.T) {
 	btc := newFakeOutspend()
 	btc.spent["spent:0"] = true
-	btc.missing["absent:0"] = true
 	store := &fakeSplitStore{statuses: map[string]bool{}}
-	e := newTestSplitEngine(forkStateWith("spent:0", "absent:0", "unspent:0"), btc, store, "ecash")
+	e := newTestSplitEngine(forkStateWith(), preFork("spent:0", "unspent:0"), btc, store, "ecash")
 
 	e.tick(context.Background())
 
 	require.Equal(t, map[string]bool{
 		"spent:0":   false,
-		"absent:0":  false,
 		"unspent:0": true,
 	}, store.statuses)
+}
+
+func TestSplitEngineDoesNotCacheNotFound(t *testing.T) {
+	btc := newFakeOutspend()
+	btc.missing["absent:0"] = true
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), preFork("absent:0", "unspent:0"), btc, store, "ecash")
+
+	e.tick(context.Background())
+
+	require.Empty(t, store.statuses["absent:0"])
+	require.NotContains(t, store.statuses, "absent:0")
+	require.Equal(t, true, store.statuses["unspent:0"])
+
+	btc.missing["absent:0"] = false
+	e.passRecheckInterval()
+	e.tick(context.Background())
+
+	require.Equal(t, 2, btc.calls["absent:0"])
+	require.Equal(t, true, store.statuses["absent:0"])
+}
+
+func TestSplitEngineChecksACoinReceivedAfterTheFork(t *testing.T) {
+	// A replayed transaction puts a post-fork coin on BTC too, so the coin
+	// still needs the lookup.
+	btc := newFakeOutspend()
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), postFork("new:0"), btc, store, "ecash")
+
+	e.tick(context.Background())
+
+	require.Equal(t, 1, btc.calls["new:0"])
+	require.Equal(t, map[string]bool{"new:0": true}, store.statuses)
+}
+
+func TestSplitEngineRetriesAPostForkCoinBtcNeverSaw(t *testing.T) {
+	// eCash mines faster than Bitcoin, so a replay can land there much later.
+	btc := newFakeOutspend()
+	btc.missing["new:0"] = true
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), postFork("new:0"), btc, store, "ecash")
+
+	e.tick(context.Background())
+	require.Empty(t, store.statuses)
+
+	btc.missing["new:0"] = false
+	e.passRecheckInterval()
+	e.tick(context.Background())
+
+	require.Equal(t, 2, btc.calls["new:0"])
+	require.Equal(t, map[string]bool{"new:0": true}, store.statuses)
+}
+
+// A replay-protected send makes change no other chain holds, so most coins
+// answer absent forever. Without a backoff each costs a request per tick.
+func TestSplitEngineBacksOffACoinBtcDoesNotKnow(t *testing.T) {
+	btc := newFakeOutspend()
+	btc.missing["change:0"] = true
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), postFork("change:0"), btc, store, "ecash")
+
+	for range 5 {
+		e.tick(context.Background())
+	}
+
+	require.Equal(t, 1, btc.calls["change:0"], "the backoff must hold the extra lookups")
+	require.Empty(t, store.statuses)
+}
+
+func TestSplitEngineBackoffDoesNotBlockAnotherCoin(t *testing.T) {
+	btc := newFakeOutspend()
+	btc.missing["change:0"] = true
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), postFork("change:0", "live:0"), btc, store, "ecash")
+
+	e.tick(context.Background())
+	e.tick(context.Background())
+
+	require.Equal(t, 1, btc.calls["change:0"])
+	require.Equal(t, true, store.statuses["live:0"], "a coin BTC knows still gets its answer")
+}
+
+func TestSplitEngineForgetsASpentCoin(t *testing.T) {
+	btc := newFakeOutspend()
+	btc.missing["spent:0"] = true
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	coins := postFork("spent:0")
+	e := newTestSplitEngine(forkStateWith(), coins, btc, store, "ecash")
+
+	e.tick(context.Background())
+	require.Len(t, e.absent, 1)
+
+	coins.utxos = nil
+	e.tick(context.Background())
+
+	require.Empty(t, e.absent, "a coin the wallet lost must not hold memory")
+}
+
+func TestDueForRecheck(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+
+	require.True(t, dueForRecheck(time.Time{}, base),
+		"a coin no lookup reported absent yet is always due")
+	require.False(t, dueForRecheck(base, base.Add(absentRecheckInterval-time.Second)),
+		"a fresh absence holds the next lookup")
+	require.True(t, dueForRecheck(base, base.Add(absentRecheckInterval)),
+		"an absence expires, because a replay can land later")
+}
+
+func TestCheckReplayStatus(t *testing.T) {
+	btc := newFakeOutspend()
+	btc.spent["spent:0"] = true
+	btc.mempoolSpent["mempool:0"] = true
+	btc.missing["absent:0"] = true
+
+	cases := []struct {
+		name     string
+		outpoint string
+		want     btcStatus
+	}{
+		{name: "unspent on BTC", outpoint: "unspent:0", want: btcUnspent},
+		{name: "spent on BTC", outpoint: "spent:0", want: btcSpent},
+		{name: "spent in the BTC mempool", outpoint: "mempool:0", want: btcPending},
+		{name: "BTC does not know it", outpoint: "absent:0", want: btcUnknown},
+		{name: "malformed outpoint", outpoint: "nope", want: btcUnknown},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := checkReplayStatus(context.Background(), btc, c.outpoint)
+			require.NoError(t, err)
+			require.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestCheckReplayStatusReturnsTheLookupError(t *testing.T) {
+	btc := newFakeOutspend()
+	btc.fail["aa:0"] = true
+
+	_, err := checkReplayStatus(context.Background(), btc, "aa:0")
+
+	require.Error(t, err)
+}
+
+// passRecheckInterval moves the engine clock past the backoff, so the next
+// tick asks Bitcoin again.
+func (e *SplitEngine) passRecheckInterval() {
+	base := e.now()
+	e.now = func() time.Time { return base.Add(absentRecheckInterval) }
 }

--- a/sidechain-orchestrator/fork.go
+++ b/sidechain-orchestrator/fork.go
@@ -157,8 +157,19 @@ func (s *forkWalletScanner) Unspent(ctx context.Context, walletID string, tipHei
 	return s.coreUnspent(ctx, walletID, tipHeight)
 }
 
-// coreUnspent reads a Core wallet's UTXOs; Core only reports confirmations, so
-// height is derived tip - confirmations + 1.
+// utxoHeight is the absolute confirmation height of one coin. A backend that
+// knows the height supplies it; Core counts confirmations against its own tip.
+func utxoHeight(u wallet.UTXO, tipHeight int) int {
+	if u.BlockHeight > 0 {
+		return u.BlockHeight
+	}
+	if u.Confirmations > 0 {
+		return tipHeight - u.Confirmations + 1
+	}
+	return 0
+}
+
+// coreUnspent reads a wallet's UTXOs.
 func (s *forkWalletScanner) coreUnspent(ctx context.Context, walletID string, tipHeight int) ([]fork.Utxo, error) {
 	if s.engine == nil {
 		return nil, nil
@@ -174,16 +185,12 @@ func (s *forkWalletScanner) coreUnspent(ctx context.Context, walletID string, ti
 		}
 	}
 	return lo.Map(coreUTXOs, func(u wallet.UTXO, _ int) fork.Utxo {
-		height := 0
-		if u.Confirmations > 0 {
-			height = tipHeight - u.Confirmations + 1
-		}
 		return fork.Utxo{
 			Outpoint:  fork.Outpoint(u.TxID, u.Vout),
 			Address:   u.Address,
 			Label:     u.Label,
 			Sats:      fork.BTCToSats(u.Amount),
-			Height:    height,
+			Height:    utxoHeight(u, tipHeight),
 			Spendable: forkSpendable(u.Spendable, multisig),
 		}
 	}), nil

--- a/sidechain-orchestrator/fork.go
+++ b/sidechain-orchestrator/fork.go
@@ -16,7 +16,29 @@ import (
 // available — called from main after NewWalletEngine. The fork.Engine is the
 // single source of truth for fork state; ForkState is a thin pass-through.
 func (o *Orchestrator) InitForkEngine(we *wallet.WalletEngine) {
-	o.forkEngine = fork.NewEngine(o, &forkWalletScanner{o: o, engine: we}, time.Second)
+	o.forkScanner = &forkWalletScanner{o: o, engine: we}
+	o.forkEngine = fork.NewEngine(o, o.forkScanner, time.Second)
+}
+
+// WalletUnspent lists every coin the scannable wallets hold. A wallet whose
+// backend errors is skipped, never fatal.
+func (o *Orchestrator) WalletUnspent(ctx context.Context) ([]fork.Utxo, error) {
+	if o.forkScanner == nil {
+		return nil, nil
+	}
+	tip, err := o.ForkTip(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var out []fork.Utxo
+	for _, w := range o.forkScanner.Wallets() {
+		utxos, err := o.forkScanner.Unspent(ctx, w.ID, tip.Blocks)
+		if err != nil {
+			continue
+		}
+		out = append(out, utxos...)
+	}
+	return out, nil
 }
 
 // SetWalletEngine hands the orchestrator the engine it resets on a network swap.

--- a/sidechain-orchestrator/fork/engine.go
+++ b/sidechain-orchestrator/fork/engine.go
@@ -166,10 +166,9 @@ func (e *Engine) compute(ctx context.Context) (*ForkState, error) {
 		CurrentHeaders: tip.Headers,
 	}
 
-	// The fork has "happened" for these coins only once the tip reaches the
-	// claim boundary — guards against a fixed-height network showing claims
-	// before the fork.
-	if tip.Blocks >= claimBoundary {
+	// The chain passes the boundary, not the local node: a node in initial
+	// block download sits far behind the headers it already knows.
+	if tip.Headers >= claimBoundary {
 		st.Claims = e.scan(ctx, claimBoundary, tip.Blocks)
 	}
 	for _, c := range st.Claims {

--- a/sidechain-orchestrator/fork/engine_test.go
+++ b/sidechain-orchestrator/fork/engine_test.go
@@ -95,3 +95,26 @@ func TestFixedHeightClaimsAfterFork(t *testing.T) {
 		t.Fatalf("claims: %+v", st.Claims)
 	}
 }
+
+func TestFixedHeightClaimsWhileNodeIsBehind(t *testing.T) {
+	// The chain passed 400 long ago, but the local node still downloads
+	// blocks. The coin at 391 is claimable all the same.
+	st := state(t, Tip{Network: "regtest", Blocks: 120, Headers: 900}, walletsAt(391))
+	if !st.HasFundsToClaim {
+		t.Fatal("a coin below the boundary is claimable while the node syncs")
+	}
+	if st.ShowCountdown {
+		t.Fatal("no countdown while coins are unclaimed")
+	}
+}
+
+func TestFixedHeightNoClaimsBeforeForkByHeaders(t *testing.T) {
+	// Headers stop short of 400, so the fork did not happen yet.
+	st := state(t, Tip{Network: "regtest", Blocks: 100, Headers: 390}, walletsAt(51))
+	if st.HasFundsToClaim {
+		t.Fatal("no claims before the chain reaches the fork height")
+	}
+	if !st.ShowCountdown {
+		t.Fatal("countdown should show before the fork")
+	}
+}

--- a/sidechain-orchestrator/fork_height_test.go
+++ b/sidechain-orchestrator/fork_height_test.go
@@ -1,0 +1,25 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
+)
+
+func TestUtxoHeightPrefersTheBackendHeight(t *testing.T) {
+	// An electrum backend counts confirmations against the chain tip, so the
+	// local node's tip must not decide the height.
+	u := wallet.UTXO{BlockHeight: 963_000, Confirmations: 28_000}
+	require.Equal(t, 963_000, utxoHeight(u, 864_766))
+}
+
+func TestUtxoHeightFallsBackToConfirmations(t *testing.T) {
+	u := wallet.UTXO{Confirmations: 10}
+	require.Equal(t, 991, utxoHeight(u, 1000))
+}
+
+func TestUtxoHeightIsZeroForAnUnconfirmedCoin(t *testing.T) {
+	require.Equal(t, 0, utxoHeight(wallet.UTXO{}, 1000))
+}

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -4434,10 +4434,10 @@ type SendTransactionRequest struct {
 	FixedFeeSats int64 `protobuf:"varint,6,opt,name=fixed_fee_sats,json=fixedFeeSats,proto3" json:"fixed_fee_sats,omitempty"`
 	// Explicit wallet inputs to spend.
 	RequiredInputs []*UnspentOutput `protobuf:"bytes,7,rep,name=required_inputs,json=requiredInputs,proto3" json:"required_inputs,omitempty"`
-	// Build a replay-protected transaction: stamp the magic nLockTime
-	// (499999999) and non-final input sequences so stock Bitcoin Core rejects it
-	// as non-final, while a patched bitcoind confirms it. Core/Electrum only.
-	ReplayProtect bool `protobuf:"varint,8,opt,name=replay_protect,json=replayProtect,proto3" json:"replay_protect,omitempty"`
+	// Send a transaction that can replay onto Bitcoin. The eCash network stamps
+	// the magic nLockTime (499999999) on every send, so stock Bitcoin Core
+	// rejects it; this drops that stamp for one send.
+	AllowReplay bool `protobuf:"varint,12,opt,name=allow_replay,json=allowReplay,proto3" json:"allow_replay,omitempty"`
 	// Outputs with an explicit raw scriptPubKey, kept in order before any
 	// address/op_return outputs. Used for non-standard scripts (e.g. a sidechain
 	// OP_DRIVECHAIN treasury output).
@@ -4532,9 +4532,9 @@ func (x *SendTransactionRequest) GetRequiredInputs() []*UnspentOutput {
 	return nil
 }
 
-func (x *SendTransactionRequest) GetReplayProtect() bool {
+func (x *SendTransactionRequest) GetAllowReplay() bool {
 	if x != nil {
-		return x.ReplayProtect
+		return x.AllowReplay
 	}
 	return false
 }
@@ -4738,10 +4738,10 @@ type CreatePsbtRequest struct {
 	RequiredInputs        []*UnspentOutput       `protobuf:"bytes,7,rep,name=required_inputs,json=requiredInputs,proto3" json:"required_inputs,omitempty"`
 	RawOutputs            []*RawOutput           `protobuf:"bytes,8,rep,name=raw_outputs,json=rawOutputs,proto3" json:"raw_outputs,omitempty"`
 	ExternalInputs        []*ExternalInput       `protobuf:"bytes,9,rep,name=external_inputs,json=externalInputs,proto3" json:"external_inputs,omitempty"`
-	// Stamp the magic nLockTime (499999999) and non-final input sequences before
-	// the PSBT goes out for signatures, so the signed transaction is valid on
-	// eCash only. Electrum wallets only.
-	ReplayProtect bool `protobuf:"varint,10,opt,name=replay_protect,json=replayProtect,proto3" json:"replay_protect,omitempty"`
+	// Build a PSBT that can replay onto Bitcoin. The eCash network stamps the
+	// magic nLockTime (499999999) on every PSBT; this drops that stamp for one
+	// PSBT.
+	AllowReplay   bool `protobuf:"varint,11,opt,name=allow_replay,json=allowReplay,proto3" json:"allow_replay,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4839,9 +4839,9 @@ func (x *CreatePsbtRequest) GetExternalInputs() []*ExternalInput {
 	return nil
 }
 
-func (x *CreatePsbtRequest) GetReplayProtect() bool {
+func (x *CreatePsbtRequest) GetAllowReplay() bool {
 	if x != nil {
-		return x.ReplayProtect
+		return x.AllowReplay
 	}
 	return false
 }
@@ -9798,7 +9798,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x15GetNewAddressResponse\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x14\n" +
 	"\x05index\x18\x02 \x01(\x05R\x05index\x12'\n" +
-	"\x0fderivation_path\x18\x03 \x01(\tR\x0ederivationPath\"\xa8\x05\n" +
+	"\x0fderivation_path\x18\x03 \x01(\tR\x0ederivationPath\"\xaa\x05\n" +
 	"\x16SendTransactionRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12^\n" +
 	"\fdestinations\x18\x02 \x03(\v2:.walletmanager.v1.SendTransactionRequest.DestinationsEntryR\fdestinations\x122\n" +
@@ -9806,8 +9806,8 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x18subtract_fee_from_amount\x18\x04 \x01(\bR\x15subtractFeeFromAmount\x12\"\n" +
 	"\rop_return_hex\x18\x05 \x01(\tR\vopReturnHex\x12$\n" +
 	"\x0efixed_fee_sats\x18\x06 \x01(\x03R\ffixedFeeSats\x12H\n" +
-	"\x0frequired_inputs\x18\a \x03(\v2\x1f.walletmanager.v1.UnspentOutputR\x0erequiredInputs\x12%\n" +
-	"\x0ereplay_protect\x18\b \x01(\bR\rreplayProtect\x12<\n" +
+	"\x0frequired_inputs\x18\a \x03(\v2\x1f.walletmanager.v1.UnspentOutputR\x0erequiredInputs\x12!\n" +
+	"\fallow_replay\x18\f \x01(\bR\vallowReplay\x12<\n" +
 	"\vraw_outputs\x18\t \x03(\v2\x1b.walletmanager.v1.RawOutputR\n" +
 	"rawOutputs\x12H\n" +
 	"\x0fexternal_inputs\x18\n" +
@@ -9815,7 +9815,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\vreplaceable\x18\v \x01(\bR\vreplaceable\x1a?\n" +
 	"\x11DestinationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"-\n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01J\x04\b\b\x10\t\"-\n" +
 	"\x17SendTransactionResponse\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\"I\n" +
 	"\tRawOutput\x12\x1d\n" +
@@ -9828,7 +9828,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x04vout\x18\x02 \x01(\x05R\x04vout\x12\x1d\n" +
 	"\n" +
 	"value_sats\x18\x03 \x01(\x03R\tvalueSats\x12*\n" +
-	"\x11script_pubkey_hex\x18\x04 \x01(\tR\x0fscriptPubkeyHex\"\xfc\x04\n" +
+	"\x11script_pubkey_hex\x18\x04 \x01(\tR\x0fscriptPubkeyHex\"\xfe\x04\n" +
 	"\x11CreatePsbtRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12Y\n" +
 	"\fdestinations\x18\x02 \x03(\v25.walletmanager.v1.CreatePsbtRequest.DestinationsEntryR\fdestinations\x122\n" +
@@ -9839,12 +9839,12 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x0frequired_inputs\x18\a \x03(\v2\x1f.walletmanager.v1.UnspentOutputR\x0erequiredInputs\x12<\n" +
 	"\vraw_outputs\x18\b \x03(\v2\x1b.walletmanager.v1.RawOutputR\n" +
 	"rawOutputs\x12H\n" +
-	"\x0fexternal_inputs\x18\t \x03(\v2\x1f.walletmanager.v1.ExternalInputR\x0eexternalInputs\x12%\n" +
-	"\x0ereplay_protect\x18\n" +
-	" \x01(\bR\rreplayProtect\x1a?\n" +
+	"\x0fexternal_inputs\x18\t \x03(\v2\x1f.walletmanager.v1.ExternalInputR\x0eexternalInputs\x12!\n" +
+	"\fallow_replay\x18\v \x01(\bR\vallowReplay\x1a?\n" +
 	"\x11DestinationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"5\n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01J\x04\b\n" +
+	"\x10\v\"5\n" +
 	"\x12CreatePsbtResponse\x12\x1f\n" +
 	"\vpsbt_base64\x18\x01 \x01(\tR\n" +
 	"psbtBase64\"O\n" +

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -154,6 +154,10 @@ type Orchestrator struct {
 	// the enforcer wallet's UTXOs (set later, once the enforcer client exists).
 	forkEngine *fork.Engine
 
+	// forkScanner enumerates the wallets and their coins for the fork engine
+	// and for the split engine; wired by InitForkEngine.
+	forkScanner *forkWalletScanner
+
 	// chainTip reads the height from the wallet chain source (esplora or
 	// electrum), so an electrum wallet gets a tip with no local Core.
 	chainTip ChainTipSource

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -656,10 +656,11 @@ message SendTransactionRequest {
   int64 fixed_fee_sats = 6;
   // Explicit wallet inputs to spend.
   repeated UnspentOutput required_inputs = 7;
-  // Build a replay-protected transaction: stamp the magic nLockTime
-  // (499999999) and non-final input sequences so stock Bitcoin Core rejects it
-  // as non-final, while a patched bitcoind confirms it. Core/Electrum only.
-  bool replay_protect = 8;
+  reserved 8;
+  // Send a transaction that can replay onto Bitcoin. The eCash network stamps
+  // the magic nLockTime (499999999) on every send, so stock Bitcoin Core
+  // rejects it; this drops that stamp for one send.
+  bool allow_replay = 12;
   // Outputs with an explicit raw scriptPubKey, kept in order before any
   // address/op_return outputs. Used for non-standard scripts (e.g. a sidechain
   // OP_DRIVECHAIN treasury output).
@@ -702,10 +703,11 @@ message CreatePsbtRequest {
   repeated UnspentOutput required_inputs = 7;
   repeated RawOutput raw_outputs = 8;
   repeated ExternalInput external_inputs = 9;
-  // Stamp the magic nLockTime (499999999) and non-final input sequences before
-  // the PSBT goes out for signatures, so the signed transaction is valid on
-  // eCash only. Electrum wallets only.
-  bool replay_protect = 10;
+  reserved 10;
+  // Build a PSBT that can replay onto Bitcoin. The eCash network stamps the
+  // magic nLockTime (499999999) on every PSBT; this drops that stamp for one
+  // PSBT.
+  bool allow_replay = 11;
 }
 
 message CreatePsbtResponse {

--- a/sidechain-orchestrator/replay/replay.go
+++ b/sidechain-orchestrator/replay/replay.go
@@ -9,7 +9,13 @@
 // both the locktime and the sequences are covered by the signature.
 package replay
 
-import "github.com/btcsuite/btcd/wire"
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/btcsuite/btcd/wire"
+)
 
 // ReplayLockTime is LOCKTIME_THRESHOLD - 1 (500000000 - 1).
 const ReplayLockTime uint32 = 499999999
@@ -27,4 +33,23 @@ func ApplyLockTime(tx *wire.MsgTx) {
 			in.Sequence = nonFinalSequence
 		}
 	}
+}
+
+// ApplyLockTimeHex stamps the replay locktime on an unsigned raw transaction
+// and returns the new hex. Call it before signing.
+func ApplyLockTimeHex(rawHex string) (string, error) {
+	raw, err := hex.DecodeString(rawHex)
+	if err != nil {
+		return "", fmt.Errorf("decode raw transaction: %w", err)
+	}
+	var tx wire.MsgTx
+	if err := tx.Deserialize(bytes.NewReader(raw)); err != nil {
+		return "", fmt.Errorf("deserialize raw transaction: %w", err)
+	}
+	ApplyLockTime(&tx)
+	var buf bytes.Buffer
+	if err := tx.Serialize(&buf); err != nil {
+		return "", fmt.Errorf("serialize raw transaction: %w", err)
+	}
+	return hex.EncodeToString(buf.Bytes()), nil
 }

--- a/sidechain-orchestrator/replay/replay_test.go
+++ b/sidechain-orchestrator/replay/replay_test.go
@@ -1,6 +1,8 @@
 package replay
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -42,5 +44,70 @@ func TestApplyLockTimeLeavesNonFinalInputAlone(t *testing.T) {
 	ApplyLockTime(tx)
 	if tx.TxIn[0].Sequence != rbf {
 		t.Fatalf("non-final sequence changed: got %#x, want %#x", tx.TxIn[0].Sequence, rbf)
+	}
+}
+
+// rawHexOf serializes a tx to hex the way a builder hands it to a signer.
+func rawHexOf(t *testing.T, tx *wire.MsgTx) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := tx.Serialize(&buf); err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	return hex.EncodeToString(buf.Bytes())
+}
+
+func TestApplyLockTimeHexStampsTheRawTransaction(t *testing.T) {
+	in := rawHexOf(t, txWithSequence(wire.MaxTxInSequenceNum))
+
+	out, err := ApplyLockTimeHex(in)
+	if err != nil {
+		t.Fatalf("ApplyLockTimeHex: %v", err)
+	}
+
+	raw, err := hex.DecodeString(out)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var tx wire.MsgTx
+	if err := tx.Deserialize(bytes.NewReader(raw)); err != nil {
+		t.Fatalf("deserialize: %v", err)
+	}
+	if tx.LockTime != ReplayLockTime {
+		t.Fatalf("locktime = %d, want %d", tx.LockTime, ReplayLockTime)
+	}
+	if tx.TxIn[0].Sequence >= wire.MaxTxInSequenceNum {
+		t.Fatal("the input must be non-final, else the locktime does nothing")
+	}
+}
+
+func TestApplyLockTimeHexKeepsTheOutputs(t *testing.T) {
+	src := txWithSequence(wire.MaxTxInSequenceNum)
+	out, err := ApplyLockTimeHex(rawHexOf(t, src))
+	if err != nil {
+		t.Fatalf("ApplyLockTimeHex: %v", err)
+	}
+
+	raw, _ := hex.DecodeString(out)
+	var tx wire.MsgTx
+	if err := tx.Deserialize(bytes.NewReader(raw)); err != nil {
+		t.Fatalf("deserialize: %v", err)
+	}
+	if len(tx.TxOut) != len(src.TxOut) {
+		t.Fatalf("outputs = %d, want %d", len(tx.TxOut), len(src.TxOut))
+	}
+	if tx.TxOut[0].Value != src.TxOut[0].Value {
+		t.Fatalf("value = %d, want %d", tx.TxOut[0].Value, src.TxOut[0].Value)
+	}
+	if tx.TxIn[0].PreviousOutPoint != src.TxIn[0].PreviousOutPoint {
+		t.Fatal("the outpoint must not move: the BIP47 payload blinds against it")
+	}
+}
+
+func TestApplyLockTimeHexRejectsBadInput(t *testing.T) {
+	for _, in := range []string{"zz", "00"} {
+		if _, err := ApplyLockTimeHex(in); err == nil {
+			t.Fatalf("ApplyLockTimeHex(%q) must return an error", in)
+		}
 	}
 }

--- a/sidechain-orchestrator/replay_locktime_integration_test.go
+++ b/sidechain-orchestrator/replay_locktime_integration_test.go
@@ -34,8 +34,8 @@ func TestReplayLockTime(t *testing.T) {
 		t.Skip("set BITCOIND_STOCK and BITCOIND_REPLAY to run")
 	}
 
-	// Stock bitcoind rejects the replay-protected send as non-final, but a
-	// normal send still confirms — proving the wallet and harness work.
+	// Stock bitcoind rejects the replay-protected transaction as non-final, but
+	// a normal send still confirms — proving the wallet and harness work.
 	t.Run("StockRejects", func(t *testing.T) {
 		node := startFundedNode(t, stock)
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -50,28 +50,20 @@ func TestReplayLockTime(t *testing.T) {
 		require.NoError(t, node.Mine(ctx, t, 1))
 		requireConfirmed(ctx, t, node, normal.Msg.Txid)
 
-		_, err = node.WalletClient.SendTransaction(ctx, connect.NewRequest(&pb.SendTransactionRequest{
-			Destinations:  map[string]int64{dest: 100_000_000},
-			ReplayProtect: true,
-		}))
+		_, err = broadcastProtected(ctx, t, node, dest)
 		require.Error(t, err, "stock bitcoind must reject the replay-protected tx")
 		require.Contains(t, strings.ToLower(err.Error()), "non-final")
 	})
 
-	// bitcoind-replay accepts the same replay-protected send and confirms it.
+	// bitcoind-replay accepts the same replay-protected transaction.
 	t.Run("ReplayConfirms", func(t *testing.T) {
 		node := startFundedNode(t, replayBin)
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
 		dest := freshAddress(ctx, t, node)
-
-		resp, err := node.WalletClient.SendTransaction(ctx, connect.NewRequest(&pb.SendTransactionRequest{
-			Destinations:  map[string]int64{dest: 100_000_000},
-			ReplayProtect: true,
-		}))
+		txid, err := broadcastProtected(ctx, t, node, dest)
 		require.NoError(t, err, "bitcoind-replay must accept the replay-protected tx")
-		txid := resp.Msg.Txid
 
 		// The broadcast tx really carries the magic locktime and a non-final
 		// input — without the latter the locktime would be ignored.
@@ -83,6 +75,49 @@ func TestReplayLockTime(t *testing.T) {
 		require.NoError(t, node.Mine(ctx, t, 1))
 		requireConfirmed(ctx, t, node, txid)
 	})
+}
+
+// broadcastProtected builds, signs and broadcasts one transaction that carries
+// the magic nLockTime, straight through Core RPC. The wallet request field only
+// drops the stamp, so the raw path is the one way to force it on regtest.
+func broadcastProtected(ctx context.Context, t *testing.T, n *testharness.Node, dest string) (string, error) {
+	t.Helper()
+	coreWallet := coreWalletName(ctx, t, n)
+
+	outputs := []map[string]any{{dest: 1.0}}
+	rawHex, err := n.CoreRPC.CreateRawTransaction(ctx, []wallet.RawInput{}, outputs, replay.ReplayLockTime)
+	require.NoError(t, err)
+
+	// replaceable lowers every funded input below SEQUENCE_FINAL, else the
+	// locktime has no effect.
+	funded, err := n.CoreRPC.FundRawTransaction(ctx, coreWallet, rawHex, map[string]any{
+		"fee_rate":    2,
+		"replaceable": true,
+	})
+	require.NoError(t, err)
+
+	signed, err := n.CoreRPC.SignRawTransactionWithWallet(ctx, coreWallet, funded.Hex)
+	require.NoError(t, err)
+	require.True(t, signed.Complete, "the core wallet must sign every input")
+
+	return n.CoreRPC.SendRawTransaction(ctx, signed.Hex)
+}
+
+// coreWalletName finds the loaded Core wallet that holds coins. The harness
+// also loads an unfunded enforcer wallet.
+func coreWalletName(ctx context.Context, t *testing.T, n *testharness.Node) string {
+	t.Helper()
+	loaded, err := n.CoreRPC.ListWallets(ctx)
+	require.NoError(t, err)
+	for _, name := range loaded {
+		utxos, err := n.CoreRPC.ListUnspent(ctx, name)
+		require.NoError(t, err)
+		if len(utxos) > 0 {
+			return name
+		}
+	}
+	t.Fatalf("no loaded core wallet holds coins: %v", loaded)
+	return ""
 }
 
 // startFundedNode brings up a one-node harness against a specific bitcoind and

--- a/sidechain-orchestrator/wallet/backend_types.go
+++ b/sidechain-orchestrator/wallet/backend_types.go
@@ -14,9 +14,12 @@ type UTXO struct {
 	Label         string  `json:"label"`
 	Amount        float64 `json:"amount"`
 	Confirmations int     `json:"confirmations"`
-	Spendable     bool    `json:"spendable"`
-	Solvable      bool    `json:"solvable"`
-	ReceivedAt    int64   `json:"-"`
+	// BlockHeight is the absolute confirmation height. 0 when the coin is
+	// unconfirmed, or when the backend counts confirmations only.
+	BlockHeight int   `json:"-"`
+	Spendable   bool  `json:"spendable"`
+	Solvable    bool  `json:"solvable"`
+	ReceivedAt  int64 `json:"-"`
 	// HDPath is the BIP32 path of the owning address. Not unmarshalled: Core's
 	// listunspent doesn't supply it.
 	HDPath string `json:"-"`

--- a/sidechain-orchestrator/wallet/backend_types.go
+++ b/sidechain-orchestrator/wallet/backend_types.go
@@ -153,7 +153,7 @@ type SignRawTransactionResult struct {
 
 // SendRequest is everything a backend needs to pay destinations: amounts,
 // fee control (rate or fixed), an optional OP_RETURN payload, pinned inputs,
-// and replay protection. Backends reject fields they cannot honor.
+// and replay control. Backends reject fields they cannot honor.
 type SendRequest struct {
 	DestinationsSats      map[string]int64
 	FeeRateSatPerVB       int64 // 0 = backend's own fee estimation
@@ -161,7 +161,9 @@ type SendRequest struct {
 	OpReturnHex           string
 	RequiredInputs        []RequiredInput
 	SubtractFeeFromAmount bool
-	ReplayProtect         bool
+	// AllowReplay drops the eCash network's magic nLockTime for one send, so
+	// the transaction lands on Bitcoin too.
+	AllowReplay bool
 	// Replaceable signals BIP125, so a later transaction spending the same
 	// inputs can replace this one.
 	Replaceable bool

--- a/sidechain-orchestrator/wallet/bip47send/bip47send_test.go
+++ b/sidechain-orchestrator/wallet/bip47send/bip47send_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/replay"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47"
 )
 
@@ -228,4 +229,58 @@ func TestNetworkParams(t *testing.T) {
 
 	_, err = NetworkParams("testnet")
 	assert.Error(t, err)
+}
+
+// TestNotificationTxSurvivesTheReplayLockTime proves the replay locktime is
+// safe to stamp on a notification tx: the blinded payload commits to the
+// designated outpoint, not to the locktime or the sequence, so the recipient
+// still recovers the sender's payment code.
+func TestNotificationTxSurvivesTheReplayLockTime(t *testing.T) {
+	recipient, err := bip47.ParsePaymentCode(bobPM)
+	require.NoError(t, err)
+
+	outp := wireOutpointFromHex(t, designatedOutpointHex)
+	var rpcTxIDBytes [32]byte
+	for i := 0; i < 32; i++ {
+		rpcTxIDBytes[i] = outp.Hash[31-i]
+	}
+	desig := DesignatedInput{
+		TxID:       hex.EncodeToString(rpcTxIDBytes[:]),
+		Vout:       outp.Index,
+		AmountSats: 100_000,
+	}
+	notifAddr, err := bip47.DeriveNotificationAddress(recipient, &chaincfg.MainNetParams)
+	require.NoError(t, err)
+
+	rawHex, _, err := BuildNotificationTx(
+		aliceSeedHex, recipient, desig, designatedPriv(t),
+		notifAddr, notifAddr, 546, 1000, &chaincfg.MainNetParams,
+	)
+	require.NoError(t, err)
+
+	protectedHex, err := replay.ApplyLockTimeHex(rawHex)
+	require.NoError(t, err)
+
+	rawBytes, err := hex.DecodeString(protectedHex)
+	require.NoError(t, err)
+	var msgTx wire.MsgTx
+	require.NoError(t, msgTx.Deserialize(strings.NewReader(string(rawBytes))))
+
+	assert.EqualValues(t, replay.ReplayLockTime, msgTx.LockTime)
+	require.Len(t, msgTx.TxIn, 1)
+	assert.Less(t, msgTx.TxIn[0].Sequence, uint32(wire.MaxTxInSequenceNum),
+		"the input must be non-final, else the locktime does nothing")
+	assert.Equal(t, outp, msgTx.TxIn[0].PreviousOutPoint,
+		"the payload blinds against this outpoint, so it must not move")
+
+	var opReturnPayload []byte
+	for _, out := range msgTx.TxOut {
+		if len(out.PkScript) == 83 && out.PkScript[0] == 0x6a && out.PkScript[1] == 0x4c {
+			opReturnPayload = out.PkScript[3:]
+			break
+		}
+	}
+	require.NotNil(t, opReturnPayload, "no OP_RETURN with an 80-byte payload found")
+	assert.Equal(t, aliceBlindedPayload, hex.EncodeToString(opReturnPayload),
+		"the replay locktime must not change the blinded payload")
 }

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -440,6 +440,7 @@ func (p *CoreBackend) Send(ctx context.Context, walletID string, req SendRequest
 	if err != nil {
 		return "", err
 	}
+	protect := ReplayProtect(p.svc.Network(), req.AllowReplay)
 
 	needsRawPath := req.OpReturnHex != "" ||
 		req.FeeRateSatPerVB > 0 ||
@@ -447,7 +448,7 @@ func (p *CoreBackend) Send(ctx context.Context, walletID string, req SendRequest
 		len(req.RequiredInputs) > 0 ||
 		len(req.RawOutputs) > 0 ||
 		len(req.ExternalInputs) > 0 ||
-		req.ReplayProtect // custom serialization needs the raw-tx path
+		protect // custom serialization needs the raw-tx path
 
 	// External inputs carry no signature, so Core cannot size the fee for them.
 	if len(req.ExternalInputs) > 0 && req.FixedFeeSats <= 0 {
@@ -469,7 +470,7 @@ func (p *CoreBackend) Send(ctx context.Context, walletID string, req SendRequest
 	// Replay protection stamps a magic locktime; Core lowers the inputs it is
 	// given below SEQUENCE_FINAL so the locktime takes effect.
 	locktime := uint32(0)
-	if req.ReplayProtect {
+	if protect {
 		locktime = replay.ReplayLockTime
 	}
 
@@ -549,7 +550,7 @@ func (p *CoreBackend) Send(ctx context.Context, walletID string, req SendRequest
 	if req.SubtractFeeFromAmount && len(req.DestinationsSats) > 0 {
 		options["subtractFeeFromOutputs"] = lo.Range(len(req.DestinationsSats))
 	}
-	if req.ReplayProtect || req.Replaceable {
+	if protect || req.Replaceable {
 		// Inputs Core selects during funding must also be non-final, else the
 		// locktime is ignored and there is no replay protection.
 		options["replaceable"] = true

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -550,6 +550,7 @@ func TestCoreBackendSendFixedFeeResolvesSpentRequiredInput(t *testing.T) {
 
 func TestCoreBackendSendReplayProtect(t *testing.T) {
 	backend, fake, coreID := newCoreBackendFixture(t)
+	backend.svc.SetNetwork("ecash")
 	fake.stubEnsureFlow()
 
 	net := &chaincfg.RegressionNetParams
@@ -577,7 +578,6 @@ func TestCoreBackendSendReplayProtect(t *testing.T) {
 	_, err := backend.Send(context.Background(), coreID, SendRequest{
 		DestinationsSats: map[string]int64{dest: 50_000},
 		FixedFeeSats:     1_000,
-		ReplayProtect:    true,
 	})
 	require.NoError(t, err)
 

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -279,6 +279,7 @@ func (p *ElectrumBackend) ListUnspent(ctx context.Context, walletID string) ([]U
 				Address:       a.address,
 				Amount:        float64(u.Value) / 1e8,
 				Confirmations: confsFor(u.Status, tip),
+				BlockHeight:   heightFor(u.Status),
 				// Watch-only wallets hold no keys, so their coins are solvable
 				// (we know the script) but not spendable.
 				Spendable:  !scan.watchOnly,
@@ -2404,6 +2405,13 @@ func esploraTxToRaw(tx EsploraTx, rawHex string, tip int) *RawTransaction {
 		})
 	}
 	return raw
+}
+
+func heightFor(status EsploraStatus) int {
+	if !status.Confirmed {
+		return 0
+	}
+	return status.BlockHeight
 }
 
 func confsFor(status EsploraStatus, tip int) int {

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -600,7 +600,7 @@ func (p *ElectrumBackend) Send(ctx context.Context, walletID string, req SendReq
 	if err != nil {
 		return "", err
 	}
-	return p.signAndBroadcast(ctx, walletID, packet, psbtInputs, effect, req.ReplayProtect)
+	return p.signAndBroadcast(ctx, walletID, packet, psbtInputs, effect, ReplayProtect(p.svc.Network(), req.AllowReplay))
 }
 
 // signAndBroadcast signs the wallet's inputs in packet, finalizes, broadcasts,
@@ -989,7 +989,7 @@ func (p *ElectrumBackend) CreatePSBT(ctx context.Context, walletID string, req S
 	if err != nil {
 		return "", err
 	}
-	if req.ReplayProtect {
+	if ReplayProtect(p.svc.Network(), req.AllowReplay) {
 		replay.ApplyLockTime(packet.UnsignedTx)
 	}
 	return packet.B64Encode()

--- a/sidechain-orchestrator/wallet/electrum_backend_height_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_height_test.go
@@ -1,0 +1,15 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeightForReadsAConfirmedStatus(t *testing.T) {
+	require.Equal(t, 963_000, heightFor(EsploraStatus{Confirmed: true, BlockHeight: 963_000}))
+}
+
+func TestHeightForIgnoresAnUnconfirmedStatus(t *testing.T) {
+	require.Equal(t, 0, heightFor(EsploraStatus{BlockHeight: 963_000}))
+}

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -235,6 +235,7 @@ func TestElectrumSendBuildsSignsBroadcasts(t *testing.T) {
 // That only holds if the locktime/sequence are applied BEFORE signing.
 func TestElectrumSendReplayProtect(t *testing.T) {
 	p, fake, w, addr := newElectrumFixture(t)
+	p.svc.SetNetwork("ecash")
 	net := &chaincfg.SigNetParams
 	ctx := context.Background()
 
@@ -253,7 +254,6 @@ func TestElectrumSendReplayProtect(t *testing.T) {
 	_, err := p.Send(ctx, w.ID, SendRequest{
 		DestinationsSats: map[string]int64{dest: 50_000},
 		FeeRateSatPerVB:  2,
-		ReplayProtect:    true,
 	})
 	require.NoError(t, err)
 	require.Len(t, fake.broadcast, 1)
@@ -285,6 +285,73 @@ func TestElectrumSendReplayProtect(t *testing.T) {
 		txscript.StandardVerifyFlags|txscript.ScriptVerifyTaproot, nil, sigHashes, utxoValue, prevOuts)
 	require.NoError(t, err)
 	require.NoError(t, vm.Execute(), "replay-protected tx signature must validate")
+}
+
+// TestElectrumSendAllowReplay proves one send can drop the eCash locktime, so
+// the user who picks an unprotected send gets a transaction Bitcoin accepts.
+func TestElectrumSendAllowReplay(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	p.svc.SetNetwork("ecash")
+	ctx := context.Background()
+
+	const utxoValue = 200_000
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: utxoValue, TxCount: 1},
+	}
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID: "1111111111111111111111111111111111111111111111111111111111111111",
+		Vout: 0, Value: utxoValue,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}
+
+	dest := "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+	_, err := p.Send(ctx, w.ID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FeeRateSatPerVB:  2,
+		AllowReplay:      true,
+	})
+	require.NoError(t, err)
+	require.Len(t, fake.broadcast, 1)
+
+	var tx wire.MsgTx
+	raw, err := hex.DecodeString(fake.broadcast[0])
+	require.NoError(t, err)
+	require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+	assert.EqualValues(t, 0, tx.LockTime)
+}
+
+// TestElectrumSendOutsideEcashCarriesNoLockTime proves another network never
+// gets the magic locktime, because only a patched node reads it as final.
+func TestElectrumSendOutsideEcashCarriesNoLockTime(t *testing.T) {
+	p, fake, w, addr := newElectrumFixture(t)
+	p.svc.SetNetwork("signet")
+	ctx := context.Background()
+
+	const utxoValue = 200_000
+	fake.stats[addr] = EsploraAddressStats{
+		Address:    addr,
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: utxoValue, TxCount: 1},
+	}
+	fake.utxos[addr] = []EsploraUTXO{{
+		TxID: "1111111111111111111111111111111111111111111111111111111111111111",
+		Vout: 0, Value: utxoValue,
+		Status: EsploraStatus{Confirmed: true, BlockHeight: 100},
+	}}
+
+	dest := "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+	_, err := p.Send(ctx, w.ID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 50_000},
+		FeeRateSatPerVB:  2,
+	})
+	require.NoError(t, err)
+	require.Len(t, fake.broadcast, 1)
+
+	var tx wire.MsgTx
+	raw, err := hex.DecodeString(fake.broadcast[0])
+	require.NoError(t, err)
+	require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+	assert.EqualValues(t, 0, tx.LockTime)
 }
 
 // TestElectrumSendSidechainDeposit drives the full BIP300 M5 deposit through the
@@ -2092,6 +2159,7 @@ func TestElectrumTaprootReceivePathUsesBIP86(t *testing.T) {
 // them and the finalized transaction still holds them.
 func TestElectrumCreatePSBTReplayProtect(t *testing.T) {
 	p, fake, w, addr := newElectrumFixture(t)
+	p.svc.SetNetwork("ecash")
 	ctx := context.Background()
 
 	fake.stats[addr] = EsploraAddressStats{
@@ -2107,7 +2175,6 @@ func TestElectrumCreatePSBTReplayProtect(t *testing.T) {
 	req := SendRequest{
 		DestinationsSats: map[string]int64{"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx": 50_000},
 		FeeRateSatPerVB:  2,
-		ReplayProtect:    true,
 	}
 
 	unsigned, err := p.CreatePSBT(ctx, w.ID, req)

--- a/sidechain-orchestrator/wallet/replay_protect.go
+++ b/sidechain-orchestrator/wallet/replay_protect.go
@@ -1,0 +1,10 @@
+package wallet
+
+import "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+
+// ReplayProtect reports whether a send gets the magic nLockTime. Only a patched
+// eCash node reads that locktime as final, so no other network stamps it. A
+// caller that wants the transaction on both chains sets allowReplay.
+func ReplayProtect(network string, allowReplay bool) bool {
+	return config.NetworkFromString(network) == config.NetworkECash && !allowReplay
+}

--- a/sidechain-orchestrator/wallet/replay_protect_test.go
+++ b/sidechain-orchestrator/wallet/replay_protect_test.go
@@ -1,0 +1,28 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplayProtect(t *testing.T) {
+	cases := []struct {
+		network     string
+		allowReplay bool
+		want        bool
+	}{
+		{network: "ecash", want: true},
+		{network: "ecash", allowReplay: true},
+		{network: "mainnet"},
+		{network: "forknet"},
+		{network: "signet"},
+		{network: "regtest"},
+		{network: ""},
+	}
+	for _, c := range cases {
+		t.Run(c.network, func(t *testing.T) {
+			require.Equal(t, c.want, ReplayProtect(c.network, c.allowReplay))
+		})
+	}
+}

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -5024,10 +5024,10 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
     $core.String? opReturnHex,
     $fixnum.Int64? fixedFeeSats,
     $core.Iterable<UnspentOutput>? requiredInputs,
-    $core.bool? replayProtect,
     $core.Iterable<RawOutput>? rawOutputs,
     $core.Iterable<ExternalInput>? externalInputs,
     $core.bool? replaceable,
+    $core.bool? allowReplay,
   }) {
     final $result = create();
     if (walletId != null) {
@@ -5051,9 +5051,6 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
     if (requiredInputs != null) {
       $result.requiredInputs.addAll(requiredInputs);
     }
-    if (replayProtect != null) {
-      $result.replayProtect = replayProtect;
-    }
     if (rawOutputs != null) {
       $result.rawOutputs.addAll(rawOutputs);
     }
@@ -5062,6 +5059,9 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
     }
     if (replaceable != null) {
       $result.replaceable = replaceable;
+    }
+    if (allowReplay != null) {
+      $result.allowReplay = allowReplay;
     }
     return $result;
   }
@@ -5077,10 +5077,10 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
     ..aOS(5, _omitFieldNames ? '' : 'opReturnHex')
     ..aInt64(6, _omitFieldNames ? '' : 'fixedFeeSats')
     ..pc<UnspentOutput>(7, _omitFieldNames ? '' : 'requiredInputs', $pb.PbFieldType.PM, subBuilder: UnspentOutput.create)
-    ..aOB(8, _omitFieldNames ? '' : 'replayProtect')
     ..pc<RawOutput>(9, _omitFieldNames ? '' : 'rawOutputs', $pb.PbFieldType.PM, subBuilder: RawOutput.create)
     ..pc<ExternalInput>(10, _omitFieldNames ? '' : 'externalInputs', $pb.PbFieldType.PM, subBuilder: ExternalInput.create)
     ..aOB(11, _omitFieldNames ? '' : 'replaceable')
+    ..aOB(12, _omitFieldNames ? '' : 'allowReplay')
     ..hasRequiredFields = false
   ;
 
@@ -5159,40 +5159,40 @@ class SendTransactionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.List<UnspentOutput> get requiredInputs => $_getList(6);
 
-  /// Build a replay-protected transaction: stamp the magic nLockTime
-  /// (499999999) and non-final input sequences so stock Bitcoin Core rejects it
-  /// as non-final, while a patched bitcoind confirms it. Core/Electrum only.
-  @$pb.TagNumber(8)
-  $core.bool get replayProtect => $_getBF(7);
-  @$pb.TagNumber(8)
-  set replayProtect($core.bool v) { $_setBool(7, v); }
-  @$pb.TagNumber(8)
-  $core.bool hasReplayProtect() => $_has(7);
-  @$pb.TagNumber(8)
-  void clearReplayProtect() => clearField(8);
-
   /// Outputs with an explicit raw scriptPubKey, kept in order before any
   /// address/op_return outputs. Used for non-standard scripts (e.g. a sidechain
   /// OP_DRIVECHAIN treasury output).
   @$pb.TagNumber(9)
-  $core.List<RawOutput> get rawOutputs => $_getList(8);
+  $core.List<RawOutput> get rawOutputs => $_getList(7);
 
   /// Inputs not owned by the wallet that must be spent as-is, in order, before
   /// wallet-funded inputs. Used for anyone-can-spend scripts (e.g. a sidechain
   /// CTIP). They are added with an empty scriptSig and not signed.
   @$pb.TagNumber(10)
-  $core.List<ExternalInput> get externalInputs => $_getList(9);
+  $core.List<ExternalInput> get externalInputs => $_getList(8);
 
   /// Signal BIP125, so a later transaction spending the same inputs replaces
   /// this one. Used to raise a BMM bid.
   @$pb.TagNumber(11)
-  $core.bool get replaceable => $_getBF(10);
+  $core.bool get replaceable => $_getBF(9);
   @$pb.TagNumber(11)
-  set replaceable($core.bool v) { $_setBool(10, v); }
+  set replaceable($core.bool v) { $_setBool(9, v); }
   @$pb.TagNumber(11)
-  $core.bool hasReplaceable() => $_has(10);
+  $core.bool hasReplaceable() => $_has(9);
   @$pb.TagNumber(11)
   void clearReplaceable() => clearField(11);
+
+  /// Send a transaction that can replay onto Bitcoin. The eCash network stamps
+  /// the magic nLockTime (499999999) on every send, so stock Bitcoin Core
+  /// rejects it; this drops that stamp for one send.
+  @$pb.TagNumber(12)
+  $core.bool get allowReplay => $_getBF(10);
+  @$pb.TagNumber(12)
+  set allowReplay($core.bool v) { $_setBool(10, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasAllowReplay() => $_has(10);
+  @$pb.TagNumber(12)
+  void clearAllowReplay() => clearField(12);
 }
 
 class SendTransactionResponse extends $pb.GeneratedMessage {
@@ -5415,7 +5415,7 @@ class CreatePsbtRequest extends $pb.GeneratedMessage {
     $core.Iterable<UnspentOutput>? requiredInputs,
     $core.Iterable<RawOutput>? rawOutputs,
     $core.Iterable<ExternalInput>? externalInputs,
-    $core.bool? replayProtect,
+    $core.bool? allowReplay,
   }) {
     final $result = create();
     if (walletId != null) {
@@ -5445,8 +5445,8 @@ class CreatePsbtRequest extends $pb.GeneratedMessage {
     if (externalInputs != null) {
       $result.externalInputs.addAll(externalInputs);
     }
-    if (replayProtect != null) {
-      $result.replayProtect = replayProtect;
+    if (allowReplay != null) {
+      $result.allowReplay = allowReplay;
     }
     return $result;
   }
@@ -5464,7 +5464,7 @@ class CreatePsbtRequest extends $pb.GeneratedMessage {
     ..pc<UnspentOutput>(7, _omitFieldNames ? '' : 'requiredInputs', $pb.PbFieldType.PM, subBuilder: UnspentOutput.create)
     ..pc<RawOutput>(8, _omitFieldNames ? '' : 'rawOutputs', $pb.PbFieldType.PM, subBuilder: RawOutput.create)
     ..pc<ExternalInput>(9, _omitFieldNames ? '' : 'externalInputs', $pb.PbFieldType.PM, subBuilder: ExternalInput.create)
-    ..aOB(10, _omitFieldNames ? '' : 'replayProtect')
+    ..aOB(11, _omitFieldNames ? '' : 'allowReplay')
     ..hasRequiredFields = false
   ;
 
@@ -5546,17 +5546,17 @@ class CreatePsbtRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.List<ExternalInput> get externalInputs => $_getList(8);
 
-  /// Stamp the magic nLockTime (499999999) and non-final input sequences before
-  /// the PSBT goes out for signatures, so the signed transaction is valid on
-  /// eCash only. Electrum wallets only.
-  @$pb.TagNumber(10)
-  $core.bool get replayProtect => $_getBF(9);
-  @$pb.TagNumber(10)
-  set replayProtect($core.bool v) { $_setBool(9, v); }
-  @$pb.TagNumber(10)
-  $core.bool hasReplayProtect() => $_has(9);
-  @$pb.TagNumber(10)
-  void clearReplayProtect() => clearField(10);
+  /// Build a PSBT that can replay onto Bitcoin. The eCash network stamps the
+  /// magic nLockTime (499999999) on every PSBT; this drops that stamp for one
+  /// PSBT.
+  @$pb.TagNumber(11)
+  $core.bool get allowReplay => $_getBF(9);
+  @$pb.TagNumber(11)
+  set allowReplay($core.bool v) { $_setBool(9, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasAllowReplay() => $_has(9);
+  @$pb.TagNumber(11)
+  void clearAllowReplay() => clearField(11);
 }
 
 class CreatePsbtResponse extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -1181,12 +1181,15 @@ const SendTransactionRequest$json = {
     {'1': 'op_return_hex', '3': 5, '4': 1, '5': 9, '10': 'opReturnHex'},
     {'1': 'fixed_fee_sats', '3': 6, '4': 1, '5': 3, '10': 'fixedFeeSats'},
     {'1': 'required_inputs', '3': 7, '4': 3, '5': 11, '6': '.walletmanager.v1.UnspentOutput', '10': 'requiredInputs'},
-    {'1': 'replay_protect', '3': 8, '4': 1, '5': 8, '10': 'replayProtect'},
+    {'1': 'allow_replay', '3': 12, '4': 1, '5': 8, '10': 'allowReplay'},
     {'1': 'raw_outputs', '3': 9, '4': 3, '5': 11, '6': '.walletmanager.v1.RawOutput', '10': 'rawOutputs'},
     {'1': 'external_inputs', '3': 10, '4': 3, '5': 11, '6': '.walletmanager.v1.ExternalInput', '10': 'externalInputs'},
     {'1': 'replaceable', '3': 11, '4': 1, '5': 8, '10': 'replaceable'},
   ],
   '3': [SendTransactionRequest_DestinationsEntry$json],
+  '9': [
+    {'1': 8, '2': 9},
+  ],
 };
 
 @$core.Deprecated('Use sendTransactionRequestDescriptor instead')
@@ -1208,12 +1211,12 @@ final $typed_data.Uint8List sendTransactionRequestDescriptor = $convert.base64De
     'X2Ftb3VudBgEIAEoCFIVc3VidHJhY3RGZWVGcm9tQW1vdW50EiIKDW9wX3JldHVybl9oZXgYBS'
     'ABKAlSC29wUmV0dXJuSGV4EiQKDmZpeGVkX2ZlZV9zYXRzGAYgASgDUgxmaXhlZEZlZVNhdHMS'
     'SAoPcmVxdWlyZWRfaW5wdXRzGAcgAygLMh8ud2FsbGV0bWFuYWdlci52MS5VbnNwZW50T3V0cH'
-    'V0Ug5yZXF1aXJlZElucHV0cxIlCg5yZXBsYXlfcHJvdGVjdBgIIAEoCFINcmVwbGF5UHJvdGVj'
-    'dBI8CgtyYXdfb3V0cHV0cxgJIAMoCzIbLndhbGxldG1hbmFnZXIudjEuUmF3T3V0cHV0UgpyYX'
-    'dPdXRwdXRzEkgKD2V4dGVybmFsX2lucHV0cxgKIAMoCzIfLndhbGxldG1hbmFnZXIudjEuRXh0'
-    'ZXJuYWxJbnB1dFIOZXh0ZXJuYWxJbnB1dHMSIAoLcmVwbGFjZWFibGUYCyABKAhSC3JlcGxhY2'
-    'VhYmxlGj8KEURlc3RpbmF0aW9uc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIg'
-    'ASgDUgV2YWx1ZToCOAE=');
+    'V0Ug5yZXF1aXJlZElucHV0cxIhCgxhbGxvd19yZXBsYXkYDCABKAhSC2FsbG93UmVwbGF5EjwK'
+    'C3Jhd19vdXRwdXRzGAkgAygLMhsud2FsbGV0bWFuYWdlci52MS5SYXdPdXRwdXRSCnJhd091dH'
+    'B1dHMSSAoPZXh0ZXJuYWxfaW5wdXRzGAogAygLMh8ud2FsbGV0bWFuYWdlci52MS5FeHRlcm5h'
+    'bElucHV0Ug5leHRlcm5hbElucHV0cxIgCgtyZXBsYWNlYWJsZRgLIAEoCFILcmVwbGFjZWFibG'
+    'UaPwoRRGVzdGluYXRpb25zRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKANS'
+    'BXZhbHVlOgI4AUoECAgQCQ==');
 
 @$core.Deprecated('Use sendTransactionResponseDescriptor instead')
 const SendTransactionResponse$json = {
@@ -1271,9 +1274,12 @@ const CreatePsbtRequest$json = {
     {'1': 'required_inputs', '3': 7, '4': 3, '5': 11, '6': '.walletmanager.v1.UnspentOutput', '10': 'requiredInputs'},
     {'1': 'raw_outputs', '3': 8, '4': 3, '5': 11, '6': '.walletmanager.v1.RawOutput', '10': 'rawOutputs'},
     {'1': 'external_inputs', '3': 9, '4': 3, '5': 11, '6': '.walletmanager.v1.ExternalInput', '10': 'externalInputs'},
-    {'1': 'replay_protect', '3': 10, '4': 1, '5': 8, '10': 'replayProtect'},
+    {'1': 'allow_replay', '3': 11, '4': 1, '5': 8, '10': 'allowReplay'},
   ],
   '3': [CreatePsbtRequest_DestinationsEntry$json],
+  '9': [
+    {'1': 10, '2': 11},
+  ],
 };
 
 @$core.Deprecated('Use createPsbtRequestDescriptor instead')
@@ -1297,9 +1303,9 @@ final $typed_data.Uint8List createPsbtRequestDescriptor = $convert.base64Decode(
     'ZF9pbnB1dHMYByADKAsyHy53YWxsZXRtYW5hZ2VyLnYxLlVuc3BlbnRPdXRwdXRSDnJlcXVpcm'
     'VkSW5wdXRzEjwKC3Jhd19vdXRwdXRzGAggAygLMhsud2FsbGV0bWFuYWdlci52MS5SYXdPdXRw'
     'dXRSCnJhd091dHB1dHMSSAoPZXh0ZXJuYWxfaW5wdXRzGAkgAygLMh8ud2FsbGV0bWFuYWdlci'
-    '52MS5FeHRlcm5hbElucHV0Ug5leHRlcm5hbElucHV0cxIlCg5yZXBsYXlfcHJvdGVjdBgKIAEo'
-    'CFINcmVwbGF5UHJvdGVjdBo/ChFEZXN0aW5hdGlvbnNFbnRyeRIQCgNrZXkYASABKAlSA2tleR'
-    'IUCgV2YWx1ZRgCIAEoA1IFdmFsdWU6AjgB');
+    '52MS5FeHRlcm5hbElucHV0Ug5leHRlcm5hbElucHV0cxIhCgxhbGxvd19yZXBsYXkYCyABKAhS'
+    'C2FsbG93UmVwbGF5Gj8KEURlc3RpbmF0aW9uc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBX'
+    'ZhbHVlGAIgASgDUgV2YWx1ZToCOAFKBAgKEAs=');
 
 @$core.Deprecated('Use createPsbtResponseDescriptor instead')
 const CreatePsbtResponse$json = {

--- a/sidechain_core/lib/rpcs/orchestrator_wallet_rpc.dart
+++ b/sidechain_core/lib/rpcs/orchestrator_wallet_rpc.dart
@@ -276,7 +276,7 @@ class OrchestratorWalletRPC {
     String? opReturnMessage,
     String? opReturnHex,
     List<bwpb.UnspentOutput>? requiredInputs,
-    bool replayProtect = false,
+    bool allowReplay = false,
   }) {
     final resolvedOpReturnHex =
         opReturnHex ?? (opReturnMessage == null ? null : _bytesToHex(utf8.encode(opReturnMessage)));
@@ -292,7 +292,7 @@ class OrchestratorWalletRPC {
         opReturnHex: resolvedOpReturnHex ?? '',
         fixedFeeSats: Int64(fixedFeeSats ?? 0),
         requiredInputs: requiredInputs?.map(_mapRequiredInput).toList() ?? [],
-        replayProtect: replayProtect,
+        allowReplay: allowReplay,
       ),
     );
   }
@@ -308,7 +308,7 @@ class OrchestratorWalletRPC {
     String? opReturnMessage,
     String? opReturnHex,
     List<bwpb.UnspentOutput>? requiredInputs,
-    bool replayProtect = false,
+    bool allowReplay = false,
   }) async {
     final resolvedOpReturnHex =
         opReturnHex ?? (opReturnMessage == null ? null : _bytesToHex(utf8.encode(opReturnMessage)));
@@ -324,7 +324,7 @@ class OrchestratorWalletRPC {
         opReturnHex: resolvedOpReturnHex ?? '',
         fixedFeeSats: Int64(fixedFeeSats ?? 0),
         requiredInputs: requiredInputs?.map(_mapRequiredInput).toList() ?? [],
-        replayProtect: replayProtect,
+        allowReplay: allowReplay,
       ),
     );
     return response.psbtBase64;


### PR DESCRIPTION
The claim scan waited for the local node to reach the fork height, so a node in initial block download showed no claim card and no countdown. The chain height decides now, and an electrum wallet reports the coin height itself instead of counting confirmations against the local tip.

Replay protection was opt-in per call site, so five send paths went out with no locktime and replayed onto Bitcoin. The orchestrator stamps the locktime for every eCash send now, and only the send flow can drop it. The split check also asks Bitcoin about every coin the wallet holds, not only pre-fork claim coins, so a replayed coin someone sends you is found too.

The claim card takes a close button, and the replay dialog hugs its content instead of filling the screen.