### PR TITLE
Merge the three logs into one file

### DIFF
--- a/bitassets/lib/main.dart
+++ b/bitassets/lib/main.dart
@@ -284,16 +284,7 @@ bool isCurrentChainActive({
 }
 
 Future<File> getLogFile(Directory datadir) async {
-  try {
-    await datadir.create(recursive: true);
-  } catch (error) {
-    debugPrint('Failed to create datadir: $error');
-  }
-
-  final path = [datadir.path, 'debug.log'].join(Platform.pathSeparator);
-  final logFile = File(path);
-
-  return logFile;
+  return prepareLogFile(datadir, 'debug.log');
 }
 
 void _installSignalShutdownHandlers(Logger log) {

--- a/bitassets/lib/pages/tabs/home_page.dart
+++ b/bitassets/lib/pages/tabs/home_page.dart
@@ -288,6 +288,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
           await windowProvider.open(SubWindowTypes.logs);
         },
       ),
+      CommandItem(
+        label: openLogsLabel(),
+        category: 'This Node',
+        onSelected: openLogs,
+      ),
 
       // App menu
       CommandItem(
@@ -392,6 +397,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
                             }
                           : null,
                     ),
+                    openLogsMenuItem(),
                   ],
                 ),
               ],

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.308
+version: 1.0.309
 
 environment:
   sdk: 3.12.2

--- a/bitnames/lib/main.dart
+++ b/bitnames/lib/main.dart
@@ -266,16 +266,7 @@ bool isCurrentChainActive({
 }
 
 Future<File> getLogFile(Directory datadir) async {
-  try {
-    await datadir.create(recursive: true);
-  } catch (error) {
-    debugPrint('Failed to create datadir: $error');
-  }
-
-  final path = [datadir.path, 'debug.log'].join(Platform.pathSeparator);
-  final logFile = File(path);
-
-  return logFile;
+  return prepareLogFile(datadir, 'debug.log');
 }
 
 void _installSignalShutdownHandlers(Logger log) {

--- a/bitnames/lib/pages/tabs/home_page.dart
+++ b/bitnames/lib/pages/tabs/home_page.dart
@@ -243,6 +243,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
           await windowProvider.open(SubWindowTypes.logs);
         },
       ),
+      CommandItem(
+        label: openLogsLabel(),
+        category: 'This Node',
+        onSelected: openLogs,
+      ),
 
       // App menu
       CommandItem(
@@ -347,6 +352,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
                             }
                           : null,
                     ),
+                    openLogsMenuItem(),
                   ],
                 ),
               ],

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.308
+version: 1.0.309
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/e2e/helpers_test.go
+++ b/bitwindow/e2e/helpers_test.go
@@ -358,8 +358,8 @@ func (h *runHandle) dumpDiagnostics(t *testing.T) {
 	// startOrchestratord's --logfile). Without it, boot-time failures like the
 	// auth cookie never appearing / RPC not responsive are invisible —
 	// bitwindowd's log only shows the client side.
-	if data, err := os.ReadFile(filepath.Join(h.dataDir, "orchestratord.log")); err == nil {
-		write("orchestratord.log", string(data))
+	if data, err := os.ReadFile(filepath.Join(h.dataDir, "bitwindow.log")); err == nil {
+		write("bitwindow.log", string(data))
 	}
 }
 

--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -480,12 +480,7 @@ void ignoreOverflowErrors(
 
 Future<File> getLogFile() async {
   final datadir = await Environment.datadir();
-  await datadir.create(recursive: true);
-
-  final path = [datadir.path, 'debug.log'].join(Platform.pathSeparator);
-  final logFile = File(path);
-
-  return logFile;
+  return prepareLogFile(datadir, sharedLogFileName);
 }
 
 class BitwindowApp extends StatefulWidget {

--- a/bitwindow/lib/pages/root_page.dart
+++ b/bitwindow/lib/pages/root_page.dart
@@ -327,6 +327,11 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
         category: 'This Node',
         onSelected: () => GetIt.I.get<WindowProvider>().open(SubWindowTypes.logs),
       ),
+      CommandItem(
+        label: openLogsLabel(),
+        category: 'This Node',
+        onSelected: openLogs,
+      ),
 
       // Help
       CommandItem(
@@ -898,6 +903,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
                             }
                           : null,
                     ),
+                    openLogsMenuItem(),
                   ],
                 ),
               ],

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.176
+version: 0.2.177
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/server/api/bitwindowd/bitwindowd.go
+++ b/bitwindow/server/api/bitwindowd/bitwindowd.go
@@ -1239,7 +1239,7 @@ func (s *Server) StartMining(ctx context.Context, req *connect.Request[emptypb.E
 func (s *Server) minerLogger(ctx context.Context) (*zerolog.Logger, func()) {
 	serverLog := zerolog.Ctx(ctx)
 
-	path := filepath.Join(filepath.Dir(s.config.LogPath), "miner.log")
+	path := filepath.Join(s.config.Datadir, "miner.log")
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		serverLog.Warn().Err(err).Str("path", path).Msg("could not open miner.log, logging to server log")

--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -128,6 +128,11 @@ type Runtime struct {
 // buildRuntime opens the network-scoped DB, instantiates engines, and
 // registers all Connect sub-handlers on a fresh mux. Engines are NOT
 // started — call rt.Start to kick goroutines off.
+// coinnewsLogPath returns the coinnews log of the active network.
+func coinnewsLogPath(conf config.Config) string {
+	return filepath.Join(conf.Datadir, "coinnews-sync.log")
+}
+
 func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime, error) {
 	log := zerolog.Ctx(ctx)
 
@@ -202,10 +207,7 @@ func (s *Server) buildRuntime(ctx context.Context, conf config.Config) (*Runtime
 	rt.bitcoinEngine = engines.NewBitcoind(s.Bitcoind, rt.db, conf)
 	rt.bitcoinEngine.SetNodeMode(rt.walletEngine.NodeMode())
 
-	// Coinnews dedicated log lives next to the main server log. Path is
-	// derived from conf.LogPath which is also network-scoped (Finalize
-	// rewrites it), so each runtime's coinnews log is in its own folder.
-	coinnewsLogPath := filepath.Join(filepath.Dir(conf.LogPath), "coinnews-sync.log")
+	coinnewsLogPath := coinnewsLogPath(conf)
 	if coinnewsFile, err := os.OpenFile(coinnewsLogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666); err == nil {
 		coinnewsWriter := zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
 			w.Out = coinnewsFile

--- a/bitwindow/server/api/runtime_test.go
+++ b/bitwindow/server/api/runtime_test.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/config"
+	"github.com/stretchr/testify/require"
+)
+
+// Each network holds its own coinnews log, so a network swap does not mix the
+// records of two chains in one file.
+func TestCoinnewsLogPathFollowsTheNetworkDatadir(t *testing.T) {
+	base := t.TempDir()
+
+	conf := config.Config{Datadir: base}
+	require.NoError(t, conf.Finalize(config.NetworkSignet))
+	require.Equal(t, filepath.Join(base, "signet", "coinnews-sync.log"), coinnewsLogPath(conf))
+
+	require.NoError(t, conf.Finalize(config.NetworkMainnet))
+	require.Equal(t, filepath.Join(base, "mainnet", "coinnews-sync.log"), coinnewsLogPath(conf))
+}

--- a/bitwindow/server/config/config.go
+++ b/bitwindow/server/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	dir "github.com/LayerTwo-Labs/sidesail/bitwindow/server/dir"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/logfile"
 	"github.com/jessevdk/go-flags"
 )
 
@@ -116,7 +117,7 @@ func (c *Config) Finalize(network Network) error {
 	}
 
 	if c.baseLogPath == "" {
-		c.LogPath = filepath.Join(c.Datadir, "server.log")
+		c.LogPath = logfile.Path(c.baseDatadir)
 	} else {
 		c.LogPath = c.baseLogPath
 	}

--- a/bitwindow/server/config/config_datadir_test.go
+++ b/bitwindow/server/config/config_datadir_test.go
@@ -55,3 +55,28 @@ func TestFinalizeLeavesOtherNetworksAlone(t *testing.T) {
 
 	require.DirExists(t, legacy)
 }
+
+// The frontend, bitwindowd, and orchestratord all append to one file. It sits
+// in the root dir, so a network swap does not move it.
+func TestFinalizePutsTheLogInTheSharedFile(t *testing.T) {
+	base := t.TempDir()
+
+	conf := &Config{Datadir: base}
+	require.NoError(t, conf.Finalize(NetworkSignet))
+	require.Equal(t, filepath.Join(base, "bitwindow.log"), conf.LogPath)
+
+	require.NoError(t, conf.Finalize(NetworkMainnet))
+	require.Equal(t, filepath.Join(base, "bitwindow.log"), conf.LogPath)
+}
+
+// A user who passes --log.path keeps that file across a network swap.
+func TestFinalizeKeepsAChosenLogPath(t *testing.T) {
+	base := t.TempDir()
+	chosen := filepath.Join(base, "my.log")
+
+	conf := &Config{Datadir: base, LogPath: chosen}
+	require.NoError(t, conf.Finalize(NetworkSignet))
+	require.NoError(t, conf.Finalize(NetworkMainnet))
+
+	require.Equal(t, chosen, conf.LogPath)
+}

--- a/bitwindow/server/main.go
+++ b/bitwindow/server/main.go
@@ -34,6 +34,7 @@ import (
 	orchrpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/orchestrator/v1/orchestratorv1connect"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/lease"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/localauth"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/logfile"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bitassets"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bitnames"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/coinshift"
@@ -315,7 +316,7 @@ func initLogger(logFile *os.File, logLevel zerolog.Level) {
 	// We want pretty printing to the file as well. This is not meant for
 	// centralized log ingestion, where JSON is crucial.
 	logWriter := zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
-		w.Out = logFile
+		w.Out = logfile.Tag(logFile, "bitwindowd")
 		w.NoColor = true // ANSI colors don't work well with file output.
 		w.TimeFormat = timeFormat
 	})
@@ -378,6 +379,15 @@ func isNoisyStartupMessage(msg string) bool {
 }
 
 // startOrchestratord starts the orchestrator daemon as a subprocess.
+// orchestratordLogPath keeps the child on the same file as bitwindowd, so
+// --log.path holds the whole merged stream.
+func orchestratordLogPath(conf config.Config, bitwindowDir string) string {
+	if conf.LogPath != "" {
+		return conf.LogPath
+	}
+	return logfile.Path(bitwindowDir)
+}
+
 func startOrchestratord(ctx context.Context, conf config.Config) (*exec.Cmd, error) {
 	log := zerolog.Ctx(ctx)
 	bitwindowDir := conf.BitwindowDir()
@@ -444,7 +454,7 @@ func startOrchestratord(ctx context.Context, conf config.Config) (*exec.Cmd, err
 	//   survives.
 	// - Process.Release: tells the Go runtime to stop tracking the child so we
 	//   don't dangle a finalizer waiting on a process we've handed to init.
-	orchLogPath := filepath.Join(bitwindowDir, "orchestratord.log")
+	orchLogPath := orchestratordLogPath(conf, bitwindowDir)
 	// On a fresh install the bitwindow dir doesn't exist yet; opening the log
 	// would fail, orchestratord would never spawn, and the UI would poll a dead
 	// port until timeout. Ensure the dir exists first.
@@ -475,6 +485,9 @@ func startOrchestratord(ctx context.Context, conf config.Config) (*exec.Cmd, err
 		cmd.Stdout = io.MultiWriter(os.Stdout, orchLogFile)
 		cmd.Stderr = io.MultiWriter(os.Stderr, orchLogFile)
 	} else {
+		// The child takes the file itself. Any other writer makes os/exec
+		// insert a pipe, and this child outlives us: once we exit, the read
+		// end closes and its next write kills it.
 		cmd.Stdout = orchLogFile
 		cmd.Stderr = orchLogFile
 	}

--- a/bitwindow/server/main_test.go
+++ b/bitwindow/server/main_test.go
@@ -4,9 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"testing"
 
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExitError(t *testing.T) {
@@ -16,4 +19,15 @@ func TestExitError(t *testing.T) {
 
 	boom := errors.New("listen on \"127.0.0.1:8080\": address already in use")
 	assert.ErrorIs(t, exitError(boom), boom)
+}
+
+// A user who passes --log.path gets the whole merged stream in that file.
+func TestOrchestratordLogPathFollowsTheConfiguredPath(t *testing.T) {
+	chosen := filepath.Join("/data", "my.log")
+
+	require.Equal(t, chosen, orchestratordLogPath(config.Config{LogPath: chosen}, "/data/bitwindow"))
+	require.Equal(t,
+		filepath.Join("/data/bitwindow", "bitwindow.log"),
+		orchestratordLogPath(config.Config{}, "/data/bitwindow"),
+	)
 }

--- a/coinshift/lib/main.dart
+++ b/coinshift/lib/main.dart
@@ -258,16 +258,7 @@ bool isCurrentChainActive({
 }
 
 Future<File> getLogFile(Directory datadir) async {
-  try {
-    await datadir.create(recursive: true);
-  } catch (error) {
-    debugPrint('Failed to create datadir: $error');
-  }
-
-  final path = [datadir.path, 'debug.log'].join(Platform.pathSeparator);
-  final logFile = File(path);
-
-  return logFile;
+  return prepareLogFile(datadir, 'debug.log');
 }
 
 void bootBinaries(Logger log) {

--- a/coinshift/lib/pages/tabs/home_page.dart
+++ b/coinshift/lib/pages/tabs/home_page.dart
@@ -233,6 +233,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
           await windowProvider.open(SubWindowTypes.logs);
         },
       ),
+      CommandItem(
+        label: openLogsLabel(),
+        category: 'This Node',
+        onSelected: openLogs,
+      ),
 
       // Settings sections
       CommandItem(
@@ -386,6 +391,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
                             }
                           : null,
                     ),
+                    openLogsMenuItem(),
                   ],
                 ),
               ],

--- a/inquisition/lib/main.dart
+++ b/inquisition/lib/main.dart
@@ -262,16 +262,7 @@ bool isCurrentChainActive({
 }
 
 Future<File> getLogFile(Directory datadir) async {
-  try {
-    await datadir.create(recursive: true);
-  } catch (error) {
-    debugPrint('Failed to create datadir: $error');
-  }
-
-  final path = [datadir.path, 'debug.log'].join(Platform.pathSeparator);
-  final logFile = File(path);
-
-  return logFile;
+  return prepareLogFile(datadir, 'debug.log');
 }
 
 void _installSignalShutdownHandlers(Logger log) {

--- a/inquisition/lib/pages/tabs/home_page.dart
+++ b/inquisition/lib/pages/tabs/home_page.dart
@@ -222,6 +222,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
           await windowProvider.open(SubWindowTypes.logs);
         },
       ),
+      CommandItem(
+        label: openLogsLabel(),
+        category: 'This Node',
+        onSelected: openLogs,
+      ),
 
       // Settings sections
       CommandItem(
@@ -375,6 +380,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
                             }
                           : null,
                     ),
+                    openLogsMenuItem(),
                   ],
                 ),
               ],

--- a/photon/lib/main.dart
+++ b/photon/lib/main.dart
@@ -244,16 +244,7 @@ bool isCurrentChainActive({
 }
 
 Future<File> getLogFile(Directory datadir) async {
-  try {
-    await datadir.create(recursive: true);
-  } catch (error) {
-    debugPrint('Failed to create datadir: $error');
-  }
-
-  final path = [datadir.path, 'debug.log'].join(Platform.pathSeparator);
-  final logFile = File(path);
-
-  return logFile;
+  return prepareLogFile(datadir, 'debug.log');
 }
 
 void bootBinaries(Logger log) {

--- a/photon/lib/pages/tabs/home_page.dart
+++ b/photon/lib/pages/tabs/home_page.dart
@@ -260,6 +260,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
           await windowProvider.open(SubWindowTypes.logs);
         },
       ),
+      CommandItem(
+        label: openLogsLabel(),
+        category: 'This Node',
+        onSelected: openLogs,
+      ),
 
       // Settings sections
       CommandItem(
@@ -413,6 +418,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
                             }
                           : null,
                     ),
+                    openLogsMenuItem(),
                   ],
                 ),
               ],

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.181
+version: 1.0.182
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/config/sidechain_main.dart
+++ b/sail_ui/lib/config/sidechain_main.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
@@ -246,16 +245,7 @@ Future<void> initSidechainDependencies({
 }
 
 Future<File> getLogFile(Directory appDir) async {
-  try {
-    await appDir.create(recursive: true);
-  } catch (error) {
-    debugPrint('Failed to create appdir: $error');
-  }
-
-  final path = [appDir.path, 'debug.log'].join(Platform.pathSeparator);
-  final logFile = File(path);
-
-  return logFile;
+  return prepareLogFile(appDir, 'debug.log');
 }
 
 List<Binary> _noAdditionalBinaries() => [];

--- a/sail_ui/lib/sail_ui.dart
+++ b/sail_ui/lib/sail_ui.dart
@@ -138,6 +138,7 @@ export 'widgets/nav/persistent_status_bar.dart';
 export 'widgets/nav/side_nav.dart';
 export 'widgets/nav/top_nav.dart';
 export 'widgets/optional_builder.dart';
+export 'widgets/logs_menu.dart';
 export 'widgets/platform_menu.dart';
 export 'widgets/spacing.dart';
 export 'widgets/static/static_field.dart';

--- a/sail_ui/lib/widgets/logs_menu.dart
+++ b/sail_ui/lib/widgets/logs_menu.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/widgets.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sidechain_core/sidechain_core.dart';
+
+String openLogsLabel() => 'Open Logs in ${fileManagerName()}';
+
+Future<void> openLogs() async {
+  await openFile(GetIt.I.get<WindowProvider>().logFile);
+}
+
+PlatformMenuItem openLogsMenuItem() => PlatformMenuItem(
+  label: openLogsLabel(),
+  onSelected: openLogs,
+);

--- a/sail_ui/test/logs_menu_test.dart
+++ b/sail_ui/test/logs_menu_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+void main() {
+  test('the menu item names the file manager of this platform', () {
+    final item = openLogsMenuItem();
+
+    expect(item.label, openLogsLabel());
+    expect(item.label, contains(fileManagerName()));
+    expect(item.onSelected, isNotNull);
+  });
+
+  testWidgets('the menu bar shows the item', (tester) async {
+    await tester.pumpWidget(
+      SailTheme(
+        data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+        child: MaterialApp(
+          home: Scaffold(
+            body: SailMenuBar(
+              menus: [
+                PlatformMenu(
+                  label: 'This Node',
+                  menus: [
+                    PlatformMenuItemGroup(members: [openLogsMenuItem()]),
+                  ],
+                ),
+              ],
+              child: const SizedBox(),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('This Node'));
+    await tester.pumpAndSettle();
+
+    expect(find.text(openLogsLabel()), findsOneWidget);
+  });
+}

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -45,6 +45,7 @@ import (
 	zsiderpc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/zside/v1/zsidev1connect"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/lease"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/localauth"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/logfile"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/rpcmeter"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
 	bitassetssvc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/bitassets"
@@ -158,7 +159,7 @@ func run(cctx *cli.Context) error {
 			os.Exit(1)
 		}
 		defer f.Close() //nolint:errcheck
-		logOut = zerolog.ConsoleWriter{Out: f, NoColor: true, TimeFormat: "15:04:05.000"}
+		logOut = zerolog.ConsoleWriter{Out: logfile.Tag(f, "orchestrator"), NoColor: true, TimeFormat: "15:04:05.000"}
 	}
 	log := zerolog.New(logOut).
 		Level(level).

--- a/sidechain-orchestrator/config/binaries.go
+++ b/sidechain-orchestrator/config/binaries.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/logfile"
 	"github.com/rs/zerolog"
 )
 
@@ -573,11 +574,10 @@ func (b BinaryDirConfig) GetSettingsPaths(networkDir string, network Network, lo
 		paths = append(paths, GetExistingFilesInDir(b.RootDir(), []string{"bitwindow-enforcer.conf"}, log)...)
 
 	case "bitwindowd":
-		paths = append(paths, GetExistingFilesInDir(networkDir, []string{"server.log"}, log)...)
 		rootDir := BitWindowDirs.RootDir()
 		paths = append(paths, GetExistingFilesInDir(rootDir, []string{
-			"assets", "bitwindow-bitcoin.conf",
-			"debug.log", "downloads", "pids", "settings.json",
+			"assets", "bitwindow-bitcoin.conf", logfile.Name,
+			"downloads", "pids", "settings.json",
 		}, log)...)
 
 	case "thunder":
@@ -626,9 +626,11 @@ func (b BinaryDirConfig) GetLogPaths(networkDir string, log zerolog.Logger) []st
 		paths = append(paths, GetExistingFilesInDir(networkDir, []string{"bip300301_enforcer.log", "logs"}, log)...)
 
 	case "bitwindowd":
-		paths = append(paths, GetExistingFilesInDir(networkDir, []string{"server.log"}, log)...)
+		paths = append(paths, GetExistingFilesInDir(networkDir, []string{"miner.log", "server.log"}, log)...)
 		rootDir := BitWindowDirs.RootDir()
-		paths = append(paths, GetExistingFilesInDir(rootDir, []string{"debug.log"}, log)...)
+		paths = append(paths, GetExistingFilesInDir(rootDir, []string{
+			logfile.Name, "debug.log", "orchestratord.log",
+		}, log)...)
 
 	case "thunder", "bitnames", "bitassets", "thunder-orchard", "truthcoin", "photon", "coinshift":
 		paths = append(paths, GetExistingFilesInDir(networkDir, []string{"logs"}, log)...)
@@ -654,7 +656,7 @@ func (b BinaryDirConfig) LogPath(networkDir string) string {
 		return filepath.Join(networkDir, "debug.log")
 
 	case "bitwindowd":
-		return filepath.Join(networkDir, "server.log")
+		return logfile.Path(BitWindowDirs.RootDir())
 
 	case "bip300301-enforcer":
 		return findLatestEnforcerLog(networkDir)

--- a/sidechain-orchestrator/logfile/logfile.go
+++ b/sidechain-orchestrator/logfile/logfile.go
@@ -1,0 +1,52 @@
+// Package logfile holds the one log file that the bitwindow frontend,
+// bitwindowd, and orchestratord all append to.
+package logfile
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+)
+
+// Name of the shared log file. It sits in the bitwindow root dir, beside
+// wallet.json.
+const Name = "bitwindow.log"
+
+// Path returns the shared log file in the given bitwindow dir.
+func Path(bitwindowDir string) string {
+	return filepath.Join(bitwindowDir, Name)
+}
+
+// Width of the source tag, so the merged log file lines up in a column.
+const tagWidth = 15
+
+// Tag returns a writer that marks each line with the source name. The reader
+// of the merged file sees which process wrote which line.
+func Tag(out io.Writer, source string) io.Writer {
+	return &tagWriter{out: out, prefix: []byte(fmt.Sprintf("%-*s ", tagWidth, "["+source+"]"))}
+}
+
+type tagWriter struct {
+	out    io.Writer
+	prefix []byte
+}
+
+// Write sends one buffer to the file per call. Three processes append to the
+// same file, and a single write keeps each line whole.
+func (t *tagWriter) Write(p []byte) (int, error) {
+	var buf bytes.Buffer
+	buf.Grow(len(p) + len(t.prefix))
+	for _, line := range bytes.SplitAfter(p, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		buf.Write(t.prefix)
+		buf.Write(line)
+	}
+
+	if _, err := t.out.Write(buf.Bytes()); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/sidechain-orchestrator/logfile/logfile_test.go
+++ b/sidechain-orchestrator/logfile/logfile_test.go
@@ -1,0 +1,50 @@
+package logfile
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPath(t *testing.T) {
+	require.Equal(t, filepath.Join("/data/bitwindow", "bitwindow.log"), Path("/data/bitwindow"))
+}
+
+// Three processes append to the shared file. One Write per call keeps each
+// line whole, and the tag names the process that wrote it.
+func TestTagMarksEveryLineInOneWrite(t *testing.T) {
+	var sink countingWriter
+	w := Tag(&sink, "orchestrator")
+
+	n, err := w.Write([]byte("first\nsecond\n"))
+	require.NoError(t, err)
+	require.Equal(t, len("first\nsecond\n"), n)
+
+	require.Equal(t, 1, sink.writes)
+	require.Equal(t, "[orchestrator]  first\n[orchestrator]  second\n", sink.buf.String())
+}
+
+func TestTagPadsShortSourcesToTheSameColumn(t *testing.T) {
+	var frontend, bitwindowd countingWriter
+	_, err := Tag(&frontend, "frontend").Write([]byte("a\n"))
+	require.NoError(t, err)
+	_, err = Tag(&bitwindowd, "bitwindowd").Write([]byte("a\n"))
+	require.NoError(t, err)
+
+	require.Equal(t,
+		len(frontend.buf.String())-len("a\n"),
+		len(bitwindowd.buf.String())-len("a\n"),
+	)
+}
+
+type countingWriter struct {
+	buf    bytes.Buffer
+	writes int
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	c.writes++
+	return c.buf.Write(p)
+}

--- a/sidechain-orchestrator/reset.go
+++ b/sidechain-orchestrator/reset.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/logfile"
 )
 
 // ResetCategory maps 1:1 to the proto DeletionType enum and selects which
@@ -328,7 +329,7 @@ func (o *Orchestrator) DeleteFiles(ctx context.Context, paths []string, specs ..
 					masterTouched = true
 				}
 			} else {
-				if err := os.RemoveAll(p); err != nil && !os.IsNotExist(err) {
+				if err := removeOrTruncate(p); err != nil {
 					evt.Error = err.Error()
 				}
 			}
@@ -669,6 +670,23 @@ func isWalletPath(p string, walletSet map[string]bool) bool {
 	// Wallet directories: bitcoind's `wallets/`, the enforcer's `wallet/<net>`.
 	return strings.Contains(lower, "/wallet/") || strings.HasSuffix(lower, "/wallet") ||
 		strings.Contains(lower, "/wallets/") || strings.HasSuffix(lower, "/wallets")
+}
+
+// removeOrTruncate empties the shared log in place and removes every other
+// path. The frontend and orchestratord hold open append handles on that file,
+// and a removal leaves them writing to a file nobody can read.
+func removeOrTruncate(p string) error {
+	if filepath.Base(p) == logfile.Name {
+		if err := os.Truncate(p, 0); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+
+	if err := os.RemoveAll(p); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 func isWalletBackupPath(p string) bool {

--- a/sidechain-orchestrator/reset_integration_test.go
+++ b/sidechain-orchestrator/reset_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/logfile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -177,13 +178,13 @@ func bootedLayout(t *testing.T, home, network string) []string {
 
 	// --- bitwindowd: flutter app data + signet/ subdir. ----------------------
 	writeStub(t, filepath.Join(bwNet, "bitwindow.db"))
-	writeStub(t, filepath.Join(bwNet, "server.log"))
+	writeStub(t, filepath.Join(bwNet, "miner.log"))
 	writeStub(t, filepath.Join(bwNet, "wallet.json"))
 	writeStub(t, filepath.Join(bwNet, "wallet_encryption.json"))
 	writeDir(t, filepath.Join(bwNet, "bitdrive"))
 
 	for _, f := range []string{
-		"debug.log", "settings.json",
+		logfile.Name, "settings.json",
 		"wallet.json", "wallet_encryption.json",
 	} {
 		writeStub(t, filepath.Join(bwRoot, f))
@@ -200,13 +201,13 @@ func bootedLayout(t *testing.T, home, network string) []string {
 
 	add(
 		filepath.Join(bwNet, "bitwindow.db"),
-		filepath.Join(bwNet, "server.log"),
+		filepath.Join(bwNet, "miner.log"),
 		filepath.Join(bwNet, "wallet.json"),
 		filepath.Join(bwNet, "wallet_encryption.json"),
 		filepath.Join(bwNet, "bitdrive"),
 		filepath.Join(bwRoot, "assets"),
 		filepath.Join(bwRoot, "bitwindow-bitcoin.conf"),
-		filepath.Join(bwRoot, "debug.log"),
+		filepath.Join(bwRoot, logfile.Name),
 		filepath.Join(bwRoot, "downloads"),
 		filepath.Join(bwRoot, "pids"),
 		filepath.Join(bwRoot, "settings.json"),
@@ -338,4 +339,38 @@ func TestGather_PerSidechainScoping(t *testing.T) {
 			"gathering thunder must not surface another sidechain's paths")
 	}
 	assert.True(t, thunderSeen, "gathering thunder must enumerate its data dir")
+}
+
+// A log reset clears the shared file, the miner file, and the files an
+// earlier release wrote.
+func TestGetLogPathsFindsEveryBitwindowLog(t *testing.T) {
+	home := redirectHome(t)
+	root := filepath.Join(appRoot(home), "bitwindow")
+	networkDir := filepath.Join(root, "signet")
+
+	for _, p := range []string{
+		filepath.Join(root, logfile.Name),
+		filepath.Join(root, "debug.log"),
+		filepath.Join(root, "orchestratord.log"),
+		filepath.Join(networkDir, "miner.log"),
+		filepath.Join(networkDir, "server.log"),
+	} {
+		writeStub(t, p)
+	}
+
+	got := map[string]struct{}{}
+	for _, p := range config.BitWindowDirs.GetLogPaths(networkDir, testLogger(t)) {
+		got[filepath.Clean(p)] = struct{}{}
+	}
+
+	for _, want := range []string{
+		filepath.Join(root, logfile.Name),
+		filepath.Join(root, "debug.log"),
+		filepath.Join(root, "orchestratord.log"),
+		filepath.Join(networkDir, "miner.log"),
+		filepath.Join(networkDir, "server.log"),
+	} {
+		_, ok := got[filepath.Clean(want)]
+		require.True(t, ok, "the log reset must find %s", want)
+	}
 }

--- a/sidechain-orchestrator/reset_test.go
+++ b/sidechain-orchestrator/reset_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/logfile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -633,4 +634,29 @@ func TestResetOrdersCoverEveryDeletableBinary(t *testing.T) {
 		assert.Contains(t, resetStopOrder, binary, "%s is deletable but never stopped", binary.processName())
 		assert.Contains(t, resetStartOrder, binary, "%s is deletable but never restarted", binary.processName())
 	}
+}
+
+// A log reset runs while the frontend and orchestratord hold the shared file
+// open. Emptying it keeps their handles pointed at the file the user reads.
+func TestRemoveOrTruncateEmptiesTheSharedLog(t *testing.T) {
+	dir := t.TempDir()
+
+	shared := filepath.Join(dir, logfile.Name)
+	require.NoError(t, os.WriteFile(shared, []byte("old lines\n"), 0o644))
+
+	other := filepath.Join(dir, "server.log")
+	require.NoError(t, os.WriteFile(other, []byte("old lines\n"), 0o644))
+
+	require.NoError(t, removeOrTruncate(shared))
+	require.NoError(t, removeOrTruncate(other))
+
+	info, err := os.Stat(shared)
+	require.NoError(t, err, "the shared log must stay in place")
+	require.Zero(t, info.Size())
+
+	require.NoFileExists(t, other)
+}
+
+func TestRemoveOrTruncateAcceptsAMissingPath(t *testing.T) {
+	require.NoError(t, removeOrTruncate(filepath.Join(t.TempDir(), "gone.log")))
 }

--- a/sidechain_core/lib/config/binaries.dart
+++ b/sidechain_core/lib/config/binaries.dart
@@ -916,7 +916,7 @@ String? flutterFrontendDirFor(BinaryType type, OS os, String home) {
   };
 }
 
-/// The CPU miner runs inside bitwindowd and logs beside its server log.
+/// The CPU miner writes its own file in the network datadir.
 String minerLogPath() => filePath([BitWindow().datadirNetwork(), 'miner.log']);
 
 extension BinaryPaths on Binary {
@@ -949,7 +949,7 @@ extension BinaryPaths on Binary {
         BitcoinCore().datadirNetwork(),
         'debug.log',
       ]),
-      BinaryType.BINARY_TYPE_BITWINDOWD => filePath([datadirNetwork(), 'server.log']),
+      BinaryType.BINARY_TYPE_BITWINDOWD => filePath([datadir(), sharedLogFileName]),
       BinaryType.BINARY_TYPE_THUNDER ||
       BinaryType.BINARY_TYPE_BITNAMES ||
       BinaryType.BINARY_TYPE_BITASSETS ||

--- a/sidechain_core/lib/logger.dart
+++ b/sidechain_core/lib/logger.dart
@@ -1,7 +1,13 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:logger/logger.dart';
+
+/// Width of the source tag, so the merged log file lines up in a column.
+const _sourceTagWidth = 15;
+
+String logSourceTag(String source) => '[$source]'.padRight(_sourceTagWidth);
 
 LogPrinter _consolePrinter() {
   if (kReleaseMode) {
@@ -14,11 +20,40 @@ LogPrinter _consolePrinter() {
   );
 }
 
-Future<LogOutput> _logoutput(File? logFile) async {
+/// Appends to a log file that other processes also append to. Each event goes
+/// out as one write, so the lines of the other writers stay whole.
+class SharedFileOutput extends LogOutput {
+  SharedFileOutput({required File file, required String source})
+    : _file = file.openSync(mode: FileMode.writeOnlyAppend),
+      _tag = logSourceTag(source);
+
+  final RandomAccessFile _file;
+  final String _tag;
+
+  @override
+  void output(OutputEvent event) {
+    final buffer = StringBuffer();
+    for (final line in event.lines) {
+      buffer.writeln('$_tag $line');
+    }
+    try {
+      _file.writeFromSync(utf8.encode(buffer.toString()));
+    } catch (error) {
+      stderr.writeln('could not write to the log file: $error');
+    }
+  }
+
+  @override
+  Future<void> destroy() async {
+    await _file.close();
+  }
+}
+
+Future<LogOutput> _logoutput(File? logFile, String source) async {
   List<LogOutput> outputs = [];
 
   if (logFile != null) {
-    outputs.add(FileOutput(file: logFile, overrideExisting: true));
+    outputs.add(SharedFileOutput(file: logFile, source: source));
   }
 
   if (logFile == null || kDebugMode) {
@@ -28,9 +63,14 @@ Future<LogOutput> _logoutput(File? logFile) async {
   return MultiOutput(outputs);
 }
 
-Future<Logger> logger(bool fileLog, bool consoleLog, File? logFile) async => Logger(
+Future<Logger> logger(
+  bool fileLog,
+  bool consoleLog,
+  File? logFile, {
+  String source = 'frontend',
+}) async => Logger(
   level: Level.debug,
   filter: ProductionFilter(),
   printer: _consolePrinter(),
-  output: await _logoutput(logFile),
+  output: await _logoutput(logFile, source),
 );

--- a/sidechain_core/lib/providers/binaries/managers/process_manager.dart
+++ b/sidechain_core/lib/providers/binaries/managers/process_manager.dart
@@ -8,6 +8,7 @@ import 'package:logger/logger.dart';
 import 'package:sidechain_core/config/binaries.dart';
 import 'package:sidechain_core/providers/binaries/managers/pid_file_manager.dart';
 import 'package:sidechain_core/providers/log_provider.dart';
+import 'package:sidechain_core/utils/log_file.dart';
 
 class ProcessManager extends ChangeNotifier {
   final Directory appDir;
@@ -50,7 +51,14 @@ class ProcessManager extends ChangeNotifier {
       ),
     );
 
-    // Also write to debug.log via the logger.
+    // bitwindowd appends its own records to the shared log file, so the logger
+    // would write them a second time. Its stderr holds the boot lines and the
+    // panics that never reach that file.
+    if (writesToSharedLog(binary.type) && !isStderr) {
+      debugPrint('[${binary.name}] $cleanLine');
+      return;
+    }
+
     log.i('[${binary.name}] $cleanLine');
   }
 
@@ -106,7 +114,7 @@ class ProcessManager extends ChangeNotifier {
           (data) {
             stdoutController.add(data);
             _finalErr[binary.name] = data;
-            if (!isSpam(data)) {
+            if (!isSpam(data) && !writesToSharedLog(binary.type)) {
               log.d('${file.path.split(Platform.pathSeparator).last}: $data');
             }
             // Process each line separately for log capture

--- a/sidechain_core/lib/sidechain_core.dart
+++ b/sidechain_core/lib/sidechain_core.dart
@@ -204,6 +204,7 @@ export 'settings/homepage_configuration_setting.dart';
 export 'utils/change_tracker.dart';
 export 'utils/file_overrides.dart';
 export 'utils/file_utils.dart';
+export 'utils/log_file.dart';
 export 'utils/diff_utils.dart';
 export 'utils/ur_psbt.dart';
 export 'models/core_transaction.dart';

--- a/sidechain_core/lib/utils/file_utils.dart
+++ b/sidechain_core/lib/utils/file_utils.dart
@@ -75,29 +75,21 @@ Future<void> openDir(Directory dir) async {
   await Process.run(command, [dir.path]);
 }
 
-Future<void> openFile(File file) async {
-  final os = getOS();
+/// The command that shows [path] in the file manager of [os]. Windows takes
+/// the switch and the path as one argument, and Linux has no select flag.
+(String, List<String>) revealCommand(OS os, String path) => switch (os) {
+  OS.macos => ('open', ['-R', path]),
+  OS.windows => ('explorer', ['/select,$path']),
+  OS.linux => ('xdg-open', [File(path).parent.path]),
+};
 
+Future<void> openFile(File file) async {
   if (!await file.exists()) {
     return;
   }
 
-  switch (os) {
-    case OS.macos:
-      // On macOS, use 'open -R' to reveal and select the file
-      await Process.run('open', ['-R', file.path]);
-    case OS.windows:
-      // On Windows, use 'explorer /select,' to select the file
-      await Process.run('explorer', ['/select,', file.path]);
-    case OS.linux:
-      // On Linux, first try to use xdg-open with the file
-      // If that doesn't work, fall back to opening the directory
-      try {
-        await Process.run('xdg-open', [file.path]);
-      } catch (e) {
-        await openDir(file.parent);
-      }
-  }
+  final (command, args) = revealCommand(getOS(), file.path);
+  await Process.run(command, args);
 }
 
 enum OS {
@@ -131,3 +123,10 @@ OS getOS() {
   }
   throw Exception('unsupported platform');
 }
+
+/// Name of the file manager on this platform, for a menu label.
+String fileManagerName() => switch (getOS()) {
+  OS.macos => 'Finder',
+  OS.windows => 'File Explorer',
+  OS.linux => 'File Manager',
+};

--- a/sidechain_core/lib/utils/log_file.dart
+++ b/sidechain_core/lib/utils/log_file.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:sidechain_core/gen/orchestrator/v1/orchestrator.pbenum.dart';
+
+/// Name of the one file that the bitwindow frontend, bitwindowd, and
+/// orchestratord all append to.
+const String sharedLogFileName = 'bitwindow.log';
+
+/// True when the binary appends to the shared log file itself.
+bool writesToSharedLog(BinaryType type) => type == BinaryType.BINARY_TYPE_BITWINDOWD;
+
+/// The log file holds the lines of every restart, so cut it back at this size.
+const int maxLogFileBytes = 20 * 1024 * 1024;
+
+/// Creates [dir], then returns the log file in it. Empties the file first if
+/// it grew past [maxBytes].
+Future<File> prepareLogFile(Directory dir, String name, {int maxBytes = maxLogFileBytes}) async {
+  await dir.create(recursive: true);
+
+  final file = File([dir.path, name].join(Platform.pathSeparator));
+  if (await file.exists() && await file.length() > maxBytes) {
+    // Empty the file in place. A detached orchestratord holds an open append
+    // handle, and a rename sends its lines to a file that nobody reads.
+    await file.writeAsString('');
+  }
+
+  return file;
+}

--- a/sidechain_core/test/file_utils_test.dart
+++ b/sidechain_core/test/file_utils_test.dart
@@ -27,6 +27,35 @@ void main() {
     expect(diagnosis, contains('is a file'));
   });
 
+  test('revealCommand selects the file on macOS', () {
+    final (command, args) = revealCommand(OS.macos, '/data/bitwindow/bitwindow.log');
+    expect(command, 'open');
+    expect(args, ['-R', '/data/bitwindow/bitwindow.log']);
+  });
+
+  // Explorer takes the switch and the path as one argument. A space between
+  // them makes it open the default folder.
+  test('revealCommand joins the switch and the path on Windows', () {
+    final (command, args) = revealCommand(OS.windows, r'C:\data\bitwindow.log');
+    expect(command, 'explorer');
+    expect(args, [r'/select,C:\data\bitwindow.log']);
+  });
+
+  test('revealCommand opens the folder on Linux', () {
+    final (command, args) = revealCommand(OS.linux, '/data/bitwindow/bitwindow.log');
+    expect(command, 'xdg-open');
+    expect(args, ['/data/bitwindow']);
+  });
+
+  test('fileManagerName names the file manager of this platform', () {
+    final expected = switch (getOS()) {
+      OS.macos => 'Finder',
+      OS.windows => 'File Explorer',
+      OS.linux => 'File Manager',
+    };
+    expect(fileManagerName(), expected);
+  });
+
   test('diagnoseUncreatablePath returns null on a healthy path', () async {
     final tmp = await Directory.systemTemp.createTemp('file_utils_test');
     addTearDown(() => tmp.delete(recursive: true));

--- a/sidechain_core/test/log_file_test.dart
+++ b/sidechain_core/test/log_file_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:sidechain_core/gen/orchestrator/v1/orchestrator.pbenum.dart';
+import 'package:sidechain_core/logger.dart';
+import 'package:sidechain_core/utils/log_file.dart';
+
+void main() {
+  test('prepareLogFile creates the directory and keeps a small file', () async {
+    final tmp = await Directory.systemTemp.createTemp('log_file_test');
+    addTearDown(() => tmp.delete(recursive: true));
+
+    final dir = Directory('${tmp.path}/app');
+    final first = await prepareLogFile(dir, 'bitwindow.log');
+    await first.writeAsString('one line\n');
+
+    final second = await prepareLogFile(dir, 'bitwindow.log');
+    expect(await second.readAsString(), 'one line\n');
+  });
+
+  test('prepareLogFile empties a file that grew past the cap', () async {
+    final tmp = await Directory.systemTemp.createTemp('log_file_test');
+    addTearDown(() => tmp.delete(recursive: true));
+
+    final file = File('${tmp.path}/bitwindow.log');
+    await file.writeAsString('x' * 100);
+
+    final prepared = await prepareLogFile(tmp, 'bitwindow.log', maxBytes: 50);
+    expect(await prepared.length(), 0);
+  });
+
+  test('SharedFileOutput appends tagged lines and keeps what is already there', () async {
+    final tmp = await Directory.systemTemp.createTemp('log_file_test');
+    addTearDown(() => tmp.delete(recursive: true));
+
+    final file = File('${tmp.path}/bitwindow.log');
+    await file.writeAsString('[orchestrator]  earlier line\n');
+
+    final output = SharedFileOutput(file: file, source: 'frontend');
+    output.output(_event(['first', 'second']));
+    await output.destroy();
+
+    expect(await file.readAsLines(), [
+      '[orchestrator]  earlier line',
+      '[frontend]      first',
+      '[frontend]      second',
+    ]);
+  });
+
+  test('only bitwindowd writes to the shared log file itself', () {
+    expect(writesToSharedLog(BinaryType.BINARY_TYPE_BITWINDOWD), isTrue);
+    expect(writesToSharedLog(BinaryType.BINARY_TYPE_BITCOIND), isFalse);
+    expect(writesToSharedLog(BinaryType.BINARY_TYPE_ENFORCER), isFalse);
+    expect(writesToSharedLog(BinaryType.BINARY_TYPE_THUNDER), isFalse);
+  });
+
+  test('every source tag takes the same width', () {
+    expect(logSourceTag('frontend').length, logSourceTag('orchestrator').length);
+    expect(logSourceTag('bitwindowd').length, logSourceTag('orchestrator').length);
+  });
+}
+
+OutputEvent _event(List<String> lines) {
+  return OutputEvent(LogEvent(Level.info, lines.join('\n')), lines);
+}

--- a/thunder/lib/main.dart
+++ b/thunder/lib/main.dart
@@ -262,16 +262,7 @@ bool isCurrentChainActive({
 }
 
 Future<File> getLogFile(Directory datadir) async {
-  try {
-    await datadir.create(recursive: true);
-  } catch (error) {
-    debugPrint('Failed to create datadir: $error');
-  }
-
-  final path = [datadir.path, 'debug.log'].join(Platform.pathSeparator);
-  final logFile = File(path);
-
-  return logFile;
+  return prepareLogFile(datadir, 'debug.log');
 }
 
 void _installSignalShutdownHandlers(Logger log) {

--- a/thunder/lib/pages/tabs/home_page.dart
+++ b/thunder/lib/pages/tabs/home_page.dart
@@ -222,6 +222,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
           await windowProvider.open(SubWindowTypes.logs);
         },
       ),
+      CommandItem(
+        label: openLogsLabel(),
+        category: 'This Node',
+        onSelected: openLogs,
+      ),
 
       // Settings sections
       CommandItem(
@@ -375,6 +380,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
                             }
                           : null,
                     ),
+                    openLogsMenuItem(),
                   ],
                 ),
               ],

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.310
+version: 1.0.311
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/lib/main.dart
+++ b/truthcoin/lib/main.dart
@@ -258,16 +258,7 @@ bool isCurrentChainActive({
 }
 
 Future<File> getLogFile(Directory datadir) async {
-  try {
-    await datadir.create(recursive: true);
-  } catch (error) {
-    debugPrint('Failed to create datadir: $error');
-  }
-
-  final path = [datadir.path, 'debug.log'].join(Platform.pathSeparator);
-  final logFile = File(path);
-
-  return logFile;
+  return prepareLogFile(datadir, 'debug.log');
 }
 
 void bootBinaries(Logger log) {

--- a/truthcoin/lib/pages/tabs/home_page.dart
+++ b/truthcoin/lib/pages/tabs/home_page.dart
@@ -244,6 +244,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
           await windowProvider.open(SubWindowTypes.logs);
         },
       ),
+      CommandItem(
+        label: openLogsLabel(),
+        category: 'This Node',
+        onSelected: openLogs,
+      ),
 
       // Settings sections
       CommandItem(
@@ -397,6 +402,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
                             }
                           : null,
                     ),
+                    openLogsMenuItem(),
                   ],
                 ),
               ],

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.181
+version: 1.0.182
 
 environment:
   sdk: 3.12.2

--- a/zside/lib/main.dart
+++ b/zside/lib/main.dart
@@ -280,16 +280,7 @@ bool isCurrentChainActive({
 }
 
 Future<File> getLogFile(Directory datadir) async {
-  try {
-    await datadir.create(recursive: true);
-  } catch (error) {
-    debugPrint('Failed to create datadir: $error');
-  }
-
-  final path = [datadir.path, 'debug.log'].join(Platform.pathSeparator);
-  final logFile = File(path);
-
-  return logFile;
+  return prepareLogFile(datadir, 'debug.log');
 }
 
 void bootBinaries(Logger log) {

--- a/zside/lib/pages/tabs/home_page.dart
+++ b/zside/lib/pages/tabs/home_page.dart
@@ -242,6 +242,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
           await windowProvider.open(SubWindowTypes.logs);
         },
       ),
+      CommandItem(
+        label: openLogsLabel(),
+        category: 'This Node',
+        onSelected: openLogs,
+      ),
 
       // App menu
       CommandItem(
@@ -345,6 +350,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Window
                             }
                           : null,
                     ),
+                    openLogsMenuItem(),
                   ],
                 ),
               ],

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.308
+version: 1.0.309
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The bitwindow frontend, bitwindowd, and orchestratord append to one file, bitwindow.log, in the bitwindow root dir. Each line carries a tag that names the process that wrote it, so grep gives the per-service view.

A new menu item, Open Logs in Finder, reveals that file from This Node in every app. The file empties itself at startup above 20 MB. The miner keeps its own file.