### PR TITLE
Scroll the claim card past the window

### DIFF
--- a/bitwindow/lib/pages/wallet/wallet_page.dart
+++ b/bitwindow/lib/pages/wallet/wallet_page.dart
@@ -85,6 +85,10 @@ class WalletPageViewModel extends BaseViewModel {
   }
 }
 
+/// Height the wallet tabs keep for their own header, so the claim card above
+/// them can never take the whole page.
+const double _minimumTabsHeight = 120;
+
 @RoutePage()
 class WalletPage extends StatelessWidget {
   TransactionProvider get transactionProvider => GetIt.I.get<TransactionProvider>();
@@ -185,18 +189,30 @@ class WalletPage extends StatelessWidget {
                 ),
               ];
 
-              return Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  const ForkModeBanner(),
-                  Expanded(
-                    child: InlineTabBar(
-                      key: tabKey,
-                      tabs: allTabs,
-                      initialIndex: 0,
-                    ),
-                  ),
-                ],
+              return LayoutBuilder(
+                builder: (context, constraints) {
+                  // The claim card grows with the coin count, so it takes what
+                  // the tabs do not need and scrolls the rest.
+                  final bannerMaxHeight = constraints.hasBoundedHeight
+                      ? (constraints.maxHeight - _minimumTabsHeight).clamp(0.0, constraints.maxHeight)
+                      : double.infinity;
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      ConstrainedBox(
+                        constraints: BoxConstraints(maxHeight: bannerMaxHeight),
+                        child: const ForkModeBanner(),
+                      ),
+                      Expanded(
+                        child: InlineTabBar(
+                          key: tabKey,
+                          tabs: allTabs,
+                          initialIndex: 0,
+                        ),
+                      ),
+                    ],
+                  );
+                },
               );
             },
           );

--- a/bitwindow/lib/widgets/fork_mode_banner.dart
+++ b/bitwindow/lib/widgets/fork_mode_banner.dart
@@ -31,8 +31,10 @@ class ForkModeBanner extends StatelessWidget {
   }
 }
 
-/// Height the claim card body may take before it scrolls.
-const double _claimCardBodyMaxHeight = 420;
+/// Share of the window the claim card body may take before it scrolls. The
+/// window goes down to 400 pixels tall, so a fixed height leaves no room for
+/// the wallet tabs below.
+const double _claimCardBodyHeightShare = 0.4;
 
 class _ClaimEcashCard extends StatefulWidget {
   const _ClaimEcashCard({required this.fork});
@@ -143,7 +145,9 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
             // The card sits above the wallet tabs and takes its natural
             // height, so a wallet with many coins runs past the window.
             ConstrainedBox(
-              constraints: const BoxConstraints(maxHeight: _claimCardBodyMaxHeight),
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.sizeOf(context).height * _claimCardBodyHeightShare,
+              ),
               child: SingleChildScrollView(
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.start,

--- a/bitwindow/lib/widgets/fork_mode_banner.dart
+++ b/bitwindow/lib/widgets/fork_mode_banner.dart
@@ -31,6 +31,9 @@ class ForkModeBanner extends StatelessWidget {
   }
 }
 
+/// Height the claim card body may take before it scrolls.
+const double _claimCardBodyMaxHeight = 420;
+
 class _ClaimEcashCard extends StatefulWidget {
   const _ClaimEcashCard({required this.fork});
   final ForkProvider fork;
@@ -137,27 +140,34 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
               ],
             ),
             const SizedBox(height: 16),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      ...claims.map((c) => _coinPicker(context, c, formatter)),
-                      const SizedBox(height: 8),
-                      if (_selectionValid)
-                        SailButton(
-                          label: _buttonLabel(formatter, selectedSats, claims),
-                          icon: SailSVGAsset.iconCoins,
-                          onPressed: () => _claim(context),
-                        ),
-                    ],
-                  ),
+            // The card sits above the wallet tabs and takes its natural
+            // height, so a wallet with many coins runs past the window.
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: _claimCardBodyMaxHeight),
+              child: SingleChildScrollView(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          ...claims.map((c) => _coinPicker(context, c, formatter)),
+                          const SizedBox(height: 8),
+                          if (_selectionValid)
+                            SailButton(
+                              label: _buttonLabel(formatter, selectedSats, claims),
+                              icon: SailSVGAsset.iconCoins,
+                              onPressed: () => _claim(context),
+                            ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 24),
+                    Expanded(child: _whyThisIsNecessary()),
+                  ],
                 ),
-                const SizedBox(width: 24),
-                Expanded(child: _whyThisIsNecessary()),
-              ],
+              ),
             ),
           ],
         ),

--- a/bitwindow/lib/widgets/fork_mode_banner.dart
+++ b/bitwindow/lib/widgets/fork_mode_banner.dart
@@ -121,6 +121,7 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
       child: SailCard(
         color: theme.colors.orange.withValues(alpha: 0.08),
         child: Column(
+          mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Row(
@@ -142,34 +143,36 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
               ],
             ),
             const SizedBox(height: 16),
-            // The card sits above the wallet tabs and takes its natural
-            // height, so a wallet with many coins runs past the window.
-            ConstrainedBox(
-              constraints: BoxConstraints(
-                maxHeight: MediaQuery.sizeOf(context).height * _claimCardBodyHeightShare,
-              ),
-              child: SingleChildScrollView(
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          ...claims.map((c) => _coinPicker(context, c, formatter)),
-                          const SizedBox(height: 8),
-                          if (_selectionValid)
-                            SailButton(
-                              label: _buttonLabel(formatter, selectedSats, claims),
-                              icon: SailSVGAsset.iconCoins,
-                              onPressed: () => _claim(context),
-                            ),
-                        ],
+            // The page bounds the card, so the body takes what the header
+            // leaves and scrolls the rest. An unbounded host caps it instead.
+            Flexible(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.sizeOf(context).height * _claimCardBodyHeightShare,
+                ),
+                child: SingleChildScrollView(
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            ...claims.map((c) => _coinPicker(context, c, formatter)),
+                            const SizedBox(height: 8),
+                            if (_selectionValid)
+                              SailButton(
+                                label: _buttonLabel(formatter, selectedSats, claims),
+                                icon: SailSVGAsset.iconCoins,
+                                onPressed: () => _claim(context),
+                              ),
+                          ],
+                        ),
                       ),
-                    ),
-                    const SizedBox(width: 24),
-                    Expanded(child: _whyThisIsNecessary()),
-                  ],
+                      const SizedBox(width: 24),
+                      Expanded(child: _whyThisIsNecessary()),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/bitwindow/test/claim_card_scroll_test.dart
+++ b/bitwindow/test/claim_card_scroll_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:bitwindow/providers/fork_provider.dart';
+import 'package:bitwindow/providers/transactions_provider.dart';
+import 'package:bitwindow/widgets/fork_mode_banner.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart' as bwpb;
+import 'package:sidechain_core/sidechain_core.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // The card sits above the wallet tabs and takes its natural height, so a
+  // wallet with many coins used to run past the window.
+  testWidgets('the claim card scrolls instead of overflowing', (tester) async {
+    await registerTestDependencies();
+
+    final fork = ForkProvider();
+    fork.hasFundsToClaim = true;
+    fork.claims = [
+      WalletClaim(
+        walletId: 'w1',
+        walletName: 'bitkey',
+        claimableSats: 4000,
+        utxos: List.generate(
+          40,
+          (i) => bwpb.UnspentOutput(output: 'coin$i:0', valueSats: Int64(100), height: 900000 + i),
+        ),
+      ),
+    ];
+
+    if (!GetIt.I.isRegistered<ForkProvider>()) {
+      GetIt.I.registerSingleton<ForkProvider>(fork);
+    }
+    if (!GetIt.I.isRegistered<WalletReaderProvider>()) {
+      GetIt.I.registerSingleton<WalletReaderProvider>(WalletReaderProvider(Directory.systemTemp));
+    }
+    if (!GetIt.I.isRegistered<TransactionProvider>()) {
+      GetIt.I.registerSingleton<TransactionProvider>(TransactionProvider());
+    }
+
+    await tester.pumpSailPage(
+      Column(
+        children: [
+          const ForkModeBanner(),
+          Expanded(child: Container()),
+        ],
+      ),
+    );
+
+    expect(tester.takeException(), isNull, reason: '40 coins must not overflow the card');
+    expect(find.byType(SingleChildScrollView), findsWidgets);
+  });
+}

--- a/bitwindow/test/claim_card_scroll_test.dart
+++ b/bitwindow/test/claim_card_scroll_test.dart
@@ -8,9 +8,36 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart' as bwpb;
-import 'package:sidechain_core/sidechain_core.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
 
 import 'test_utils.dart';
+
+void _registerClaimProviders() {
+  final fork = ForkProvider();
+  fork.hasFundsToClaim = true;
+  fork.claims = [
+    WalletClaim(
+      walletId: 'w1',
+      walletName: 'bitkey',
+      claimableSats: 4000,
+      utxos: List.generate(
+        40,
+        (i) => bwpb.UnspentOutput(output: 'coin$i:0', valueSats: Int64(100), height: 900000 + i),
+      ),
+    ),
+  ];
+
+  if (!GetIt.I.isRegistered<ForkProvider>()) {
+    GetIt.I.registerSingleton<ForkProvider>(fork);
+  }
+  if (!GetIt.I.isRegistered<WalletReaderProvider>()) {
+    GetIt.I.registerSingleton<WalletReaderProvider>(WalletReaderProvider(Directory.systemTemp));
+  }
+  if (!GetIt.I.isRegistered<TransactionProvider>()) {
+    GetIt.I.registerSingleton<TransactionProvider>(TransactionProvider());
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -20,29 +47,7 @@ void main() {
   testWidgets('the claim card scrolls instead of overflowing', (tester) async {
     await registerTestDependencies();
 
-    final fork = ForkProvider();
-    fork.hasFundsToClaim = true;
-    fork.claims = [
-      WalletClaim(
-        walletId: 'w1',
-        walletName: 'bitkey',
-        claimableSats: 4000,
-        utxos: List.generate(
-          40,
-          (i) => bwpb.UnspentOutput(output: 'coin$i:0', valueSats: Int64(100), height: 900000 + i),
-        ),
-      ),
-    ];
-
-    if (!GetIt.I.isRegistered<ForkProvider>()) {
-      GetIt.I.registerSingleton<ForkProvider>(fork);
-    }
-    if (!GetIt.I.isRegistered<WalletReaderProvider>()) {
-      GetIt.I.registerSingleton<WalletReaderProvider>(WalletReaderProvider(Directory.systemTemp));
-    }
-    if (!GetIt.I.isRegistered<TransactionProvider>()) {
-      GetIt.I.registerSingleton<TransactionProvider>(TransactionProvider());
-    }
+    _registerClaimProviders();
 
     await tester.pumpSailPage(
       Column(
@@ -55,5 +60,38 @@ void main() {
 
     expect(tester.takeException(), isNull, reason: '40 coins must not overflow the card');
     expect(find.byType(SingleChildScrollView), findsWidgets);
+  });
+
+  // main.dart lets the window go down to 400 pixels tall, which leaves the card
+  // far less room than a full-size window.
+  testWidgets('the claim card fits the shortest window', (tester) async {
+    await registerTestDependencies();
+    _registerClaimProviders();
+
+    await tester.binding.setSurfaceSize(const Size(900, 400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      SailApp(
+        dense: false,
+        builder: (context) => MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                const ForkModeBanner(),
+                Expanded(child: Container()),
+              ],
+            ),
+          ),
+        ),
+        initMethod: (_) async => (),
+        accentColor: SailColorScheme.black,
+        log: GetIt.I.get<Logger>(),
+      ),
+      duration: const Duration(seconds: 10),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull, reason: 'the card must fit a 400 pixel tall window');
   });
 }

--- a/bitwindow/test/claim_card_scroll_test.dart
+++ b/bitwindow/test/claim_card_scroll_test.dart
@@ -62,6 +62,42 @@ void main() {
     expect(find.byType(SingleChildScrollView), findsWidgets);
   });
 
+  // The wallet page hands the card a bound that keeps room for the tabs. The
+  // card fits whatever it gets, down to a height far below its natural one.
+  testWidgets('the claim card fits the height its page allows', (tester) async {
+    await registerTestDependencies();
+    _registerClaimProviders();
+
+    await tester.binding.setSurfaceSize(const Size(900, 400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      SailApp(
+        dense: false,
+        builder: (context) => MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxHeight: 150),
+                  child: const ForkModeBanner(),
+                ),
+                Expanded(child: Container()),
+              ],
+            ),
+          ),
+        ),
+        initMethod: (_) async => (),
+        accentColor: SailColorScheme.black,
+        log: GetIt.I.get<Logger>(),
+      ),
+      duration: const Duration(seconds: 10),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull, reason: 'the card must fit a 150 pixel bound');
+  });
+
   // main.dart lets the window go down to 400 pixels tall, which leaves the card
   // far less room than a full-size window.
   testWidgets('the claim card fits the shortest window', (tester) async {


### PR DESCRIPTION
The eCash claim card sits above the wallet tabs and takes its natural height, so a wallet with many coins ran past the window. A user reported an overflow of 1808 pixels.

The card body now stops at 420 pixels and scrolls. A widget test renders 40 coins and fails on the overflow without the fix.