### PR TITLE
Walk a short lookahead on a refresh scan

### DIFF
--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -2166,18 +2166,41 @@ func gapLimitFor(deep bool) int {
 	return electrumRefreshGapLimit
 }
 
+// priorHighestUsed reports the highest index a previous scan saw in use on one
+// chain. A refresh walks through that index before it applies its lookahead,
+// so a coin further out than the lookahead stays in the wallet.
+func priorHighestUsed(prior *electrumScan, kind ScriptKind, change bool) uint32 {
+	if prior == nil {
+		return 0
+	}
+	var highest uint32
+	for _, a := range prior.addrs {
+		if a.kind == kind && a.change == change && a.stats.Used() && a.index > highest {
+			highest = a.index
+		}
+	}
+	return highest
+}
+
 func (p *ElectrumBackend) scanChain(ctx context.Context, walletID, chain string, derive chainDeriver, prior *electrumScan, deep, reportProgress bool) ([]scannedAddr, error) {
 	var out []scannedAddr
 	gap := gapLimitFor(deep)
 	consecutiveUnused := 0
 	found := 0
-	for i := uint32(0); consecutiveUnused < gap && i < electrumMaxScan; i++ {
-		if reportProgress {
-			p.svc.syncReporter.publish(walletID, scanProgress(chain, len(out), found))
-		}
+	var keepThrough uint32
+	for i := uint32(0); i < electrumMaxScan; i++ {
 		a, err := derive(i)
 		if err != nil {
 			return nil, err
+		}
+		if i == 0 {
+			keepThrough = priorHighestUsed(prior, a.kind, a.change)
+		}
+		if i > keepThrough && consecutiveUnused >= gap {
+			break
+		}
+		if reportProgress {
+			p.svc.syncReporter.publish(walletID, scanProgress(chain, len(out), found))
 		}
 		if err := p.hydrate(ctx, walletID, &a, prior); err != nil {
 			return nil, err

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -36,6 +36,13 @@ const (
 	// electrumGapLimit is the BIP44 gap limit: scanning a chain stops after
 	// this many consecutive unused addresses.
 	electrumGapLimit = 20
+	// electrumRefreshGapLimit is the lookahead a refresh walks past the last
+	// used address. A refresh runs every few seconds, so the full BIP44 gap
+	// costs four times the requests to find the same coins.
+	electrumRefreshGapLimit = 5
+	// electrumDeepScanEvery forces the full gap again, so a payment to an
+	// address past the refresh lookahead still lands.
+	electrumDeepScanEvery = 5 * time.Minute
 	// electrumMaxScan caps per-chain derivation so a misbehaving backend
 	// can't drive an unbounded scan.
 	electrumMaxScan = 1000
@@ -75,6 +82,7 @@ type ElectrumBackend struct {
 	watchKeys   map[string][]WatchKey    // walletID -> extra keys to track
 	warm        map[string]bool          // walletID -> a scan is available to serve
 	liveScanned map[string]bool          // walletID -> a live walk finished this process
+	deepAt      map[string]time.Time     // walletID -> when the full-gap walk last ran
 	warmScan    map[string]*electrumScan // walletID -> cached scan, served between blocks
 	tipAt       map[string]int           // walletID -> chain tip the cached scan reflects
 	scanAt      map[string]time.Time     // walletID -> when the cached scan was taken
@@ -113,6 +121,7 @@ func NewElectrumBackend(svc *Service, client ChainDataSource, params ParamsFunc,
 		watchKeys:   make(map[string][]WatchKey),
 		warm:        make(map[string]bool),
 		liveScanned: make(map[string]bool),
+		deepAt:      make(map[string]time.Time),
 		warmScan:    make(map[string]*electrumScan),
 		tipAt:       make(map[string]int),
 		scanAt:      make(map[string]time.Time),
@@ -153,6 +162,7 @@ func (p *ElectrumBackend) dropScanCaches() {
 	p.scanAt = make(map[string]time.Time)
 	p.warm = make(map[string]bool)
 	p.liveScanned = make(map[string]bool)
+	p.deepAt = make(map[string]time.Time)
 	p.lastScan = make(map[string][]byte)
 	p.mu.Unlock()
 
@@ -1735,6 +1745,12 @@ func (p *ElectrumBackend) scan(ctx context.Context, walletID string, allowCache 
 	// streaming those would spin the bottom-nav "Scanning…" status forever.
 	p.mu.Lock()
 	initial := !p.liveScanned[walletID]
+	// A refresh walks a short lookahead past the last used address. The full
+	// gap returns on the first scan and every electrumDeepScanEvery after it.
+	deep := initial || time.Since(p.deepAt[walletID]) >= electrumDeepScanEvery
+	if deep {
+		p.deepAt[walletID] = time.Now()
+	}
 	prior := p.warmScan[walletID]
 	p.mu.Unlock()
 	// prior holds the wallet's last known chain data (warm cache, else the
@@ -1760,7 +1776,7 @@ func (p *ElectrumBackend) scan(ctx context.Context, walletID string, allowCache 
 			if i < len(chainNames) {
 				chain = chainNames[i]
 			}
-			addrs, err := p.scanChain(ctx, walletID, chain, d, prior, initial)
+			addrs, err := p.scanChain(ctx, walletID, chain, d, prior, deep, initial)
 			if err != nil {
 				return nil, err
 			}
@@ -2141,12 +2157,22 @@ func (p *ElectrumBackend) kindDerivers(w *WalletData, kind ScriptKind) ([]chainD
 	return out, nil
 }
 
-func (p *ElectrumBackend) scanChain(ctx context.Context, walletID, chain string, derive chainDeriver, prior *electrumScan, initial bool) ([]scannedAddr, error) {
+// gapLimitFor reports how many unused addresses in a row end a walk. A deep
+// walk takes the BIP44 gap; a refresh takes the short lookahead.
+func gapLimitFor(deep bool) int {
+	if deep {
+		return electrumGapLimit
+	}
+	return electrumRefreshGapLimit
+}
+
+func (p *ElectrumBackend) scanChain(ctx context.Context, walletID, chain string, derive chainDeriver, prior *electrumScan, deep, reportProgress bool) ([]scannedAddr, error) {
 	var out []scannedAddr
+	gap := gapLimitFor(deep)
 	consecutiveUnused := 0
 	found := 0
-	for i := uint32(0); consecutiveUnused < electrumGapLimit && i < electrumMaxScan; i++ {
-		if initial {
+	for i := uint32(0); consecutiveUnused < gap && i < electrumMaxScan; i++ {
+		if reportProgress {
 			p.svc.syncReporter.publish(walletID, scanProgress(chain, len(out), found))
 		}
 		a, err := derive(i)

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -1746,8 +1746,9 @@ func (p *ElectrumBackend) scan(ctx context.Context, walletID string, allowCache 
 	p.mu.Lock()
 	initial := !p.liveScanned[walletID]
 	// A refresh walks a short lookahead past the last used address. The full
-	// gap returns on the first scan and every electrumDeepScanEvery after it.
-	deep := initial || time.Since(p.deepAt[walletID]) >= electrumDeepScanEvery
+	// gap returns on the first scan, on a rescan the user asked for, and every
+	// electrumDeepScanEvery after that.
+	deep := !allowCache || initial || time.Since(p.deepAt[walletID]) >= electrumDeepScanEvery
 	if deep {
 		p.deepAt[walletID] = time.Now()
 	}

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -2328,3 +2328,40 @@ func TestPriorHighestUsed(t *testing.T) {
 	assert.Equal(t, uint32(12), priorHighestUsed(prior, ScriptNativeSegwit, true))
 	assert.Equal(t, uint32(30), priorHighestUsed(prior, ScriptTaproot, false))
 }
+
+// A user asks for a rescan when a payment is missing, so it walks the full gap
+// however recently the periodic deep walk ran.
+func TestElectrumRescanWalksTheFullGap(t *testing.T) {
+	svc := newTestService(t)
+	w, err := svc.CreateElectrumWallet("Electrum", nil, nil, "", "", "", "", 0, "")
+	require.NoError(t, err)
+
+	addrs, err := DeriveBIP84Addresses(w.Master.SeedHex, &chaincfg.SigNetParams, 0, 20)
+	require.NoError(t, err)
+
+	fake := newFakeEsplora()
+	p := NewElectrumBackend(svc, fake, StaticParams(&chaincfg.SigNetParams), zerolog.New(zerolog.NewTestWriter(t)))
+	ctx := context.Background()
+
+	_, _, err = p.Balance(ctx, w.ID)
+	require.NoError(t, err)
+
+	// A payment lands far past the refresh lookahead, and the deep walk just ran.
+	fake.stats[addrs[15]] = EsploraAddressStats{
+		Address:    addrs[15],
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 100_000, TxCount: 1},
+	}
+	p.mu.Lock()
+	p.scanAt[w.ID] = time.Now().Add(-time.Hour)
+	p.deepAt[w.ID] = time.Now()
+	p.mu.Unlock()
+
+	scan, err := p.scan(ctx, w.ID, false)
+	require.NoError(t, err)
+
+	var total int64
+	for _, a := range scan.addrs {
+		total += a.stats.ChainStats.FundedTxoSum
+	}
+	require.Equal(t, int64(100_000), total, "a rescan must reach the far payment")
+}

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/replay"
@@ -2224,4 +2225,51 @@ func TestElectrumCreatePSBTNoReplayProtect(t *testing.T) {
 	packet, err := decodePSBTBase64(unsigned)
 	require.NoError(t, err)
 	require.NotEqual(t, replay.ReplayLockTime, packet.UnsignedTx.LockTime)
+}
+
+func TestGapLimitFor(t *testing.T) {
+	assert.Equal(t, 20, gapLimitFor(true))
+	assert.Equal(t, 5, gapLimitFor(false))
+}
+
+// A refresh runs every few seconds. It walks a short lookahead past the last
+// used address, while the full BIP44 gap returns on the periodic deep walk.
+func TestElectrumRefreshWalksAShortLookahead(t *testing.T) {
+	svc := newTestService(t)
+	w, err := svc.CreateElectrumWallet("Electrum", nil, nil, "", "", "", "", 0, "")
+	require.NoError(t, err)
+
+	addrs, err := DeriveBIP84Addresses(w.Master.SeedHex, &chaincfg.SigNetParams, 0, 1)
+	require.NoError(t, err)
+
+	counting := &countingEsplora{ChainDataSource: newFakeEsplora()}
+	p := NewElectrumBackend(svc, counting, StaticParams(&chaincfg.SigNetParams), zerolog.New(zerolog.NewTestWriter(t)))
+	ctx := context.Background()
+
+	fake, ok := counting.ChainDataSource.(*fakeEsplora)
+	require.True(t, ok)
+	fake.stats[addrs[0]] = EsploraAddressStats{
+		Address:    addrs[0],
+		ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 100_000, TxCount: 1},
+	}
+
+	_, _, err = p.Balance(ctx, w.ID)
+	require.NoError(t, err)
+	deepCalls := atomic.LoadInt32(&counting.statsCalls)
+	require.Positive(t, deepCalls)
+
+	// Age the cache so the next read re-walks, and mark the deep walk recent so
+	// that re-walk takes the refresh gap.
+	p.mu.Lock()
+	p.scanAt[w.ID] = time.Now().Add(-time.Hour)
+	p.deepAt[w.ID] = time.Now()
+	p.mu.Unlock()
+
+	_, _, err = p.Balance(ctx, w.ID)
+	require.NoError(t, err)
+	refreshCalls := atomic.LoadInt32(&counting.statsCalls) - deepCalls
+
+	t.Logf("deep walk: %d requests, refresh walk: %d requests", deepCalls, refreshCalls)
+	require.Positive(t, refreshCalls, "a refresh still checks the addresses in use")
+	require.Less(t, refreshCalls, deepCalls, "a refresh must cost fewer requests than the full gap")
 }

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -2273,3 +2273,58 @@ func TestElectrumRefreshWalksAShortLookahead(t *testing.T) {
 	require.Positive(t, refreshCalls, "a refresh still checks the addresses in use")
 	require.Less(t, refreshCalls, deepCalls, "a refresh must cost fewer requests than the full gap")
 }
+
+// A chain can hold a wide gap between two used addresses. A refresh must walk
+// through the far one, or its coins drop out of the wallet until the next deep
+// scan and drop out again after it.
+func TestElectrumRefreshKeepsAnAddressPastTheLookahead(t *testing.T) {
+	svc := newTestService(t)
+	w, err := svc.CreateElectrumWallet("Electrum", nil, nil, "", "", "", "", 0, "")
+	require.NoError(t, err)
+
+	addrs, err := DeriveBIP84Addresses(w.Master.SeedHex, &chaincfg.SigNetParams, 0, 8)
+	require.NoError(t, err)
+
+	fake := newFakeEsplora()
+	// Index 0 and index 6 hold coins, with five unused addresses between them.
+	for _, i := range []int{0, 6} {
+		fake.stats[addrs[i]] = EsploraAddressStats{
+			Address:    addrs[i],
+			ChainStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 100_000, TxCount: 1},
+		}
+	}
+
+	p := NewElectrumBackend(svc, fake, StaticParams(&chaincfg.SigNetParams), zerolog.New(zerolog.NewTestWriter(t)))
+	ctx := context.Background()
+
+	deep, _, err := p.Balance(ctx, w.ID)
+	require.NoError(t, err)
+	require.InDelta(t, 0.002, deep, 1e-9, "the deep scan finds both coins")
+
+	// Age the cache so the next read re-walks, and mark the deep walk recent so
+	// that re-walk takes the refresh gap.
+	p.mu.Lock()
+	p.scanAt[w.ID] = time.Now().Add(-time.Hour)
+	p.deepAt[w.ID] = time.Now()
+	p.mu.Unlock()
+
+	refresh, _, err := p.Balance(ctx, w.ID)
+	require.NoError(t, err)
+	require.InDelta(t, deep, refresh, 1e-9, "a refresh must not lose the far coin")
+}
+
+func TestPriorHighestUsed(t *testing.T) {
+	require.Zero(t, priorHighestUsed(nil, ScriptNativeSegwit, false))
+
+	prior := &electrumScan{addrs: []scannedAddr{
+		{index: 0, kind: ScriptNativeSegwit, stats: EsploraAddressStats{ChainStats: EsploraTxoStats{TxCount: 1}}},
+		{index: 6, kind: ScriptNativeSegwit, stats: EsploraAddressStats{ChainStats: EsploraTxoStats{TxCount: 1}}},
+		{index: 9, kind: ScriptNativeSegwit},
+		{index: 12, kind: ScriptNativeSegwit, change: true, stats: EsploraAddressStats{ChainStats: EsploraTxoStats{TxCount: 1}}},
+		{index: 30, kind: ScriptTaproot, stats: EsploraAddressStats{ChainStats: EsploraTxoStats{TxCount: 1}}},
+	}}
+
+	assert.Equal(t, uint32(6), priorHighestUsed(prior, ScriptNativeSegwit, false), "an unused index does not count")
+	assert.Equal(t, uint32(12), priorHighestUsed(prior, ScriptNativeSegwit, true))
+	assert.Equal(t, uint32(30), priorHighestUsed(prior, ScriptTaproot, false))
+}


### PR DESCRIPTION
The electrum wallet scan walked the full BIP44 gap of 20 unused addresses on every refresh, several times a minute. On one user's machine that made 16768 Esplora requests for 347 addresses in 35 minutes, and the balance never rendered.

A refresh now walks 5 addresses past the last used one. The full gap returns on the first scan of a wallet and every 5 minutes after it, so a payment past the lookahead still lands. Measured in the new test: 81 requests deep, 21 on a refresh.