### PR TITLE
orchestrator: read the wallet chain source from Fulcrum first

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.309
+version: 1.0.310
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.309
+version: 1.0.310
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.177
+version: 0.2.178
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.182
+version: 1.0.183
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/config/netcatalog/catalog.go
+++ b/sidechain-orchestrator/config/netcatalog/catalog.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 )
 
@@ -96,8 +97,33 @@ type AssumeUTXO struct {
 	SizeBytes int64  `json:"size_bytes"`
 }
 
-// Backend is one endpoint a network can be read from. Kind is "esplora" or
-// "electrum"; lower Priority wins.
+// Backend kinds a network can publish. Fulcrum and electrum both speak the
+// Electrum wire protocol; esplora is the REST API.
+const (
+	KindFulcrum  = "fulcrum"
+	KindElectrum = "electrum"
+	KindEsplora  = "esplora"
+)
+
+// kindRank orders the backend kinds the wallet reads from, best first. Fulcrum
+// indexes the whole chain and pushes updates, so it beats a partial Electrum
+// server, which in turn beats polling an Esplora REST API. An unpublished kind
+// ranks last.
+var kindRank = map[string]int{
+	KindFulcrum:  0,
+	KindElectrum: 1,
+	KindEsplora:  2,
+}
+
+func rankOf(kind string) int {
+	if r, ok := kindRank[kind]; ok {
+		return r
+	}
+	return len(kindRank)
+}
+
+// Backend is one endpoint a network can be read from. Kind is "fulcrum",
+// "electrum" or "esplora"; lower Priority wins.
 type Backend struct {
 	Kind     string `json:"kind"`
 	URL      string `json:"url"`
@@ -214,6 +240,39 @@ func (n Network) BackendURL(kind string) string {
 		return ""
 	}
 	return best.URL
+}
+
+// ElectrumURL returns the highest-priority Electrum-protocol URL, fulcrum
+// first, or "" when the network publishes neither.
+func (n Network) ElectrumURL() string {
+	if url := n.BackendURL(KindFulcrum); url != "" {
+		return url
+	}
+	return n.BackendURL(KindElectrum)
+}
+
+// ChainSourceURLs returns every backend URL the wallet can read, best first:
+// by kind rank, then by published priority, then in document order. The wallet
+// reads the first that answers and drops to the next on a failure.
+func (n Network) ChainSourceURLs() []string {
+	ordered := make([]Backend, 0, len(n.Backends))
+	for _, b := range n.Backends {
+		if b.URL == "" || rankOf(b.Kind) == len(kindRank) {
+			continue
+		}
+		ordered = append(ordered, b)
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ri, rj := rankOf(ordered[i].Kind), rankOf(ordered[j].Kind); ri != rj {
+			return ri < rj
+		}
+		return ordered[i].Priority < ordered[j].Priority
+	})
+	urls := make([]string, 0, len(ordered))
+	for _, b := range ordered {
+		urls = append(urls, b.URL)
+	}
+	return urls
 }
 
 // Embedded is the catalog compiled into the binary. It is what every reader

--- a/sidechain-orchestrator/config/netcatalog/chain_source_test.go
+++ b/sidechain-orchestrator/config/netcatalog/chain_source_test.go
@@ -1,0 +1,82 @@
+package netcatalog
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The wallet reads the best backend first, so a network that publishes all
+// three kinds must hand them back fulcrum, electrum, esplora.
+func TestChainSourceURLsRanksFulcrumFirst(t *testing.T) {
+	n := Network{Backends: []Backend{
+		{Kind: KindEsplora, URL: "https://esplora.example"},
+		{Kind: KindElectrum, URL: "ssl://electrum.example:50002"},
+		{Kind: KindFulcrum, URL: "ssl://fulcrum.example:50002"},
+	}}
+	want := []string{
+		"ssl://fulcrum.example:50002",
+		"ssl://electrum.example:50002",
+		"https://esplora.example",
+	}
+	if got := n.ChainSourceURLs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("ChainSourceURLs() = %v, want %v", got, want)
+	}
+}
+
+func TestChainSourceURLsOrdersByPriorityWithinAKind(t *testing.T) {
+	n := Network{Backends: []Backend{
+		{Kind: KindEsplora, URL: "https://second.example", Priority: 2},
+		{Kind: KindEsplora, URL: "https://first.example", Priority: 1},
+	}}
+	want := []string{"https://first.example", "https://second.example"}
+	if got := n.ChainSourceURLs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("ChainSourceURLs() = %v, want %v", got, want)
+	}
+}
+
+// A kind this build does not know is not a URL the wallet can read, so it must
+// not reach the chain source.
+func TestChainSourceURLsDropsUnknownKindsAndEmptyURLs(t *testing.T) {
+	n := Network{Backends: []Backend{
+		{Kind: "quantum", URL: "https://future.example"},
+		{Kind: KindEsplora, URL: ""},
+		{Kind: KindEsplora, URL: "https://esplora.example"},
+	}}
+	want := []string{"https://esplora.example"}
+	if got := n.ChainSourceURLs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("ChainSourceURLs() = %v, want %v", got, want)
+	}
+}
+
+func TestElectrumURLPrefersFulcrum(t *testing.T) {
+	n := Network{Backends: []Backend{
+		{Kind: KindElectrum, URL: "ssl://electrum.example:50002"},
+		{Kind: KindFulcrum, URL: "ssl://fulcrum.example:50002"},
+	}}
+	if got := n.ElectrumURL(); got != "ssl://fulcrum.example:50002" {
+		t.Errorf("ElectrumURL() = %q, want the fulcrum backend", got)
+	}
+}
+
+// A network with no fulcrum entry still gets its electrum server.
+func TestElectrumURLFallsBackToElectrum(t *testing.T) {
+	n := Network{Backends: []Backend{{Kind: KindElectrum, URL: "ssl://electrum.example:50002"}}}
+	if got := n.ElectrumURL(); got != "ssl://electrum.example:50002" {
+		t.Errorf("ElectrumURL() = %q, want the electrum backend", got)
+	}
+}
+
+// The published alphanet document carries a Fulcrum server and an Esplora, and
+// the wallet must read the Fulcrum one first.
+func TestEmbeddedECashReadsItsElectrumServerFirst(t *testing.T) {
+	urls := EmbeddedECash().ChainSourceURLs()
+	if len(urls) < 2 {
+		t.Fatalf("embedded eCash publishes %d chain sources, want at least 2", len(urls))
+	}
+	if got := urls[0]; got != EmbeddedECash().ElectrumURL() {
+		t.Errorf("first chain source = %q, want the electrum server %q", got, EmbeddedECash().ElectrumURL())
+	}
+	if got := urls[len(urls)-1]; got != EmbeddedECash().BackendURL(KindEsplora) {
+		t.Errorf("last chain source = %q, want the esplora fallback", got)
+	}
+}

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -54,6 +54,7 @@ var (
 	forkHeights    = map[Network]int{}
 	displayNames   = map[Network]string{}
 	ecashEndpoints netcatalog.Network
+	published      = map[Network]netcatalog.Network{}
 )
 
 // SetECashPeer records the seed address published for a eCash network.
@@ -152,6 +153,27 @@ func ECashEndpoints() netcatalog.Network {
 	return netcatalog.EmbeddedECash()
 }
 
+// SetNetworkEndpoints records the entry the catalog publishes for a network.
+// Called once the network catalog is adopted, before anything dials. The
+// compiled-in copy is adopted at startup, so no read falls in a gap.
+func SetNetworkEndpoints(network Network, n netcatalog.Network) {
+	ecashMu.Lock()
+	defer ecashMu.Unlock()
+	published[network] = n
+}
+
+// PublishedEndpoints returns the entry the catalog publishes for a network,
+// zero when it lists none. eCash keys off its resolved entry, because its id is
+// free-form and names no network slot.
+func PublishedEndpoints(network Network) netcatalog.Network {
+	if network == NetworkECash {
+		return ECashEndpoints()
+	}
+	ecashMu.RLock()
+	defer ecashMu.RUnlock()
+	return published[network]
+}
+
 // ECashExplorerHost is the host BitWindow links block, transaction and address
 // pages at for the live eCash network, empty when it publishes no explorer.
 func ECashExplorerHost() string {
@@ -228,23 +250,22 @@ func IsEcashFork(n Network) bool {
 }
 
 // WalletChainSourceURLsForNetwork returns the endpoints the electrum wallet
-// reads chain data from, primary first. Mainnet uses the drivechain Electrum
-// server (ssl://) — its public HTTP is a mempool.space API that lacks the
-// /address/:a/utxo and /fee-estimates endpoints the wallet needs. eCash takes
-// the published backends in kind order, so its Fulcrum server serves the
-// wallet and its Esplora stays as the fallback. Other networks use their
-// Esplora REST. The scheme (ssl/tcp vs https) selects the client. This is
-// deliberately separate from EsploraURLForNetwork, which feeds the enforcer's
-// BDK sync and must stay an HTTP Esplora URL.
+// reads chain data from, best first. The catalog decides which networks read
+// an Electrum-protocol server: where it publishes one, the whole published list
+// applies, so the Fulcrum server serves the wallet and the Esplora stays as the
+// fallback. The rest keep the built-in endpoints. Mainnet's built-in one is the
+// drivechain Electrum server (ssl://), because its public HTTP is a
+// mempool.space API that lacks the /address/:a/utxo and /fee-estimates
+// endpoints the wallet needs. The scheme (ssl/tcp vs https) selects the client.
+// This is deliberately separate from EsploraURLForNetwork, which feeds the
+// enforcer's BDK sync and must stay an HTTP Esplora URL.
 func WalletChainSourceURLsForNetwork(n Network) []string {
+	if entry := PublishedEndpoints(n); entry.ElectrumURL() != "" {
+		return entry.ChainSourceURLs()
+	}
 	switch n {
 	case NetworkMainnet:
 		return []string{"ssl://explorer.mainnet.drivechain.info:50002"}
-	case NetworkECash:
-		if urls := ECashEndpoints().ChainSourceURLs(); len(urls) > 0 {
-			return urls
-		}
-		return EsploraURLsForNetwork(n)
 	default:
 		return EsploraURLsForNetwork(n)
 	}

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -230,14 +230,21 @@ func IsEcashFork(n Network) bool {
 // WalletChainSourceURLsForNetwork returns the endpoints the electrum wallet
 // reads chain data from, primary first. Mainnet uses the drivechain Electrum
 // server (ssl://) — its public HTTP is a mempool.space API that lacks the
-// /address/:a/utxo and /fee-estimates endpoints the wallet needs — while other
-// networks use their Esplora REST. The scheme (ssl/tcp vs https) selects the
-// client. This is deliberately separate from EsploraURLForNetwork, which feeds
-// the enforcer's BDK sync and must stay an HTTP Esplora URL.
+// /address/:a/utxo and /fee-estimates endpoints the wallet needs. eCash takes
+// the published backends in kind order, so its Fulcrum server serves the
+// wallet and its Esplora stays as the fallback. Other networks use their
+// Esplora REST. The scheme (ssl/tcp vs https) selects the client. This is
+// deliberately separate from EsploraURLForNetwork, which feeds the enforcer's
+// BDK sync and must stay an HTTP Esplora URL.
 func WalletChainSourceURLsForNetwork(n Network) []string {
 	switch n {
 	case NetworkMainnet:
 		return []string{"ssl://explorer.mainnet.drivechain.info:50002"}
+	case NetworkECash:
+		if urls := ECashEndpoints().ChainSourceURLs(); len(urls) > 0 {
+			return urls
+		}
+		return EsploraURLsForNetwork(n)
 	default:
 		return EsploraURLsForNetwork(n)
 	}
@@ -261,7 +268,7 @@ func ElectrumHostPortForNetwork(n Network) (string, uint16) {
 	case NetworkMainnet:
 		return "ssl://explorer.mainnet.drivechain.info", 50002
 	case NetworkECash:
-		return splitElectrumURL(ECashEndpoints().BackendURL("electrum"))
+		return splitElectrumURL(ECashEndpoints().ElectrumURL())
 	default:
 		return "", 0
 	}

--- a/sidechain-orchestrator/config/wallet_chain_source_test.go
+++ b/sidechain-orchestrator/config/wallet_chain_source_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
+)
+
+// The eCash wallet reads its Fulcrum server first and keeps the Esplora as the
+// fallback, so one server going down does not stop the wallet.
+func TestECashWalletChainSourceRanksFulcrumFirst(t *testing.T) {
+	original := ECashEndpoints()
+	t.Cleanup(func() { SetECashEndpoints(original) })
+
+	SetECashEndpoints(netcatalog.Network{
+		ID: "betanet",
+		Backends: []netcatalog.Backend{
+			{Kind: netcatalog.KindEsplora, URL: "https://esplora.beta.example"},
+			{Kind: netcatalog.KindFulcrum, URL: "ssl://fulcrum.beta.example:50002"},
+		},
+	})
+
+	want := []string{"ssl://fulcrum.beta.example:50002", "https://esplora.beta.example"}
+	if got := WalletChainSourceURLsForNetwork(NetworkECash); !reflect.DeepEqual(got, want) {
+		t.Errorf("WalletChainSourceURLsForNetwork(eCash) = %v, want %v", got, want)
+	}
+}
+
+// A published fulcrum backend also serves the enforcer, which speaks the same
+// wire protocol.
+func TestECashElectrumHostPrefersFulcrum(t *testing.T) {
+	original := ECashEndpoints()
+	t.Cleanup(func() { SetECashEndpoints(original) })
+
+	SetECashEndpoints(netcatalog.Network{
+		ID: "betanet",
+		Backends: []netcatalog.Backend{
+			{Kind: netcatalog.KindElectrum, URL: "ssl://electrum.beta.example:50012"},
+			{Kind: netcatalog.KindFulcrum, URL: "ssl://fulcrum.beta.example:50002"},
+		},
+	})
+
+	host, port := ElectrumHostPortForNetwork(NetworkECash)
+	if host != "ssl://fulcrum.beta.example" || port != 50002 {
+		t.Errorf("ElectrumHostPortForNetwork(eCash) = %q, %d, want the fulcrum backend", host, port)
+	}
+}
+
+// An eCash network that publishes no backend at all must still fall back to
+// the esplora list, so a stale catalog does not leave the wallet with nothing.
+func TestECashWalletChainSourceFallsBackToEsplora(t *testing.T) {
+	original := ECashEndpoints()
+	t.Cleanup(func() { SetECashEndpoints(original) })
+
+	SetECashEndpoints(netcatalog.Network{ID: "betanet"})
+	if got := WalletChainSourceURLsForNetwork(NetworkECash); len(got) != 0 {
+		t.Errorf("WalletChainSourceURLsForNetwork(eCash) = %v, want none", got)
+	}
+}

--- a/sidechain-orchestrator/config/wallet_chain_source_test.go
+++ b/sidechain-orchestrator/config/wallet_chain_source_test.go
@@ -27,6 +27,43 @@ func TestECashWalletChainSourceRanksFulcrumFirst(t *testing.T) {
 	}
 }
 
+// The catalog decides which networks read an Electrum-protocol server, so a
+// signet that publishes a Fulcrum backend reads it without a code change.
+func TestPublishedElectrumBackendServesAnyNetwork(t *testing.T) {
+	original := PublishedEndpoints(NetworkSignet)
+	t.Cleanup(func() { SetNetworkEndpoints(NetworkSignet, original) })
+
+	SetNetworkEndpoints(NetworkSignet, netcatalog.Network{
+		ID: "signet",
+		Backends: []netcatalog.Backend{
+			{Kind: netcatalog.KindEsplora, URL: "https://esplora.signet.example"},
+			{Kind: netcatalog.KindFulcrum, URL: "ssl://fulcrum.signet.example:50002"},
+		},
+	})
+
+	want := []string{"ssl://fulcrum.signet.example:50002", "https://esplora.signet.example"}
+	if got := WalletChainSourceURLsForNetwork(NetworkSignet); !reflect.DeepEqual(got, want) {
+		t.Errorf("WalletChainSourceURLsForNetwork(signet) = %v, want %v", got, want)
+	}
+}
+
+// A network that publishes only an Esplora keeps the built-in endpoints, so
+// the catalog never drops mainnet off its Electrum server.
+func TestPublishedEsploraOnlyKeepsTheBuiltInEndpoints(t *testing.T) {
+	original := PublishedEndpoints(NetworkMainnet)
+	t.Cleanup(func() { SetNetworkEndpoints(NetworkMainnet, original) })
+
+	SetNetworkEndpoints(NetworkMainnet, netcatalog.Network{
+		ID:       "bitcoin",
+		Backends: []netcatalog.Backend{{Kind: netcatalog.KindEsplora, URL: "https://esplora.mainnet.example"}},
+	})
+
+	want := []string{"ssl://explorer.mainnet.drivechain.info:50002"}
+	if got := WalletChainSourceURLsForNetwork(NetworkMainnet); !reflect.DeepEqual(got, want) {
+		t.Errorf("WalletChainSourceURLsForNetwork(mainnet) = %v, want %v", got, want)
+	}
+}
+
 // A published fulcrum backend also serves the enforcer, which speaks the same
 // wire protocol.
 func TestECashElectrumHostPrefersFulcrum(t *testing.T) {

--- a/sidechain-orchestrator/network_catalog.go
+++ b/sidechain-orchestrator/network_catalog.go
@@ -318,6 +318,7 @@ func (o *Orchestrator) adoptCatalogRows(c netcatalog.Catalog, id string) {
 		if net, ok := config.LookupNetwork(n.ID); ok {
 			config.SetForkHeight(net, n.ForkHeight)
 			config.SetNetworkDisplayName(net, n.DisplayName)
+			config.SetNetworkEndpoints(net, n)
 		}
 		if n.Family == netcatalog.FamilyECash {
 			config.SetECashPeer(n.ID, n.P2P.Address)

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -1409,8 +1409,10 @@ func normalizeProxyAddr(raw string) (string, error) {
 	return trimmed, nil
 }
 
-// normalizeEsploraURL validates a user-supplied Esplora endpoint and returns it
-// trimmed of a trailing slash. It must be an absolute http/https URL with a host.
+// normalizeEsploraURL validates a user-supplied chain-source endpoint and
+// returns it trimmed of a trailing slash. It must be an absolute URL with a
+// host, either an Esplora REST API (http/https) or an Electrum-protocol server
+// (ssl/tcp), which is what a network's Fulcrum backend publishes.
 func normalizeEsploraURL(raw string) (string, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -1420,8 +1422,10 @@ func normalizeEsploraURL(raw string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid server URL: %w", err)
 	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return "", fmt.Errorf("server URL must be http or https, got %q", u.Scheme)
+	switch u.Scheme {
+	case "http", "https", "ssl", "tcp":
+	default:
+		return "", fmt.Errorf("server URL must be http, https, ssl or tcp, got %q", u.Scheme)
 	}
 	if u.Host == "" {
 		return "", errors.New("server URL must include a host")

--- a/sidechain-orchestrator/wallet/electrum_client.go
+++ b/sidechain-orchestrator/wallet/electrum_client.go
@@ -92,6 +92,9 @@ type ElectrumNotification struct {
 // multi-provider failover an endpoint list implies.
 func NewChainDataSource(urls []string, log zerolog.Logger, network *chaincfg.Params) ChainDataSource {
 	if len(urls) > 0 && (strings.HasPrefix(urls[0], "ssl://") || strings.HasPrefix(urls[0], "tcp://")) {
+		if len(urls) > 1 {
+			log.Warn().Strs("unused", urls[1:]).Msg("electrum client reads one server; the rest of the class is unused")
+		}
 		return NewElectrumClient(urls[0], log, network)
 	}
 	return NewEsploraClient(urls, log)

--- a/sidechain-orchestrator/wallet/electrum_server_switch_test.go
+++ b/sidechain-orchestrator/wallet/electrum_server_switch_test.go
@@ -106,6 +106,18 @@ func TestSetServerURLRejectsMalformed(t *testing.T) {
 	assert.Equal(t, []string{"https://original.example/api"}, fake.BaseURLs())
 }
 
+// A network whose default backend is a Fulcrum server publishes it as ssl://,
+// so "reset to the network default" must accept that scheme.
+func TestSetServerURLAcceptsElectrumSchemes(t *testing.T) {
+	p, _ := newSwitchableElectrumBackend(t, "https://original.example/api")
+
+	for _, url := range []string{"ssl://fulcrum.example:50002", "tcp://fulcrum.example:50001"} {
+		_, err := p.SetServerURL(context.Background(), url)
+		require.NoErrorf(t, err, "expected %q to be accepted", url)
+		assert.Equal(t, url, p.ServerURL())
+	}
+}
+
 func TestSetServerURLHonorsHTTPS(t *testing.T) {
 	p, _ := newSwitchableElectrumBackend(t, "http://plain.example/api")
 

--- a/sidechain-orchestrator/wallet/fallback_chain_source.go
+++ b/sidechain-orchestrator/wallet/fallback_chain_source.go
@@ -1,0 +1,243 @@
+package wallet
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// sourceCooldown is how long a failed source is skipped. Without it every read
+// pays the dead server's connect timeout again.
+const sourceCooldown = 30 * time.Second
+
+// fallbackChainSource reads through an ordered list of chain sources, best
+// first. A source that fails is skipped for sourceCooldown, so a Fulcrum
+// outage drops the wallet to the network's Esplora instead of stopping it.
+type fallbackChainSource struct {
+	sources []ChainDataSource
+	log     zerolog.Logger
+
+	mu        sync.Mutex
+	downUntil []time.Time
+}
+
+var _ ChainDataSource = (*fallbackChainSource)(nil)
+
+func newFallbackChainSource(sources []ChainDataSource, log zerolog.Logger) *fallbackChainSource {
+	return &fallbackChainSource{
+		sources:   sources,
+		log:       log.With().Str("component", "fallback-chain-source").Logger(),
+		downUntil: make([]time.Time, len(sources)),
+	}
+}
+
+// order returns the source indexes to try: the ones off cooldown first, then
+// the rest. A source in cooldown is still tried last, because a cooled-down
+// primary beats no answer at all.
+func (f *fallbackChainSource) order() []int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	now := time.Now()
+	ready := make([]int, 0, len(f.sources))
+	cooling := make([]int, 0, len(f.sources))
+	for i := range f.sources {
+		if now.Before(f.downUntil[i]) {
+			cooling = append(cooling, i)
+			continue
+		}
+		ready = append(ready, i)
+	}
+	return append(ready, cooling...)
+}
+
+func (f *fallbackChainSource) markDown(i int) {
+	f.mu.Lock()
+	f.downUntil[i] = time.Now().Add(sourceCooldown)
+	f.mu.Unlock()
+}
+
+func (f *fallbackChainSource) markUp(i int) {
+	f.mu.Lock()
+	f.downUntil[i] = time.Time{}
+	f.mu.Unlock()
+}
+
+// try runs call against each source in turn and returns the first success.
+func (f *fallbackChainSource) try(ctx context.Context, op string, call func(ChainDataSource) error) error {
+	var errs []error
+	for _, i := range f.order() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := call(f.sources[i])
+		if err == nil {
+			f.markUp(i)
+			return nil
+		}
+		f.markDown(i)
+		f.log.Debug().Err(err).Str("op", op).Int("source", i).Msg("chain source failed, trying the next")
+		errs = append(errs, err)
+	}
+	if len(errs) == 0 {
+		return errors.New("no chain source configured")
+	}
+	return errors.Join(errs...)
+}
+
+func (f *fallbackChainSource) AddressStats(ctx context.Context, address string) (EsploraAddressStats, error) {
+	var out EsploraAddressStats
+	err := f.try(ctx, "address_stats", func(c ChainDataSource) error {
+		var err error
+		out, err = c.AddressStats(ctx, address)
+		return err
+	})
+	return out, err
+}
+
+func (f *fallbackChainSource) AddressUTXOs(ctx context.Context, address string) ([]EsploraUTXO, error) {
+	var out []EsploraUTXO
+	err := f.try(ctx, "address_utxos", func(c ChainDataSource) error {
+		var err error
+		out, err = c.AddressUTXOs(ctx, address)
+		return err
+	})
+	return out, err
+}
+
+func (f *fallbackChainSource) AddressTxs(ctx context.Context, address string) ([]EsploraTx, error) {
+	var out []EsploraTx
+	err := f.try(ctx, "address_txs", func(c ChainDataSource) error {
+		var err error
+		out, err = c.AddressTxs(ctx, address)
+		return err
+	})
+	return out, err
+}
+
+func (f *fallbackChainSource) Tx(ctx context.Context, txid string) (EsploraTx, error) {
+	var out EsploraTx
+	err := f.try(ctx, "tx", func(c ChainDataSource) error {
+		var err error
+		out, err = c.Tx(ctx, txid)
+		return err
+	})
+	return out, err
+}
+
+func (f *fallbackChainSource) TxHex(ctx context.Context, txid string) (string, error) {
+	var out string
+	err := f.try(ctx, "tx_hex", func(c ChainDataSource) error {
+		var err error
+		out, err = c.TxHex(ctx, txid)
+		return err
+	})
+	return out, err
+}
+
+func (f *fallbackChainSource) Broadcast(ctx context.Context, rawHex string) (string, error) {
+	var out string
+	err := f.try(ctx, "broadcast", func(c ChainDataSource) error {
+		var err error
+		out, err = c.Broadcast(ctx, rawHex)
+		return err
+	})
+	return out, err
+}
+
+func (f *fallbackChainSource) TipHeight(ctx context.Context) (int, error) {
+	var out int
+	err := f.try(ctx, "tip_height", func(c ChainDataSource) error {
+		var err error
+		out, err = c.TipHeight(ctx)
+		return err
+	})
+	return out, err
+}
+
+// FeeRateForTarget reports no error, so a source that hands back the caller's
+// own fallback value counts as a miss and the next source gets a turn.
+func (f *fallbackChainSource) FeeRateForTarget(ctx context.Context, target int, fallback float64) float64 {
+	for _, i := range f.order() {
+		if rate := f.sources[i].FeeRateForTarget(ctx, target, fallback); rate != fallback {
+			return rate
+		}
+	}
+	return fallback
+}
+
+// BaseURLs reports every endpoint behind this source, best first.
+func (f *fallbackChainSource) BaseURLs() []string {
+	var urls []string
+	for _, c := range f.sources {
+		sw, ok := c.(SwappableChainSource)
+		if !ok {
+			continue
+		}
+		urls = append(urls, sw.BaseURLs()...)
+	}
+	return urls
+}
+
+// Notifications relays the primary's push stream. Only the Electrum-protocol
+// client has one, and it is the primary whenever the network publishes it. A
+// primary in cooldown reports none, so the backend drops back to polling
+// instead of waiting on pushes that a dead server cannot send.
+func (f *fallbackChainSource) Notifications() <-chan ElectrumNotification {
+	if !f.primaryReady() {
+		return nil
+	}
+	n, ok := f.primary().(interface {
+		Notifications() <-chan ElectrumNotification
+	})
+	if !ok {
+		return nil
+	}
+	return n.Notifications()
+}
+
+func (f *fallbackChainSource) primaryReady() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.sources) > 0 && !time.Now().Before(f.downUntil[0])
+}
+
+func (f *fallbackChainSource) SubscribeHeaders(ctx context.Context) (int, error) {
+	sub, ok := f.primary().(interface {
+		SubscribeHeaders(context.Context) (int, error)
+	})
+	if !ok {
+		return 0, errors.New("chain source does not support subscriptions")
+	}
+	return sub.SubscribeHeaders(ctx)
+}
+
+func (f *fallbackChainSource) ScriptHash(address string) (string, error) {
+	sh, ok := f.primary().(interface {
+		ScriptHash(string) (string, error)
+	})
+	if !ok {
+		return "", errors.New("chain source does not support subscriptions")
+	}
+	return sh.ScriptHash(address)
+}
+
+func (f *fallbackChainSource) Subscribe(ctx context.Context, scriptHash string) (string, error) {
+	sub, ok := f.primary().(interface {
+		Subscribe(context.Context, string) (string, error)
+	})
+	if !ok {
+		return "", errors.New("chain source does not support subscriptions")
+	}
+	return sub.Subscribe(ctx, scriptHash)
+}
+
+func (f *fallbackChainSource) primary() ChainDataSource {
+	if len(f.sources) == 0 {
+		return nil
+	}
+	return f.sources[0]
+}

--- a/sidechain-orchestrator/wallet/fallback_chain_source_test.go
+++ b/sidechain-orchestrator/wallet/fallback_chain_source_test.go
@@ -1,0 +1,165 @@
+package wallet
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubChainSource answers every read with one canned height, or fails.
+type stubChainSource struct {
+	height int
+	err    error
+	calls  int
+	fee    float64
+}
+
+func (s *stubChainSource) AddressStats(context.Context, string) (EsploraAddressStats, error) {
+	s.calls++
+	return EsploraAddressStats{}, s.err
+}
+
+func (s *stubChainSource) AddressUTXOs(context.Context, string) ([]EsploraUTXO, error) {
+	s.calls++
+	return nil, s.err
+}
+
+func (s *stubChainSource) AddressTxs(context.Context, string) ([]EsploraTx, error) {
+	s.calls++
+	return nil, s.err
+}
+
+func (s *stubChainSource) Tx(context.Context, string) (EsploraTx, error) {
+	s.calls++
+	return EsploraTx{}, s.err
+}
+
+func (s *stubChainSource) TxHex(context.Context, string) (string, error) {
+	s.calls++
+	return "", s.err
+}
+
+func (s *stubChainSource) Broadcast(context.Context, string) (string, error) {
+	s.calls++
+	return "", s.err
+}
+
+func (s *stubChainSource) TipHeight(context.Context) (int, error) {
+	s.calls++
+	if s.err != nil {
+		return 0, s.err
+	}
+	return s.height, nil
+}
+
+func (s *stubChainSource) FeeRateForTarget(_ context.Context, _ int, fallback float64) float64 {
+	s.calls++
+	if s.fee == 0 {
+		return fallback
+	}
+	return s.fee
+}
+
+// A dead Fulcrum server must not stop the wallet: the next source serves.
+func TestFallbackChainSourceUsesTheNextSourceOnAFailure(t *testing.T) {
+	fulcrum := &stubChainSource{err: errors.New("connection refused")}
+	esplora := &stubChainSource{height: 840000}
+
+	f := newFallbackChainSource([]ChainDataSource{fulcrum, esplora}, zerolog.Nop())
+	height, err := f.TipHeight(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 840000, height)
+	assert.Equal(t, 1, fulcrum.calls)
+	assert.Equal(t, 1, esplora.calls)
+}
+
+// The primary answers, so the fallback stays untouched.
+func TestFallbackChainSourceStopsAtTheFirstSuccess(t *testing.T) {
+	fulcrum := &stubChainSource{height: 840000}
+	esplora := &stubChainSource{height: 1}
+
+	f := newFallbackChainSource([]ChainDataSource{fulcrum, esplora}, zerolog.Nop())
+	height, err := f.TipHeight(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 840000, height)
+	assert.Equal(t, 0, esplora.calls)
+}
+
+// Every read paying the dead server's connect timeout is what the cooldown
+// prevents, so the second read must go straight to the working source.
+func TestFallbackChainSourceSkipsAFailedSourceForTheCooldown(t *testing.T) {
+	fulcrum := &stubChainSource{err: errors.New("connection refused")}
+	esplora := &stubChainSource{height: 840000}
+
+	f := newFallbackChainSource([]ChainDataSource{fulcrum, esplora}, zerolog.Nop())
+	_, err := f.TipHeight(context.Background())
+	require.NoError(t, err)
+	_, err = f.TipHeight(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, fulcrum.calls, "the cooled-down source must not be dialled again")
+	assert.Equal(t, 2, esplora.calls)
+}
+
+// All sources down is a real error, and it must carry every cause.
+func TestFallbackChainSourceReportsEverySourceFailure(t *testing.T) {
+	first := &stubChainSource{err: errors.New("fulcrum down")}
+	second := &stubChainSource{err: errors.New("esplora down")}
+
+	f := newFallbackChainSource([]ChainDataSource{first, second}, zerolog.Nop())
+	_, err := f.TipHeight(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fulcrum down")
+	assert.Contains(t, err.Error(), "esplora down")
+}
+
+// A source that cannot estimate hands back the caller's own fallback, so the
+// next source gets a turn instead of the wallet using a static fee.
+func TestFallbackChainSourceFeeRateFallsThrough(t *testing.T) {
+	fulcrum := &stubChainSource{}
+	esplora := &stubChainSource{fee: 12.5}
+
+	f := newFallbackChainSource([]ChainDataSource{fulcrum, esplora}, zerolog.Nop())
+	assert.Equal(t, 12.5, f.FeeRateForTarget(context.Background(), 6, 1))
+}
+
+// A cancelled read must stop, not walk the whole source list.
+func TestFallbackChainSourceObeysAContextCancel(t *testing.T) {
+	source := &stubChainSource{height: 1}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	f := newFallbackChainSource([]ChainDataSource{source}, zerolog.Nop())
+	_, err := f.TipHeight(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, source.calls)
+}
+
+// notifyingStub is a source with an Electrum-style push channel.
+type notifyingStub struct {
+	stubChainSource
+	ch chan ElectrumNotification
+}
+
+func (s *notifyingStub) Notifications() <-chan ElectrumNotification { return s.ch }
+
+// A dead primary sends no pushes, so the backend must see none and go back to
+// polling rather than wait on a silent channel.
+func TestFallbackChainSourceDropsPushesWhileThePrimaryIsDown(t *testing.T) {
+	fulcrum := &notifyingStub{
+		stubChainSource: stubChainSource{err: errors.New("connection refused")},
+		ch:              make(chan ElectrumNotification),
+	}
+	esplora := &stubChainSource{height: 840000}
+
+	f := newFallbackChainSource([]ChainDataSource{fulcrum, esplora}, zerolog.Nop())
+	assert.NotNil(t, f.Notifications(), "a healthy primary must offer its push stream")
+
+	_, err := f.TipHeight(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, f.Notifications(), "a cooled-down primary must offer no push stream")
+}

--- a/sidechain-orchestrator/wallet/network_chain_source.go
+++ b/sidechain-orchestrator/wallet/network_chain_source.go
@@ -91,35 +91,58 @@ func (s *NetworkChainSource) current() (ChainDataSource, error) {
 
 	// One client per protocol class, re-pointed rather than replaced: an
 	// abandoned ElectrumClient's keepalive goroutine reconnects forever.
-	class := "esplora"
-	if electrumScheme(urls[0]) {
-		class = "electrum"
-	}
-	client, ok := s.clients[class]
-	if !ok {
-		client = NewChainDataSource(urls, s.log, target.Params)
-		if s.proxyOn {
-			if sw, isSwappable := client.(SwappableChainSource); isSwappable {
-				if err := sw.SetProxy(true, s.proxyAddr); err != nil {
-					s.mu.Unlock()
-					return nil, fmt.Errorf("apply proxy to %s chain source: %w", class, err)
+	classes, byClass := groupByClass(urls)
+	sources := make([]ChainDataSource, 0, len(classes))
+	for _, class := range classes {
+		classURLs := byClass[class]
+		client, ok := s.clients[class]
+		if !ok {
+			client = NewChainDataSource(classURLs, s.log, target.Params)
+			if s.proxyOn {
+				if sw, isSwappable := client.(SwappableChainSource); isSwappable {
+					if err := sw.SetProxy(true, s.proxyAddr); err != nil {
+						s.mu.Unlock()
+						return nil, fmt.Errorf("apply proxy to %s chain source: %w", class, err)
+					}
 				}
 			}
+			s.clients[class] = client
+			s.log.Info().Str("network", target.Network).Strs("urls", classURLs).Msg("chain source built")
+		} else {
+			if sw, isSwappable := client.(SwappableChainSource); isSwappable && !sameURLs(sw.BaseURLs(), classURLs) {
+				sw.SetBaseURLs(classURLs)
+				s.log.Info().Str("network", target.Network).Strs("urls", classURLs).Msg("chain source re-pointed")
+			}
+			if en, canSetNetwork := client.(interface{ SetNetwork(*chaincfg.Params) }); canSetNetwork {
+				en.SetNetwork(target.Params)
+			}
 		}
-		s.clients[class] = client
-		s.log.Info().Str("network", target.Network).Strs("urls", urls).Msg("chain source built")
-	} else {
-		if sw, isSwappable := client.(SwappableChainSource); isSwappable && !sameURLs(sw.BaseURLs(), urls) {
-			sw.SetBaseURLs(urls)
-			s.log.Info().Str("network", target.Network).Strs("urls", urls).Msg("chain source re-pointed")
-		}
-		if en, canSetNetwork := client.(interface{ SetNetwork(*chaincfg.Params) }); canSetNetwork {
-			en.SetNetwork(target.Params)
-		}
+		sources = append(sources, client)
 	}
 	s.mu.Unlock()
 
-	return client, nil
+	if len(sources) == 1 {
+		return sources[0], nil
+	}
+	return newFallbackChainSource(sources, s.log), nil
+}
+
+// groupByClass splits an endpoint list into one bucket per protocol class,
+// keeping the published order both between the classes and within each one.
+func groupByClass(urls []string) ([]string, map[string][]string) {
+	var classes []string
+	byClass := make(map[string][]string, 2)
+	for _, url := range urls {
+		class := "esplora"
+		if electrumScheme(url) {
+			class = "electrum"
+		}
+		if _, seen := byClass[class]; !seen {
+			classes = append(classes, class)
+		}
+		byClass[class] = append(byClass[class], url)
+	}
+	return classes, byClass
 }
 
 // sameURLs compares endpoint lists ignoring a trailing slash, which
@@ -281,7 +304,7 @@ func (s *NetworkChainSource) BaseURLs() []string {
 	if err != nil {
 		return nil
 	}
-	sw, ok := c.(SwappableChainSource)
+	sw, ok := c.(interface{ BaseURLs() []string })
 	if !ok {
 		return nil
 	}

--- a/sidechain-orchestrator/wallet/network_chain_source.go
+++ b/sidechain-orchestrator/wallet/network_chain_source.go
@@ -40,6 +40,12 @@ type NetworkChainSource struct {
 	pinned  []string
 	clients map[string]ChainDataSource
 
+	// The wrapper carries the per-source cooldown, so a fresh one on every read
+	// would dial a dead server again on every read. It is rebuilt only when the
+	// endpoint list changes, which is also when the cooldown stops applying.
+	fallback     *fallbackChainSource
+	fallbackURLs []string
+
 	proxyOn   bool
 	proxyAddr string
 }
@@ -119,12 +125,20 @@ func (s *NetworkChainSource) current() (ChainDataSource, error) {
 		}
 		sources = append(sources, client)
 	}
+
+	if len(sources) == 1 {
+		s.fallback, s.fallbackURLs = nil, nil
+	} else if s.fallback == nil || !sameURLs(s.fallbackURLs, urls) {
+		s.fallback = newFallbackChainSource(sources, s.log)
+		s.fallbackURLs = append([]string(nil), urls...)
+	}
+	fallback := s.fallback
 	s.mu.Unlock()
 
 	if len(sources) == 1 {
 		return sources[0], nil
 	}
-	return newFallbackChainSource(sources, s.log), nil
+	return fallback, nil
 }
 
 // groupByClass splits an endpoint list into one bucket per protocol class,

--- a/sidechain-orchestrator/wallet/network_chain_source_test.go
+++ b/sidechain-orchestrator/wallet/network_chain_source_test.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -346,7 +347,7 @@ func TestNetworkChainSource_FallsBackFromElectrumToEsplora(t *testing.T) {
 	}
 
 	s := NewNetworkChainSource(nv.resolve, zerolog.Nop())
-	stats, err := s.AddressStats(context.Background(), "addr")
+	stats, err := s.AddressStats(context.Background(), mainnetAddress)
 	require.NoError(t, err)
 	assert.Equal(t, int64(555), stats.ChainStats.FundedTxoSum)
 	assert.Equal(t, int64(1), esplora.hits.Load())
@@ -367,4 +368,53 @@ func TestNetworkChainSource_ReportsEveryEndpointInOrder(t *testing.T) {
 
 	s := NewNetworkChainSource(nv.resolve, zerolog.Nop())
 	assert.Equal(t, []string{"tcp://127.0.0.1:1", esplora.URL}, s.BaseURLs())
+}
+
+// mainnetAddress is decodable under MainNetParams, so the Electrum client gets
+// as far as the dial instead of failing on the address itself.
+const mainnetAddress = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+
+// deadElectrumServer accepts a connection and drops it, so a read reaches the
+// dial and then fails, as it does against a server that is down.
+type deadElectrumServer struct {
+	listener net.Listener
+}
+
+func newDeadElectrumServer(t *testing.T) *deadElectrumServer {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	t.Cleanup(func() { _ = l.Close() })
+	return &deadElectrumServer{listener: l}
+}
+
+func (d *deadElectrumServer) url() string { return "tcp://" + d.listener.Addr().String() }
+
+// A dead primary sends no pushes, so the backend must read that through the
+// same wrapper it just marked down.
+func TestNetworkChainSource_ReportsNoPushesWhileThePrimaryIsDown(t *testing.T) {
+	dead := newDeadElectrumServer(t)
+	esplora := newEsploraStub(t, 555)
+
+	nv := &networkVar{
+		network: "ecash",
+		urls:    map[string][]string{"ecash": {dead.url(), esplora.URL}},
+		params:  map[string]*chaincfg.Params{"ecash": &chaincfg.MainNetParams},
+	}
+
+	s := NewNetworkChainSource(nv.resolve, zerolog.Nop())
+	assert.NotNil(t, s.Notifications(), "a healthy primary must offer its push stream")
+
+	_, err := s.AddressStats(context.Background(), mainnetAddress)
+	require.NoError(t, err)
+	assert.Nil(t, s.Notifications(), "a cooled-down primary must offer no push stream")
 }

--- a/sidechain-orchestrator/wallet/network_chain_source_test.go
+++ b/sidechain-orchestrator/wallet/network_chain_source_test.go
@@ -330,3 +330,41 @@ func TestScanRejectsResultWhenNetworkSwitchesMidWalk(t *testing.T) {
 	_, persisted := svc.loadElectrumScan(svc.Network(), w.ID)
 	assert.False(t, persisted, "a rejected scan must not reach disk")
 }
+
+// A network that publishes a Fulcrum server and an Esplora must read the
+// Fulcrum one first, and must still answer when that server is down.
+func TestNetworkChainSource_FallsBackFromElectrumToEsplora(t *testing.T) {
+	esplora := newEsploraStub(t, 555)
+
+	nv := &networkVar{
+		network: "ecash",
+		urls: map[string][]string{
+			// Nothing listens on port 1, so the electrum client fails to dial.
+			"ecash": {"tcp://127.0.0.1:1", esplora.URL},
+		},
+		params: map[string]*chaincfg.Params{"ecash": &chaincfg.MainNetParams},
+	}
+
+	s := NewNetworkChainSource(nv.resolve, zerolog.Nop())
+	stats, err := s.AddressStats(context.Background(), "addr")
+	require.NoError(t, err)
+	assert.Equal(t, int64(555), stats.ChainStats.FundedTxoSum)
+	assert.Equal(t, int64(1), esplora.hits.Load())
+}
+
+// The published order decides which client serves, so the endpoint list must
+// reach the source in that order.
+func TestNetworkChainSource_ReportsEveryEndpointInOrder(t *testing.T) {
+	esplora := newEsploraStub(t, 1)
+
+	nv := &networkVar{
+		network: "ecash",
+		urls: map[string][]string{
+			"ecash": {"tcp://127.0.0.1:1", esplora.URL},
+		},
+		params: map[string]*chaincfg.Params{"ecash": &chaincfg.MainNetParams},
+	}
+
+	s := NewNetworkChainSource(nv.resolve, zerolog.Nop())
+	assert.Equal(t, []string{"tcp://127.0.0.1:1", esplora.URL}, s.BaseURLs())
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.311
+version: 1.0.312
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.182
+version: 1.0.183
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.309
+version: 1.0.310
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The catalog publishes a Fulcrum server for alphanet and signet, but the wallet read their Esplora. Backends now rank fulcrum, electrum, esplora, and the chain source falls back to the next protocol when one fails.

Every network takes its chain source from the catalog: publish a Fulcrum backend and the wallet reads it, with no code change.