### PR TITLE
bitwindow: derive the addresses a wallet actually owns

### DIFF
--- a/bitwindow/lib/env.dart
+++ b/bitwindow/lib/env.dart
@@ -33,7 +33,7 @@ class Environment {
   );
   static const network = Variable(
     'BITWINDOW_NETWORK',
-    String.fromEnvironment('BITWINDOW_NETWORK', defaultValue: 'signet'),
+    String.fromEnvironment('BITWINDOW_NETWORK', defaultValue: 'ecash'),
   );
 
   static Future<Directory> datadir() async {

--- a/bitwindow/lib/pages/welcome/create_another_wallet_page.dart
+++ b/bitwindow/lib/pages/welcome/create_another_wallet_page.dart
@@ -148,6 +148,7 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
           name: _walletName,
           gradient: _selectedGradient!,
           xpubOrDescriptor: descriptor,
+          scriptType: _singleScriptType,
           hardwareDeviceType: _hardwareDeviceType,
           hardwareFingerprint: _hardwareFingerprint,
         );
@@ -157,6 +158,7 @@ class _CreateAnotherWalletPageState extends State<CreateAnotherWalletPage> {
           gradient: _selectedGradient!,
           customMnemonic: _mnemonic,
           passphrase: _passphrase,
+          scriptType: _singleScriptType,
           derivationPath: _singleDerivationPath.isEmpty ? null : _singleDerivationPath,
         );
       } else {

--- a/bitwindow/lib/pages/welcome/multisig_config_step.dart
+++ b/bitwindow/lib/pages/welcome/multisig_config_step.dart
@@ -844,16 +844,11 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
     return 'Require $sigs to move funds, out of $keys total';
   }
 
-  // Electrum takes the script type directly, so a standard path is left off to
-  // keep every address kind open. Core has no script-type input.
+  // A stored path pins the coin type to the network the wallet was made on, so
+  // a later switch would leave the descriptor on the old coin. Both providers
+  // carry the address kind in its own field, so only a path the user typed
+  // himself travels with the wallet.
   String? _derivationPathToSubmit(CosignerKeystore k) {
-    // Electrum takes a script type; Core only takes a path, so dropping it
-    // there would silently ignore the address type just chosen. The enforcer
-    // honours neither — it mints its own addresses — so it gets the path only
-    // when the user set one explicitly.
-    if (_coreAvailable && _effectiveProvider == 'core') {
-      return k.derivationPath.isNotEmpty ? k.derivationPath : _standardPath;
-    }
     return k.derivationPath == _standardPath ? null : k.derivationPath;
   }
 

--- a/bitwindow/lib/pages/welcome/multisig_config_step.dart
+++ b/bitwindow/lib/pages/welcome/multisig_config_step.dart
@@ -181,6 +181,11 @@ class SingleSigResult {
   });
 }
 
+/// The provider a new wallet starts on. A full-mode install runs Bitcoin Core,
+/// which is what the user asked for on the node mode step; light mode runs no
+/// local node, so only electrum can serve it.
+String defaultWalletProvider({required bool runsLocalBackends}) => runsLocalBackends ? 'core' : 'electrum';
+
 class MultisigConfigStep extends StatefulWidget {
   final void Function(WalletSetupResult result) onConfigured;
 
@@ -218,7 +223,9 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
   String _scriptType = 'wpkh'; // multi: wsh|sh-wsh|sh|tr; single: wpkh|sh-wpkh|pkh|tr
   int _selectedTab = 0;
   bool _settingsOpen = false;
-  String _provider = 'electrum'; // electrum | core | enforcer
+  String _provider = defaultWalletProvider(
+    runsLocalBackends: NodeModeProvider.runsLocalBackends,
+  ); // electrum | core | enforcer
 
   /// One key is a single-sig wallet; the quorum slider is what makes it multisig.
   bool get _isSingle => _total == 1;

--- a/bitwindow/lib/providers/hd_wallet_provider.dart
+++ b/bitwindow/lib/providers/hd_wallet_provider.dart
@@ -439,7 +439,7 @@ class HDWalletProvider extends ChangeNotifier implements NetworkScoped {
   }
 
   Future<Map<String, String>> deriveKeyInfo(String mnemonic, String path) async {
-    final isMainnet = const String.fromEnvironment('BITWINDOW_NETWORK', defaultValue: 'signet') == 'mainnet';
+    final isMainnet = GetIt.I.get<BitcoinConfProvider>().usesMainnetParams;
     return deriveExtendedKeyInfo(mnemonic, path, isMainnet);
   }
 }

--- a/bitwindow/lib/widgets/create_multisig_modal.dart
+++ b/bitwindow/lib/widgets/create_multisig_modal.dart
@@ -453,7 +453,7 @@ class CreateMultisigModalViewModel extends BaseViewModel {
 
   final Set<int> _sessionUsedAccountIndices = <int>{};
 
-  final bool isMainnet = const String.fromEnvironment('BITWINDOW_NETWORK', defaultValue: 'signet') == 'mainnet';
+  final bool isMainnet = GetIt.I.get<BitcoinConfProvider>().usesMainnetParams;
 
   String get coinType => isMainnet ? "0'" : "1'";
   String get xpubPrefix => isMainnet ? 'xpub' : 'tpub';

--- a/bitwindow/lib/widgets/import_txid_modal.dart
+++ b/bitwindow/lib/widgets/import_txid_modal.dart
@@ -317,7 +317,7 @@ class ImportTxidModalViewModel extends BaseViewModel {
         return 0;
       }
 
-      const isMainnet = String.fromEnvironment('BITWINDOW_NETWORK', defaultValue: 'signet') == 'mainnet';
+      final isMainnet = GetIt.I.get<BitcoinConfProvider>().usesMainnetParams;
 
       for (int i = 0; i < keys.length; i++) {
         final keyData = keys[i];

--- a/bitwindow/lib/widgets/proof_of_funds_modal.dart
+++ b/bitwindow/lib/widgets/proof_of_funds_modal.dart
@@ -6,7 +6,6 @@ import 'dart:typed_data';
 import 'package:bitcoin_base/bitcoin_base.dart';
 import 'package:convert/convert.dart';
 
-import 'package:bitwindow/env.dart';
 import 'package:bitwindow/providers/hd_wallet_provider.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/widgets.dart';
@@ -857,7 +856,7 @@ class ProofOfFundsViewModel extends BaseViewModel {
         throw Exception('HD wallet not initialized');
       }
 
-      final isMainnet = env(Environment.network) == 'mainnet';
+      final isMainnet = GetIt.I.get<BitcoinConfProvider>().usesMainnetParams;
 
       // Find the correct derivation path for the address
       final keyInfo = await _findKeyForAddress(address, isMainnet);
@@ -1079,7 +1078,7 @@ class ProofOfFundsViewModel extends BaseViewModel {
     String address,
   ) async {
     try {
-      final isMainnet = env(Environment.network) == 'mainnet';
+      final isMainnet = GetIt.I.get<BitcoinConfProvider>().usesMainnetParams;
 
       final derivedAddress = _publicKeyToBech32Address(publicKeyHex, isMainnet);
       if (derivedAddress != address) {

--- a/bitwindow/scripts/download-binaries.sh
+++ b/bitwindow/scripts/download-binaries.sh
@@ -52,9 +52,11 @@ build_orch_tool() {
         [[ -n "$goarch" ]] && export GOARCH="$goarch"
         # Keep CGO on for the amd64-on-arm cross build.
         export CGO_ENABLED=1
-        # Bake the default network into orchestratord only.
-        if [[ "$cmd" == "orchestratord" && -n "${BITWINDOW_DEFAULT_NETWORK:-}" ]]; then
-            go build -ldflags "-X main.defaultNetwork=${BITWINDOW_DEFAULT_NETWORK}" -o "$out" "./cmd/$cmd"
+        # Bake the default network into every tool. The daemon and the control
+        # CLI read one value, so a wipe cannot target a network the daemon
+        # never ran.
+        if [[ -n "${BITWINDOW_DEFAULT_NETWORK:-}" ]]; then
+            go build -ldflags "-X github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config.DefaultNetwork=${BITWINDOW_DEFAULT_NETWORK}" -o "$out" "./cmd/$cmd"
         else
             go build -o "$out" "./cmd/$cmd"
         fi

--- a/bitwindow/scripts/set-app-name.sh
+++ b/bitwindow/scripts/set-app-name.sh
@@ -17,9 +17,10 @@ if [ "$BITWINDOW_VARIANT" = "forknet" ]; then
         echo "BITWINDOW_NETWORK=forknet"
         echo "BITWINDOW_APPCAST_URL=https://releases.drivechain.info/appcast-bitwindow-forknet.xml"
     } > build-vars.env
-    # Picked up by download-binaries.sh to embed the default network into
-    # orchestratord (-ldflags -X main.defaultNetwork). This is the authoritative
-    # lever — orchestratord owns the first-run network; Flutter follows it.
+    # Picked up by download-binaries.sh to embed the default network into every
+    # orchestrator tool (-ldflags -X config.DefaultNetwork). This is the
+    # authoritative lever — orchestratord owns the first-run network; Flutter
+    # follows it.
     export BITWINDOW_DEFAULT_NETWORK=forknet
 else
     echo "" > build-vars.env

--- a/bitwindow/test/wallet_setup_step_test.dart
+++ b/bitwindow/test/wallet_setup_step_test.dart
@@ -14,6 +14,18 @@ void main() {
     });
   });
 
+  group('defaultWalletProvider', () {
+    // A user who picks Full node gets a Bitcoin Core wallet, not an electrum
+    // one. The wizard defaulted to electrum whatever the node mode was.
+    test('full mode starts on Bitcoin Core', () {
+      expect(defaultWalletProvider(runsLocalBackends: true), 'core');
+    });
+
+    test('light mode starts on electrum, which is all it can run', () {
+      expect(defaultWalletProvider(runsLocalBackends: false), 'electrum');
+    });
+  });
+
   group('coldcardConfig', () {
     MultisigWalletSpec spec(String scriptType, {String? fingerprint = 'd34db33f'}) {
       return MultisigWalletSpec(

--- a/sail_ui/test/wallet_writer_provider_test.dart
+++ b/sail_ui/test/wallet_writer_provider_test.dart
@@ -29,6 +29,7 @@ class _FakeWalletRPC extends OrchestratorWalletRPC {
   String? generatedName;
   String? generatedMnemonic;
   String? generatedPassphrase;
+  String? generatedScriptType;
   List<int>? previewEntropy;
   String? previewSourceText;
   int? previewWordCount;
@@ -59,11 +60,13 @@ class _FakeWalletRPC extends OrchestratorWalletRPC {
     String? passphrase,
     int account = 0,
     String? derivationPath,
+    String? scriptType,
   }) async {
     generateWalletCalls++;
     generatedName = name;
     generatedMnemonic = customMnemonic;
     generatedPassphrase = passphrase;
+    generatedScriptType = scriptType;
     return wmpb.GenerateWalletResponse(walletId: 'wallet-1', mnemonic: customMnemonic);
   }
 }

--- a/sidechain-orchestrator/api/generate_wallet_path_test.go
+++ b/sidechain-orchestrator/api/generate_wallet_path_test.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
+)
+
+// A Core wallet infers its address kind from the path, so a caller that states
+// no script type may still ask for any standard path. SailCreateWalletPage is
+// one such caller: it sends a typed path and no type at all.
+func TestGenerateWalletAcceptsAStandardPathWithNoScriptType(t *testing.T) {
+	h, _, _, _, _ := newRoutedHandler(t)
+
+	resp, err := h.GenerateWallet(context.Background(), connect.NewRequest(&pb.GenerateWalletRequest{
+		Name:           "Taproot",
+		DerivationPath: "m/86'/1'/0'",
+	}))
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Msg.WalletId)
+}
+
+// A stated type and a path that disagree would scan addresses the wallet does
+// not own, so the pair is refused rather than silently resolved.
+func TestGenerateWalletRefusesAPathThatFightsTheScriptType(t *testing.T) {
+	h, _, _, _, _ := newRoutedHandler(t)
+
+	_, err := h.GenerateWallet(context.Background(), connect.NewRequest(&pb.GenerateWalletRequest{
+		Name:           "Mismatch",
+		DerivationPath: "m/86'/1'/0'",
+		ScriptType:     "legacy",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -431,7 +431,15 @@ func (h *WalletHandler) CreateElectrumWallet(ctx context.Context, req *connect.R
 			return nil, err
 		}
 	}
-	w, err := h.svc.CreateElectrumWallet(req.Msg.Name, json.RawMessage(req.Msg.GradientJson), req.Msg.Slots, req.Msg.CustomMnemonic, req.Msg.Passphrase, req.Msg.XpubOrDescriptor, req.Msg.ScriptType, account, path)
+	// A bare extended key states no kind, so its own history places it. With
+	// no history the chosen type stands.
+	scriptType := req.Msg.ScriptType
+	if req.Msg.XpubOrDescriptor != "" && wallet.BareKeyWithoutKind(req.Msg.XpubOrDescriptor) {
+		if detected, ok := h.engine.DetectScriptKind(ctx, req.Msg.XpubOrDescriptor); ok {
+			scriptType = detected.String()
+		}
+	}
+	w, err := h.svc.CreateElectrumWallet(req.Msg.Name, json.RawMessage(req.Msg.GradientJson), req.Msg.Slots, req.Msg.CustomMnemonic, req.Msg.Passphrase, req.Msg.XpubOrDescriptor, scriptType, account, path)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -116,12 +116,35 @@ func (h *WalletHandler) GetWalletStatus(ctx context.Context, req *connect.Reques
 	}), nil
 }
 
+// checkPathMatchesScriptType rejects a derivation path whose BIP purpose names
+// a different address kind than scriptType. One wallet derives one kind, so a
+// mismatch scans and signs addresses it does not own. An empty scriptType
+// states nothing, and the kind then comes from the path itself.
+func checkPathMatchesScriptType(path, scriptType string) error {
+	if path == "" || scriptType == "" {
+		return nil
+	}
+	ap, err := wallet.ParseAccountPath(path)
+	if err != nil {
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	want, ok := wallet.HotScriptKind(scriptType).Purpose()
+	if !ap.Standard() || !ok || ap.Purpose == want {
+		return nil
+	}
+	return connect.NewError(connect.CodeInvalidArgument,
+		fmt.Errorf("derivation purpose %d' does not match script type %q (want %d')", ap.Purpose, scriptType, want))
+}
+
 func (h *WalletHandler) GenerateWallet(ctx context.Context, req *connect.Request[pb.GenerateWalletRequest]) (*connect.Response[pb.GenerateWalletResponse], error) {
 	account, path, err := wallet.ResolveCreateDerivationPath(req.Msg.Account, req.Msg.DerivationPath)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
-	w, err := h.svc.GenerateWalletWithPath(req.Msg.Name, req.Msg.CustomMnemonic, req.Msg.Passphrase, account, path, allSidechainSlots())
+	if err := checkPathMatchesScriptType(path, req.Msg.ScriptType); err != nil {
+		return nil, err
+	}
+	w, err := h.svc.GenerateWalletWithPath(req.Msg.Name, req.Msg.CustomMnemonic, req.Msg.Passphrase, account, path, req.Msg.ScriptType, allSidechainSlots())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -403,18 +426,9 @@ func (h *WalletHandler) CreateElectrumWallet(ctx context.Context, req *connect.R
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
-	// An explicit path must match the chosen script type's purpose — an electrum
-	// wallet derives one address kind, so importing a path whose purpose implies
-	// a different kind would mismatch the addresses it scans and signs.
-	if path != "" && req.Msg.XpubOrDescriptor == "" {
-		ap, perr := wallet.ParseAccountPath(path)
-		if perr != nil {
-			return nil, connect.NewError(connect.CodeInvalidArgument, perr)
-		}
-		want, ok := wallet.HotScriptKind(req.Msg.ScriptType).Purpose()
-		if ap.Standard() && ok && ap.Purpose != want {
-			return nil, connect.NewError(connect.CodeInvalidArgument,
-				fmt.Errorf("derivation purpose %d' does not match script type %q (want %d')", ap.Purpose, req.Msg.ScriptType, want))
+	if req.Msg.XpubOrDescriptor == "" {
+		if err := checkPathMatchesScriptType(path, req.Msg.ScriptType); err != nil {
+			return nil, err
 		}
 	}
 	w, err := h.svc.CreateElectrumWallet(req.Msg.Name, json.RawMessage(req.Msg.GradientJson), req.Msg.Slots, req.Msg.CustomMnemonic, req.Msg.Passphrase, req.Msg.XpubOrDescriptor, req.Msg.ScriptType, account, path)

--- a/sidechain-orchestrator/cmd/orchestratord/main.go
+++ b/sidechain-orchestrator/cmd/orchestratord/main.go
@@ -61,12 +61,6 @@ import (
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47state"
 )
 
-// defaultNetwork is the network the orchestrator boots on when there's no saved
-// config and no --network/ORCHESTRATOR_NETWORK override. "signet" for the standard
-// build; variant builds override it at build time (the forknet build sets "forknet")
-// via: go build -ldflags "-X main.defaultNetwork=forknet" ./cmd/orchestratord
-var defaultNetwork = "signet"
-
 func main() {
 	app := &cli.App{
 		Name:  "orchestratord",
@@ -81,7 +75,7 @@ func main() {
 			&cli.StringFlag{
 				Name:    "network",
 				Usage:   "bitcoin network (mainnet, testnet, signet, regtest, forknet, ecash)",
-				Value:   defaultNetwork,
+				Value:   config.DefaultNetwork,
 				EnvVars: []string{"ORCHESTRATOR_NETWORK"},
 			},
 			&cli.StringFlag{

--- a/sidechain-orchestrator/commands/commands.go
+++ b/sidechain-orchestrator/commands/commands.go
@@ -55,7 +55,7 @@ var GlobalFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    "network",
 		Usage:   "bitcoin network",
-		Value:   "signet",
+		Value:   config.DefaultNetwork,
 		EnvVars: []string{"ORCHESTRATOR_NETWORK"},
 	},
 	&cli.BoolFlag{

--- a/sidechain-orchestrator/commands/default_network_test.go
+++ b/sidechain-orchestrator/commands/default_network_test.go
@@ -1,0 +1,25 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+)
+
+// The control CLI picks the paths that wipe deletes. A default of its own would
+// let it stop the running daemon and erase another network's data.
+func TestControlCLIDefaultsToTheSharedNetwork(t *testing.T) {
+	for _, f := range GlobalFlags {
+		sf, ok := f.(*cli.StringFlag)
+		if !ok || sf.Name != "network" {
+			continue
+		}
+		if sf.Value != config.DefaultNetwork {
+			t.Fatalf("network flag defaults to %q, want the shared %q", sf.Value, config.DefaultNetwork)
+		}
+		return
+	}
+	t.Fatal("GlobalFlags carries no network flag")
+}

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -22,6 +22,14 @@ const (
 	NetworkTestnet Network = "testnet"
 )
 
+// DefaultNetwork is the network an install runs with no saved config and no
+// --network/ORCHESTRATOR_NETWORK override. Every binary reads this one value,
+// so the daemon and the control CLI cannot target different networks. Variant
+// builds override it at link time:
+//
+//	go build -ldflags "-X <this package>.DefaultNetwork=forknet"
+var DefaultNetwork = string(NetworkECash)
+
 // AllNetworks lists every network the app can run.
 func AllNetworks() []Network {
 	return []Network{

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -883,8 +883,12 @@ type GenerateWalletRequest struct {
 	// overriding the default purpose/coin/account. Empty = default (BIP84,
 	// network coin, account field). All three levels must be hardened.
 	DerivationPath string `protobuf:"bytes,5,opt,name=derivation_path,json=derivationPath,proto3" json:"derivation_path,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Address type: "legacy", "nested-segwit", "native-segwit" (default), or
+	// "taproot". Pass this rather than a derivation_path that only names the
+	// address type: a stored path pins the coin type to one network.
+	ScriptType    string `protobuf:"bytes,6,opt,name=script_type,json=scriptType,proto3" json:"script_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GenerateWalletRequest) Reset() {
@@ -948,6 +952,13 @@ func (x *GenerateWalletRequest) GetAccount() uint32 {
 func (x *GenerateWalletRequest) GetDerivationPath() string {
 	if x != nil {
 		return x.DerivationPath
+	}
+	return ""
+}
+
+func (x *GenerateWalletRequest) GetScriptType() string {
+	if x != nil {
+		return x.ScriptType
 	}
 	return ""
 }
@@ -2913,9 +2924,10 @@ type CreateElectrumWalletRequest struct {
 	// (no private keys; cannot sign or send). Mutually exclusive with
 	// custom_mnemonic.
 	XpubOrDescriptor string `protobuf:"bytes,5,opt,name=xpub_or_descriptor,json=xpubOrDescriptor,proto3" json:"xpub_or_descriptor,omitempty"`
-	// Address type for a hot wallet: "legacy", "nested-segwit",
-	// "native-segwit" (default), or "taproot". Ignored for watch-only imports
-	// (the descriptor's own type wins).
+	// Address type: "legacy", "nested-segwit", "native-segwit" (default), or
+	// "taproot". A watch-only import uses it only for a bare extended key, which
+	// states no type of its own; a script wrapper, a SLIP-0132 header and an
+	// origin path's purpose all win over it.
 	ScriptType string `protobuf:"bytes,6,opt,name=script_type,json=scriptType,proto3" json:"script_type,omitempty"`
 	// Optional BIP32 account index for the account-level key. 0 = standard.
 	// Ignored when derivation_path set or for watch-only imports.
@@ -9553,7 +9565,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x14light_mode_available\x18\x02 \x01(\bR\x12lightModeAvailable\"D\n" +
 	"\x12SetNodeModeRequest\x12.\n" +
 	"\x04mode\x18\x01 \x01(\x0e2\x1a.walletmanager.v1.NodeModeR\x04mode\"\x15\n" +
-	"\x13SetNodeModeResponse\"\xb7\x01\n" +
+	"\x13SetNodeModeResponse\"\xd8\x01\n" +
 	"\x15GenerateWalletRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12'\n" +
 	"\x0fcustom_mnemonic\x18\x02 \x01(\tR\x0ecustomMnemonic\x12\x1e\n" +
@@ -9561,7 +9573,9 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"passphrase\x18\x03 \x01(\tR\n" +
 	"passphrase\x12\x18\n" +
 	"\aaccount\x18\x04 \x01(\rR\aaccount\x12'\n" +
-	"\x0fderivation_path\x18\x05 \x01(\tR\x0ederivationPath\"Q\n" +
+	"\x0fderivation_path\x18\x05 \x01(\tR\x0ederivationPath\x12\x1f\n" +
+	"\vscript_type\x18\x06 \x01(\tR\n" +
+	"scriptType\"Q\n" +
 	"\x16GenerateWalletResponse\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x1a\n" +
 	"\bmnemonic\x18\x02 \x01(\tR\bmnemonic\"1\n" +

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -225,6 +225,10 @@ message GenerateWalletRequest {
   // overriding the default purpose/coin/account. Empty = default (BIP84,
   // network coin, account field). All three levels must be hardened.
   string derivation_path = 5;
+  // Address type: "legacy", "nested-segwit", "native-segwit" (default), or
+  // "taproot". Pass this rather than a derivation_path that only names the
+  // address type: a stored path pins the coin type to one network.
+  string script_type = 6;
 }
 
 message GenerateWalletResponse {
@@ -469,9 +473,10 @@ message CreateElectrumWalletRequest {
   // (no private keys; cannot sign or send). Mutually exclusive with
   // custom_mnemonic.
   string xpub_or_descriptor = 5;
-  // Address type for a hot wallet: "legacy", "nested-segwit",
-  // "native-segwit" (default), or "taproot". Ignored for watch-only imports
-  // (the descriptor's own type wins).
+  // Address type: "legacy", "nested-segwit", "native-segwit" (default), or
+  // "taproot". A watch-only import uses it only for a bare extended key, which
+  // states no type of its own; a script wrapper, a SLIP-0132 header and an
+  // origin path's purpose all win over it.
   string script_type = 6;
   // Optional BIP32 account index for the account-level key. 0 = standard.
   // Ignored when derivation_path set or for watch-only imports.

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -935,19 +935,14 @@ func (p *CoreBackend) createBitcoinCoreWallet(ctx context.Context, walletName st
 
 	var purposes []ScriptKind
 	if w.usesExplicitPath() {
-		ap, err := ParseAccountPath(w.DerivationPath)
-		if err != nil {
+		if _, err := ParseAccountPath(w.DerivationPath); err != nil {
 			return fmt.Errorf("invalid derivation path: %w", err)
 		}
-		// A custom path names no BIP purpose, so the wallet's own script type
-		// decides what Core imports.
-		kind, ok := purposeToCoreKind(ap.Purpose)
-		if !ok {
-			kind = w.scriptKind()
-		}
-		purposes = []ScriptKind{kind}
+		purposes = []ScriptKind{coreScriptKind(w)}
 	} else {
-		purposes = []ScriptKind{ScriptNativeSegwit, ScriptTaproot}
+		// Exactly what the wallet advertises on the Receive page. Core hands out
+		// no address it holds no descriptor for, so the two sets must be one.
+		purposes = ReceiveKinds(w)
 	}
 
 	var descriptors []ImportDescriptor
@@ -1159,15 +1154,25 @@ func createAndImport(
 // imported) gives bech32 from getnewaddress, i.e. native segwit.
 func (p *CoreBackend) walletScriptKind(walletID string) ScriptKind {
 	w := p.svc.GetWalletByID(walletID)
-	if w == nil || !w.usesExplicitPath() {
+	if w == nil {
 		return ScriptNativeSegwit
+	}
+	return coreScriptKind(w)
+}
+
+// coreScriptKind is the address kind a Core wallet derives: the BIP purpose of
+// an explicit path when it names one, else the kind the wallet stores. The
+// import reads it too, or Core is asked for a family it holds no descriptor for.
+func coreScriptKind(w *WalletData) ScriptKind {
+	if !w.usesExplicitPath() {
+		return w.scriptKind()
 	}
 	ap, err := ParseAccountPath(w.DerivationPath)
 	if err != nil {
-		return ScriptNativeSegwit
+		return w.scriptKind()
 	}
 	if kind, ok := purposeToCoreKind(ap.Purpose); ok {
 		return kind
 	}
-	return ScriptNativeSegwit
+	return w.scriptKind()
 }

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -666,7 +666,7 @@ func TestCoreBackendCreateCpfpTaproot(t *testing.T) {
 	_, err := svc.GenerateWallet("Enforcer", "", "", testSlots)
 	require.NoError(t, err)
 	// Explicit BIP86 path => taproot-only Core wallet (imports only tr()).
-	core, err := svc.GenerateWalletWithPath("CoreTaproot", "", "", 0, "m/86'/1'/0'", testSlots)
+	core, err := svc.GenerateWalletWithPath("CoreTaproot", "", "", 0, "m/86'/1'/0'", "", testSlots)
 	require.NoError(t, err)
 	require.Equal(t, WalletTypeBitcoinCore, core.WalletType)
 
@@ -766,7 +766,7 @@ func TestCoreBackendCpfpBase58Kinds(t *testing.T) {
 			svc := newTestService(t)
 			_, err := svc.GenerateWallet("Enforcer", "", "", testSlots)
 			require.NoError(t, err)
-			core, err := svc.GenerateWalletWithPath("Core-"+tc.name, "", "", 0, tc.path, testSlots)
+			core, err := svc.GenerateWalletWithPath("Core-"+tc.name, "", "", 0, tc.path, "", testSlots)
 			require.NoError(t, err)
 
 			fake := newFakeBitcoind(t)
@@ -1022,7 +1022,7 @@ func TestCoreBackendNextChangeAddressKind(t *testing.T) {
 		svc := newTestService(t)
 		_, err := svc.GenerateWallet("Enforcer", "", "", testSlots)
 		require.NoError(t, err)
-		core, err := svc.GenerateWalletWithPath("CoreTaproot", "", "", 0, "m/86'/1'/0'", testSlots)
+		core, err := svc.GenerateWalletWithPath("CoreTaproot", "", "", 0, "m/86'/1'/0'", "", testSlots)
 		require.NoError(t, err)
 
 		fake := newFakeBitcoind(t)
@@ -1229,4 +1229,60 @@ func TestCoreBackendRetryReimportsDescriptorsAfterPartialCreate(t *testing.T) {
 	require.NoError(t, json.Unmarshal(imports[1].Params[0], &singleSig))
 	require.Len(t, singleSig, 4)
 	assert.Contains(t, singleSig[0].Desc, "/84'/1'/0']")
+}
+
+// Core hands out no address it holds no descriptor for, so it imports exactly
+// the kinds the wallet advertises. A legacy wallet advertises legacy alone.
+func TestCoreBackendImportsTheWalletScriptTypeWithoutAPath(t *testing.T) {
+	svc := newTestService(t)
+	_, err := svc.GenerateWallet("Enforcer", "", "", testSlots)
+	require.NoError(t, err)
+	core, err := svc.GenerateWalletWithPath("CoreLegacy", "", "", 0, "", "legacy", testSlots)
+	require.NoError(t, err)
+	require.Empty(t, core.DerivationPath, "no path may travel with the wallet")
+	require.Equal(t, "legacy", core.ScriptType)
+
+	fake := newFakeBitcoind(t)
+	backend := NewCoreBackend(svc, fake.client(t), StaticParams(&chaincfg.RegressionNetParams), zerolog.New(zerolog.NewTestWriter(t)))
+	fake.stubEnsureFlow()
+
+	_, err = backend.Ensure(context.Background(), core.ID)
+	require.NoError(t, err)
+
+	imports := fake.callsFor("importdescriptors")
+	require.NotEmpty(t, imports)
+	var singleSig []ImportDescriptor
+	require.NoError(t, json.Unmarshal(imports[0].Params[0], &singleSig))
+	require.Len(t, singleSig, 2, "the legacy pair alone, external + change")
+	assert.Contains(t, singleSig[0].Desc, "pkh([")
+	assert.Contains(t, singleSig[0].Desc, "/44'/1'/0']")
+
+	// Address requests, change and CPFP sizing all read this. A different kind
+	// here asks Core for a family it holds no descriptor for.
+	assert.Equal(t, ScriptLegacy, backend.walletScriptKind(core.ID))
+	assert.Equal(t, []ScriptKind{ScriptLegacy}, ReceiveKinds(core))
+}
+
+// A taproot wallet advertises taproot and native segwit, so Core imports both
+// pairs. Importing the taproot pair alone would break the segwit Receive tab.
+func TestCoreBackendImportsEveryKindTheWalletAdvertises(t *testing.T) {
+	svc := newTestService(t)
+	_, err := svc.GenerateWallet("Enforcer", "", "", testSlots)
+	require.NoError(t, err)
+	core, err := svc.GenerateWalletWithPath("CoreTaproot", "", "", 0, "", "taproot", testSlots)
+	require.NoError(t, err)
+	require.Equal(t, []ScriptKind{ScriptTaproot, ScriptNativeSegwit}, ReceiveKinds(core))
+
+	fake := newFakeBitcoind(t)
+	backend := NewCoreBackend(svc, fake.client(t), StaticParams(&chaincfg.RegressionNetParams), zerolog.New(zerolog.NewTestWriter(t)))
+	fake.stubEnsureFlow()
+
+	_, err = backend.Ensure(context.Background(), core.ID)
+	require.NoError(t, err)
+
+	var singleSig []ImportDescriptor
+	require.NoError(t, json.Unmarshal(fake.callsFor("importdescriptors")[0].Params[0], &singleSig))
+	require.Len(t, singleSig, 4, "the taproot pair and the segwit pair")
+	assert.Contains(t, singleSig[0].Desc, "tr([")
+	assert.Contains(t, singleSig[2].Desc, "wpkh([")
 }

--- a/sidechain-orchestrator/wallet/derivation_test.go
+++ b/sidechain-orchestrator/wallet/derivation_test.go
@@ -186,3 +186,29 @@ func TestDescriptorHDPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "m/84'/1'/0'/0/7", descriptorHDPath(d, net, false, 7))
 }
+
+// A wallet made on signet and then switched to a mainnet-params network must
+// derive under the new coin type. A stored path froze it on 84'/1', so the
+// descriptor stayed on signet and the coins never showed.
+func TestAccountPathFollowsTheNetworkWithoutAStoredPath(t *testing.T) {
+	w := &WalletData{ScriptType: "taproot"}
+
+	ap, err := accountPathFor(w, ScriptTaproot, &chaincfg.SigNetParams)
+	require.NoError(t, err)
+	assert.Equal(t, "m/86'/1'/0'", ap.String())
+
+	ap, err = accountPathFor(w, ScriptTaproot, &chaincfg.MainNetParams)
+	require.NoError(t, err)
+	assert.Equal(t, "m/86'/0'/0'", ap.String())
+}
+
+// A path the user set himself is an override, so it stays whatever the network.
+func TestAccountPathKeepsAUserPathAcrossNetworks(t *testing.T) {
+	w := &WalletData{DerivationPath: "m/84'/1'/0'"}
+
+	for _, net := range []*chaincfg.Params{&chaincfg.SigNetParams, &chaincfg.MainNetParams} {
+		ap, err := accountPathFor(w, ScriptNativeSegwit, net)
+		require.NoError(t, err)
+		assert.Equal(t, "m/84'/1'/0'", ap.String())
+	}
+}

--- a/sidechain-orchestrator/wallet/descriptor.go
+++ b/sidechain-orchestrator/wallet/descriptor.go
@@ -39,6 +39,13 @@ type DescriptorKey struct {
 // extended key (no script function) is accepted as native segwit for backward
 // compatibility. Multisig descriptors are handled by parseMultisig.
 func ParseDescriptor(s string) (*Descriptor, error) {
+	return ParseDescriptorAs(s, ScriptNativeSegwit)
+}
+
+// ParseDescriptorAs is ParseDescriptor with the script kind to assume for a
+// bare extended key that names none. A wrapper, a SLIP-0132 header and an
+// origin purpose each state the kind, so all three beat fallback.
+func ParseDescriptorAs(s string, fallback ScriptKind) (*Descriptor, error) {
 	body, err := stripDescriptorChecksum(s)
 	if err != nil {
 		return nil, err
@@ -48,15 +55,14 @@ func ParseDescriptor(s string) (*Descriptor, error) {
 		return nil, errors.New("empty descriptor")
 	}
 
-	// Bare extended key — no script wrapper. A SLIP-0132 header (ypub/zpub/…)
-	// sets the kind; a plain xpub/tpub defaults to native segwit (BIP84).
+	// Bare extended key — no script wrapper.
 	if !strings.Contains(body, "(") {
 		key, kind, hasKind, err := parseKeyExprKind(body)
 		if err != nil {
 			return nil, err
 		}
 		if !hasKind {
-			kind = ScriptNativeSegwit
+			kind = originScriptKind(key.Origin, fallback)
 		}
 		return &Descriptor{Kind: kind, Threshold: 1, Keys: []DescriptorKey{key}}, nil
 	}
@@ -162,6 +168,25 @@ func parseKeyExprKind(expr string) (DescriptorKey, ScriptKind, bool, error) {
 		return DescriptorKey{}, 0, false, fmt.Errorf("parse extended key %q: %w", keyToken, err)
 	}
 	return DescriptorKey{Origin: origin, Account: acct}, kind, hasKind, nil
+}
+
+// originScriptKind reads the script kind from a key origin's BIP purpose:
+// "d34db33f/44'/0'/0'" is legacy. Returns fallback when the origin is absent or
+// names no standard purpose.
+func originScriptKind(origin string, fallback ScriptKind) ScriptKind {
+	_, path, found := strings.Cut(origin, "/")
+	if !found {
+		return fallback
+	}
+	ap, err := ParseAccountPath(path)
+	if err != nil || !ap.Standard() {
+		return fallback
+	}
+	kind, ok := purposeToCoreKind(ap.Purpose)
+	if !ok {
+		return fallback
+	}
+	return kind
 }
 
 // validateBranchSuffix accepts only the standard wallet layouts so we never

--- a/sidechain-orchestrator/wallet/descriptor_test.go
+++ b/sidechain-orchestrator/wallet/descriptor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -301,4 +302,83 @@ func TestDeriveWalletReceiveAddresses(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEqual(t, acct0, got, "custom-account preview must differ from account 0")
 	})
+}
+
+// A Trezor legacy account exports a plain xpub, which states no script type.
+// Guessing BIP84 derives bc1 addresses the wallet does not own, so the import
+// reads as an empty wallet. The origin path's purpose settles it exactly.
+func TestBareKeyTakesTheKindFromItsOriginPurpose(t *testing.T) {
+	seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, ""))
+	net := &chaincfg.MainNetParams
+
+	acct44, err := accountKeyFromSeed(seedHex, ScriptLegacy, net)
+	require.NoError(t, err)
+	xpub := neuter(t, acct44)
+
+	d, err := ParseDescriptor("[d34db33f/44'/0'/0']" + xpub)
+	require.NoError(t, err)
+	assert.Equal(t, ScriptLegacy, d.Kind, "a 44' origin names a legacy account")
+
+	ds, _, err := d.DeriveScript(false, 0, net)
+	require.NoError(t, err)
+	assert.Equal(t, byte('1'), ds.address.EncodeAddress()[0], "legacy addresses start with 1")
+}
+
+// With no origin and no SLIP-0132 header the string states nothing, so the
+// address type the user picked decides rather than a fixed guess.
+func TestBareKeyFallsBackToTheRequestedKind(t *testing.T) {
+	seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, ""))
+	net := &chaincfg.MainNetParams
+
+	acct44, err := accountKeyFromSeed(seedHex, ScriptLegacy, net)
+	require.NoError(t, err)
+	xpub := neuter(t, acct44)
+
+	d, err := ParseDescriptorAs(xpub, ScriptLegacy)
+	require.NoError(t, err)
+	assert.Equal(t, ScriptLegacy, d.Kind)
+
+	// Backward compatibility: an unstated type still reads as native segwit.
+	d, err = ParseDescriptor(xpub)
+	require.NoError(t, err)
+	assert.Equal(t, ScriptNativeSegwit, d.Kind)
+}
+
+// A SLIP-0132 header states the type, so it beats the requested one.
+func TestSLIP132HeaderBeatsTheRequestedKind(t *testing.T) {
+	seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, ""))
+	net := &chaincfg.MainNetParams
+
+	acct84, err := accountKeyFromSeed(seedHex, ScriptNativeSegwit, net)
+	require.NoError(t, err)
+	zpub := reencodeVersion(t, neuter(t, acct84), 0x04B24746)
+
+	d, err := ParseDescriptorAs(zpub, ScriptLegacy)
+	require.NoError(t, err)
+	assert.Equal(t, ScriptNativeSegwit, d.Kind)
+}
+
+// The whole import path: a Trezor legacy xpub with the address type the user
+// picked must produce a legacy wallet, not a native segwit one.
+func TestWatchOnlyImportHonoursTheChosenAddressType(t *testing.T) {
+	seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, ""))
+	acct44, err := accountKeyFromSeed(seedHex, ScriptLegacy, &chaincfg.MainNetParams)
+	require.NoError(t, err)
+	xpub := neuter(t, acct44)
+
+	svc := newTestService(t)
+	w, err := svc.CreateElectrumWallet("Trezor", nil, nil, "", "", xpub, "legacy", 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, ScriptLegacy.String(), w.ScriptType)
+
+	// The backend re-parses the stored key on every scan, so the kind must
+	// survive the round trip rather than fall back to native segwit again.
+	backend := NewElectrumBackend(svc, nil, StaticParams(&chaincfg.MainNetParams), zerolog.Nop())
+	d, err := backend.walletDescriptor(w)
+	require.NoError(t, err)
+	assert.Equal(t, ScriptLegacy, d.Kind)
+
+	ds, _, err := d.DeriveScript(false, 0, &chaincfg.MainNetParams)
+	require.NoError(t, err)
+	assert.Equal(t, byte('1'), ds.address.EncodeAddress()[0], "a legacy import must scan 1-prefixed addresses")
 }

--- a/sidechain-orchestrator/wallet/detect_script_kind.go
+++ b/sidechain-orchestrator/wallet/detect_script_kind.go
@@ -1,0 +1,109 @@
+package wallet
+
+import (
+	"context"
+	"strings"
+)
+
+// detectScriptKinds are the single-sig kinds a bare extended key could be,
+// most common first.
+var detectScriptKinds = []ScriptKind{ScriptNativeSegwit, ScriptNestedSegwit, ScriptLegacy, ScriptTaproot}
+
+// detectScanDepth is how many addresses of each branch every kind is probed at.
+// Each index costs one lookup per kind per branch, so the walk stays shallow.
+const detectScanDepth = 6
+
+// BareKeyWithoutKind reports whether s is a bare extended key that states no
+// script kind: no script wrapper, no SLIP-0132 header, and no origin path with
+// a standard BIP purpose.
+func BareKeyWithoutKind(s string) bool {
+	body, err := stripDescriptorChecksum(s)
+	if err != nil {
+		return false
+	}
+	body = strings.TrimSpace(body)
+	if body == "" || strings.Contains(body, "(") {
+		return false
+	}
+	key, _, hasKind, err := parseKeyExprKind(body)
+	if err != nil || hasKind {
+		return false
+	}
+	return originScriptKind(key.Origin, ScriptUnknown) == ScriptUnknown
+}
+
+// DetectScriptKind probes the chain under each single-sig script kind and
+// returns the one kind that shows history. It walks index-major: every kind at
+// index 0, then every kind at index 1. Both branches are probed, because a key
+// whose only history sits on a change address is still a used key.
+//
+// It returns false unless exactly one kind carries history, and the caller then
+// keeps the kind it already had. Two kinds carrying history place nothing — a
+// dusted address under a second wrapper must not overrule a stated choice — and
+// a lookup that fails leaves the walk incomplete rather than proving the key
+// was never used. Both cases reach the log.
+func (p *ElectrumBackend) DetectScriptKind(ctx context.Context, xpubOrDescriptor string) (ScriptKind, bool) {
+	net := p.params()
+	if net == nil || p.client == nil {
+		return ScriptUnknown, false
+	}
+
+	descs := make(map[ScriptKind]*Descriptor, len(detectScriptKinds))
+	for _, kind := range detectScriptKinds {
+		d, err := ParseDescriptorAs(xpubOrDescriptor, kind)
+		if err != nil || d.Kind != kind {
+			continue
+		}
+		descs[kind] = d
+	}
+
+	var unread int
+	used := make(map[ScriptKind]bool, len(detectScriptKinds))
+	for i := 0; i < detectScanDepth; i++ {
+		for _, kind := range detectScriptKinds {
+			d, ok := descs[kind]
+			if !ok || used[kind] {
+				continue
+			}
+			if err := ctx.Err(); err != nil {
+				return ScriptUnknown, false
+			}
+			for _, change := range []bool{false, true} {
+				ds, _, err := d.DeriveScript(change, uint32(i), net)
+				if err != nil {
+					continue
+				}
+				stats, err := p.client.AddressStats(ctx, ds.address.EncodeAddress())
+				if err != nil {
+					unread++
+					continue
+				}
+				if !stats.Used() {
+					continue
+				}
+				used[kind] = true
+				if len(used) > 1 {
+					p.log.Warn().
+						Msg("watch-only import kept its chosen script type; more than one kind carries history")
+					return ScriptUnknown, false
+				}
+				break
+			}
+		}
+	}
+	if unread > 0 {
+		p.log.Warn().
+			Int("unread", unread).
+			Msg("watch-only import kept its chosen script type; some address lookups failed")
+	}
+	if len(used) != 1 {
+		return ScriptUnknown, false
+	}
+	for kind := range used {
+		p.log.Info().
+			Str("script_type", kind.String()).
+			Msg("watch-only import placed by its on-chain history")
+		return kind, true
+	}
+	return ScriptUnknown, false
+}

--- a/sidechain-orchestrator/wallet/detect_script_kind_test.go
+++ b/sidechain-orchestrator/wallet/detect_script_kind_test.go
@@ -1,0 +1,146 @@
+package wallet
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// usedAddressSource reports history for a fixed address set and records every
+// address a probe asked about, so a test can pin the probe order.
+type usedAddressSource struct {
+	stubChainSource
+	used    map[string]bool
+	asked   []string
+	failAll bool
+}
+
+func (s *usedAddressSource) AddressStats(_ context.Context, address string) (EsploraAddressStats, error) {
+	s.asked = append(s.asked, address)
+	if s.failAll {
+		return EsploraAddressStats{}, errors.New("chain source unreachable")
+	}
+	if !s.used[address] {
+		return EsploraAddressStats{Address: address}, nil
+	}
+	return EsploraAddressStats{Address: address, ChainStats: EsploraTxoStats{TxCount: 2}}, nil
+}
+
+// addressAt returns the address a bare key derives at index i on one branch
+// under one script kind.
+func addressAt(t *testing.T, xpub string, kind ScriptKind, change bool, i uint32, net *chaincfg.Params) string {
+	t.Helper()
+	d, err := ParseDescriptorAs(xpub, kind)
+	require.NoError(t, err)
+	ds, _, err := d.DeriveScript(change, i, net)
+	require.NoError(t, err)
+	return ds.address.EncodeAddress()
+}
+
+func legacyAccountXpub(t *testing.T) string {
+	t.Helper()
+	seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, ""))
+	acct, err := accountKeyFromSeed(seedHex, ScriptLegacy, &chaincfg.MainNetParams)
+	require.NoError(t, err)
+	return neuter(t, acct)
+}
+
+func detectBackend(t *testing.T, src ChainDataSource) *ElectrumBackend {
+	t.Helper()
+	return NewElectrumBackend(newTestService(t), src, StaticParams(&chaincfg.MainNetParams), zerolog.Nop())
+}
+
+// A Trezor legacy account exports a bare xpub. Its own history says legacy, so
+// the import stops deriving bc1 addresses the wallet does not own.
+func TestDetectScriptKindFindsTheUsedKind(t *testing.T) {
+	net := &chaincfg.MainNetParams
+	xpub := legacyAccountXpub(t)
+
+	src := &usedAddressSource{used: map[string]bool{addressAt(t, xpub, ScriptLegacy, false, 0, net): true}}
+	kind, ok := detectBackend(t, src).DetectScriptKind(context.Background(), xpub)
+	require.True(t, ok)
+	assert.Equal(t, ScriptLegacy, kind)
+}
+
+// The probe walks index-major, so a wallet whose first address went unused is
+// still placed rather than lost behind a full walk of the wrong kind.
+func TestDetectScriptKindWalksIndexMajor(t *testing.T) {
+	net := &chaincfg.MainNetParams
+	xpub := legacyAccountXpub(t)
+
+	src := &usedAddressSource{used: map[string]bool{addressAt(t, xpub, ScriptLegacy, false, 3, net): true}}
+	kind, ok := detectBackend(t, src).DetectScriptKind(context.Background(), xpub)
+	require.True(t, ok)
+	assert.Equal(t, ScriptLegacy, kind)
+
+	// Every kind and branch at index 0 comes before anything at index 1.
+	perIndex := len(detectScriptKinds) * 2
+	require.Greater(t, len(src.asked), perIndex)
+	assert.Equal(t, addressAt(t, xpub, ScriptNativeSegwit, false, 0, net), src.asked[0], "the most common kind goes first")
+	assert.Equal(t, addressAt(t, xpub, ScriptNativeSegwit, true, 0, net), src.asked[1], "its change branch comes next")
+	assert.Equal(t, addressAt(t, xpub, ScriptNativeSegwit, false, 1, net), src.asked[perIndex])
+}
+
+// Funds sent straight to an exported change address leave the receive branch
+// untouched, and the key is still a used key.
+func TestDetectScriptKindFindsHistoryOnTheChangeBranch(t *testing.T) {
+	net := &chaincfg.MainNetParams
+	xpub := legacyAccountXpub(t)
+
+	src := &usedAddressSource{used: map[string]bool{addressAt(t, xpub, ScriptLegacy, true, 2, net): true}}
+	kind, ok := detectBackend(t, src).DetectScriptKind(context.Background(), xpub)
+	require.True(t, ok)
+	assert.Equal(t, ScriptLegacy, kind)
+}
+
+// A fresh key has no history, so nothing overrides the type the user picked.
+func TestDetectScriptKindReportsNothingForAnUnusedKey(t *testing.T) {
+	xpub := legacyAccountXpub(t)
+
+	src := &usedAddressSource{used: map[string]bool{}}
+	_, ok := detectBackend(t, src).DetectScriptKind(context.Background(), xpub)
+	assert.False(t, ok)
+	assert.Len(t, src.asked, len(detectScriptKinds)*detectScanDepth*2, "both branches of every kind at every index, and no more")
+}
+
+// A dusted address under a second wrapper must not overrule the kind the user
+// stated. Two kinds with history place nothing.
+func TestDetectScriptKindRefusesAnAmbiguousKey(t *testing.T) {
+	net := &chaincfg.MainNetParams
+	xpub := legacyAccountXpub(t)
+
+	src := &usedAddressSource{used: map[string]bool{
+		addressAt(t, xpub, ScriptLegacy, false, 1, net):       true,
+		addressAt(t, xpub, ScriptNativeSegwit, false, 0, net): true,
+	}}
+	_, ok := detectBackend(t, src).DetectScriptKind(context.Background(), xpub)
+	assert.False(t, ok)
+}
+
+// A lookup that fails leaves the walk incomplete. The import still keeps the
+// chosen kind, and the failure reaches the log rather than passing as a clean
+// "this key was never used".
+func TestDetectScriptKindReportsNothingWhenEveryLookupFails(t *testing.T) {
+	xpub := legacyAccountXpub(t)
+
+	src := &usedAddressSource{used: map[string]bool{}, failAll: true}
+	_, ok := detectBackend(t, src).DetectScriptKind(context.Background(), xpub)
+	assert.False(t, ok)
+	assert.Len(t, src.asked, len(detectScriptKinds)*detectScanDepth*2)
+}
+
+// Only a key that states no type needs the chain probed.
+func TestBareKeyWithoutKind(t *testing.T) {
+	xpub := legacyAccountXpub(t)
+
+	assert.True(t, BareKeyWithoutKind(xpub))
+	assert.False(t, BareKeyWithoutKind("[d34db33f/44'/0'/0']"+xpub), "an origin purpose states the type")
+	assert.False(t, BareKeyWithoutKind("pkh("+xpub+"/0/*)"), "a script wrapper states the type")
+	assert.False(t, BareKeyWithoutKind(""))
+}

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -1495,7 +1495,8 @@ func (p *ElectrumBackend) walletDescriptorFor(w *WalletData, kind ScriptKind) (*
 	if err != nil {
 		return nil, err
 	}
-	return ParseDescriptor(desc)
+	// A bare xpub states no kind, so the one recorded at import decides.
+	return ParseDescriptorAs(desc, w.scriptKind())
 }
 
 // multisigSigningDescriptor builds the wallet's multisig descriptor, substituting

--- a/sidechain-orchestrator/wallet/engine.go
+++ b/sidechain-orchestrator/wallet/engine.go
@@ -179,6 +179,16 @@ func (e *WalletEngine) SetElectrumServerURL(ctx context.Context, url string) (in
 	return eb.SetServerURL(ctx, url)
 }
 
+// DetectScriptKind probes the chain for the script kind a bare extended key
+// actually uses. See ElectrumBackend.DetectScriptKind.
+func (e *WalletEngine) DetectScriptKind(ctx context.Context, xpubOrDescriptor string) (ScriptKind, bool) {
+	eb, err := e.electrumBackend()
+	if err != nil {
+		return ScriptUnknown, false
+	}
+	return eb.DetectScriptKind(ctx, xpubOrDescriptor)
+}
+
 // TorConfig reports whether the electrum wallet routes chain connections
 // through a SOCKS5 proxy and the proxy address.
 func (e *WalletEngine) TorConfig() (bool, string, error) {

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -733,13 +733,13 @@ func (s *Service) CreateBitcoinCoreWallet(name string, gradientJSON json.RawMess
 // xpubOrDescriptor instead creates a watch-only electrum wallet with no
 // private keys; it is mutually exclusive with customMnemonic.
 func (s *Service) CreateElectrumWallet(name string, gradient json.RawMessage, slots []uint32, customMnemonic, passphrase, xpubOrDescriptor, scriptType string, accountIndex uint32, derivationPath string) (*WalletData, error) {
-	if xpubOrDescriptor != "" {
-		return s.createElectrumWatchOnly(name, gradient, xpubOrDescriptor)
-	}
-
 	st, err := validateHotScriptType(scriptType)
 	if err != nil {
 		return nil, err
+	}
+
+	if xpubOrDescriptor != "" {
+		return s.createElectrumWatchOnly(name, gradient, xpubOrDescriptor, HotScriptKind(st))
 	}
 
 	sidechainSlots := make([]SidechainSlot, len(slots))
@@ -752,17 +752,7 @@ func (s *Service) CreateElectrumWallet(name string, gradient json.RawMessage, sl
 		s.mu.Unlock()
 		return nil, fmt.Errorf("wallet is locked, unlock before creating a wallet")
 	}
-	wallet, err := s.generateWalletOfType(name, customMnemonic, passphrase, accountIndex, derivationPath, sidechainSlots, WalletTypeElectrum)
-	if err == nil && st != "" {
-		for i := range s.wallets {
-			if s.wallets[i].ID == wallet.ID {
-				s.wallets[i].ScriptType = st
-				wallet.ScriptType = st
-				break
-			}
-		}
-		err = s.saveWalletFile()
-	}
+	wallet, err := s.generateWalletOfType(name, customMnemonic, passphrase, accountIndex, derivationPath, st, sidechainSlots, WalletTypeElectrum)
 	s.mu.Unlock()
 	if err != nil {
 		return nil, err
@@ -785,17 +775,18 @@ func validateHotScriptType(s string) (string, error) {
 	case "legacy", "nested-segwit", "taproot":
 		return s, nil
 	default:
-		return "", fmt.Errorf("unsupported electrum script type %q", s)
+		return "", fmt.Errorf("unsupported script type %q", s)
 	}
 }
 
 // createElectrumWatchOnly creates a watch-only electrum wallet from an xpub or
 // descriptor. Addresses derive from the public key material; with no seed the
-// ElectrumBackend can read balances/history but cannot sign or send.
-func (s *Service) createElectrumWatchOnly(name string, gradient json.RawMessage, xpubOrDescriptor string) (*WalletData, error) {
+// ElectrumBackend can read balances/history but cannot sign or send. requested
+// is the kind to record when the key states none of its own.
+func (s *Service) createElectrumWatchOnly(name string, gradient json.RawMessage, xpubOrDescriptor string, requested ScriptKind) (*WalletData, error) {
 	// Parse-validate the descriptor and record its script kind so derivation
 	// scans the addresses the descriptor actually owns.
-	desc, err := ParseDescriptor(xpubOrDescriptor)
+	desc, err := ParseDescriptorAs(xpubOrDescriptor, requested)
 	if err != nil {
 		return nil, fmt.Errorf("invalid watch-only descriptor: %w", err)
 	}
@@ -1008,13 +999,18 @@ func (s *Service) UpdateWallet(wallet WalletData) error {
 // --- Generate ---
 
 func (s *Service) GenerateWallet(name, customMnemonic, passphrase string, slots []SidechainSlot) (*WalletData, error) {
-	return s.GenerateWalletWithPath(name, customMnemonic, passphrase, 0, "", slots)
+	return s.GenerateWalletWithPath(name, customMnemonic, passphrase, 0, "", "", slots)
 }
 
 // GenerateWalletWithPath is GenerateWallet with an optional account-index/
 // derivation-path override stored on the wallet so descriptor derivation honors
 // it. Both override args must be pre-validated (see ResolveCreateDerivationPath).
-func (s *Service) GenerateWalletWithPath(name, customMnemonic, passphrase string, accountIndex uint32, derivationPath string, slots []SidechainSlot) (*WalletData, error) {
+func (s *Service) GenerateWalletWithPath(name, customMnemonic, passphrase string, accountIndex uint32, derivationPath, scriptType string, slots []SidechainSlot) (*WalletData, error) {
+	st, err := validateHotScriptType(scriptType)
+	if err != nil {
+		return nil, err
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -1022,14 +1018,14 @@ func (s *Service) GenerateWalletWithPath(name, customMnemonic, passphrase string
 		return nil, fmt.Errorf("wallet is locked, unlock before generating a wallet")
 	}
 
-	return s.generateWalletOfType(name, customMnemonic, passphrase, accountIndex, derivationPath, slots, WalletTypeBitcoinCore)
+	return s.generateWalletOfType(name, customMnemonic, passphrase, accountIndex, derivationPath, st, slots, WalletTypeBitcoinCore)
 }
 
 // generateWalletOfType derives a full local wallet of the given type, appends
 // it as the new active wallet, and persists. Keys are always generated locally;
 // walletType only controls which daemon callbacks fire afterwards. Must be
 // called with mu held.
-func (s *Service) generateWalletOfType(name, customMnemonic, passphrase string, accountIndex uint32, derivationPath string, slots []SidechainSlot, walletType WalletType) (*WalletData, error) {
+func (s *Service) generateWalletOfType(name, customMnemonic, passphrase string, accountIndex uint32, derivationPath, scriptType string, slots []SidechainSlot, walletType WalletType) (*WalletData, error) {
 	s.log.Info().
 		Str("name", name).
 		Str("wallet_type", string(walletType)).
@@ -1058,6 +1054,7 @@ func (s *Service) generateWalletOfType(name, customMnemonic, passphrase string, 
 	wallet.Gradient = nil
 	wallet.AccountIndex = accountIndex
 	wallet.DerivationPath = derivationPath
+	wallet.ScriptType = scriptType
 
 	// Add to list and set as active
 	s.wallets = append(s.wallets, *wallet)

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -735,6 +735,7 @@ class GenerateWalletRequest extends $pb.GeneratedMessage {
     $core.String? passphrase,
     $core.int? account,
     $core.String? derivationPath,
+    $core.String? scriptType,
   }) {
     final $result = create();
     if (name != null) {
@@ -752,6 +753,9 @@ class GenerateWalletRequest extends $pb.GeneratedMessage {
     if (derivationPath != null) {
       $result.derivationPath = derivationPath;
     }
+    if (scriptType != null) {
+      $result.scriptType = scriptType;
+    }
     return $result;
   }
   GenerateWalletRequest._() : super();
@@ -764,6 +768,7 @@ class GenerateWalletRequest extends $pb.GeneratedMessage {
     ..aOS(3, _omitFieldNames ? '' : 'passphrase')
     ..a<$core.int>(4, _omitFieldNames ? '' : 'account', $pb.PbFieldType.OU3)
     ..aOS(5, _omitFieldNames ? '' : 'derivationPath')
+    ..aOS(6, _omitFieldNames ? '' : 'scriptType')
     ..hasRequiredFields = false
   ;
 
@@ -837,6 +842,18 @@ class GenerateWalletRequest extends $pb.GeneratedMessage {
   $core.bool hasDerivationPath() => $_has(4);
   @$pb.TagNumber(5)
   void clearDerivationPath() => clearField(5);
+
+  /// Address type: "legacy", "nested-segwit", "native-segwit" (default), or
+  /// "taproot". Pass this rather than a derivation_path that only names the
+  /// address type: a stored path pins the coin type to one network.
+  @$pb.TagNumber(6)
+  $core.String get scriptType => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set scriptType($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasScriptType() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearScriptType() => clearField(6);
 }
 
 class GenerateWalletResponse extends $pb.GeneratedMessage {
@@ -3276,9 +3293,10 @@ class CreateElectrumWalletRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   void clearXpubOrDescriptor() => clearField(5);
 
-  /// Address type for a hot wallet: "legacy", "nested-segwit",
-  /// "native-segwit" (default), or "taproot". Ignored for watch-only imports
-  /// (the descriptor's own type wins).
+  /// Address type: "legacy", "nested-segwit", "native-segwit" (default), or
+  /// "taproot". A watch-only import uses it only for a bare extended key, which
+  /// states no type of its own; a script wrapper, a SLIP-0132 header and an
+  /// origin path's purpose all win over it.
   @$pb.TagNumber(6)
   $core.String get scriptType => $_getSZ(5);
   @$pb.TagNumber(6)

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -259,6 +259,7 @@ const GenerateWalletRequest$json = {
     {'1': 'passphrase', '3': 3, '4': 1, '5': 9, '10': 'passphrase'},
     {'1': 'account', '3': 4, '4': 1, '5': 13, '10': 'account'},
     {'1': 'derivation_path', '3': 5, '4': 1, '5': 9, '10': 'derivationPath'},
+    {'1': 'script_type', '3': 6, '4': 1, '5': 9, '10': 'scriptType'},
   ],
 };
 
@@ -267,7 +268,7 @@ final $typed_data.Uint8List generateWalletRequestDescriptor = $convert.base64Dec
     'ChVHZW5lcmF0ZVdhbGxldFJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRInCg9jdXN0b21fbW'
     '5lbW9uaWMYAiABKAlSDmN1c3RvbU1uZW1vbmljEh4KCnBhc3NwaHJhc2UYAyABKAlSCnBhc3Nw'
     'aHJhc2USGAoHYWNjb3VudBgEIAEoDVIHYWNjb3VudBInCg9kZXJpdmF0aW9uX3BhdGgYBSABKA'
-    'lSDmRlcml2YXRpb25QYXRo');
+    'lSDmRlcml2YXRpb25QYXRoEh8KC3NjcmlwdF90eXBlGAYgASgJUgpzY3JpcHRUeXBl');
 
 @$core.Deprecated('Use generateWalletResponseDescriptor instead')
 const GenerateWalletResponse$json = {

--- a/sidechain_core/lib/providers/bitcoin_conf_provider.dart
+++ b/sidechain_core/lib/providers/bitcoin_conf_provider.dart
@@ -81,6 +81,15 @@ class BitcoinConfProvider extends ChangeNotifier {
   /// enforcer/orchestrator, so it returns false there.
   bool get drivechainFeaturesAvailable => networkSupportsSidechains;
 
+  /// Whether the running network derives keys under Bitcoin mainnet
+  /// parameters. Forknet and eCash fork mainnet, so they share its coin type
+  /// and address prefixes; the orchestrator maps all three to MainNetParams.
+  bool get usesMainnetParams {
+    return network == BitcoinNetwork.BITCOIN_NETWORK_MAINNET ||
+        network == BitcoinNetwork.BITCOIN_NETWORK_FORKNET ||
+        network == BitcoinNetwork.BITCOIN_NETWORK_ECASH;
+  }
+
   int rpcPort = 38332;
 
   /// True when the active network and wallet backend need a datadir the user

--- a/sidechain_core/lib/providers/wallet_writer_provider.dart
+++ b/sidechain_core/lib/providers/wallet_writer_provider.dart
@@ -39,6 +39,7 @@ class WalletWriterProvider extends ChangeNotifier {
     String? passphrase,
     int account = 0,
     String? derivationPath,
+    String? scriptType,
   }) async {
     try {
       final resp = await _client.generateWallet(
@@ -47,6 +48,7 @@ class WalletWriterProvider extends ChangeNotifier {
         passphrase: passphrase,
         account: account,
         derivationPath: derivationPath,
+        scriptType: scriptType,
       );
 
       _logger.i(
@@ -73,6 +75,7 @@ class WalletWriterProvider extends ChangeNotifier {
     String? passphrase,
     int account = 0,
     String? derivationPath,
+    String? scriptType,
   }) async {
     final result = await generateWallet(
       name: name,
@@ -80,6 +83,7 @@ class WalletWriterProvider extends ChangeNotifier {
       passphrase: passphrase,
       account: account,
       derivationPath: derivationPath,
+      scriptType: scriptType,
     );
     final walletId = result['wallet_id'] as String?;
     if (walletId != null) {

--- a/sidechain_core/lib/rpcs/orchestrator_wallet_rpc.dart
+++ b/sidechain_core/lib/rpcs/orchestrator_wallet_rpc.dart
@@ -65,6 +65,7 @@ class OrchestratorWalletRPC {
     String? passphrase,
     int account = 0,
     String? derivationPath,
+    String? scriptType,
   }) {
     return _unaryClient.generateWallet(
       wmpb.GenerateWalletRequest(
@@ -73,6 +74,7 @@ class OrchestratorWalletRPC {
         passphrase: passphrase ?? '',
         account: account,
         derivationPath: derivationPath ?? '',
+        scriptType: scriptType ?? '',
       ),
     );
   }


### PR DESCRIPTION
A wallet recorded its address kind inside its derivation path, because GenerateWallet had no field for one. The path pinned the coin type, so a wallet made on signet kept 84'/1' on every later network and its descriptor never followed. The kind now travels in its own field, and only a path the user typed himself stays with the wallet.

A watch-only import of a bare xpub assumed BIP84, so a Trezor legacy account scanned bc1 addresses it does not own and read as empty. The kind now comes from the origin purpose, then from the key's own history at receive indexes 0-5, then from the type the user picked.

BitWindow also boots on eCash rather than signet, and a full-node install starts its first wallet on Bitcoin Core. Wallets that already exist keep their stored path.