### PR TITLE
Claim the wallet you have open

### DIFF
--- a/bitwindow/lib/pages/root_page.dart
+++ b/bitwindow/lib/pages/root_page.dart
@@ -17,6 +17,7 @@ import 'package:bitwindow/main.dart';
 import 'package:bitwindow/pages/merchants/chain_merchants_dialog.dart';
 import 'package:bitwindow/pages/overview_page.dart';
 import 'package:bitwindow/pages/wallet/bitcoin_uri_dialog.dart';
+import 'package:bitwindow/providers/fork_provider.dart';
 import 'package:bitwindow/providers/transactions_provider.dart';
 import 'package:bitwindow/widgets/fork_countdown_timer.dart';
 import 'package:bitwindow/widgets/proof_of_funds_modal.dart';
@@ -973,108 +974,112 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver, Window
                                 SailText.primary13('Switching wallet...', bold: true),
                               ],
                             )
-                          : WalletDropdown(
-                              currentWallet: _walletReader.availableWallets
-                                  .where((w) => w.id == _walletReader.activeWalletId)
-                                  .firstOrNull,
-                              availableWallets: _walletReader.availableWallets,
-                              onWalletSelected: (walletId) async {
-                                if (_isWalletSwitching) {
-                                  return;
-                                }
-
-                                final log = GetIt.I.get<Logger>();
-                                log.i('Switching to wallet: $walletId');
-
-                                // Resolve anything the backend needs from the
-                                // user before the spinner goes up.
-                                final String switchDataDir;
-                                try {
-                                  switchDataDir = await _walletReader.resolveSwitchRequirements(context, walletId);
-                                } on NetworkChangeDeclined {
-                                  return;
-                                }
-
-                                // Show loading immediately and schedule the actual switch
-                                setState(() => _isWalletSwitching = true);
-
-                                // Run the switch in a microtask to allow UI to update first
-                                await Future.microtask(() async {
-                                  try {
-                                    if (!mounted) {
-                                      return;
-                                    }
-                                    // Clear previous wallet data FIRST
-                                    GetIt.I.get<TransactionProvider>().clear();
-                                    GetIt.I.get<BalanceProvider>().clear();
-
-                                    // Step 1: Switch the active wallet (updates UI immediately)
-                                    log.i('Step 1: Switching active wallet');
-                                    await _walletReader
-                                        .switchWallet(walletId, dataDir: switchDataDir)
-                                        .timeout(
-                                          const Duration(minutes: 5),
-                                          onTimeout: () => throw TimeoutException('switchWallet timed out'),
-                                        );
-                                    log.i('Step 1: Complete');
-
-                                    // Reset providers in background
-                                    unawaited(() async {
-                                      try {
-                                        log.i('Step 2: Refreshing balance provider');
-                                        final balanceProvider = GetIt.I.get<BalanceProvider>();
-                                        await balanceProvider.fetch();
-                                        log.i('Step 2: Complete');
-                                      } catch (e) {
-                                        log.w('Step 2: Failed to refresh balance: $e');
-                                      }
-
-                                      try {
-                                        log.i('Step 3: Refreshing transaction provider');
-                                        final transactionProvider = GetIt.I.get<TransactionProvider>();
-                                        await transactionProvider.fetch();
-                                        log.i('Step 3: Complete');
-                                      } catch (e) {
-                                        log.w('Step 3: Failed to refresh transactions: $e');
-                                      }
-                                    }());
-
-                                    log.i('Wallet switch complete (background tasks continuing)');
-                                  } catch (e, stack) {
-                                    log.e('Failed to switch wallet: $e\n$stack');
-                                  } finally {
-                                    // Hide loading after core operations complete
-                                    if (mounted) {
-                                      setState(() => _isWalletSwitching = false);
-                                    }
+                          : ListenableBuilder(
+                              listenable: GetIt.I<ForkProvider>(),
+                              builder: (context, _) => WalletDropdown(
+                                currentWallet: _walletReader.availableWallets
+                                    .where((w) => w.id == _walletReader.activeWalletId)
+                                    .firstOrNull,
+                                availableWallets: _walletReader.availableWallets,
+                                walletsNeedingAttention: GetIt.I<ForkProvider>().walletsWithClaims,
+                                onWalletSelected: (walletId) async {
+                                  if (_isWalletSwitching) {
+                                    return;
                                   }
-                                });
-                              },
-                              onCreateWallet: () async {
-                                await GetIt.I.get<AppRouter>().push(CreateAnotherWalletRoute());
-                              },
-                              onEditWallet: (wallet) async {
-                                final renamed = await showRenameWalletDialog(context, wallet.name);
-                                if (renamed == null || renamed == wallet.name) {
-                                  return;
-                                }
-                                await _walletReader.updateWalletMetadata(wallet.id, renamed, wallet.gradient);
-                              },
-                              onBackgroundChanged: (walletId, newBackgroundSvg) async {
-                                final wallet = _walletReader.availableWallets
-                                    .where((w) => w.id == walletId)
-                                    .firstOrNull;
-                                if (wallet != null) {
-                                  final updatedGradient = wallet.gradient.copyWith(
-                                    backgroundSvg: newBackgroundSvg,
-                                  );
-                                  await _walletReader.updateWalletMetadata(
-                                    walletId,
-                                    wallet.name,
-                                    updatedGradient,
-                                  );
-                                }
-                              },
+
+                                  final log = GetIt.I.get<Logger>();
+                                  log.i('Switching to wallet: $walletId');
+
+                                  // Resolve anything the backend needs from the
+                                  // user before the spinner goes up.
+                                  final String switchDataDir;
+                                  try {
+                                    switchDataDir = await _walletReader.resolveSwitchRequirements(context, walletId);
+                                  } on NetworkChangeDeclined {
+                                    return;
+                                  }
+
+                                  // Show loading immediately and schedule the actual switch
+                                  setState(() => _isWalletSwitching = true);
+
+                                  // Run the switch in a microtask to allow UI to update first
+                                  await Future.microtask(() async {
+                                    try {
+                                      if (!mounted) {
+                                        return;
+                                      }
+                                      // Clear previous wallet data FIRST
+                                      GetIt.I.get<TransactionProvider>().clear();
+                                      GetIt.I.get<BalanceProvider>().clear();
+
+                                      // Step 1: Switch the active wallet (updates UI immediately)
+                                      log.i('Step 1: Switching active wallet');
+                                      await _walletReader
+                                          .switchWallet(walletId, dataDir: switchDataDir)
+                                          .timeout(
+                                            const Duration(minutes: 5),
+                                            onTimeout: () => throw TimeoutException('switchWallet timed out'),
+                                          );
+                                      log.i('Step 1: Complete');
+
+                                      // Reset providers in background
+                                      unawaited(() async {
+                                        try {
+                                          log.i('Step 2: Refreshing balance provider');
+                                          final balanceProvider = GetIt.I.get<BalanceProvider>();
+                                          await balanceProvider.fetch();
+                                          log.i('Step 2: Complete');
+                                        } catch (e) {
+                                          log.w('Step 2: Failed to refresh balance: $e');
+                                        }
+
+                                        try {
+                                          log.i('Step 3: Refreshing transaction provider');
+                                          final transactionProvider = GetIt.I.get<TransactionProvider>();
+                                          await transactionProvider.fetch();
+                                          log.i('Step 3: Complete');
+                                        } catch (e) {
+                                          log.w('Step 3: Failed to refresh transactions: $e');
+                                        }
+                                      }());
+
+                                      log.i('Wallet switch complete (background tasks continuing)');
+                                    } catch (e, stack) {
+                                      log.e('Failed to switch wallet: $e\n$stack');
+                                    } finally {
+                                      // Hide loading after core operations complete
+                                      if (mounted) {
+                                        setState(() => _isWalletSwitching = false);
+                                      }
+                                    }
+                                  });
+                                },
+                                onCreateWallet: () async {
+                                  await GetIt.I.get<AppRouter>().push(CreateAnotherWalletRoute());
+                                },
+                                onEditWallet: (wallet) async {
+                                  final renamed = await showRenameWalletDialog(context, wallet.name);
+                                  if (renamed == null || renamed == wallet.name) {
+                                    return;
+                                  }
+                                  await _walletReader.updateWalletMetadata(wallet.id, renamed, wallet.gradient);
+                                },
+                                onBackgroundChanged: (walletId, newBackgroundSvg) async {
+                                  final wallet = _walletReader.availableWallets
+                                      .where((w) => w.id == walletId)
+                                      .firstOrNull;
+                                  if (wallet != null) {
+                                    final updatedGradient = wallet.gradient.copyWith(
+                                      backgroundSvg: newBackgroundSvg,
+                                    );
+                                    await _walletReader.updateWalletMetadata(
+                                      walletId,
+                                      wallet.name,
+                                      updatedGradient,
+                                    );
+                                  }
+                                },
+                              ),
                             ),
                       routes: [for (final t in _navTabs) t.nav],
                       endWidget: SailRow(

--- a/bitwindow/lib/providers/fork_provider.dart
+++ b/bitwindow/lib/providers/fork_provider.dart
@@ -420,9 +420,12 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
   /// no action.
   bool get hasSelectableCoins => sweepableClaims.any((c) => selectableInputs(c).isNotEmpty);
 
-  /// Every wallet that still holds a coin to claim.
-  Set<String> get walletsWithClaims =>
-      sweepableClaims.where((c) => selectableInputs(c).isNotEmpty).map((c) => c.walletId).toSet();
+  /// Every wallet whose claim card the user can still open. A wallet whose
+  /// card the user closed carries no mark, or the mark points at nothing.
+  Set<String> get walletsWithClaims => sweepableClaims
+      .where((c) => selectableInputs(c).isNotEmpty && !claimCardDismissedFor(c.walletId))
+      .map((c) => c.walletId)
+      .toSet();
 
   /// The claims of one wallet. The card speaks for the wallet the user has
   /// open; the wallet picker marks the rest.

--- a/bitwindow/lib/providers/fork_provider.dart
+++ b/bitwindow/lib/providers/fork_provider.dart
@@ -145,13 +145,20 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
   /// the card back.
   Set<String> _dismissedClaimOutpoints = {};
 
-  /// True while the user hid the card and no new claimable coin arrived.
-  bool get claimCardDismissed =>
-      claimOutpoints.isNotEmpty && claimOutpoints.difference(_dismissedClaimOutpoints).isEmpty;
+  /// The coins one wallet can still claim.
+  Set<String> claimOutpointsFor(String? walletId) =>
+      claimsForWallet(walletId).expand((c) => c.utxos).map((u) => u.output).toSet();
 
-  /// Hides the claim card until a new claimable coin arrives.
-  void dismissClaimCard() {
-    _dismissedClaimOutpoints = claimOutpoints;
+  /// True while the user hid this wallet's card and no new coin arrived for
+  /// it. The card belongs to one wallet, so hiding it leaves the others alone.
+  bool claimCardDismissedFor(String? walletId) {
+    final outpoints = claimOutpointsFor(walletId);
+    return outpoints.isNotEmpty && outpoints.difference(_dismissedClaimOutpoints).isEmpty;
+  }
+
+  /// Hides one wallet's claim card until a new claimable coin arrives for it.
+  void dismissClaimCardFor(String? walletId) {
+    _dismissedClaimOutpoints = {..._dismissedClaimOutpoints, ...claimOutpointsFor(walletId)};
     notifyListeners();
   }
 

--- a/bitwindow/lib/providers/fork_provider.dart
+++ b/bitwindow/lib/providers/fork_provider.dart
@@ -413,6 +413,16 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
   /// no action.
   bool get hasSelectableCoins => sweepableClaims.any((c) => selectableInputs(c).isNotEmpty);
 
+  /// Every wallet that still holds a coin to claim.
+  Set<String> get walletsWithClaims =>
+      sweepableClaims.where((c) => selectableInputs(c).isNotEmpty).map((c) => c.walletId).toSet();
+
+  /// The claims of one wallet. The card speaks for the wallet the user has
+  /// open; the wallet picker marks the rest.
+  List<WalletClaim> claimsForWallet(String? walletId) => walletId == null
+      ? const []
+      : sweepableClaims.where((c) => c.walletId == walletId && selectableInputs(c).isNotEmpty).toList();
+
   /// Smallest selected sum a sweep can pay: the post-fee output must stay
   /// above dust. Generous estimate at the 1 sat/vB sweep rate.
   static int minClaimSats(int inputCount) => 546 + 150 + 70 * inputCount;

--- a/bitwindow/lib/providers/fork_provider.dart
+++ b/bitwindow/lib/providers/fork_provider.dart
@@ -143,7 +143,7 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
 
   /// The coins the user hid the claim card for. A new claimable coin brings
   /// the card back.
-  Set<String> _dismissedClaimOutpoints = {};
+  final Map<String, Set<String>> _dismissedClaimOutpoints = {};
 
   /// The coins one wallet can still claim.
   Set<String> claimOutpointsFor(String? walletId) =>
@@ -153,12 +153,15 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
   /// it. The card belongs to one wallet, so hiding it leaves the others alone.
   bool claimCardDismissedFor(String? walletId) {
     final outpoints = claimOutpointsFor(walletId);
-    return outpoints.isNotEmpty && outpoints.difference(_dismissedClaimOutpoints).isEmpty;
+    final dismissed = _dismissedClaimOutpoints[walletId ?? ''] ?? const <String>{};
+    return outpoints.isNotEmpty && outpoints.difference(dismissed).isEmpty;
   }
 
   /// Hides one wallet's claim card until a new claimable coin arrives for it.
   void dismissClaimCardFor(String? walletId) {
-    _dismissedClaimOutpoints = {..._dismissedClaimOutpoints, ...claimOutpointsFor(walletId)};
+    // Two wallets can watch the same coins, so each carries its own record.
+    final key = walletId ?? '';
+    _dismissedClaimOutpoints[key] = {...?_dismissedClaimOutpoints[key], ...claimOutpointsFor(walletId)};
     notifyListeners();
   }
 
@@ -217,7 +220,7 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
     _readPsbtByDraft.clear();
     _splitsInFlight.clear();
     replayedTxids.clear();
-    _dismissedClaimOutpoints = {};
+    _dismissedClaimOutpoints.clear();
     walletsWithUnreadDrafts = {};
     notifyListeners();
     fetch();

--- a/bitwindow/lib/widgets/claim_ecx_card.dart
+++ b/bitwindow/lib/widgets/claim_ecx_card.dart
@@ -513,7 +513,6 @@ class _ClaimedCard extends StatelessWidget {
     final url = mempoolTxUrl(txid, network);
 
     return SailCard(
-      color: theme.colors.success.withValues(alpha: 0.13),
       child: SailColumn(
         spacing: 0,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -579,7 +578,6 @@ class _FailedCard extends StatelessWidget {
     final theme = SailTheme.of(context);
 
     return SailCard(
-      color: theme.colors.error.withValues(alpha: 0.10),
       child: SailColumn(
         spacing: 0,
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/bitwindow/lib/widgets/fork_mode_banner.dart
+++ b/bitwindow/lib/widgets/fork_mode_banner.dart
@@ -23,7 +23,7 @@ class ForkModeBanner extends StatelessWidget {
         // ForkCountdownTimer, and is hidden by the engine while coins are
         // unclaimed, so the two never overlap.
         final active = GetIt.I<WalletReaderProvider>().activeWalletId;
-        if (!_fork.hasFundsToClaim || _fork.claimsForWallet(active).isEmpty || _fork.claimCardDismissed) {
+        if (!_fork.hasFundsToClaim || _fork.claimsForWallet(active).isEmpty || _fork.claimCardDismissedFor(active)) {
           return const SizedBox.shrink();
         }
         return _ClaimEcashCard(fork: _fork, walletId: active);
@@ -141,7 +141,7 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
                 SailButton(
                   variant: ButtonVariant.icon,
                   icon: SailSVGAsset.iconClose,
-                  onPressed: () async => widget.fork.dismissClaimCard(),
+                  onPressed: () async => widget.fork.dismissClaimCardFor(widget.walletId),
                 ),
               ],
             ),

--- a/bitwindow/lib/widgets/fork_mode_banner.dart
+++ b/bitwindow/lib/widgets/fork_mode_banner.dart
@@ -16,17 +16,22 @@ class ForkModeBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final walletReader = GetIt.I<WalletReaderProvider>();
+
+    // A wallet switch does not always reach the fork provider, and the card
+    // spends the wallet it holds, so it follows the picker as well.
     return ListenableBuilder(
-      listenable: _fork,
+      listenable: Listenable.merge([_fork, walletReader]),
       builder: (context, _) {
         // Claim card only — the countdown is handled globally by
         // ForkCountdownTimer, and is hidden by the engine while coins are
         // unclaimed, so the two never overlap.
-        final active = GetIt.I<WalletReaderProvider>().activeWalletId;
+        final active = walletReader.activeWalletId;
         if (!_fork.hasFundsToClaim || _fork.claimsForWallet(active).isEmpty || _fork.claimCardDismissedFor(active)) {
           return const SizedBox.shrink();
         }
-        return _ClaimEcashCard(fork: _fork, walletId: active);
+        // The key drops the previous wallet's selection with its card.
+        return _ClaimEcashCard(key: ValueKey(active ?? ''), fork: _fork, walletId: active);
       },
     );
   }
@@ -38,7 +43,7 @@ class ForkModeBanner extends StatelessWidget {
 const double _claimCardBodyHeightShare = 0.4;
 
 class _ClaimEcashCard extends StatefulWidget {
-  const _ClaimEcashCard({required this.fork, required this.walletId});
+  const _ClaimEcashCard({super.key, required this.fork, required this.walletId});
   final ForkProvider fork;
   final String? walletId;
 

--- a/bitwindow/lib/widgets/fork_mode_banner.dart
+++ b/bitwindow/lib/widgets/fork_mode_banner.dart
@@ -22,10 +22,11 @@ class ForkModeBanner extends StatelessWidget {
         // Claim card only — the countdown is handled globally by
         // ForkCountdownTimer, and is hidden by the engine while coins are
         // unclaimed, so the two never overlap.
-        if (!_fork.hasFundsToClaim || !_fork.hasSelectableCoins || _fork.claimCardDismissed) {
+        final active = GetIt.I<WalletReaderProvider>().activeWalletId;
+        if (!_fork.hasFundsToClaim || _fork.claimsForWallet(active).isEmpty || _fork.claimCardDismissed) {
           return const SizedBox.shrink();
         }
-        return _ClaimEcashCard(fork: _fork);
+        return _ClaimEcashCard(fork: _fork, walletId: active);
       },
     );
   }
@@ -37,8 +38,9 @@ class ForkModeBanner extends StatelessWidget {
 const double _claimCardBodyHeightShare = 0.4;
 
 class _ClaimEcashCard extends StatefulWidget {
-  const _ClaimEcashCard({required this.fork});
+  const _ClaimEcashCard({required this.fork, required this.walletId});
   final ForkProvider fork;
+  final String? walletId;
 
   @override
   State<_ClaimEcashCard> createState() => _ClaimEcashCardState();
@@ -113,13 +115,11 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
     final formatter = GetIt.I<FormatterProvider>();
     _syncSelection();
     final selectedSats = _selectedSats;
-    // A wallet with no selectable coin gets no picker — it offers no action.
-    final claims = widget.fork.sweepableClaims.where((c) => widget.fork.selectableInputs(c).isNotEmpty).toList();
+    final claims = widget.fork.claimsForWallet(widget.walletId);
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: SailCard(
-        color: theme.colors.orange.withValues(alpha: 0.08),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -209,7 +209,13 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SailText.secondary12('COINS TO SPLIT', bold: true),
+            Row(
+              children: [
+                SailText.secondary12(claim.walletName.toUpperCase(), bold: true),
+                const SizedBox(width: 8),
+                SailText.secondary12('${claim.utxos.length} coins'),
+              ],
+            ),
             const SizedBox(height: 12),
             Row(
               children: [

--- a/bitwindow/lib/widgets/fork_mode_banner.dart
+++ b/bitwindow/lib/widgets/fork_mode_banner.dart
@@ -56,11 +56,14 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
   /// coins that left, drop coins that turned non-splittable, and check each
   /// coin the first time it appears while it is selectable. A user uncheck
   /// stays unchecked — a seen coin is never re-added.
+  /// The claims this card acts on: the open wallet's, and no other.
+  List<WalletClaim> get _claims => widget.fork.claimsForWallet(widget.walletId);
+
   void _syncSelection() {
-    final walletIds = widget.fork.sweepableClaims.map((c) => c.walletId).toSet();
+    final walletIds = _claims.map((c) => c.walletId).toSet();
     _selected.removeWhere((id, _) => !walletIds.contains(id));
     _seen.removeWhere((id, _) => !walletIds.contains(id));
-    for (final claim in widget.fork.sweepableClaims) {
+    for (final claim in _claims) {
       final seen = _seen.putIfAbsent(claim.walletId, () => {});
       final selected = _selected.putIfAbsent(claim.walletId, () => {});
       final selectable = <String>{};
@@ -80,7 +83,7 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
 
   int get _selectedSats {
     var sum = 0;
-    for (final claim in widget.fork.sweepableClaims) {
+    for (final claim in _claims) {
       final selected = _selected[claim.walletId] ?? {};
       for (final u in claim.utxos) {
         if (selected.contains(u.output)) {
@@ -95,7 +98,7 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
   /// selection can pay its sweep fee.
   bool get _selectionValid {
     var any = false;
-    for (final claim in widget.fork.sweepableClaims) {
+    for (final claim in _claims) {
       final selected = _selected[claim.walletId] ?? {};
       if (selected.isEmpty) {
         continue;
@@ -115,7 +118,7 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
     final formatter = GetIt.I<FormatterProvider>();
     _syncSelection();
     final selectedSats = _selectedSats;
-    final claims = widget.fork.claimsForWallet(widget.walletId);
+    final claims = _claims;
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
@@ -327,7 +330,7 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
       'You have coins on both BTC and ECX. We recommend splitting your coins to not lose any ECX or BTC you currently own.',
       'By default, a transaction valid on bitcoin is also valid on eCash. Therefore, by spending your bitcoin, you will make that same transaction on eCash. If you do not control the receiving eCash wallet, you will lose your eCash.',
       'Claiming sweeps the selected coins to a fresh address in the same wallet.',
-      if (widget.fork.sweepableClaims.any((c) => c.isMultisig))
+      if (_claims.any((c) => c.isMultisig))
         'A multisig wallet holds some of these coins. BitWindow builds a PSBT instead of a finished transaction, and nothing is broadcast until the cosigners sign it on the send tab.',
     ];
     return Column(
@@ -348,7 +351,7 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
   Future<void> _claim(BuildContext context) async {
     // Snapshot the plan first — claim() refetches and replaces the claims,
     // so one wallet's failure must not misreport the wallets already swept.
-    final planned = widget.fork.sweepableClaims
+    final planned = _claims
         .map(
           (c) => (
             walletId: c.walletId,

--- a/bitwindow/test/claim_card_scroll_test.dart
+++ b/bitwindow/test/claim_card_scroll_test.dart
@@ -32,7 +32,9 @@ void _registerClaimProviders() {
     GetIt.I.registerSingleton<ForkProvider>(fork);
   }
   if (!GetIt.I.isRegistered<WalletReaderProvider>()) {
-    GetIt.I.registerSingleton<WalletReaderProvider>(WalletReaderProvider(Directory.systemTemp));
+    final reader = WalletReaderProvider(Directory.systemTemp);
+    reader.activeWalletId = 'w1';
+    GetIt.I.registerSingleton<WalletReaderProvider>(reader);
   }
   if (!GetIt.I.isRegistered<TransactionProvider>()) {
     GetIt.I.registerSingleton<TransactionProvider>(TransactionProvider());

--- a/bitwindow/test/claim_card_scroll_test.dart
+++ b/bitwindow/test/claim_card_scroll_test.dart
@@ -42,6 +42,8 @@ void _registerClaimProviders() {
 }
 
 void main() {
+  _walletSwitchTests();
+
   TestWidgetsFlutterBinding.ensureInitialized();
 
   // The card sits above the wallet tabs and takes its natural height, so a
@@ -131,5 +133,27 @@ void main() {
     await tester.pump();
 
     expect(tester.takeException(), isNull, reason: 'the card must fit a 400 pixel tall window');
+  });
+}
+
+void _walletSwitchTests() {
+  // The card spends the wallet it holds, so it carries that wallet's key. A
+  // switch then builds a new card instead of keeping the old one.
+  testWidgets('the card is keyed by the wallet it acts for', (tester) async {
+    await registerTestDependencies();
+    _registerClaimProviders();
+
+    await tester.pumpSailPage(
+      Column(
+        children: [
+          const ForkModeBanner(),
+          Expanded(child: Container()),
+        ],
+      ),
+    );
+
+    final card = tester.widget(find.byType(SailCard).first);
+    expect(find.byKey(const ValueKey('w1')), findsOneWidget);
+    expect(card, isNotNull);
   });
 }

--- a/bitwindow/test/fork_provider_test.dart
+++ b/bitwindow/test/fork_provider_test.dart
@@ -25,6 +25,8 @@ WalletClaim claimWith(List<bwpb.UnspentOutput> utxos, {wmpb.MultisigInfo? multis
 wmpb.MultisigInfo policy(int m, int n) => wmpb.MultisigInfo(m: m, n: n);
 
 void main() {
+  _oneWalletActionTests();
+
   _claimsForWalletTests();
 
   test('a coin with unknown BTC status stays selectable', () {
@@ -214,5 +216,24 @@ void _claimsForWalletTests() {
     ];
 
     expect(fork.walletsWithClaims, {'one', 'two'});
+  });
+}
+
+void _oneWalletActionTests() {
+  // The card acts for the wallet the user has open. A claim there must never
+  // reach into another wallet's coins.
+  test('the open wallet sees only its own claims', () {
+    final fork = ForkProvider();
+    fork.claims = [
+      WalletClaim(walletId: 'open', walletName: 'Open', claimableSats: 100, utxos: [utxo('a:0'), utxo('b:0')]),
+      WalletClaim(walletId: 'other', walletName: 'Other', claimableSats: 100, utxos: [utxo('c:0')]),
+    ];
+
+    final mine = fork.claimsForWallet('open');
+    expect(mine, hasLength(1));
+    expect(mine.single.utxos.map((u) => u.output), ['a:0', 'b:0']);
+
+    final coins = mine.expand((c) => c.utxos).map((u) => u.output).toSet();
+    expect(coins.contains('c:0'), isFalse, reason: "another wallet's coin must not appear");
   });
 }

--- a/bitwindow/test/fork_provider_test.dart
+++ b/bitwindow/test/fork_provider_test.dart
@@ -25,6 +25,8 @@ WalletClaim claimWith(List<bwpb.UnspentOutput> utxos, {wmpb.MultisigInfo? multis
 wmpb.MultisigInfo policy(int m, int n) => wmpb.MultisigInfo(m: m, n: n);
 
 void main() {
+  _claimsForWalletTests();
+
   test('a coin with unknown BTC status stays selectable', () {
     expect(ForkProvider.isSelectable(utxo('aa:0')), isTrue);
   });
@@ -170,5 +172,47 @@ void main() {
       PendingSplit(walletId: 'w1', draftId: 'new', outpoints: {'aa:0'}),
     ];
     expect(ForkProvider.keepLivePendingSplits(pending, {}, {}, {}).length, 1);
+  });
+}
+
+void _claimsForWalletTests() {
+  test('claimsForWallet returns only the open wallet', () {
+    final fork = ForkProvider();
+    fork.claims = [
+      WalletClaim(walletId: 'open', walletName: 'Open', claimableSats: 100, utxos: [utxo('a:0')]),
+      WalletClaim(walletId: 'other', walletName: 'Other', claimableSats: 100, utxos: [utxo('b:0')]),
+    ];
+
+    expect(fork.claimsForWallet('open').map((c) => c.walletId), ['open']);
+    expect(fork.claimsForWallet('other').map((c) => c.walletId), ['other']);
+  });
+
+  test('claimsForWallet is empty without an open wallet', () {
+    final fork = ForkProvider();
+    fork.claims = [
+      WalletClaim(walletId: 'open', walletName: 'Open', claimableSats: 100, utxos: [utxo('a:0')]),
+    ];
+
+    expect(fork.claimsForWallet(null), isEmpty);
+  });
+
+  test('a wallet whose coins are all unselectable drops out', () {
+    final fork = ForkProvider();
+    fork.claims = [
+      WalletClaim(walletId: 'spent', walletName: 'Spent', claimableSats: 100, utxos: [utxo('a:0', splittable: false)]),
+    ];
+
+    expect(fork.claimsForWallet('spent'), isEmpty);
+    expect(fork.walletsWithClaims, isEmpty);
+  });
+
+  test('walletsWithClaims names every wallet the picker must mark', () {
+    final fork = ForkProvider();
+    fork.claims = [
+      WalletClaim(walletId: 'one', walletName: 'One', claimableSats: 100, utxos: [utxo('a:0')]),
+      WalletClaim(walletId: 'two', walletName: 'Two', claimableSats: 100, utxos: [utxo('b:0')]),
+    ];
+
+    expect(fork.walletsWithClaims, {'one', 'two'});
   });
 }

--- a/bitwindow/test/fork_provider_test.dart
+++ b/bitwindow/test/fork_provider_test.dart
@@ -25,6 +25,8 @@ WalletClaim claimWith(List<bwpb.UnspentOutput> utxos, {wmpb.MultisigInfo? multis
 wmpb.MultisigInfo policy(int m, int n) => wmpb.MultisigInfo(m: m, n: n);
 
 void main() {
+  _dismissalTests();
+
   _oneWalletActionTests();
 
   _claimsForWalletTests();
@@ -235,5 +237,43 @@ void _oneWalletActionTests() {
 
     final coins = mine.expand((c) => c.utxos).map((u) => u.output).toSet();
     expect(coins.contains('c:0'), isFalse, reason: "another wallet's coin must not appear");
+  });
+}
+
+void _dismissalTests() {
+  ForkProvider twoWallets() {
+    final fork = ForkProvider();
+    fork.hasFundsToClaim = true;
+    fork.claims = [
+      WalletClaim(walletId: 'a', walletName: 'A', claimableSats: 100, utxos: [utxo('a1:0')]),
+      WalletClaim(walletId: 'b', walletName: 'B', claimableSats: 100, utxos: [utxo('b1:0')]),
+    ];
+    return fork;
+  }
+
+  // Closing one wallet's card must leave the other wallet's card, or its red
+  // dot points at a card that never opens.
+  test('closing one card leaves the other wallet alone', () {
+    final fork = twoWallets();
+    fork.dismissClaimCardFor('a');
+
+    expect(fork.claimCardDismissedFor('a'), isTrue);
+    expect(fork.claimCardDismissedFor('b'), isFalse);
+  });
+
+  test('a new coin brings the card back for that wallet', () {
+    final fork = twoWallets();
+    fork.dismissClaimCardFor('a');
+
+    fork.claims = [
+      WalletClaim(walletId: 'a', walletName: 'A', claimableSats: 200, utxos: [utxo('a1:0'), utxo('a2:0')]),
+      WalletClaim(walletId: 'b', walletName: 'B', claimableSats: 100, utxos: [utxo('b1:0')]),
+    ];
+
+    expect(fork.claimCardDismissedFor('a'), isFalse);
+  });
+
+  test('a wallet with no claim reads as not dismissed', () {
+    expect(twoWallets().claimCardDismissedFor('missing'), isFalse);
   });
 }

--- a/bitwindow/test/fork_provider_test.dart
+++ b/bitwindow/test/fork_provider_test.dart
@@ -25,6 +25,8 @@ WalletClaim claimWith(List<bwpb.UnspentOutput> utxos, {wmpb.MultisigInfo? multis
 wmpb.MultisigInfo policy(int m, int n) => wmpb.MultisigInfo(m: m, n: n);
 
 void main() {
+  _sharedCoinDismissalTests();
+
   _dotFollowsDismissalTests();
 
   _dismissalTests();
@@ -294,6 +296,25 @@ void _dotFollowsDismissalTests() {
     expect(fork.walletsWithClaims, {'a', 'b'});
 
     fork.dismissClaimCardFor('a');
+    expect(fork.walletsWithClaims, {'b'});
+  });
+}
+
+void _sharedCoinDismissalTests() {
+  // Two wallet records can watch the same descriptor, so they report the same
+  // coins. Closing one card must not close the other.
+  test('two wallets on the same coins keep their own card', () {
+    final fork = ForkProvider();
+    fork.hasFundsToClaim = true;
+    fork.claims = [
+      WalletClaim(walletId: 'a', walletName: 'A', claimableSats: 100, utxos: [utxo('shared:0')]),
+      WalletClaim(walletId: 'b', walletName: 'B', claimableSats: 100, utxos: [utxo('shared:0')]),
+    ];
+
+    fork.dismissClaimCardFor('a');
+
+    expect(fork.claimCardDismissedFor('a'), isTrue);
+    expect(fork.claimCardDismissedFor('b'), isFalse, reason: 'the other wallet keeps its card');
     expect(fork.walletsWithClaims, {'b'});
   });
 }

--- a/bitwindow/test/fork_provider_test.dart
+++ b/bitwindow/test/fork_provider_test.dart
@@ -25,6 +25,8 @@ WalletClaim claimWith(List<bwpb.UnspentOutput> utxos, {wmpb.MultisigInfo? multis
 wmpb.MultisigInfo policy(int m, int n) => wmpb.MultisigInfo(m: m, n: n);
 
 void main() {
+  _dotFollowsDismissalTests();
+
   _dismissalTests();
 
   _oneWalletActionTests();
@@ -275,5 +277,23 @@ void _dismissalTests() {
 
   test('a wallet with no claim reads as not dismissed', () {
     expect(twoWallets().claimCardDismissedFor('missing'), isFalse);
+  });
+}
+
+void _dotFollowsDismissalTests() {
+  // The dot sends the user to a card. A wallet whose card is closed must not
+  // carry one.
+  test('a dismissed wallet loses its mark', () {
+    final fork = ForkProvider();
+    fork.hasFundsToClaim = true;
+    fork.claims = [
+      WalletClaim(walletId: 'a', walletName: 'A', claimableSats: 100, utxos: [utxo('a1:0')]),
+      WalletClaim(walletId: 'b', walletName: 'B', claimableSats: 100, utxos: [utxo('b1:0')]),
+    ];
+
+    expect(fork.walletsWithClaims, {'a', 'b'});
+
+    fork.dismissClaimCardFor('a');
+    expect(fork.walletsWithClaims, {'b'});
   });
 }

--- a/sail_ui/lib/widgets/wallet_dropdown.dart
+++ b/sail_ui/lib/widgets/wallet_dropdown.dart
@@ -10,6 +10,9 @@ class WalletDropdown extends StatelessWidget {
   final Function(String walletId, String newBackgroundSvg)? onBackgroundChanged;
   final Function(WalletMetadata wallet)? onEditWallet;
 
+  /// Wallets that hold something the user still has to act on.
+  final Set<String> walletsNeedingAttention;
+
   const WalletDropdown({
     super.key,
     required this.currentWallet,
@@ -18,6 +21,7 @@ class WalletDropdown extends StatelessWidget {
     required this.onCreateWallet,
     this.onBackgroundChanged,
     this.onEditWallet,
+    this.walletsNeedingAttention = const {},
   });
 
   @override
@@ -53,6 +57,17 @@ class WalletDropdown extends StatelessWidget {
                     ),
                     const SizedBox(width: 12),
                     SailText.primary13(wallet.name),
+                    if (walletsNeedingAttention.contains(wallet.id)) ...[
+                      const SizedBox(width: 8),
+                      Container(
+                        width: 8,
+                        height: 8,
+                        decoration: BoxDecoration(
+                          color: theme.colors.error,
+                          shape: BoxShape.circle,
+                        ),
+                      ),
+                    ],
                     if (onEditWallet != null && wallet.id != currentWallet?.id) ...[
                       const Spacer(),
                       const SizedBox(width: 12),

--- a/sail_ui/test/wallet_dropdown_dot_test.dart
+++ b/sail_ui/test/wallet_dropdown_dot_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+WalletMetadata _wallet(String id, String name) => WalletMetadata(
+  id: id,
+  name: name,
+  gradient: WalletGradient(
+    backgroundSvg: 'background_northern.svg',
+    colors: const ['#000000', '#111111', '#222222'],
+    stops: const [0, 0.5, 1],
+    centerX: 0,
+    centerY: 0,
+    radius: 1.2,
+    seed: 1,
+  ),
+  createdAt: DateTime(2026),
+  lastUsed: DateTime(2026),
+);
+
+void main() {
+  Widget host(Set<String> attention) => SailTheme(
+    data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+    child: MaterialApp(
+      home: Scaffold(
+        body: WalletDropdown(
+          currentWallet: _wallet('a', 'Main'),
+          availableWallets: [_wallet('a', 'Main'), _wallet('b', 'Cold')],
+          onWalletSelected: (_) {},
+          onCreateWallet: () {},
+          walletsNeedingAttention: attention,
+        ),
+      ),
+    ),
+  );
+
+  // A wallet the user is not in can hold coins to claim, and the picker is the
+  // only place that says so.
+  testWidgets('a wallet with something to claim carries a dot', (tester) async {
+    await tester.pumpWidget(host({'b'}));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(WalletDropdown));
+    await tester.pumpAndSettle();
+
+    final dots = tester.widgetList<Container>(find.byType(Container)).where((c) {
+      final d = c.decoration;
+      return d is BoxDecoration && d.shape == BoxShape.circle && c.constraints?.maxWidth == 8;
+    });
+    expect(dots.length, 1, reason: 'exactly the wallet with a claim gets a dot');
+  });
+
+  testWidgets('no dot without a claim', (tester) async {
+    await tester.pumpWidget(host(const {}));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(WalletDropdown));
+    await tester.pumpAndSettle();
+
+    final dots = tester.widgetList<Container>(find.byType(Container)).where((c) {
+      final d = c.decoration;
+      return d is BoxDecoration && d.shape == BoxShape.circle && c.constraints?.maxWidth == 8;
+    });
+    expect(dots, isEmpty);
+  });
+}


### PR DESCRIPTION
The claim card drew a coin table for every wallet, so several wallets read as identical panels and the card ran past the window. It now shows the wallet the user has open, and the wallet picker carries a red dot on every other wallet that still holds coins to claim.

The card washes go too: the claim card was orange at 8 percent, the ECX success card green at 13, the failure card red at 10. All three are plain bordered panels now, and the head icon keeps the colour.

Matches the Claim eCash flow page in Figma, frames 3 and 4.