### PR TITLE
Say why orchestratord did not start

### DIFF
--- a/bitwindow/lib/main.dart
+++ b/bitwindow/lib/main.dart
@@ -335,6 +335,17 @@ Future<(Directory, File, Logger)> init(String arguments) async {
 }
 
 Future<void> runMainWindow(Logger log, Directory applicationDir, File logFile) async {
+  // bitwindowd's output already reaches the console. orchestratord runs
+  // detached and writes to the shared file, so a terminal launch shows nothing
+  // of the daemon that starts every other one.
+  if (!orchestratorLogsToStdout(Platform.environment)) {
+    await SharedLogTail(
+      file: logFile,
+      source: 'orchestrator',
+      onLine: debugPrint,
+    ).start();
+  }
+
   const windowOptions = WindowOptions(
     minimumSize: Size(400, 400),
     size: Size(1200, 600),

--- a/bitwindow/lib/pages/welcome/node_mode_page.dart
+++ b/bitwindow/lib/pages/welcome/node_mode_page.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
 import 'package:sail_ui/sail_ui.dart';
 import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
 
@@ -16,21 +19,63 @@ class NodeModePage extends StatefulWidget {
   State<NodeModePage> createState() => _NodeModePageState();
 }
 
+const String _backendDown = 'BitWindow cannot reach the local backend.';
+
 class _NodeModePageState extends State<NodeModePage> {
   NodeModeProvider get _nodeMode => GetIt.I.get<NodeModeProvider>();
+  Logger get _log => GetIt.I.get<Logger>();
 
   wmpb.NodeMode _selected = wmpb.NodeMode.NODE_MODE_LIGHT;
   bool _saving = false;
   String? _error;
+  Timer? _poll;
+  bool _reloading = false;
 
   @override
   void initState() {
     super.initState();
-    // A network with no remote chain server runs full mode only, so start the
-    // selection somewhere the user can confirm.
+    _alignSelection();
+    if (!_nodeMode.loaded) {
+      _poll = Timer.periodic(const Duration(seconds: 2), (_) => unawaited(_reload()));
+    }
+  }
+
+  @override
+  void dispose() {
+    _poll?.cancel();
+    super.dispose();
+  }
+
+  // A network with no remote chain server runs full mode only, so start the
+  // selection somewhere the user can confirm.
+  void _alignSelection() {
     if (!_nodeMode.lightModeAvailable) {
       _selected = wmpb.NodeMode.NODE_MODE_FULL;
     }
+  }
+
+  /// A dead backend asks no question. Read again until it answers, then either
+  /// show the choice or move on with the choice the user already made.
+  Future<void> _reload() async {
+    if (_reloading) {
+      return;
+    }
+    _reloading = true;
+    try {
+      await _nodeMode.load();
+    } finally {
+      _reloading = false;
+    }
+    if (!mounted || !_nodeMode.loaded) {
+      return;
+    }
+    _poll?.cancel();
+    _poll = null;
+    if (!_nodeMode.needsChoice) {
+      widget.onModePicked();
+      return;
+    }
+    setState(_alignSelection);
   }
 
   Future<void> _confirm() async {
@@ -42,7 +87,8 @@ class _NodeModePageState extends State<NodeModePage> {
       await _nodeMode.select(_selected);
       widget.onModePicked();
     } catch (e) {
-      setState(() => _error = '$e');
+      _log.e('node mode: could not record the choice: $e');
+      setState(() => _error = _backendDown);
     } finally {
       if (mounted) {
         setState(() => _saving = false);
@@ -52,6 +98,23 @@ class _NodeModePageState extends State<NodeModePage> {
 
   @override
   Widget build(BuildContext context) {
+    if (!_nodeMode.loaded) {
+      return SailPage(
+        title: 'BitWindow starts the local backend',
+        body: SailColumn(
+          spacing: SailStyleValues.padding20,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SailText.secondary13(_backendDown, color: SailTheme.of(context).colors.error),
+            SailButton(
+              label: 'Try again',
+              onPressed: _reload,
+            ),
+          ],
+        ),
+      );
+    }
+
     return SailPage(
       title: 'How do you want to run Bitcoin?',
       scrollable: true,

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.178
+version: 0.2.179
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/server/main.go
+++ b/bitwindow/server/main.go
@@ -89,16 +89,17 @@ func realMain(ctx context.Context, cancelCtx context.CancelFunc) error {
 		return nil
 	}
 
-	// orchestratord owns bitcoin.conf: the network identity and RPC creds both
-	// live there. Start it, then ask it for the network.
-	bootLogger := zerolog.New(os.Stderr).With().Timestamp().Logger()
-	bootCtx := bootLogger.WithContext(ctx)
-
 	// Base bitwindow dir (pre-Finalize) holding wallet.json and the shared
 	// .auth.cookie. Capture before Finalize suffixes Datadir with the network,
 	// and point the orchestrator (Bitcoind proxy) client at it for local auth.
 	bitwindowDir := conf.BitwindowDir()
 	dial.SetCookieDir(bitwindowDir)
+
+	// orchestratord owns bitcoin.conf: the network identity and RPC creds both
+	// live there. Start it, then ask it for the network.
+	bootLogger := zerolog.New(bootLogWriter(orchestratordLogPath(conf, bitwindowDir), os.Stderr)).
+		With().Timestamp().Logger()
+	bootCtx := bootLogger.WithContext(ctx)
 
 	clients := lease.New(conf.OwnerPID, lease.DefaultGrace, func() {
 		bootLogger.Info().Msg("no clients left and the owner is gone, shutting down")
@@ -452,8 +453,8 @@ func startOrchestratord(ctx context.Context, conf config.Config) (*exec.Cmd, err
 	//   zerolog (panics, child-process spew). Bitwindowd's fd closes when the
 	//   defer below runs; orchestratord inherits an independent fd that
 	//   survives.
-	// - Process.Release: tells the Go runtime to stop tracking the child so we
-	//   don't dangle a finalizer waiting on a process we've handed to init.
+	// - watchOrchestratord: bitwindowd keeps the handle and reaps the child, so
+	//   an early exit gets a line in the log instead of a silent dead port.
 	orchLogPath := orchestratordLogPath(conf, bitwindowDir)
 	// On a fresh install the bitwindow dir doesn't exist yet; opening the log
 	// would fail, orchestratord would never spawn, and the UI would poll a dead
@@ -498,11 +499,45 @@ func startOrchestratord(ctx context.Context, conf config.Config) (*exec.Cmd, err
 
 	log.Info().Int("pid", cmd.Process.Pid).Msg("orchestratord started")
 
-	if err := cmd.Process.Release(); err != nil {
-		log.Warn().Err(err).Msg("release orchestratord process handle (continuing — child is independent)")
-	}
+	go watchOrchestratord(cmd, log)
 
 	return cmd, nil
+}
+
+// bootLogWriter sends the boot lines to console and to the shared log file.
+// bitwindowd spawns orchestratord before initLogger runs, so without this the
+// one line that names a spawn failure reaches neither the file nor the user.
+// The handle stays open for the process lifetime, because watchOrchestratord
+// writes through it later.
+func bootLogWriter(path string, console io.Writer) io.Writer {
+	const timeFormat = time.DateTime + ".000"
+	consoleWriter := zerolog.ConsoleWriter{Out: console, TimeFormat: timeFormat}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return consoleWriter
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return consoleWriter
+	}
+	return zerolog.MultiLevelWriter(consoleWriter, zerolog.ConsoleWriter{
+		Out:        logfile.Tag(file, "bitwindowd"),
+		NoColor:    true,
+		TimeFormat: timeFormat,
+	})
+}
+
+// watchOrchestratord logs the exit of the child. bitwindowd serves on after
+// orchestratord dies, so the exit code is the one clue the log file holds.
+func watchOrchestratord(cmd *exec.Cmd, log *zerolog.Logger) {
+	err := cmd.Wait()
+	code := -1
+	if cmd.ProcessState != nil {
+		code = cmd.ProcessState.ExitCode()
+	}
+	log.Error().Err(err).
+		Int("pid", cmd.Process.Pid).
+		Int("exit_code", code).
+		Msg("orchestratord exited, its RPC port stays dead until BitWindow restarts")
 }
 
 func existingOrchestratorAdoptable(addr, bitwindowDir string) (bool, error) {

--- a/bitwindow/server/main_test.go
+++ b/bitwindow/server/main_test.go
@@ -3,11 +3,17 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/config"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,4 +36,47 @@ func TestOrchestratordLogPathFollowsTheConfiguredPath(t *testing.T) {
 		filepath.Join("/data/bitwindow", "bitwindow.log"),
 		orchestratordLogPath(config.Config{}, "/data/bitwindow"),
 	)
+}
+
+// The spawn of orchestratord happens before initLogger, and a user who sends us
+// the log file must get the reason it failed.
+func TestBootLogWriterTagsTheSharedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "bitwindow.log")
+
+	log := zerolog.New(bootLogWriter(path, io.Discard)).With().Timestamp().Logger()
+	log.Info().Msg("starting orchestratord (detached)")
+
+	written, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(written), "[bitwindowd]")
+	require.Contains(t, string(written), "starting orchestratord (detached)")
+}
+
+func TestBootLogWriterKeepsTheConsoleOnAnUnwritablePath(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "file")
+	require.NoError(t, os.WriteFile(blocker, nil, 0o644))
+	console := &strings.Builder{}
+
+	log := zerolog.New(bootLogWriter(filepath.Join(blocker, "deeper.log"), console))
+	log.Info().Msg("boot line")
+
+	require.Contains(t, console.String(), "boot line")
+}
+
+// A dead orchestratord leaves bitwindowd serving on a port nothing answers, so
+// the exit code is the one clue the log holds.
+func TestWatchOrchestratordLogsTheExitCode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the test command is a POSIX shell")
+	}
+	out := &strings.Builder{}
+	log := zerolog.New(out)
+
+	cmd := exec.Command("sh", "-c", "exit 7")
+	require.NoError(t, cmd.Start())
+	watchOrchestratord(cmd, &log)
+
+	require.Contains(t, out.String(), `"exit_code":7`)
+	require.Contains(t, out.String(), "orchestratord exited")
 }

--- a/bitwindow/test/node_mode_page_test.dart
+++ b/bitwindow/test/node_mode_page_test.dart
@@ -1,0 +1,134 @@
+import 'dart:async';
+
+import 'package:bitwindow/pages/welcome/node_mode_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+
+import 'test_utils.dart';
+
+// A backend that does not answer is not a user who did not pick. The page used
+// to ask the first-run question and then print the raw socket error.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeWallet wallet;
+  late int picked;
+
+  Future<void> pumpPage(WidgetTester tester) async {
+    picked = 0;
+    await tester.pumpSailPage(NodeModePage(onModePicked: () => picked++));
+  }
+
+  setUp(() async {
+    await GetIt.I.reset();
+    GetIt.I.registerSingleton<Logger>(Logger(level: Level.off));
+    wallet = _FakeWallet();
+    GetIt.I.registerSingleton<OrchestratorRPC>(_FakeOrchestrator(wallet));
+    GetIt.I.registerSingleton<NodeModeProvider>(NodeModeProvider());
+  });
+
+  tearDown(() async => GetIt.I.reset());
+
+  testWidgets('holds the question while the backend does not answer', (tester) async {
+    await pumpPage(tester);
+
+    expect(find.text('BitWindow cannot reach the local backend.'), findsOneWidget);
+    expect(find.text('Light'), findsNothing);
+    expect(find.text('Full node'), findsNothing);
+  });
+
+  testWidgets('asks the question once the backend says the mode is unpicked', (tester) async {
+    await pumpPage(tester);
+    wallet.up = true;
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+
+    expect(find.text('Light'), findsOneWidget);
+    expect(find.text('Full node'), findsOneWidget);
+    expect(picked, 0);
+  });
+
+  testWidgets('moves on when the backend reports the mode the user already picked', (tester) async {
+    await pumpPage(tester);
+    wallet.up = true;
+    wallet.mode = wmpb.NodeMode.NODE_MODE_FULL;
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+
+    expect(picked, 1);
+    expect(find.text('Light'), findsNothing);
+  });
+
+  // A backend that accepts the socket and never answers used to collect one
+  // more read every two seconds.
+  testWidgets('starts one read at a time', (tester) async {
+    wallet.hang = true;
+    await pumpPage(tester);
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump(const Duration(seconds: 2));
+
+    expect(wallet.reads, 1);
+
+    wallet.release();
+    await tester.pump();
+  });
+
+  testWidgets('reads again when the user taps the button', (tester) async {
+    await pumpPage(tester);
+    final before = wallet.reads;
+
+    await tester.tap(find.byType(SailButton));
+    await tester.pump();
+
+    expect(wallet.reads, greaterThan(before));
+  });
+}
+
+class _FakeOrchestrator implements OrchestratorRPC {
+  _FakeOrchestrator(this._wallet);
+
+  final OrchestratorWalletRPC _wallet;
+
+  @override
+  OrchestratorWalletRPC get wallet => _wallet;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeWallet implements OrchestratorWalletRPC {
+  bool up = false;
+  bool hang = false;
+  wmpb.NodeMode mode = wmpb.NodeMode.NODE_MODE_UNSPECIFIED;
+  int reads = 0;
+
+  final Completer<void> _held = Completer<void>();
+
+  void release() {
+    if (!_held.isCompleted) {
+      _held.complete();
+    }
+  }
+
+  @override
+  Future<wmpb.GetNodeModeResponse> getNodeMode() async {
+    reads++;
+    if (hang) {
+      await _held.future;
+    }
+    if (!up) {
+      throw Exception('connection refused');
+    }
+    return wmpb.GetNodeModeResponse(mode: mode, lightModeAvailable: true);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/sidechain_core/lib/providers/node_mode_provider.dart
+++ b/sidechain_core/lib/providers/node_mode_provider.dart
@@ -16,6 +16,10 @@ class NodeModeProvider extends ChangeNotifier implements NetworkScoped {
   /// False on a network with no remote chain server. Regtest and testnet.
   bool lightModeAvailable = true;
 
+  /// True once a read reaches the backend. A failed read is not an unpicked
+  /// mode, so the first-run question waits for this.
+  bool loaded = false;
+
   /// True until the user picks. The app must ask before it boots anything.
   bool get needsChoice => mode == wmpb.NodeMode.NODE_MODE_UNSPECIFIED;
 
@@ -41,6 +45,7 @@ class NodeModeProvider extends ChangeNotifier implements NetworkScoped {
       final resp = await _client.getNodeMode();
       mode = resp.mode;
       lightModeAvailable = resp.lightModeAvailable;
+      loaded = true;
       notifyListeners();
     } catch (e) {
       // A failed read is not an unpicked mode. Clearing it here would drop a
@@ -57,6 +62,7 @@ class NodeModeProvider extends ChangeNotifier implements NetworkScoped {
     final previous = mode;
     await _client.setNodeMode(next);
     mode = next;
+    loaded = true;
     notifyListeners();
 
     if (next == previous) {

--- a/sidechain_core/lib/sidechain_core.dart
+++ b/sidechain_core/lib/sidechain_core.dart
@@ -205,6 +205,7 @@ export 'utils/change_tracker.dart';
 export 'utils/file_overrides.dart';
 export 'utils/file_utils.dart';
 export 'utils/log_file.dart';
+export 'utils/shared_log_tail.dart';
 export 'utils/diff_utils.dart';
 export 'utils/ur_psbt.dart';
 export 'models/core_transaction.dart';

--- a/sidechain_core/lib/utils/shared_log_tail.dart
+++ b/sidechain_core/lib/utils/shared_log_tail.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// True when bitwindowd already sends the orchestrator lines to its own stdout,
+/// which the process manager forwards to the console. The tail would print the
+/// file copy of the same lines a second time.
+///
+/// It reads the value exactly as bitwindowd reads it. A looser rule here would
+/// hold the tail back on a value that leaves the backend in file-only mode, and
+/// the console would then show nothing at all.
+bool orchestratorLogsToStdout(Map<String, String> env) {
+  final value = env['ORCHESTRATORD_STDOUT'];
+  return value == '1' || value == 'true';
+}
+
+/// Prints the lines that another process appends to the shared log file.
+///
+/// orchestratord runs detached, so its output reaches no pipe the frontend
+/// owns. A pipe would also kill it: the child outlives bitwindowd, and the
+/// first write after the reader goes away ends the process.
+///
+/// It prints the lines of [source] and every line with no tag. A daemon that
+/// dies before its logger exists writes the reason to its raw stderr, and that
+/// reason lands in the same file with no tag in front of it.
+class SharedLogTail {
+  SharedLogTail({
+    required this.file,
+    required this.source,
+    required this.onLine,
+    this.interval = const Duration(milliseconds: 250),
+  });
+
+  final File file;
+
+  /// The tag the writer puts in front of its lines, without the brackets.
+  final String source;
+  final void Function(String line) onLine;
+  final Duration interval;
+
+  late final String _prefix = '[$source]';
+
+  /// The tag another writer puts in front of its own lines.
+  static final RegExp _anyTag = RegExp(r'^\[[A-Za-z0-9_-]+\]');
+
+  Timer? _timer;
+  int _offset = 0;
+  String _partial = '';
+  bool _reading = false;
+
+  /// Starts at the end of the file, so a restart prints this run only.
+  Future<void> start() async {
+    _offset = await _lengthOrZero();
+    _timer = Timer.periodic(interval, (_) => unawaited(readNow()));
+  }
+
+  Future<void> stop() async {
+    _timer?.cancel();
+    _timer = null;
+    await readNow();
+  }
+
+  /// Reads what the file grew by since the last call. Public for the tests.
+  Future<void> readNow() async {
+    if (_reading) {
+      return;
+    }
+    _reading = true;
+    try {
+      final length = await _lengthOrZero();
+      if (length < _offset) {
+        _offset = 0;
+        _partial = '';
+      }
+      if (length == _offset) {
+        return;
+      }
+      final chunks = await file.openRead(_offset, length).toList();
+      _offset = length;
+      _partial += utf8.decode(chunks.expand((c) => c).toList(), allowMalformed: true);
+
+      final lines = _partial.split('\n');
+      _partial = lines.removeLast();
+      for (final line in lines) {
+        if (_carries(line)) {
+          onLine(line.trimRight());
+        }
+      }
+    } catch (_) {
+      // The file comes and goes with a network swap. The next tick reads it.
+    } finally {
+      _reading = false;
+    }
+  }
+
+  bool _carries(String line) {
+    if (line.trim().isEmpty) {
+      return false;
+    }
+    if (line.startsWith(_prefix)) {
+      return true;
+    }
+    return !_anyTag.hasMatch(line);
+  }
+
+  Future<int> _lengthOrZero() async {
+    try {
+      return await file.length();
+    } catch (_) {
+      return 0;
+    }
+  }
+}

--- a/sidechain_core/test/shared_log_tail_test.dart
+++ b/sidechain_core/test/shared_log_tail_test.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/utils/shared_log_tail.dart';
+
+void main() {
+  late File file;
+  late List<String> printed;
+
+  SharedLogTail tailOf(File file) => SharedLogTail(
+    file: file,
+    source: 'orchestrator',
+    onLine: printed.add,
+  );
+
+  setUp(() async {
+    final dir = await Directory.systemTemp.createTemp('shared_log_tail_test');
+    addTearDown(() => dir.delete(recursive: true));
+    file = File('${dir.path}/bitwindow.log');
+    printed = [];
+  });
+
+  test('holds the tail back when bitwindowd already prints those lines', () {
+    expect(orchestratorLogsToStdout({'ORCHESTRATORD_STDOUT': '1'}), isTrue);
+    expect(orchestratorLogsToStdout({'ORCHESTRATORD_STDOUT': 'true'}), isTrue);
+    expect(orchestratorLogsToStdout({'ORCHESTRATORD_STDOUT': 'TRUE'}), isFalse);
+    expect(orchestratorLogsToStdout({'ORCHESTRATORD_STDOUT': '0'}), isFalse);
+    expect(orchestratorLogsToStdout({}), isFalse);
+  });
+
+  test('prints the lines of the chosen source only', () async {
+    await file.writeAsString('');
+    final tail = tailOf(file);
+    await tail.start();
+
+    await file.writeAsString(
+      '[orchestrator]  starting orchestratord\n[bitwindowd]    listening\n',
+      mode: FileMode.append,
+    );
+    await tail.readNow();
+
+    expect(printed, ['[orchestrator]  starting orchestratord']);
+  });
+
+  // orchestratord writes the reason it refuses to start to its raw stderr,
+  // before its logger exists. That line reaches the file with no tag.
+  test('prints a line that carries no tag', () async {
+    await file.writeAsString('');
+    final tail = tailOf(file);
+    await tail.start();
+
+    await file.writeAsString(
+      'error: RPC address localhost:30400 is already in use\n'
+      '[bitwindowd]    listening on localhost:30301\n'
+      '\n',
+      mode: FileMode.append,
+    );
+    await tail.readNow();
+
+    expect(printed, ['error: RPC address localhost:30400 is already in use']);
+  });
+
+  test('prints a panic line that starts with a bracket', () async {
+    await file.writeAsString('');
+    final tail = tailOf(file);
+    await tail.start();
+
+    await file.writeAsString('[signal SIGSEGV: segmentation violation]\n', mode: FileMode.append);
+    await tail.readNow();
+
+    expect(printed, ['[signal SIGSEGV: segmentation violation]']);
+  });
+
+  test('skips what the earlier run wrote', () async {
+    await file.writeAsString('[orchestrator]  the run before\n');
+    final tail = tailOf(file);
+    await tail.start();
+
+    await file.writeAsString('[orchestrator]  this run\n', mode: FileMode.append);
+    await tail.readNow();
+
+    expect(printed, ['[orchestrator]  this run']);
+  });
+
+  test('holds a part line until the newline arrives', () async {
+    await file.writeAsString('');
+    final tail = tailOf(file);
+    await tail.start();
+
+    await file.writeAsString('[orchestrator]  half', mode: FileMode.append);
+    await tail.readNow();
+    expect(printed, isEmpty);
+
+    await file.writeAsString(' a line\n', mode: FileMode.append);
+    await tail.readNow();
+    expect(printed, ['[orchestrator]  half a line']);
+  });
+
+  test('reads from the top again after the file is emptied', () async {
+    await file.writeAsString('[orchestrator]  first\n');
+    final tail = tailOf(file);
+    await tail.start();
+
+    await file.writeAsString('');
+    await tail.readNow();
+
+    await file.writeAsString('[orchestrator]  after the cut\n', mode: FileMode.append);
+    await tail.readNow();
+
+    expect(printed, ['[orchestrator]  after the cut']);
+  });
+
+  test('stop reads the last lines and cancels the timer', () async {
+    await file.writeAsString('');
+    final tail = tailOf(file);
+    await tail.start();
+
+    await file.writeAsString('[orchestrator]  last\n', mode: FileMode.append);
+    await tail.stop();
+
+    expect(printed, ['[orchestrator]  last']);
+  });
+}


### PR DESCRIPTION
A dead orchestratord left no line anywhere: bitwindowd spawned it before the logger existed, never waited on it, and the detached child wrote to a file nothing printed. The user got the first-run node-mode question and a raw SocketException.

bitwindowd now tees its boot lines into the shared log file and logs the child's exit code. The frontend prints the orchestrator lines from the shared file, so a terminal launch shows them. The node-mode page waits for the backend instead of asking a question it cannot record.