### PR TITLE
Show the daemon banner when orchestratord stops

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.310
+version: 1.0.311
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.310
+version: 1.0.311
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.178
+version: 0.2.179
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.183
+version: 1.0.184
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/widgets/nav/persistent_status_bar.dart
+++ b/sail_ui/lib/widgets/nav/persistent_status_bar.dart
@@ -8,7 +8,8 @@ import 'package:sail_ui/sail_ui.dart';
 /// Renders [SizedBox.shrink] while everything is booting or running — the
 /// banner only appears when a monitored daemon reports a terminal failure
 /// (`connectionError != null` and no longer initializing). Tapping Restart
-/// re-invokes [BinaryProvider.start] for each failed daemon.
+/// re-invokes [BinaryProvider.start] for each failed daemon, and Send Logs To
+/// Devs shows the shared log file in the file manager.
 class PersistentStatusBar extends StatelessWidget {
   /// Binary types to monitor. Bitwindow wires up `orchestratord` +
   /// `bitWindow` here; other clients can pass their own pair.
@@ -19,12 +20,35 @@ class PersistentStatusBar extends StatelessWidget {
     this.monitored = const [BinaryType.BINARY_TYPE_ORCHESTRATORD, BinaryType.BINARY_TYPE_BITWINDOWD],
   });
 
+  /// orchestratord maps to no RPCConnection, so its outage reads from the
+  /// poll that already watches it.
+  static bool _orchestratorDown() {
+    if (!GetIt.I.isRegistered<BackendStateProvider>()) {
+      return false;
+    }
+    return !GetIt.I.get<BackendStateProvider>().orchestratorReachable;
+  }
+
+  static bool _isDown(BinaryProvider binaryProvider, Binary binary) {
+    if (binaryProvider.isConnected(binary) ||
+        binaryProvider.isInitializing(binary) ||
+        binaryProvider.isStopping(binary)) {
+      return false;
+    }
+    final err = binaryProvider.connectionError(binary);
+    if (err != null && err.isNotEmpty) {
+      return true;
+    }
+    return binary.type == BinaryType.BINARY_TYPE_ORCHESTRATORD && _orchestratorDown();
+  }
+
   @override
   Widget build(BuildContext context) {
     final binaryProvider = GetIt.I.get<BinaryProvider>();
+    final backendState = GetIt.I.isRegistered<BackendStateProvider>() ? GetIt.I.get<BackendStateProvider>() : null;
 
     return ListenableBuilder(
-      listenable: binaryProvider,
+      listenable: backendState == null ? binaryProvider : Listenable.merge([binaryProvider, backendState]),
       builder: (context, _) {
         final broken = <Binary>[];
         for (final type in monitored) {
@@ -32,17 +56,7 @@ class PersistentStatusBar extends StatelessWidget {
           if (binary == null) {
             continue;
           }
-          if (binaryProvider.isConnected(binary)) {
-            continue;
-          }
-          if (binaryProvider.isInitializing(binary)) {
-            continue;
-          }
-          if (binaryProvider.isStopping(binary)) {
-            continue;
-          }
-          final err = binaryProvider.connectionError(binary);
-          if (err == null || err.isEmpty) {
+          if (!_isDown(binaryProvider, binary)) {
             continue;
           }
           broken.add(binary);
@@ -75,6 +89,13 @@ class PersistentStatusBar extends StatelessWidget {
                     Expanded(
                       child: SailText.primary12(label, color: SailColorScheme.red),
                     ),
+                    SailButton(
+                      label: 'Send Logs To Devs',
+                      small: true,
+                      variant: ButtonVariant.outline,
+                      onPressed: openLogs,
+                    ),
+                    const SizedBox(width: 8),
                     SailButton(
                       label: 'Restart',
                       small: true,

--- a/sail_ui/test/widgets/persistent_status_bar_test.dart
+++ b/sail_ui/test/widgets/persistent_status_bar_test.dart
@@ -53,6 +53,20 @@ class _FakeBinaryProvider extends BinaryProvider {
   Future<void> stop(Binary binary, {bool skipDownstream = false, bool expectRestart = false}) async {}
 }
 
+class _FakeOrchestrator implements OrchestratorRPC {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeBackendState extends BackendStateProvider {
+  _FakeBackendState() : super(_FakeOrchestrator());
+
+  void setReachable(bool value) {
+    orchestratorReachable = value;
+    notifyListeners();
+  }
+}
+
 class _MockStore implements KeyValueStore {
   final _db = <String, String>{};
 
@@ -72,6 +86,7 @@ class _MockStore implements KeyValueStore {
 
 void main() {
   late _FakeBinaryProvider binaryProvider;
+  late _FakeBackendState backendState;
 
   setUpAll(() {
     TestWidgetsFlutterBinding.ensureInitialized();
@@ -95,6 +110,9 @@ void main() {
       binaries: [Orchestratord(), BitWindow()],
     );
     getIt.registerSingleton<BinaryProvider>(binaryProvider);
+
+    backendState = _FakeBackendState();
+    getIt.registerSingleton<BackendStateProvider>(backendState);
   });
 
   tearDown(() async {
@@ -159,13 +177,49 @@ void main() {
     await tester.pumpWidget(wrap(const PersistentStatusBar()));
     await tester.pump();
 
-    await tester.tap(find.byType(SailButton));
+    await tester.tap(find.widgetWithText(SailButton, 'Restart').first);
     await tester.pumpAndSettle();
 
     expect(
       binaryProvider.restartedTypes,
       containsAll(<BinaryType>[BinaryType.BINARY_TYPE_ORCHESTRATORD, BinaryType.BINARY_TYPE_BITWINDOWD]),
     );
+  });
+
+  // orchestratord maps to no RPCConnection, so its error field stays null
+  // whatever the daemon does. The poll that watches it is the only source.
+  testWidgets('shows the banner when the orchestrator misses its polls', (tester) async {
+    binaryProvider.setState(BinaryType.BINARY_TYPE_ORCHESTRATORD);
+    binaryProvider.setState(BinaryType.BINARY_TYPE_BITWINDOWD, connected: true);
+    backendState.setReachable(false);
+
+    await tester.pumpWidget(wrap(const PersistentStatusBar()));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    expect(find.textContaining('Orchestratord'), findsOneWidget);
+  });
+
+  testWidgets('stays hidden while the orchestrator answers its polls', (tester) async {
+    binaryProvider.setState(BinaryType.BINARY_TYPE_ORCHESTRATORD);
+    binaryProvider.setState(BinaryType.BINARY_TYPE_BITWINDOWD, connected: true);
+    backendState.setReachable(true);
+
+    await tester.pumpWidget(wrap(const PersistentStatusBar()));
+    await tester.pump();
+
+    final size = tester.getSize(find.byType(PersistentStatusBar));
+    expect(size.height, 0);
+  });
+
+  testWidgets('offers the logs to a stuck user', (tester) async {
+    binaryProvider.setState(BinaryType.BINARY_TYPE_ORCHESTRATORD, error: 'down');
+    binaryProvider.setState(BinaryType.BINARY_TYPE_BITWINDOWD, connected: true);
+
+    await tester.pumpWidget(wrap(const PersistentStatusBar()));
+    await tester.pump();
+
+    expect(find.widgetWithText(SailButton, 'Send Logs To Devs'), findsWidgets);
   });
 
   testWidgets('mounts cleanly as Scaffold.bottomNavigationBar under MaterialApp.builder (crash regression)', (

--- a/sidechain_core/lib/providers/backend_state_provider.dart
+++ b/sidechain_core/lib/providers/backend_state_provider.dart
@@ -35,6 +35,11 @@ class BackendStateProvider extends ChangeNotifier {
   /// Live binary status from the backend.
   Map<String, BinaryStatusMsg> binaries = {};
 
+  /// False once the orchestrator misses [_failuresBeforeDisconnected] polls in
+  /// a row. It is the only orchestratord health the frontend holds, because no
+  /// RPCConnection maps to that binary.
+  bool orchestratorReachable = true;
+
   Timer? _pollTimer;
   bool _polling = false;
   int _consecutiveFailures = 0;
@@ -65,6 +70,7 @@ class BackendStateProvider extends ChangeNotifier {
     try {
       final resp = await _orchestrator.listBinaries(forceBackend: Binary.isSidechainApp);
       _consecutiveFailures = 0;
+      orchestratorReachable = true;
       _apply(resp.binaries);
     } catch (e) {
       // A blip keeps the last frame on screen, but an orchestrator that stays
@@ -72,6 +78,7 @@ class BackendStateProvider extends ChangeNotifier {
       _consecutiveFailures++;
       if (_consecutiveFailures == _failuresBeforeDisconnected) {
         _log.w('BackendStateProvider: orchestrator unreachable, marking binaries disconnected: $e');
+        orchestratorReachable = false;
         _markAllDisconnected();
       }
       _log.d('BackendStateProvider: listBinaries failed: $e');

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.312
+version: 1.0.313
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.183
+version: 1.0.184
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.310
+version: 1.0.311
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The banner could never fire for orchestratord: no RPCConnection maps to that binary, so its connectionError stayed null and the row was always skipped. BackendStateProvider already knows — it counts five missed ListBinaries polls — so the banner reads that flag.

The bar also carries a Send Logs To Devs button. It shows bitwindow.log in Finder, File Explorer or the Linux file manager, through the reveal helper the log menu already uses.

Design: https://www.figma.com/design/Uvj2xZiMJsOt3nDaSxDGLQ/sailui-design-system?node-id=682-829