### PR TITLE
Restart orchestratord through the daemon that owns it

### DIFF
--- a/sidechain_core/lib/providers/binaries/binary_provider.dart
+++ b/sidechain_core/lib/providers/binaries/binary_provider.dart
@@ -8,6 +8,19 @@ import 'package:logger/logger.dart';
 import 'package:path/path.dart' as path;
 import 'package:sidechain_core/sidechain_core.dart';
 
+/// The binary whose restart brings [binary] back.
+///
+/// bitwindowd spawns orchestratord with the data directory, the bitwindow
+/// directory and the owner pid. A restart from the frontend carries none of
+/// them, so it would start a second orchestratord on the default paths. A
+/// sidechain app spawns orchestratord itself, with the right arguments.
+Binary restartTarget(Binary binary, List<Binary> binaries, {required bool isSidechainApp}) {
+  if (binary is! Orchestratord || isSidechainApp) {
+    return binary;
+  }
+  return binaries.whereType<BitWindow>().firstOrNull ?? binary;
+}
+
 /// Manages binaries via the Go orchestrator daemon.
 ///
 /// Orchestrator-managed binaries (bitcoind, enforcer, sidechains) are
@@ -160,6 +173,12 @@ class BinaryProvider extends ChangeNotifier {
   /// chain-settings modals, the persistent status bar, and the sidechains
   /// page. Reserve [start] for first-time chain bootstrap.
   Future<void> restart(Binary binary) async {
+    final owner = restartTarget(binary, binaries, isSidechainApp: isSidechainApp);
+    if (!identical(owner, binary)) {
+      log.i('BinaryProvider: restarting ${owner.name}, which owns ${binary.name}');
+      return restart(owner);
+    }
+
     if (_isDaemonBinary(binary)) {
       await _stopDaemonBinary(binary);
       await _startDaemonBinary(binary);

--- a/sidechain_core/test/restart_target_test.dart
+++ b/sidechain_core/test/restart_target_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/sidechain_core.dart';
+
+// bitwindowd owns orchestratord. A restart from the frontend would start a
+// second one on the default paths, with no owner pid and no bitwindow dir.
+void main() {
+  final orchestratord = Orchestratord();
+  final bitwindowd = BitWindow();
+
+  test('bitwindow restarts the daemon that owns orchestratord', () {
+    final target = restartTarget(orchestratord, [orchestratord, bitwindowd], isSidechainApp: false);
+    expect(target, same(bitwindowd));
+  });
+
+  test('a sidechain app restarts orchestratord itself, because it spawns it', () {
+    final target = restartTarget(orchestratord, [orchestratord], isSidechainApp: true);
+    expect(target, same(orchestratord));
+  });
+
+  test('an app with no bitwindowd restarts orchestratord itself', () {
+    final target = restartTarget(orchestratord, [orchestratord], isSidechainApp: false);
+    expect(target, same(orchestratord));
+  });
+
+  test('every other binary restarts itself', () {
+    expect(restartTarget(bitwindowd, [orchestratord, bitwindowd], isSidechainApp: false), same(bitwindowd));
+
+    final core = BitcoinCore();
+    expect(restartTarget(core, [core, bitwindowd], isSidechainApp: false), same(core));
+  });
+}


### PR DESCRIPTION
The status bar now reaches orchestratord, and its Restart button called BinaryProvider.restart on that binary directly. No RPC maps to orchestratord, so the frontend spawned it from extraBootArgs — without the data directory, the bitwindow directory or the owner pid that bitwindowd passes. The replacement then wrote its cookie and read its state from the default paths while the frontend kept polling the configured ones.

A restart of orchestratord in bitwindow restarts bitwindowd instead, which spawns the child with the right arguments. A sidechain app spawns orchestratord itself, so it restarts it in place.