### PR TITLE
bitwindow: ask for the data directory before anything syncs

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.311
+version: 1.0.312
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.311
+version: 1.0.312
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/lib/routing/router.dart
+++ b/bitwindow/lib/routing/router.dart
@@ -88,12 +88,14 @@ class AppRouter extends RootStackRouter {
         ),
       ],
       guards: [
-        DataDirGuard(),
-        // Ahead of WalletGuard: the mode decides whether a local node runs, so
-        // a wallet made first could pick a backend the mode cannot serve.
+        // First: the mode decides whether a local node runs at all, so both
+        // gates below depend on it. A wallet made first could pick a backend
+        // the mode cannot serve, and a datadir asked for first is asked for
+        // even in light mode, which stores no chain.
         NodeModeGuard(
           nodeModeRoute: (onModePicked) => NodeModeRoute(onModePicked: onModePicked),
         ),
+        DataDirGuard(),
         WalletGuard(
           createWalletRoute: (onWalletCreated) => CreateAnotherWalletRoute(onWalletCreated: onWalletCreated),
         ),

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.179
+version: 0.2.180
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/test/network_swap_routing_test.dart
+++ b/bitwindow/test/network_swap_routing_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
 
 import 'test_utils.dart';
 
@@ -31,12 +32,20 @@ void main() {
   // Regression for "switching to Mainnet doesn't give an option for a datadir":
   // entering the app on a network that requires a datadir but has none must
   // route to DataDirSetupPage (DataDirGuard), not silently continue.
+  //
+  // The mode gate runs first, so the mode is already picked here. A datadir
+  // asked for ahead of it would be asked for in light mode too, which stores
+  // no chain at all.
   testWidgets('no datadir for mainnet routes to the datadir setup page', (tester) async {
     await registerTestDependencies();
     if (GetIt.I.isRegistered<BitcoinConfProvider>()) {
       await GetIt.I.unregister<BitcoinConfProvider>();
     }
     GetIt.I.registerSingleton<BitcoinConfProvider>(_FakeConf(mustSelectDatadir: true));
+    if (GetIt.I.isRegistered<NodeModeProvider>()) {
+      await GetIt.I.unregister<NodeModeProvider>();
+    }
+    GetIt.I.registerSingleton<NodeModeProvider>(NodeModeProvider()..mode = wmpb.NodeMode.NODE_MODE_FULL);
 
     final router = AppRouter();
     await tester.pumpWidget(

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.184
+version: 1.0.185
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/routing/datadir_guard.dart
+++ b/sail_ui/lib/routing/datadir_guard.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
 import 'package:sail_ui/pages/router.gr.dart' show DataDirSetupRoute;
 import 'package:sail_ui/sail_ui.dart';
 
@@ -10,6 +11,9 @@ class DataDirGuard extends AutoRouteGuard {
   void onNavigation(NavigationResolver resolver, StackRouter router) async {
     final confProvider = GetIt.I.get<BitcoinConfProvider>();
 
+    // The node mode gate runs first and decides whether a local node runs at
+    // all, so a polled value can predate the mode the user just picked.
+    await confProvider.loadConfig();
     if (!confProvider.mustSelectDatadir) {
       resolver.next(true);
       return;
@@ -18,6 +22,23 @@ class DataDirGuard extends AutoRouteGuard {
     await router.push(DataDirSetupRoute(network: confProvider.network));
     await confProvider.loadConfig();
 
-    resolver.next(!confProvider.mustSelectDatadir);
+    final ready = !confProvider.mustSelectDatadir;
+    if (ready) {
+      // The backend refuses to boot without a directory, so the mode choice
+      // started nothing. Now it can.
+      await _startLocalBackends();
+    }
+    resolver.next(ready);
+  }
+
+  Future<void> _startLocalBackends() async {
+    if (!NodeModeProvider.runsLocalBackends) {
+      return;
+    }
+    try {
+      await GetIt.I.get<OrchestratorRPC>().startWithL1('enforcer');
+    } catch (e) {
+      GetIt.I.get<Logger>().w('DataDirGuard: could not start the Bitcoin backends: $e');
+    }
   }
 }

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -821,6 +821,13 @@ func (o *Orchestrator) StartWithL1(ctx context.Context, target string, opts Star
 	if err := o.refuseWhileParked(); err != nil {
 		return nil, err
 	}
+	// Mainnet, forknet and eCash keep their chain outside the platform default,
+	// so booting before the user picks a directory syncs a second copy over
+	// whatever they already run. The node mode gate above and this one are the
+	// only gates here, so no frontend can force the local stack up.
+	if plan := o.PlanNetworkChange(NetworkChangeRequest{}); plan.MustSelectDatadir {
+		return nil, fmt.Errorf("network %s has no data directory yet; pick one before starting the Bitcoin backends", plan.Network)
+	}
 
 	ch := make(chan StartupProgress, 100)
 

--- a/sidechain-orchestrator/start_with_l1_datadir_test.go
+++ b/sidechain-orchestrator/start_with_l1_datadir_test.go
@@ -1,0 +1,35 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+)
+
+// A full-mode boot writes a chain. Without a directory of its own it writes to
+// the platform default, over whatever the user already runs there, so the
+// backend refuses rather than trusting every frontend to ask first.
+func TestStartWithL1RefusesUntilTheNetworkHasADatadir(t *testing.T) {
+	o := planFixture(t, "ecash")
+	require.NoError(t, WriteNodeMode(o.BitwindowDir, NodeModeFull))
+	require.True(t, o.PlanNetworkChange(NetworkChangeRequest{}).MustSelectDatadir)
+
+	_, err := o.StartWithL1(context.Background(), "enforcer", StartOpts{})
+	require.ErrorContains(t, err, "no data directory")
+}
+
+// With a directory chosen the gate is silent, and the boot runs as before.
+func TestStartWithL1RunsOnceTheDatadirExists(t *testing.T) {
+	o := planFixture(t, "ecash")
+	require.NoError(t, WriteNodeMode(o.BitwindowDir, NodeModeFull))
+	require.NoError(t, o.BitcoinConf.UpdateDataDir(t.TempDir(), config.NetworkECash))
+	require.False(t, o.PlanNetworkChange(NetworkChangeRequest{}).MustSelectDatadir)
+
+	_, err := o.StartWithL1(context.Background(), "enforcer", StartOpts{})
+	if err != nil {
+		require.NotContains(t, err.Error(), "no data directory")
+	}
+}

--- a/sidechain_core/lib/providers/node_mode_provider.dart
+++ b/sidechain_core/lib/providers/node_mode_provider.dart
@@ -71,6 +71,14 @@ class NodeModeProvider extends ChangeNotifier implements NetworkScoped {
     try {
       final orchestrator = GetIt.I.get<OrchestratorRPC>();
       if (next == wmpb.NodeMode.NODE_MODE_FULL) {
+        // The backend refuses this until the network has a data directory, and
+        // the datadir gate runs right after this one. Skipping the call keeps
+        // a refusal out of the log on a first run.
+        final conf = GetIt.I.get<BitcoinConfProvider>();
+        await conf.loadConfig();
+        if (conf.mustSelectDatadir) {
+          return;
+        }
         await orchestrator.startWithL1('enforcer');
       } else {
         await orchestrator.shutdownAll().drain<void>();

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.313
+version: 1.0.314
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.184
+version: 1.0.185
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.311
+version: 1.0.312
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
Picking Full mode started the L1 stack at once, and the datadir gate ran one guard earlier, when no mode was picked yet and the gate therefore passed. eCash keeps its chain outside the platform default, so a fresh install synced into the default path without ever asking.

The orchestrator now refuses to start L1 while the network has no directory, so no frontend can boot into the wrong place. The mode gate runs first, the datadir gate second, and the stack starts once the directory is known.