### PR TITLE
bitwindow: run the datadir step when Settings turns full mode on

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.313
+version: 1.0.314
 
 environment:
   sdk: 3.12.2

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.312
+version: 1.0.313
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.313
+version: 1.0.314
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.312
+version: 1.0.313
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/lib/pages/settings/settings_node_mode.dart
+++ b/bitwindow/lib/pages/settings/settings_node_mode.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
 import 'package:sail_ui/sail_ui.dart';
@@ -45,6 +46,11 @@ class _SettingsNodeModeState extends State<SettingsNodeMode> {
       return;
     }
 
+    // The side navigation stays live through the awaits below, so this page can
+    // go away mid-transition. The router outlives it, and a half-applied mode
+    // leaves full mode written with no directory and no daemons.
+    final router = context.router;
+
     final confirmed = await _confirm(next);
     if (!confirmed) {
       return;
@@ -56,13 +62,32 @@ class _SettingsNodeModeState extends State<SettingsNodeMode> {
     });
     try {
       await _nodeMode.select(next);
+      // select() starts nothing while the network has no data directory, and
+      // the route guards never re-run for a page already on screen. So this
+      // toggle walks the same path the guard does.
+      if (next == wmpb.NodeMode.NODE_MODE_FULL) {
+        final ready = await ensureDataDirThenStartBackends(router);
+        if (!ready) {
+          // select() already wrote full mode, so a toggle left on here would
+          // read as full mode with every local daemon down.
+          await _nodeMode.select(wmpb.NodeMode.NODE_MODE_LIGHT);
+          _showError('Full mode stores the chain on disk, so it needs a data directory.');
+        }
+      }
     } catch (e) {
-      setState(() => _error = '$e');
+      _showError('$e');
     } finally {
       if (mounted) {
         setState(() => _switching = false);
       }
     }
+  }
+
+  void _showError(String message) {
+    if (!mounted) {
+      return;
+    }
+    setState(() => _error = message);
   }
 
   /// True when the active wallet reads its chain from the local node.

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.180
+version: 0.2.181
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.181
+version: 0.2.182
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.185
+version: 1.0.186
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.186
+version: 1.0.187
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/routing/datadir_guard.dart
+++ b/sail_ui/lib/routing/datadir_guard.dart
@@ -4,41 +4,48 @@ import 'package:logger/logger.dart';
 import 'package:sail_ui/pages/router.gr.dart' show DataDirSetupRoute;
 import 'package:sail_ui/sail_ui.dart';
 
+/// Makes sure the running network has a data directory. Returns false when the
+/// user backs out of the picker.
+///
+/// The orchestrator refuses to start L1 without a directory, so every path onto
+/// full mode runs this: the guard below on the way into the app, and the
+/// Settings toggle, which the guards never re-run for. It starts the backends
+/// only when it supplies the missing directory, because that is the one case
+/// where nothing else did: a network that already has one is booted by
+/// bitwindow's startup or by NodeModeProvider.select. Two dispatches race each
+/// other's pre-start checks, and the loser reports a startup failure.
+Future<bool> ensureDataDirThenStartBackends(StackRouter router) async {
+  final conf = GetIt.I.get<BitcoinConfProvider>();
+
+  // The node mode decides whether a local node runs at all, and it is picked
+  // one step earlier, so a polled value can predate it.
+  await conf.loadConfig();
+  if (!conf.mustSelectDatadir) {
+    return true;
+  }
+
+  await router.push(DataDirSetupRoute(network: conf.network));
+  await conf.loadConfig();
+  if (conf.mustSelectDatadir) {
+    return false;
+  }
+
+  if (!NodeModeProvider.runsLocalBackends) {
+    return true;
+  }
+  try {
+    await GetIt.I.get<OrchestratorRPC>().startWithL1('enforcer');
+  } catch (e) {
+    GetIt.I.get<Logger>().w('could not start the Bitcoin backends: $e');
+  }
+  return true;
+}
+
 /// Prompts for a Bitcoin datadir when one is actually needed. Whether it is
 /// depends on the wallet backend as well as the network, so the backend decides.
 class DataDirGuard extends AutoRouteGuard {
   @override
   void onNavigation(NavigationResolver resolver, StackRouter router) async {
-    final confProvider = GetIt.I.get<BitcoinConfProvider>();
-
-    // The node mode gate runs first and decides whether a local node runs at
-    // all, so a polled value can predate the mode the user just picked.
-    await confProvider.loadConfig();
-    if (!confProvider.mustSelectDatadir) {
-      resolver.next(true);
-      return;
-    }
-
-    await router.push(DataDirSetupRoute(network: confProvider.network));
-    await confProvider.loadConfig();
-
-    final ready = !confProvider.mustSelectDatadir;
-    if (ready) {
-      // The backend refuses to boot without a directory, so the mode choice
-      // started nothing. Now it can.
-      await _startLocalBackends();
-    }
-    resolver.next(ready);
-  }
-
-  Future<void> _startLocalBackends() async {
-    if (!NodeModeProvider.runsLocalBackends) {
-      return;
-    }
-    try {
-      await GetIt.I.get<OrchestratorRPC>().startWithL1('enforcer');
-    } catch (e) {
-      GetIt.I.get<Logger>().w('DataDirGuard: could not start the Bitcoin backends: $e');
-    }
+    resolver.next(await ensureDataDirThenStartBackends(router));
   }
 }

--- a/sail_ui/test/datadir_guard_test.dart
+++ b/sail_ui/test/datadir_guard_test.dart
@@ -1,0 +1,121 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/gen/orchestrator/v1/orchestrator.pb.dart' as orch_pb;
+
+/// Reports whether a datadir is outstanding, and flips on the reload that
+/// follows the picker so a test can play out a pick or a refusal.
+class _FakeConf extends ChangeNotifier implements BitcoinConfProvider {
+  _FakeConf({required this.mustSelectDatadir, this.picksOne = true});
+
+  @override
+  BitcoinNetwork network = BitcoinNetwork.BITCOIN_NETWORK_ECASH;
+
+  @override
+  bool mustSelectDatadir;
+
+  final bool picksOne;
+  bool _prompted = false;
+
+  void promptHappened() => _prompted = true;
+
+  @override
+  Future<void> loadConfig({bool isFirst = false, bool userInitiated = false}) async {
+    if (_prompted && picksOne) {
+      mustSelectDatadir = false;
+    }
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeRouter implements StackRouter {
+  _FakeRouter(this.conf);
+
+  final _FakeConf conf;
+  int pushes = 0;
+
+  @override
+  Future<T?> push<T extends Object?>(PageRouteInfo route, {OnNavigationFailure? onFailure}) async {
+    pushes++;
+    conf.promptHappened();
+    return null;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeOrchestratorRPC extends OrchestratorRPC {
+  _FakeOrchestratorRPC() : super(host: '127.0.0.1', port: 1);
+
+  int starts = 0;
+
+  @override
+  Future<orch_pb.StartWithL1Response> startWithL1(
+    String target, {
+    List<String>? targetArgs,
+    Map<String, String>? targetEnv,
+    List<String>? coreArgs,
+    List<String>? enforcerArgs,
+    bool immediate = false,
+    bool forceBackend = false,
+  }) async {
+    starts++;
+    return orch_pb.StartWithL1Response();
+  }
+}
+
+void main() {
+  late _FakeOrchestratorRPC orchestrator;
+
+  setUp(() async {
+    await GetIt.I.reset();
+    GetIt.I.registerSingleton<Logger>(Logger(level: Level.off));
+    orchestrator = _FakeOrchestratorRPC();
+    GetIt.I.registerSingleton<OrchestratorRPC>(orchestrator);
+  });
+
+  tearDown(() async => GetIt.I.reset());
+
+  // The orchestrator refuses to start L1 without a directory, so the picker has
+  // to come first and the start has to follow it.
+  test('asks for the missing directory, then starts the backends', () async {
+    final conf = _FakeConf(mustSelectDatadir: true);
+    GetIt.I.registerSingleton<BitcoinConfProvider>(conf);
+    final router = _FakeRouter(conf);
+
+    expect(await ensureDataDirThenStartBackends(router), isTrue);
+    expect(router.pushes, 1);
+    expect(orchestrator.starts, 1);
+  });
+
+  // A user who backs out of the picker leaves the network without a directory,
+  // so nothing may boot and the caller has to hear about it.
+  test('starts nothing when the user backs out of the picker', () async {
+    final conf = _FakeConf(mustSelectDatadir: true, picksOne: false);
+    GetIt.I.registerSingleton<BitcoinConfProvider>(conf);
+    final router = _FakeRouter(conf);
+
+    expect(await ensureDataDirThenStartBackends(router), isFalse);
+    expect(router.pushes, 1);
+    expect(orchestrator.starts, 0);
+  });
+
+  // A network that already has its directory is booted by bitwindow's startup
+  // or by select(). A second dispatch races the first, and the loser reports a
+  // startup failure.
+  test('starts nothing when the directory is already set', () async {
+    final conf = _FakeConf(mustSelectDatadir: false);
+    GetIt.I.registerSingleton<BitcoinConfProvider>(conf);
+    final router = _FakeRouter(conf);
+
+    expect(await ensureDataDirThenStartBackends(router), isTrue);
+    expect(router.pushes, 0);
+    expect(orchestrator.starts, 0);
+  });
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.314
+version: 1.0.315
 
 environment:
   sdk: 3.12.2

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.315
+version: 1.0.316
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.186
+version: 1.0.187
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.185
+version: 1.0.186
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.312
+version: 1.0.313
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.313
+version: 1.0.314
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The orchestrator refuses to start L1 without a data directory, so picking full mode starts nothing on its own. The route guards supply the directory on the way into the app, but they never re-run for a page already on screen. Flipping the Settings toggle therefore reported full mode with every local daemon down until the next launch.

The guard body moves into ensureDataDirThenStartBackends, and both paths call it: the guard on entry, and the toggle. One rule, so neither can drift from the other.