### PR TITLE
bitwindow: drop the second build that defaulted to forknet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,9 +168,6 @@ jobs:
           add_client_configs "zside" "${{ needs.check-changes.outputs.zside }}"
           add_client_configs "coinshift" "${{ needs.check-changes.outputs.coinshift }}"
           add_client_configs "bitwindow" "${{ needs.check-changes.outputs.bitwindow }}"
-          # Second BitWindow build: identical app that defaults to ForkNet, shipped as
-          # the bitwindow-forknet variant (eCash brand). Same source, build-time flag only.
-          add_client_configs "bitwindow" "${{ needs.check-changes.outputs.bitwindow }}" "forknet"
 
           # Join configurations with commas
           matrix=$(IFS=,; echo "{\"include\":[${configurations[*]}]}")
@@ -391,7 +388,7 @@ jobs:
             fi
           fi
 
-          # Variant flavor consumed by set-app-name.sh (standard | forknet).
+          # Variant flavor consumed by set-app-name.sh (standard).
           export BITWINDOW_VARIANT="${{ matrix.variant }}"
 
           # Everything after the third line is only relevant for macOS
@@ -446,11 +443,8 @@ jobs:
           fi
 
       - name: Generate appcast fragment for this build
-        # Only the standard build feeds the BitWindow appcast. The forknet variant
-        # would otherwise emit a "bitwindow" fragment whose EdDSA signature is over
-        # the forknet zip, poisoning the standard auto-update feed. Forknet
-        # auto-update is a follow-up (needs its own release-name mapping in the
-        # appcast scripts + appcast-bitwindow-forknet.xml).
+        # A variant build would emit a "bitwindow" fragment whose EdDSA signature
+        # is over its own zip, which poisons the standard auto-update feed.
         if: matrix.variant == '' || matrix.variant == 'standard'
         continue-on-error: true
         run: |
@@ -1009,18 +1003,6 @@ jobs:
             mv bitwindow-binaries-Windows/bitwindow.exe BitWindow-latest-x86_64-windows.exe || true
           else
             echo "Skipping BitWindow artifacts (version not increased)"
-          fi
-
-          # BitWindow forknet variant - same source/version, defaults to ForkNet.
-          # Rides BitWindow's version gate (same pubspec). The BitWindow-* scp and
-          # hashes globs below already pick up these BitWindow-forknet-* files.
-          if [ "$UPLOAD_BITWINDOW" = "true" ]; then
-            echo "Preparing BitWindow (forknet) artifacts for upload..."
-            mv bitwindow-binaries-macOS-forknet/bitwindow-osx64.zip BitWindow-forknet-latest-x86_64-apple-darwin.zip || true
-            mv bitwindow-binaries-macOS-forknet/bitwindow-osx64.dmg BitWindow-forknet-latest-x86_64-apple-darwin.dmg || true
-            mv bitwindow-binaries-Linux-forknet/bitwindow-x86_64-linux-gnu.zip BitWindow-forknet-latest-x86_64-unknown-linux-gnu.zip || true
-            mv bitwindow-binaries-Linux-forknet/BitWindow-x86_64.AppImage BitWindow-forknet-latest-x86_64-unknown-linux-gnu.AppImage || true
-            mv bitwindow-binaries-Windows-forknet/bitwindow.exe BitWindow-forknet-latest-x86_64-windows.exe || true
           fi
 
       - name: Install jq for merging version files

--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.314
+version: 1.0.315
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.314
+version: 1.0.315
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.182
+version: 0.2.183
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/scripts/set-app-name.sh
+++ b/bitwindow/scripts/set-app-name.sh
@@ -2,29 +2,15 @@
 
 set -e
 
-# Same name/icon for every variant (default-network-only variants, no rebrand).
+# Same name/icon for every build.
 app_name=BitWindow
 
-# BITWINDOW_VARIANT selects the build flavor: "standard" (default) or "forknet".
-# The forknet variant ships an identical app that simply defaults to ForkNet and
-# self-updates from its own appcast feed. Everything below is the only build-time
-# difference between the two.
+# BITWINDOW_VARIANT selects the build flavor. Only "standard" ships today: the
+# default network lives in the orchestrator, and every build reads that one
+# value. A variant reappears the day two builds must default to two networks.
 : "${BITWINDOW_VARIANT:=standard}"
 
-if [ "$BITWINDOW_VARIANT" = "forknet" ]; then
-    # Flutter compile-time defines (consumed via --dart-define-from-file).
-    {
-        echo "BITWINDOW_NETWORK=forknet"
-        echo "BITWINDOW_APPCAST_URL=https://releases.drivechain.info/appcast-bitwindow-forknet.xml"
-    } > build-vars.env
-    # Picked up by download-binaries.sh to embed the default network into every
-    # orchestrator tool (-ldflags -X config.DefaultNetwork). This is the
-    # authoritative lever — drivechaind owns the first-run network; Flutter
-    # follows it.
-    export BITWINDOW_DEFAULT_NETWORK=forknet
-else
-    echo "" > build-vars.env
-fi
+echo "" > build-vars.env
 
 # Export so the parent build script (and the binary build it spawns) see them.
 export app_name BITWINDOW_VARIANT

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.187
+version: 1.0.188
 
 environment:
   sdk: 3.12.2

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.316
+version: 1.0.317
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.187
+version: 1.0.188
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.314
+version: 1.0.315
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
CI built BitWindow twice. The second build was labelled the eCash brand, but it defaulted to forknet, and the published catalog lists only bitcoin, signet and alphanet. Its appcast feed was never generated either, so appcast-bitwindow-forknet.xml returns 404 and nothing ever auto-updated from it.

The standard build already defaults to alphanet, so the variant had nothing left to distinguish it. One build ships now. The BITWINDOW_DEFAULT_NETWORK lever stays in download-binaries.sh, so a variant costs one line the day two builds must default to two networks.