### PR TITLE
orchestrator: stop the orphans this install left behind

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.315
+version: 1.0.316
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.315
+version: 1.0.316
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.183
+version: 0.2.184
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.188
+version: 1.0.189
 
 environment:
   sdk: 3.12.2

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -200,20 +200,8 @@ func run(cctx *cli.Context) error {
 	orch := orchestrator.New(dataDir, network, bitwindowDir, configs, log)
 
 	// Whoever holds this owns the binaries in dataDir. The kernel frees it when
-	// the holder dies, so a leftover from a crashed run is ours to stop rather
-	// than a stranger's process. Without it every drain skipped adopted
-	// binaries, and one bad exit made a daemon permanent.
-	ownerLock, held, lockErr := orchestrator.TakeOwnerLock(dataDir)
-	if lockErr != nil {
-		return fmt.Errorf("take the owner lock: %w", lockErr)
-	}
-	if held {
-		defer func() { _ = ownerLock.Release() }()
-		orch.SetOwnerLock(ownerLock)
-	} else {
-		log.Warn().Str("datadir", dataDir).
-			Msg("another install owns this data directory; leaving its binaries alone")
-	}
+	// the holder dies, so a leftover from a crashed run is ours to stop.
+	orch.ClaimOwnerLock(ctx, dataDir)
 
 	orch.StartReleaseChecks(ctx)
 

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -198,6 +198,23 @@ func run(cctx *cli.Context) error {
 	configPath := orchestrator.ConfigFilePath(bitwindowDir)
 	configs := orchestrator.LoadConfigFile(configPath, log)
 	orch := orchestrator.New(dataDir, network, bitwindowDir, configs, log)
+
+	// Whoever holds this owns the binaries in dataDir. The kernel frees it when
+	// the holder dies, so a leftover from a crashed run is ours to stop rather
+	// than a stranger's process. Without it every drain skipped adopted
+	// binaries, and one bad exit made a daemon permanent.
+	ownerLock, held, lockErr := orchestrator.TakeOwnerLock(dataDir)
+	if lockErr != nil {
+		return fmt.Errorf("take the owner lock: %w", lockErr)
+	}
+	if held {
+		defer func() { _ = ownerLock.Release() }()
+		orch.SetOwnerLock(ownerLock)
+	} else {
+		log.Warn().Str("datadir", dataDir).
+			Msg("another install owns this data directory; leaving its binaries alone")
+	}
+
 	orch.StartReleaseChecks(ctx)
 
 	// Local RPC auth (bitcoind-style cookie). When enabled, a fresh token is

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -173,6 +173,7 @@ type Orchestrator struct {
 	configs    map[string]BinaryConfig
 	download   *DownloadManager
 	process    *ProcessManager
+	ownerMu    sync.Mutex
 	ownerLock  *OwnerLock
 	pidManager *PidFileManager
 	clients    *lease.Lease
@@ -293,13 +294,20 @@ func (o *Orchestrator) DownloadStates() map[string]DownloadState {
 // SetOwnerLock records the lock this run holds. A nil lock means the install
 // belongs to somebody else, so the drain leaves adopted binaries alone.
 func (o *Orchestrator) SetOwnerLock(lock *OwnerLock) {
+	o.ownerMu.Lock()
+	defer o.ownerMu.Unlock()
 	o.ownerLock = lock
 }
 
 // OwnsInstall reports whether this run holds the owner lock, and may therefore
 // stop the binaries it finds running.
 func (o *Orchestrator) OwnsInstall() bool {
-	return o != nil && o.ownerLock != nil
+	if o == nil {
+		return false
+	}
+	o.ownerMu.Lock()
+	defer o.ownerMu.Unlock()
+	return o.ownerLock != nil
 }
 
 func New(dataDir, network, bitwindowDir string, configs []BinaryConfig, log zerolog.Logger) *Orchestrator {

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -300,6 +300,13 @@ func (o *Orchestrator) SetOwnerLock(lock *OwnerLock) {
 	o.ownerLock = lock
 }
 
+// mayStopAdopted reports whether an adopted binary is ours to stop: a run of
+// this install started it, and the owner lock proves no other install is alive
+// to claim it.
+func (o *Orchestrator) mayStopAdopted(name string) bool {
+	return o.process.IsOrphan(name) && o.OwnsInstall()
+}
+
 // OwnsInstall reports whether this run holds the owner lock, and may therefore
 // stop the binaries it finds running.
 func (o *Orchestrator) OwnsInstall() bool {
@@ -1735,12 +1742,9 @@ func (o *Orchestrator) ShutdownAll(ctx context.Context, force bool) (<-chan Shut
 		ordered := orderForShutdown(running)
 
 		for _, name := range ordered {
-			// An adopted binary is only somebody else's while somebody else is
-			// alive. Holding the owner lock proves no other install is, so a
-			// leftover is an orphan of a dead run and this drain stops it.
 			// Skipping every adopted binary is what made one bad exit permanent.
-			if o.process.IsAdopted(name) && !o.OwnsInstall() {
-				o.log.Info().Str("binary", name).Msg("another install owns this process, skipping shutdown")
+			if o.process.IsAdopted(name) && !o.mayStopAdopted(name) {
+				o.log.Info().Str("binary", name).Msg("not ours to stop, skipping shutdown")
 				o.process.Remove(name)
 
 				// Transition monitor to connect-mode-only so it can detect

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -173,6 +173,7 @@ type Orchestrator struct {
 	configs    map[string]BinaryConfig
 	download   *DownloadManager
 	process    *ProcessManager
+	ownerLock  *OwnerLock
 	pidManager *PidFileManager
 	clients    *lease.Lease
 	log        zerolog.Logger
@@ -289,6 +290,18 @@ func (o *Orchestrator) DownloadStates() map[string]DownloadState {
 }
 
 // New creates a new Orchestrator.
+// SetOwnerLock records the lock this run holds. A nil lock means the install
+// belongs to somebody else, so the drain leaves adopted binaries alone.
+func (o *Orchestrator) SetOwnerLock(lock *OwnerLock) {
+	o.ownerLock = lock
+}
+
+// OwnsInstall reports whether this run holds the owner lock, and may therefore
+// stop the binaries it finds running.
+func (o *Orchestrator) OwnsInstall() bool {
+	return o != nil && o.ownerLock != nil
+}
+
 func New(dataDir, network, bitwindowDir string, configs []BinaryConfig, log zerolog.Logger) *Orchestrator {
 	pidMgr := NewPidFileManager(dataDir, log)
 
@@ -1713,15 +1726,12 @@ func (o *Orchestrator) ShutdownAll(ctx context.Context, force bool) (<-chan Shut
 		ordered := orderForShutdown(running)
 
 		for _, name := range ordered {
-			// Dart binary_provider.dart pattern: don't shut down processes we
-			// didn't start. If it was adopted (running externally), just
-			// remove it from our tracking — the owning process manages its
-			// lifecycle.
-			if o.process.IsAdopted(name) {
-				// Dart binary_provider.dart pattern: don't shut down processes we
-				// didn't start. The owning process manages its lifecycle.
-				// Dart RPCConnection.markDisconnected() — keep timer in connectModeOnly
-				o.log.Info().Str("binary", name).Msg("adopted process, skipping shutdown (not ours to stop)")
+			// An adopted binary is only somebody else's while somebody else is
+			// alive. Holding the owner lock proves no other install is, so a
+			// leftover is an orphan of a dead run and this drain stops it.
+			// Skipping every adopted binary is what made one bad exit permanent.
+			if o.process.IsAdopted(name) && !o.OwnsInstall() {
+				o.log.Info().Str("binary", name).Msg("another install owns this process, skipping shutdown")
 				o.process.Remove(name)
 
 				// Transition monitor to connect-mode-only so it can detect

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"connectrpc.com/connect"
@@ -1818,9 +1819,14 @@ func (o *Orchestrator) stopBinaryViaRPC(_ context.Context, name string) bool {
 		rpcErr = o.callSidechainStopRPC(cfg)
 	}
 
-	// Wait even if the ack failed — daemons close their RPC listener
-	// partway through shutdown, and re-signaling a flushing daemon can
-	// corrupt on-disk state.
+	// Any other error may follow a request that landed: bitcoind answers `stop`
+	// and then drops the connection while it flushes, and re-signaling it there
+	// can corrupt on-disk state. Wait that one out.
+	if unreachable(rpcErr) {
+		o.log.Info().Err(rpcErr).Str("binary", name).Msg("stop RPC never reached the daemon, signalling instead")
+		return false
+	}
+
 	if o.process.WaitForExit(name, gracefulKillTimeout) {
 		o.log.Info().Err(rpcErr).Str("binary", name).Msg("stopped via RPC")
 		return true
@@ -1830,10 +1836,29 @@ func (o *Orchestrator) stopBinaryViaRPC(_ context.Context, name string) bool {
 	return false
 }
 
+// errNoStopClient means the stop RPC had nothing to send the request with.
+var errNoStopClient = errors.New("no stop client")
+
+// unreachable reports whether the stop RPC never got to the daemon, so no
+// shutdown is under way and waiting for one buys nothing.
+func unreachable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errNoStopClient) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EHOSTUNREACH) {
+		return true
+	}
+	var netErr *net.OpError
+	return errors.As(err, &netErr) && netErr.Op == "dial"
+}
+
 func (o *Orchestrator) callBitcoindStopRPC() error {
 	client, err := o.CoreStatusClient()
 	if err != nil {
-		return fmt.Errorf("bitcoind RPC stop: no core client: %w", err)
+		return fmt.Errorf("bitcoind RPC stop: %w: %w", errNoStopClient, err)
 	}
 	// Detached: a near-expired upstream ctx would force an unsafe fallback.
 	rpcCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -1851,7 +1876,7 @@ func (o *Orchestrator) callSidechainStopRPC(cfg BinaryConfig) error {
 func (o *Orchestrator) callEnforcerStopRPC() error {
 	cfg, ok := o.Configs()["enforcer"]
 	if !ok || cfg.Port == 0 {
-		return fmt.Errorf("enforcer RPC stop: no config")
+		return fmt.Errorf("enforcer RPC stop: %w: no config", errNoStopClient)
 	}
 	httpClient := &http.Client{
 		Transport: &http2.Transport{

--- a/sidechain-orchestrator/orphan_drain_test.go
+++ b/sidechain-orchestrator/orphan_drain_test.go
@@ -1,0 +1,197 @@
+//go:build !windows
+
+package orchestrator
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// startSleeper runs a real child this test can watch die. A PID from exec is a
+// live process, so the drain has something it must actually signal.
+func startSleeper(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("sleep", "300")
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	go func() { _, _ = cmd.Process.Wait() }()
+	return pid
+}
+
+// alive reports whether the pid still exists. Signal 0 asks the kernel without
+// sending anything.
+func alive(t *testing.T, pid int) bool {
+	t.Helper()
+	return syscall.Kill(pid, 0) == nil
+}
+
+func waitGone(t *testing.T, pid int, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !alive(t, pid) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return !alive(t, pid)
+}
+
+// adoptSleeper starts a child and hands it to the orchestrator as bitcoind.
+// recordPid writes this install's PID record first, which is what marks the
+// process as a leftover of an earlier run of ours.
+func adoptSleeper(t *testing.T, o *Orchestrator, recordPid bool) int {
+	t.Helper()
+	pid := startSleeper(t)
+	cfg, err := o.getConfig("bitcoind")
+	require.NoError(t, err)
+	if recordPid {
+		require.NoError(t, o.pidManager.WritePidFile(cfg.BinaryName, pid))
+	}
+	o.process.AdoptProcess(cfg, pid)
+	require.True(t, o.process.IsAdopted("bitcoind"))
+	return pid
+}
+
+func drain(t *testing.T, o *Orchestrator) {
+	t.Helper()
+	ch, err := o.ShutdownAll(context.Background(), false)
+	require.NoError(t, err)
+	for range ch {
+	}
+}
+
+// backdatePidRecord makes the PID record predate the process it names, which
+// is the shape a reused PID leaves behind.
+func backdatePidRecord(t *testing.T, o *Orchestrator, binaryName string) {
+	t.Helper()
+	path := filepath.Join(PidDir(o.DataDir), binaryName+".pid")
+	old := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(path, old, old))
+}
+
+func ownThisInstall(t *testing.T, o *Orchestrator) {
+	t.Helper()
+	lock, held, err := TakeOwnerLock(t.TempDir())
+	require.NoError(t, err)
+	require.True(t, held)
+	t.Cleanup(func() { _ = lock.Release() })
+	o.SetOwnerLock(lock)
+}
+
+// The bug: a daemon that survived one bad exit got adopted on the next boot,
+// and the drain then refused to stop it. It stayed for good and held the ports
+// the fresh stack wants.
+func TestDrainStopsAnAdoptedOrphanThisInstallOwns(t *testing.T) {
+	o := newTestOrchestrator(t)
+	ownThisInstall(t, o)
+
+	pid := adoptSleeper(t, o, true)
+	drain(t, o)
+
+	require.True(t, waitGone(t, pid, 30*time.Second), "the drain must stop an orphan this install owns")
+}
+
+// A binary a different live install owns stays untouched, whatever this run
+// finds on disk.
+func TestDrainLeavesAnAdoptedProcessAnotherInstallOwns(t *testing.T) {
+	o := newTestOrchestrator(t)
+	require.False(t, o.OwnsInstall())
+
+	pid := adoptSleeper(t, o, true)
+	drain(t, o)
+
+	require.True(t, alive(t, pid), "another install's process must survive this drain")
+}
+
+// A daemon the user started themselves has no PID record here. Owning the
+// install says nothing about it, so the drain leaves their node running.
+func TestDrainLeavesADaemonThisInstallNeverStarted(t *testing.T) {
+	o := newTestOrchestrator(t)
+	ownThisInstall(t, o)
+
+	pid := adoptSleeper(t, o, false)
+	require.False(t, o.process.IsOrphan("bitcoind"))
+	drain(t, o)
+
+	require.True(t, alive(t, pid), "a daemon this install never started must survive the drain")
+}
+
+// The wait for an adopted binary must end when the process does. Nothing
+// closes its exit channel otherwise, so every stop burned the whole window.
+func TestAdoptedProcessExitEndsTheWait(t *testing.T) {
+	o := newTestOrchestrator(t)
+	pid := adoptSleeper(t, o, true)
+
+	require.NoError(t, syscall.Kill(pid, syscall.SIGKILL))
+
+	require.True(t, o.process.WaitForExit("bitcoind", 30*time.Second),
+		"the wait must end when the adopted process dies")
+	require.False(t, o.process.IsRunning("bitcoind"))
+}
+
+// The OS reuses PID numbers. A stale record can name a PID the kernel later
+// gave to a daemon the user started, so the record alone proves nothing.
+func TestDrainLeavesAProcessThatReusedARecordedPid(t *testing.T) {
+	o := newTestOrchestrator(t)
+	ownThisInstall(t, o)
+
+	pid := startSleeper(t)
+	cfg, err := o.getConfig("bitcoind")
+	require.NoError(t, err)
+	require.NoError(t, o.pidManager.WritePidFile(cfg.BinaryName, pid))
+	backdatePidRecord(t, o, cfg.BinaryName)
+
+	o.process.AdoptProcess(cfg, pid)
+	require.False(t, o.process.IsOrphan("bitcoind"), "a record older than the process proves nothing")
+
+	drain(t, o)
+
+	require.True(t, alive(t, pid), "a process that reused a recorded PID must survive the drain")
+}
+
+// ps prints the elapsed time in four shapes. A misread age makes a real orphan
+// look young, and the drain then leaves it running.
+func TestParseElapsedReadsEveryPsShape(t *testing.T) {
+	tests := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"05:30", 5*time.Minute + 30*time.Second},
+		{"01:05:30", time.Hour + 5*time.Minute + 30*time.Second},
+		{"2-01:05:30", 49*time.Hour + 5*time.Minute + 30*time.Second},
+		{"10-00:00:00", 240 * time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := parseElapsed(tt.in)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+
+	for _, bad := range []string{"", "abc", "1:2:3:4", "x-01:00:00"} {
+		_, err := parseElapsed(bad)
+		require.Error(t, err, "parseElapsed(%q) must fail", bad)
+	}
+}
+
+// A process this run started is younger than nothing, so its own age must read
+// back as a real duration.
+func TestProcessAgeReadsALiveProcess(t *testing.T) {
+	pid := startSleeper(t)
+	age, err := processAge(pid)
+	require.NoError(t, err)
+	require.Less(t, age, time.Minute, "a process started just now must read as young")
+}

--- a/sidechain-orchestrator/ownerlock.go
+++ b/sidechain-orchestrator/ownerlock.go
@@ -1,0 +1,58 @@
+package orchestrator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ownerLockName is the file every install holds open while it runs.
+const ownerLockName = "owner.lock"
+
+// OwnerLock answers one question: may this install stop the binaries it finds
+// running? It holds an exclusive lock for the process lifetime, so the kernel
+// releases it the moment the holder dies — a crash included.
+//
+// A held lock means no other install is live, so every leftover binary is an
+// orphan of a dead run and this install cleans it up. Asking a recorded PID
+// instead cannot answer this: the OS reuses PIDs, so a stale number names a
+// stranger as often as it names the process that wrote it.
+type OwnerLock struct {
+	file *os.File
+}
+
+// TakeOwnerLock claims the install. held is false when another live install
+// already holds it, which is not an error.
+func TakeOwnerLock(dataDir string) (lock *OwnerLock, held bool, err error) {
+	dir := PidDir(dataDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, false, fmt.Errorf("create pid dir %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, ownerLockName)
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, false, fmt.Errorf("open owner lock %s: %w", path, err)
+	}
+
+	held, err = takeOwnerLock(f)
+	if err != nil || !held {
+		_ = f.Close()
+		if err != nil {
+			return nil, false, fmt.Errorf("lock %s: %w", path, err)
+		}
+		return nil, false, nil
+	}
+	return &OwnerLock{file: f}, true, nil
+}
+
+// Release drops the lock. The kernel does this on exit too, so a caller only
+// needs it to hand the install over while it keeps running.
+func (l *OwnerLock) Release() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	f := l.file
+	l.file = nil
+	return f.Close()
+}

--- a/sidechain-orchestrator/ownerlock.go
+++ b/sidechain-orchestrator/ownerlock.go
@@ -1,9 +1,11 @@
 package orchestrator
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // ownerLockName is the file every install holds open while it runs.
@@ -44,6 +46,46 @@ func TakeOwnerLock(dataDir string) (lock *OwnerLock, held bool, err error) {
 		return nil, false, nil
 	}
 	return &OwnerLock{file: f}, true, nil
+}
+
+// ClaimOwnerLock takes the lock, and keeps retrying in the background until it
+// does, because a start that races the previous session's exit finds it held
+// for a moment. Nothing waits on this: an unowned install serves normally.
+func (o *Orchestrator) ClaimOwnerLock(ctx context.Context, dataDir string) {
+	lock, held, err := TakeOwnerLock(dataDir)
+	if err != nil {
+		o.log.Warn().Err(err).Msg("owner lock failed")
+		return
+	}
+	if held {
+		o.SetOwnerLock(lock)
+		return
+	}
+
+	o.log.Info().Str("datadir", dataDir).
+		Msg("the previous session still owns this data directory, waiting for it to let go")
+
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+			lock, held, err := TakeOwnerLock(dataDir)
+			if err != nil {
+				o.log.Warn().Err(err).Msg("owner lock retry failed")
+				return
+			}
+			if held {
+				o.SetOwnerLock(lock)
+				o.log.Info().Str("datadir", dataDir).Msg("the previous install let go, this one owns its binaries now")
+				return
+			}
+		}
+	}()
 }
 
 // Release drops the lock. The kernel does this on exit too, so a caller only

--- a/sidechain-orchestrator/ownerlock_rule_test.go
+++ b/sidechain-orchestrator/ownerlock_rule_test.go
@@ -1,0 +1,25 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The bug this fixes: the drain skipped every adopted binary, so a daemon that
+// survived one bad exit got adopted on the next boot and no drain ever stopped
+// it again. It then held the ports and the datadir lock the fresh stack wants.
+func TestOwnedInstallMayStopAnAdoptedBinary(t *testing.T) {
+	dir := t.TempDir()
+
+	lock, held, err := TakeOwnerLock(dir)
+	require.NoError(t, err)
+	require.True(t, held)
+	t.Cleanup(func() { _ = lock.Release() })
+
+	o := &Orchestrator{}
+	require.False(t, o.OwnsInstall(), "a run with no lock owns nothing")
+
+	o.SetOwnerLock(lock)
+	require.True(t, o.OwnsInstall(), "the lock holder stops what it finds")
+}

--- a/sidechain-orchestrator/ownerlock_rule_test.go
+++ b/sidechain-orchestrator/ownerlock_rule_test.go
@@ -1,7 +1,9 @@
 package orchestrator
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -22,4 +24,28 @@ func TestOwnedInstallMayStopAnAdoptedBinary(t *testing.T) {
 
 	o.SetOwnerLock(lock)
 	require.True(t, o.OwnsInstall(), "the lock holder stops what it finds")
+}
+
+// Case 2: a restart races the previous session's exit. The lock is held for a
+// moment, and the install must claim itself when it frees — without a second
+// restart, and without holding up its own startup.
+func TestClaimOwnerLockTakesOverWhenThePreviousSessionLetsGo(t *testing.T) {
+	dir := t.TempDir()
+
+	first, held, err := TakeOwnerLock(dir)
+	require.NoError(t, err)
+	require.True(t, held)
+
+	o := newTestOrchestrator(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	start := time.Now()
+	o.ClaimOwnerLock(ctx, dir)
+	require.Less(t, time.Since(start), time.Second, "a contested lock must not hold up startup")
+	require.False(t, o.OwnsInstall(), "a live holder keeps the install")
+
+	require.NoError(t, first.Release())
+	require.Eventually(t, o.OwnsInstall, 5*time.Second, 50*time.Millisecond,
+		"the install must claim itself once the previous session lets go")
 }

--- a/sidechain-orchestrator/ownerlock_test.go
+++ b/sidechain-orchestrator/ownerlock_test.go
@@ -1,0 +1,81 @@
+package orchestrator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// One install at a time. A second one must not stop binaries the first owns.
+func TestOwnerLockRefusesASecondHolder(t *testing.T) {
+	dir := t.TempDir()
+
+	first, held, err := TakeOwnerLock(dir)
+	require.NoError(t, err)
+	require.True(t, held)
+	t.Cleanup(func() { _ = first.Release() })
+
+	_, held, err = TakeOwnerLock(dir)
+	require.NoError(t, err, "a busy lock is not an error")
+	require.False(t, held)
+}
+
+// The kernel drops the lock when the holder dies, which is the whole point: a
+// crashed install leaves its binaries reclaimable rather than immortal.
+func TestOwnerLockFreesWhenTheHolderDies(t *testing.T) {
+	dir := t.TempDir()
+
+	holder := exec.Command(os.Args[0], "-test.run=TestOwnerLockHolderHelper")
+	holder.Env = append(os.Environ(), "ORCHESTRATOR_LOCK_HELPER_DIR="+dir)
+	out, err := holder.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	lock, held, err := TakeOwnerLock(dir)
+	require.NoError(t, err)
+	require.True(t, held, "the dead holder's lock must be free")
+	require.NoError(t, lock.Release())
+}
+
+// TestOwnerLockHolderHelper runs in a child process: it takes the lock and
+// exits, so the parent can prove the kernel released it.
+func TestOwnerLockHolderHelper(t *testing.T) {
+	dir := os.Getenv("ORCHESTRATOR_LOCK_HELPER_DIR")
+	if dir == "" {
+		t.Skip("helper for TestOwnerLockFreesWhenTheHolderDies")
+	}
+	_, held, err := TakeOwnerLock(dir)
+	require.NoError(t, err)
+	require.True(t, held)
+}
+
+// Release hands the install over without an exit, so a caller that keeps
+// running can pass ownership on.
+func TestOwnerLockReleaseLetsTheNextHolderIn(t *testing.T) {
+	dir := t.TempDir()
+
+	first, held, err := TakeOwnerLock(dir)
+	require.NoError(t, err)
+	require.True(t, held)
+	require.NoError(t, first.Release())
+
+	second, held, err := TakeOwnerLock(dir)
+	require.NoError(t, err)
+	require.True(t, held)
+	require.NoError(t, second.Release())
+}
+
+// The lock lives beside the PID files it speaks for.
+func TestOwnerLockSitsInThePidDir(t *testing.T) {
+	dir := t.TempDir()
+
+	lock, held, err := TakeOwnerLock(dir)
+	require.NoError(t, err)
+	require.True(t, held)
+	t.Cleanup(func() { _ = lock.Release() })
+
+	_, err = os.Stat(filepath.Join(PidDir(dir), ownerLockName))
+	require.NoError(t, err)
+}

--- a/sidechain-orchestrator/ownerlock_unix.go
+++ b/sidechain-orchestrator/ownerlock_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package orchestrator
+
+import (
+	"os"
+	"syscall"
+)
+
+// takeOwnerLock holds an exclusive lock on an open file until the process ends.
+// The kernel releases it when the holder dies, which is what makes a leftover
+// binary safe to reclaim without asking whether a recorded PID is still alive.
+func takeOwnerLock(f *os.File) (bool, error) {
+	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if err == syscall.EWOULDBLOCK || err == syscall.EAGAIN {
+		return false, nil
+	}
+	return false, err
+}

--- a/sidechain-orchestrator/ownerlock_windows.go
+++ b/sidechain-orchestrator/ownerlock_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package orchestrator
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// takeOwnerLock holds an exclusive lock on an open file until the process ends.
+// The kernel releases it when the holder dies, which is what makes a leftover
+// binary safe to reclaim without asking whether a recorded PID is still alive.
+func takeOwnerLock(f *os.File) (bool, error) {
+	const flags = windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY
+	err := windows.LockFileEx(windows.Handle(f.Fd()), flags, 0, 1, 0, new(windows.Overlapped))
+	if err == nil {
+		return true, nil
+	}
+	if err == windows.ERROR_LOCK_VIOLATION || err == windows.ERROR_IO_PENDING {
+		return false, nil
+	}
+	return false, err
+}

--- a/sidechain-orchestrator/platform_unix.go
+++ b/sidechain-orchestrator/platform_unix.go
@@ -39,6 +39,48 @@ func isPidAlive(pid int) bool {
 	return stat != "" && !strings.HasPrefix(stat, "Z")
 }
 
+// processAge returns how long the process at pid ran. The OS reuses PID
+// numbers, so a caller that recorded a PID needs the age to tell that process
+// from a stranger that later took its number.
+func processAge(pid int) (time.Duration, error) {
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "etime=").Output()
+	if err != nil {
+		return 0, fmt.Errorf("read the age of PID %d: %w", pid, err)
+	}
+	return parseElapsed(strings.TrimSpace(string(out)))
+}
+
+// parseElapsed reads the ps elapsed-time column, which is [[DD-]HH:]MM:SS.
+func parseElapsed(elapsed string) (time.Duration, error) {
+	days := 0
+	if head, tail, cut := strings.Cut(elapsed, "-"); cut {
+		parsed, err := strconv.Atoi(head)
+		if err != nil {
+			return 0, fmt.Errorf("parse the day count %q: %w", head, err)
+		}
+		days, elapsed = parsed, tail
+	}
+
+	fields := strings.Split(elapsed, ":")
+	if len(fields) < 2 || len(fields) > 3 {
+		return 0, fmt.Errorf("parse the elapsed time %q", elapsed)
+	}
+	for len(fields) < 3 {
+		fields = append([]string{"0"}, fields...)
+	}
+
+	units := []time.Duration{time.Hour, time.Minute, time.Second}
+	age := time.Duration(days) * 24 * time.Hour
+	for i, field := range fields {
+		value, err := strconv.Atoi(field)
+		if err != nil {
+			return 0, fmt.Errorf("parse the elapsed time %q: %w", elapsed, err)
+		}
+		age += time.Duration(value) * units[i]
+	}
+	return age, nil
+}
+
 // getProcessName returns the executable name for a given PID.
 func getProcessName(pid int) (string, error) {
 	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=").CombinedOutput()

--- a/sidechain-orchestrator/platform_unix.go
+++ b/sidechain-orchestrator/platform_unix.go
@@ -28,11 +28,15 @@ func chmod(path string) error {
 	return os.Chmod(path, 0o755)
 }
 
-// isPidAlive checks if a process with the given PID is alive.
-// Dart: isPidAlive (L91-101) — uses exitCode == 0
+// isPidAlive checks if a process with the given PID is alive. A zombie still
+// answers `ps -p`, so the state column decides.
 func isPidAlive(pid int) bool {
-	err := exec.Command("ps", "-p", strconv.Itoa(pid)).Run()
-	return err == nil
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "stat=").Output()
+	if err != nil {
+		return false
+	}
+	stat := strings.TrimSpace(string(out))
+	return stat != "" && !strings.HasPrefix(stat, "Z")
 }
 
 // getProcessName returns the executable name for a given PID.

--- a/sidechain-orchestrator/platform_windows.go
+++ b/sidechain-orchestrator/platform_windows.go
@@ -49,6 +49,22 @@ func isPidAlive(pid int) bool {
 	return strings.Contains(string(out), strconv.Itoa(pid))
 }
 
+// processAge returns how long the process at pid ran. The OS reuses PID
+// numbers, so a caller that recorded a PID needs the age to tell that process
+// from a stranger that later took its number.
+func processAge(pid int) (time.Duration, error) {
+	out, err := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command",
+		fmt.Sprintf("[int]((Get-Date) - (Get-Process -Id %d).StartTime).TotalSeconds", pid)).Output()
+	if err != nil {
+		return 0, fmt.Errorf("read the age of PID %d: %w", pid, err)
+	}
+	seconds, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, fmt.Errorf("parse the age of PID %d: %w", pid, err)
+	}
+	return time.Duration(seconds) * time.Second, nil
+}
+
 func getProcessName(pid int) (string, error) {
 	out, err := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/FO", "CSV", "/NH").CombinedOutput()
 	if err != nil {

--- a/sidechain-orchestrator/process.go
+++ b/sidechain-orchestrator/process.go
@@ -32,6 +32,7 @@ type ManagedProcess struct {
 	PidName      string // PID-file basename used for this process
 	Started      time.Time
 	Adopted      bool // true if this process was found from a previous session
+	Orphan       bool // true if a previous run of this install started it and left it behind
 	ForceBackend bool // true if this sidechain was launched with --force-backend (skips flutter_frontend variant)
 
 	mu       sync.Mutex
@@ -721,6 +722,8 @@ func (pm *ProcessManager) AdoptProcessResolved(config BinaryConfig, pid int, bin
 		return
 	}
 
+	orphan := pm.startedInAnEarlierRun(pidName, pid)
+
 	delete(pm.lastExited, config.Name)
 	pm.processes[config.Name] = &ManagedProcess{
 		Config:       config,
@@ -729,6 +732,7 @@ func (pm *ProcessManager) AdoptProcessResolved(config BinaryConfig, pid int, bin
 		PidName:      pidName,
 		Started:      time.Now(),
 		Adopted:      true,
+		Orphan:       orphan,
 		ForceBackend: forceBackend,
 		logs:         make([]LogEntry, 0),
 		exitCh:       make(chan struct{}),
@@ -772,6 +776,45 @@ func (pm *ProcessManager) watchAdopted(name string, proc *ManagedProcess) {
 		close(proc.exitCh)
 		return
 	}
+}
+
+// pidRecordSkew covers the gap between a process start and the PID record this
+// install writes for it, plus the one-second resolution of a process age.
+const pidRecordSkew = 5 * time.Second
+
+// startedInAnEarlierRun reports whether a run of this install started the
+// process at pid. The PID record must name it, and the process must be older
+// than that record. A stranger that later took the same number is younger, so
+// the age is what a bare PID match cannot prove.
+func (pm *ProcessManager) startedInAnEarlierRun(pidName string, pid int) bool {
+	recorded, err := pm.pidManager.ReadPidFile(pidName)
+	if err != nil || recorded != pid {
+		return false
+	}
+
+	written, err := pm.pidManager.RecordTime(pidName)
+	if err != nil {
+		pm.log.Warn().Err(err).Str("binary", pidName).Msg("read the PID record time")
+		return false
+	}
+
+	age, err := processAge(pid)
+	if err != nil {
+		pm.log.Warn().Err(err).Int("pid", pid).Msg("read the process age")
+		return false
+	}
+
+	return time.Since(written) <= age+pidRecordSkew
+}
+
+// IsOrphan reports whether a previous run of this install started the named
+// process and left it behind. False for a process somebody else launched
+// against the same data directory.
+func (pm *ProcessManager) IsOrphan(name string) bool {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	p, exists := pm.processes[name]
+	return exists && p.Orphan
 }
 
 // IsAdopted returns true if the named process was adopted (not started by us).
@@ -888,6 +931,15 @@ func (m *PidFileManager) WritePidFile(binaryName string, pid int) error {
 	}
 	m.log.Debug().Str("binary", binaryName).Int("pid", pid).Msg("wrote PID file")
 	return nil
+}
+
+// RecordTime returns when this install wrote the PID record for a binary.
+func (m *PidFileManager) RecordTime(binaryName string) (time.Time, error) {
+	info, err := os.Stat(m.pidPath(binaryName))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("stat the PID file for %s: %w", binaryName, err)
+	}
+	return info.ModTime(), nil
 }
 
 func (m *PidFileManager) ReadPidFile(binaryName string) (int, error) {

--- a/sidechain-orchestrator/process.go
+++ b/sidechain-orchestrator/process.go
@@ -735,6 +735,43 @@ func (pm *ProcessManager) AdoptProcessResolved(config BinaryConfig, pid int, bin
 	}
 
 	pm.log.Info().Str("binary", config.Name).Int("pid", pid).Msg("adopted orphaned process")
+
+	go pm.watchAdopted(config.Name, pm.processes[config.Name])
+}
+
+const adoptedPollInterval = time.Second
+
+// watchAdopted closes the exit channel of an adopted process once it dies.
+// Only a parent gets word of a child's exit, so an adopted PID needs a poll.
+func (pm *ProcessManager) watchAdopted(name string, proc *ManagedProcess) {
+	for {
+		time.Sleep(adoptedPollInterval)
+
+		pm.mu.Lock()
+		tracked := pm.processes[name] == proc
+		pm.mu.Unlock()
+		if !tracked {
+			return
+		}
+
+		if isPidAlive(proc.Pid) {
+			continue
+		}
+
+		pm.mu.Lock()
+		if pm.processes[name] != proc {
+			pm.mu.Unlock()
+			return
+		}
+		delete(pm.processes, name)
+		pm.lastExited[name] = proc
+		pm.mu.Unlock()
+
+		_ = pm.pidManager.DeletePidFile(proc.PidName)
+		pm.log.Info().Str("binary", name).Int("pid", proc.Pid).Msg("adopted process exited")
+		close(proc.exitCh)
+		return
+	}
 }
 
 // IsAdopted returns true if the named process was adopted (not started by us).

--- a/sidechain-orchestrator/stopwait_test.go
+++ b/sidechain-orchestrator/stopwait_test.go
@@ -1,0 +1,35 @@
+package orchestrator
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A stop RPC that never landed must skip the graceful wait. A stop RPC that
+// may have landed must not: bitcoind answers `stop`, then drops the connection
+// while it flushes, and a signal there can corrupt on-disk state.
+func TestUnreachableTellsAMissedStopFromAFlushingDaemon(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"no error", nil, false},
+		{"no client", fmt.Errorf("bitcoind RPC stop: %w: down", errNoStopClient), true},
+		{"connection refused", fmt.Errorf("stop: %w", syscall.ECONNREFUSED), true},
+		{"dial failed", &net.OpError{Op: "dial", Err: errors.New("no route")}, true},
+		{"read after the ack", &net.OpError{Op: "read", Err: errors.New("reset by peer")}, false},
+		{"timeout", errors.New("stop: context deadline exceeded"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, unreachable(tt.err))
+		})
+	}
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.317
+version: 1.0.318
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.188
+version: 1.0.189
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.315
+version: 1.0.316
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
The shutdown drain skipped every adopted binary, so a daemon that survived one bad exit got adopted on the next boot and no drain ever stopped it again. It then held the ports and the datadir lock the fresh stack wants.

A drain now stops an adopted binary when two things hold. First, a run of this install started it: the PID record names it, and the process is older than that record, which a stranger that later took the same number cannot be. Second, this install holds an exclusive lock on pids/owner.lock. The kernel frees that lock when the holder dies, a crash included, so a leftover is an orphan of a dead run. A daemon the user started themselves fails both tests and survives the drain.

The wait for an adopted binary to exit now polls the PID, and a zombie reads as dead, so a graceful stop ends when the process does instead of burning the whole window.