### PR TITLE
Show verification progress on the Bitcoin Core card

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.316
+version: 1.0.317
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.316
+version: 1.0.317
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.184
+version: 0.2.185
 
 environment:
   sdk: 3.12.2

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.189
+version: 1.0.190
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/widgets/components/daemon_connection_card.dart
+++ b/sail_ui/lib/widgets/components/daemon_connection_card.dart
@@ -136,8 +136,8 @@ class DaemonConnectionCard extends StatelessWidget {
           // The row stays even with nothing to report, so a card that gains
           // sync info or a download does not grow.
           SizedBox(
-            width: 350,
-            height: progressRowHeight(context),
+            width: progressBlockWidth(downloadProgress != null ? 1 : syncRowCount(syncInfo)),
+            height: progressBlockHeight(context, downloadProgress != null ? 1 : syncRowCount(syncInfo)),
             child: downloadProgress != null
                 ? DownloadStatusRow(
                     name: connection.binary.name,
@@ -185,6 +185,12 @@ class DaemonConnectionCard extends StatelessWidget {
 /// Height of the progress bar itself.
 const double progressBarHeight = 16;
 
+/// Width of the progress bar itself.
+const double progressBarWidth = 350;
+
+/// Width the label column holds when a card draws more than one bar.
+const double syncLabelWidth = 56;
+
 /// The style the daemon status text renders in. One style measures and renders,
 /// or a block reserves a height the reader never gets.
 TextStyle daemonStatusStyle(BuildContext context) {
@@ -208,6 +214,18 @@ double daemonStatusRowHeight(BuildContext context) {
 /// Height the progress row holds whether or not a daemon reports progress. A
 /// synced daemon puts text there instead of a bar, so the row fits both.
 double progressRowHeight(BuildContext context) => math.max(progressBarHeight, daemonStatusRowHeight(context));
+
+/// Bars a daemon card draws. One is the chain tip alone.
+int syncRowCount(SyncInfo? info) => info == null ? 1 : BlockStatus.rowsFor(info).length;
+
+/// Width the progress block holds. One bar carries no label, so it keeps the
+/// bar's own width.
+double progressBlockWidth(int rows) =>
+    rows > 1 ? syncLabelWidth + SailStyleValues.padding08 + progressBarWidth : progressBarWidth;
+
+/// Height the progress block holds for [rows] stacked bars.
+double progressBlockHeight(BuildContext context, int rows) =>
+    progressRowHeight(context) * rows + SailStyleValues.padding08 * (rows - 1);
 
 /// Daemon status in a block that always holds the same height, so a card never
 /// resizes as errors come and go. A message taller than the block hides behind
@@ -420,14 +438,58 @@ Color resolveDaemonStatusColor({
   return theme.colors.orangeLight;
 }
 
+/// One sync a daemon reports, with the height it counts towards.
+class SyncRow {
+  final String label;
+  final double current;
+  final double goal;
+
+  const SyncRow(this.label, this.current, this.goal);
+}
+
 class BlockStatus extends StatelessWidget {
   final String name;
   final SyncInfo syncInfo;
 
   const BlockStatus({super.key, required this.name, required this.syncInfo});
 
+  /// Every sync the daemon reports. Bitcoin Core adds the height it verified
+  /// from genesis while it runs from a UTXO snapshot. Verification finishes at
+  /// the snapshot's base block, so that row carries its own goal.
+  static List<SyncRow> rowsFor(SyncInfo info) {
+    final rows = <SyncRow>[SyncRow('Blocks', info.progressCurrent, info.progressGoal)];
+    if (info.verifiedBlocks > 0 && info.verifiedGoal > 0) {
+      rows.add(SyncRow('Verified', info.verifiedBlocks.toDouble(), info.verifiedGoal.toDouble()));
+    }
+    return rows;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final rows = rowsFor(syncInfo);
+    if (rows.length > 1) {
+      return SailColumn(
+        spacing: SailStyleValues.padding08,
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (final row in rows)
+            SailRow(
+              spacing: SailStyleValues.padding08,
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                SizedBox(width: syncLabelWidth, child: SailText.secondary12(row.label)),
+                SizedBox(
+                  width: progressBarWidth,
+                  child: ProgressBar(current: row.current, goal: row.goal),
+                ),
+              ],
+            ),
+        ],
+      );
+    }
+
     final currentProgress = formatProgress(syncInfo.progressCurrent, false);
     final goalProgress = formatProgress(syncInfo.progressGoal, false);
 

--- a/sail_ui/lib/widgets/nav/bottom_nav.dart
+++ b/sail_ui/lib/widgets/nav/bottom_nav.dart
@@ -245,7 +245,7 @@ class BottomNav extends StatelessWidget {
                 children: [
                   if (showMainchain &&
                       (!model.mainchain.connected ||
-                          !(model.syncProvider.mainchainSyncInfo?.isSynced ?? false) ||
+                          !(model.syncProvider.mainchainSyncInfo?.allSyncsComplete ?? false) ||
                           (model.syncProvider.mainchainSyncInfo?.offNetwork ?? false) ||
                           !onlyShowAdditional))
                     DaemonConnectionCard(
@@ -267,7 +267,7 @@ class BottomNav extends StatelessWidget {
                     ),
                   if (showEnforcer &&
                       (!model.enforcer.connected ||
-                          !(model.syncProvider.enforcerSyncInfo?.isSynced ?? false) ||
+                          !(model.syncProvider.enforcerSyncInfo?.allSyncsComplete ?? false) ||
                           !onlyShowAdditional))
                     DaemonConnectionCard(
                       connection: model.enforcer,

--- a/sail_ui/test/widgets/block_status_test.dart
+++ b/sail_ui/test/widgets/block_status_test.dart
@@ -1,0 +1,124 @@
+// Behind a UTXO snapshot Core reports the tip long before it verifies the
+// blocks below it, so one bar reads 100% while the node is 61% done. The card
+// draws a bar per sync the daemon reports.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+SyncInfo info({
+  double current = 996466,
+  double goal = 996466,
+  int verified = 0,
+  int verifiedGoal = 0,
+}) => SyncInfo(
+  progressCurrent: current,
+  progressGoal: goal,
+  lastBlockAt: null,
+  verifiedBlocks: verified,
+  verifiedGoal: verifiedGoal,
+);
+
+void main() {
+  Widget wrap(Widget child) => MaterialApp(
+    home: SailTheme(
+      data: SailThemeData.lightTheme(SailColorScheme.orange, true, SailFontValues.inter),
+      child: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(width: 900, child: child),
+        ),
+      ),
+    ),
+  );
+
+  group('rowsFor', () {
+    test('a plain node reports the chain tip alone', () {
+      final rows = BlockStatus.rowsFor(info());
+
+      expect(rows.map((r) => r.label), ['Blocks']);
+      expect(rows.single.current, 996466);
+    });
+
+    test('a node behind a snapshot adds the verified height', () {
+      final rows = BlockStatus.rowsFor(info(verified: 796524, verifiedGoal: 880000));
+
+      expect(rows.map((r) => r.label), ['Blocks', 'Verified']);
+      expect(rows[1].current, 796524);
+    });
+
+    // Verification finishes at the snapshot base, not the chain tip. Against
+    // headers the bar would read 90% at the moment Core is done.
+    test('the verified row counts towards the snapshot base, not the tip', () {
+      final rows = BlockStatus.rowsFor(info(verified: 880000, verifiedGoal: 880000));
+
+      expect(rows[0].goal, 996466);
+      expect(rows[1].goal, 880000);
+      expect(rows[1].current, rows[1].goal);
+    });
+
+    test('a verified height with no goal adds no row', () {
+      expect(BlockStatus.rowsFor(info(verified: 796524)).length, 1);
+    });
+
+    test('a zero height adds no row', () {
+      expect(BlockStatus.rowsFor(info(verified: 0)).length, 1);
+    });
+  });
+
+  group('sizing', () {
+    test('one bar carries no label column', () {
+      expect(progressBlockWidth(1), progressBarWidth);
+    });
+
+    test('two bars make room for the label column', () {
+      expect(progressBlockWidth(2), syncLabelWidth + SailStyleValues.padding08 + progressBarWidth);
+    });
+
+    test('a null sync info still holds one row', () {
+      expect(syncRowCount(null), 1);
+    });
+
+    test('a snapshot node holds two rows', () {
+      expect(syncRowCount(info(verified: 796524, verifiedGoal: 880000)), 2);
+    });
+  });
+
+  testWidgets('a synced node draws its height as text, not a bar', (tester) async {
+    await tester.pumpWidget(wrap(BlockStatus(name: 'Bitcoin Core', syncInfo: info())));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(ProgressBar), findsNothing);
+    expect(find.text('Blocks'), findsNothing);
+  });
+
+  testWidgets('a node behind a snapshot draws both bars with labels', (tester) async {
+    await tester.pumpWidget(
+      wrap(BlockStatus(name: 'Bitcoin Core', syncInfo: info(verified: 796524, verifiedGoal: 880000))),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(ProgressBar), findsNWidgets(2));
+    expect(find.text('Blocks'), findsOneWidget);
+    expect(find.text('Verified'), findsOneWidget);
+  });
+
+  group('allSyncsComplete', () {
+    test('a plain node at the tip is complete', () {
+      expect(info().allSyncsComplete, isTrue);
+    });
+
+    test('a snapshot node at the tip is not complete until it verifies', () {
+      final snapshot = info(verified: 796524, verifiedGoal: 880000);
+
+      expect(snapshot.isSynced, isTrue);
+      expect(snapshot.allSyncsComplete, isFalse);
+    });
+
+    test('a snapshot node that reached the snapshot base is complete', () {
+      expect(info(verified: 880000, verifiedGoal: 880000).allSyncsComplete, isTrue);
+    });
+  });
+}

--- a/sidechain-orchestrator/api/orchestrator_handler.go
+++ b/sidechain-orchestrator/api/orchestrator_handler.go
@@ -512,6 +512,8 @@ func chainSyncToProto(s *orchestrator.ChainSyncResult) *pb.ChainSync {
 		PeerBestHeight:     int32(s.PeerBestHeight),
 		RejectedBranch:     s.RejectedBranch,
 		RefusedBranchStart: int32(s.RefusedBranchStart),
+		VerifiedBlocks:     int32(s.VerifiedBlocks),
+		VerifiedGoal:       int32(s.VerifiedGoal),
 	}
 }
 

--- a/sidechain-orchestrator/bitcoind_rpc.go
+++ b/sidechain-orchestrator/bitcoind_rpc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -84,12 +85,33 @@ func CallBitcoindRPC(ctx context.Context, url, user, password, method string, pa
 		return nil, fmt.Errorf("decode %s: %w", method, jerr)
 	}
 	if rpcResp.Error != nil {
-		return nil, fmt.Errorf("%s RPC error %d: %s", method, rpcResp.Error.Code, rpcResp.Error.Message)
+		return nil, &RPCError{Method: method, Code: rpcResp.Error.Code, Message: rpcResp.Error.Message}
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%s: HTTP %d", method, resp.StatusCode)
 	}
 	return rpcResp.Result, nil
+}
+
+// RPCMethodNotFound is the JSON-RPC code Core answers for an unknown method.
+const RPCMethodNotFound = -32601
+
+// RPCError is a JSON-RPC error reply from bitcoind, carrying Core's own code so
+// a caller can tell a missing method from a call that simply failed.
+type RPCError struct {
+	Method  string
+	Code    int
+	Message string
+}
+
+func (e *RPCError) Error() string {
+	return fmt.Sprintf("%s RPC error %d: %s", e.Method, e.Code, e.Message)
+}
+
+// CoreLacksMethod reports an RPC this Core does not implement at all.
+func CoreLacksMethod(err error) bool {
+	var rpcErr *RPCError
+	return errors.As(err, &rpcErr) && rpcErr.Code == RPCMethodNotFound
 }
 
 func acquireBitcoindRPCSlot(ctx context.Context, method string) (release func(), err error) {

--- a/sidechain-orchestrator/chainstates_test.go
+++ b/sidechain-orchestrator/chainstates_test.go
@@ -1,0 +1,166 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A node behind a UTXO snapshot reports two chainstates. getblockchaininfo
+// only ever shows the snapshot one, which reads 100% while the node still
+// verifies the blocks below the snapshot.
+const snapshotChainStates = `{
+  "headers": 996466,
+  "chainstates": [
+    {
+      "blocks": 796524,
+      "bestblockhash": "00000000000000000001d4ef8c328dd61ed6e0c49056cfb990d89e9c49bfa9b7",
+      "verificationprogress": 0.6125775303214621,
+      "validated": true
+    },
+    {
+      "blocks": 996466,
+      "bestblockhash": "0000000000000000d8faf1f614361327d1a67ad73cfeff1aac91cc5909f59514",
+      "verificationprogress": 1,
+      "snapshot_blockhash": "0000000000b360c17636b7a6c366e3effbe91a847eb5d61b7a7b29476439e924",
+      "validated": false
+    }
+  ]
+}`
+
+const plainChainStates = `{
+  "headers": 996466,
+  "chainstates": [
+    {
+      "blocks": 996466,
+      "bestblockhash": "0000000000000000d8faf1f614361327d1a67ad73cfeff1aac91cc5909f59514",
+      "verificationprogress": 1,
+      "validated": true
+    }
+  ]
+}`
+
+func TestParseChainStatesFindsTheVerifiedHeightBehindASnapshot(t *testing.T) {
+	states, err := parseChainStates([]byte(snapshotChainStates))
+	require.NoError(t, err)
+
+	assert.True(t, states.Snapshot.Present)
+	assert.Equal(t, int64(996466), states.Snapshot.Height)
+	assert.False(t, states.Snapshot.Validated)
+	assert.Equal(t, int64(796524), states.VerifiedBlocks)
+}
+
+func TestParseChainStatesReportsNoVerifiedHeightWithoutASnapshot(t *testing.T) {
+	states, err := parseChainStates([]byte(plainChainStates))
+	require.NoError(t, err)
+
+	assert.False(t, states.Snapshot.Present)
+	assert.Zero(t, states.VerifiedBlocks)
+}
+
+func TestParseChainStatesTakesTheHighestBackgroundChainstate(t *testing.T) {
+	raw := `{"chainstates":[
+	  {"blocks": 700000},
+	  {"blocks": 796524},
+	  {"blocks": 996466, "snapshot_blockhash": "aa"}
+	]}`
+	states, err := parseChainStates([]byte(raw))
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(796524), states.VerifiedBlocks)
+}
+
+func TestParseChainStatesRejectsGarbage(t *testing.T) {
+	_, err := parseChainStates([]byte("not json"))
+	assert.Error(t, err)
+}
+
+// CachedConnection holds its TTL only after a success, so an error out of this
+// probe would re-run getchainstates on every 100ms sync poll.
+func TestParseBlockHeightReadsTheHeight(t *testing.T) {
+	height, err := parseBlockHeight([]byte(`{"hash":"ab","height":880000}`))
+	require.NoError(t, err)
+	assert.Equal(t, int64(880000), height)
+}
+
+func TestParseBlockHeightRejectsGarbage(t *testing.T) {
+	_, err := parseBlockHeight([]byte("not json"))
+	assert.Error(t, err)
+}
+
+// A Core with no getchainstates answers every poll the same way, so the probe
+// caches "no snapshot" rather than re-asking at the 100ms sync cadence.
+func TestCoreLacksMethodOnlyMatchesMethodNotFound(t *testing.T) {
+	missing := &RPCError{Method: "getchainstates", Code: RPCMethodNotFound, Message: "Method not found"}
+	assert.True(t, CoreLacksMethod(fmt.Errorf("probe: %w", missing)))
+
+	busy := &RPCError{Method: "getchainstates", Code: -4, Message: "Wallet is currently rescanning"}
+	assert.False(t, CoreLacksMethod(busy))
+	assert.False(t, CoreLacksMethod(errors.New("context deadline exceeded")))
+}
+
+// A transient failure must stay an error, so CachedConnection keeps the last
+// good heights instead of blanking the Verified row.
+func TestChainStatesProbeReturnsTransientFailuresAsErrors(t *testing.T) {
+	o := &Orchestrator{log: zerolog.Nop()}
+	c := &chainStatesConnection{o: o}
+
+	states, err := c.Fetch(t.Context())
+
+	assert.Error(t, err)
+	assert.Nil(t, states)
+}
+
+// Core keeps the snapshot chainstate but drops the background one once it
+// finishes validating, so the verified height reads 0 with the goal still set.
+func TestCompleteValidatedSnapshotReadsAFinishedVerificationAsDone(t *testing.T) {
+	states := CoreChainStates{
+		Snapshot:     ActiveSnapshot{Present: true, Validated: true},
+		VerifiedGoal: 880000,
+	}
+
+	assert.Equal(t, int64(880000), completeValidatedSnapshot(states).VerifiedBlocks)
+}
+
+func TestCompleteValidatedSnapshotLeavesAnUnfinishedVerificationAlone(t *testing.T) {
+	states := CoreChainStates{
+		Snapshot:       ActiveSnapshot{Present: true, Validated: false},
+		VerifiedBlocks: 796524,
+		VerifiedGoal:   880000,
+	}
+
+	assert.Equal(t, int64(796524), completeValidatedSnapshot(states).VerifiedBlocks)
+}
+
+type stubChainStates struct {
+	states *CoreChainStates
+	err    error
+}
+
+func (s *stubChainStates) Fetch(context.Context) (*CoreChainStates, error) {
+	return s.states, s.err
+}
+
+// GetSyncStatus keeps the cached heights when a refresh fails, so the Verified
+// row survives a transient RPC timeout instead of blanking.
+func TestCachedChainStatesKeepsTheLastGoodValueOnAFailedRefresh(t *testing.T) {
+	stub := &stubChainStates{states: &CoreChainStates{VerifiedBlocks: 796524, VerifiedGoal: 880000}}
+	cache := &CachedConnection[*CoreChainStates]{inner: stub, ttl: 0}
+
+	good, err := cache.Fetch(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, int64(796524), good.VerifiedBlocks)
+
+	stub.states, stub.err = nil, errors.New("context deadline exceeded")
+	states, err := cache.Fetch(t.Context())
+
+	assert.Error(t, err)
+	require.NotNil(t, states)
+	assert.Equal(t, int64(796524), states.VerifiedBlocks)
+	assert.Equal(t, int64(880000), states.VerifiedGoal)
+}

--- a/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
+++ b/sidechain-orchestrator/gen/orchestrator/v1/orchestrator.pb.go
@@ -2808,8 +2808,15 @@ type ChainSync struct {
 	// Where the refused branch leaves this node's chain, 0 when the node
 	// refuses none. The invalid block sits at or above it. Mainchain only.
 	RefusedBranchStart int32 `protobuf:"varint,7,opt,name=refused_branch_start,json=refusedBranchStart,proto3" json:"refused_branch_start,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Height Core verified from genesis, 0 when it loaded no UTXO snapshot.
+	// Behind a snapshot, blocks reaches the tip long before this does.
+	// Mainchain only.
+	VerifiedBlocks int32 `protobuf:"varint,8,opt,name=verified_blocks,json=verifiedBlocks,proto3" json:"verified_blocks,omitempty"`
+	// Height verified_blocks counts towards: the block the snapshot commits to,
+	// not the chain tip. 0 when no snapshot is loaded. Mainchain only.
+	VerifiedGoal  int32 `protobuf:"varint,9,opt,name=verified_goal,json=verifiedGoal,proto3" json:"verified_goal,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ChainSync) Reset() {
@@ -2887,6 +2894,20 @@ func (x *ChainSync) GetRejectedBranch() bool {
 func (x *ChainSync) GetRefusedBranchStart() int32 {
 	if x != nil {
 		return x.RefusedBranchStart
+	}
+	return 0
+}
+
+func (x *ChainSync) GetVerifiedBlocks() int32 {
+	if x != nil {
+		return x.VerifiedBlocks
+	}
+	return 0
+}
+
+func (x *ChainSync) GetVerifiedGoal() int32 {
+	if x != nil {
+		return x.VerifiedGoal
 	}
 	return 0
 }
@@ -5048,7 +5069,7 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\fchain_source\x18\x06 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\vchainSourceJ\x04\b\x05\x10\x06R\x0fenforcer_wallet\"u\n" +
 	"\x0fSidechainStatus\x122\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x1e.orchestrator.v1.SidechainTypeR\x04type\x12.\n" +
-	"\x04sync\x18\x02 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\x04sync\"\xec\x01\n" +
+	"\x04sync\x18\x02 \x01(\v2\x1a.orchestrator.v1.ChainSyncR\x04sync\"\xba\x02\n" +
 	"\tChainSync\x12\x16\n" +
 	"\x06blocks\x18\x01 \x01(\x05R\x06blocks\x12\x18\n" +
 	"\aheaders\x18\x02 \x01(\x05R\aheaders\x12\x12\n" +
@@ -5056,7 +5077,9 @@ const file_orchestrator_v1_orchestrator_proto_rawDesc = "" +
 	"\x05error\x18\x04 \x01(\tR\x05error\x12(\n" +
 	"\x10peer_best_height\x18\x05 \x01(\x05R\x0epeerBestHeight\x12'\n" +
 	"\x0frejected_branch\x18\x06 \x01(\bR\x0erejectedBranch\x120\n" +
-	"\x14refused_branch_start\x18\a \x01(\x05R\x12refusedBranchStart\"\x1a\n" +
+	"\x14refused_branch_start\x18\a \x01(\x05R\x12refusedBranchStart\x12'\n" +
+	"\x0fverified_blocks\x18\b \x01(\x05R\x0everifiedBlocks\x12#\n" +
+	"\rverified_goal\x18\t \x01(\x05R\fverifiedGoal\"\x1a\n" +
 	"\x18GetDownloadStatusRequest\"Z\n" +
 	"\x19GetDownloadStatusResponse\x12=\n" +
 	"\tdownloads\x18\x01 \x03(\v2\x1f.orchestrator.v1.DownloadStatusR\tdownloads\"\x9f\x01\n" +

--- a/sidechain-orchestrator/orchestrator.go
+++ b/sidechain-orchestrator/orchestrator.go
@@ -231,6 +231,7 @@ type Orchestrator struct {
 	enforcerSync      *CachedConnection[*ChainSyncResult]
 	sidechainSyncs    map[string]*CachedConnection[*ChainSyncResult]
 	chainFork         *CachedConnection[*ChainForkState]
+	chainStates       *CachedConnection[*CoreChainStates]
 	chainSourceHeight *CachedConnection[int]
 
 	// httpClientsMu guards the lazy HTTP-client singletons used by the
@@ -2443,6 +2444,7 @@ func (o *Orchestrator) clearNetworkSwapCaches() {
 	o.enforcerSync = nil
 	o.sidechainSyncs = nil
 	o.chainFork = nil
+	o.chainStates = nil
 	o.chainSourceHeight = nil
 	o.syncConnMu.Unlock()
 
@@ -2690,6 +2692,10 @@ const chainSyncCacheTTL = 100 * time.Millisecond
 // this reads far less often than the tip itself.
 const chainForkCacheTTL = 30 * time.Second
 
+// chainStatesCacheTTL bounds the getchainstates probe. Core verifies the blocks
+// below a snapshot over hours, so a second-old number is still current.
+const chainStatesCacheTTL = 2 * time.Second
+
 // Connection is the only thing that differs between chains: a pure RPC call
 // that returns one typed value or an error. No caching, no single-flight,
 // no error preservation. Implementations wrap their wire protocol and
@@ -2910,6 +2916,38 @@ func forkStateFrom(tips []coreChainTip, peers []corePeerTip) ChainForkState {
 	}
 }
 
+// chainStatesConnection reads getchainstates. A node behind a UTXO snapshot
+// counts the tip in Blocks long before it verifies the blocks below it.
+type chainStatesConnection struct{ o *Orchestrator }
+
+// Fetch reports no snapshot on a Core that has no getchainstates at all. That
+// answer is cached; the cache holds its TTL only after a success, so returning
+// an error would re-probe an old Core on every 100ms poll. Every other failure
+// stays an error, which keeps the last-good heights instead of blanking them.
+func (c *chainStatesConnection) Fetch(ctx context.Context) (*CoreChainStates, error) {
+	states, err := c.o.chainStatesFrom(ctx)
+	if err == nil {
+		return &states, nil
+	}
+	if CoreLacksMethod(err) {
+		return &CoreChainStates{}, nil
+	}
+	return nil, err
+}
+
+// chainStatesCached returns the shared cache for the getchainstates probe.
+func (o *Orchestrator) chainStatesCached() *CachedConnection[*CoreChainStates] {
+	o.syncConnMu.Lock()
+	defer o.syncConnMu.Unlock()
+	if o.chainStates == nil {
+		o.chainStates = &CachedConnection[*CoreChainStates]{
+			inner: &chainStatesConnection{o: o},
+			ttl:   chainStatesCacheTTL,
+		}
+	}
+	return o.chainStates
+}
+
 // chainForkCached returns the shared cache for the fork probe. Two more RPCs
 // per poll would be wasteful: a refused branch stays refused.
 func (o *Orchestrator) chainForkCached() *CachedConnection[*ChainForkState] {
@@ -3066,6 +3104,12 @@ type ChainSyncResult struct {
 	// RefusedBranchStart is where the refused branch leaves this node's
 	// chain, zero when none. The invalid block sits at or above it.
 	RefusedBranchStart int64
+	// VerifiedBlocks is the height Core verified from genesis, zero when it
+	// loaded no UTXO snapshot. Mainchain only.
+	VerifiedBlocks int64
+	// VerifiedGoal is the height VerifiedBlocks counts towards: the snapshot's
+	// base block, zero when no snapshot is loaded. Mainchain only.
+	VerifiedGoal int64
 }
 
 // SyncStatus is the atomic snapshot returned by GetSyncStatus. Mainchain +
@@ -3227,7 +3271,27 @@ func (o *Orchestrator) GetSyncStatus(ctx context.Context) (*SyncStatus, error) {
 		}()
 	}
 
+	var chainStates *CoreChainStates
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		states, err := o.chainStatesCached().Fetch(ctx)
+		if err != nil {
+			o.log.Debug().Err(err).Msg("getchainstates probe failed")
+		}
+		// The cache hands back its last good states next to a transient error,
+		// so a failed refresh must not blank the verified heights.
+		if states != nil {
+			chainStates = states
+		}
+	}()
+
 	wg.Wait()
+
+	if chainStates != nil && out.Mainchain.Error == "" {
+		out.Mainchain.VerifiedBlocks = chainStates.VerifiedBlocks
+		out.Mainchain.VerifiedGoal = chainStates.VerifiedGoal
+	}
 
 	if fork != nil && out.Mainchain.Error == "" {
 		out.Mainchain.PeerBestHeight = fork.PeerBestHeight

--- a/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
+++ b/sidechain-orchestrator/proto/orchestrator/v1/orchestrator.proto
@@ -545,6 +545,13 @@ message ChainSync {
   // Where the refused branch leaves this node's chain, 0 when the node
   // refuses none. The invalid block sits at or above it. Mainchain only.
   int32 refused_branch_start = 7;
+  // Height Core verified from genesis, 0 when it loaded no UTXO snapshot.
+  // Behind a snapshot, blocks reaches the tip long before this does.
+  // Mainchain only.
+  int32 verified_blocks = 8;
+  // Height verified_blocks counts towards: the block the snapshot commits to,
+  // not the chain tip. 0 when no snapshot is loaded. Mainchain only.
+  int32 verified_goal = 9;
 }
 
 // GetDownloadStatus

--- a/sidechain-orchestrator/snapshot.go
+++ b/sidechain-orchestrator/snapshot.go
@@ -178,26 +178,90 @@ type ActiveSnapshot struct {
 	VerificationProgress float64
 }
 
+// CoreChainStates is what getchainstates reports: the snapshot chainstate Core
+// loaded, and the height it verified from genesis behind that snapshot.
+type CoreChainStates struct {
+	Snapshot ActiveSnapshot
+	// VerifiedBlocks is the tip of the background chainstate, the one Core
+	// validates from genesis. Zero when Core loaded no snapshot, because a
+	// node without one verifies every block it counts in Blocks.
+	VerifiedBlocks int64
+	// VerifiedGoal is the height the background chainstate must reach: the
+	// block the snapshot commits to, not the chain tip. Zero with no snapshot.
+	VerifiedGoal int64
+}
+
 // SnapshotStatus returns the published and currently-loaded snapshots.
 func (o *Orchestrator) SnapshotStatus(ctx context.Context) SnapshotStatus {
-	s := SnapshotStatus{Active: o.activeSnapshot(ctx)}
+	s := SnapshotStatus{}
+	if states, err := o.chainStatesFrom(ctx); err == nil {
+		s.Active = states.Snapshot
+	}
 	if a := o.publishedSnapshot(); a != nil {
 		s.Available = *a
 	}
 	return s
 }
 
-// activeSnapshot returns the assumeutxo chainstate loaded in Core.
-func (o *Orchestrator) activeSnapshot(ctx context.Context) ActiveSnapshot {
+// chainStatesFrom reads getchainstates from the running Core, then resolves the
+// snapshot's base height. Verification finishes at that base, not at the tip, so
+// a bar measured against headers never reaches 100%.
+func (o *Orchestrator) chainStatesFrom(ctx context.Context) (CoreChainStates, error) {
 	client, err := o.CoreStatusClient()
 	if err != nil {
-		return ActiveSnapshot{}
+		return CoreChainStates{}, err
 	}
 	raw, err := client.call(ctx, "getchainstates")
 	if err != nil {
-		return ActiveSnapshot{}
+		return CoreChainStates{}, err
 	}
-	var states struct {
+	states, err := parseChainStates(raw)
+	if err != nil {
+		return CoreChainStates{}, err
+	}
+	if !states.Snapshot.Present {
+		return states, nil
+	}
+
+	header, err := client.call(ctx, "getblockheader", states.Snapshot.Blockhash)
+	if err != nil {
+		return CoreChainStates{}, err
+	}
+	states.VerifiedGoal, err = parseBlockHeight(header)
+	if err != nil {
+		return CoreChainStates{}, err
+	}
+	return completeValidatedSnapshot(states), nil
+}
+
+// completeValidatedSnapshot reads a finished verification as finished. Core
+// removes the background chainstate once it validates the snapshot, so the
+// verified height drops to zero while the goal stays set — which reads as
+// "never started" instead of "done".
+func completeValidatedSnapshot(states CoreChainStates) CoreChainStates {
+	if states.Snapshot.Validated && states.VerifiedBlocks == 0 {
+		states.VerifiedBlocks = states.VerifiedGoal
+	}
+	return states
+}
+
+// parseBlockHeight reads the height out of a getblockheader reply.
+func parseBlockHeight(raw []byte) (int64, error) {
+	var header struct {
+		Height int64 `json:"height"`
+	}
+	if err := json.Unmarshal(raw, &header); err != nil {
+		return 0, fmt.Errorf("decode getblockheader: %w", err)
+	}
+	return header.Height, nil
+}
+
+// parseChainStates projects a getchainstates reply. Core reports one
+// chainstate normally and two behind an assumeutxo snapshot: the snapshot one
+// carries snapshot_blockhash and sits at the tip, and the other holds the
+// height Core verified from genesis.
+func parseChainStates(raw []byte) (CoreChainStates, error) {
+	var reply struct {
 		ChainStates []struct {
 			Blocks               int64   `json:"blocks"`
 			SnapshotBlockhash    string  `json:"snapshot_blockhash"`
@@ -205,21 +269,29 @@ func (o *Orchestrator) activeSnapshot(ctx context.Context) ActiveSnapshot {
 			VerificationProgress float64 `json:"verificationprogress"`
 		} `json:"chainstates"`
 	}
-	if err := json.Unmarshal(raw, &states); err != nil {
-		return ActiveSnapshot{}
+	if err := json.Unmarshal(raw, &reply); err != nil {
+		return CoreChainStates{}, fmt.Errorf("decode getchainstates: %w", err)
 	}
-	for _, s := range states.ChainStates {
-		if s.SnapshotBlockhash != "" {
-			return ActiveSnapshot{
-				Present:              true,
-				Blockhash:            s.SnapshotBlockhash,
-				Height:               s.Blocks,
-				Validated:            s.Validated,
-				VerificationProgress: s.VerificationProgress,
-			}
+
+	var out CoreChainStates
+	var background int64
+	for _, s := range reply.ChainStates {
+		if s.SnapshotBlockhash == "" {
+			background = max(background, s.Blocks)
+			continue
+		}
+		out.Snapshot = ActiveSnapshot{
+			Present:              true,
+			Blockhash:            s.SnapshotBlockhash,
+			Height:               s.Blocks,
+			Validated:            s.Validated,
+			VerificationProgress: s.VerificationProgress,
 		}
 	}
-	return ActiveSnapshot{}
+	if out.Snapshot.Present {
+		out.VerifiedBlocks = background
+	}
+	return out, nil
 }
 
 func catalogEntryForNetwork(cat netcatalog.Catalog, n config.Network) (netcatalog.Network, bool) {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pb.dart
@@ -3026,6 +3026,8 @@ class ChainSync extends $pb.GeneratedMessage {
     $core.int? peerBestHeight,
     $core.bool? rejectedBranch,
     $core.int? refusedBranchStart,
+    $core.int? verifiedBlocks,
+    $core.int? verifiedGoal,
   }) {
     final $result = create();
     if (blocks != null) {
@@ -3049,6 +3051,12 @@ class ChainSync extends $pb.GeneratedMessage {
     if (refusedBranchStart != null) {
       $result.refusedBranchStart = refusedBranchStart;
     }
+    if (verifiedBlocks != null) {
+      $result.verifiedBlocks = verifiedBlocks;
+    }
+    if (verifiedGoal != null) {
+      $result.verifiedGoal = verifiedGoal;
+    }
     return $result;
   }
   ChainSync._() : super();
@@ -3063,6 +3071,8 @@ class ChainSync extends $pb.GeneratedMessage {
     ..a<$core.int>(5, _omitFieldNames ? '' : 'peerBestHeight', $pb.PbFieldType.O3)
     ..aOB(6, _omitFieldNames ? '' : 'rejectedBranch')
     ..a<$core.int>(7, _omitFieldNames ? '' : 'refusedBranchStart', $pb.PbFieldType.O3)
+    ..a<$core.int>(8, _omitFieldNames ? '' : 'verifiedBlocks', $pb.PbFieldType.O3)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'verifiedGoal', $pb.PbFieldType.O3)
     ..hasRequiredFields = false
   ;
 
@@ -3161,6 +3171,29 @@ class ChainSync extends $pb.GeneratedMessage {
   $core.bool hasRefusedBranchStart() => $_has(6);
   @$pb.TagNumber(7)
   void clearRefusedBranchStart() => clearField(7);
+
+  /// Height Core verified from genesis, 0 when it loaded no UTXO snapshot.
+  /// Behind a snapshot, blocks reaches the tip long before this does.
+  /// Mainchain only.
+  @$pb.TagNumber(8)
+  $core.int get verifiedBlocks => $_getIZ(7);
+  @$pb.TagNumber(8)
+  set verifiedBlocks($core.int v) { $_setSignedInt32(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasVerifiedBlocks() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearVerifiedBlocks() => clearField(8);
+
+  /// Height verified_blocks counts towards: the block the snapshot commits to,
+  /// not the chain tip. 0 when no snapshot is loaded. Mainchain only.
+  @$pb.TagNumber(9)
+  $core.int get verifiedGoal => $_getIZ(8);
+  @$pb.TagNumber(9)
+  set verifiedGoal($core.int v) { $_setSignedInt32(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasVerifiedGoal() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearVerifiedGoal() => clearField(9);
 }
 
 class GetDownloadStatusRequest extends $pb.GeneratedMessage {

--- a/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
+++ b/sidechain_core/lib/gen/orchestrator/v1/orchestrator.pbjson.dart
@@ -771,6 +771,8 @@ const ChainSync$json = {
     {'1': 'peer_best_height', '3': 5, '4': 1, '5': 5, '10': 'peerBestHeight'},
     {'1': 'rejected_branch', '3': 6, '4': 1, '5': 8, '10': 'rejectedBranch'},
     {'1': 'refused_branch_start', '3': 7, '4': 1, '5': 5, '10': 'refusedBranchStart'},
+    {'1': 'verified_blocks', '3': 8, '4': 1, '5': 5, '10': 'verifiedBlocks'},
+    {'1': 'verified_goal', '3': 9, '4': 1, '5': 5, '10': 'verifiedGoal'},
   ],
 };
 
@@ -780,7 +782,8 @@ final $typed_data.Uint8List chainSyncDescriptor = $convert.base64Decode(
     'VhZGVycxISCgR0aW1lGAMgASgDUgR0aW1lEhQKBWVycm9yGAQgASgJUgVlcnJvchIoChBwZWVy'
     'X2Jlc3RfaGVpZ2h0GAUgASgFUg5wZWVyQmVzdEhlaWdodBInCg9yZWplY3RlZF9icmFuY2gYBi'
     'ABKAhSDnJlamVjdGVkQnJhbmNoEjAKFHJlZnVzZWRfYnJhbmNoX3N0YXJ0GAcgASgFUhJyZWZ1'
-    'c2VkQnJhbmNoU3RhcnQ=');
+    'c2VkQnJhbmNoU3RhcnQSJwoPdmVyaWZpZWRfYmxvY2tzGAggASgFUg52ZXJpZmllZEJsb2Nrcx'
+    'IjCg12ZXJpZmllZF9nb2FsGAkgASgFUgx2ZXJpZmllZEdvYWw=');
 
 @$core.Deprecated('Use getDownloadStatusRequestDescriptor instead')
 const GetDownloadStatusRequest$json = {

--- a/sidechain_core/lib/providers/sync_provider.dart
+++ b/sidechain_core/lib/providers/sync_provider.dart
@@ -29,8 +29,21 @@ class SyncInfo {
   /// none. The invalid block sits at or above it.
   final int refusedBranchStart;
 
+  /// Height Core verified from genesis, 0 when it loaded no UTXO snapshot.
+  /// Behind a snapshot, progressCurrent reaches the tip long before this does.
+  final int verifiedBlocks;
+
+  /// Height [verifiedBlocks] counts towards: the block the snapshot commits
+  /// to, not the chain tip. 0 when no snapshot is loaded.
+  final int verifiedGoal;
+
   double get progress => progressGoal == 0 ? 0 : progressCurrent / progressGoal;
   bool get isSynced => progressGoal > 0 && progressCurrent == progressGoal;
+
+  /// True when every height this daemon reports reached the goal. A snapshot
+  /// node hits the tip in blocks hours before it verifies the rest, so a card
+  /// that hides on [isSynced] hides the one bar the reader wants.
+  bool get allSyncsComplete => isSynced && (verifiedGoal == 0 || verifiedBlocks >= verifiedGoal);
 
   /// The node refuses a branch at or above its own tip while its peers run
   /// ahead. Blocks and headers both read 100% here, because the node counts
@@ -48,6 +61,8 @@ class SyncInfo {
     this.peerBestHeight = 0,
     this.rejectedBranch = false,
     this.refusedBranchStart = 0,
+    this.verifiedBlocks = 0,
+    this.verifiedGoal = 0,
   });
 
   @override
@@ -61,12 +76,22 @@ class SyncInfo {
         other.lastBlockAt == lastBlockAt &&
         other.peerBestHeight == peerBestHeight &&
         other.rejectedBranch == rejectedBranch &&
-        other.refusedBranchStart == refusedBranchStart;
+        other.refusedBranchStart == refusedBranchStart &&
+        other.verifiedBlocks == verifiedBlocks &&
+        other.verifiedGoal == verifiedGoal;
   }
 
   @override
-  int get hashCode =>
-      Object.hash(progressCurrent, progressGoal, lastBlockAt, peerBestHeight, rejectedBranch, refusedBranchStart);
+  int get hashCode => Object.hash(
+    progressCurrent,
+    progressGoal,
+    lastBlockAt,
+    peerBestHeight,
+    rejectedBranch,
+    refusedBranchStart,
+    verifiedBlocks,
+    verifiedGoal,
+  );
 }
 
 /// Represents a binary that has some sort of sync-status
@@ -426,6 +451,8 @@ class SyncProvider extends ChangeNotifier implements NetworkScoped {
       peerBestHeight: cs?.peerBestHeight ?? 0,
       rejectedBranch: cs?.rejectedBranch ?? false,
       refusedBranchStart: cs?.refusedBranchStart ?? 0,
+      verifiedBlocks: cs?.verifiedBlocks ?? 0,
+      verifiedGoal: cs?.verifiedGoal ?? 0,
     );
   }
 

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.318
+version: 1.0.319
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.189
+version: 1.0.190
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.316
+version: 1.0.317
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
A node that runs from a UTXO snapshot reports the chain tip in `getblockchaininfo` long before it verifies the blocks below the snapshot. The card read 100% while the node was 61% done, and the enforcer behind it looked stuck.

The Bitcoin Core card now draws a second bar, Verified, from the `getchainstates` chainstate that carries no `snapshot_blockhash`. A node with no snapshot loaded reports zero there and looks exactly as it does today.

`SyncInfo.allSyncsComplete` keeps the card on screen while verification lags. Gating it on `isSynced` hid the card the moment blocks reached the tip, which is when the new bar matters most.