### PR TITLE
Bump the fee of an unconfirmed transaction

### DIFF
--- a/bitwindow/lib/pages/wallet/bump_fee_choices.dart
+++ b/bitwindow/lib/pages/wallet/bump_fee_choices.dart
@@ -1,0 +1,70 @@
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+
+/// What the bump-fee dialog offers for one preview: which buttons it draws, and
+/// the line it prints under them. The buttons and the line come from one place,
+/// so the dialog can never point at an action it does not offer.
+class BumpFeeChoices {
+  /// The wallet can sign a replacement, so the dialog keeps the Replace button.
+  /// A fee rate that is too low disables it, and never removes it.
+  final bool showReplace;
+
+  /// The backend funds the higher fee from another coin, so Replace works even
+  /// with no plan on screen.
+  final bool replaceWithoutPlan;
+
+  /// The transaction has no change output, so the fee comes out of a payment
+  /// only when the user picks that output.
+  final bool showOverride;
+
+  /// A child transaction can lift this one instead.
+  final bool showAccelerate;
+
+  /// What went wrong, and what the user does next. Empty when a plan exists.
+  final String reason;
+
+  const BumpFeeChoices({
+    required this.showReplace,
+    required this.replaceWithoutPlan,
+    required this.showOverride,
+    required this.showAccelerate,
+    required this.reason,
+  });
+
+  factory BumpFeeChoices.of(wmpb.PreviewBumpFeeResponse preview, {required bool pickOutput}) {
+    final ownsAnOutput = preview.outputs.any((o) => o.isMine);
+    final hasChange = preview.outputs.any((o) => o.isChange);
+    final hasPayableOutput = preview.outputs.any((o) => o.address.isNotEmpty);
+
+    // A child already spends this transaction. A replacement must outpay that
+    // child, and a second child cannot spend an output the first one took.
+    final showAccelerate = !preview.hasChild && ownsAnOutput && (!preview.canReplace || !hasChange);
+
+    return BumpFeeChoices(
+      showReplace: preview.canReplace,
+      replaceWithoutPlan: preview.canReplace && preview.addsInputs,
+      showOverride: preview.canReplace && !hasChange && !pickOutput && hasPayableOutput,
+      showAccelerate: showAccelerate,
+      reason: _reason(preview, ownsAnOutput: ownsAnOutput, showAccelerate: showAccelerate),
+    );
+  }
+
+  static String _reason(
+    wmpb.PreviewBumpFeeResponse preview, {
+    required bool ownsAnOutput,
+    required bool showAccelerate,
+  }) {
+    if (preview.reason.isEmpty) {
+      return '';
+    }
+    if (preview.hasChild) {
+      return '${preview.reason}. Bump the fee of that transaction instead.';
+    }
+    if (showAccelerate) {
+      return '${preview.reason}. We suggest CPFP instead.';
+    }
+    if (!preview.canReplace && !ownsAnOutput) {
+      return '${preview.reason}. This wallet owns no output of it, so CPFP cannot speed it up either.';
+    }
+    return preview.reason;
+  }
+}

--- a/bitwindow/lib/pages/wallet/bump_fee_dialog.dart
+++ b/bitwindow/lib/pages/wallet/bump_fee_dialog.dart
@@ -1,0 +1,376 @@
+import 'dart:async';
+
+import 'package:bitwindow/pages/wallet/bump_fee_choices.dart';
+import 'package:bitwindow/providers/transactions_provider.dart';
+import 'package:bitwindow/utils/fee_estimation.dart';
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+
+/// Replaces an unconfirmed transaction with one that pays a higher fee. The
+/// preview comes from the backend, so the fee, the size and the output that
+/// pays are the wallet's own numbers.
+class BumpFeeDialog extends StatefulWidget {
+  final String txid;
+
+  const BumpFeeDialog({super.key, required this.txid});
+
+  @override
+  State<BumpFeeDialog> createState() => _BumpFeeDialogState();
+}
+
+class _BumpFeeDialogState extends State<BumpFeeDialog> {
+  OrchestratorWalletRPC get _wallet => GetIt.I.get<OrchestratorRPC>().wallet;
+  TransactionProvider get _transactions => GetIt.I.get<TransactionProvider>();
+  WalletReaderProvider get _walletReader => GetIt.I.get<WalletReaderProvider>();
+
+  final TextEditingController _rateController = TextEditingController();
+  Timer? _debounce;
+
+  wmpb.PreviewBumpFeeResponse? _preview;
+  int? _feeFromVout;
+  // Counts the previews asked for. A slower answer to an older question must
+  // not overwrite the newer one the user reads.
+  int _requestId = 0;
+  bool _loading = true;
+  bool _replacing = false;
+  // Set when a preview fails: the plan on screen answers an older question.
+  bool _stale = false;
+  bool _pickOutput = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_loadPreview());
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _rateController.dispose();
+    super.dispose();
+  }
+
+  int? get _rate {
+    final rate = int.tryParse(_rateController.text.trim());
+    if (rate == null || rate <= 0) {
+      return null;
+    }
+    return rate;
+  }
+
+  Future<void> _loadPreview() async {
+    final requestId = ++_requestId;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final walletId = _walletReader.activeWalletId;
+      if (walletId == null) {
+        throw Exception('No active wallet');
+      }
+      final preview = await _wallet.previewBumpFee(
+        walletId: walletId,
+        txid: widget.txid,
+        newFeeRate: _rate,
+        feeFromVout: _feeFromVout,
+      );
+      if (!mounted || requestId != _requestId) {
+        return;
+      }
+      final first = _preview == null;
+      setState(() {
+        _preview = preview;
+        _stale = false;
+        _loading = false;
+        if (first && _rateController.text.isEmpty) {
+          _rateController.text = preview.suggestedFeeRate.toString();
+        }
+      });
+    } catch (e) {
+      if (!mounted || requestId != _requestId) {
+        return;
+      }
+      setState(() {
+        _error = e.toString();
+        // The plan on screen belongs to a question this one failed to answer.
+        // It stays visible, but it cannot broadcast anything.
+        _stale = true;
+        _loading = false;
+      });
+    }
+  }
+
+  void _onRateChanged(String _) {
+    _debounce?.cancel();
+    // The plan on screen belongs to the rate before this keystroke, and so does
+    // any answer still in flight. Both go stale here, or a fast press
+    // broadcasts a fee the user never read.
+    setState(() {
+      _requestId++;
+      _loading = true;
+      _stale = false;
+      _error = null;
+    });
+    _debounce = Timer(const Duration(milliseconds: 400), () {
+      unawaited(_loadPreview());
+    });
+  }
+
+  Future<void> _selectOutput(int vout) async {
+    setState(() => _feeFromVout = vout);
+    await _loadPreview();
+  }
+
+  Future<void> _replace() async {
+    setState(() {
+      _replacing = true;
+      _error = null;
+    });
+    try {
+      final walletId = _walletReader.activeWalletId;
+      if (walletId == null) {
+        throw Exception('No active wallet');
+      }
+      final result = await _wallet.bumpFee(
+        walletId: walletId,
+        txid: widget.txid,
+        newFeeRate: _rate,
+        feeFromVout: _feeFromVout,
+      );
+      if (!mounted) {
+        GetIt.I<Logger>().i('replaced ${widget.txid} with ${result.newTxid}');
+        return;
+      }
+      showSailToast(context, 'Replaced. New txid: ${result.newTxid}', variant: SailToastVariant.success);
+      Navigator.of(context).pop();
+      // The network holds the replacement already. A refresh that fails changes
+      // nothing about that, so it never reports the send as failed.
+      unawaited(_transactions.fetch());
+    } catch (e) {
+      if (!mounted) {
+        GetIt.I<Logger>().e('failed to replace ${widget.txid}: $e');
+        return;
+      }
+      setState(() {
+        _error = e.toString();
+        _replacing = false;
+      });
+    }
+  }
+
+  Future<void> _accelerate() async {
+    Navigator.of(context).pop(BumpFeeOutcome.accelerate);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final preview = _preview;
+    final plan = preview != null && preview.hasPlan() ? preview.plan : null;
+    final choices = preview == null ? null : BumpFeeChoices.of(preview, pickOutput: _pickOutput);
+    // Core adds a coin when the change cannot pay, so it replaces the
+    // transaction even with no plan to show.
+    final hasWay = plan != null || (choices?.replaceWithoutPlan ?? false);
+    final canReplace = hasWay && !_loading && !_replacing && !_stale;
+
+    return PopScope(
+      canPop: !_replacing,
+      child: SailDialog(
+        title: 'Bump the fee',
+        maxWidth: 620,
+        maxHeight: 620,
+        error: _error,
+        actions: [
+          SailButton(
+            label: 'Cancel',
+            onPressed: () async => Navigator.of(context).pop(),
+            variant: ButtonVariant.secondary,
+            disabled: _replacing,
+          ),
+          if (choices != null && choices.showOverride)
+            SailButton(
+              label: 'I want to RBF it',
+              onPressed: () async => setState(() => _pickOutput = true),
+              variant: ButtonVariant.secondary,
+              disabled: _replacing,
+            ),
+          if (choices != null && choices.showAccelerate)
+            SailButton(
+              label: 'Accelerate (CPFP)',
+              onPressed: _accelerate,
+              variant: choices.showReplace ? ButtonVariant.secondary : ButtonVariant.primary,
+              disabled: _replacing,
+            ),
+          if (choices != null && choices.showReplace)
+            SailButton(
+              label: _replacing ? 'Replacing...' : 'Replace transaction',
+              onPressed: _replace,
+              disabled: !canReplace,
+            ),
+        ],
+        child: _loading && preview == null
+            ? const Padding(
+                padding: EdgeInsets.all(48),
+                child: Center(child: LoadingIndicator()),
+              )
+            : SailColumn(
+                spacing: SailStyleValues.padding12,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (preview != null) ..._transactionDetails(preview),
+                  if (preview != null) ..._newFee(preview),
+                ],
+              ),
+      ),
+    );
+  }
+
+  List<Widget> _transactionDetails(wmpb.PreviewBumpFeeResponse preview) {
+    final formatter = GetIt.I<FormatterProvider>();
+    return [
+      SailText.primary15('This transaction'),
+      DetailRow(label: 'Transaction ID', value: widget.txid),
+      DetailRow(label: 'Inputs', value: '${preview.inputCount} coins · ${preview.vsizeVbytes} vB'),
+      DetailRow(
+        label: 'Fee now',
+        value:
+            '${formatter.formatSats(preview.oldFeeSats.toInt())} · '
+            '${preview.oldFeeRateSatVb.toStringAsFixed(1)} ${activeTicker.feeRate}',
+      ),
+    ];
+  }
+
+  List<Widget> _newFee(wmpb.PreviewBumpFeeResponse preview) {
+    final formatter = GetIt.I<FormatterProvider>();
+    final plan = preview.hasPlan() ? preview.plan : null;
+    final theme = SailTheme.of(context);
+
+    return [
+      const SailSpacing(SailStyleValues.padding08),
+      SailText.primary15('New fee'),
+      SailRow(
+        spacing: SailStyleValues.padding08,
+        children: [
+          SizedBox(
+            width: 120,
+            child: SailTextField(
+              controller: _rateController,
+              size: TextFieldSize.small,
+              textFieldType: TextFieldType.number,
+              hintText: preview.suggestedFeeRate.toString(),
+              enabled: !_replacing,
+              onChanged: _onRateChanged,
+            ),
+          ),
+          SailText.secondary13(activeTicker.feeRate),
+          const Spacer(),
+          SailDropdownButton<int>(
+            value: null,
+            hint: 'Estimate',
+            items: [
+              SailDropdownItem(value: 1, label: 'Fast · 1 block'),
+              SailDropdownItem(value: 3, label: 'Medium · 3 blocks'),
+              SailDropdownItem(value: 6, label: 'Slow · 6 blocks'),
+            ],
+            onChanged: (confTarget) => unawaited(_applyEstimate(confTarget)),
+          ),
+        ],
+      ),
+      if (plan != null) ...[
+        DetailRow(
+          label: 'New fee',
+          value:
+              '${formatter.formatSats(plan.newFeeSats.toInt())} · '
+              '${plan.newFeeRateSatVb.toStringAsFixed(1)} ${activeTicker.feeRate}',
+        ),
+        DetailRow(label: 'You pay more', value: formatter.formatSats(plan.extraFeeSats.toInt())),
+        DetailRow(
+          label: 'Output ${plan.feeFromVout} · ${plan.reducesPayment ? 'payment' : 'change'}',
+          value: plan.outputRemoved
+              ? '${formatter.formatSats(plan.amountBeforeSats.toInt())} → goes away'
+              : '${formatter.formatSats(plan.amountBeforeSats.toInt())} → '
+                    '${formatter.formatSats(plan.amountAfterSats.toInt())}',
+        ),
+        if (plan.reducesPayment)
+          SailText.primary13(
+            'The recipient of output ${plan.feeFromVout} gets '
+            '${formatter.formatSats(plan.extraFeeSats.toInt())} less.',
+            color: theme.colors.orange,
+          ),
+      ],
+      if (preview.reason.isNotEmpty)
+        SailText.primary13(
+          BumpFeeChoices.of(preview, pickOutput: _pickOutput).reason,
+          color: theme.colors.orange,
+        ),
+      if (_pickOutput) ..._outputPicker(preview),
+    ];
+  }
+
+  List<Widget> _outputPicker(wmpb.PreviewBumpFeeResponse preview) {
+    final formatter = GetIt.I<FormatterProvider>();
+    return [
+      const SailSpacing(SailStyleValues.padding08),
+      SailText.primary15('Take the fee from'),
+      ...preview.outputs
+          .where((o) => o.address.isNotEmpty)
+          .map(
+            (output) => SailRow(
+              spacing: SailStyleValues.padding08,
+              children: [
+                SailRadioButton<int>(
+                  value: output.vout,
+                  groupValue: _feeFromVout ?? (preview.hasPlan() ? preview.plan.feeFromVout : -1),
+                  onChanged: _replacing ? null : (vout) => unawaited(_selectOutput(vout)),
+                ),
+                Expanded(
+                  child: SailText.primary13(
+                    'Output ${output.vout} · ${output.isChange ? 'change' : 'payment'} · ${output.address}',
+                  ),
+                ),
+                SailText.secondary13(formatter.formatSats(output.amountSats.toInt())),
+              ],
+            ),
+          ),
+    ];
+  }
+
+  Future<void> _applyEstimate(int? confTarget) async {
+    if (confTarget == null || _replacing) {
+      return;
+    }
+    _debounce?.cancel();
+    setState(() {
+      _requestId++;
+      _loading = true;
+      _stale = false;
+      _error = null;
+    });
+    double? rate;
+    try {
+      rate = await feeRateForTarget(confTarget);
+    } catch (e) {
+      rate = null;
+    }
+    if (!mounted) {
+      return;
+    }
+    if (rate == null) {
+      setState(() {
+        _error = 'No fee estimate for $confTarget blocks. Type a rate instead.';
+        _loading = false;
+        _stale = true;
+      });
+      return;
+    }
+    _rateController.text = rate.ceil().toString();
+    await _loadPreview();
+  }
+}
+
+/// What the user chose when the dialog cannot build a replacement.
+enum BumpFeeOutcome { accelerate }

--- a/bitwindow/lib/pages/wallet/wallet_overview.dart
+++ b/bitwindow/lib/pages/wallet/wallet_overview.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:bitwindow/pages/explorer/block_explorer_dialog.dart';
+import 'package:bitwindow/pages/wallet/bump_fee_dialog.dart';
 import 'package:bitwindow/providers/transactions_provider.dart';
 import 'package:collection/collection.dart';
 import 'package:csv/csv.dart';
@@ -131,6 +132,18 @@ class OverviewTab extends StatelessWidget {
   }
 }
 
+/// Column keys of the transaction table, in the order the table draws them.
+/// The last column holds the row actions and does not sort.
+const List<String> transactionColumns = ['date', 'txid', 'address', 'note', 'status', 'amount', ''];
+
+/// Width of the action column, so its button never widens the table.
+const double bumpFeeColumnWidth = 104;
+
+/// Only a transaction that waits for a block can carry a replacement. Whether
+/// this wallet signs its inputs comes from the backend preview, because a
+/// self-send and a consolidation both read as amount zero here.
+bool canBumpFee(WalletTransaction tx) => tx.confirmationTime.height == 0;
+
 class TransactionTable extends StatefulWidget {
   final Widget searchWidget;
   final OverviewViewModel model;
@@ -173,6 +186,10 @@ class _TransactionTableState extends State<TransactionTable> {
         case 'note':
           aValue = a.note;
           bValue = b.note;
+          break;
+        case 'status':
+          aValue = a.confirmationTime.height;
+          bValue = b.confirmationTime.height;
           break;
         case 'amount':
           // Calculate total amount for each transaction
@@ -269,13 +286,24 @@ class _TransactionTableState extends State<TransactionTable> {
                           onSort: () => onSort('note'),
                         ),
                         SailTableHeaderCell(
+                          name: 'Status',
+                          alignment: Alignment.centerLeft,
+                          onSort: () => onSort('status'),
+                        ),
+                        SailTableHeaderCell(
                           name: 'Amount',
                           alignment: Alignment.centerLeft,
                           onSort: () => onSort('amount'),
                         ),
+                        const SailTableHeaderCell(
+                          name: '',
+                          alignment: Alignment.centerRight,
+                        ),
                       ],
                       rowBuilder: (context, row, selected) {
                         final entry = entries[row];
+                        final unconfirmed = entry.confirmationTime.height == 0;
+                        final replaceable = canBumpFee(entry);
 
                         // Calculate amount and determine sign
                         final amountDiff = entry.receivedSatoshi - entry.sentSatoshi;
@@ -301,9 +329,26 @@ class _TransactionTableState extends State<TransactionTable> {
                             alignment: Alignment.centerLeft,
                           ),
                           SailTableCell(
+                            value: unconfirmed ? 'Unconfirmed' : 'Confirmed',
+                            alignment: Alignment.centerLeft,
+                            textColor: unconfirmed ? context.sailTheme.colors.orange : null,
+                          ),
+                          SailTableCell(
                             value: formattedAmount,
                             alignment: Alignment.centerLeft,
                             monospace: true,
+                          ),
+                          SailTableCell(
+                            value: replaceable ? 'Bump fee' : '',
+                            width: bumpFeeColumnWidth,
+                            alignment: Alignment.centerRight,
+                            child: replaceable
+                                ? SailButton(
+                                    label: 'Bump fee',
+                                    onPressed: () async => widget.model.openBumpFee(context, entry),
+                                    insideTable: true,
+                                  )
+                                : const SizedBox.shrink(),
                           ),
                         ];
                       },
@@ -347,13 +392,13 @@ class _TransactionTableState extends State<TransactionTable> {
                             },
                             child: SailText.primary12(entry.note.isEmpty ? 'Add Note' : 'Update Note'),
                           ),
-                          // RBF bump fee - only for unconfirmed Core wallet transactions
-                          if (isUnconfirmed && widget.model.isCoreWallet)
+                          if (canBumpFee(entry))
                             SailMenuItem(
+                              closeOnSelect: false,
                               onSelected: () async {
-                                await widget.model.bumpFee(context, entry);
+                                await widget.model.openBumpFee(context, entry);
                               },
-                              child: SailText.primary12('Bump Fee (RBF)'),
+                              child: SailText.primary12('Bump fee'),
                             ),
                           // CPFP - accelerate an unconfirmed incoming tx whose
                           // output this wallet can spend (RBF can't bump it).
@@ -371,16 +416,14 @@ class _TransactionTableState extends State<TransactionTable> {
                       rowCount: entries.length,
                       emptyPlaceholder: 'No transactions yet',
                       drawGrid: true,
-                      sortColumnIndex: [
-                        'date',
-                        'txid',
-                        'address',
-                        'note',
-                        'amount',
-                      ].indexOf(sortColumn),
+                      sortColumnIndex: transactionColumns.indexOf(sortColumn),
                       sortAscending: sortAscending,
                       onSort: (columnIndex, ascending) {
-                        onSort(['date', 'txid', 'address', 'note', 'amount'][columnIndex]);
+                        final column = transactionColumns[columnIndex];
+                        if (column.isEmpty) {
+                          return;
+                        }
+                        onSort(column);
                       },
                       onDoubleTap: (rowId) => showTransactionDetails(context, rowId),
                     ),
@@ -491,9 +534,6 @@ class OverviewViewModel extends BaseViewModel with ChangeTrackingMixin {
 
     return filteredTransactions;
   }
-
-  /// Electrum wallets cannot bump a fee, so the RBF menu item hides for them.
-  bool get isCoreWallet => !(_walletReader.activeWallet?.isElectrum ?? false);
 
   String sortColumn = 'date';
   bool sortAscending = true;
@@ -620,30 +660,15 @@ class OverviewViewModel extends BaseViewModel with ChangeTrackingMixin {
     }
   }
 
-  Future<void> bumpFee(BuildContext context, WalletTransaction tx) async {
-    final log = GetIt.I<Logger>();
-
-    try {
-      final walletId = _walletReader.activeWalletId;
-      if (walletId == null) {
-        throw Exception('No active wallet');
-      }
-
-      final result = await _orchestratorWallet.bumpFee(
-        walletId: walletId,
-        txid: tx.txid,
-      );
-
-      log.i('RBF transaction broadcast: ${result.newTxid} (replaced ${tx.txid})');
-
-      if (context.mounted) {
-        showSailToast(context, 'Fee bumped! New txid: ${result.newTxid}');
-      }
-    } catch (e) {
-      log.e('Failed to bump fee: $e');
-      if (context.mounted) {
-        showSailToast(context, 'Failed to bump fee: $e');
-      }
+  /// Opens the fee bump. A transaction with no change output has no
+  /// replacement to build, so the dialog offers CPFP and hands it back here.
+  Future<void> openBumpFee(BuildContext context, WalletTransaction tx) async {
+    final outcome = await showThemedDialog<BumpFeeOutcome>(
+      context: context,
+      builder: (context) => BumpFeeDialog(txid: tx.txid),
+    );
+    if (outcome == BumpFeeOutcome.accelerate && context.mounted) {
+      await accelerateCpfp(context, tx);
     }
   }
 

--- a/bitwindow/server/tests/mocks/mock_walletmanager.go
+++ b/bitwindow/server/tests/mocks/mock_walletmanager.go
@@ -748,6 +748,21 @@ func (mr *MockWalletManagerServiceClientMockRecorder) ParseMultisigConfig(arg0, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParseMultisigConfig", reflect.TypeOf((*MockWalletManagerServiceClient)(nil).ParseMultisigConfig), arg0, arg1)
 }
 
+// PreviewBumpFee mocks base method.
+func (m *MockWalletManagerServiceClient) PreviewBumpFee(arg0 context.Context, arg1 *connect.Request[walletmanagerv1.PreviewBumpFeeRequest]) (*connect.Response[walletmanagerv1.PreviewBumpFeeResponse], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PreviewBumpFee", arg0, arg1)
+	ret0, _ := ret[0].(*connect.Response[walletmanagerv1.PreviewBumpFeeResponse])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PreviewBumpFee indicates an expected call of PreviewBumpFee.
+func (mr *MockWalletManagerServiceClientMockRecorder) PreviewBumpFee(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreviewBumpFee", reflect.TypeOf((*MockWalletManagerServiceClient)(nil).PreviewBumpFee), arg0, arg1)
+}
+
 // PreviewWalletFromEntropy mocks base method.
 func (m *MockWalletManagerServiceClient) PreviewWalletFromEntropy(arg0 context.Context, arg1 *connect.Request[walletmanagerv1.PreviewWalletFromEntropyRequest]) (*connect.Response[walletmanagerv1.PreviewWalletFromEntropyResponse], error) {
 	m.ctrl.T.Helper()
@@ -1790,6 +1805,21 @@ func (m *MockWalletManagerServiceHandler) ParseMultisigConfig(arg0 context.Conte
 func (mr *MockWalletManagerServiceHandlerMockRecorder) ParseMultisigConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParseMultisigConfig", reflect.TypeOf((*MockWalletManagerServiceHandler)(nil).ParseMultisigConfig), arg0, arg1)
+}
+
+// PreviewBumpFee mocks base method.
+func (m *MockWalletManagerServiceHandler) PreviewBumpFee(arg0 context.Context, arg1 *connect.Request[walletmanagerv1.PreviewBumpFeeRequest]) (*connect.Response[walletmanagerv1.PreviewBumpFeeResponse], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PreviewBumpFee", arg0, arg1)
+	ret0, _ := ret[0].(*connect.Response[walletmanagerv1.PreviewBumpFeeResponse])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PreviewBumpFee indicates an expected call of PreviewBumpFee.
+func (mr *MockWalletManagerServiceHandlerMockRecorder) PreviewBumpFee(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreviewBumpFee", reflect.TypeOf((*MockWalletManagerServiceHandler)(nil).PreviewBumpFee), arg0, arg1)
 }
 
 // PreviewWalletFromEntropy mocks base method.

--- a/bitwindow/test/bump_fee_choices_test.dart
+++ b/bitwindow/test/bump_fee_choices_test.dart
@@ -1,0 +1,175 @@
+import 'package:bitwindow/pages/wallet/bump_fee_choices.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+
+wmpb.BumpFeeOutput _output({
+  required int vout,
+  String address = 'tb1qpayment',
+  bool isMine = false,
+  bool isChange = false,
+}) {
+  return wmpb.BumpFeeOutput(vout: vout, address: address, isMine: isMine, isChange: isChange);
+}
+
+wmpb.PreviewBumpFeeResponse _preview({
+  required bool canReplace,
+  bool hasChild = false,
+  bool addsInputs = false,
+  String reason = '',
+  wmpb.BumpFeePlan? plan,
+  List<wmpb.BumpFeeOutput>? outputs,
+}) {
+  return wmpb.PreviewBumpFeeResponse(
+    canReplace: canReplace,
+    hasChild: hasChild,
+    addsInputs: addsInputs,
+    reason: reason,
+    plan: plan,
+    outputs:
+        outputs ??
+        [
+          _output(vout: 0),
+          _output(vout: 1, address: 'tb1qchange', isMine: true, isChange: true),
+        ],
+  );
+}
+
+void main() {
+  group('BumpFeeChoices', () {
+    test('a plan offers Replace alone', () {
+      final choices = BumpFeeChoices.of(
+        _preview(canReplace: true, plan: wmpb.BumpFeePlan(feeFromVout: 1)),
+        pickOutput: false,
+      );
+      expect(choices.showReplace, isTrue);
+      expect(choices.showAccelerate, isFalse);
+      expect(choices.showOverride, isFalse);
+      expect(choices.reason, isEmpty);
+    });
+
+    test('a fee rate that is too low keeps Replace, and never points at CPFP', () {
+      final choices = BumpFeeChoices.of(
+        _preview(canReplace: true, reason: 'fee rate 2 sat/vB does not replace it; use 5 sat/vB or more'),
+        pickOutput: false,
+      );
+      expect(choices.showReplace, isTrue, reason: 'a typed rate must not remove the button');
+      expect(choices.showAccelerate, isFalse);
+      expect(choices.reason, isNot(contains('CPFP')));
+    });
+
+    test('no change output offers the override, and CPFP while the wallet owns an output', () {
+      final choices = BumpFeeChoices.of(
+        _preview(
+          canReplace: true,
+          reason: 'transaction has no change output',
+          outputs: [
+            _output(vout: 0),
+            _output(vout: 1, address: 'tb1qmine', isMine: true),
+          ],
+        ),
+        pickOutput: false,
+      );
+      expect(choices.showOverride, isTrue);
+      expect(choices.showAccelerate, isTrue);
+      expect(choices.reason, contains('We suggest CPFP instead'));
+    });
+
+    test('the override stays available after the picker opens, and CPFP does too', () {
+      final choices = BumpFeeChoices.of(
+        _preview(
+          canReplace: true,
+          reason: 'transaction has no change output',
+          outputs: [
+            _output(vout: 0),
+            _output(vout: 1, address: 'tb1qmine', isMine: true),
+          ],
+        ),
+        pickOutput: true,
+      );
+      expect(choices.showOverride, isFalse, reason: 'the picker is already open');
+      expect(choices.showAccelerate, isTrue, reason: 'the picker must not hide the only other action');
+    });
+
+    test('a wallet that cannot sign it offers CPFP alone', () {
+      final choices = BumpFeeChoices.of(
+        _preview(
+          canReplace: false,
+          reason: 'this wallet signs none of the inputs',
+          outputs: [_output(vout: 0, address: 'tb1qmine', isMine: true)],
+        ),
+        pickOutput: false,
+      );
+      expect(choices.showReplace, isFalse);
+      expect(choices.showOverride, isFalse);
+      expect(choices.showAccelerate, isTrue);
+      expect(choices.reason, contains('We suggest CPFP instead'));
+    });
+
+    test('a transaction the wallet owns no output of offers neither, and says so', () {
+      final choices = BumpFeeChoices.of(
+        _preview(
+          canReplace: false,
+          reason: 'this wallet signs none of the inputs',
+          outputs: [_output(vout: 0)],
+        ),
+        pickOutput: false,
+      );
+      expect(choices.showReplace, isFalse);
+      expect(choices.showAccelerate, isFalse);
+      expect(choices.reason, contains('CPFP cannot speed it up either'));
+    });
+
+    test('a transaction with a child offers neither, and points at the child', () {
+      final choices = BumpFeeChoices.of(
+        _preview(
+          canReplace: false,
+          hasChild: true,
+          reason: 'another transaction already spends this one',
+          outputs: [_output(vout: 0, address: 'tb1qmine', isMine: true)],
+        ),
+        pickOutput: false,
+      );
+      expect(choices.showReplace, isFalse);
+      expect(choices.showAccelerate, isFalse, reason: 'the child already spent that output');
+      expect(choices.reason, contains('Bump the fee of that transaction instead'));
+      expect(choices.reason, isNot(contains('We suggest CPFP')));
+    });
+
+    test('a change output too small to pay keeps Replace alive on Core', () {
+      // Core adds a coin of its own, so the user presses Replace and it works.
+      final choices = BumpFeeChoices.of(
+        _preview(
+          canReplace: true,
+          addsInputs: true,
+          reason: 'output 1 holds 850 sats, and the higher fee takes 2850 sats',
+        ),
+        pickOutput: false,
+      );
+      expect(choices.showReplace, isTrue);
+      expect(choices.replaceWithoutPlan, isTrue);
+    });
+
+    test('a backend that cannot add a coin leaves Replace disabled', () {
+      final choices = BumpFeeChoices.of(
+        _preview(canReplace: true, reason: 'output 1 holds 850 sats, and the higher fee takes 2850 sats'),
+        pickOutput: false,
+      );
+      expect(choices.showReplace, isTrue);
+      expect(choices.replaceWithoutPlan, isFalse);
+    });
+
+    test('every reason the dialog prints matches a button it draws', () {
+      for (final preview in [
+        _preview(canReplace: true, reason: 'rate too low'),
+        _preview(canReplace: false, reason: 'not ours'),
+        _preview(canReplace: false, hasChild: true, reason: 'has a child'),
+        _preview(canReplace: false, reason: 'not ours', outputs: [_output(vout: 0)]),
+      ]) {
+        final choices = BumpFeeChoices.of(preview, pickOutput: false);
+        if (choices.reason.contains('We suggest CPFP')) {
+          expect(choices.showAccelerate, isTrue, reason: 'the text names a button the dialog hides');
+        }
+      }
+    });
+  });
+}

--- a/bitwindow/test/bump_fee_test.dart
+++ b/bitwindow/test/bump_fee_test.dart
@@ -1,0 +1,47 @@
+import 'package:bitwindow/pages/wallet/wallet_overview.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart';
+
+WalletTransaction _tx({required int height, required int sent, required int received}) {
+  return WalletTransaction(
+    txid: 'abc',
+    sentSatoshi: Int64(sent),
+    receivedSatoshi: Int64(received),
+    confirmationTime: Confirmation(height: height),
+  );
+}
+
+void main() {
+  group('canBumpFee', () {
+    test('a transaction the wallet sent, with no block yet, can be replaced', () {
+      expect(canBumpFee(_tx(height: 0, sent: 100000, received: 0)), isTrue);
+    });
+
+    test('a confirmed transaction cannot be replaced', () {
+      expect(canBumpFee(_tx(height: 3, sent: 100000, received: 0)), isFalse);
+    });
+
+    test('a consolidation reads as amount zero, and still offers the bump', () {
+      // Electrum reports a self-send with no payment row, so both amounts are
+      // zero. The wallet still signs every input of it.
+      expect(canBumpFee(_tx(height: 0, sent: 0, received: 0)), isTrue);
+    });
+
+    test('an incoming payment offers the bump, and the preview says it cannot replace it', () {
+      expect(canBumpFee(_tx(height: 0, sent: 0, received: 100000)), isTrue);
+    });
+  });
+
+  group('transactionColumns', () {
+    test('holds one key per column, and the action column sorts nothing', () {
+      expect(transactionColumns, ['date', 'txid', 'address', 'note', 'status', 'amount', '']);
+      expect(transactionColumns.last, isEmpty);
+    });
+
+    test('every sortable key is unique', () {
+      final sortable = transactionColumns.where((c) => c.isNotEmpty).toList();
+      expect(sortable.toSet().length, sortable.length);
+    });
+  });
+}

--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -1347,14 +1347,88 @@ func (h *WalletHandler) BumpFee(ctx context.Context, req *connect.Request[pb.Bum
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	newTxID, err := h.engine.Backend().BumpFee(ctx, walletID, req.Msg.Txid, req.Msg.NewFeeRate)
+	result, err := h.engine.Backend().BumpFee(ctx, walletID, wallet.BumpFeeRequest{
+		TxID:        req.Msg.Txid,
+		NewFeeRate:  req.Msg.NewFeeRate,
+		FeeFromVout: voutPointer(req.Msg.FeeFromVout),
+	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, rpcError(err)
 	}
 
 	return connect.NewResponse(&pb.BumpFeeResponse{
-		NewTxid: newTxID,
+		NewTxid: result.NewTxID,
+		Plan:    bumpFeePlanToProto(result.Plan),
 	}), nil
+}
+
+func (h *WalletHandler) PreviewBumpFee(ctx context.Context, req *connect.Request[pb.PreviewBumpFeeRequest]) (*connect.Response[pb.PreviewBumpFeeResponse], error) {
+	if err := h.requireEngine(); err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+
+	walletID, err := h.engine.ResolveWalletID(req.Msg.WalletId)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	preview, err := h.engine.Backend().PreviewBumpFee(ctx, walletID, wallet.BumpFeeRequest{
+		TxID:        req.Msg.Txid,
+		NewFeeRate:  req.Msg.NewFeeRate,
+		FeeFromVout: voutPointer(req.Msg.FeeFromVout),
+	})
+	if err != nil {
+		return nil, rpcError(err)
+	}
+
+	resp := &pb.PreviewBumpFeeResponse{
+		InputCount:       int32(preview.InputCount),
+		VsizeVbytes:      preview.VsizeVBytes,
+		OldFeeSats:       preview.OldFeeSats,
+		OldFeeRateSatVb:  preview.OldFeeRate,
+		SuggestedFeeRate: preview.SuggestedRate,
+		Reason:           preview.Reason,
+		CanReplace:       preview.CanReplace,
+		HasChild:         preview.HasChild,
+		AddsInputs:       preview.AddsInputs,
+		Outputs: lo.Map(preview.Outputs, func(o wallet.BumpFeeOutput, _ int) *pb.BumpFeeOutput {
+			return &pb.BumpFeeOutput{
+				Vout:       int32(o.Vout),
+				AmountSats: o.AmountSats,
+				Address:    o.Address,
+				IsChange:   o.IsChange,
+				DustSats:   o.DustSats,
+				IsMine:     o.IsMine,
+			}
+		}),
+	}
+	if preview.Plan != nil {
+		resp.Plan = bumpFeePlanToProto(*preview.Plan)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// voutPointer maps the request's optional output index onto the backend's.
+func voutPointer(vout *int32) *int {
+	if vout == nil {
+		return nil
+	}
+	v := int(*vout)
+	return &v
+}
+
+func bumpFeePlanToProto(plan wallet.BumpFeePlan) *pb.BumpFeePlan {
+	return &pb.BumpFeePlan{
+		OldFeeSats:       plan.OldFeeSats,
+		NewFeeSats:       plan.NewFeeSats,
+		ExtraFeeSats:     plan.ExtraFeeSats,
+		NewFeeRateSatVb:  plan.NewFeeRate,
+		FeeFromVout:      int32(plan.FeeFromVout),
+		AmountBeforeSats: plan.AmountBefore,
+		AmountAfterSats:  plan.AmountAfter,
+		OutputRemoved:    plan.OutputRemoved,
+		ReducesPayment:   plan.ReducesPayment,
+	}
 }
 
 func (h *WalletHandler) CreateCpfp(ctx context.Context, req *connect.Request[pb.CreateCpfpRequest]) (*connect.Response[pb.CreateCpfpResponse], error) {

--- a/sidechain-orchestrator/api/wallet_handler_routing_test.go
+++ b/sidechain-orchestrator/api/wallet_handler_routing_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"google.golang.org/protobuf/proto"
+
 	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/walletmanager/v1"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
 )
@@ -21,6 +23,9 @@ type recordingProvider struct {
 	lastSendWallet string
 	lastSend       wallet.SendRequest
 	sendErr        error
+	lastBumpWallet string
+	lastBump       wallet.BumpFeeRequest
+	bumpErr        error
 }
 
 func (f *recordingProvider) Send(ctx context.Context, walletID string, req wallet.SendRequest) (string, error) {
@@ -143,4 +148,110 @@ func TestGetBalanceEmptyWalletIDResolvesActive(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, float64(150_000_000), resp.Msg.ConfirmedSats)
 	_ = coreID
+}
+
+func (f *recordingProvider) BumpFee(ctx context.Context, walletID string, req wallet.BumpFeeRequest) (*wallet.BumpFeeResult, error) {
+	f.lastBumpWallet = walletID
+	f.lastBump = req
+	if f.bumpErr != nil {
+		return nil, f.bumpErr
+	}
+	return &wallet.BumpFeeResult{
+		NewTxID: "replacement-txid",
+		Plan: wallet.BumpFeePlan{
+			OldFeeSats: 150, NewFeeSats: 1500, ExtraFeeSats: 1350, NewFeeRate: 10,
+			FeeFromVout: 1, AmountBefore: 99_850, AmountAfter: 98_500,
+			OutputRemoved: false, ReducesPayment: true,
+		},
+	}, nil
+}
+
+func (f *recordingProvider) PreviewBumpFee(ctx context.Context, walletID string, req wallet.BumpFeeRequest) (*wallet.BumpFeePreview, error) {
+	f.lastBumpWallet = walletID
+	f.lastBump = req
+	return &wallet.BumpFeePreview{
+		InputCount: 2, VsizeVBytes: 151, OldFeeSats: 151, OldFeeRate: 1, SuggestedRate: 10,
+		CanReplace: true, HasChild: true, Reason: "another transaction already spends this one",
+		Outputs: []wallet.BumpFeeOutput{
+			{Vout: 0, AmountSats: 100_000, Address: "tb1qpayment", DustSats: 294, VsizeBytes: 31},
+			{Vout: 1, AmountSats: 99_849, Address: "tb1qchange", IsChange: true, IsMine: true, DustSats: 294, VsizeBytes: 31},
+		},
+	}, nil
+}
+
+// Output 0 is a real choice. It must not arrive at the backend as "take it from
+// the change output", which would replace the transaction the user never asked
+// for.
+func TestBumpFeeCarriesOutputZero(t *testing.T) {
+	h, elecFake, _, elecID, _ := newRoutedHandler(t)
+
+	_, err := h.BumpFee(context.Background(), connect.NewRequest(&pb.BumpFeeRequest{
+		WalletId: elecID, Txid: "abc", NewFeeRate: 10, FeeFromVout: proto.Int32(0),
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, elecFake.lastBump.FeeFromVout)
+	assert.Equal(t, 0, *elecFake.lastBump.FeeFromVout)
+
+	_, err = h.BumpFee(context.Background(), connect.NewRequest(&pb.BumpFeeRequest{
+		WalletId: elecID, Txid: "abc", NewFeeRate: 10,
+	}))
+	require.NoError(t, err)
+	assert.Nil(t, elecFake.lastBump.FeeFromVout, "an unset output means the change output")
+}
+
+func TestBumpFeeReportsThePlan(t *testing.T) {
+	h, _, _, elecID, _ := newRoutedHandler(t)
+
+	resp, err := h.BumpFee(context.Background(), connect.NewRequest(&pb.BumpFeeRequest{
+		WalletId: elecID, Txid: "abc", NewFeeRate: 10,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, "replacement-txid", resp.Msg.NewTxid)
+	require.NotNil(t, resp.Msg.Plan)
+	assert.Equal(t, int64(150), resp.Msg.Plan.OldFeeSats)
+	assert.Equal(t, int64(1500), resp.Msg.Plan.NewFeeSats)
+	assert.Equal(t, int64(1350), resp.Msg.Plan.ExtraFeeSats)
+	assert.InDelta(t, 10.0, resp.Msg.Plan.NewFeeRateSatVb, 0.001)
+	assert.Equal(t, int32(1), resp.Msg.Plan.FeeFromVout)
+	assert.Equal(t, int64(99_850), resp.Msg.Plan.AmountBeforeSats)
+	assert.Equal(t, int64(98_500), resp.Msg.Plan.AmountAfterSats)
+	assert.False(t, resp.Msg.Plan.OutputRemoved)
+	assert.True(t, resp.Msg.Plan.ReducesPayment)
+}
+
+func TestPreviewBumpFeeReportsEveryField(t *testing.T) {
+	h, _, _, elecID, _ := newRoutedHandler(t)
+
+	resp, err := h.PreviewBumpFee(context.Background(), connect.NewRequest(&pb.PreviewBumpFeeRequest{
+		WalletId: elecID, Txid: "abc",
+	}))
+	require.NoError(t, err)
+	msg := resp.Msg
+	assert.Equal(t, int32(2), msg.InputCount)
+	assert.Equal(t, int64(151), msg.VsizeVbytes)
+	assert.Equal(t, int64(151), msg.OldFeeSats)
+	assert.Equal(t, int64(10), msg.SuggestedFeeRate)
+	assert.True(t, msg.CanReplace)
+	assert.True(t, msg.HasChild)
+	assert.Contains(t, msg.Reason, "already spends this one")
+	assert.Nil(t, msg.Plan)
+	require.Len(t, msg.Outputs, 2)
+	assert.Equal(t, int32(1), msg.Outputs[1].Vout)
+	assert.Equal(t, "tb1qchange", msg.Outputs[1].Address)
+	assert.True(t, msg.Outputs[1].IsChange)
+	assert.True(t, msg.Outputs[1].IsMine)
+	assert.Equal(t, int64(294), msg.Outputs[1].DustSats)
+	assert.False(t, msg.Outputs[0].IsMine)
+}
+
+func TestBumpFeeKeepsTheBackendErrorCode(t *testing.T) {
+	h, elecFake, _, elecID, _ := newRoutedHandler(t)
+	elecFake.bumpErr = connect.NewError(connect.CodeFailedPrecondition, errors.New("transaction is confirmed"))
+
+	_, err := h.BumpFee(context.Background(), connect.NewRequest(&pb.BumpFeeRequest{
+		WalletId: elecID, Txid: "abc",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err),
+		"the dialog shows a reason, not an internal error")
 }

--- a/sidechain-orchestrator/commands/wallet.go
+++ b/sidechain-orchestrator/commands/wallet.go
@@ -901,10 +901,12 @@ var walletBumpFeeCommand = &cli.Command{
 	ArgsUsage: "[wallet-id] <txid>",
 	Flags: []cli.Flag{
 		&cli.Int64Flag{Name: "fee-rate", Usage: "new fee rate in sat/vB (0 = automatic)"},
+		&cli.IntFlag{Name: "from-output", Usage: "output that pays the higher fee (default: the change output)", Value: -1},
+		&cli.BoolFlag{Name: "preview", Usage: "report what the bump costs, and broadcast nothing"},
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() == 0 {
-			return fmt.Errorf("usage: drivechain-cli wallet bump-fee [wallet-id] <txid> [--fee-rate N]")
+			return fmt.Errorf("usage: drivechain-cli wallet bump-fee [wallet-id] <txid> [--fee-rate N] [--from-output N] [--preview]")
 		}
 		client := newWalletClient(cctx)
 		var walletID, txid string
@@ -921,17 +923,70 @@ var walletBumpFeeCommand = &cli.Command{
 			txid = cctx.Args().Get(1)
 		}
 
+		var feeFromVout *int32
+		if v := cctx.Int("from-output"); v >= 0 {
+			vout := int32(v)
+			feeFromVout = &vout
+		}
+
+		if cctx.Bool("preview") {
+			resp, err := client.PreviewBumpFee(cctx.Context, connect.NewRequest(&pb.PreviewBumpFeeRequest{
+				WalletId:    walletID,
+				Txid:        txid,
+				NewFeeRate:  cctx.Int64("fee-rate"),
+				FeeFromVout: feeFromVout,
+			}))
+			if err != nil {
+				return err
+			}
+			msg := resp.Msg
+			fmt.Printf("inputs: %d, size: %d vB\n", msg.InputCount, msg.VsizeVbytes)
+			fmt.Printf("fee now: %d sats (%.2f sat/vB), suggested rate: %d sat/vB\n",
+				msg.OldFeeSats, msg.OldFeeRateSatVb, msg.SuggestedFeeRate)
+			for _, out := range msg.Outputs {
+				kind := "payment"
+				if out.IsChange {
+					kind = "change"
+				}
+				fmt.Printf("  output %d: %d sats %s %s\n", out.Vout, out.AmountSats, kind, out.Address)
+			}
+			if msg.Plan == nil {
+				fmt.Printf("no replacement: %s\n", msg.Reason)
+				return nil
+			}
+			printBumpFeePlan(msg.Plan)
+			return nil
+		}
+
 		resp, err := client.BumpFee(cctx.Context, connect.NewRequest(&pb.BumpFeeRequest{
-			WalletId:   walletID,
-			Txid:       txid,
-			NewFeeRate: cctx.Int64("fee-rate"),
+			WalletId:    walletID,
+			Txid:        txid,
+			NewFeeRate:  cctx.Int64("fee-rate"),
+			FeeFromVout: feeFromVout,
 		}))
 		if err != nil {
 			return err
 		}
 		fmt.Printf("replaced txid: %s\n", resp.Msg.NewTxid)
+		printBumpFeePlan(resp.Msg.Plan)
 		return nil
 	},
+}
+
+func printBumpFeePlan(plan *pb.BumpFeePlan) {
+	if plan == nil {
+		return
+	}
+	fmt.Printf("fee: %d -> %d sats (%.2f sat/vB), %d sats more\n",
+		plan.OldFeeSats, plan.NewFeeSats, plan.NewFeeRateSatVb, plan.ExtraFeeSats)
+	if plan.OutputRemoved {
+		fmt.Printf("output %d goes away, its %d sats join the fee\n", plan.FeeFromVout, plan.AmountBeforeSats)
+		return
+	}
+	fmt.Printf("output %d: %d -> %d sats\n", plan.FeeFromVout, plan.AmountBeforeSats, plan.AmountAfterSats)
+	if plan.ReducesPayment {
+		fmt.Println("the recipient of that output gets less")
+	}
 }
 
 var walletDeriveCommand = &cli.Command{

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanager.pb.go
@@ -7958,10 +7958,13 @@ func (x *DecodeTransactionResponse) GetRaw() string {
 }
 
 type BumpFeeRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	WalletId      string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
-	Txid          string                 `protobuf:"bytes,2,opt,name=txid,proto3" json:"txid,omitempty"`
-	NewFeeRate    int64                  `protobuf:"varint,3,opt,name=new_fee_rate,json=newFeeRate,proto3" json:"new_fee_rate,omitempty"` // sat/vB, 0 = automatic
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	WalletId   string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	Txid       string                 `protobuf:"bytes,2,opt,name=txid,proto3" json:"txid,omitempty"`
+	NewFeeRate int64                  `protobuf:"varint,3,opt,name=new_fee_rate,json=newFeeRate,proto3" json:"new_fee_rate,omitempty"` // sat/vB, 0 = automatic
+	// Output that pays the higher fee. Unset takes it from the change output,
+	// which is the only output a bump may touch without the user's consent.
+	FeeFromVout   *int32 `protobuf:"varint,4,opt,name=fee_from_vout,json=feeFromVout,proto3,oneof" json:"fee_from_vout,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -8017,9 +8020,17 @@ func (x *BumpFeeRequest) GetNewFeeRate() int64 {
 	return 0
 }
 
+func (x *BumpFeeRequest) GetFeeFromVout() int32 {
+	if x != nil && x.FeeFromVout != nil {
+		return *x.FeeFromVout
+	}
+	return 0
+}
+
 type BumpFeeResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	NewTxid       string                 `protobuf:"bytes,1,opt,name=new_txid,json=newTxid,proto3" json:"new_txid,omitempty"`
+	Plan          *BumpFeePlan           `protobuf:"bytes,2,opt,name=plan,proto3" json:"plan,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -8061,6 +8072,417 @@ func (x *BumpFeeResponse) GetNewTxid() string {
 	return ""
 }
 
+func (x *BumpFeeResponse) GetPlan() *BumpFeePlan {
+	if x != nil {
+		return x.Plan
+	}
+	return nil
+}
+
+type PreviewBumpFeeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	WalletId      string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
+	Txid          string                 `protobuf:"bytes,2,opt,name=txid,proto3" json:"txid,omitempty"`
+	NewFeeRate    int64                  `protobuf:"varint,3,opt,name=new_fee_rate,json=newFeeRate,proto3" json:"new_fee_rate,omitempty"` // sat/vB, 0 = the backend's own estimate
+	FeeFromVout   *int32                 `protobuf:"varint,4,opt,name=fee_from_vout,json=feeFromVout,proto3,oneof" json:"fee_from_vout,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PreviewBumpFeeRequest) Reset() {
+	*x = PreviewBumpFeeRequest{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[132]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PreviewBumpFeeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PreviewBumpFeeRequest) ProtoMessage() {}
+
+func (x *PreviewBumpFeeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[132]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PreviewBumpFeeRequest.ProtoReflect.Descriptor instead.
+func (*PreviewBumpFeeRequest) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{132}
+}
+
+func (x *PreviewBumpFeeRequest) GetWalletId() string {
+	if x != nil {
+		return x.WalletId
+	}
+	return ""
+}
+
+func (x *PreviewBumpFeeRequest) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+func (x *PreviewBumpFeeRequest) GetNewFeeRate() int64 {
+	if x != nil {
+		return x.NewFeeRate
+	}
+	return 0
+}
+
+func (x *PreviewBumpFeeRequest) GetFeeFromVout() int32 {
+	if x != nil && x.FeeFromVout != nil {
+		return *x.FeeFromVout
+	}
+	return 0
+}
+
+type PreviewBumpFeeResponse struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	InputCount      int32                  `protobuf:"varint,1,opt,name=input_count,json=inputCount,proto3" json:"input_count,omitempty"`
+	VsizeVbytes     int64                  `protobuf:"varint,2,opt,name=vsize_vbytes,json=vsizeVbytes,proto3" json:"vsize_vbytes,omitempty"`
+	OldFeeSats      int64                  `protobuf:"varint,3,opt,name=old_fee_sats,json=oldFeeSats,proto3" json:"old_fee_sats,omitempty"`
+	OldFeeRateSatVb float64                `protobuf:"fixed64,4,opt,name=old_fee_rate_sat_vb,json=oldFeeRateSatVb,proto3" json:"old_fee_rate_sat_vb,omitempty"`
+	// Fee rate the backend suggests for the next blocks, in sat/vB.
+	SuggestedFeeRate int64 `protobuf:"varint,5,opt,name=suggested_fee_rate,json=suggestedFeeRate,proto3" json:"suggested_fee_rate,omitempty"`
+	// Every output of the transaction, in order.
+	Outputs []*BumpFeeOutput `protobuf:"bytes,6,rep,name=outputs,proto3" json:"outputs,omitempty"`
+	// The replacement. Unset when the wallet cannot build one.
+	Plan *BumpFeePlan `protobuf:"bytes,7,opt,name=plan,proto3" json:"plan,omitempty"`
+	// Why the wallet cannot build a replacement. Empty when plan is set.
+	Reason string `protobuf:"bytes,8,opt,name=reason,proto3" json:"reason,omitempty"`
+	// The wallet holds the keys of every input, so it can sign a replacement at
+	// some fee rate. False marks a transaction no rate can replace.
+	CanReplace bool `protobuf:"varint,9,opt,name=can_replace,json=canReplace,proto3" json:"can_replace,omitempty"`
+	// Another transaction already spends this one. A replacement must outpay that
+	// child too, and a child transaction cannot speed this one up either.
+	HasChild bool `protobuf:"varint,10,opt,name=has_child,json=hasChild,proto3" json:"has_child,omitempty"`
+	// The backend funds a higher fee from another coin when the chosen output
+	// cannot cover it, so a replacement holds even with no plan to show.
+	AddsInputs    bool `protobuf:"varint,11,opt,name=adds_inputs,json=addsInputs,proto3" json:"adds_inputs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PreviewBumpFeeResponse) Reset() {
+	*x = PreviewBumpFeeResponse{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[133]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PreviewBumpFeeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PreviewBumpFeeResponse) ProtoMessage() {}
+
+func (x *PreviewBumpFeeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[133]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PreviewBumpFeeResponse.ProtoReflect.Descriptor instead.
+func (*PreviewBumpFeeResponse) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{133}
+}
+
+func (x *PreviewBumpFeeResponse) GetInputCount() int32 {
+	if x != nil {
+		return x.InputCount
+	}
+	return 0
+}
+
+func (x *PreviewBumpFeeResponse) GetVsizeVbytes() int64 {
+	if x != nil {
+		return x.VsizeVbytes
+	}
+	return 0
+}
+
+func (x *PreviewBumpFeeResponse) GetOldFeeSats() int64 {
+	if x != nil {
+		return x.OldFeeSats
+	}
+	return 0
+}
+
+func (x *PreviewBumpFeeResponse) GetOldFeeRateSatVb() float64 {
+	if x != nil {
+		return x.OldFeeRateSatVb
+	}
+	return 0
+}
+
+func (x *PreviewBumpFeeResponse) GetSuggestedFeeRate() int64 {
+	if x != nil {
+		return x.SuggestedFeeRate
+	}
+	return 0
+}
+
+func (x *PreviewBumpFeeResponse) GetOutputs() []*BumpFeeOutput {
+	if x != nil {
+		return x.Outputs
+	}
+	return nil
+}
+
+func (x *PreviewBumpFeeResponse) GetPlan() *BumpFeePlan {
+	if x != nil {
+		return x.Plan
+	}
+	return nil
+}
+
+func (x *PreviewBumpFeeResponse) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+func (x *PreviewBumpFeeResponse) GetCanReplace() bool {
+	if x != nil {
+		return x.CanReplace
+	}
+	return false
+}
+
+func (x *PreviewBumpFeeResponse) GetHasChild() bool {
+	if x != nil {
+		return x.HasChild
+	}
+	return false
+}
+
+func (x *PreviewBumpFeeResponse) GetAddsInputs() bool {
+	if x != nil {
+		return x.AddsInputs
+	}
+	return false
+}
+
+// BumpFeeOutput is one output of the transaction the fee can come from.
+type BumpFeeOutput struct {
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Vout       int32                  `protobuf:"varint,1,opt,name=vout,proto3" json:"vout,omitempty"`
+	AmountSats int64                  `protobuf:"varint,2,opt,name=amount_sats,json=amountSats,proto3" json:"amount_sats,omitempty"`
+	Address    string                 `protobuf:"bytes,3,opt,name=address,proto3" json:"address,omitempty"`
+	// The wallet owns this output and it sits on the change chain.
+	IsChange bool `protobuf:"varint,4,opt,name=is_change,json=isChange,proto3" json:"is_change,omitempty"`
+	// Amount below which the output cannot stay in the transaction.
+	DustSats int64 `protobuf:"varint,5,opt,name=dust_sats,json=dustSats,proto3" json:"dust_sats,omitempty"`
+	// The wallet owns this output. CPFP spends such an output, so a transaction
+	// with none of them has no child to speed it up.
+	IsMine        bool `protobuf:"varint,6,opt,name=is_mine,json=isMine,proto3" json:"is_mine,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BumpFeeOutput) Reset() {
+	*x = BumpFeeOutput{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[134]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BumpFeeOutput) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BumpFeeOutput) ProtoMessage() {}
+
+func (x *BumpFeeOutput) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[134]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BumpFeeOutput.ProtoReflect.Descriptor instead.
+func (*BumpFeeOutput) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{134}
+}
+
+func (x *BumpFeeOutput) GetVout() int32 {
+	if x != nil {
+		return x.Vout
+	}
+	return 0
+}
+
+func (x *BumpFeeOutput) GetAmountSats() int64 {
+	if x != nil {
+		return x.AmountSats
+	}
+	return 0
+}
+
+func (x *BumpFeeOutput) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *BumpFeeOutput) GetIsChange() bool {
+	if x != nil {
+		return x.IsChange
+	}
+	return false
+}
+
+func (x *BumpFeeOutput) GetDustSats() int64 {
+	if x != nil {
+		return x.DustSats
+	}
+	return 0
+}
+
+func (x *BumpFeeOutput) GetIsMine() bool {
+	if x != nil {
+		return x.IsMine
+	}
+	return false
+}
+
+// BumpFeePlan is the replacement transaction a fee bump builds.
+type BumpFeePlan struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	OldFeeSats      int64                  `protobuf:"varint,1,opt,name=old_fee_sats,json=oldFeeSats,proto3" json:"old_fee_sats,omitempty"`
+	NewFeeSats      int64                  `protobuf:"varint,2,opt,name=new_fee_sats,json=newFeeSats,proto3" json:"new_fee_sats,omitempty"`
+	ExtraFeeSats    int64                  `protobuf:"varint,3,opt,name=extra_fee_sats,json=extraFeeSats,proto3" json:"extra_fee_sats,omitempty"`
+	NewFeeRateSatVb float64                `protobuf:"fixed64,4,opt,name=new_fee_rate_sat_vb,json=newFeeRateSatVb,proto3" json:"new_fee_rate_sat_vb,omitempty"`
+	// Output that pays, and what it holds before and after.
+	FeeFromVout      int32 `protobuf:"varint,5,opt,name=fee_from_vout,json=feeFromVout,proto3" json:"fee_from_vout,omitempty"`
+	AmountBeforeSats int64 `protobuf:"varint,6,opt,name=amount_before_sats,json=amountBeforeSats,proto3" json:"amount_before_sats,omitempty"`
+	AmountAfterSats  int64 `protobuf:"varint,7,opt,name=amount_after_sats,json=amountAfterSats,proto3" json:"amount_after_sats,omitempty"`
+	// The output falls under the dust limit, so it goes away and its remainder
+	// joins the fee.
+	OutputRemoved bool `protobuf:"varint,8,opt,name=output_removed,json=outputRemoved,proto3" json:"output_removed,omitempty"`
+	// The output belongs to the recipient, not to the wallet.
+	ReducesPayment bool `protobuf:"varint,9,opt,name=reduces_payment,json=reducesPayment,proto3" json:"reduces_payment,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *BumpFeePlan) Reset() {
+	*x = BumpFeePlan{}
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[135]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BumpFeePlan) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BumpFeePlan) ProtoMessage() {}
+
+func (x *BumpFeePlan) ProtoReflect() protoreflect.Message {
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[135]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BumpFeePlan.ProtoReflect.Descriptor instead.
+func (*BumpFeePlan) Descriptor() ([]byte, []int) {
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{135}
+}
+
+func (x *BumpFeePlan) GetOldFeeSats() int64 {
+	if x != nil {
+		return x.OldFeeSats
+	}
+	return 0
+}
+
+func (x *BumpFeePlan) GetNewFeeSats() int64 {
+	if x != nil {
+		return x.NewFeeSats
+	}
+	return 0
+}
+
+func (x *BumpFeePlan) GetExtraFeeSats() int64 {
+	if x != nil {
+		return x.ExtraFeeSats
+	}
+	return 0
+}
+
+func (x *BumpFeePlan) GetNewFeeRateSatVb() float64 {
+	if x != nil {
+		return x.NewFeeRateSatVb
+	}
+	return 0
+}
+
+func (x *BumpFeePlan) GetFeeFromVout() int32 {
+	if x != nil {
+		return x.FeeFromVout
+	}
+	return 0
+}
+
+func (x *BumpFeePlan) GetAmountBeforeSats() int64 {
+	if x != nil {
+		return x.AmountBeforeSats
+	}
+	return 0
+}
+
+func (x *BumpFeePlan) GetAmountAfterSats() int64 {
+	if x != nil {
+		return x.AmountAfterSats
+	}
+	return 0
+}
+
+func (x *BumpFeePlan) GetOutputRemoved() bool {
+	if x != nil {
+		return x.OutputRemoved
+	}
+	return false
+}
+
+func (x *BumpFeePlan) GetReducesPayment() bool {
+	if x != nil {
+		return x.ReducesPayment
+	}
+	return false
+}
+
 type CreateCpfpRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	WalletId      string                 `protobuf:"bytes,1,opt,name=wallet_id,json=walletId,proto3" json:"wallet_id,omitempty"`
@@ -8073,7 +8495,7 @@ type CreateCpfpRequest struct {
 
 func (x *CreateCpfpRequest) Reset() {
 	*x = CreateCpfpRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[132]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8085,7 +8507,7 @@ func (x *CreateCpfpRequest) String() string {
 func (*CreateCpfpRequest) ProtoMessage() {}
 
 func (x *CreateCpfpRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[132]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8098,7 +8520,7 @@ func (x *CreateCpfpRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCpfpRequest.ProtoReflect.Descriptor instead.
 func (*CreateCpfpRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{132}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *CreateCpfpRequest) GetWalletId() string {
@@ -8138,7 +8560,7 @@ type CreateCpfpResponse struct {
 
 func (x *CreateCpfpResponse) Reset() {
 	*x = CreateCpfpResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[133]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8150,7 +8572,7 @@ func (x *CreateCpfpResponse) String() string {
 func (*CreateCpfpResponse) ProtoMessage() {}
 
 func (x *CreateCpfpResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[133]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8163,7 +8585,7 @@ func (x *CreateCpfpResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCpfpResponse.ProtoReflect.Descriptor instead.
 func (*CreateCpfpResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{133}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *CreateCpfpResponse) GetChildTxid() string {
@@ -8184,7 +8606,7 @@ type DeriveAddressesRequest struct {
 
 func (x *DeriveAddressesRequest) Reset() {
 	*x = DeriveAddressesRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[134]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8196,7 +8618,7 @@ func (x *DeriveAddressesRequest) String() string {
 func (*DeriveAddressesRequest) ProtoMessage() {}
 
 func (x *DeriveAddressesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[134]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8209,7 +8631,7 @@ func (x *DeriveAddressesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeriveAddressesRequest.ProtoReflect.Descriptor instead.
 func (*DeriveAddressesRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{134}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *DeriveAddressesRequest) GetWalletId() string {
@@ -8242,7 +8664,7 @@ type DeriveAddressesResponse struct {
 
 func (x *DeriveAddressesResponse) Reset() {
 	*x = DeriveAddressesResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[135]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8254,7 +8676,7 @@ func (x *DeriveAddressesResponse) String() string {
 func (*DeriveAddressesResponse) ProtoMessage() {}
 
 func (x *DeriveAddressesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[135]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8267,7 +8689,7 @@ func (x *DeriveAddressesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeriveAddressesResponse.ProtoReflect.Descriptor instead.
 func (*DeriveAddressesResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{135}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *DeriveAddressesResponse) GetAddresses() []string {
@@ -8295,7 +8717,7 @@ type PreviewWalletFromEntropyRequest struct {
 
 func (x *PreviewWalletFromEntropyRequest) Reset() {
 	*x = PreviewWalletFromEntropyRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[136]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8307,7 +8729,7 @@ func (x *PreviewWalletFromEntropyRequest) String() string {
 func (*PreviewWalletFromEntropyRequest) ProtoMessage() {}
 
 func (x *PreviewWalletFromEntropyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[136]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8320,7 +8742,7 @@ func (x *PreviewWalletFromEntropyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewWalletFromEntropyRequest.ProtoReflect.Descriptor instead.
 func (*PreviewWalletFromEntropyRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{136}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *PreviewWalletFromEntropyRequest) GetEntropy() []byte {
@@ -8369,7 +8791,7 @@ type PreviewWalletFromEntropyResponse struct {
 
 func (x *PreviewWalletFromEntropyResponse) Reset() {
 	*x = PreviewWalletFromEntropyResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[137]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8381,7 +8803,7 @@ func (x *PreviewWalletFromEntropyResponse) String() string {
 func (*PreviewWalletFromEntropyResponse) ProtoMessage() {}
 
 func (x *PreviewWalletFromEntropyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[137]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8394,7 +8816,7 @@ func (x *PreviewWalletFromEntropyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewWalletFromEntropyResponse.ProtoReflect.Descriptor instead.
 func (*PreviewWalletFromEntropyResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{137}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *PreviewWalletFromEntropyResponse) GetEntropyHex() string {
@@ -8462,7 +8884,7 @@ type GetWalletSeedRequest struct {
 
 func (x *GetWalletSeedRequest) Reset() {
 	*x = GetWalletSeedRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[138]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8474,7 +8896,7 @@ func (x *GetWalletSeedRequest) String() string {
 func (*GetWalletSeedRequest) ProtoMessage() {}
 
 func (x *GetWalletSeedRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[138]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8487,7 +8909,7 @@ func (x *GetWalletSeedRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletSeedRequest.ProtoReflect.Descriptor instead.
 func (*GetWalletSeedRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{138}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *GetWalletSeedRequest) GetWalletId() string {
@@ -8508,7 +8930,7 @@ type GetWalletSeedResponse struct {
 
 func (x *GetWalletSeedResponse) Reset() {
 	*x = GetWalletSeedResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[139]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8520,7 +8942,7 @@ func (x *GetWalletSeedResponse) String() string {
 func (*GetWalletSeedResponse) ProtoMessage() {}
 
 func (x *GetWalletSeedResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[139]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8533,7 +8955,7 @@ func (x *GetWalletSeedResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletSeedResponse.ProtoReflect.Descriptor instead.
 func (*GetWalletSeedResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{139}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{143}
 }
 
 func (x *GetWalletSeedResponse) GetSeedHex() string {
@@ -8558,7 +8980,7 @@ type ListCoreVariantsRequest struct {
 
 func (x *ListCoreVariantsRequest) Reset() {
 	*x = ListCoreVariantsRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[140]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8570,7 +8992,7 @@ func (x *ListCoreVariantsRequest) String() string {
 func (*ListCoreVariantsRequest) ProtoMessage() {}
 
 func (x *ListCoreVariantsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[140]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8583,7 +9005,7 @@ func (x *ListCoreVariantsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCoreVariantsRequest.ProtoReflect.Descriptor instead.
 func (*ListCoreVariantsRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{140}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{144}
 }
 
 type CoreVariant struct {
@@ -8597,7 +9019,7 @@ type CoreVariant struct {
 
 func (x *CoreVariant) Reset() {
 	*x = CoreVariant{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[141]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8609,7 +9031,7 @@ func (x *CoreVariant) String() string {
 func (*CoreVariant) ProtoMessage() {}
 
 func (x *CoreVariant) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[141]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8622,7 +9044,7 @@ func (x *CoreVariant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoreVariant.ProtoReflect.Descriptor instead.
 func (*CoreVariant) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{141}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{145}
 }
 
 func (x *CoreVariant) GetId() string {
@@ -8656,7 +9078,7 @@ type ListCoreVariantsResponse struct {
 
 func (x *ListCoreVariantsResponse) Reset() {
 	*x = ListCoreVariantsResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[142]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8668,7 +9090,7 @@ func (x *ListCoreVariantsResponse) String() string {
 func (*ListCoreVariantsResponse) ProtoMessage() {}
 
 func (x *ListCoreVariantsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[142]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8681,7 +9103,7 @@ func (x *ListCoreVariantsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCoreVariantsResponse.ProtoReflect.Descriptor instead.
 func (*ListCoreVariantsResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{142}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *ListCoreVariantsResponse) GetVariants() []*CoreVariant {
@@ -8706,7 +9128,7 @@ type GetCoreVariantRequest struct {
 
 func (x *GetCoreVariantRequest) Reset() {
 	*x = GetCoreVariantRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[143]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8718,7 +9140,7 @@ func (x *GetCoreVariantRequest) String() string {
 func (*GetCoreVariantRequest) ProtoMessage() {}
 
 func (x *GetCoreVariantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[143]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8731,7 +9153,7 @@ func (x *GetCoreVariantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreVariantRequest.ProtoReflect.Descriptor instead.
 func (*GetCoreVariantRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{143}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{147}
 }
 
 type GetCoreVariantResponse struct {
@@ -8743,7 +9165,7 @@ type GetCoreVariantResponse struct {
 
 func (x *GetCoreVariantResponse) Reset() {
 	*x = GetCoreVariantResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[144]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8755,7 +9177,7 @@ func (x *GetCoreVariantResponse) String() string {
 func (*GetCoreVariantResponse) ProtoMessage() {}
 
 func (x *GetCoreVariantResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[144]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8768,7 +9190,7 @@ func (x *GetCoreVariantResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoreVariantResponse.ProtoReflect.Descriptor instead.
 func (*GetCoreVariantResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{144}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *GetCoreVariantResponse) GetId() string {
@@ -8787,7 +9209,7 @@ type SetCoreVariantRequest struct {
 
 func (x *SetCoreVariantRequest) Reset() {
 	*x = SetCoreVariantRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[145]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8799,7 +9221,7 @@ func (x *SetCoreVariantRequest) String() string {
 func (*SetCoreVariantRequest) ProtoMessage() {}
 
 func (x *SetCoreVariantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[145]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8812,7 +9234,7 @@ func (x *SetCoreVariantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCoreVariantRequest.ProtoReflect.Descriptor instead.
 func (*SetCoreVariantRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{145}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *SetCoreVariantRequest) GetId() string {
@@ -8830,7 +9252,7 @@ type SetCoreVariantResponse struct {
 
 func (x *SetCoreVariantResponse) Reset() {
 	*x = SetCoreVariantResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[146]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8842,7 +9264,7 @@ func (x *SetCoreVariantResponse) String() string {
 func (*SetCoreVariantResponse) ProtoMessage() {}
 
 func (x *SetCoreVariantResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[146]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8855,7 +9277,7 @@ func (x *SetCoreVariantResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCoreVariantResponse.ProtoReflect.Descriptor instead.
 func (*SetCoreVariantResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{146}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{150}
 }
 
 type GetElectrumServerRequest struct {
@@ -8866,7 +9288,7 @@ type GetElectrumServerRequest struct {
 
 func (x *GetElectrumServerRequest) Reset() {
 	*x = GetElectrumServerRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[147]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8878,7 +9300,7 @@ func (x *GetElectrumServerRequest) String() string {
 func (*GetElectrumServerRequest) ProtoMessage() {}
 
 func (x *GetElectrumServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[147]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8891,7 +9313,7 @@ func (x *GetElectrumServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetElectrumServerRequest.ProtoReflect.Descriptor instead.
 func (*GetElectrumServerRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{147}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{151}
 }
 
 type GetElectrumServerResponse struct {
@@ -8908,7 +9330,7 @@ type GetElectrumServerResponse struct {
 
 func (x *GetElectrumServerResponse) Reset() {
 	*x = GetElectrumServerResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[148]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8920,7 +9342,7 @@ func (x *GetElectrumServerResponse) String() string {
 func (*GetElectrumServerResponse) ProtoMessage() {}
 
 func (x *GetElectrumServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[148]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8933,7 +9355,7 @@ func (x *GetElectrumServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetElectrumServerResponse.ProtoReflect.Descriptor instead.
 func (*GetElectrumServerResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{148}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{152}
 }
 
 func (x *GetElectrumServerResponse) GetUrl() string {
@@ -8967,7 +9389,7 @@ type SetElectrumServerRequest struct {
 
 func (x *SetElectrumServerRequest) Reset() {
 	*x = SetElectrumServerRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[149]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8979,7 +9401,7 @@ func (x *SetElectrumServerRequest) String() string {
 func (*SetElectrumServerRequest) ProtoMessage() {}
 
 func (x *SetElectrumServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[149]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8992,7 +9414,7 @@ func (x *SetElectrumServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetElectrumServerRequest.ProtoReflect.Descriptor instead.
 func (*SetElectrumServerRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{149}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{153}
 }
 
 func (x *SetElectrumServerRequest) GetUrl() string {
@@ -9014,7 +9436,7 @@ type SetElectrumServerResponse struct {
 
 func (x *SetElectrumServerResponse) Reset() {
 	*x = SetElectrumServerResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[150]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9026,7 +9448,7 @@ func (x *SetElectrumServerResponse) String() string {
 func (*SetElectrumServerResponse) ProtoMessage() {}
 
 func (x *SetElectrumServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[150]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9039,7 +9461,7 @@ func (x *SetElectrumServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetElectrumServerResponse.ProtoReflect.Descriptor instead.
 func (*SetElectrumServerResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{150}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{154}
 }
 
 func (x *SetElectrumServerResponse) GetUrl() string {
@@ -9064,7 +9486,7 @@ type GetTorConfigRequest struct {
 
 func (x *GetTorConfigRequest) Reset() {
 	*x = GetTorConfigRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[151]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9076,7 +9498,7 @@ func (x *GetTorConfigRequest) String() string {
 func (*GetTorConfigRequest) ProtoMessage() {}
 
 func (x *GetTorConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[151]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9089,7 +9511,7 @@ func (x *GetTorConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTorConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetTorConfigRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{151}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{155}
 }
 
 type GetTorConfigResponse struct {
@@ -9106,7 +9528,7 @@ type GetTorConfigResponse struct {
 
 func (x *GetTorConfigResponse) Reset() {
 	*x = GetTorConfigResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[152]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9118,7 +9540,7 @@ func (x *GetTorConfigResponse) String() string {
 func (*GetTorConfigResponse) ProtoMessage() {}
 
 func (x *GetTorConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[152]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9131,7 +9553,7 @@ func (x *GetTorConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTorConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetTorConfigResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{152}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{156}
 }
 
 func (x *GetTorConfigResponse) GetEnabled() bool {
@@ -9167,7 +9589,7 @@ type SetTorConfigRequest struct {
 
 func (x *SetTorConfigRequest) Reset() {
 	*x = SetTorConfigRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[153]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9179,7 +9601,7 @@ func (x *SetTorConfigRequest) String() string {
 func (*SetTorConfigRequest) ProtoMessage() {}
 
 func (x *SetTorConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[153]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9192,7 +9614,7 @@ func (x *SetTorConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTorConfigRequest.ProtoReflect.Descriptor instead.
 func (*SetTorConfigRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{153}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *SetTorConfigRequest) GetEnabled() bool {
@@ -9222,7 +9644,7 @@ type SetTorConfigResponse struct {
 
 func (x *SetTorConfigResponse) Reset() {
 	*x = SetTorConfigResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[154]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9234,7 +9656,7 @@ func (x *SetTorConfigResponse) String() string {
 func (*SetTorConfigResponse) ProtoMessage() {}
 
 func (x *SetTorConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[154]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9247,7 +9669,7 @@ func (x *SetTorConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTorConfigResponse.ProtoReflect.Descriptor instead.
 func (*SetTorConfigResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{154}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{158}
 }
 
 func (x *SetTorConfigResponse) GetEnabled() bool {
@@ -9296,7 +9718,7 @@ type WatchWalletDataResponse struct {
 
 func (x *WatchWalletDataResponse) Reset() {
 	*x = WatchWalletDataResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[155]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9308,7 +9730,7 @@ func (x *WatchWalletDataResponse) String() string {
 func (*WatchWalletDataResponse) ProtoMessage() {}
 
 func (x *WatchWalletDataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[155]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9321,7 +9743,7 @@ func (x *WatchWalletDataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchWalletDataResponse.ProtoReflect.Descriptor instead.
 func (*WatchWalletDataResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{155}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *WatchWalletDataResponse) GetHasWallet() bool {
@@ -9405,7 +9827,7 @@ type CreateDepositRequest struct {
 
 func (x *CreateDepositRequest) Reset() {
 	*x = CreateDepositRequest{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[156]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9417,7 +9839,7 @@ func (x *CreateDepositRequest) String() string {
 func (*CreateDepositRequest) ProtoMessage() {}
 
 func (x *CreateDepositRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[156]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9430,7 +9852,7 @@ func (x *CreateDepositRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDepositRequest.ProtoReflect.Descriptor instead.
 func (*CreateDepositRequest) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{156}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *CreateDepositRequest) GetSlot() int32 {
@@ -9479,7 +9901,7 @@ type CreateDepositResponse struct {
 
 func (x *CreateDepositResponse) Reset() {
 	*x = CreateDepositResponse{}
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[157]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9491,7 +9913,7 @@ func (x *CreateDepositResponse) String() string {
 func (*CreateDepositResponse) ProtoMessage() {}
 
 func (x *CreateDepositResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[157]
+	mi := &file_walletmanager_v1_walletmanager_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9504,7 +9926,7 @@ func (x *CreateDepositResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDepositResponse.ProtoReflect.Descriptor instead.
 func (*CreateDepositResponse) Descriptor() ([]byte, []int) {
-	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{157}
+	return file_walletmanager_v1_walletmanager_proto_rawDescGZIP(), []int{161}
 }
 
 func (x *CreateDepositResponse) GetTxid() string {
@@ -10118,14 +10540,61 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x0ffee_rate_sat_vb\x18\x0f \x01(\x01R\ffeeRateSatVb\x12\x17\n" +
 	"\ais_psbt\x18\x10 \x01(\bR\x06isPsbt\x12#\n" +
 	"\rsigned_inputs\x18\x11 \x01(\x05R\fsignedInputs\x12\x10\n" +
-	"\x03raw\x18\x12 \x01(\tR\x03raw\"c\n" +
+	"\x03raw\x18\x12 \x01(\tR\x03raw\"\x9e\x01\n" +
 	"\x0eBumpFeeRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x12\n" +
 	"\x04txid\x18\x02 \x01(\tR\x04txid\x12 \n" +
 	"\fnew_fee_rate\x18\x03 \x01(\x03R\n" +
-	"newFeeRate\",\n" +
+	"newFeeRate\x12'\n" +
+	"\rfee_from_vout\x18\x04 \x01(\x05H\x00R\vfeeFromVout\x88\x01\x01B\x10\n" +
+	"\x0e_fee_from_vout\"_\n" +
 	"\x0fBumpFeeResponse\x12\x19\n" +
-	"\bnew_txid\x18\x01 \x01(\tR\anewTxid\"\x9a\x01\n" +
+	"\bnew_txid\x18\x01 \x01(\tR\anewTxid\x121\n" +
+	"\x04plan\x18\x02 \x01(\v2\x1d.walletmanager.v1.BumpFeePlanR\x04plan\"\xa5\x01\n" +
+	"\x15PreviewBumpFeeRequest\x12\x1b\n" +
+	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x12\n" +
+	"\x04txid\x18\x02 \x01(\tR\x04txid\x12 \n" +
+	"\fnew_fee_rate\x18\x03 \x01(\x03R\n" +
+	"newFeeRate\x12'\n" +
+	"\rfee_from_vout\x18\x04 \x01(\x05H\x00R\vfeeFromVout\x88\x01\x01B\x10\n" +
+	"\x0e_fee_from_vout\"\xbf\x03\n" +
+	"\x16PreviewBumpFeeResponse\x12\x1f\n" +
+	"\vinput_count\x18\x01 \x01(\x05R\n" +
+	"inputCount\x12!\n" +
+	"\fvsize_vbytes\x18\x02 \x01(\x03R\vvsizeVbytes\x12 \n" +
+	"\fold_fee_sats\x18\x03 \x01(\x03R\n" +
+	"oldFeeSats\x12,\n" +
+	"\x13old_fee_rate_sat_vb\x18\x04 \x01(\x01R\x0foldFeeRateSatVb\x12,\n" +
+	"\x12suggested_fee_rate\x18\x05 \x01(\x03R\x10suggestedFeeRate\x129\n" +
+	"\aoutputs\x18\x06 \x03(\v2\x1f.walletmanager.v1.BumpFeeOutputR\aoutputs\x121\n" +
+	"\x04plan\x18\a \x01(\v2\x1d.walletmanager.v1.BumpFeePlanR\x04plan\x12\x16\n" +
+	"\x06reason\x18\b \x01(\tR\x06reason\x12\x1f\n" +
+	"\vcan_replace\x18\t \x01(\bR\n" +
+	"canReplace\x12\x1b\n" +
+	"\thas_child\x18\n" +
+	" \x01(\bR\bhasChild\x12\x1f\n" +
+	"\vadds_inputs\x18\v \x01(\bR\n" +
+	"addsInputs\"\xb1\x01\n" +
+	"\rBumpFeeOutput\x12\x12\n" +
+	"\x04vout\x18\x01 \x01(\x05R\x04vout\x12\x1f\n" +
+	"\vamount_sats\x18\x02 \x01(\x03R\n" +
+	"amountSats\x12\x18\n" +
+	"\aaddress\x18\x03 \x01(\tR\aaddress\x12\x1b\n" +
+	"\tis_change\x18\x04 \x01(\bR\bisChange\x12\x1b\n" +
+	"\tdust_sats\x18\x05 \x01(\x03R\bdustSats\x12\x17\n" +
+	"\ais_mine\x18\x06 \x01(\bR\x06isMine\"\xf3\x02\n" +
+	"\vBumpFeePlan\x12 \n" +
+	"\fold_fee_sats\x18\x01 \x01(\x03R\n" +
+	"oldFeeSats\x12 \n" +
+	"\fnew_fee_sats\x18\x02 \x01(\x03R\n" +
+	"newFeeSats\x12$\n" +
+	"\x0eextra_fee_sats\x18\x03 \x01(\x03R\fextraFeeSats\x12,\n" +
+	"\x13new_fee_rate_sat_vb\x18\x04 \x01(\x01R\x0fnewFeeRateSatVb\x12\"\n" +
+	"\rfee_from_vout\x18\x05 \x01(\x05R\vfeeFromVout\x12,\n" +
+	"\x12amount_before_sats\x18\x06 \x01(\x03R\x10amountBeforeSats\x12*\n" +
+	"\x11amount_after_sats\x18\a \x01(\x03R\x0famountAfterSats\x12%\n" +
+	"\x0eoutput_removed\x18\b \x01(\bR\routputRemoved\x12'\n" +
+	"\x0freduces_payment\x18\t \x01(\bR\x0ereducesPayment\"\x9a\x01\n" +
 	"\x11CreateCpfpRequest\x12\x1b\n" +
 	"\twallet_id\x18\x01 \x01(\tR\bwalletId\x12\x1f\n" +
 	"\vparent_txid\x18\x02 \x01(\tR\n" +
@@ -10253,7 +10722,7 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x18DECODED_FORM_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11DECODED_FORM_TXID\x10\x01\x12\x17\n" +
 	"\x13DECODED_FORM_RAW_TX\x10\x02\x12\x15\n" +
-	"\x11DECODED_FORM_PSBT\x10\x032\xc58\n" +
+	"\x11DECODED_FORM_PSBT\x10\x032\xaa9\n" +
 	"\x14WalletManagerService\x12f\n" +
 	"\x0fGetWalletStatus\x12(.walletmanager.v1.GetWalletStatusRequest\x1a).walletmanager.v1.GetWalletStatusResponse\x12x\n" +
 	"\x15ListSidechainDeposits\x12..walletmanager.v1.ListSidechainDepositsRequest\x1a/.walletmanager.v1.ListSidechainDepositsResponse\x12\x84\x01\n" +
@@ -10296,7 +10765,8 @@ const file_walletmanager_v1_walletmanager_proto_rawDesc = "" +
 	"\x14ListReceiveAddresses\x12-.walletmanager.v1.ListReceiveAddressesRequest\x1a..walletmanager.v1.ListReceiveAddressesResponse\x12x\n" +
 	"\x15GetTransactionDetails\x12..walletmanager.v1.GetTransactionDetailsRequest\x1a/.walletmanager.v1.GetTransactionDetailsResponse\x12l\n" +
 	"\x11DecodeTransaction\x12*.walletmanager.v1.DecodeTransactionRequest\x1a+.walletmanager.v1.DecodeTransactionResponse\x12N\n" +
-	"\aBumpFee\x12 .walletmanager.v1.BumpFeeRequest\x1a!.walletmanager.v1.BumpFeeResponse\x12W\n" +
+	"\aBumpFee\x12 .walletmanager.v1.BumpFeeRequest\x1a!.walletmanager.v1.BumpFeeResponse\x12c\n" +
+	"\x0ePreviewBumpFee\x12'.walletmanager.v1.PreviewBumpFeeRequest\x1a(.walletmanager.v1.PreviewBumpFeeResponse\x12W\n" +
 	"\n" +
 	"CreateCpfp\x12#.walletmanager.v1.CreateCpfpRequest\x1a$.walletmanager.v1.CreateCpfpResponse\x12f\n" +
 	"\x0fDeriveAddresses\x12(.walletmanager.v1.DeriveAddressesRequest\x1a).walletmanager.v1.DeriveAddressesResponse\x12W\n" +
@@ -10342,7 +10812,7 @@ func file_walletmanager_v1_walletmanager_proto_rawDescGZIP() []byte {
 }
 
 var file_walletmanager_v1_walletmanager_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_walletmanager_v1_walletmanager_proto_msgTypes = make([]protoimpl.MessageInfo, 160)
+var file_walletmanager_v1_walletmanager_proto_msgTypes = make([]protoimpl.MessageInfo, 164)
 var file_walletmanager_v1_walletmanager_proto_goTypes = []any{
 	(NodeMode)(0),                                // 0: walletmanager.v1.NodeMode
 	(WalletType)(0),                              // 1: walletmanager.v1.WalletType
@@ -10481,37 +10951,41 @@ var file_walletmanager_v1_walletmanager_proto_goTypes = []any{
 	(*DecodeTransactionResponse)(nil),            // 134: walletmanager.v1.DecodeTransactionResponse
 	(*BumpFeeRequest)(nil),                       // 135: walletmanager.v1.BumpFeeRequest
 	(*BumpFeeResponse)(nil),                      // 136: walletmanager.v1.BumpFeeResponse
-	(*CreateCpfpRequest)(nil),                    // 137: walletmanager.v1.CreateCpfpRequest
-	(*CreateCpfpResponse)(nil),                   // 138: walletmanager.v1.CreateCpfpResponse
-	(*DeriveAddressesRequest)(nil),               // 139: walletmanager.v1.DeriveAddressesRequest
-	(*DeriveAddressesResponse)(nil),              // 140: walletmanager.v1.DeriveAddressesResponse
-	(*PreviewWalletFromEntropyRequest)(nil),      // 141: walletmanager.v1.PreviewWalletFromEntropyRequest
-	(*PreviewWalletFromEntropyResponse)(nil),     // 142: walletmanager.v1.PreviewWalletFromEntropyResponse
-	(*GetWalletSeedRequest)(nil),                 // 143: walletmanager.v1.GetWalletSeedRequest
-	(*GetWalletSeedResponse)(nil),                // 144: walletmanager.v1.GetWalletSeedResponse
-	(*ListCoreVariantsRequest)(nil),              // 145: walletmanager.v1.ListCoreVariantsRequest
-	(*CoreVariant)(nil),                          // 146: walletmanager.v1.CoreVariant
-	(*ListCoreVariantsResponse)(nil),             // 147: walletmanager.v1.ListCoreVariantsResponse
-	(*GetCoreVariantRequest)(nil),                // 148: walletmanager.v1.GetCoreVariantRequest
-	(*GetCoreVariantResponse)(nil),               // 149: walletmanager.v1.GetCoreVariantResponse
-	(*SetCoreVariantRequest)(nil),                // 150: walletmanager.v1.SetCoreVariantRequest
-	(*SetCoreVariantResponse)(nil),               // 151: walletmanager.v1.SetCoreVariantResponse
-	(*GetElectrumServerRequest)(nil),             // 152: walletmanager.v1.GetElectrumServerRequest
-	(*GetElectrumServerResponse)(nil),            // 153: walletmanager.v1.GetElectrumServerResponse
-	(*SetElectrumServerRequest)(nil),             // 154: walletmanager.v1.SetElectrumServerRequest
-	(*SetElectrumServerResponse)(nil),            // 155: walletmanager.v1.SetElectrumServerResponse
-	(*GetTorConfigRequest)(nil),                  // 156: walletmanager.v1.GetTorConfigRequest
-	(*GetTorConfigResponse)(nil),                 // 157: walletmanager.v1.GetTorConfigResponse
-	(*SetTorConfigRequest)(nil),                  // 158: walletmanager.v1.SetTorConfigRequest
-	(*SetTorConfigResponse)(nil),                 // 159: walletmanager.v1.SetTorConfigResponse
-	(*WatchWalletDataResponse)(nil),              // 160: walletmanager.v1.WatchWalletDataResponse
-	(*CreateDepositRequest)(nil),                 // 161: walletmanager.v1.CreateDepositRequest
-	(*CreateDepositResponse)(nil),                // 162: walletmanager.v1.CreateDepositResponse
-	nil,                                          // 163: walletmanager.v1.SendTransactionRequest.DestinationsEntry
-	nil,                                          // 164: walletmanager.v1.CreatePsbtRequest.DestinationsEntry
-	(v1.BinaryType)(0),                           // 165: orchestrator.v1.BinaryType
-	(*timestamppb.Timestamp)(nil),                // 166: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                        // 167: google.protobuf.Empty
+	(*PreviewBumpFeeRequest)(nil),                // 137: walletmanager.v1.PreviewBumpFeeRequest
+	(*PreviewBumpFeeResponse)(nil),               // 138: walletmanager.v1.PreviewBumpFeeResponse
+	(*BumpFeeOutput)(nil),                        // 139: walletmanager.v1.BumpFeeOutput
+	(*BumpFeePlan)(nil),                          // 140: walletmanager.v1.BumpFeePlan
+	(*CreateCpfpRequest)(nil),                    // 141: walletmanager.v1.CreateCpfpRequest
+	(*CreateCpfpResponse)(nil),                   // 142: walletmanager.v1.CreateCpfpResponse
+	(*DeriveAddressesRequest)(nil),               // 143: walletmanager.v1.DeriveAddressesRequest
+	(*DeriveAddressesResponse)(nil),              // 144: walletmanager.v1.DeriveAddressesResponse
+	(*PreviewWalletFromEntropyRequest)(nil),      // 145: walletmanager.v1.PreviewWalletFromEntropyRequest
+	(*PreviewWalletFromEntropyResponse)(nil),     // 146: walletmanager.v1.PreviewWalletFromEntropyResponse
+	(*GetWalletSeedRequest)(nil),                 // 147: walletmanager.v1.GetWalletSeedRequest
+	(*GetWalletSeedResponse)(nil),                // 148: walletmanager.v1.GetWalletSeedResponse
+	(*ListCoreVariantsRequest)(nil),              // 149: walletmanager.v1.ListCoreVariantsRequest
+	(*CoreVariant)(nil),                          // 150: walletmanager.v1.CoreVariant
+	(*ListCoreVariantsResponse)(nil),             // 151: walletmanager.v1.ListCoreVariantsResponse
+	(*GetCoreVariantRequest)(nil),                // 152: walletmanager.v1.GetCoreVariantRequest
+	(*GetCoreVariantResponse)(nil),               // 153: walletmanager.v1.GetCoreVariantResponse
+	(*SetCoreVariantRequest)(nil),                // 154: walletmanager.v1.SetCoreVariantRequest
+	(*SetCoreVariantResponse)(nil),               // 155: walletmanager.v1.SetCoreVariantResponse
+	(*GetElectrumServerRequest)(nil),             // 156: walletmanager.v1.GetElectrumServerRequest
+	(*GetElectrumServerResponse)(nil),            // 157: walletmanager.v1.GetElectrumServerResponse
+	(*SetElectrumServerRequest)(nil),             // 158: walletmanager.v1.SetElectrumServerRequest
+	(*SetElectrumServerResponse)(nil),            // 159: walletmanager.v1.SetElectrumServerResponse
+	(*GetTorConfigRequest)(nil),                  // 160: walletmanager.v1.GetTorConfigRequest
+	(*GetTorConfigResponse)(nil),                 // 161: walletmanager.v1.GetTorConfigResponse
+	(*SetTorConfigRequest)(nil),                  // 162: walletmanager.v1.SetTorConfigRequest
+	(*SetTorConfigResponse)(nil),                 // 163: walletmanager.v1.SetTorConfigResponse
+	(*WatchWalletDataResponse)(nil),              // 164: walletmanager.v1.WatchWalletDataResponse
+	(*CreateDepositRequest)(nil),                 // 165: walletmanager.v1.CreateDepositRequest
+	(*CreateDepositResponse)(nil),                // 166: walletmanager.v1.CreateDepositResponse
+	nil,                                          // 167: walletmanager.v1.SendTransactionRequest.DestinationsEntry
+	nil,                                          // 168: walletmanager.v1.CreatePsbtRequest.DestinationsEntry
+	(v1.BinaryType)(0),                           // 169: orchestrator.v1.BinaryType
+	(*timestamppb.Timestamp)(nil),                // 170: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                        // 171: google.protobuf.Empty
 }
 var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	8,   // 0: walletmanager.v1.ListSidechainDepositsResponse.deposits:type_name -> walletmanager.v1.SidechainDeposit
@@ -10523,9 +10997,9 @@ var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	3,   // 6: walletmanager.v1.WalletMetadata.receive_address_types:type_name -> walletmanager.v1.AddressType
 	30,  // 7: walletmanager.v1.MultisigInfo.cosigners:type_name -> walletmanager.v1.MultisigCosignerInfo
 	28,  // 8: walletmanager.v1.ListWalletsResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
-	165, // 9: walletmanager.v1.BalanceSnapshot.binary:type_name -> orchestrator.v1.BinaryType
-	166, // 10: walletmanager.v1.BalanceSnapshot.updated_at:type_name -> google.protobuf.Timestamp
-	166, // 11: walletmanager.v1.WalletBackup.created_at:type_name -> google.protobuf.Timestamp
+	169, // 9: walletmanager.v1.BalanceSnapshot.binary:type_name -> orchestrator.v1.BinaryType
+	170, // 10: walletmanager.v1.BalanceSnapshot.updated_at:type_name -> google.protobuf.Timestamp
+	170, // 11: walletmanager.v1.WalletBackup.created_at:type_name -> google.protobuf.Timestamp
 	43,  // 12: walletmanager.v1.WalletBackup.wallets:type_name -> walletmanager.v1.BackupWalletSummary
 	42,  // 13: walletmanager.v1.WalletBackup.latest_known_balance:type_name -> walletmanager.v1.BalanceSnapshot
 	44,  // 14: walletmanager.v1.ListWalletBackupsResponse.backups:type_name -> walletmanager.v1.WalletBackup
@@ -10537,11 +11011,11 @@ var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	66,  // 20: walletmanager.v1.ListDerivationPathsResponse.options:type_name -> walletmanager.v1.DerivationPathOption
 	60,  // 21: walletmanager.v1.ValidateDescriptorResponse.keys:type_name -> walletmanager.v1.ParsedCosigner
 	3,   // 22: walletmanager.v1.GetNewAddressRequest.address_type:type_name -> walletmanager.v1.AddressType
-	163, // 23: walletmanager.v1.SendTransactionRequest.destinations:type_name -> walletmanager.v1.SendTransactionRequest.DestinationsEntry
+	167, // 23: walletmanager.v1.SendTransactionRequest.destinations:type_name -> walletmanager.v1.SendTransactionRequest.DestinationsEntry
 	124, // 24: walletmanager.v1.SendTransactionRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
 	83,  // 25: walletmanager.v1.SendTransactionRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
 	84,  // 26: walletmanager.v1.SendTransactionRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
-	164, // 27: walletmanager.v1.CreatePsbtRequest.destinations:type_name -> walletmanager.v1.CreatePsbtRequest.DestinationsEntry
+	168, // 27: walletmanager.v1.CreatePsbtRequest.destinations:type_name -> walletmanager.v1.CreatePsbtRequest.DestinationsEntry
 	124, // 28: walletmanager.v1.CreatePsbtRequest.required_inputs:type_name -> walletmanager.v1.UnspentOutput
 	83,  // 29: walletmanager.v1.CreatePsbtRequest.raw_outputs:type_name -> walletmanager.v1.RawOutput
 	84,  // 30: walletmanager.v1.CreatePsbtRequest.external_inputs:type_name -> walletmanager.v1.ExternalInput
@@ -10554,7 +11028,7 @@ var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	105, // 37: walletmanager.v1.CloseDeviceRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
 	105, // 38: walletmanager.v1.DeriveKeystoreRequest.device:type_name -> walletmanager.v1.HardwareDeviceSelector
 	121, // 39: walletmanager.v1.ListTransactionsResponse.transactions:type_name -> walletmanager.v1.TransactionEntry
-	166, // 40: walletmanager.v1.UnspentOutput.received_at:type_name -> google.protobuf.Timestamp
+	170, // 40: walletmanager.v1.UnspentOutput.received_at:type_name -> google.protobuf.Timestamp
 	124, // 41: walletmanager.v1.ListUnspentResponse.utxos:type_name -> walletmanager.v1.UnspentOutput
 	127, // 42: walletmanager.v1.ListReceiveAddressesResponse.addresses:type_name -> walletmanager.v1.ReceiveAddress
 	121, // 43: walletmanager.v1.GetTransactionDetailsResponse.transaction:type_name -> walletmanager.v1.TransactionEntry
@@ -10563,149 +11037,154 @@ var file_walletmanager_v1_walletmanager_proto_depIdxs = []int32{
 	4,   // 46: walletmanager.v1.DecodeTransactionResponse.form:type_name -> walletmanager.v1.DecodedForm
 	131, // 47: walletmanager.v1.DecodeTransactionResponse.inputs:type_name -> walletmanager.v1.TransactionInput
 	132, // 48: walletmanager.v1.DecodeTransactionResponse.outputs:type_name -> walletmanager.v1.TransactionOutput
-	146, // 49: walletmanager.v1.ListCoreVariantsResponse.variants:type_name -> walletmanager.v1.CoreVariant
-	28,  // 50: walletmanager.v1.WatchWalletDataResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
-	5,   // 51: walletmanager.v1.WalletManagerService.GetWalletStatus:input_type -> walletmanager.v1.GetWalletStatusRequest
-	7,   // 52: walletmanager.v1.WalletManagerService.ListSidechainDeposits:input_type -> walletmanager.v1.ListSidechainDepositsRequest
-	10,  // 53: walletmanager.v1.WalletManagerService.GetSidechainDepositTotals:input_type -> walletmanager.v1.GetSidechainDepositTotalsRequest
-	12,  // 54: walletmanager.v1.WalletManagerService.GetNodeMode:input_type -> walletmanager.v1.GetNodeModeRequest
-	14,  // 55: walletmanager.v1.WalletManagerService.SetNodeMode:input_type -> walletmanager.v1.SetNodeModeRequest
-	16,  // 56: walletmanager.v1.WalletManagerService.GenerateWallet:input_type -> walletmanager.v1.GenerateWalletRequest
-	18,  // 57: walletmanager.v1.WalletManagerService.UnlockWallet:input_type -> walletmanager.v1.UnlockWalletRequest
-	20,  // 58: walletmanager.v1.WalletManagerService.LockWallet:input_type -> walletmanager.v1.LockWalletRequest
-	22,  // 59: walletmanager.v1.WalletManagerService.EncryptWallet:input_type -> walletmanager.v1.EncryptWalletRequest
-	24,  // 60: walletmanager.v1.WalletManagerService.ChangePassword:input_type -> walletmanager.v1.ChangePasswordRequest
-	26,  // 61: walletmanager.v1.WalletManagerService.RemoveEncryption:input_type -> walletmanager.v1.RemoveEncryptionRequest
-	32,  // 62: walletmanager.v1.WalletManagerService.ListWallets:input_type -> walletmanager.v1.ListWalletsRequest
-	34,  // 63: walletmanager.v1.WalletManagerService.SwitchWallet:input_type -> walletmanager.v1.SwitchWalletRequest
-	36,  // 64: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:input_type -> walletmanager.v1.UpdateWalletMetadataRequest
-	38,  // 65: walletmanager.v1.WalletManagerService.DeleteWallet:input_type -> walletmanager.v1.DeleteWalletRequest
-	40,  // 66: walletmanager.v1.WalletManagerService.DeleteAllWallets:input_type -> walletmanager.v1.DeleteAllWalletsRequest
-	45,  // 67: walletmanager.v1.WalletManagerService.ListWalletBackups:input_type -> walletmanager.v1.ListWalletBackupsRequest
-	47,  // 68: walletmanager.v1.WalletManagerService.RestoreWalletBackup:input_type -> walletmanager.v1.RestoreWalletBackupRequest
-	47,  // 69: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:input_type -> walletmanager.v1.RestoreWalletBackupRequest
-	52,  // 70: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:input_type -> walletmanager.v1.CreateWatchOnlyWalletRequest
-	54,  // 71: walletmanager.v1.WalletManagerService.CreateElectrumWallet:input_type -> walletmanager.v1.CreateElectrumWalletRequest
-	57,  // 72: walletmanager.v1.WalletManagerService.CreateMultisigWallet:input_type -> walletmanager.v1.CreateMultisigWalletRequest
-	59,  // 73: walletmanager.v1.WalletManagerService.ParseMultisigConfig:input_type -> walletmanager.v1.ParseMultisigConfigRequest
-	62,  // 74: walletmanager.v1.WalletManagerService.ValidateDescriptor:input_type -> walletmanager.v1.ValidateDescriptorRequest
-	63,  // 75: walletmanager.v1.WalletManagerService.ValidateDerivationPath:input_type -> walletmanager.v1.ValidateDerivationPathRequest
-	65,  // 76: walletmanager.v1.WalletManagerService.ListDerivationPaths:input_type -> walletmanager.v1.ListDerivationPathsRequest
-	69,  // 77: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:input_type -> walletmanager.v1.CreateBitcoinCoreWalletRequest
-	71,  // 78: walletmanager.v1.WalletManagerService.EnsureCoreWallets:input_type -> walletmanager.v1.EnsureCoreWalletsRequest
-	73,  // 79: walletmanager.v1.WalletManagerService.GetBalance:input_type -> walletmanager.v1.GetBalanceRequest
-	74,  // 80: walletmanager.v1.WalletManagerService.RescanWallet:input_type -> walletmanager.v1.RescanWalletRequest
-	76,  // 81: walletmanager.v1.WalletManagerService.EstimateFee:input_type -> walletmanager.v1.EstimateFeeRequest
-	79,  // 82: walletmanager.v1.WalletManagerService.GetNewAddress:input_type -> walletmanager.v1.GetNewAddressRequest
-	81,  // 83: walletmanager.v1.WalletManagerService.SendTransaction:input_type -> walletmanager.v1.SendTransactionRequest
-	161, // 84: walletmanager.v1.WalletManagerService.CreateDeposit:input_type -> walletmanager.v1.CreateDepositRequest
-	120, // 85: walletmanager.v1.WalletManagerService.ListTransactions:input_type -> walletmanager.v1.ListTransactionsRequest
-	123, // 86: walletmanager.v1.WalletManagerService.ListUnspent:input_type -> walletmanager.v1.ListUnspentRequest
-	126, // 87: walletmanager.v1.WalletManagerService.ListReceiveAddresses:input_type -> walletmanager.v1.ListReceiveAddressesRequest
-	129, // 88: walletmanager.v1.WalletManagerService.GetTransactionDetails:input_type -> walletmanager.v1.GetTransactionDetailsRequest
-	133, // 89: walletmanager.v1.WalletManagerService.DecodeTransaction:input_type -> walletmanager.v1.DecodeTransactionRequest
-	135, // 90: walletmanager.v1.WalletManagerService.BumpFee:input_type -> walletmanager.v1.BumpFeeRequest
-	137, // 91: walletmanager.v1.WalletManagerService.CreateCpfp:input_type -> walletmanager.v1.CreateCpfpRequest
-	139, // 92: walletmanager.v1.WalletManagerService.DeriveAddresses:input_type -> walletmanager.v1.DeriveAddressesRequest
-	85,  // 93: walletmanager.v1.WalletManagerService.CreatePsbt:input_type -> walletmanager.v1.CreatePsbtRequest
-	87,  // 94: walletmanager.v1.WalletManagerService.SignPsbt:input_type -> walletmanager.v1.SignPsbtRequest
-	89,  // 95: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:input_type -> walletmanager.v1.SignPsbtWithCosignerRequest
-	91,  // 96: walletmanager.v1.WalletManagerService.CombinePsbt:input_type -> walletmanager.v1.CombinePsbtRequest
-	93,  // 97: walletmanager.v1.WalletManagerService.FinalizePsbt:input_type -> walletmanager.v1.FinalizePsbtRequest
-	95,  // 98: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:input_type -> walletmanager.v1.MultisigPsbtStatusRequest
-	97,  // 99: walletmanager.v1.WalletManagerService.BroadcastTransaction:input_type -> walletmanager.v1.BroadcastTransactionRequest
-	99,  // 100: walletmanager.v1.WalletManagerService.GetAddressUnspent:input_type -> walletmanager.v1.GetAddressUnspentRequest
-	102, // 101: walletmanager.v1.WalletManagerService.BroadcastElectrumTransaction:input_type -> walletmanager.v1.BroadcastElectrumTransactionRequest
-	106, // 102: walletmanager.v1.WalletManagerService.EnumerateHardwareDevices:input_type -> walletmanager.v1.EnumerateHardwareDevicesRequest
-	108, // 103: walletmanager.v1.WalletManagerService.GetHardwareXpub:input_type -> walletmanager.v1.GetHardwareXpubRequest
-	110, // 104: walletmanager.v1.WalletManagerService.SignPsbtWithDevice:input_type -> walletmanager.v1.SignPsbtWithDeviceRequest
-	112, // 105: walletmanager.v1.WalletManagerService.PromptDevicePin:input_type -> walletmanager.v1.PromptDevicePinRequest
-	114, // 106: walletmanager.v1.WalletManagerService.SendDevicePin:input_type -> walletmanager.v1.SendDevicePinRequest
-	116, // 107: walletmanager.v1.WalletManagerService.CloseDevice:input_type -> walletmanager.v1.CloseDeviceRequest
-	118, // 108: walletmanager.v1.WalletManagerService.DeriveKeystore:input_type -> walletmanager.v1.DeriveKeystoreRequest
-	141, // 109: walletmanager.v1.WalletManagerService.PreviewWalletFromEntropy:input_type -> walletmanager.v1.PreviewWalletFromEntropyRequest
-	143, // 110: walletmanager.v1.WalletManagerService.GetWalletSeed:input_type -> walletmanager.v1.GetWalletSeedRequest
-	145, // 111: walletmanager.v1.WalletManagerService.ListCoreVariants:input_type -> walletmanager.v1.ListCoreVariantsRequest
-	148, // 112: walletmanager.v1.WalletManagerService.GetCoreVariant:input_type -> walletmanager.v1.GetCoreVariantRequest
-	150, // 113: walletmanager.v1.WalletManagerService.SetCoreVariant:input_type -> walletmanager.v1.SetCoreVariantRequest
-	152, // 114: walletmanager.v1.WalletManagerService.GetElectrumServer:input_type -> walletmanager.v1.GetElectrumServerRequest
-	154, // 115: walletmanager.v1.WalletManagerService.SetElectrumServer:input_type -> walletmanager.v1.SetElectrumServerRequest
-	156, // 116: walletmanager.v1.WalletManagerService.GetTorConfig:input_type -> walletmanager.v1.GetTorConfigRequest
-	158, // 117: walletmanager.v1.WalletManagerService.SetTorConfig:input_type -> walletmanager.v1.SetTorConfigRequest
-	167, // 118: walletmanager.v1.WalletManagerService.WatchWalletData:input_type -> google.protobuf.Empty
-	6,   // 119: walletmanager.v1.WalletManagerService.GetWalletStatus:output_type -> walletmanager.v1.GetWalletStatusResponse
-	9,   // 120: walletmanager.v1.WalletManagerService.ListSidechainDeposits:output_type -> walletmanager.v1.ListSidechainDepositsResponse
-	11,  // 121: walletmanager.v1.WalletManagerService.GetSidechainDepositTotals:output_type -> walletmanager.v1.GetSidechainDepositTotalsResponse
-	13,  // 122: walletmanager.v1.WalletManagerService.GetNodeMode:output_type -> walletmanager.v1.GetNodeModeResponse
-	15,  // 123: walletmanager.v1.WalletManagerService.SetNodeMode:output_type -> walletmanager.v1.SetNodeModeResponse
-	17,  // 124: walletmanager.v1.WalletManagerService.GenerateWallet:output_type -> walletmanager.v1.GenerateWalletResponse
-	19,  // 125: walletmanager.v1.WalletManagerService.UnlockWallet:output_type -> walletmanager.v1.UnlockWalletResponse
-	21,  // 126: walletmanager.v1.WalletManagerService.LockWallet:output_type -> walletmanager.v1.LockWalletResponse
-	23,  // 127: walletmanager.v1.WalletManagerService.EncryptWallet:output_type -> walletmanager.v1.EncryptWalletResponse
-	25,  // 128: walletmanager.v1.WalletManagerService.ChangePassword:output_type -> walletmanager.v1.ChangePasswordResponse
-	27,  // 129: walletmanager.v1.WalletManagerService.RemoveEncryption:output_type -> walletmanager.v1.RemoveEncryptionResponse
-	33,  // 130: walletmanager.v1.WalletManagerService.ListWallets:output_type -> walletmanager.v1.ListWalletsResponse
-	35,  // 131: walletmanager.v1.WalletManagerService.SwitchWallet:output_type -> walletmanager.v1.SwitchWalletResponse
-	37,  // 132: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:output_type -> walletmanager.v1.UpdateWalletMetadataResponse
-	39,  // 133: walletmanager.v1.WalletManagerService.DeleteWallet:output_type -> walletmanager.v1.DeleteWalletResponse
-	41,  // 134: walletmanager.v1.WalletManagerService.DeleteAllWallets:output_type -> walletmanager.v1.DeleteAllWalletsResponse
-	46,  // 135: walletmanager.v1.WalletManagerService.ListWalletBackups:output_type -> walletmanager.v1.ListWalletBackupsResponse
-	48,  // 136: walletmanager.v1.WalletManagerService.RestoreWalletBackup:output_type -> walletmanager.v1.RestoreWalletBackupResponse
-	51,  // 137: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:output_type -> walletmanager.v1.RestoreWalletBackupProgressResponse
-	53,  // 138: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:output_type -> walletmanager.v1.CreateWatchOnlyWalletResponse
-	55,  // 139: walletmanager.v1.WalletManagerService.CreateElectrumWallet:output_type -> walletmanager.v1.CreateElectrumWalletResponse
-	58,  // 140: walletmanager.v1.WalletManagerService.CreateMultisigWallet:output_type -> walletmanager.v1.CreateMultisigWalletResponse
-	61,  // 141: walletmanager.v1.WalletManagerService.ParseMultisigConfig:output_type -> walletmanager.v1.ParseMultisigConfigResponse
-	68,  // 142: walletmanager.v1.WalletManagerService.ValidateDescriptor:output_type -> walletmanager.v1.ValidateDescriptorResponse
-	64,  // 143: walletmanager.v1.WalletManagerService.ValidateDerivationPath:output_type -> walletmanager.v1.ValidateDerivationPathResponse
-	67,  // 144: walletmanager.v1.WalletManagerService.ListDerivationPaths:output_type -> walletmanager.v1.ListDerivationPathsResponse
-	70,  // 145: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:output_type -> walletmanager.v1.CreateBitcoinCoreWalletResponse
-	72,  // 146: walletmanager.v1.WalletManagerService.EnsureCoreWallets:output_type -> walletmanager.v1.EnsureCoreWalletsResponse
-	78,  // 147: walletmanager.v1.WalletManagerService.GetBalance:output_type -> walletmanager.v1.GetBalanceResponse
-	75,  // 148: walletmanager.v1.WalletManagerService.RescanWallet:output_type -> walletmanager.v1.RescanWalletResponse
-	77,  // 149: walletmanager.v1.WalletManagerService.EstimateFee:output_type -> walletmanager.v1.EstimateFeeResponse
-	80,  // 150: walletmanager.v1.WalletManagerService.GetNewAddress:output_type -> walletmanager.v1.GetNewAddressResponse
-	82,  // 151: walletmanager.v1.WalletManagerService.SendTransaction:output_type -> walletmanager.v1.SendTransactionResponse
-	162, // 152: walletmanager.v1.WalletManagerService.CreateDeposit:output_type -> walletmanager.v1.CreateDepositResponse
-	122, // 153: walletmanager.v1.WalletManagerService.ListTransactions:output_type -> walletmanager.v1.ListTransactionsResponse
-	125, // 154: walletmanager.v1.WalletManagerService.ListUnspent:output_type -> walletmanager.v1.ListUnspentResponse
-	128, // 155: walletmanager.v1.WalletManagerService.ListReceiveAddresses:output_type -> walletmanager.v1.ListReceiveAddressesResponse
-	130, // 156: walletmanager.v1.WalletManagerService.GetTransactionDetails:output_type -> walletmanager.v1.GetTransactionDetailsResponse
-	134, // 157: walletmanager.v1.WalletManagerService.DecodeTransaction:output_type -> walletmanager.v1.DecodeTransactionResponse
-	136, // 158: walletmanager.v1.WalletManagerService.BumpFee:output_type -> walletmanager.v1.BumpFeeResponse
-	138, // 159: walletmanager.v1.WalletManagerService.CreateCpfp:output_type -> walletmanager.v1.CreateCpfpResponse
-	140, // 160: walletmanager.v1.WalletManagerService.DeriveAddresses:output_type -> walletmanager.v1.DeriveAddressesResponse
-	86,  // 161: walletmanager.v1.WalletManagerService.CreatePsbt:output_type -> walletmanager.v1.CreatePsbtResponse
-	88,  // 162: walletmanager.v1.WalletManagerService.SignPsbt:output_type -> walletmanager.v1.SignPsbtResponse
-	90,  // 163: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:output_type -> walletmanager.v1.SignPsbtWithCosignerResponse
-	92,  // 164: walletmanager.v1.WalletManagerService.CombinePsbt:output_type -> walletmanager.v1.CombinePsbtResponse
-	94,  // 165: walletmanager.v1.WalletManagerService.FinalizePsbt:output_type -> walletmanager.v1.FinalizePsbtResponse
-	96,  // 166: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:output_type -> walletmanager.v1.MultisigPsbtStatusResponse
-	98,  // 167: walletmanager.v1.WalletManagerService.BroadcastTransaction:output_type -> walletmanager.v1.BroadcastTransactionResponse
-	101, // 168: walletmanager.v1.WalletManagerService.GetAddressUnspent:output_type -> walletmanager.v1.GetAddressUnspentResponse
-	103, // 169: walletmanager.v1.WalletManagerService.BroadcastElectrumTransaction:output_type -> walletmanager.v1.BroadcastElectrumTransactionResponse
-	107, // 170: walletmanager.v1.WalletManagerService.EnumerateHardwareDevices:output_type -> walletmanager.v1.EnumerateHardwareDevicesResponse
-	109, // 171: walletmanager.v1.WalletManagerService.GetHardwareXpub:output_type -> walletmanager.v1.GetHardwareXpubResponse
-	111, // 172: walletmanager.v1.WalletManagerService.SignPsbtWithDevice:output_type -> walletmanager.v1.SignPsbtWithDeviceResponse
-	113, // 173: walletmanager.v1.WalletManagerService.PromptDevicePin:output_type -> walletmanager.v1.PromptDevicePinResponse
-	115, // 174: walletmanager.v1.WalletManagerService.SendDevicePin:output_type -> walletmanager.v1.SendDevicePinResponse
-	117, // 175: walletmanager.v1.WalletManagerService.CloseDevice:output_type -> walletmanager.v1.CloseDeviceResponse
-	119, // 176: walletmanager.v1.WalletManagerService.DeriveKeystore:output_type -> walletmanager.v1.DeriveKeystoreResponse
-	142, // 177: walletmanager.v1.WalletManagerService.PreviewWalletFromEntropy:output_type -> walletmanager.v1.PreviewWalletFromEntropyResponse
-	144, // 178: walletmanager.v1.WalletManagerService.GetWalletSeed:output_type -> walletmanager.v1.GetWalletSeedResponse
-	147, // 179: walletmanager.v1.WalletManagerService.ListCoreVariants:output_type -> walletmanager.v1.ListCoreVariantsResponse
-	149, // 180: walletmanager.v1.WalletManagerService.GetCoreVariant:output_type -> walletmanager.v1.GetCoreVariantResponse
-	151, // 181: walletmanager.v1.WalletManagerService.SetCoreVariant:output_type -> walletmanager.v1.SetCoreVariantResponse
-	153, // 182: walletmanager.v1.WalletManagerService.GetElectrumServer:output_type -> walletmanager.v1.GetElectrumServerResponse
-	155, // 183: walletmanager.v1.WalletManagerService.SetElectrumServer:output_type -> walletmanager.v1.SetElectrumServerResponse
-	157, // 184: walletmanager.v1.WalletManagerService.GetTorConfig:output_type -> walletmanager.v1.GetTorConfigResponse
-	159, // 185: walletmanager.v1.WalletManagerService.SetTorConfig:output_type -> walletmanager.v1.SetTorConfigResponse
-	160, // 186: walletmanager.v1.WalletManagerService.WatchWalletData:output_type -> walletmanager.v1.WatchWalletDataResponse
-	119, // [119:187] is the sub-list for method output_type
-	51,  // [51:119] is the sub-list for method input_type
-	51,  // [51:51] is the sub-list for extension type_name
-	51,  // [51:51] is the sub-list for extension extendee
-	0,   // [0:51] is the sub-list for field type_name
+	140, // 49: walletmanager.v1.BumpFeeResponse.plan:type_name -> walletmanager.v1.BumpFeePlan
+	139, // 50: walletmanager.v1.PreviewBumpFeeResponse.outputs:type_name -> walletmanager.v1.BumpFeeOutput
+	140, // 51: walletmanager.v1.PreviewBumpFeeResponse.plan:type_name -> walletmanager.v1.BumpFeePlan
+	150, // 52: walletmanager.v1.ListCoreVariantsResponse.variants:type_name -> walletmanager.v1.CoreVariant
+	28,  // 53: walletmanager.v1.WatchWalletDataResponse.wallets:type_name -> walletmanager.v1.WalletMetadata
+	5,   // 54: walletmanager.v1.WalletManagerService.GetWalletStatus:input_type -> walletmanager.v1.GetWalletStatusRequest
+	7,   // 55: walletmanager.v1.WalletManagerService.ListSidechainDeposits:input_type -> walletmanager.v1.ListSidechainDepositsRequest
+	10,  // 56: walletmanager.v1.WalletManagerService.GetSidechainDepositTotals:input_type -> walletmanager.v1.GetSidechainDepositTotalsRequest
+	12,  // 57: walletmanager.v1.WalletManagerService.GetNodeMode:input_type -> walletmanager.v1.GetNodeModeRequest
+	14,  // 58: walletmanager.v1.WalletManagerService.SetNodeMode:input_type -> walletmanager.v1.SetNodeModeRequest
+	16,  // 59: walletmanager.v1.WalletManagerService.GenerateWallet:input_type -> walletmanager.v1.GenerateWalletRequest
+	18,  // 60: walletmanager.v1.WalletManagerService.UnlockWallet:input_type -> walletmanager.v1.UnlockWalletRequest
+	20,  // 61: walletmanager.v1.WalletManagerService.LockWallet:input_type -> walletmanager.v1.LockWalletRequest
+	22,  // 62: walletmanager.v1.WalletManagerService.EncryptWallet:input_type -> walletmanager.v1.EncryptWalletRequest
+	24,  // 63: walletmanager.v1.WalletManagerService.ChangePassword:input_type -> walletmanager.v1.ChangePasswordRequest
+	26,  // 64: walletmanager.v1.WalletManagerService.RemoveEncryption:input_type -> walletmanager.v1.RemoveEncryptionRequest
+	32,  // 65: walletmanager.v1.WalletManagerService.ListWallets:input_type -> walletmanager.v1.ListWalletsRequest
+	34,  // 66: walletmanager.v1.WalletManagerService.SwitchWallet:input_type -> walletmanager.v1.SwitchWalletRequest
+	36,  // 67: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:input_type -> walletmanager.v1.UpdateWalletMetadataRequest
+	38,  // 68: walletmanager.v1.WalletManagerService.DeleteWallet:input_type -> walletmanager.v1.DeleteWalletRequest
+	40,  // 69: walletmanager.v1.WalletManagerService.DeleteAllWallets:input_type -> walletmanager.v1.DeleteAllWalletsRequest
+	45,  // 70: walletmanager.v1.WalletManagerService.ListWalletBackups:input_type -> walletmanager.v1.ListWalletBackupsRequest
+	47,  // 71: walletmanager.v1.WalletManagerService.RestoreWalletBackup:input_type -> walletmanager.v1.RestoreWalletBackupRequest
+	47,  // 72: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:input_type -> walletmanager.v1.RestoreWalletBackupRequest
+	52,  // 73: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:input_type -> walletmanager.v1.CreateWatchOnlyWalletRequest
+	54,  // 74: walletmanager.v1.WalletManagerService.CreateElectrumWallet:input_type -> walletmanager.v1.CreateElectrumWalletRequest
+	57,  // 75: walletmanager.v1.WalletManagerService.CreateMultisigWallet:input_type -> walletmanager.v1.CreateMultisigWalletRequest
+	59,  // 76: walletmanager.v1.WalletManagerService.ParseMultisigConfig:input_type -> walletmanager.v1.ParseMultisigConfigRequest
+	62,  // 77: walletmanager.v1.WalletManagerService.ValidateDescriptor:input_type -> walletmanager.v1.ValidateDescriptorRequest
+	63,  // 78: walletmanager.v1.WalletManagerService.ValidateDerivationPath:input_type -> walletmanager.v1.ValidateDerivationPathRequest
+	65,  // 79: walletmanager.v1.WalletManagerService.ListDerivationPaths:input_type -> walletmanager.v1.ListDerivationPathsRequest
+	69,  // 80: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:input_type -> walletmanager.v1.CreateBitcoinCoreWalletRequest
+	71,  // 81: walletmanager.v1.WalletManagerService.EnsureCoreWallets:input_type -> walletmanager.v1.EnsureCoreWalletsRequest
+	73,  // 82: walletmanager.v1.WalletManagerService.GetBalance:input_type -> walletmanager.v1.GetBalanceRequest
+	74,  // 83: walletmanager.v1.WalletManagerService.RescanWallet:input_type -> walletmanager.v1.RescanWalletRequest
+	76,  // 84: walletmanager.v1.WalletManagerService.EstimateFee:input_type -> walletmanager.v1.EstimateFeeRequest
+	79,  // 85: walletmanager.v1.WalletManagerService.GetNewAddress:input_type -> walletmanager.v1.GetNewAddressRequest
+	81,  // 86: walletmanager.v1.WalletManagerService.SendTransaction:input_type -> walletmanager.v1.SendTransactionRequest
+	165, // 87: walletmanager.v1.WalletManagerService.CreateDeposit:input_type -> walletmanager.v1.CreateDepositRequest
+	120, // 88: walletmanager.v1.WalletManagerService.ListTransactions:input_type -> walletmanager.v1.ListTransactionsRequest
+	123, // 89: walletmanager.v1.WalletManagerService.ListUnspent:input_type -> walletmanager.v1.ListUnspentRequest
+	126, // 90: walletmanager.v1.WalletManagerService.ListReceiveAddresses:input_type -> walletmanager.v1.ListReceiveAddressesRequest
+	129, // 91: walletmanager.v1.WalletManagerService.GetTransactionDetails:input_type -> walletmanager.v1.GetTransactionDetailsRequest
+	133, // 92: walletmanager.v1.WalletManagerService.DecodeTransaction:input_type -> walletmanager.v1.DecodeTransactionRequest
+	135, // 93: walletmanager.v1.WalletManagerService.BumpFee:input_type -> walletmanager.v1.BumpFeeRequest
+	137, // 94: walletmanager.v1.WalletManagerService.PreviewBumpFee:input_type -> walletmanager.v1.PreviewBumpFeeRequest
+	141, // 95: walletmanager.v1.WalletManagerService.CreateCpfp:input_type -> walletmanager.v1.CreateCpfpRequest
+	143, // 96: walletmanager.v1.WalletManagerService.DeriveAddresses:input_type -> walletmanager.v1.DeriveAddressesRequest
+	85,  // 97: walletmanager.v1.WalletManagerService.CreatePsbt:input_type -> walletmanager.v1.CreatePsbtRequest
+	87,  // 98: walletmanager.v1.WalletManagerService.SignPsbt:input_type -> walletmanager.v1.SignPsbtRequest
+	89,  // 99: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:input_type -> walletmanager.v1.SignPsbtWithCosignerRequest
+	91,  // 100: walletmanager.v1.WalletManagerService.CombinePsbt:input_type -> walletmanager.v1.CombinePsbtRequest
+	93,  // 101: walletmanager.v1.WalletManagerService.FinalizePsbt:input_type -> walletmanager.v1.FinalizePsbtRequest
+	95,  // 102: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:input_type -> walletmanager.v1.MultisigPsbtStatusRequest
+	97,  // 103: walletmanager.v1.WalletManagerService.BroadcastTransaction:input_type -> walletmanager.v1.BroadcastTransactionRequest
+	99,  // 104: walletmanager.v1.WalletManagerService.GetAddressUnspent:input_type -> walletmanager.v1.GetAddressUnspentRequest
+	102, // 105: walletmanager.v1.WalletManagerService.BroadcastElectrumTransaction:input_type -> walletmanager.v1.BroadcastElectrumTransactionRequest
+	106, // 106: walletmanager.v1.WalletManagerService.EnumerateHardwareDevices:input_type -> walletmanager.v1.EnumerateHardwareDevicesRequest
+	108, // 107: walletmanager.v1.WalletManagerService.GetHardwareXpub:input_type -> walletmanager.v1.GetHardwareXpubRequest
+	110, // 108: walletmanager.v1.WalletManagerService.SignPsbtWithDevice:input_type -> walletmanager.v1.SignPsbtWithDeviceRequest
+	112, // 109: walletmanager.v1.WalletManagerService.PromptDevicePin:input_type -> walletmanager.v1.PromptDevicePinRequest
+	114, // 110: walletmanager.v1.WalletManagerService.SendDevicePin:input_type -> walletmanager.v1.SendDevicePinRequest
+	116, // 111: walletmanager.v1.WalletManagerService.CloseDevice:input_type -> walletmanager.v1.CloseDeviceRequest
+	118, // 112: walletmanager.v1.WalletManagerService.DeriveKeystore:input_type -> walletmanager.v1.DeriveKeystoreRequest
+	145, // 113: walletmanager.v1.WalletManagerService.PreviewWalletFromEntropy:input_type -> walletmanager.v1.PreviewWalletFromEntropyRequest
+	147, // 114: walletmanager.v1.WalletManagerService.GetWalletSeed:input_type -> walletmanager.v1.GetWalletSeedRequest
+	149, // 115: walletmanager.v1.WalletManagerService.ListCoreVariants:input_type -> walletmanager.v1.ListCoreVariantsRequest
+	152, // 116: walletmanager.v1.WalletManagerService.GetCoreVariant:input_type -> walletmanager.v1.GetCoreVariantRequest
+	154, // 117: walletmanager.v1.WalletManagerService.SetCoreVariant:input_type -> walletmanager.v1.SetCoreVariantRequest
+	156, // 118: walletmanager.v1.WalletManagerService.GetElectrumServer:input_type -> walletmanager.v1.GetElectrumServerRequest
+	158, // 119: walletmanager.v1.WalletManagerService.SetElectrumServer:input_type -> walletmanager.v1.SetElectrumServerRequest
+	160, // 120: walletmanager.v1.WalletManagerService.GetTorConfig:input_type -> walletmanager.v1.GetTorConfigRequest
+	162, // 121: walletmanager.v1.WalletManagerService.SetTorConfig:input_type -> walletmanager.v1.SetTorConfigRequest
+	171, // 122: walletmanager.v1.WalletManagerService.WatchWalletData:input_type -> google.protobuf.Empty
+	6,   // 123: walletmanager.v1.WalletManagerService.GetWalletStatus:output_type -> walletmanager.v1.GetWalletStatusResponse
+	9,   // 124: walletmanager.v1.WalletManagerService.ListSidechainDeposits:output_type -> walletmanager.v1.ListSidechainDepositsResponse
+	11,  // 125: walletmanager.v1.WalletManagerService.GetSidechainDepositTotals:output_type -> walletmanager.v1.GetSidechainDepositTotalsResponse
+	13,  // 126: walletmanager.v1.WalletManagerService.GetNodeMode:output_type -> walletmanager.v1.GetNodeModeResponse
+	15,  // 127: walletmanager.v1.WalletManagerService.SetNodeMode:output_type -> walletmanager.v1.SetNodeModeResponse
+	17,  // 128: walletmanager.v1.WalletManagerService.GenerateWallet:output_type -> walletmanager.v1.GenerateWalletResponse
+	19,  // 129: walletmanager.v1.WalletManagerService.UnlockWallet:output_type -> walletmanager.v1.UnlockWalletResponse
+	21,  // 130: walletmanager.v1.WalletManagerService.LockWallet:output_type -> walletmanager.v1.LockWalletResponse
+	23,  // 131: walletmanager.v1.WalletManagerService.EncryptWallet:output_type -> walletmanager.v1.EncryptWalletResponse
+	25,  // 132: walletmanager.v1.WalletManagerService.ChangePassword:output_type -> walletmanager.v1.ChangePasswordResponse
+	27,  // 133: walletmanager.v1.WalletManagerService.RemoveEncryption:output_type -> walletmanager.v1.RemoveEncryptionResponse
+	33,  // 134: walletmanager.v1.WalletManagerService.ListWallets:output_type -> walletmanager.v1.ListWalletsResponse
+	35,  // 135: walletmanager.v1.WalletManagerService.SwitchWallet:output_type -> walletmanager.v1.SwitchWalletResponse
+	37,  // 136: walletmanager.v1.WalletManagerService.UpdateWalletMetadata:output_type -> walletmanager.v1.UpdateWalletMetadataResponse
+	39,  // 137: walletmanager.v1.WalletManagerService.DeleteWallet:output_type -> walletmanager.v1.DeleteWalletResponse
+	41,  // 138: walletmanager.v1.WalletManagerService.DeleteAllWallets:output_type -> walletmanager.v1.DeleteAllWalletsResponse
+	46,  // 139: walletmanager.v1.WalletManagerService.ListWalletBackups:output_type -> walletmanager.v1.ListWalletBackupsResponse
+	48,  // 140: walletmanager.v1.WalletManagerService.RestoreWalletBackup:output_type -> walletmanager.v1.RestoreWalletBackupResponse
+	51,  // 141: walletmanager.v1.WalletManagerService.RestoreWalletBackupStream:output_type -> walletmanager.v1.RestoreWalletBackupProgressResponse
+	53,  // 142: walletmanager.v1.WalletManagerService.CreateWatchOnlyWallet:output_type -> walletmanager.v1.CreateWatchOnlyWalletResponse
+	55,  // 143: walletmanager.v1.WalletManagerService.CreateElectrumWallet:output_type -> walletmanager.v1.CreateElectrumWalletResponse
+	58,  // 144: walletmanager.v1.WalletManagerService.CreateMultisigWallet:output_type -> walletmanager.v1.CreateMultisigWalletResponse
+	61,  // 145: walletmanager.v1.WalletManagerService.ParseMultisigConfig:output_type -> walletmanager.v1.ParseMultisigConfigResponse
+	68,  // 146: walletmanager.v1.WalletManagerService.ValidateDescriptor:output_type -> walletmanager.v1.ValidateDescriptorResponse
+	64,  // 147: walletmanager.v1.WalletManagerService.ValidateDerivationPath:output_type -> walletmanager.v1.ValidateDerivationPathResponse
+	67,  // 148: walletmanager.v1.WalletManagerService.ListDerivationPaths:output_type -> walletmanager.v1.ListDerivationPathsResponse
+	70,  // 149: walletmanager.v1.WalletManagerService.CreateBitcoinCoreWallet:output_type -> walletmanager.v1.CreateBitcoinCoreWalletResponse
+	72,  // 150: walletmanager.v1.WalletManagerService.EnsureCoreWallets:output_type -> walletmanager.v1.EnsureCoreWalletsResponse
+	78,  // 151: walletmanager.v1.WalletManagerService.GetBalance:output_type -> walletmanager.v1.GetBalanceResponse
+	75,  // 152: walletmanager.v1.WalletManagerService.RescanWallet:output_type -> walletmanager.v1.RescanWalletResponse
+	77,  // 153: walletmanager.v1.WalletManagerService.EstimateFee:output_type -> walletmanager.v1.EstimateFeeResponse
+	80,  // 154: walletmanager.v1.WalletManagerService.GetNewAddress:output_type -> walletmanager.v1.GetNewAddressResponse
+	82,  // 155: walletmanager.v1.WalletManagerService.SendTransaction:output_type -> walletmanager.v1.SendTransactionResponse
+	166, // 156: walletmanager.v1.WalletManagerService.CreateDeposit:output_type -> walletmanager.v1.CreateDepositResponse
+	122, // 157: walletmanager.v1.WalletManagerService.ListTransactions:output_type -> walletmanager.v1.ListTransactionsResponse
+	125, // 158: walletmanager.v1.WalletManagerService.ListUnspent:output_type -> walletmanager.v1.ListUnspentResponse
+	128, // 159: walletmanager.v1.WalletManagerService.ListReceiveAddresses:output_type -> walletmanager.v1.ListReceiveAddressesResponse
+	130, // 160: walletmanager.v1.WalletManagerService.GetTransactionDetails:output_type -> walletmanager.v1.GetTransactionDetailsResponse
+	134, // 161: walletmanager.v1.WalletManagerService.DecodeTransaction:output_type -> walletmanager.v1.DecodeTransactionResponse
+	136, // 162: walletmanager.v1.WalletManagerService.BumpFee:output_type -> walletmanager.v1.BumpFeeResponse
+	138, // 163: walletmanager.v1.WalletManagerService.PreviewBumpFee:output_type -> walletmanager.v1.PreviewBumpFeeResponse
+	142, // 164: walletmanager.v1.WalletManagerService.CreateCpfp:output_type -> walletmanager.v1.CreateCpfpResponse
+	144, // 165: walletmanager.v1.WalletManagerService.DeriveAddresses:output_type -> walletmanager.v1.DeriveAddressesResponse
+	86,  // 166: walletmanager.v1.WalletManagerService.CreatePsbt:output_type -> walletmanager.v1.CreatePsbtResponse
+	88,  // 167: walletmanager.v1.WalletManagerService.SignPsbt:output_type -> walletmanager.v1.SignPsbtResponse
+	90,  // 168: walletmanager.v1.WalletManagerService.SignPsbtWithCosigner:output_type -> walletmanager.v1.SignPsbtWithCosignerResponse
+	92,  // 169: walletmanager.v1.WalletManagerService.CombinePsbt:output_type -> walletmanager.v1.CombinePsbtResponse
+	94,  // 170: walletmanager.v1.WalletManagerService.FinalizePsbt:output_type -> walletmanager.v1.FinalizePsbtResponse
+	96,  // 171: walletmanager.v1.WalletManagerService.MultisigPsbtStatus:output_type -> walletmanager.v1.MultisigPsbtStatusResponse
+	98,  // 172: walletmanager.v1.WalletManagerService.BroadcastTransaction:output_type -> walletmanager.v1.BroadcastTransactionResponse
+	101, // 173: walletmanager.v1.WalletManagerService.GetAddressUnspent:output_type -> walletmanager.v1.GetAddressUnspentResponse
+	103, // 174: walletmanager.v1.WalletManagerService.BroadcastElectrumTransaction:output_type -> walletmanager.v1.BroadcastElectrumTransactionResponse
+	107, // 175: walletmanager.v1.WalletManagerService.EnumerateHardwareDevices:output_type -> walletmanager.v1.EnumerateHardwareDevicesResponse
+	109, // 176: walletmanager.v1.WalletManagerService.GetHardwareXpub:output_type -> walletmanager.v1.GetHardwareXpubResponse
+	111, // 177: walletmanager.v1.WalletManagerService.SignPsbtWithDevice:output_type -> walletmanager.v1.SignPsbtWithDeviceResponse
+	113, // 178: walletmanager.v1.WalletManagerService.PromptDevicePin:output_type -> walletmanager.v1.PromptDevicePinResponse
+	115, // 179: walletmanager.v1.WalletManagerService.SendDevicePin:output_type -> walletmanager.v1.SendDevicePinResponse
+	117, // 180: walletmanager.v1.WalletManagerService.CloseDevice:output_type -> walletmanager.v1.CloseDeviceResponse
+	119, // 181: walletmanager.v1.WalletManagerService.DeriveKeystore:output_type -> walletmanager.v1.DeriveKeystoreResponse
+	146, // 182: walletmanager.v1.WalletManagerService.PreviewWalletFromEntropy:output_type -> walletmanager.v1.PreviewWalletFromEntropyResponse
+	148, // 183: walletmanager.v1.WalletManagerService.GetWalletSeed:output_type -> walletmanager.v1.GetWalletSeedResponse
+	151, // 184: walletmanager.v1.WalletManagerService.ListCoreVariants:output_type -> walletmanager.v1.ListCoreVariantsResponse
+	153, // 185: walletmanager.v1.WalletManagerService.GetCoreVariant:output_type -> walletmanager.v1.GetCoreVariantResponse
+	155, // 186: walletmanager.v1.WalletManagerService.SetCoreVariant:output_type -> walletmanager.v1.SetCoreVariantResponse
+	157, // 187: walletmanager.v1.WalletManagerService.GetElectrumServer:output_type -> walletmanager.v1.GetElectrumServerResponse
+	159, // 188: walletmanager.v1.WalletManagerService.SetElectrumServer:output_type -> walletmanager.v1.SetElectrumServerResponse
+	161, // 189: walletmanager.v1.WalletManagerService.GetTorConfig:output_type -> walletmanager.v1.GetTorConfigResponse
+	163, // 190: walletmanager.v1.WalletManagerService.SetTorConfig:output_type -> walletmanager.v1.SetTorConfigResponse
+	164, // 191: walletmanager.v1.WalletManagerService.WatchWalletData:output_type -> walletmanager.v1.WatchWalletDataResponse
+	123, // [123:192] is the sub-list for method output_type
+	54,  // [54:123] is the sub-list for method input_type
+	54,  // [54:54] is the sub-list for extension type_name
+	54,  // [54:54] is the sub-list for extension extendee
+	0,   // [0:54] is the sub-list for field type_name
 }
 
 func init() { file_walletmanager_v1_walletmanager_proto_init() }
@@ -10714,13 +11193,15 @@ func file_walletmanager_v1_walletmanager_proto_init() {
 		return
 	}
 	file_walletmanager_v1_walletmanager_proto_msgTypes[119].OneofWrappers = []any{}
+	file_walletmanager_v1_walletmanager_proto_msgTypes[130].OneofWrappers = []any{}
+	file_walletmanager_v1_walletmanager_proto_msgTypes[132].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_walletmanager_v1_walletmanager_proto_rawDesc), len(file_walletmanager_v1_walletmanager_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   160,
+			NumMessages:   164,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect/walletmanager.connect.go
+++ b/sidechain-orchestrator/gen/walletmanager/v1/walletmanagerv1connect/walletmanager.connect.go
@@ -154,6 +154,9 @@ const (
 	// WalletManagerServiceBumpFeeProcedure is the fully-qualified name of the WalletManagerService's
 	// BumpFee RPC.
 	WalletManagerServiceBumpFeeProcedure = "/walletmanager.v1.WalletManagerService/BumpFee"
+	// WalletManagerServicePreviewBumpFeeProcedure is the fully-qualified name of the
+	// WalletManagerService's PreviewBumpFee RPC.
+	WalletManagerServicePreviewBumpFeeProcedure = "/walletmanager.v1.WalletManagerService/PreviewBumpFee"
 	// WalletManagerServiceCreateCpfpProcedure is the fully-qualified name of the WalletManagerService's
 	// CreateCpfp RPC.
 	WalletManagerServiceCreateCpfpProcedure = "/walletmanager.v1.WalletManagerService/CreateCpfp"
@@ -300,6 +303,9 @@ type WalletManagerServiceClient interface {
 	GetTransactionDetails(context.Context, *connect.Request[v1.GetTransactionDetailsRequest]) (*connect.Response[v1.GetTransactionDetailsResponse], error)
 	DecodeTransaction(context.Context, *connect.Request[v1.DecodeTransactionRequest]) (*connect.Response[v1.DecodeTransactionResponse], error)
 	BumpFee(context.Context, *connect.Request[v1.BumpFeeRequest]) (*connect.Response[v1.BumpFeeResponse], error)
+	// PreviewBumpFee reports what a fee bump costs, and which output pays it,
+	// without broadcasting anything.
+	PreviewBumpFee(context.Context, *connect.Request[v1.PreviewBumpFeeRequest]) (*connect.Response[v1.PreviewBumpFeeResponse], error)
 	// CreateCpfp spends an unconfirmed wallet UTXO with a child transaction whose
 	// fee lifts the parent+child package to the target fee rate (CPFP).
 	CreateCpfp(context.Context, *connect.Request[v1.CreateCpfpRequest]) (*connect.Response[v1.CreateCpfpResponse], error)
@@ -607,6 +613,12 @@ func NewWalletManagerServiceClient(httpClient connect.HTTPClient, baseURL string
 			connect.WithSchema(walletManagerServiceMethods.ByName("BumpFee")),
 			connect.WithClientOptions(opts...),
 		),
+		previewBumpFee: connect.NewClient[v1.PreviewBumpFeeRequest, v1.PreviewBumpFeeResponse](
+			httpClient,
+			baseURL+WalletManagerServicePreviewBumpFeeProcedure,
+			connect.WithSchema(walletManagerServiceMethods.ByName("PreviewBumpFee")),
+			connect.WithClientOptions(opts...),
+		),
 		createCpfp: connect.NewClient[v1.CreateCpfpRequest, v1.CreateCpfpResponse](
 			httpClient,
 			baseURL+WalletManagerServiceCreateCpfpProcedure,
@@ -820,6 +832,7 @@ type walletManagerServiceClient struct {
 	getTransactionDetails        *connect.Client[v1.GetTransactionDetailsRequest, v1.GetTransactionDetailsResponse]
 	decodeTransaction            *connect.Client[v1.DecodeTransactionRequest, v1.DecodeTransactionResponse]
 	bumpFee                      *connect.Client[v1.BumpFeeRequest, v1.BumpFeeResponse]
+	previewBumpFee               *connect.Client[v1.PreviewBumpFeeRequest, v1.PreviewBumpFeeResponse]
 	createCpfp                   *connect.Client[v1.CreateCpfpRequest, v1.CreateCpfpResponse]
 	deriveAddresses              *connect.Client[v1.DeriveAddressesRequest, v1.DeriveAddressesResponse]
 	createPsbt                   *connect.Client[v1.CreatePsbtRequest, v1.CreatePsbtResponse]
@@ -1050,6 +1063,11 @@ func (c *walletManagerServiceClient) BumpFee(ctx context.Context, req *connect.R
 	return c.bumpFee.CallUnary(ctx, req)
 }
 
+// PreviewBumpFee calls walletmanager.v1.WalletManagerService.PreviewBumpFee.
+func (c *walletManagerServiceClient) PreviewBumpFee(ctx context.Context, req *connect.Request[v1.PreviewBumpFeeRequest]) (*connect.Response[v1.PreviewBumpFeeResponse], error) {
+	return c.previewBumpFee.CallUnary(ctx, req)
+}
+
 // CreateCpfp calls walletmanager.v1.WalletManagerService.CreateCpfp.
 func (c *walletManagerServiceClient) CreateCpfp(ctx context.Context, req *connect.Request[v1.CreateCpfpRequest]) (*connect.Response[v1.CreateCpfpResponse], error) {
 	return c.createCpfp.CallUnary(ctx, req)
@@ -1252,6 +1270,9 @@ type WalletManagerServiceHandler interface {
 	GetTransactionDetails(context.Context, *connect.Request[v1.GetTransactionDetailsRequest]) (*connect.Response[v1.GetTransactionDetailsResponse], error)
 	DecodeTransaction(context.Context, *connect.Request[v1.DecodeTransactionRequest]) (*connect.Response[v1.DecodeTransactionResponse], error)
 	BumpFee(context.Context, *connect.Request[v1.BumpFeeRequest]) (*connect.Response[v1.BumpFeeResponse], error)
+	// PreviewBumpFee reports what a fee bump costs, and which output pays it,
+	// without broadcasting anything.
+	PreviewBumpFee(context.Context, *connect.Request[v1.PreviewBumpFeeRequest]) (*connect.Response[v1.PreviewBumpFeeResponse], error)
 	// CreateCpfp spends an unconfirmed wallet UTXO with a child transaction whose
 	// fee lifts the parent+child package to the target fee rate (CPFP).
 	CreateCpfp(context.Context, *connect.Request[v1.CreateCpfpRequest]) (*connect.Response[v1.CreateCpfpResponse], error)
@@ -1555,6 +1576,12 @@ func NewWalletManagerServiceHandler(svc WalletManagerServiceHandler, opts ...con
 		connect.WithSchema(walletManagerServiceMethods.ByName("BumpFee")),
 		connect.WithHandlerOptions(opts...),
 	)
+	walletManagerServicePreviewBumpFeeHandler := connect.NewUnaryHandler(
+		WalletManagerServicePreviewBumpFeeProcedure,
+		svc.PreviewBumpFee,
+		connect.WithSchema(walletManagerServiceMethods.ByName("PreviewBumpFee")),
+		connect.WithHandlerOptions(opts...),
+	)
 	walletManagerServiceCreateCpfpHandler := connect.NewUnaryHandler(
 		WalletManagerServiceCreateCpfpProcedure,
 		svc.CreateCpfp,
@@ -1805,6 +1832,8 @@ func NewWalletManagerServiceHandler(svc WalletManagerServiceHandler, opts ...con
 			walletManagerServiceDecodeTransactionHandler.ServeHTTP(w, r)
 		case WalletManagerServiceBumpFeeProcedure:
 			walletManagerServiceBumpFeeHandler.ServeHTTP(w, r)
+		case WalletManagerServicePreviewBumpFeeProcedure:
+			walletManagerServicePreviewBumpFeeHandler.ServeHTTP(w, r)
 		case WalletManagerServiceCreateCpfpProcedure:
 			walletManagerServiceCreateCpfpHandler.ServeHTTP(w, r)
 		case WalletManagerServiceDeriveAddressesProcedure:
@@ -2028,6 +2057,10 @@ func (UnimplementedWalletManagerServiceHandler) DecodeTransaction(context.Contex
 
 func (UnimplementedWalletManagerServiceHandler) BumpFee(context.Context, *connect.Request[v1.BumpFeeRequest]) (*connect.Response[v1.BumpFeeResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.BumpFee is not implemented"))
+}
+
+func (UnimplementedWalletManagerServiceHandler) PreviewBumpFee(context.Context, *connect.Request[v1.PreviewBumpFeeRequest]) (*connect.Response[v1.PreviewBumpFeeResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("walletmanager.v1.WalletManagerService.PreviewBumpFee is not implemented"))
 }
 
 func (UnimplementedWalletManagerServiceHandler) CreateCpfp(context.Context, *connect.Request[v1.CreateCpfpRequest]) (*connect.Response[v1.CreateCpfpResponse], error) {

--- a/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
+++ b/sidechain-orchestrator/proto/walletmanager/v1/walletmanager.proto
@@ -68,6 +68,9 @@ service WalletManagerService {
   rpc GetTransactionDetails(GetTransactionDetailsRequest) returns (GetTransactionDetailsResponse);
   rpc DecodeTransaction(DecodeTransactionRequest) returns (DecodeTransactionResponse);
   rpc BumpFee(BumpFeeRequest) returns (BumpFeeResponse);
+  // PreviewBumpFee reports what a fee bump costs, and which output pays it,
+  // without broadcasting anything.
+  rpc PreviewBumpFee(PreviewBumpFeeRequest) returns (PreviewBumpFeeResponse);
   // CreateCpfp spends an unconfirmed wallet UTXO with a child transaction whose
   // fee lifts the parent+child package to the target fee rate (CPFP).
   rpc CreateCpfp(CreateCpfpRequest) returns (CreateCpfpResponse);
@@ -1067,10 +1070,76 @@ message BumpFeeRequest {
   string wallet_id = 1;
   string txid = 2;
   int64 new_fee_rate = 3;  // sat/vB, 0 = automatic
+  // Output that pays the higher fee. Unset takes it from the change output,
+  // which is the only output a bump may touch without the user's consent.
+  optional int32 fee_from_vout = 4;
 }
 
 message BumpFeeResponse {
   string new_txid = 1;
+  BumpFeePlan plan = 2;
+}
+
+message PreviewBumpFeeRequest {
+  string wallet_id = 1;
+  string txid = 2;
+  int64 new_fee_rate = 3;  // sat/vB, 0 = the backend's own estimate
+  optional int32 fee_from_vout = 4;
+}
+
+message PreviewBumpFeeResponse {
+  int32 input_count = 1;
+  int64 vsize_vbytes = 2;
+  int64 old_fee_sats = 3;
+  double old_fee_rate_sat_vb = 4;
+  // Fee rate the backend suggests for the next blocks, in sat/vB.
+  int64 suggested_fee_rate = 5;
+  // Every output of the transaction, in order.
+  repeated BumpFeeOutput outputs = 6;
+  // The replacement. Unset when the wallet cannot build one.
+  BumpFeePlan plan = 7;
+  // Why the wallet cannot build a replacement. Empty when plan is set.
+  string reason = 8;
+  // The wallet holds the keys of every input, so it can sign a replacement at
+  // some fee rate. False marks a transaction no rate can replace.
+  bool can_replace = 9;
+  // Another transaction already spends this one. A replacement must outpay that
+  // child too, and a child transaction cannot speed this one up either.
+  bool has_child = 10;
+  // The backend funds a higher fee from another coin when the chosen output
+  // cannot cover it, so a replacement holds even with no plan to show.
+  bool adds_inputs = 11;
+}
+
+// BumpFeeOutput is one output of the transaction the fee can come from.
+message BumpFeeOutput {
+  int32 vout = 1;
+  int64 amount_sats = 2;
+  string address = 3;
+  // The wallet owns this output and it sits on the change chain.
+  bool is_change = 4;
+  // Amount below which the output cannot stay in the transaction.
+  int64 dust_sats = 5;
+  // The wallet owns this output. CPFP spends such an output, so a transaction
+  // with none of them has no child to speed it up.
+  bool is_mine = 6;
+}
+
+// BumpFeePlan is the replacement transaction a fee bump builds.
+message BumpFeePlan {
+  int64 old_fee_sats = 1;
+  int64 new_fee_sats = 2;
+  int64 extra_fee_sats = 3;
+  double new_fee_rate_sat_vb = 4;
+  // Output that pays, and what it holds before and after.
+  int32 fee_from_vout = 5;
+  int64 amount_before_sats = 6;
+  int64 amount_after_sats = 7;
+  // The output falls under the dust limit, so it goes away and its remainder
+  // joins the fee.
+  bool output_removed = 8;
+  // The output belongs to the recipient, not to the wallet.
+  bool reduces_payment = 9;
 }
 
 message CreateCpfpRequest {

--- a/sidechain-orchestrator/wallet/backend.go
+++ b/sidechain-orchestrator/wallet/backend.go
@@ -47,7 +47,8 @@ type Backend interface {
 	// signing, and broadcast however the backend does it.
 	Send(ctx context.Context, walletID string, req SendRequest) (string, error)
 	SignTransaction(ctx context.Context, walletID, rawHex string) (*SignRawTransactionResult, error)
-	BumpFee(ctx context.Context, walletID, txid string, newFeeRate int64) (string, error)
+	BumpFee(ctx context.Context, walletID string, req BumpFeeRequest) (*BumpFeeResult, error)
+	PreviewBumpFee(ctx context.Context, walletID string, req BumpFeeRequest) (*BumpFeePreview, error)
 	// CreateCpfp spends an unconfirmed wallet UTXO with a child transaction whose
 	// fee lifts the parent+child package to req.TargetRate, then broadcasts it and
 	// returns the child txid.

--- a/sidechain-orchestrator/wallet/bumpfee.go
+++ b/sidechain-orchestrator/wallet/bumpfee.go
@@ -1,0 +1,209 @@
+package wallet
+
+import (
+	"fmt"
+	"math"
+)
+
+const (
+	// minRelayFeeRate is the sat/vB a replacement adds on top of the fee it
+	// replaces, so the mempool accepts it (BIP125 rule 4).
+	minRelayFeeRate = 1
+	// coreBumpFeeTarget is the confirmation target, in blocks, behind the fee
+	// rate a fee bump suggests.
+	coreBumpFeeTarget = 3
+)
+
+func btcToSats(btc float64) int64 {
+	return int64(math.Round(btc * 1e8))
+}
+
+// BumpFeeRequest replaces an unconfirmed transaction with one that pays more.
+type BumpFeeRequest struct {
+	TxID string
+	// NewFeeRate is the sat/vB the replacement pays. Zero asks the backend for
+	// its own estimate.
+	NewFeeRate int64
+	// FeeFromVout takes the higher fee from that output. Nil takes it from the
+	// change output.
+	FeeFromVout *int
+}
+
+// BumpFeeOutput is one output of the transaction the higher fee can come from.
+type BumpFeeOutput struct {
+	Vout       int
+	AmountSats int64
+	Address    string
+	// IsChange marks an output the wallet pays back to itself.
+	IsChange bool
+	// IsMine marks an output the wallet can spend.
+	IsMine bool
+	// DustSats is the amount below which the output cannot stay.
+	DustSats int64
+	// VsizeBytes is what this output costs the transaction.
+	VsizeBytes int64
+}
+
+// BumpFeePlan is the replacement transaction a fee bump builds.
+type BumpFeePlan struct {
+	OldFeeSats   int64
+	NewFeeSats   int64
+	ExtraFeeSats int64
+	NewFeeRate   float64
+	FeeFromVout  int
+	AmountBefore int64
+	AmountAfter  int64
+	// OutputRemoved drops the output, because the rest of it falls under the
+	// dust limit. Its remainder joins the fee.
+	OutputRemoved bool
+	// ReducesPayment marks a plan that pays the fee out of a recipient's
+	// output, so the recipient gets less.
+	ReducesPayment bool
+}
+
+// BumpFeeResult is the replacement a fee bump broadcast.
+type BumpFeeResult struct {
+	NewTxID string
+	Plan    BumpFeePlan
+}
+
+// BumpFeePreview reports what a fee bump costs, before it happens.
+type BumpFeePreview struct {
+	InputCount    int
+	VsizeVBytes   int64
+	OldFeeSats    int64
+	OldFeeRate    float64
+	SuggestedRate int64
+	Outputs       []BumpFeeOutput
+	Plan          *BumpFeePlan
+	Reason        string
+	// CanReplace marks a transaction this wallet can sign again. A fee rate that
+	// is too low leaves Plan empty, but CanReplace stays true.
+	CanReplace bool
+	// HasChild marks a transaction another one already spends.
+	HasChild bool
+	// AddsInputs marks a backend that funds a higher fee from another coin when
+	// the chosen output cannot cover it. A replacement then holds even with no
+	// plan to show.
+	AddsInputs bool
+}
+
+func changeOutput(outputs []BumpFeeOutput) (BumpFeeOutput, bool) {
+	for _, o := range outputs {
+		if o.IsChange {
+			return o, true
+		}
+	}
+	return BumpFeeOutput{}, false
+}
+
+func pickBumpFeeOutput(outputs []BumpFeeOutput, vout *int) (BumpFeeOutput, error) {
+	if vout == nil {
+		target, ok := changeOutput(outputs)
+		if !ok {
+			return BumpFeeOutput{}, fmt.Errorf("transaction has no change output, so the higher fee has no output to come from")
+		}
+		return target, nil
+	}
+	for _, o := range outputs {
+		if o.Vout != *vout {
+			continue
+		}
+		if o.Address == "" {
+			return BumpFeeOutput{}, fmt.Errorf("output %d has no address, so it cannot pay the fee", *vout)
+		}
+		return o, nil
+	}
+	return BumpFeeOutput{}, fmt.Errorf("output %d is not part of the transaction", *vout)
+}
+
+// replacementVsize is the largest size the replacement can reach. It holds the
+// same inputs and no more outputs, so only a signature can grow, by one byte
+// per input at most.
+func replacementVsize(vsize int64, inputCount int) int64 {
+	return vsize + int64(inputCount)
+}
+
+// minBumpFeeRate is the lowest sat/vB a replacement of a transaction of vsize
+// vbytes paying oldFeeSats can use. It answers for the largest replacement, so
+// a signature that grows by a byte cannot drop the fee under the relay floor.
+func minBumpFeeRate(oldFeeSats, vsize int64, inputCount int) int64 {
+	if vsize <= 0 {
+		return 0
+	}
+	worst := replacementVsize(vsize, inputCount)
+	return int64(math.Ceil(float64(oldFeeSats+worst*minRelayFeeRate) / float64(vsize)))
+}
+
+// bumpFeeTx is the transaction a fee bump replaces. InputCount sizes the worst
+// case the replacement can reach once it carries new signatures.
+type bumpFeeTx struct {
+	OldFeeSats  int64
+	VsizeBytes  int64
+	InputCount  int
+	OutputCount int
+}
+
+// planBumpFee computes the replacement that pays newFeeRate, and takes the
+// higher fee out of target.
+func planBumpFee(tx bumpFeeTx, newFeeRate int64, target BumpFeeOutput) (BumpFeePlan, error) {
+	oldFeeSats, vsize, inputCount := tx.OldFeeSats, tx.VsizeBytes, tx.InputCount
+	if vsize <= 0 {
+		return BumpFeePlan{}, fmt.Errorf("transaction size %d vB is not valid", vsize)
+	}
+	if newFeeRate <= 0 {
+		return BumpFeePlan{}, fmt.Errorf("fee rate must be positive")
+	}
+	minRate := minBumpFeeRate(oldFeeSats, vsize, inputCount)
+	if newFeeRate < minRate {
+		return BumpFeePlan{}, fmt.Errorf("fee rate %d sat/vB does not replace a transaction that pays %d sats; use %d sat/vB or more", newFeeRate, oldFeeSats, minRate)
+	}
+	if newFeeRate > math.MaxInt64/vsize {
+		return BumpFeePlan{}, fmt.Errorf("fee rate %d sat/vB is too high for a transaction of %d vB", newFeeRate, vsize)
+	}
+
+	newFee := vsize * newFeeRate
+	extra := newFee - oldFeeSats
+	remainder := target.AmountSats - extra
+	if remainder < 0 {
+		return BumpFeePlan{}, fmt.Errorf("output %d holds %d sats, and the higher fee takes %d sats", target.Vout, target.AmountSats, extra)
+	}
+
+	plan := BumpFeePlan{
+		OldFeeSats:     oldFeeSats,
+		NewFeeSats:     newFee,
+		ExtraFeeSats:   extra,
+		FeeFromVout:    target.Vout,
+		AmountBefore:   target.AmountSats,
+		AmountAfter:    remainder,
+		ReducesPayment: !target.IsChange,
+	}
+	// The replacement pays the same fee over fewer bytes once an output goes
+	// away, so it carries a higher rate than the one asked for.
+	paidVsize := vsize
+	if remainder < target.DustSats {
+		if tx.OutputCount <= 1 {
+			return BumpFeePlan{}, fmt.Errorf("output %d is the only output, and the higher fee leaves it under the dust limit", target.Vout)
+		}
+		plan.OutputRemoved = true
+		plan.AmountAfter = 0
+		plan.NewFeeSats = oldFeeSats + target.AmountSats
+		plan.ExtraFeeSats = target.AmountSats
+		if target.VsizeBytes > 0 && target.VsizeBytes < vsize {
+			paidVsize = vsize - target.VsizeBytes
+		}
+	}
+	plan.NewFeeRate = float64(plan.NewFeeSats) / float64(paidVsize)
+	return plan, nil
+}
+
+// signalsBip125 reports whether any input carries a sequence below the final
+// one, which marks a transaction its sender allows a replacement of.
+func signalsBip125(sequences []int64) bool {
+	for _, sequence := range sequences {
+		if sequence < 0xfffffffe {
+			return true
+		}
+	}
+	return false
+}

--- a/sidechain-orchestrator/wallet/bumpfee_test.go
+++ b/sidechain-orchestrator/wallet/bumpfee_test.go
@@ -1,0 +1,141 @@
+package wallet
+
+import "testing"
+
+func TestMinBumpFeeRate(t *testing.T) {
+	if got := minBumpFeeRate(200, 200, 0); got != 2 {
+		t.Fatalf("min rate = %d, want 2", got)
+	}
+	if got := minBumpFeeRate(0, 200, 0); got != 1 {
+		t.Fatalf("min rate = %d, want 1", got)
+	}
+	if got := minBumpFeeRate(250, 200, 0); got != 3 {
+		t.Fatalf("min rate = %d, want 3", got)
+	}
+}
+
+// A replacement carries new signatures, so it can grow by a byte per input. The
+// floor covers that growth, or the node rejects the replacement.
+func TestMinBumpFeeRateCoversASignatureThatGrows(t *testing.T) {
+	plain := minBumpFeeRate(200, 200, 0)
+	padded := minBumpFeeRate(200, 200, 20)
+	if padded <= plain {
+		t.Fatalf("floor with 20 inputs = %d, want more than %d", padded, plain)
+	}
+	// The floor must still pay the relay increment for the largest replacement.
+	if padded*200 < 200+replacementVsize(200, 20) {
+		t.Fatalf("floor %d sat/vB pays %d sats, under the relay increment", padded, padded*200)
+	}
+}
+
+func TestPlanBumpFeeTakesFromChange(t *testing.T) {
+	change := BumpFeeOutput{Vout: 1, AmountSats: 10000, IsChange: true, DustSats: 294}
+	plan, err := planBumpFee(bumpFeeTx{OldFeeSats: 200, VsizeBytes: 200, InputCount: 1, OutputCount: 2}, 8, change)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if plan.NewFeeSats != 1600 {
+		t.Fatalf("new fee = %d, want 1600", plan.NewFeeSats)
+	}
+	if plan.ExtraFeeSats != 1400 {
+		t.Fatalf("extra = %d, want 1400", plan.ExtraFeeSats)
+	}
+	if plan.AmountAfter != 8600 {
+		t.Fatalf("amount after = %d, want 8600", plan.AmountAfter)
+	}
+	if plan.OutputRemoved {
+		t.Fatal("plan removes an output that stays above dust")
+	}
+	if plan.ReducesPayment {
+		t.Fatal("plan reduces a payment, but it takes the fee from change")
+	}
+	if plan.NewFeeRate != 8 {
+		t.Fatalf("new rate = %v, want 8", plan.NewFeeRate)
+	}
+}
+
+func TestPlanBumpFeeRefusesRateBelowMinimum(t *testing.T) {
+	change := BumpFeeOutput{Vout: 1, AmountSats: 10000, IsChange: true, DustSats: 294}
+	if _, err := planBumpFee(bumpFeeTx{OldFeeSats: 200, VsizeBytes: 200, InputCount: 1, OutputCount: 2}, 1, change); err == nil {
+		t.Fatal("plan accepts a fee rate that does not replace the transaction")
+	}
+}
+
+func TestPlanBumpFeeDropsDustChange(t *testing.T) {
+	change := BumpFeeOutput{Vout: 1, AmountSats: 1500, IsChange: true, DustSats: 294}
+	plan, err := planBumpFee(bumpFeeTx{OldFeeSats: 200, VsizeBytes: 200, InputCount: 1, OutputCount: 2}, 8, change)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if !plan.OutputRemoved {
+		t.Fatal("plan keeps a change output that falls under the dust limit")
+	}
+	if plan.AmountAfter != 0 {
+		t.Fatalf("amount after = %d, want 0", plan.AmountAfter)
+	}
+	if plan.NewFeeSats != 1700 {
+		t.Fatalf("new fee = %d, want 1700", plan.NewFeeSats)
+	}
+	if plan.ExtraFeeSats != 1500 {
+		t.Fatalf("extra = %d, want 1500", plan.ExtraFeeSats)
+	}
+}
+
+func TestPlanBumpFeeRefusesOutputThatCannotPay(t *testing.T) {
+	change := BumpFeeOutput{Vout: 1, AmountSats: 1000, IsChange: true, DustSats: 294}
+	if _, err := planBumpFee(bumpFeeTx{OldFeeSats: 200, VsizeBytes: 200, InputCount: 1, OutputCount: 2}, 8, change); err == nil {
+		t.Fatal("plan accepts an output that cannot pay the higher fee")
+	}
+}
+
+func TestPlanBumpFeeMarksReducedPayment(t *testing.T) {
+	payment := BumpFeeOutput{Vout: 0, AmountSats: 20000, DustSats: 294}
+	plan, err := planBumpFee(bumpFeeTx{OldFeeSats: 200, VsizeBytes: 200, InputCount: 1, OutputCount: 2}, 8, payment)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if !plan.ReducesPayment {
+		t.Fatal("plan takes the fee from a payment, but does not mark it")
+	}
+	if plan.AmountAfter != 18600 {
+		t.Fatalf("amount after = %d, want 18600", plan.AmountAfter)
+	}
+}
+
+func TestPickBumpFeeOutput(t *testing.T) {
+	outputs := []BumpFeeOutput{
+		{Vout: 0, AmountSats: 20000, Address: "tb1qpayment"},
+		{Vout: 1, AmountSats: 10000, Address: "tb1qchange", IsChange: true},
+	}
+	target, err := pickBumpFeeOutput(outputs, nil)
+	if err != nil {
+		t.Fatalf("pick: %v", err)
+	}
+	if target.Vout != 1 {
+		t.Fatalf("pick = %d, want the change output at 1", target.Vout)
+	}
+
+	vout := 0
+	target, err = pickBumpFeeOutput(outputs, &vout)
+	if err != nil {
+		t.Fatalf("pick: %v", err)
+	}
+	if target.Vout != 0 {
+		t.Fatalf("pick = %d, want 0", target.Vout)
+	}
+
+	missing := 7
+	if _, err := pickBumpFeeOutput(outputs, &missing); err == nil {
+		t.Fatal("pick accepts an output the transaction does not hold")
+	}
+
+	if _, err := pickBumpFeeOutput(outputs[:1], nil); err == nil {
+		t.Fatal("pick finds a change output in a transaction that has none")
+	}
+
+	opReturn := []BumpFeeOutput{{Vout: 0, AmountSats: 0}}
+	zero := 0
+	if _, err := pickBumpFeeOutput(opReturn, &zero); err == nil {
+		t.Fatal("pick accepts an output with no address")
+	}
+}

--- a/sidechain-orchestrator/wallet/core_backend.go
+++ b/sidechain-orchestrator/wallet/core_backend.go
@@ -568,7 +568,7 @@ func (p *CoreBackend) Send(ctx context.Context, walletID string, req SendRequest
 func (p *CoreBackend) createRawTx(
 	ctx context.Context, req SendRequest, inputs []RawInput, outputs []TxOutSpec, locktime uint32,
 ) (string, error) {
-	if len(req.RawOutputs) == 0 && len(req.ExternalInputs) == 0 {
+	if len(req.RawOutputs) == 0 && len(req.ExternalInputs) == 0 && !req.Replaceable {
 		rawHex, err := p.rpc.CreateRawTransaction(ctx, inputs, rpcOutputs(outputs), locktime)
 		if err != nil {
 			return "", fmt.Errorf("create raw transaction: %w", err)
@@ -739,12 +739,244 @@ func (p *CoreBackend) SignTransaction(ctx context.Context, walletID, rawHex stri
 	return p.rpc.SignRawTransactionWithWallet(ctx, name, rawHex)
 }
 
-func (p *CoreBackend) BumpFee(ctx context.Context, walletID, txid string, newFeeRate int64) (string, error) {
+// PreviewBumpFee reports what a replacement of req.TxID costs, and which output
+// pays for it. A transaction it cannot replace comes back with a Reason and no
+// Plan, so the caller can tell the user why.
+func (p *CoreBackend) PreviewBumpFee(ctx context.Context, walletID string, req BumpFeeRequest) (*BumpFeePreview, error) {
 	name, err := p.walletName(ctx, walletID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return p.rpc.BumpFee(ctx, name, txid, newFeeRate)
+	preview, _, err := p.previewBumpFee(ctx, name, req)
+	return preview, err
+}
+
+func (p *CoreBackend) previewBumpFee(ctx context.Context, name string, req BumpFeeRequest) (*BumpFeePreview, *RawTransaction, error) {
+	entry, err := p.rpc.GetMempoolEntry(ctx, req.TxID)
+	if err != nil {
+		return nil, nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("transaction %s waits in no mempool: %w", req.TxID, err))
+	}
+	if entry.Vsize <= 0 {
+		return nil, nil, fmt.Errorf("transaction %s reports no size", req.TxID)
+	}
+	tx, err := p.rpc.GetRawTransaction(ctx, req.TxID)
+	if err != nil {
+		return nil, nil, err
+	}
+	oldFee := btcToSats(entry.Fees.Base)
+
+	outputs := make([]BumpFeeOutput, 0, len(tx.Vout))
+	for _, vout := range tx.Vout {
+		out := BumpFeeOutput{
+			Vout:       vout.N,
+			AmountSats: btcToSats(vout.Value),
+			Address:    vout.ScriptPubKey.Address,
+		}
+		if out.Address != "" {
+			kind := addressKind(out.Address, p.net())
+			out.DustSats = dustThreshold(kind)
+			out.VsizeBytes = int64(outputVsizeForKind(kind))
+			info, err := p.rpc.GetAddressInfo(ctx, name, out.Address)
+			if err != nil {
+				return nil, nil, err
+			}
+			out.IsMine = info.IsMine
+			out.IsChange = info.IsMine && info.IsChange
+		} else {
+			out.VsizeBytes = int64(outputVsizeForKind(ScriptLegacy))
+		}
+		outputs = append(outputs, out)
+	}
+
+	suggested := minBumpFeeRate(oldFee, entry.Vsize, len(tx.Vin))
+	// A node with no fee history answers nothing; the floor above then stands.
+	if rate, err := p.rpc.EstimateSmartFee(ctx, coreBumpFeeTarget); err == nil {
+		if ceil := int64(math.Ceil(rate)); ceil > suggested {
+			suggested = ceil
+		}
+	}
+	preview := &BumpFeePreview{
+		InputCount:    len(tx.Vin),
+		VsizeVBytes:   entry.Vsize,
+		OldFeeSats:    oldFee,
+		OldFeeRate:    float64(oldFee) / float64(entry.Vsize),
+		SuggestedRate: suggested,
+		Outputs:       outputs,
+	}
+
+	// A replacement must outpay the transaction it replaces and every child of
+	// it. Core's own bumpfee refuses such a parent, and so does this. It answers
+	// before ownership, because a child blocks every path.
+	if entry.DescendantCount > 1 {
+		preview.HasChild = true
+		preview.Reason = "another transaction already spends this one, so it has no replacement"
+		return preview, tx, nil
+	}
+	// Core refuses to bump a transaction that does not signal BIP125.
+	if !signalsBip125(lo.Map(tx.Vin, func(in RawTxIn, _ int) int64 { return in.Sequence })) {
+		preview.Reason = "this transaction does not signal replacement, so no replacement can follow it"
+		return preview, tx, nil
+	}
+
+	// Core reports the fee of a transaction only when this wallet paid it. A
+	// transaction with no fee here spends inputs this wallet cannot sign, so it
+	// has no replacement to build.
+	raw, err := p.rpc.GetTransaction(ctx, name, req.TxID)
+	if err != nil {
+		preview.Reason = "this wallet does not hold the transaction, so it cannot build a replacement"
+		return preview, tx, nil
+	}
+	var walletTx struct {
+		Fee *float64 `json:"fee"`
+	}
+	if err := json.Unmarshal(raw, &walletTx); err != nil {
+		return nil, nil, fmt.Errorf("decode gettransaction: %w", err)
+	}
+	if walletTx.Fee == nil {
+		preview.Reason = "this wallet signs none of the inputs, so it cannot build a replacement"
+		return preview, tx, nil
+	}
+	// Core reports the fee as the wallet's own debit less the outputs, so it
+	// matches the real fee only when the wallet funds every input. A rebuild
+	// signs them all again, and Core's own bumpfee refuses a foreign input too.
+	if btcToSats(-*walletTx.Fee) != oldFee {
+		preview.Reason = "this wallet signs only part of the inputs, so it cannot replace the transaction"
+		return preview, tx, nil
+	}
+
+	preview.CanReplace = true
+	// Core's own bumpfee adds a coin when the change cannot pay the higher fee,
+	// so the change path holds even when the planner finds no room.
+	preview.AddsInputs = true
+
+	rate := req.NewFeeRate
+	if rate <= 0 {
+		rate = suggested
+	}
+	target, err := pickBumpFeeOutput(outputs, req.FeeFromVout)
+	if err != nil {
+		preview.Reason = err.Error()
+		return preview, tx, nil
+	}
+	// A rebuild spends exactly what the transaction it replaces spends, so only
+	// the change path reaches Core's own coin selection.
+	preview.AddsInputs = target.IsChange
+	plan, err := planBumpFee(bumpFeeTx{
+		OldFeeSats:  oldFee,
+		VsizeBytes:  entry.Vsize,
+		InputCount:  len(tx.Vin),
+		OutputCount: len(tx.Vout),
+	}, rate, target)
+	if err != nil {
+		preview.Reason = err.Error()
+		return preview, tx, nil
+	}
+	preview.Plan = &plan
+	return preview, tx, nil
+}
+
+// BumpFee replaces req.TxID with a transaction that pays a higher fee out of
+// one output. Core's own bumpfee takes it from the change output; an output the
+// user picks by hand is a rebuild, because bumpfee refuses to touch a payment.
+func (p *CoreBackend) BumpFee(ctx context.Context, walletID string, req BumpFeeRequest) (*BumpFeeResult, error) {
+	name, err := p.walletName(ctx, walletID)
+	if err != nil {
+		return nil, err
+	}
+	preview, tx, err := p.previewBumpFee(ctx, name, req)
+	if err != nil {
+		return nil, err
+	}
+	if preview.Plan == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(preview.Reason))
+	}
+	plan := *preview.Plan
+	rate := req.NewFeeRate
+	if rate <= 0 {
+		rate = preview.SuggestedRate
+	}
+	var targetAddress string
+	for _, out := range preview.Outputs {
+		if out.Vout == plan.FeeFromVout {
+			targetAddress = out.Address
+			break
+		}
+	}
+
+	if !plan.ReducesPayment {
+		newTxID, err := p.rpc.BumpFee(ctx, name, req.TxID, rate)
+		if err != nil {
+			return nil, err
+		}
+		return &BumpFeeResult{NewTxID: newTxID, Plan: p.settledPlan(ctx, newTxID, targetAddress, plan)}, nil
+	}
+
+	inputs := lo.Map(tx.Vin, func(in RawTxIn, _ int) RawInput {
+		return RawInput{TxID: in.TxID, Vout: in.Vout}
+	})
+	outputs := make([]TxOutSpec, 0, len(tx.Vout))
+	for _, vout := range tx.Vout {
+		amount := btcToSats(vout.Value)
+		if vout.N == plan.FeeFromVout {
+			if plan.OutputRemoved {
+				continue
+			}
+			amount = plan.AmountAfter
+		}
+		out := TxOutSpec{AmountBTC: float64(amount) / 1e8, AmountSats: amount}
+		if vout.ScriptPubKey.Address == "" {
+			out.RawScriptHex = vout.ScriptPubKey.Hex
+		} else {
+			out.Address = vout.ScriptPubKey.Address
+		}
+		outputs = append(outputs, out)
+	}
+	// The replacement keeps the locktime of the transaction it replaces, so an
+	// eCash send keeps its replay stamp.
+	rawHex, err := p.createRawTx(ctx, SendRequest{Replaceable: true}, inputs, outputs, uint32(tx.Locktime))
+	if err != nil {
+		return nil, err
+	}
+	newTxID, err := p.signAndBroadcast(ctx, name, rawHex, false)
+	if err != nil {
+		return nil, err
+	}
+	return &BumpFeeResult{NewTxID: newTxID, Plan: p.settledPlan(ctx, newTxID, targetAddress, plan)}, nil
+}
+
+// settledPlan replaces the planned numbers with what the broadcast transaction
+// really pays and really holds. Core picks its own inputs, size and output to
+// reduce, so the plan alone would report numbers nobody paid.
+func (p *CoreBackend) settledPlan(ctx context.Context, txid, targetAddress string, plan BumpFeePlan) BumpFeePlan {
+	entry, err := p.rpc.GetMempoolEntry(ctx, txid)
+	if err != nil || entry.Vsize <= 0 {
+		p.log.Warn().Err(err).Str("txid", txid).Msg("replacement broadcast, but its own fee stays unread")
+		return plan
+	}
+	plan.NewFeeSats = btcToSats(entry.Fees.Base)
+	plan.ExtraFeeSats = plan.NewFeeSats - plan.OldFeeSats
+	plan.NewFeeRate = float64(plan.NewFeeSats) / float64(entry.Vsize)
+
+	raw, err := p.rpc.GetRawTransaction(ctx, txid)
+	if err != nil || raw == nil {
+		p.log.Warn().Err(err).Str("txid", txid).Msg("replacement broadcast, but its own outputs stay unread")
+		return plan
+	}
+	if targetAddress == "" {
+		return plan
+	}
+	plan.OutputRemoved = true
+	plan.AmountAfter = 0
+	for _, vout := range raw.Vout {
+		if vout.ScriptPubKey.Address != targetAddress {
+			continue
+		}
+		plan.OutputRemoved = false
+		plan.FeeFromVout = vout.N
+		plan.AmountAfter = btcToSats(vout.Value)
+		break
+	}
+	return plan
 }
 
 func (p *CoreBackend) CreateCpfp(ctx context.Context, walletID string, req CpfpRequest) (string, error) {

--- a/sidechain-orchestrator/wallet/core_backend_test.go
+++ b/sidechain-orchestrator/wallet/core_backend_test.go
@@ -1286,3 +1286,311 @@ func TestCoreBackendImportsEveryKindTheWalletAdvertises(t *testing.T) {
 	assert.Contains(t, singleSig[0].Desc, "tr([")
 	assert.Contains(t, singleSig[2].Desc, "wpkh([")
 }
+
+// coreBumpFeeFixture stubs an unconfirmed wallet transaction that pays a
+// stranger and returns change, so a fee bump has both kinds of output.
+func coreBumpFeeFixture(t *testing.T) (*CoreBackend, *fakeBitcoind, string, string, string) {
+	t.Helper()
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+
+	paymentAddr := p2wpkhAddr(t, fixedKey(0x88), &chaincfg.RegressionNetParams)
+	changeAddr := p2wpkhAddr(t, fixedKey(0x99), &chaincfg.RegressionNetParams)
+
+	fake.handle("getmempoolentry", func(c bitcoindCall) (any, string) {
+		var txid string
+		_ = json.Unmarshal(c.Params[0], &txid)
+		if txid != coreBumpTxid {
+			// Core picks its own size and fee for the replacement, and they
+			// differ from what the plan predicted.
+			return map[string]any{"vsize": 162, "fees": map[string]any{"base": float64(1620) / 1e8}, "descendantcount": 1}, ""
+		}
+		return map[string]any{"vsize": 150, "fees": map[string]any{"base": float64(150) / 1e8}, "descendantcount": 1}, ""
+	})
+	fake.handle("estimatesmartfee", func(bitcoindCall) (any, string) {
+		return map[string]any{"feerate": 0.00002, "blocks": 3}, ""
+	})
+	fake.handle("gettransaction", func(bitcoindCall) (any, string) {
+		return map[string]any{"txid": coreBumpTxid, "fee": -0.00000150}, ""
+	})
+	// Core carries no prevout for a transaction that waits in the mempool, so
+	// the funding transaction answers who owns each input.
+	fake.handle("getrawtransaction", func(c bitcoindCall) (any, string) {
+		if mustString(t, c.Params[0]) == coreBumpFundingTxid {
+			return map[string]any{
+				"txid": coreBumpFundingTxid,
+				"vout": []map[string]any{
+					{"value": 0.002, "n": 0, "scriptPubKey": map[string]any{"address": changeAddr, "type": "witness_v0_keyhash"}},
+				},
+			}, ""
+		}
+		return map[string]any{
+			"txid":     coreBumpTxid,
+			"vsize":    150,
+			"locktime": 0,
+			"vin":      []map[string]any{{"txid": coreBumpFundingTxid, "vout": 0, "sequence": 4294967293}},
+			"vout": []map[string]any{
+				{"value": 0.001, "n": 0, "scriptPubKey": map[string]any{"address": paymentAddr, "type": "witness_v0_keyhash"}},
+				{"value": 0.0009985, "n": 1, "scriptPubKey": map[string]any{"address": changeAddr, "type": "witness_v0_keyhash"}},
+			},
+		}, ""
+	})
+	fake.handle("getaddressinfo", func(c bitcoindCall) (any, string) {
+		var address string
+		_ = json.Unmarshal(c.Params[0], &address)
+		return map[string]any{
+			"address":   address,
+			"hdkeypath": "m/84'/1'/0'/1/0",
+			"ismine":    address == changeAddr,
+			"ischange":  address == changeAddr,
+		}, ""
+	})
+	return backend, fake, coreID, paymentAddr, changeAddr
+}
+
+// serveReplacement teaches the fake to answer getrawtransaction for the
+// transaction a bump broadcasts, the way Core answers for its own replacement.
+func (f *fakeBitcoind) serveReplacement(t *testing.T, txid, paymentAddr string, paymentBTC float64, changeAddr string, changeBTC float64) {
+	t.Helper()
+	previous := f.handlers["getrawtransaction"]
+	f.handle("getrawtransaction", func(c bitcoindCall) (any, string) {
+		if mustString(t, c.Params[0]) == txid {
+			return map[string]any{
+				"txid": txid,
+				"vout": []map[string]any{
+					{"value": paymentBTC, "n": 0, "scriptPubKey": map[string]any{"address": paymentAddr}},
+					{"value": changeBTC, "n": 1, "scriptPubKey": map[string]any{"address": changeAddr}},
+				},
+			}, ""
+		}
+		return previous(c)
+	})
+}
+
+const (
+	coreBumpTxid        = "77777777777777777777777777777777777777777777777777777777777777aa"
+	coreBumpFundingTxid = "88888888888888888888888888888888888888888888888888888888888888bb"
+)
+
+func TestCoreBackendBumpFeeTakesItFromChange(t *testing.T) {
+	backend, fake, coreID, paymentAddr, changeAddr := coreBumpFeeFixture(t)
+	fake.handle("bumpfee", func(bitcoindCall) (any, string) {
+		return map[string]any{"txid": "replacement-txid"}, ""
+	})
+	fake.serveReplacement(t, "replacement-txid", paymentAddr, 0.001, changeAddr, 0.0009838)
+
+	result, err := backend.BumpFee(context.Background(), coreID, BumpFeeRequest{TxID: coreBumpTxid, NewFeeRate: 10})
+	require.NoError(t, err)
+	assert.Equal(t, "replacement-txid", result.NewTxID)
+	assert.False(t, result.Plan.ReducesPayment)
+	assert.Equal(t, 1, result.Plan.FeeFromVout, "the change output pays")
+	assert.Equal(t, int64(1620), result.Plan.NewFeeSats, "the plan reports what the replacement really pays, not what it planned")
+	assert.Equal(t, int64(1470), result.Plan.ExtraFeeSats)
+	assert.InDelta(t, 10.0, result.Plan.NewFeeRate, 0.001, "the rate follows the size Core chose")
+	assert.Equal(t, int64(98_380), result.Plan.AmountAfter, "the plan reports what the change output really holds")
+
+	calls := fake.callsFor("bumpfee")
+	require.Len(t, calls, 1)
+	require.Len(t, calls[0].Params, 2, "bumpfee must carry the fee rate")
+	var options map[string]any
+	require.NoError(t, json.Unmarshal(calls[0].Params[1], &options))
+	assert.Equal(t, float64(10), options["fee_rate"])
+	assert.Empty(t, fake.callsFor("sendrawtransaction"), "Core builds the replacement itself")
+}
+
+func TestCoreBackendBumpFeeTakesItFromAPayment(t *testing.T) {
+	backend, fake, coreID, paymentAddr, changeAddr := coreBumpFeeFixture(t)
+	fake.serveReplacement(t, "rebuilt-txid", paymentAddr, 0.0009865, changeAddr, 0.0009985)
+	var signedHex string
+	fake.handle("signrawtransactionwithwallet", func(c bitcoindCall) (any, string) {
+		signedHex = mustString(t, c.Params[0])
+		return map[string]any{"hex": signedHex, "complete": true}, ""
+	})
+	fake.handle("sendrawtransaction", func(bitcoindCall) (any, string) { return "rebuilt-txid", "" })
+
+	vout := 0
+	result, err := backend.BumpFee(context.Background(), coreID, BumpFeeRequest{
+		TxID: coreBumpTxid, NewFeeRate: 10, FeeFromVout: &vout,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "rebuilt-txid", result.NewTxID)
+	assert.True(t, result.Plan.ReducesPayment)
+	assert.Equal(t, int64(98_650), result.Plan.AmountAfter)
+	assert.Empty(t, fake.callsFor("bumpfee"), "Core's bumpfee refuses to touch a payment")
+
+	raw, err := hex.DecodeString(signedHex)
+	require.NoError(t, err)
+	var tx wire.MsgTx
+	require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+	require.Len(t, tx.TxIn, 1, "the replacement spends the same input")
+	assert.Equal(t, coreBumpFundingTxid, tx.TxIn[0].PreviousOutPoint.Hash.String())
+	assert.Equal(t, bip125Sequence, tx.TxIn[0].Sequence, "the replacement stays replaceable")
+	require.Len(t, tx.TxOut, 2)
+	assert.Equal(t, int64(98_650), tx.TxOut[0].Value, "the recipient pays the higher fee")
+	assert.Equal(t, int64(99_850), tx.TxOut[1].Value, "the change keeps its amount")
+}
+
+func TestCoreBackendPreviewBumpFeeReportsTheOutputs(t *testing.T) {
+	backend, _, coreID, paymentAddr, changeAddr := coreBumpFeeFixture(t)
+
+	preview, err := backend.PreviewBumpFee(context.Background(), coreID, BumpFeeRequest{TxID: coreBumpTxid, NewFeeRate: 10})
+	require.NoError(t, err)
+	assert.Equal(t, int64(150), preview.OldFeeSats)
+	assert.Equal(t, int64(150), preview.VsizeVBytes)
+	assert.Equal(t, 1, preview.InputCount)
+	require.Len(t, preview.Outputs, 2)
+	assert.Equal(t, paymentAddr, preview.Outputs[0].Address)
+	assert.False(t, preview.Outputs[0].IsChange)
+	assert.Equal(t, changeAddr, preview.Outputs[1].Address)
+	assert.True(t, preview.Outputs[1].IsChange)
+	require.NotNil(t, preview.Plan)
+	assert.Equal(t, int64(1350), preview.Plan.ExtraFeeSats)
+}
+
+// A transaction this wallet does not fund has no replacement to build: Core
+// reports no fee for it, and the rebuild could never sign its inputs.
+func TestCoreBackendPreviewBumpFeeRefusesForeignInputs(t *testing.T) {
+	backend, fake, coreID, _, _ := coreBumpFeeFixture(t)
+	fake.handle("gettransaction", func(bitcoindCall) (any, string) {
+		return map[string]any{"txid": coreBumpTxid}, ""
+	})
+
+	preview, err := backend.PreviewBumpFee(context.Background(), coreID, BumpFeeRequest{TxID: coreBumpTxid, NewFeeRate: 10})
+	require.NoError(t, err)
+	assert.Nil(t, preview.Plan)
+	assert.Contains(t, preview.Reason, "signs none of the inputs")
+
+	vout := 0
+	_, err = backend.BumpFee(context.Background(), coreID, BumpFeeRequest{TxID: coreBumpTxid, NewFeeRate: 10, FeeFromVout: &vout})
+	require.Error(t, err, "a replacement it cannot sign must not reach the node")
+	assert.Empty(t, fake.callsFor("sendrawtransaction"))
+}
+
+// A rebuild signs every input again. A transaction with an input this wallet
+// cannot sign — a sidechain CTIP, or a collaborative send — has no rebuild.
+func TestCoreBackendPreviewBumpFeeRefusesAPartlyOwnedTransaction(t *testing.T) {
+	backend, fake, coreID, _, _ := coreBumpFeeFixture(t)
+	// Core counts only the wallet's own debit, so its fee falls short of the
+	// fee the mempool reports when a foreign input helps fund the transaction.
+	fake.handle("gettransaction", func(bitcoindCall) (any, string) {
+		return map[string]any{"txid": coreBumpTxid, "fee": -0.00000100}, ""
+	})
+
+	for _, req := range []BumpFeeRequest{
+		{TxID: coreBumpTxid, NewFeeRate: 10},
+		{TxID: coreBumpTxid, NewFeeRate: 10, FeeFromVout: intPtr(0)},
+	} {
+		preview, err := backend.PreviewBumpFee(context.Background(), coreID, req)
+		require.NoError(t, err)
+		assert.Nil(t, preview.Plan)
+		assert.False(t, preview.CanReplace, "neither Core's bumpfee nor a rebuild can sign it")
+		assert.Contains(t, preview.Reason, "only part of the inputs")
+	}
+}
+
+// A transaction that already carries a child has no replacement: it must outpay
+// the child too, and Core's own bumpfee refuses such a parent.
+func TestCoreBackendPreviewBumpFeeRefusesAParentWithAChild(t *testing.T) {
+	backend, fake, coreID, _, _ := coreBumpFeeFixture(t)
+	fake.handle("getmempoolentry", func(bitcoindCall) (any, string) {
+		return map[string]any{"vsize": 150, "fees": map[string]any{"base": float64(150) / 1e8}, "descendantcount": 2}, ""
+	})
+
+	preview, err := backend.PreviewBumpFee(context.Background(), coreID, BumpFeeRequest{TxID: coreBumpTxid, NewFeeRate: 10})
+	require.NoError(t, err)
+	assert.Nil(t, preview.Plan)
+	assert.False(t, preview.CanReplace)
+	assert.True(t, preview.HasChild, "a child transaction cannot speed this one up either")
+	assert.Contains(t, preview.Reason, "already spends this one")
+}
+
+func intPtr(v int) *int { return &v }
+
+// A send that asks to stay replaceable must carry BIP125 sequences, so a fee
+// bump can follow it. createrawtransaction cannot set them.
+func TestCoreBackendReplaceableSendSignalsBip125(t *testing.T) {
+	backend, fake, coreID := newCoreBackendFixture(t)
+	fake.stubEnsureFlow()
+	dest := p2wpkhAddr(t, fixedKey(0x21), &chaincfg.RegressionNetParams)
+
+	fake.handle("listunspent", func(bitcoindCall) (any, string) {
+		return []map[string]any{
+			{"txid": coreBumpFundingTxid, "vout": 0, "amount": 0.01, "spendable": true, "confirmations": 3},
+		}, ""
+	})
+	fake.handle("getrawchangeaddress", func(bitcoindCall) (any, string) {
+		return p2wpkhAddr(t, fixedKey(0x22), &chaincfg.RegressionNetParams), ""
+	})
+	var signedHex string
+	fake.handle("signrawtransactionwithwallet", func(c bitcoindCall) (any, string) {
+		signedHex = mustString(t, c.Params[0])
+		return map[string]any{"hex": signedHex, "complete": true}, ""
+	})
+	fake.handle("sendrawtransaction", func(bitcoindCall) (any, string) { return "sent-txid", "" })
+
+	_, err := backend.Send(context.Background(), coreID, SendRequest{
+		DestinationsSats: map[string]int64{dest: 500_000},
+		FixedFeeSats:     1_000,
+		Replaceable:      true,
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, fake.callsFor("createrawtransaction"),
+		"createrawtransaction cannot signal BIP125, so the send builds the transaction itself")
+	raw, err := hex.DecodeString(signedHex)
+	require.NoError(t, err)
+	var tx wire.MsgTx
+	require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+	require.NotEmpty(t, tx.TxIn)
+	for i, in := range tx.TxIn {
+		assert.Equal(t, bip125Sequence, in.Sequence, "input %d does not signal BIP125", i)
+	}
+}
+
+// Core refuses to bump a transaction that does not signal replacement, so the
+// preview says so before the dialog offers one.
+func TestCoreBackendPreviewBumpFeeRefusesAFinalTransaction(t *testing.T) {
+	backend, fake, coreID, paymentAddr, changeAddr := coreBumpFeeFixture(t)
+	fake.handle("getrawtransaction", func(c bitcoindCall) (any, string) {
+		if mustString(t, c.Params[0]) == coreBumpFundingTxid {
+			return map[string]any{
+				"txid": coreBumpFundingTxid,
+				"vout": []map[string]any{{"value": 0.002, "n": 0, "scriptPubKey": map[string]any{"address": changeAddr}}},
+			}, ""
+		}
+		return map[string]any{
+			"txid":     coreBumpTxid,
+			"vsize":    150,
+			"locktime": 0,
+			"vin":      []map[string]any{{"txid": coreBumpFundingTxid, "vout": 0, "sequence": 4294967295}},
+			"vout": []map[string]any{
+				{"value": 0.001, "n": 0, "scriptPubKey": map[string]any{"address": paymentAddr}},
+				{"value": 0.0009985, "n": 1, "scriptPubKey": map[string]any{"address": changeAddr}},
+			},
+		}, ""
+	})
+
+	preview, err := backend.PreviewBumpFee(context.Background(), coreID, BumpFeeRequest{TxID: coreBumpTxid, NewFeeRate: 10})
+	require.NoError(t, err)
+	assert.Nil(t, preview.Plan)
+	assert.False(t, preview.CanReplace)
+	assert.Contains(t, preview.Reason, "does not signal replacement")
+}
+
+// Core adds a coin when the change cannot pay the higher fee, so the change
+// path holds even when the planner finds no room in that output.
+func TestCoreBackendPreviewBumpFeeAddsInputsForTheChangePath(t *testing.T) {
+	backend, _, coreID, _, _ := coreBumpFeeFixture(t)
+
+	preview, err := backend.PreviewBumpFee(context.Background(), coreID, BumpFeeRequest{TxID: coreBumpTxid, NewFeeRate: 10})
+	require.NoError(t, err)
+	assert.True(t, preview.AddsInputs, "Core funds the change path itself")
+
+	// A rebuild spends exactly what it replaces, so it cannot add a coin.
+	vout := 0
+	preview, err = backend.PreviewBumpFee(context.Background(), coreID, BumpFeeRequest{
+		TxID: coreBumpTxid, NewFeeRate: 10, FeeFromVout: &vout,
+	})
+	require.NoError(t, err)
+	assert.False(t, preview.AddsInputs)
+}

--- a/sidechain-orchestrator/wallet/core_rpc.go
+++ b/sidechain-orchestrator/wallet/core_rpc.go
@@ -500,6 +500,8 @@ type MempoolEntry struct {
 	Fees  struct {
 		Base float64 `json:"base"`
 	} `json:"fees"`
+	// DescendantCount counts this transaction and every child of it.
+	DescendantCount int64 `json:"descendantcount"`
 }
 
 // GetMempoolEntry returns mempool metadata for an unconfirmed txid, including
@@ -514,6 +516,26 @@ func (c *CoreRPCClient) GetMempoolEntry(ctx context.Context, txid string) (*Memp
 		return nil, fmt.Errorf("decode getmempoolentry: %w", err)
 	}
 	return &entry, nil
+}
+
+// EstimateSmartFee returns the fee rate in sat/vB Core expects for a
+// confirmation target in blocks. A node with no fee history answers an error.
+func (c *CoreRPCClient) EstimateSmartFee(ctx context.Context, confTarget int) (float64, error) {
+	result, err := c.call(ctx, "", "estimatesmartfee", confTarget)
+	if err != nil {
+		return 0, err
+	}
+	var resp struct {
+		FeeRate float64  `json:"feerate"`
+		Errors  []string `json:"errors"`
+	}
+	if err := json.Unmarshal(result, &resp); err != nil {
+		return 0, fmt.Errorf("decode estimatesmartfee: %w", err)
+	}
+	if resp.FeeRate <= 0 {
+		return 0, fmt.Errorf("no fee estimate for %d blocks: %v", confTarget, resp.Errors)
+	}
+	return resp.FeeRate * 1e8 / 1000, nil
 }
 
 // GetBlockchainInfo returns blockchain info (used for health checks and sync).
@@ -561,6 +583,7 @@ type AddressInfo struct {
 	HDKeyPath  string `json:"hdkeypath"`
 	HDSeedID   string `json:"hdseedid"`
 	IsMine     bool   `json:"ismine"`
+	IsChange   bool   `json:"ischange"`
 	Solvable   bool   `json:"solvable"`
 	IsScript   bool   `json:"isscript"`
 	IsWitness  bool   `json:"iswitness"`

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -43,6 +43,9 @@ const (
 	// electrumDeepScanEvery forces the full gap again, so a payment to an
 	// address past the refresh lookahead still lands.
 	electrumDeepScanEvery = 5 * time.Minute
+	// electrumBumpFeeTarget is the confirmation target, in blocks, behind the
+	// fee rate a fee bump suggests.
+	electrumBumpFeeTarget = 3
 	// electrumMaxScan caps per-chain derivation so a misbehaving backend
 	// can't drive an unbounded scan.
 	electrumMaxScan = 1000
@@ -652,6 +655,79 @@ func (p *ElectrumBackend) signAndBroadcast(ctx context.Context, walletID string,
 	return txid, nil
 }
 
+// holdsTx reports whether the history already carries that transaction.
+func holdsTx(txs []EsploraTx, txid string) bool {
+	for _, t := range txs {
+		if t.TxID == txid {
+			return true
+		}
+	}
+	return false
+}
+
+// scanHoldsChildOf reports whether the wallet knows a transaction that spends
+// txid. A replacement evicts such a child, so it must outpay that child too.
+func scanHoldsChildOf(scan *electrumScan, txid string) bool {
+	for _, a := range scan.addrs {
+		for _, t := range a.txs {
+			if t.TxID == txid {
+				continue
+			}
+			for _, vin := range t.Vin {
+				if vin.TxID == txid {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// creditScan adds one output the send pays to this wallet into the cached scan,
+// so balance and UTXO reads carry it before the next walk.
+func creditScan(scan *electrumScan, txid string, sentTx EsploraTx, addr scannedAddr, sats int64, vout int) {
+	if vout < 0 {
+		return
+	}
+	utxo := EsploraUTXO{TxID: txid, Vout: vout, Value: sats}
+	if i := indexOfAddr(scan.addrs, addr.address); i >= 0 {
+		a := &scan.addrs[i]
+		a.utxos = append(append([]EsploraUTXO(nil), a.utxos...), utxo)
+		a.stats.MempoolStats.FundedTxoSum += sats
+		a.stats.MempoolStats.FundedTxoCount++
+		if !holdsTx(a.txs, txid) {
+			a.stats.MempoolStats.TxCount++
+			a.txs = append(append([]EsploraTx(nil), a.txs...), sentTx)
+		}
+		return
+	}
+	ca := addr
+	ca.utxos = []EsploraUTXO{utxo}
+	ca.txs = []EsploraTx{sentTx}
+	ca.stats.Address = ca.address
+	ca.stats.MempoolStats.FundedTxoSum += sats
+	ca.stats.MempoolStats.FundedTxoCount++
+	ca.stats.MempoolStats.TxCount++
+	scan.addrs = append(scan.addrs, ca)
+}
+
+// findVout returns the index of the output paying script for sats, or -1.
+func findVout(packet *psbt.Packet, script []byte, sats int64) int {
+	for i, out := range packet.UnsignedTx.TxOut {
+		if bytes.Equal(out.PkScript, script) && out.Value == sats {
+			return i
+		}
+	}
+	return -1
+}
+
+// walletCredit is one output a send pays back to this wallet.
+type walletCredit struct {
+	addr scannedAddr
+	sats int64
+	vout int
+}
+
 // spendEffect captures what a send consumed and produced so the cached scan can
 // be updated in place after broadcast instead of re-walking the wallet: the
 // inputs it spent and the change it created (change is nil when none).
@@ -659,6 +735,19 @@ type spendEffect struct {
 	spent      []electrumUTXO
 	change     *scannedAddr
 	changeSats int64
+	// evicted holds outputs the broadcast kills without spending them: the
+	// outputs of a transaction that a replacement pushes out of the mempool.
+	// They leave the cache, but they are not inputs of the new transaction.
+	evicted []electrumUTXO
+	// credited holds every output the send pays to this wallet, for a send that
+	// pays itself on more than the change branch.
+	credited []walletCredit
+	// replacedTxID is the transaction this one pushes out of the mempool.
+	replacedTxID string
+	// replaces marks a transaction that replaces another one. The cache already
+	// counts its inputs as spent, because the transaction it replaces spent
+	// them, so only the outputs move.
+	replaces bool
 }
 
 // applySpend folds a just-broadcast send into the cached scan with no network
@@ -684,55 +773,60 @@ func (p *ElectrumBackend) applySpend(walletID, txid string, effect *spendEffect,
 	// version from Esplora.
 	sentTx := buildSentTx(txid, effect, packet, net, time.Now().Unix())
 
-	spentOutpoints := make(map[string]bool, len(effect.spent))
-	spentByAddr := make(map[string]int64)
-	for _, u := range effect.spent {
+	dead := map[string]bool{}
+	if effect.replacedTxID != "" {
+		dead[effect.replacedTxID] = true
+	}
+	if len(dead) > 0 {
+		for i := range scan.addrs {
+			a := &scan.addrs[i]
+			a.txs = lo.Filter(a.txs, func(t EsploraTx, _ int) bool { return !dead[t.TxID] })
+		}
+	}
+
+	gone := append(append([]electrumUTXO(nil), effect.spent...), effect.evicted...)
+	spentOutpoints := make(map[string]bool, len(gone))
+	for _, u := range gone {
 		spentOutpoints[fmt.Sprintf("%s:%d", u.txid, u.vout)] = true
+	}
+	// Every address the send touches carries its history row, but a replacement
+	// spends what the transaction it replaces already spent: counting those
+	// inputs again would drop the balance by their whole value.
+	touched := make(map[string]bool, len(gone))
+	for _, u := range gone {
+		touched[u.address] = true
+	}
+	counted := effect.evicted
+	if !effect.replaces {
+		counted = gone
+	}
+	spentByAddr := make(map[string]int64)
+	for _, u := range counted {
 		spentByAddr[u.address] += u.amountSats
 	}
 	for i := range scan.addrs {
 		a := &scan.addrs[i]
-		sats, ok := spentByAddr[a.address]
-		if !ok {
+		if !touched[a.address] {
 			continue
 		}
 		a.utxos = lo.Filter(a.utxos, func(u EsploraUTXO, _ int) bool {
 			return !spentOutpoints[fmt.Sprintf("%s:%d", u.TxID, u.Vout)]
 		})
-		a.stats.MempoolStats.SpentTxoSum += sats
-		a.stats.MempoolStats.SpentTxoCount++
-		a.stats.MempoolStats.TxCount++
-		a.txs = append(append([]EsploraTx(nil), a.txs...), sentTx)
+		if sats, counts := spentByAddr[a.address]; counts {
+			a.stats.MempoolStats.SpentTxoSum += sats
+			a.stats.MempoolStats.SpentTxoCount++
+		}
+		if !holdsTx(a.txs, txid) {
+			a.stats.MempoolStats.TxCount++
+			a.txs = append(append([]EsploraTx(nil), a.txs...), sentTx)
+		}
 	}
 
 	if effect.change != nil {
-		vout := -1
-		for i, out := range packet.UnsignedTx.TxOut {
-			if bytes.Equal(out.PkScript, effect.change.scriptPubKey) {
-				vout = i
-				break
-			}
-		}
-		if vout >= 0 {
-			utxo := EsploraUTXO{TxID: txid, Vout: vout, Value: effect.changeSats}
-			if i := indexOfAddr(scan.addrs, effect.change.address); i >= 0 {
-				a := &scan.addrs[i]
-				a.utxos = append(append([]EsploraUTXO(nil), a.utxos...), utxo)
-				a.stats.MempoolStats.FundedTxoSum += effect.changeSats
-				a.stats.MempoolStats.FundedTxoCount++
-				a.stats.MempoolStats.TxCount++
-				a.txs = append(append([]EsploraTx(nil), a.txs...), sentTx)
-			} else {
-				ca := *effect.change
-				ca.utxos = []EsploraUTXO{utxo}
-				ca.txs = []EsploraTx{sentTx}
-				ca.stats.Address = ca.address
-				ca.stats.MempoolStats.FundedTxoSum += effect.changeSats
-				ca.stats.MempoolStats.FundedTxoCount++
-				ca.stats.MempoolStats.TxCount++
-				scan.addrs = append(scan.addrs, ca)
-			}
-		}
+		creditScan(scan, txid, sentTx, *effect.change, effect.changeSats, findVout(packet, effect.change.scriptPubKey, effect.changeSats))
+	}
+	for _, credit := range effect.credited {
+		creditScan(scan, txid, sentTx, credit.addr, credit.sats, credit.vout)
 	}
 
 	finalizeScan(scan)
@@ -1212,8 +1306,213 @@ func (p *ElectrumBackend) SignTransaction(ctx context.Context, walletID, rawHex 
 	return SignTransactionLocal(rawHex, prevOuts, scan.keys, net)
 }
 
-func (p *ElectrumBackend) BumpFee(ctx context.Context, walletID, txid string, newFeeRate int64) (string, error) {
-	return "", errors.New("fee bumping is not supported for electrum wallets")
+// PreviewBumpFee reports what a replacement of req.TxID costs, and which output
+// pays for it. A transaction it cannot replace comes back with a Reason and no
+// Plan, so the caller can tell the user why.
+func (p *ElectrumBackend) PreviewBumpFee(ctx context.Context, walletID string, req BumpFeeRequest) (*BumpFeePreview, error) {
+	if err := p.requireElectrum(walletID); err != nil {
+		return nil, err
+	}
+	scan, err := p.scanWallet(ctx, walletID)
+	if err != nil {
+		return nil, err
+	}
+	tx, err := p.client.Tx(ctx, req.TxID)
+	if err != nil {
+		return nil, err
+	}
+	return p.previewBumpFee(ctx, scan, tx, req)
+}
+
+func (p *ElectrumBackend) previewBumpFee(ctx context.Context, scan *electrumScan, tx EsploraTx, req BumpFeeRequest) (*BumpFeePreview, error) {
+	net := p.params()
+	if tx.Status.Confirmed {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("transaction %s is confirmed", tx.TxID))
+	}
+	if tx.Weight <= 0 {
+		return nil, fmt.Errorf("transaction %s reports no weight", tx.TxID)
+	}
+	vsize := int64(math.Ceil(float64(tx.Weight) / 4))
+
+	outputs := make([]BumpFeeOutput, 0, len(tx.Vout))
+	for i, vout := range tx.Vout {
+		out := BumpFeeOutput{Vout: i, AmountSats: vout.Value, Address: vout.ScriptPubKeyAddress}
+		// A watch-only wallet knows the address but holds no key for it. It can
+		// neither replace the transaction nor spend the output with a child.
+		if sa, owned := scan.byAddr[vout.ScriptPubKeyAddress]; owned && !scan.watchOnly {
+			out.IsMine = true
+			out.IsChange = sa.change
+		}
+		if out.Address != "" {
+			kind := addressKind(out.Address, net)
+			out.DustSats = dustThreshold(kind)
+			out.VsizeBytes = int64(outputVsizeForKind(kind))
+		}
+		outputs = append(outputs, out)
+	}
+
+	suggested := int64(math.Ceil(p.FeeRateForTarget(ctx, electrumBumpFeeTarget)))
+	if floor := minBumpFeeRate(tx.Fee, vsize, len(tx.Vin)); suggested < floor {
+		suggested = floor
+	}
+	preview := &BumpFeePreview{
+		InputCount:    len(tx.Vin),
+		VsizeVBytes:   vsize,
+		OldFeeSats:    tx.Fee,
+		OldFeeRate:    float64(tx.Fee) / float64(vsize),
+		SuggestedRate: suggested,
+		Outputs:       outputs,
+	}
+
+	if scan.watchOnly {
+		preview.Reason = "this wallet holds no key, so it cannot sign a replacement"
+		return preview, nil
+	}
+	if scanHoldsChildOf(scan, tx.TxID) {
+		preview.HasChild = true
+		preview.Reason = "another transaction already spends this one, so it has no replacement"
+		return preview, nil
+	}
+	for _, vin := range tx.Vin {
+		if vin.Prevout == nil || !scan.owns(vin.Prevout.ScriptPubKeyAddress) {
+			preview.Reason = fmt.Sprintf("this wallet signs none of input %s:%d, so it cannot build a replacement", vin.TxID, vin.Vout)
+			return preview, nil
+		}
+	}
+
+	preview.CanReplace = true
+
+	rate := req.NewFeeRate
+	if rate <= 0 {
+		rate = suggested
+	}
+	target, err := pickBumpFeeOutput(outputs, req.FeeFromVout)
+	if err != nil {
+		preview.Reason = err.Error()
+		return preview, nil
+	}
+	plan, err := planBumpFee(bumpFeeTx{
+		OldFeeSats:  tx.Fee,
+		VsizeBytes:  vsize,
+		InputCount:  len(tx.Vin),
+		OutputCount: len(tx.Vout),
+	}, rate, target)
+	if err != nil {
+		preview.Reason = err.Error()
+		return preview, nil
+	}
+	preview.Plan = &plan
+	return preview, nil
+}
+
+// BumpFee replaces req.TxID with a transaction that spends the same inputs and
+// pays the same recipients, but pays a higher fee out of one output. Every
+// signature of the original dies with the changed output, so the replacement is
+// built and signed from the start.
+func (p *ElectrumBackend) BumpFee(ctx context.Context, walletID string, req BumpFeeRequest) (*BumpFeeResult, error) {
+	if err := p.requireElectrum(walletID); err != nil {
+		return nil, err
+	}
+	scan, err := p.scanWallet(ctx, walletID)
+	if err != nil {
+		return nil, err
+	}
+	if scan.watchOnly {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("watch-only electrum wallet cannot sign or send"))
+	}
+	tx, err := p.client.Tx(ctx, req.TxID)
+	if err != nil {
+		return nil, err
+	}
+	preview, err := p.previewBumpFee(ctx, scan, tx, req)
+	if err != nil {
+		return nil, err
+	}
+	if preview.Plan == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(preview.Reason))
+	}
+	plan := *preview.Plan
+
+	net := p.params()
+	psbtInputs := make([]psbtInput, 0, len(tx.Vin))
+	spent := make([]electrumUTXO, 0, len(tx.Vin))
+	for _, vin := range tx.Vin {
+		sa, ok := scan.byAddr[vin.Prevout.ScriptPubKeyAddress]
+		if !ok {
+			return nil, fmt.Errorf("no derivation info for input address %s", vin.Prevout.ScriptPubKeyAddress)
+		}
+		h, err := chainhash.NewHashFromStr(vin.TxID)
+		if err != nil {
+			return nil, fmt.Errorf("parse input txid %q: %w", vin.TxID, err)
+		}
+		psbtInputs = append(psbtInputs, psbtInput{
+			outpoint: wire.OutPoint{Hash: *h, Index: uint32(vin.Vout)},
+			amount:   vin.Prevout.Value,
+			addr:     sa,
+		})
+		spent = append(spent, electrumUTXO{
+			txid:       vin.TxID,
+			vout:       vin.Vout,
+			address:    sa.address,
+			amountSats: vin.Prevout.Value,
+		})
+	}
+
+	// The replaced transaction dies with its own outputs. The cached scan holds
+	// them as spendable, so they leave the cache with it.
+	var evicted []electrumUTXO
+	for i, vout := range tx.Vout {
+		if !scan.owns(vout.ScriptPubKeyAddress) {
+			continue
+		}
+		evicted = append(evicted, electrumUTXO{
+			txid:       tx.TxID,
+			vout:       i,
+			address:    vout.ScriptPubKeyAddress,
+			amountSats: vout.Value,
+		})
+	}
+
+	effect := &spendEffect{spent: spent, evicted: evicted, replaces: true, replacedTxID: tx.TxID}
+	outputs := make([]TxOutSpec, 0, len(tx.Vout))
+	for i, vout := range tx.Vout {
+		amount := vout.Value
+		if i == plan.FeeFromVout {
+			if plan.OutputRemoved {
+				continue
+			}
+			amount = plan.AmountAfter
+		}
+		spec := TxOutSpec{AmountBTC: float64(amount) / 1e8, AmountSats: amount}
+		if vout.ScriptPubKeyAddress == "" {
+			spec.RawScriptHex = vout.ScriptPubKey
+			outputs = append(outputs, spec)
+			continue
+		}
+		spec.Address = vout.ScriptPubKeyAddress
+		if sa, owned := scan.byAddr[vout.ScriptPubKeyAddress]; owned {
+			spec.Kind = sa.kind
+			spec.Derivations = sa.derivations
+			// Every output this wallet owns goes back into the cache, not only
+			// the change one: a consolidation pays itself on the receive branch.
+			effect.credited = append(effect.credited, walletCredit{addr: sa, sats: amount, vout: len(outputs)})
+		}
+		outputs = append(outputs, spec)
+	}
+
+	packet, err := buildPSBT(psbtInputs, outputs, net, p.prevTxFetcher(ctx))
+	if err != nil {
+		return nil, err
+	}
+	// The replacement keeps the locktime of the transaction it replaces, so an
+	// eCash send keeps its replay stamp.
+	packet.UnsignedTx.LockTime = uint32(tx.Locktime)
+
+	newTxID, err := p.signAndBroadcast(ctx, walletID, packet, psbtInputs, effect, false)
+	if err != nil {
+		return nil, err
+	}
+	return &BumpFeeResult{NewTxID: newTxID, Plan: plan}, nil
 }
 
 // CreateCpfp builds a child transaction that spends an unconfirmed wallet UTXO

--- a/sidechain-orchestrator/wallet/electrum_backend_test.go
+++ b/sidechain-orchestrator/wallet/electrum_backend_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2364,4 +2365,519 @@ func TestElectrumRescanWalksTheFullGap(t *testing.T) {
 		total += a.stats.ChainStats.FundedTxoSum
 	}
 	require.Equal(t, int64(100_000), total, "a rescan must reach the far payment")
+}
+
+// bumpFeeFixture wires an unconfirmed wallet transaction that pays a stranger
+// and returns change, so a fee bump has both kinds of output to pick from.
+func bumpFeeFixture(t *testing.T) (*ElectrumBackend, *fakeEsplora, *WalletData, string, string) {
+	t.Helper()
+	p, fake, w, addr := newElectrumFixture(t)
+
+	changeAddr, err := p.NextChangeAddress(context.Background(), w.ID)
+	require.NoError(t, err)
+
+	const (
+		txid        = "3333333333333333333333333333333333333333333333333333333333333333"
+		fundingTxid = "1111111111111111111111111111111111111111111111111111111111111111"
+		paymentAddr = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+	)
+	tx := EsploraTx{
+		TxID:   txid,
+		Weight: 601, // 151 vB
+		Fee:    151, // 1 sat/vB, deliberately too low
+		Status: EsploraStatus{Confirmed: false},
+		Vin: []EsploraVin{{
+			TxID:    fundingTxid,
+			Vout:    0,
+			Prevout: &EsploraVout{ScriptPubKeyAddress: addr, Value: 200_000},
+		}},
+		Vout: []EsploraVout{
+			{ScriptPubKeyAddress: paymentAddr, Value: 100_000},
+			{ScriptPubKeyAddress: changeAddr, Value: 99_849},
+		},
+	}
+	fake.txByID[txid] = tx
+
+	// The wallet already knows the transaction: the input is spent in the
+	// mempool, and the change waits there as a coin.
+	fake.stats[addr] = EsploraAddressStats{
+		Address:      addr,
+		ChainStats:   EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 200_000, TxCount: 1},
+		MempoolStats: EsploraTxoStats{SpentTxoCount: 1, SpentTxoSum: 200_000, TxCount: 1},
+	}
+	fake.txs[addr] = []EsploraTx{tx}
+	fake.stats[changeAddr] = EsploraAddressStats{
+		Address:      changeAddr,
+		MempoolStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 99_849, TxCount: 1},
+	}
+	fake.utxos[changeAddr] = []EsploraUTXO{{TxID: txid, Vout: 1, Value: 99_849}}
+	fake.txs[changeAddr] = []EsploraTx{tx}
+	return p, fake, w, txid, changeAddr
+}
+
+func TestElectrumBumpFeeTakesItFromChange(t *testing.T) {
+	p, fake, w, txid, _ := bumpFeeFixture(t)
+	ctx := context.Background()
+
+	result, err := p.BumpFee(ctx, w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+	assert.Equal(t, "broadcasttxid", result.NewTxID)
+	assert.False(t, result.Plan.ReducesPayment)
+	assert.Equal(t, int64(1510), result.Plan.NewFeeSats)
+	assert.Equal(t, int64(1359), result.Plan.ExtraFeeSats)
+	assert.Equal(t, int64(98_490), result.Plan.AmountAfter)
+
+	require.Len(t, fake.broadcast, 1)
+	raw, err := hex.DecodeString(fake.broadcast[0])
+	require.NoError(t, err)
+	var tx wire.MsgTx
+	require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+
+	require.Len(t, tx.TxIn, 1, "the replacement spends the same input")
+	assert.Equal(t, "1111111111111111111111111111111111111111111111111111111111111111", tx.TxIn[0].PreviousOutPoint.Hash.String())
+	require.NotEmpty(t, tx.TxIn[0].Witness, "the replacement carries a new signature")
+	assert.Equal(t, bip125Sequence, tx.TxIn[0].Sequence, "the replacement stays replaceable")
+
+	require.Len(t, tx.TxOut, 2)
+	assert.Equal(t, int64(100_000), tx.TxOut[0].Value, "the payment keeps its amount")
+	assert.Equal(t, int64(98_490), tx.TxOut[1].Value, "the change pays the higher fee")
+}
+
+func TestElectrumBumpFeeRefusesRateBelowMinimum(t *testing.T) {
+	p, _, w, txid, _ := bumpFeeFixture(t)
+
+	preview, err := p.PreviewBumpFee(context.Background(), w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 1})
+	require.NoError(t, err)
+	assert.Nil(t, preview.Plan)
+	assert.NotEmpty(t, preview.Reason)
+	assert.Equal(t, int64(151), preview.OldFeeSats)
+	assert.Equal(t, int64(151), preview.VsizeVBytes)
+}
+
+func TestElectrumPreviewBumpFeeMarksTheChangeOutput(t *testing.T) {
+	p, _, w, txid, changeAddr := bumpFeeFixture(t)
+
+	preview, err := p.PreviewBumpFee(context.Background(), w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+	require.Len(t, preview.Outputs, 2)
+	assert.False(t, preview.Outputs[0].IsChange)
+	assert.False(t, preview.Outputs[0].IsMine)
+	assert.True(t, preview.Outputs[1].IsChange)
+	assert.True(t, preview.Outputs[1].IsMine)
+	assert.Equal(t, changeAddr, preview.Outputs[1].Address)
+	assert.Positive(t, preview.Outputs[1].DustSats)
+	assert.Equal(t, 1, preview.InputCount)
+	require.NotNil(t, preview.Plan)
+	assert.Equal(t, 1, preview.Plan.FeeFromVout)
+}
+
+func TestElectrumBumpFeeTakesItFromAPayment(t *testing.T) {
+	p, fake, w, txid, _ := bumpFeeFixture(t)
+	vout := 0
+
+	result, err := p.BumpFee(context.Background(), w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10, FeeFromVout: &vout})
+	require.NoError(t, err)
+	assert.True(t, result.Plan.ReducesPayment)
+	assert.Equal(t, int64(98_641), result.Plan.AmountAfter)
+
+	require.Len(t, fake.broadcast, 1)
+	raw, err := hex.DecodeString(fake.broadcast[0])
+	require.NoError(t, err)
+	var tx wire.MsgTx
+	require.NoError(t, tx.Deserialize(bytes.NewReader(raw)))
+	require.Len(t, tx.TxOut, 2)
+	assert.Equal(t, int64(98_641), tx.TxOut[0].Value, "the recipient pays the higher fee")
+	assert.Equal(t, int64(99_849), tx.TxOut[1].Value, "the change keeps its amount")
+}
+
+func TestElectrumBumpFeeRefusesATransactionWithNoChange(t *testing.T) {
+	p, fake, w, txid, _ := bumpFeeFixture(t)
+	tx := fake.txByID[txid]
+	tx.Vout = tx.Vout[:1] // the payment alone, no change
+	tx.Fee = 100_151
+	fake.txByID[txid] = tx
+
+	preview, err := p.PreviewBumpFee(context.Background(), w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+	assert.Nil(t, preview.Plan)
+	assert.Contains(t, preview.Reason, "no change output")
+
+	_, err = p.BumpFee(context.Background(), w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+func TestElectrumBumpFeeRefusesAConfirmedTransaction(t *testing.T) {
+	p, fake, w, txid, _ := bumpFeeFixture(t)
+	tx := fake.txByID[txid]
+	tx.Status = EsploraStatus{Confirmed: true, BlockHeight: 100}
+	fake.txByID[txid] = tx
+
+	_, err := p.BumpFee(context.Background(), w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+// A replacement kills the outputs of the transaction it replaces. The cached
+// scan must drop them, or the next send picks an outpoint that no longer
+// exists.
+func TestElectrumBumpFeeDropsTheReplacedChange(t *testing.T) {
+	p, fake, w, txid, changeAddr := bumpFeeFixture(t)
+	ctx := context.Background()
+
+	fake.stats[changeAddr] = EsploraAddressStats{
+		Address:      changeAddr,
+		MempoolStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 99_849, TxCount: 1},
+	}
+	fake.utxos[changeAddr] = []EsploraUTXO{{
+		TxID: txid, Vout: 1, Value: 99_849,
+		Status: EsploraStatus{Confirmed: false},
+	}}
+	p.mu.Lock()
+	delete(p.warmScan, w.ID)
+	p.mu.Unlock()
+
+	before, err := p.ListUnspent(ctx, w.ID)
+	require.NoError(t, err)
+	require.True(t, holdsOutpoint(before, txid, 1), "the wallet starts with the original change")
+
+	_, err = p.BumpFee(ctx, w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+
+	after, err := p.ListUnspent(ctx, w.ID)
+	require.NoError(t, err)
+	assert.False(t, holdsOutpoint(after, txid, 1), "the replaced change stays spendable")
+
+	// The replaced change leaves the cache, but it is no input of the
+	// replacement. A history row that counts it reports a fee nobody paid.
+	rows, err := p.ListTransactions(ctx, w.ID, 20)
+	require.NoError(t, err)
+	var found bool
+	for _, row := range rows {
+		if row.TxID != "broadcasttxid" {
+			continue
+		}
+		found = true
+		assert.InDelta(t, -0.0000151, row.Fee, 1e-9, "the replacement reports the fee it pays")
+	}
+	require.True(t, found, "the replacement shows in the history")
+}
+
+func holdsOutpoint(utxos []UTXO, txid string, vout int) bool {
+	for _, u := range utxos {
+		if u.TxID == txid && u.Vout == vout {
+			return true
+		}
+	}
+	return false
+}
+
+// A wallet that signs none of the inputs cannot replace the transaction. The
+// preview says so, so the dialog can offer CPFP instead of an error.
+func TestElectrumPreviewBumpFeeReportsForeignInputs(t *testing.T) {
+	p, fake, w, txid, _ := bumpFeeFixture(t)
+	tx := fake.txByID[txid]
+	tx.Vin[0].Prevout = &EsploraVout{ScriptPubKeyAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx", Value: 200_000}
+	fake.txByID[txid] = tx
+
+	preview, err := p.PreviewBumpFee(context.Background(), w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+	assert.Nil(t, preview.Plan)
+	assert.Contains(t, preview.Reason, "signs none of input")
+	assert.True(t, preview.Outputs[1].IsMine, "the wallet still owns its own output, so CPFP stays open")
+}
+
+// A consolidation pays itself on the receive branch, not the change branch. The
+// cache must carry that output after a bump, or the balance loses the coin
+// until the next walk.
+func TestElectrumBumpFeeKeepsAReceiveBranchOutput(t *testing.T) {
+	p, fake, w, txid, changeAddr := bumpFeeFixture(t)
+	ctx := context.Background()
+
+	tx := fake.txByID[txid]
+	receiveAddr := tx.Vin[0].Prevout.ScriptPubKeyAddress
+	tx.Vout[0].ScriptPubKeyAddress = receiveAddr
+	fake.txByID[txid] = tx
+
+	fake.stats[changeAddr] = EsploraAddressStats{
+		Address:      changeAddr,
+		MempoolStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 99_849, TxCount: 1},
+	}
+	fake.utxos[changeAddr] = []EsploraUTXO{{TxID: txid, Vout: 1, Value: 99_849}}
+	fake.utxos[receiveAddr] = []EsploraUTXO{{TxID: txid, Vout: 0, Value: 100_000}}
+	p.mu.Lock()
+	delete(p.warmScan, w.ID)
+	p.mu.Unlock()
+
+	_, err := p.BumpFee(ctx, w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+
+	after, err := p.ListUnspent(ctx, w.ID)
+	require.NoError(t, err)
+	values := map[int64]bool{}
+	for _, u := range after {
+		if u.TxID == "broadcasttxid" {
+			values[int64(math.Round(u.Amount*1e8))] = true
+		}
+	}
+	assert.True(t, values[100_000], "the receive-branch output leaves the cache")
+	assert.Len(t, after, 2, "the cache holds one coin per output of the replacement")
+	assert.True(t, values[98_490], "the change output leaves the cache")
+	assert.False(t, holdsOutpoint(after, txid, 0), "the replaced receive output stays spendable")
+	assert.False(t, holdsOutpoint(after, txid, 1), "the replaced change stays spendable")
+}
+
+// The replacement pushes the original out of the mempool. A history that keeps
+// both offers a fee bump for a transaction that no longer exists.
+func TestElectrumBumpFeeDropsTheReplacedHistoryRow(t *testing.T) {
+	p, fake, w, txid, changeAddr := bumpFeeFixture(t)
+	ctx := context.Background()
+
+	fake.stats[changeAddr] = EsploraAddressStats{
+		Address:      changeAddr,
+		MempoolStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 99_849, TxCount: 1},
+	}
+	fake.utxos[changeAddr] = []EsploraUTXO{{TxID: txid, Vout: 1, Value: 99_849}}
+	fake.txs[changeAddr] = []EsploraTx{fake.txByID[txid]}
+	p.mu.Lock()
+	delete(p.warmScan, w.ID)
+	p.mu.Unlock()
+
+	_, err := p.BumpFee(ctx, w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+
+	rows, err := p.ListTransactions(ctx, w.ID, 20)
+	require.NoError(t, err)
+	for _, row := range rows {
+		assert.NotEqual(t, txid, row.TxID, "the replaced transaction stays in the history")
+	}
+}
+
+// A replacement spends what the transaction it replaces already spent. The
+// balance may fall by the higher fee, and by nothing more.
+func TestElectrumBumpFeeMovesTheBalanceByTheFeeOnly(t *testing.T) {
+	p, fake, w, txid, changeAddr := bumpFeeFixture(t)
+	ctx := context.Background()
+
+	inputAddr := fake.txByID[txid].Vin[0].Prevout.ScriptPubKeyAddress
+	fake.stats[inputAddr] = EsploraAddressStats{
+		Address:      inputAddr,
+		ChainStats:   EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 200_000, TxCount: 1},
+		MempoolStats: EsploraTxoStats{SpentTxoCount: 1, SpentTxoSum: 200_000, TxCount: 1},
+	}
+	fake.stats[changeAddr] = EsploraAddressStats{
+		Address:      changeAddr,
+		MempoolStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 99_849, TxCount: 1},
+	}
+	fake.utxos[changeAddr] = []EsploraUTXO{{TxID: txid, Vout: 1, Value: 99_849}}
+	p.mu.Lock()
+	delete(p.warmScan, w.ID)
+	p.mu.Unlock()
+
+	confirmedBefore, pendingBefore, err := p.Balance(ctx, w.ID)
+	require.NoError(t, err)
+
+	_, err = p.BumpFee(ctx, w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+
+	confirmedAfter, pendingAfter, err := p.Balance(ctx, w.ID)
+	require.NoError(t, err)
+
+	before := confirmedBefore + pendingBefore
+	after := confirmedAfter + pendingAfter
+	assert.InDelta(t, 0.00001359, before-after, 1e-9,
+		"the balance falls by the higher fee alone (%v -> %v)", before, after)
+}
+
+// A watch-only wallet knows its addresses but holds no key. It can neither sign
+// a replacement nor spend an output with a child, so the preview says so before
+// the dialog offers either.
+func TestElectrumPreviewBumpFeeRefusesAWatchOnlyWallet(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	seedWallet, err := svc.CreateElectrumWallet("Seed", nil, nil, testMnemonic, "", "", "", 0, "")
+	require.NoError(t, err)
+	xpub := accountXpub(t, seedWallet.Master.SeedHex, &chaincfg.SigNetParams)
+	woWallet, err := svc.CreateElectrumWallet("Watch", nil, nil, "", "", xpub, "", 0, "")
+	require.NoError(t, err)
+
+	seedAddrs, err := DeriveBIP84Addresses(seedWallet.Master.SeedHex, &chaincfg.SigNetParams, 0, 1)
+	require.NoError(t, err)
+	addr := seedAddrs[0]
+
+	fake := newFakeEsplora()
+	p := NewElectrumBackend(svc, fake, StaticParams(&chaincfg.SigNetParams), zerolog.New(zerolog.NewTestWriter(t)))
+	const txid = "6666666666666666666666666666666666666666666666666666666666666666"
+	fake.stats[addr] = EsploraAddressStats{
+		Address:      addr,
+		MempoolStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 99_849, TxCount: 1},
+	}
+	fake.txByID[txid] = EsploraTx{
+		TxID:   txid,
+		Weight: 600,
+		Fee:    150,
+		Status: EsploraStatus{Confirmed: false},
+		Vin: []EsploraVin{{
+			TxID:    "1111111111111111111111111111111111111111111111111111111111111111",
+			Vout:    0,
+			Prevout: &EsploraVout{ScriptPubKeyAddress: addr, Value: 200_000},
+		}},
+		Vout: []EsploraVout{
+			{ScriptPubKeyAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx", Value: 100_000},
+			{ScriptPubKeyAddress: addr, Value: 99_850},
+		},
+	}
+
+	preview, err := p.PreviewBumpFee(ctx, woWallet.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+	assert.Nil(t, preview.Plan)
+	assert.Contains(t, preview.Reason, "holds no key")
+	for _, out := range preview.Outputs {
+		assert.False(t, out.IsMine, "a watched output offers no child transaction either")
+	}
+
+	_, err = p.BumpFee(ctx, woWallet.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.Error(t, err)
+}
+
+// A replacement evicts every child of the transaction it replaces, so it must
+// outpay them too. The wallet refuses the bump and points at CPFP instead.
+func TestElectrumPreviewBumpFeeRefusesAParentWithAChild(t *testing.T) {
+	p, fake, w, txid, changeAddr := bumpFeeFixture(t)
+
+	const childTxid = "9999999999999999999999999999999999999999999999999999999999999999"
+	fake.stats[changeAddr] = EsploraAddressStats{
+		Address:      changeAddr,
+		MempoolStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 99_849, TxCount: 2},
+	}
+	fake.txs[changeAddr] = []EsploraTx{
+		fake.txByID[txid],
+		{TxID: childTxid, Vin: []EsploraVin{{TxID: txid, Vout: 1}}, Fee: 2_200},
+	}
+	p.mu.Lock()
+	delete(p.warmScan, w.ID)
+	p.mu.Unlock()
+
+	preview, err := p.PreviewBumpFee(context.Background(), w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+	assert.Nil(t, preview.Plan)
+	assert.False(t, preview.CanReplace)
+	assert.True(t, preview.HasChild, "a child transaction cannot speed this one up either")
+	assert.Contains(t, preview.Reason, "already spends this one")
+}
+
+// A replacement drops the transaction it replaces from the history, even when
+// the wallet owns none of its outputs.
+func TestElectrumBumpFeeDropsAReplacedSendWithNoChange(t *testing.T) {
+	p, fake, w, txid, _ := bumpFeeFixture(t)
+	ctx := context.Background()
+
+	inputAddr := fake.txByID[txid].Vin[0].Prevout.ScriptPubKeyAddress
+	tx := fake.txByID[txid]
+	tx.Vout = []EsploraVout{{ScriptPubKeyAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx", Value: 199_849}}
+	fake.txByID[txid] = tx
+	fake.txs[inputAddr] = []EsploraTx{tx}
+	p.mu.Lock()
+	delete(p.warmScan, w.ID)
+	p.mu.Unlock()
+
+	vout := 0
+	_, err := p.BumpFee(ctx, w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10, FeeFromVout: &vout})
+	require.NoError(t, err)
+
+	rows, err := p.ListTransactions(ctx, w.ID, 20)
+	require.NoError(t, err)
+	var replacement bool
+	for _, row := range rows {
+		assert.NotEqual(t, txid, row.TxID, "the replaced transaction stays in the history")
+		if row.TxID == "broadcasttxid" {
+			replacement = true
+		}
+	}
+	assert.True(t, replacement, "the replacement takes its place in the history")
+}
+
+// A change output that falls under the dust limit goes away, and its remainder
+// joins the fee. The broadcast transaction must carry one output less.
+func TestElectrumBumpFeeDropsADustChangeOutput(t *testing.T) {
+	p, fake, w, txid, changeAddr := bumpFeeFixture(t)
+	ctx := context.Background()
+
+	tx := fake.txByID[txid]
+	tx.Vout[1].Value = 1_500 // a change output the higher fee nearly consumes
+	fake.txByID[txid] = tx
+	fake.stats[changeAddr] = EsploraAddressStats{
+		Address:      changeAddr,
+		MempoolStats: EsploraTxoStats{FundedTxoCount: 1, FundedTxoSum: 1_500, TxCount: 1},
+	}
+	fake.utxos[changeAddr] = []EsploraUTXO{{TxID: txid, Vout: 1, Value: 1_500}}
+	p.mu.Lock()
+	delete(p.warmScan, w.ID)
+	p.mu.Unlock()
+
+	result, err := p.BumpFee(ctx, w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+	require.True(t, result.Plan.OutputRemoved, "the plan keeps a change output under the dust limit")
+	assert.Equal(t, int64(0), result.Plan.AmountAfter)
+	assert.Equal(t, int64(1_651), result.Plan.NewFeeSats, "the whole change joins the fee")
+	// The replacement drops a 31 vB output, so it pays over fewer bytes than the
+	// transaction it replaces.
+	assert.InDelta(t, float64(1_651)/float64(151-31), result.Plan.NewFeeRate, 0.01,
+		"the rate follows the size the replacement really carries")
+
+	require.Len(t, fake.broadcast, 1)
+	raw, err := hex.DecodeString(fake.broadcast[0])
+	require.NoError(t, err)
+	var built wire.MsgTx
+	require.NoError(t, built.Deserialize(bytes.NewReader(raw)))
+	require.Len(t, built.TxOut, 1, "the replacement drops the dust change output")
+	assert.Equal(t, int64(100_000), built.TxOut[0].Value, "the payment keeps its amount")
+
+	after, err := p.ListUnspent(ctx, w.ID)
+	require.NoError(t, err)
+	assert.Empty(t, after, "the dust change leaves the wallet no coin")
+}
+
+// The replacement keeps the locktime of the transaction it replaces, so an
+// eCash send keeps its replay stamp.
+func TestElectrumBumpFeeKeepsTheLockTime(t *testing.T) {
+	p, fake, w, txid, _ := bumpFeeFixture(t)
+
+	tx := fake.txByID[txid]
+	tx.Locktime = 499_999_999
+	fake.txByID[txid] = tx
+
+	_, err := p.BumpFee(context.Background(), w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+	require.Len(t, fake.broadcast, 1)
+	raw, err := hex.DecodeString(fake.broadcast[0])
+	require.NoError(t, err)
+	var built wire.MsgTx
+	require.NoError(t, built.Deserialize(bytes.NewReader(raw)))
+	assert.Equal(t, uint32(499_999_999), built.LockTime)
+}
+
+// One transaction leaves one history row per address. The scan cache holds a
+// unique index on (address, txid), and a second row rolls the whole write back.
+func TestElectrumBumpFeeWritesOneHistoryRowPerAddress(t *testing.T) {
+	p, _, w, txid, _ := bumpFeeFixture(t)
+	ctx := context.Background()
+
+	_, err := p.BumpFee(ctx, w.ID, BumpFeeRequest{TxID: txid, NewFeeRate: 10})
+	require.NoError(t, err)
+
+	p.mu.Lock()
+	scan := p.warmScan[w.ID]
+	p.mu.Unlock()
+	require.NotNil(t, scan)
+	for _, a := range scan.addrs {
+		seen := map[string]int{}
+		for _, tx := range a.txs {
+			seen[tx.TxID]++
+		}
+		for id, count := range seen {
+			assert.Equal(t, 1, count, "address %s carries %s twice", a.address, id)
+		}
+	}
 }

--- a/sidechain-orchestrator/wallet/integration_test.go
+++ b/sidechain-orchestrator/wallet/integration_test.go
@@ -461,14 +461,44 @@ func TestWalletIntegration(t *testing.T) {
 		require.NoError(t, err)
 		origTxid := sendResp.Msg.Txid
 
-		// BumpFee.
-		bumpResp, err := client.BumpFee(ctx, connect.NewRequest(&pb.BumpFeeRequest{
+		// The preview reports the fee, the size and the change output that pays.
+		preview, err := client.PreviewBumpFee(ctx, connect.NewRequest(&pb.PreviewBumpFeeRequest{
 			Txid: origTxid,
+		}))
+		require.NoError(t, err)
+		require.Empty(t, preview.Msg.Reason)
+		require.NotNil(t, preview.Msg.Plan)
+		require.Positive(t, preview.Msg.OldFeeSats)
+		require.Positive(t, preview.Msg.VsizeVbytes)
+		require.NotEmpty(t, preview.Msg.Outputs)
+		var changeOutputs int
+		for _, out := range preview.Msg.Outputs {
+			if out.IsChange {
+				changeOutputs++
+			}
+		}
+		require.Equal(t, 1, changeOutputs, "the send returns change, and the preview marks it")
+		require.False(t, preview.Msg.Plan.ReducesPayment, "the change pays, not the recipient")
+
+		newRate := preview.Msg.SuggestedFeeRate + 5
+		bumpResp, err := client.BumpFee(ctx, connect.NewRequest(&pb.BumpFeeRequest{
+			Txid:       origTxid,
+			NewFeeRate: newRate,
 		}))
 		require.NoError(t, err)
 		require.NotEmpty(t, bumpResp.Msg.NewTxid)
 		require.NotEqual(t, origTxid, bumpResp.Msg.NewTxid)
-		t.Logf("bumped fee: %s → %s", origTxid, bumpResp.Msg.NewTxid)
+		require.NotNil(t, bumpResp.Msg.Plan)
+		require.Greater(t, bumpResp.Msg.Plan.NewFeeSats, bumpResp.Msg.Plan.OldFeeSats,
+			"the replacement pays more than the transaction it replaces")
+		t.Logf("bumped fee: %s → %s (%d → %d sats)", origTxid, bumpResp.Msg.NewTxid,
+			bumpResp.Msg.Plan.OldFeeSats, bumpResp.Msg.Plan.NewFeeSats)
+
+		// A confirmed transaction has no replacement.
+		_, err = client.PreviewBumpFee(ctx, connect.NewRequest(&pb.PreviewBumpFeeRequest{
+			Txid: "0000000000000000000000000000000000000000000000000000000000000000",
+		}))
+		require.Error(t, err, "a transaction that waits in no mempool cannot be replaced")
 
 		// Mine 1 block.
 		err = nodeA.Mine(ctx, t, 1)

--- a/sidechain-orchestrator/wallet/router.go
+++ b/sidechain-orchestrator/wallet/router.go
@@ -184,12 +184,20 @@ func (r *BackendRouter) SignTransaction(ctx context.Context, walletID, rawHex st
 	return p.SignTransaction(ctx, walletID, rawHex)
 }
 
-func (r *BackendRouter) BumpFee(ctx context.Context, walletID, txid string, newFeeRate int64) (string, error) {
+func (r *BackendRouter) BumpFee(ctx context.Context, walletID string, req BumpFeeRequest) (*BumpFeeResult, error) {
 	p, err := r.pick(walletID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return p.BumpFee(ctx, walletID, txid, newFeeRate)
+	return p.BumpFee(ctx, walletID, req)
+}
+
+func (r *BackendRouter) PreviewBumpFee(ctx context.Context, walletID string, req BumpFeeRequest) (*BumpFeePreview, error) {
+	p, err := r.pick(walletID)
+	if err != nil {
+		return nil, err
+	}
+	return p.PreviewBumpFee(ctx, walletID, req)
 }
 
 func (r *BackendRouter) CreateCpfp(ctx context.Context, walletID string, req CpfpRequest) (string, error) {

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.connect.client.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.connect.client.dart
@@ -707,6 +707,25 @@ extension type WalletManagerServiceClient (connect.Transport _transport) {
     );
   }
 
+  /// PreviewBumpFee reports what a fee bump costs, and which output pays it,
+  /// without broadcasting anything.
+  Future<walletmanagerv1walletmanager.PreviewBumpFeeResponse> previewBumpFee(
+    walletmanagerv1walletmanager.PreviewBumpFeeRequest input, {
+    connect.Headers? headers,
+    connect.AbortSignal? signal,
+    Function(connect.Headers)? onHeader,
+    Function(connect.Headers)? onTrailer,
+  }) {
+    return connect.Client(_transport).unary(
+      specs.WalletManagerService.previewBumpFee,
+      input,
+      signal: signal,
+      headers: headers,
+      onHeader: onHeader,
+      onTrailer: onTrailer,
+    );
+  }
+
   /// CreateCpfp spends an unconfirmed wallet UTXO with a child transaction whose
   /// fee lifts the parent+child package to the target fee rate (CPFP).
   Future<walletmanagerv1walletmanager.CreateCpfpResponse> createCpfp(

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.connect.spec.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.connect.spec.dart
@@ -309,6 +309,15 @@ abstract final class WalletManagerService {
     walletmanagerv1walletmanager.BumpFeeResponse.new,
   );
 
+  /// PreviewBumpFee reports what a fee bump costs, and which output pays it,
+  /// without broadcasting anything.
+  static const previewBumpFee = connect.Spec(
+    '/$name/PreviewBumpFee',
+    connect.StreamType.unary,
+    walletmanagerv1walletmanager.PreviewBumpFeeRequest.new,
+    walletmanagerv1walletmanager.PreviewBumpFeeResponse.new,
+  );
+
   /// CreateCpfp spends an unconfirmed wallet UTXO with a child transaction whose
   /// fee lifts the parent+child package to the target fee rate (CPFP).
   static const createCpfp = connect.Spec(

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pb.dart
@@ -9591,6 +9591,7 @@ class BumpFeeRequest extends $pb.GeneratedMessage {
     $core.String? walletId,
     $core.String? txid,
     $fixnum.Int64? newFeeRate,
+    $core.int? feeFromVout,
   }) {
     final $result = create();
     if (walletId != null) {
@@ -9602,6 +9603,9 @@ class BumpFeeRequest extends $pb.GeneratedMessage {
     if (newFeeRate != null) {
       $result.newFeeRate = newFeeRate;
     }
+    if (feeFromVout != null) {
+      $result.feeFromVout = feeFromVout;
+    }
     return $result;
   }
   BumpFeeRequest._() : super();
@@ -9612,6 +9616,7 @@ class BumpFeeRequest extends $pb.GeneratedMessage {
     ..aOS(1, _omitFieldNames ? '' : 'walletId')
     ..aOS(2, _omitFieldNames ? '' : 'txid')
     ..aInt64(3, _omitFieldNames ? '' : 'newFeeRate')
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'feeFromVout', $pb.PbFieldType.O3)
     ..hasRequiredFields = false
   ;
 
@@ -9662,15 +9667,30 @@ class BumpFeeRequest extends $pb.GeneratedMessage {
   $core.bool hasNewFeeRate() => $_has(2);
   @$pb.TagNumber(3)
   void clearNewFeeRate() => clearField(3);
+
+  /// Output that pays the higher fee. Unset takes it from the change output,
+  /// which is the only output a bump may touch without the user's consent.
+  @$pb.TagNumber(4)
+  $core.int get feeFromVout => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set feeFromVout($core.int v) { $_setSignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasFeeFromVout() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearFeeFromVout() => clearField(4);
 }
 
 class BumpFeeResponse extends $pb.GeneratedMessage {
   factory BumpFeeResponse({
     $core.String? newTxid,
+    BumpFeePlan? plan,
   }) {
     final $result = create();
     if (newTxid != null) {
       $result.newTxid = newTxid;
+    }
+    if (plan != null) {
+      $result.plan = plan;
     }
     return $result;
   }
@@ -9680,6 +9700,7 @@ class BumpFeeResponse extends $pb.GeneratedMessage {
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BumpFeeResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'newTxid')
+    ..aOM<BumpFeePlan>(2, _omitFieldNames ? '' : 'plan', subBuilder: BumpFeePlan.create)
     ..hasRequiredFields = false
   ;
 
@@ -9712,6 +9733,597 @@ class BumpFeeResponse extends $pb.GeneratedMessage {
   $core.bool hasNewTxid() => $_has(0);
   @$pb.TagNumber(1)
   void clearNewTxid() => clearField(1);
+
+  @$pb.TagNumber(2)
+  BumpFeePlan get plan => $_getN(1);
+  @$pb.TagNumber(2)
+  set plan(BumpFeePlan v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasPlan() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPlan() => clearField(2);
+  @$pb.TagNumber(2)
+  BumpFeePlan ensurePlan() => $_ensure(1);
+}
+
+class PreviewBumpFeeRequest extends $pb.GeneratedMessage {
+  factory PreviewBumpFeeRequest({
+    $core.String? walletId,
+    $core.String? txid,
+    $fixnum.Int64? newFeeRate,
+    $core.int? feeFromVout,
+  }) {
+    final $result = create();
+    if (walletId != null) {
+      $result.walletId = walletId;
+    }
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    if (newFeeRate != null) {
+      $result.newFeeRate = newFeeRate;
+    }
+    if (feeFromVout != null) {
+      $result.feeFromVout = feeFromVout;
+    }
+    return $result;
+  }
+  PreviewBumpFeeRequest._() : super();
+  factory PreviewBumpFeeRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PreviewBumpFeeRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PreviewBumpFeeRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'walletId')
+    ..aOS(2, _omitFieldNames ? '' : 'txid')
+    ..aInt64(3, _omitFieldNames ? '' : 'newFeeRate')
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'feeFromVout', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PreviewBumpFeeRequest clone() => PreviewBumpFeeRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PreviewBumpFeeRequest copyWith(void Function(PreviewBumpFeeRequest) updates) => super.copyWith((message) => updates(message as PreviewBumpFeeRequest)) as PreviewBumpFeeRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PreviewBumpFeeRequest create() => PreviewBumpFeeRequest._();
+  PreviewBumpFeeRequest createEmptyInstance() => create();
+  static $pb.PbList<PreviewBumpFeeRequest> createRepeated() => $pb.PbList<PreviewBumpFeeRequest>();
+  @$core.pragma('dart2js:noInline')
+  static PreviewBumpFeeRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PreviewBumpFeeRequest>(create);
+  static PreviewBumpFeeRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get walletId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set walletId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWalletId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWalletId() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get txid => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set txid($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTxid() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTxid() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get newFeeRate => $_getI64(2);
+  @$pb.TagNumber(3)
+  set newFeeRate($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasNewFeeRate() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearNewFeeRate() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get feeFromVout => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set feeFromVout($core.int v) { $_setSignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasFeeFromVout() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearFeeFromVout() => clearField(4);
+}
+
+class PreviewBumpFeeResponse extends $pb.GeneratedMessage {
+  factory PreviewBumpFeeResponse({
+    $core.int? inputCount,
+    $fixnum.Int64? vsizeVbytes,
+    $fixnum.Int64? oldFeeSats,
+    $core.double? oldFeeRateSatVb,
+    $fixnum.Int64? suggestedFeeRate,
+    $core.Iterable<BumpFeeOutput>? outputs,
+    BumpFeePlan? plan,
+    $core.String? reason,
+    $core.bool? canReplace,
+    $core.bool? hasChild,
+    $core.bool? addsInputs,
+  }) {
+    final $result = create();
+    if (inputCount != null) {
+      $result.inputCount = inputCount;
+    }
+    if (vsizeVbytes != null) {
+      $result.vsizeVbytes = vsizeVbytes;
+    }
+    if (oldFeeSats != null) {
+      $result.oldFeeSats = oldFeeSats;
+    }
+    if (oldFeeRateSatVb != null) {
+      $result.oldFeeRateSatVb = oldFeeRateSatVb;
+    }
+    if (suggestedFeeRate != null) {
+      $result.suggestedFeeRate = suggestedFeeRate;
+    }
+    if (outputs != null) {
+      $result.outputs.addAll(outputs);
+    }
+    if (plan != null) {
+      $result.plan = plan;
+    }
+    if (reason != null) {
+      $result.reason = reason;
+    }
+    if (canReplace != null) {
+      $result.canReplace = canReplace;
+    }
+    if (hasChild != null) {
+      $result.hasChild = hasChild;
+    }
+    if (addsInputs != null) {
+      $result.addsInputs = addsInputs;
+    }
+    return $result;
+  }
+  PreviewBumpFeeResponse._() : super();
+  factory PreviewBumpFeeResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PreviewBumpFeeResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PreviewBumpFeeResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'inputCount', $pb.PbFieldType.O3)
+    ..aInt64(2, _omitFieldNames ? '' : 'vsizeVbytes')
+    ..aInt64(3, _omitFieldNames ? '' : 'oldFeeSats')
+    ..a<$core.double>(4, _omitFieldNames ? '' : 'oldFeeRateSatVb', $pb.PbFieldType.OD)
+    ..aInt64(5, _omitFieldNames ? '' : 'suggestedFeeRate')
+    ..pc<BumpFeeOutput>(6, _omitFieldNames ? '' : 'outputs', $pb.PbFieldType.PM, subBuilder: BumpFeeOutput.create)
+    ..aOM<BumpFeePlan>(7, _omitFieldNames ? '' : 'plan', subBuilder: BumpFeePlan.create)
+    ..aOS(8, _omitFieldNames ? '' : 'reason')
+    ..aOB(9, _omitFieldNames ? '' : 'canReplace')
+    ..aOB(10, _omitFieldNames ? '' : 'hasChild')
+    ..aOB(11, _omitFieldNames ? '' : 'addsInputs')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PreviewBumpFeeResponse clone() => PreviewBumpFeeResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PreviewBumpFeeResponse copyWith(void Function(PreviewBumpFeeResponse) updates) => super.copyWith((message) => updates(message as PreviewBumpFeeResponse)) as PreviewBumpFeeResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PreviewBumpFeeResponse create() => PreviewBumpFeeResponse._();
+  PreviewBumpFeeResponse createEmptyInstance() => create();
+  static $pb.PbList<PreviewBumpFeeResponse> createRepeated() => $pb.PbList<PreviewBumpFeeResponse>();
+  @$core.pragma('dart2js:noInline')
+  static PreviewBumpFeeResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PreviewBumpFeeResponse>(create);
+  static PreviewBumpFeeResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get inputCount => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set inputCount($core.int v) { $_setSignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasInputCount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearInputCount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get vsizeVbytes => $_getI64(1);
+  @$pb.TagNumber(2)
+  set vsizeVbytes($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasVsizeVbytes() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearVsizeVbytes() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get oldFeeSats => $_getI64(2);
+  @$pb.TagNumber(3)
+  set oldFeeSats($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasOldFeeSats() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearOldFeeSats() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.double get oldFeeRateSatVb => $_getN(3);
+  @$pb.TagNumber(4)
+  set oldFeeRateSatVb($core.double v) { $_setDouble(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasOldFeeRateSatVb() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearOldFeeRateSatVb() => clearField(4);
+
+  /// Fee rate the backend suggests for the next blocks, in sat/vB.
+  @$pb.TagNumber(5)
+  $fixnum.Int64 get suggestedFeeRate => $_getI64(4);
+  @$pb.TagNumber(5)
+  set suggestedFeeRate($fixnum.Int64 v) { $_setInt64(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasSuggestedFeeRate() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearSuggestedFeeRate() => clearField(5);
+
+  /// Every output of the transaction, in order.
+  @$pb.TagNumber(6)
+  $core.List<BumpFeeOutput> get outputs => $_getList(5);
+
+  /// The replacement. Unset when the wallet cannot build one.
+  @$pb.TagNumber(7)
+  BumpFeePlan get plan => $_getN(6);
+  @$pb.TagNumber(7)
+  set plan(BumpFeePlan v) { setField(7, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasPlan() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearPlan() => clearField(7);
+  @$pb.TagNumber(7)
+  BumpFeePlan ensurePlan() => $_ensure(6);
+
+  /// Why the wallet cannot build a replacement. Empty when plan is set.
+  @$pb.TagNumber(8)
+  $core.String get reason => $_getSZ(7);
+  @$pb.TagNumber(8)
+  set reason($core.String v) { $_setString(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasReason() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearReason() => clearField(8);
+
+  /// The wallet holds the keys of every input, so it can sign a replacement at
+  /// some fee rate. False marks a transaction no rate can replace.
+  @$pb.TagNumber(9)
+  $core.bool get canReplace => $_getBF(8);
+  @$pb.TagNumber(9)
+  set canReplace($core.bool v) { $_setBool(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasCanReplace() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearCanReplace() => clearField(9);
+
+  /// Another transaction already spends this one. A replacement must outpay that
+  /// child too, and a child transaction cannot speed this one up either.
+  @$pb.TagNumber(10)
+  $core.bool get hasChild => $_getBF(9);
+  @$pb.TagNumber(10)
+  set hasChild($core.bool v) { $_setBool(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasHasChild() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearHasChild() => clearField(10);
+
+  /// The backend funds a higher fee from another coin when the chosen output
+  /// cannot cover it, so a replacement holds even with no plan to show.
+  @$pb.TagNumber(11)
+  $core.bool get addsInputs => $_getBF(10);
+  @$pb.TagNumber(11)
+  set addsInputs($core.bool v) { $_setBool(10, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasAddsInputs() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearAddsInputs() => clearField(11);
+}
+
+/// BumpFeeOutput is one output of the transaction the fee can come from.
+class BumpFeeOutput extends $pb.GeneratedMessage {
+  factory BumpFeeOutput({
+    $core.int? vout,
+    $fixnum.Int64? amountSats,
+    $core.String? address,
+    $core.bool? isChange,
+    $fixnum.Int64? dustSats,
+    $core.bool? isMine,
+  }) {
+    final $result = create();
+    if (vout != null) {
+      $result.vout = vout;
+    }
+    if (amountSats != null) {
+      $result.amountSats = amountSats;
+    }
+    if (address != null) {
+      $result.address = address;
+    }
+    if (isChange != null) {
+      $result.isChange = isChange;
+    }
+    if (dustSats != null) {
+      $result.dustSats = dustSats;
+    }
+    if (isMine != null) {
+      $result.isMine = isMine;
+    }
+    return $result;
+  }
+  BumpFeeOutput._() : super();
+  factory BumpFeeOutput.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BumpFeeOutput.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BumpFeeOutput', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'vout', $pb.PbFieldType.O3)
+    ..aInt64(2, _omitFieldNames ? '' : 'amountSats')
+    ..aOS(3, _omitFieldNames ? '' : 'address')
+    ..aOB(4, _omitFieldNames ? '' : 'isChange')
+    ..aInt64(5, _omitFieldNames ? '' : 'dustSats')
+    ..aOB(6, _omitFieldNames ? '' : 'isMine')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BumpFeeOutput clone() => BumpFeeOutput()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BumpFeeOutput copyWith(void Function(BumpFeeOutput) updates) => super.copyWith((message) => updates(message as BumpFeeOutput)) as BumpFeeOutput;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BumpFeeOutput create() => BumpFeeOutput._();
+  BumpFeeOutput createEmptyInstance() => create();
+  static $pb.PbList<BumpFeeOutput> createRepeated() => $pb.PbList<BumpFeeOutput>();
+  @$core.pragma('dart2js:noInline')
+  static BumpFeeOutput getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BumpFeeOutput>(create);
+  static BumpFeeOutput? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get vout => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set vout($core.int v) { $_setSignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasVout() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearVout() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get amountSats => $_getI64(1);
+  @$pb.TagNumber(2)
+  set amountSats($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAmountSats() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAmountSats() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get address => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set address($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAddress() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearAddress() => clearField(3);
+
+  /// The wallet owns this output and it sits on the change chain.
+  @$pb.TagNumber(4)
+  $core.bool get isChange => $_getBF(3);
+  @$pb.TagNumber(4)
+  set isChange($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasIsChange() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearIsChange() => clearField(4);
+
+  /// Amount below which the output cannot stay in the transaction.
+  @$pb.TagNumber(5)
+  $fixnum.Int64 get dustSats => $_getI64(4);
+  @$pb.TagNumber(5)
+  set dustSats($fixnum.Int64 v) { $_setInt64(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasDustSats() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearDustSats() => clearField(5);
+
+  /// The wallet owns this output. CPFP spends such an output, so a transaction
+  /// with none of them has no child to speed it up.
+  @$pb.TagNumber(6)
+  $core.bool get isMine => $_getBF(5);
+  @$pb.TagNumber(6)
+  set isMine($core.bool v) { $_setBool(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasIsMine() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearIsMine() => clearField(6);
+}
+
+/// BumpFeePlan is the replacement transaction a fee bump builds.
+class BumpFeePlan extends $pb.GeneratedMessage {
+  factory BumpFeePlan({
+    $fixnum.Int64? oldFeeSats,
+    $fixnum.Int64? newFeeSats,
+    $fixnum.Int64? extraFeeSats,
+    $core.double? newFeeRateSatVb,
+    $core.int? feeFromVout,
+    $fixnum.Int64? amountBeforeSats,
+    $fixnum.Int64? amountAfterSats,
+    $core.bool? outputRemoved,
+    $core.bool? reducesPayment,
+  }) {
+    final $result = create();
+    if (oldFeeSats != null) {
+      $result.oldFeeSats = oldFeeSats;
+    }
+    if (newFeeSats != null) {
+      $result.newFeeSats = newFeeSats;
+    }
+    if (extraFeeSats != null) {
+      $result.extraFeeSats = extraFeeSats;
+    }
+    if (newFeeRateSatVb != null) {
+      $result.newFeeRateSatVb = newFeeRateSatVb;
+    }
+    if (feeFromVout != null) {
+      $result.feeFromVout = feeFromVout;
+    }
+    if (amountBeforeSats != null) {
+      $result.amountBeforeSats = amountBeforeSats;
+    }
+    if (amountAfterSats != null) {
+      $result.amountAfterSats = amountAfterSats;
+    }
+    if (outputRemoved != null) {
+      $result.outputRemoved = outputRemoved;
+    }
+    if (reducesPayment != null) {
+      $result.reducesPayment = reducesPayment;
+    }
+    return $result;
+  }
+  BumpFeePlan._() : super();
+  factory BumpFeePlan.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BumpFeePlan.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BumpFeePlan', package: const $pb.PackageName(_omitMessageNames ? '' : 'walletmanager.v1'), createEmptyInstance: create)
+    ..aInt64(1, _omitFieldNames ? '' : 'oldFeeSats')
+    ..aInt64(2, _omitFieldNames ? '' : 'newFeeSats')
+    ..aInt64(3, _omitFieldNames ? '' : 'extraFeeSats')
+    ..a<$core.double>(4, _omitFieldNames ? '' : 'newFeeRateSatVb', $pb.PbFieldType.OD)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'feeFromVout', $pb.PbFieldType.O3)
+    ..aInt64(6, _omitFieldNames ? '' : 'amountBeforeSats')
+    ..aInt64(7, _omitFieldNames ? '' : 'amountAfterSats')
+    ..aOB(8, _omitFieldNames ? '' : 'outputRemoved')
+    ..aOB(9, _omitFieldNames ? '' : 'reducesPayment')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BumpFeePlan clone() => BumpFeePlan()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BumpFeePlan copyWith(void Function(BumpFeePlan) updates) => super.copyWith((message) => updates(message as BumpFeePlan)) as BumpFeePlan;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BumpFeePlan create() => BumpFeePlan._();
+  BumpFeePlan createEmptyInstance() => create();
+  static $pb.PbList<BumpFeePlan> createRepeated() => $pb.PbList<BumpFeePlan>();
+  @$core.pragma('dart2js:noInline')
+  static BumpFeePlan getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BumpFeePlan>(create);
+  static BumpFeePlan? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get oldFeeSats => $_getI64(0);
+  @$pb.TagNumber(1)
+  set oldFeeSats($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasOldFeeSats() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearOldFeeSats() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get newFeeSats => $_getI64(1);
+  @$pb.TagNumber(2)
+  set newFeeSats($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNewFeeSats() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNewFeeSats() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get extraFeeSats => $_getI64(2);
+  @$pb.TagNumber(3)
+  set extraFeeSats($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasExtraFeeSats() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearExtraFeeSats() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.double get newFeeRateSatVb => $_getN(3);
+  @$pb.TagNumber(4)
+  set newFeeRateSatVb($core.double v) { $_setDouble(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasNewFeeRateSatVb() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearNewFeeRateSatVb() => clearField(4);
+
+  /// Output that pays, and what it holds before and after.
+  @$pb.TagNumber(5)
+  $core.int get feeFromVout => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set feeFromVout($core.int v) { $_setSignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasFeeFromVout() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearFeeFromVout() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get amountBeforeSats => $_getI64(5);
+  @$pb.TagNumber(6)
+  set amountBeforeSats($fixnum.Int64 v) { $_setInt64(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasAmountBeforeSats() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearAmountBeforeSats() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get amountAfterSats => $_getI64(6);
+  @$pb.TagNumber(7)
+  set amountAfterSats($fixnum.Int64 v) { $_setInt64(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasAmountAfterSats() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearAmountAfterSats() => clearField(7);
+
+  /// The output falls under the dust limit, so it goes away and its remainder
+  /// joins the fee.
+  @$pb.TagNumber(8)
+  $core.bool get outputRemoved => $_getBF(7);
+  @$pb.TagNumber(8)
+  set outputRemoved($core.bool v) { $_setBool(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasOutputRemoved() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearOutputRemoved() => clearField(8);
+
+  /// The output belongs to the recipient, not to the wallet.
+  @$pb.TagNumber(9)
+  $core.bool get reducesPayment => $_getBF(8);
+  @$pb.TagNumber(9)
+  set reducesPayment($core.bool v) { $_setBool(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasReducesPayment() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearReducesPayment() => clearField(9);
 }
 
 class CreateCpfpRequest extends $pb.GeneratedMessage {
@@ -11625,6 +12237,9 @@ class WalletManagerServiceApi {
   ;
   $async.Future<BumpFeeResponse> bumpFee($pb.ClientContext? ctx, BumpFeeRequest request) =>
     _client.invoke<BumpFeeResponse>(ctx, 'WalletManagerService', 'BumpFee', request, BumpFeeResponse())
+  ;
+  $async.Future<PreviewBumpFeeResponse> previewBumpFee($pb.ClientContext? ctx, PreviewBumpFeeRequest request) =>
+    _client.invoke<PreviewBumpFeeResponse>(ctx, 'WalletManagerService', 'PreviewBumpFee', request, PreviewBumpFeeResponse())
   ;
   $async.Future<CreateCpfpResponse> createCpfp($pb.ClientContext? ctx, CreateCpfpRequest request) =>
     _client.invoke<CreateCpfpResponse>(ctx, 'WalletManagerService', 'CreateCpfp', request, CreateCpfpResponse())

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbjson.dart
@@ -2106,25 +2106,128 @@ const BumpFeeRequest$json = {
     {'1': 'wallet_id', '3': 1, '4': 1, '5': 9, '10': 'walletId'},
     {'1': 'txid', '3': 2, '4': 1, '5': 9, '10': 'txid'},
     {'1': 'new_fee_rate', '3': 3, '4': 1, '5': 3, '10': 'newFeeRate'},
+    {'1': 'fee_from_vout', '3': 4, '4': 1, '5': 5, '9': 0, '10': 'feeFromVout', '17': true},
+  ],
+  '8': [
+    {'1': '_fee_from_vout'},
   ],
 };
 
 /// Descriptor for `BumpFeeRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List bumpFeeRequestDescriptor = $convert.base64Decode(
     'Cg5CdW1wRmVlUmVxdWVzdBIbCgl3YWxsZXRfaWQYASABKAlSCHdhbGxldElkEhIKBHR4aWQYAi'
-    'ABKAlSBHR4aWQSIAoMbmV3X2ZlZV9yYXRlGAMgASgDUgpuZXdGZWVSYXRl');
+    'ABKAlSBHR4aWQSIAoMbmV3X2ZlZV9yYXRlGAMgASgDUgpuZXdGZWVSYXRlEicKDWZlZV9mcm9t'
+    'X3ZvdXQYBCABKAVIAFILZmVlRnJvbVZvdXSIAQFCEAoOX2ZlZV9mcm9tX3ZvdXQ=');
 
 @$core.Deprecated('Use bumpFeeResponseDescriptor instead')
 const BumpFeeResponse$json = {
   '1': 'BumpFeeResponse',
   '2': [
     {'1': 'new_txid', '3': 1, '4': 1, '5': 9, '10': 'newTxid'},
+    {'1': 'plan', '3': 2, '4': 1, '5': 11, '6': '.walletmanager.v1.BumpFeePlan', '10': 'plan'},
   ],
 };
 
 /// Descriptor for `BumpFeeResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List bumpFeeResponseDescriptor = $convert.base64Decode(
-    'Cg9CdW1wRmVlUmVzcG9uc2USGQoIbmV3X3R4aWQYASABKAlSB25ld1R4aWQ=');
+    'Cg9CdW1wRmVlUmVzcG9uc2USGQoIbmV3X3R4aWQYASABKAlSB25ld1R4aWQSMQoEcGxhbhgCIA'
+    'EoCzIdLndhbGxldG1hbmFnZXIudjEuQnVtcEZlZVBsYW5SBHBsYW4=');
+
+@$core.Deprecated('Use previewBumpFeeRequestDescriptor instead')
+const PreviewBumpFeeRequest$json = {
+  '1': 'PreviewBumpFeeRequest',
+  '2': [
+    {'1': 'wallet_id', '3': 1, '4': 1, '5': 9, '10': 'walletId'},
+    {'1': 'txid', '3': 2, '4': 1, '5': 9, '10': 'txid'},
+    {'1': 'new_fee_rate', '3': 3, '4': 1, '5': 3, '10': 'newFeeRate'},
+    {'1': 'fee_from_vout', '3': 4, '4': 1, '5': 5, '9': 0, '10': 'feeFromVout', '17': true},
+  ],
+  '8': [
+    {'1': '_fee_from_vout'},
+  ],
+};
+
+/// Descriptor for `PreviewBumpFeeRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List previewBumpFeeRequestDescriptor = $convert.base64Decode(
+    'ChVQcmV2aWV3QnVtcEZlZVJlcXVlc3QSGwoJd2FsbGV0X2lkGAEgASgJUgh3YWxsZXRJZBISCg'
+    'R0eGlkGAIgASgJUgR0eGlkEiAKDG5ld19mZWVfcmF0ZRgDIAEoA1IKbmV3RmVlUmF0ZRInCg1m'
+    'ZWVfZnJvbV92b3V0GAQgASgFSABSC2ZlZUZyb21Wb3V0iAEBQhAKDl9mZWVfZnJvbV92b3V0');
+
+@$core.Deprecated('Use previewBumpFeeResponseDescriptor instead')
+const PreviewBumpFeeResponse$json = {
+  '1': 'PreviewBumpFeeResponse',
+  '2': [
+    {'1': 'input_count', '3': 1, '4': 1, '5': 5, '10': 'inputCount'},
+    {'1': 'vsize_vbytes', '3': 2, '4': 1, '5': 3, '10': 'vsizeVbytes'},
+    {'1': 'old_fee_sats', '3': 3, '4': 1, '5': 3, '10': 'oldFeeSats'},
+    {'1': 'old_fee_rate_sat_vb', '3': 4, '4': 1, '5': 1, '10': 'oldFeeRateSatVb'},
+    {'1': 'suggested_fee_rate', '3': 5, '4': 1, '5': 3, '10': 'suggestedFeeRate'},
+    {'1': 'outputs', '3': 6, '4': 3, '5': 11, '6': '.walletmanager.v1.BumpFeeOutput', '10': 'outputs'},
+    {'1': 'plan', '3': 7, '4': 1, '5': 11, '6': '.walletmanager.v1.BumpFeePlan', '10': 'plan'},
+    {'1': 'reason', '3': 8, '4': 1, '5': 9, '10': 'reason'},
+    {'1': 'can_replace', '3': 9, '4': 1, '5': 8, '10': 'canReplace'},
+    {'1': 'has_child', '3': 10, '4': 1, '5': 8, '10': 'hasChild'},
+    {'1': 'adds_inputs', '3': 11, '4': 1, '5': 8, '10': 'addsInputs'},
+  ],
+};
+
+/// Descriptor for `PreviewBumpFeeResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List previewBumpFeeResponseDescriptor = $convert.base64Decode(
+    'ChZQcmV2aWV3QnVtcEZlZVJlc3BvbnNlEh8KC2lucHV0X2NvdW50GAEgASgFUgppbnB1dENvdW'
+    '50EiEKDHZzaXplX3ZieXRlcxgCIAEoA1ILdnNpemVWYnl0ZXMSIAoMb2xkX2ZlZV9zYXRzGAMg'
+    'ASgDUgpvbGRGZWVTYXRzEiwKE29sZF9mZWVfcmF0ZV9zYXRfdmIYBCABKAFSD29sZEZlZVJhdG'
+    'VTYXRWYhIsChJzdWdnZXN0ZWRfZmVlX3JhdGUYBSABKANSEHN1Z2dlc3RlZEZlZVJhdGUSOQoH'
+    'b3V0cHV0cxgGIAMoCzIfLndhbGxldG1hbmFnZXIudjEuQnVtcEZlZU91dHB1dFIHb3V0cHV0cx'
+    'IxCgRwbGFuGAcgASgLMh0ud2FsbGV0bWFuYWdlci52MS5CdW1wRmVlUGxhblIEcGxhbhIWCgZy'
+    'ZWFzb24YCCABKAlSBnJlYXNvbhIfCgtjYW5fcmVwbGFjZRgJIAEoCFIKY2FuUmVwbGFjZRIbCg'
+    'loYXNfY2hpbGQYCiABKAhSCGhhc0NoaWxkEh8KC2FkZHNfaW5wdXRzGAsgASgIUgphZGRzSW5w'
+    'dXRz');
+
+@$core.Deprecated('Use bumpFeeOutputDescriptor instead')
+const BumpFeeOutput$json = {
+  '1': 'BumpFeeOutput',
+  '2': [
+    {'1': 'vout', '3': 1, '4': 1, '5': 5, '10': 'vout'},
+    {'1': 'amount_sats', '3': 2, '4': 1, '5': 3, '10': 'amountSats'},
+    {'1': 'address', '3': 3, '4': 1, '5': 9, '10': 'address'},
+    {'1': 'is_change', '3': 4, '4': 1, '5': 8, '10': 'isChange'},
+    {'1': 'dust_sats', '3': 5, '4': 1, '5': 3, '10': 'dustSats'},
+    {'1': 'is_mine', '3': 6, '4': 1, '5': 8, '10': 'isMine'},
+  ],
+};
+
+/// Descriptor for `BumpFeeOutput`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List bumpFeeOutputDescriptor = $convert.base64Decode(
+    'Cg1CdW1wRmVlT3V0cHV0EhIKBHZvdXQYASABKAVSBHZvdXQSHwoLYW1vdW50X3NhdHMYAiABKA'
+    'NSCmFtb3VudFNhdHMSGAoHYWRkcmVzcxgDIAEoCVIHYWRkcmVzcxIbCglpc19jaGFuZ2UYBCAB'
+    'KAhSCGlzQ2hhbmdlEhsKCWR1c3Rfc2F0cxgFIAEoA1IIZHVzdFNhdHMSFwoHaXNfbWluZRgGIA'
+    'EoCFIGaXNNaW5l');
+
+@$core.Deprecated('Use bumpFeePlanDescriptor instead')
+const BumpFeePlan$json = {
+  '1': 'BumpFeePlan',
+  '2': [
+    {'1': 'old_fee_sats', '3': 1, '4': 1, '5': 3, '10': 'oldFeeSats'},
+    {'1': 'new_fee_sats', '3': 2, '4': 1, '5': 3, '10': 'newFeeSats'},
+    {'1': 'extra_fee_sats', '3': 3, '4': 1, '5': 3, '10': 'extraFeeSats'},
+    {'1': 'new_fee_rate_sat_vb', '3': 4, '4': 1, '5': 1, '10': 'newFeeRateSatVb'},
+    {'1': 'fee_from_vout', '3': 5, '4': 1, '5': 5, '10': 'feeFromVout'},
+    {'1': 'amount_before_sats', '3': 6, '4': 1, '5': 3, '10': 'amountBeforeSats'},
+    {'1': 'amount_after_sats', '3': 7, '4': 1, '5': 3, '10': 'amountAfterSats'},
+    {'1': 'output_removed', '3': 8, '4': 1, '5': 8, '10': 'outputRemoved'},
+    {'1': 'reduces_payment', '3': 9, '4': 1, '5': 8, '10': 'reducesPayment'},
+  ],
+};
+
+/// Descriptor for `BumpFeePlan`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List bumpFeePlanDescriptor = $convert.base64Decode(
+    'CgtCdW1wRmVlUGxhbhIgCgxvbGRfZmVlX3NhdHMYASABKANSCm9sZEZlZVNhdHMSIAoMbmV3X2'
+    'ZlZV9zYXRzGAIgASgDUgpuZXdGZWVTYXRzEiQKDmV4dHJhX2ZlZV9zYXRzGAMgASgDUgxleHRy'
+    'YUZlZVNhdHMSLAoTbmV3X2ZlZV9yYXRlX3NhdF92YhgEIAEoAVIPbmV3RmVlUmF0ZVNhdFZiEi'
+    'IKDWZlZV9mcm9tX3ZvdXQYBSABKAVSC2ZlZUZyb21Wb3V0EiwKEmFtb3VudF9iZWZvcmVfc2F0'
+    'cxgGIAEoA1IQYW1vdW50QmVmb3JlU2F0cxIqChFhbW91bnRfYWZ0ZXJfc2F0cxgHIAEoA1IPYW'
+    '1vdW50QWZ0ZXJTYXRzEiUKDm91dHB1dF9yZW1vdmVkGAggASgIUg1vdXRwdXRSZW1vdmVkEicK'
+    'D3JlZHVjZXNfcGF5bWVudBgJIAEoCFIOcmVkdWNlc1BheW1lbnQ=');
 
 @$core.Deprecated('Use createCpfpRequestDescriptor instead')
 const CreateCpfpRequest$json = {
@@ -2535,6 +2638,7 @@ const $core.Map<$core.String, $core.dynamic> WalletManagerServiceBase$json = {
     {'1': 'GetTransactionDetails', '2': '.walletmanager.v1.GetTransactionDetailsRequest', '3': '.walletmanager.v1.GetTransactionDetailsResponse'},
     {'1': 'DecodeTransaction', '2': '.walletmanager.v1.DecodeTransactionRequest', '3': '.walletmanager.v1.DecodeTransactionResponse'},
     {'1': 'BumpFee', '2': '.walletmanager.v1.BumpFeeRequest', '3': '.walletmanager.v1.BumpFeeResponse'},
+    {'1': 'PreviewBumpFee', '2': '.walletmanager.v1.PreviewBumpFeeRequest', '3': '.walletmanager.v1.PreviewBumpFeeResponse'},
     {'1': 'CreateCpfp', '2': '.walletmanager.v1.CreateCpfpRequest', '3': '.walletmanager.v1.CreateCpfpResponse'},
     {'1': 'DeriveAddresses', '2': '.walletmanager.v1.DeriveAddressesRequest', '3': '.walletmanager.v1.DeriveAddressesResponse'},
     {'1': 'CreatePsbt', '2': '.walletmanager.v1.CreatePsbtRequest', '3': '.walletmanager.v1.CreatePsbtResponse'},
@@ -2669,6 +2773,10 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> WalletMana
   '.walletmanager.v1.DecodeTransactionResponse': DecodeTransactionResponse$json,
   '.walletmanager.v1.BumpFeeRequest': BumpFeeRequest$json,
   '.walletmanager.v1.BumpFeeResponse': BumpFeeResponse$json,
+  '.walletmanager.v1.BumpFeePlan': BumpFeePlan$json,
+  '.walletmanager.v1.PreviewBumpFeeRequest': PreviewBumpFeeRequest$json,
+  '.walletmanager.v1.PreviewBumpFeeResponse': PreviewBumpFeeResponse$json,
+  '.walletmanager.v1.BumpFeeOutput': BumpFeeOutput$json,
   '.walletmanager.v1.CreateCpfpRequest': CreateCpfpRequest$json,
   '.walletmanager.v1.CreateCpfpResponse': CreateCpfpResponse$json,
   '.walletmanager.v1.DeriveAddressesRequest': DeriveAddressesRequest$json,
@@ -2811,58 +2919,60 @@ final $typed_data.Uint8List walletManagerServiceDescriptor = $convert.base64Deco
     'c2USbAoRRGVjb2RlVHJhbnNhY3Rpb24SKi53YWxsZXRtYW5hZ2VyLnYxLkRlY29kZVRyYW5zYW'
     'N0aW9uUmVxdWVzdBorLndhbGxldG1hbmFnZXIudjEuRGVjb2RlVHJhbnNhY3Rpb25SZXNwb25z'
     'ZRJOCgdCdW1wRmVlEiAud2FsbGV0bWFuYWdlci52MS5CdW1wRmVlUmVxdWVzdBohLndhbGxldG'
-    '1hbmFnZXIudjEuQnVtcEZlZVJlc3BvbnNlElcKCkNyZWF0ZUNwZnASIy53YWxsZXRtYW5hZ2Vy'
-    'LnYxLkNyZWF0ZUNwZnBSZXF1ZXN0GiQud2FsbGV0bWFuYWdlci52MS5DcmVhdGVDcGZwUmVzcG'
-    '9uc2USZgoPRGVyaXZlQWRkcmVzc2VzEigud2FsbGV0bWFuYWdlci52MS5EZXJpdmVBZGRyZXNz'
-    'ZXNSZXF1ZXN0Gikud2FsbGV0bWFuYWdlci52MS5EZXJpdmVBZGRyZXNzZXNSZXNwb25zZRJXCg'
-    'pDcmVhdGVQc2J0EiMud2FsbGV0bWFuYWdlci52MS5DcmVhdGVQc2J0UmVxdWVzdBokLndhbGxl'
-    'dG1hbmFnZXIudjEuQ3JlYXRlUHNidFJlc3BvbnNlElEKCFNpZ25Qc2J0EiEud2FsbGV0bWFuYW'
-    'dlci52MS5TaWduUHNidFJlcXVlc3QaIi53YWxsZXRtYW5hZ2VyLnYxLlNpZ25Qc2J0UmVzcG9u'
-    'c2USdQoUU2lnblBzYnRXaXRoQ29zaWduZXISLS53YWxsZXRtYW5hZ2VyLnYxLlNpZ25Qc2J0V2'
-    'l0aENvc2lnbmVyUmVxdWVzdBouLndhbGxldG1hbmFnZXIudjEuU2lnblBzYnRXaXRoQ29zaWdu'
-    'ZXJSZXNwb25zZRJaCgtDb21iaW5lUHNidBIkLndhbGxldG1hbmFnZXIudjEuQ29tYmluZVBzYn'
-    'RSZXF1ZXN0GiUud2FsbGV0bWFuYWdlci52MS5Db21iaW5lUHNidFJlc3BvbnNlEl0KDEZpbmFs'
-    'aXplUHNidBIlLndhbGxldG1hbmFnZXIudjEuRmluYWxpemVQc2J0UmVxdWVzdBomLndhbGxldG'
-    '1hbmFnZXIudjEuRmluYWxpemVQc2J0UmVzcG9uc2USbwoSTXVsdGlzaWdQc2J0U3RhdHVzEisu'
-    'd2FsbGV0bWFuYWdlci52MS5NdWx0aXNpZ1BzYnRTdGF0dXNSZXF1ZXN0Giwud2FsbGV0bWFuYW'
-    'dlci52MS5NdWx0aXNpZ1BzYnRTdGF0dXNSZXNwb25zZRJ1ChRCcm9hZGNhc3RUcmFuc2FjdGlv'
-    'bhItLndhbGxldG1hbmFnZXIudjEuQnJvYWRjYXN0VHJhbnNhY3Rpb25SZXF1ZXN0Gi4ud2FsbG'
-    'V0bWFuYWdlci52MS5Ccm9hZGNhc3RUcmFuc2FjdGlvblJlc3BvbnNlEmwKEUdldEFkZHJlc3NV'
-    'bnNwZW50Eioud2FsbGV0bWFuYWdlci52MS5HZXRBZGRyZXNzVW5zcGVudFJlcXVlc3QaKy53YW'
-    'xsZXRtYW5hZ2VyLnYxLkdldEFkZHJlc3NVbnNwZW50UmVzcG9uc2USjQEKHEJyb2FkY2FzdEVs'
-    'ZWN0cnVtVHJhbnNhY3Rpb24SNS53YWxsZXRtYW5hZ2VyLnYxLkJyb2FkY2FzdEVsZWN0cnVtVH'
-    'JhbnNhY3Rpb25SZXF1ZXN0GjYud2FsbGV0bWFuYWdlci52MS5Ccm9hZGNhc3RFbGVjdHJ1bVRy'
-    'YW5zYWN0aW9uUmVzcG9uc2USgQEKGEVudW1lcmF0ZUhhcmR3YXJlRGV2aWNlcxIxLndhbGxldG'
-    '1hbmFnZXIudjEuRW51bWVyYXRlSGFyZHdhcmVEZXZpY2VzUmVxdWVzdBoyLndhbGxldG1hbmFn'
-    'ZXIudjEuRW51bWVyYXRlSGFyZHdhcmVEZXZpY2VzUmVzcG9uc2USZgoPR2V0SGFyZHdhcmVYcH'
-    'ViEigud2FsbGV0bWFuYWdlci52MS5HZXRIYXJkd2FyZVhwdWJSZXF1ZXN0Gikud2FsbGV0bWFu'
-    'YWdlci52MS5HZXRIYXJkd2FyZVhwdWJSZXNwb25zZRJvChJTaWduUHNidFdpdGhEZXZpY2USKy'
-    '53YWxsZXRtYW5hZ2VyLnYxLlNpZ25Qc2J0V2l0aERldmljZVJlcXVlc3QaLC53YWxsZXRtYW5h'
-    'Z2VyLnYxLlNpZ25Qc2J0V2l0aERldmljZVJlc3BvbnNlEmYKD1Byb21wdERldmljZVBpbhIoLn'
-    'dhbGxldG1hbmFnZXIudjEuUHJvbXB0RGV2aWNlUGluUmVxdWVzdBopLndhbGxldG1hbmFnZXIu'
-    'djEuUHJvbXB0RGV2aWNlUGluUmVzcG9uc2USYAoNU2VuZERldmljZVBpbhImLndhbGxldG1hbm'
-    'FnZXIudjEuU2VuZERldmljZVBpblJlcXVlc3QaJy53YWxsZXRtYW5hZ2VyLnYxLlNlbmREZXZp'
-    'Y2VQaW5SZXNwb25zZRJaCgtDbG9zZURldmljZRIkLndhbGxldG1hbmFnZXIudjEuQ2xvc2VEZX'
-    'ZpY2VSZXF1ZXN0GiUud2FsbGV0bWFuYWdlci52MS5DbG9zZURldmljZVJlc3BvbnNlEmMKDkRl'
-    'cml2ZUtleXN0b3JlEicud2FsbGV0bWFuYWdlci52MS5EZXJpdmVLZXlzdG9yZVJlcXVlc3QaKC'
-    '53YWxsZXRtYW5hZ2VyLnYxLkRlcml2ZUtleXN0b3JlUmVzcG9uc2USgQEKGFByZXZpZXdXYWxs'
-    'ZXRGcm9tRW50cm9weRIxLndhbGxldG1hbmFnZXIudjEuUHJldmlld1dhbGxldEZyb21FbnRyb3'
-    'B5UmVxdWVzdBoyLndhbGxldG1hbmFnZXIudjEuUHJldmlld1dhbGxldEZyb21FbnRyb3B5UmVz'
-    'cG9uc2USYAoNR2V0V2FsbGV0U2VlZBImLndhbGxldG1hbmFnZXIudjEuR2V0V2FsbGV0U2VlZF'
-    'JlcXVlc3QaJy53YWxsZXRtYW5hZ2VyLnYxLkdldFdhbGxldFNlZWRSZXNwb25zZRJpChBMaXN0'
-    'Q29yZVZhcmlhbnRzEikud2FsbGV0bWFuYWdlci52MS5MaXN0Q29yZVZhcmlhbnRzUmVxdWVzdB'
-    'oqLndhbGxldG1hbmFnZXIudjEuTGlzdENvcmVWYXJpYW50c1Jlc3BvbnNlEmMKDkdldENvcmVW'
-    'YXJpYW50Eicud2FsbGV0bWFuYWdlci52MS5HZXRDb3JlVmFyaWFudFJlcXVlc3QaKC53YWxsZX'
-    'RtYW5hZ2VyLnYxLkdldENvcmVWYXJpYW50UmVzcG9uc2USYwoOU2V0Q29yZVZhcmlhbnQSJy53'
-    'YWxsZXRtYW5hZ2VyLnYxLlNldENvcmVWYXJpYW50UmVxdWVzdBooLndhbGxldG1hbmFnZXIudj'
-    'EuU2V0Q29yZVZhcmlhbnRSZXNwb25zZRJsChFHZXRFbGVjdHJ1bVNlcnZlchIqLndhbGxldG1h'
-    'bmFnZXIudjEuR2V0RWxlY3RydW1TZXJ2ZXJSZXF1ZXN0Gisud2FsbGV0bWFuYWdlci52MS5HZX'
-    'RFbGVjdHJ1bVNlcnZlclJlc3BvbnNlEmwKEVNldEVsZWN0cnVtU2VydmVyEioud2FsbGV0bWFu'
-    'YWdlci52MS5TZXRFbGVjdHJ1bVNlcnZlclJlcXVlc3QaKy53YWxsZXRtYW5hZ2VyLnYxLlNldE'
-    'VsZWN0cnVtU2VydmVyUmVzcG9uc2USXQoMR2V0VG9yQ29uZmlnEiUud2FsbGV0bWFuYWdlci52'
-    'MS5HZXRUb3JDb25maWdSZXF1ZXN0GiYud2FsbGV0bWFuYWdlci52MS5HZXRUb3JDb25maWdSZX'
-    'Nwb25zZRJdCgxTZXRUb3JDb25maWcSJS53YWxsZXRtYW5hZ2VyLnYxLlNldFRvckNvbmZpZ1Jl'
-    'cXVlc3QaJi53YWxsZXRtYW5hZ2VyLnYxLlNldFRvckNvbmZpZ1Jlc3BvbnNlElYKD1dhdGNoV2'
-    'FsbGV0RGF0YRIWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRopLndhbGxldG1hbmFnZXIudjEuV2F0'
-    'Y2hXYWxsZXREYXRhUmVzcG9uc2UwAQ==');
+    '1hbmFnZXIudjEuQnVtcEZlZVJlc3BvbnNlEmMKDlByZXZpZXdCdW1wRmVlEicud2FsbGV0bWFu'
+    'YWdlci52MS5QcmV2aWV3QnVtcEZlZVJlcXVlc3QaKC53YWxsZXRtYW5hZ2VyLnYxLlByZXZpZX'
+    'dCdW1wRmVlUmVzcG9uc2USVwoKQ3JlYXRlQ3BmcBIjLndhbGxldG1hbmFnZXIudjEuQ3JlYXRl'
+    'Q3BmcFJlcXVlc3QaJC53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZUNwZnBSZXNwb25zZRJmCg9EZX'
+    'JpdmVBZGRyZXNzZXMSKC53YWxsZXRtYW5hZ2VyLnYxLkRlcml2ZUFkZHJlc3Nlc1JlcXVlc3Qa'
+    'KS53YWxsZXRtYW5hZ2VyLnYxLkRlcml2ZUFkZHJlc3Nlc1Jlc3BvbnNlElcKCkNyZWF0ZVBzYn'
+    'QSIy53YWxsZXRtYW5hZ2VyLnYxLkNyZWF0ZVBzYnRSZXF1ZXN0GiQud2FsbGV0bWFuYWdlci52'
+    'MS5DcmVhdGVQc2J0UmVzcG9uc2USUQoIU2lnblBzYnQSIS53YWxsZXRtYW5hZ2VyLnYxLlNpZ2'
+    '5Qc2J0UmVxdWVzdBoiLndhbGxldG1hbmFnZXIudjEuU2lnblBzYnRSZXNwb25zZRJ1ChRTaWdu'
+    'UHNidFdpdGhDb3NpZ25lchItLndhbGxldG1hbmFnZXIudjEuU2lnblBzYnRXaXRoQ29zaWduZX'
+    'JSZXF1ZXN0Gi4ud2FsbGV0bWFuYWdlci52MS5TaWduUHNidFdpdGhDb3NpZ25lclJlc3BvbnNl'
+    'EloKC0NvbWJpbmVQc2J0EiQud2FsbGV0bWFuYWdlci52MS5Db21iaW5lUHNidFJlcXVlc3QaJS'
+    '53YWxsZXRtYW5hZ2VyLnYxLkNvbWJpbmVQc2J0UmVzcG9uc2USXQoMRmluYWxpemVQc2J0EiUu'
+    'd2FsbGV0bWFuYWdlci52MS5GaW5hbGl6ZVBzYnRSZXF1ZXN0GiYud2FsbGV0bWFuYWdlci52MS'
+    '5GaW5hbGl6ZVBzYnRSZXNwb25zZRJvChJNdWx0aXNpZ1BzYnRTdGF0dXMSKy53YWxsZXRtYW5h'
+    'Z2VyLnYxLk11bHRpc2lnUHNidFN0YXR1c1JlcXVlc3QaLC53YWxsZXRtYW5hZ2VyLnYxLk11bH'
+    'Rpc2lnUHNidFN0YXR1c1Jlc3BvbnNlEnUKFEJyb2FkY2FzdFRyYW5zYWN0aW9uEi0ud2FsbGV0'
+    'bWFuYWdlci52MS5Ccm9hZGNhc3RUcmFuc2FjdGlvblJlcXVlc3QaLi53YWxsZXRtYW5hZ2VyLn'
+    'YxLkJyb2FkY2FzdFRyYW5zYWN0aW9uUmVzcG9uc2USbAoRR2V0QWRkcmVzc1Vuc3BlbnQSKi53'
+    'YWxsZXRtYW5hZ2VyLnYxLkdldEFkZHJlc3NVbnNwZW50UmVxdWVzdBorLndhbGxldG1hbmFnZX'
+    'IudjEuR2V0QWRkcmVzc1Vuc3BlbnRSZXNwb25zZRKNAQocQnJvYWRjYXN0RWxlY3RydW1UcmFu'
+    'c2FjdGlvbhI1LndhbGxldG1hbmFnZXIudjEuQnJvYWRjYXN0RWxlY3RydW1UcmFuc2FjdGlvbl'
+    'JlcXVlc3QaNi53YWxsZXRtYW5hZ2VyLnYxLkJyb2FkY2FzdEVsZWN0cnVtVHJhbnNhY3Rpb25S'
+    'ZXNwb25zZRKBAQoYRW51bWVyYXRlSGFyZHdhcmVEZXZpY2VzEjEud2FsbGV0bWFuYWdlci52MS'
+    '5FbnVtZXJhdGVIYXJkd2FyZURldmljZXNSZXF1ZXN0GjIud2FsbGV0bWFuYWdlci52MS5FbnVt'
+    'ZXJhdGVIYXJkd2FyZURldmljZXNSZXNwb25zZRJmCg9HZXRIYXJkd2FyZVhwdWISKC53YWxsZX'
+    'RtYW5hZ2VyLnYxLkdldEhhcmR3YXJlWHB1YlJlcXVlc3QaKS53YWxsZXRtYW5hZ2VyLnYxLkdl'
+    'dEhhcmR3YXJlWHB1YlJlc3BvbnNlEm8KElNpZ25Qc2J0V2l0aERldmljZRIrLndhbGxldG1hbm'
+    'FnZXIudjEuU2lnblBzYnRXaXRoRGV2aWNlUmVxdWVzdBosLndhbGxldG1hbmFnZXIudjEuU2ln'
+    'blBzYnRXaXRoRGV2aWNlUmVzcG9uc2USZgoPUHJvbXB0RGV2aWNlUGluEigud2FsbGV0bWFuYW'
+    'dlci52MS5Qcm9tcHREZXZpY2VQaW5SZXF1ZXN0Gikud2FsbGV0bWFuYWdlci52MS5Qcm9tcHRE'
+    'ZXZpY2VQaW5SZXNwb25zZRJgCg1TZW5kRGV2aWNlUGluEiYud2FsbGV0bWFuYWdlci52MS5TZW'
+    '5kRGV2aWNlUGluUmVxdWVzdBonLndhbGxldG1hbmFnZXIudjEuU2VuZERldmljZVBpblJlc3Bv'
+    'bnNlEloKC0Nsb3NlRGV2aWNlEiQud2FsbGV0bWFuYWdlci52MS5DbG9zZURldmljZVJlcXVlc3'
+    'QaJS53YWxsZXRtYW5hZ2VyLnYxLkNsb3NlRGV2aWNlUmVzcG9uc2USYwoORGVyaXZlS2V5c3Rv'
+    'cmUSJy53YWxsZXRtYW5hZ2VyLnYxLkRlcml2ZUtleXN0b3JlUmVxdWVzdBooLndhbGxldG1hbm'
+    'FnZXIudjEuRGVyaXZlS2V5c3RvcmVSZXNwb25zZRKBAQoYUHJldmlld1dhbGxldEZyb21FbnRy'
+    'b3B5EjEud2FsbGV0bWFuYWdlci52MS5QcmV2aWV3V2FsbGV0RnJvbUVudHJvcHlSZXF1ZXN0Gj'
+    'Iud2FsbGV0bWFuYWdlci52MS5QcmV2aWV3V2FsbGV0RnJvbUVudHJvcHlSZXNwb25zZRJgCg1H'
+    'ZXRXYWxsZXRTZWVkEiYud2FsbGV0bWFuYWdlci52MS5HZXRXYWxsZXRTZWVkUmVxdWVzdBonLn'
+    'dhbGxldG1hbmFnZXIudjEuR2V0V2FsbGV0U2VlZFJlc3BvbnNlEmkKEExpc3RDb3JlVmFyaWFu'
+    'dHMSKS53YWxsZXRtYW5hZ2VyLnYxLkxpc3RDb3JlVmFyaWFudHNSZXF1ZXN0Gioud2FsbGV0bW'
+    'FuYWdlci52MS5MaXN0Q29yZVZhcmlhbnRzUmVzcG9uc2USYwoOR2V0Q29yZVZhcmlhbnQSJy53'
+    'YWxsZXRtYW5hZ2VyLnYxLkdldENvcmVWYXJpYW50UmVxdWVzdBooLndhbGxldG1hbmFnZXIudj'
+    'EuR2V0Q29yZVZhcmlhbnRSZXNwb25zZRJjCg5TZXRDb3JlVmFyaWFudBInLndhbGxldG1hbmFn'
+    'ZXIudjEuU2V0Q29yZVZhcmlhbnRSZXF1ZXN0Gigud2FsbGV0bWFuYWdlci52MS5TZXRDb3JlVm'
+    'FyaWFudFJlc3BvbnNlEmwKEUdldEVsZWN0cnVtU2VydmVyEioud2FsbGV0bWFuYWdlci52MS5H'
+    'ZXRFbGVjdHJ1bVNlcnZlclJlcXVlc3QaKy53YWxsZXRtYW5hZ2VyLnYxLkdldEVsZWN0cnVtU2'
+    'VydmVyUmVzcG9uc2USbAoRU2V0RWxlY3RydW1TZXJ2ZXISKi53YWxsZXRtYW5hZ2VyLnYxLlNl'
+    'dEVsZWN0cnVtU2VydmVyUmVxdWVzdBorLndhbGxldG1hbmFnZXIudjEuU2V0RWxlY3RydW1TZX'
+    'J2ZXJSZXNwb25zZRJdCgxHZXRUb3JDb25maWcSJS53YWxsZXRtYW5hZ2VyLnYxLkdldFRvckNv'
+    'bmZpZ1JlcXVlc3QaJi53YWxsZXRtYW5hZ2VyLnYxLkdldFRvckNvbmZpZ1Jlc3BvbnNlEl0KDF'
+    'NldFRvckNvbmZpZxIlLndhbGxldG1hbmFnZXIudjEuU2V0VG9yQ29uZmlnUmVxdWVzdBomLndh'
+    'bGxldG1hbmFnZXIudjEuU2V0VG9yQ29uZmlnUmVzcG9uc2USVgoPV2F0Y2hXYWxsZXREYXRhEh'
+    'YuZ29vZ2xlLnByb3RvYnVmLkVtcHR5Gikud2FsbGV0bWFuYWdlci52MS5XYXRjaFdhbGxldERh'
+    'dGFSZXNwb25zZTAB');
 

--- a/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbserver.dart
+++ b/sidechain_core/lib/gen/walletmanager/v1/walletmanager.pbserver.dart
@@ -62,6 +62,7 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
   $async.Future<$17.GetTransactionDetailsResponse> getTransactionDetails($pb.ServerContext ctx, $17.GetTransactionDetailsRequest request);
   $async.Future<$17.DecodeTransactionResponse> decodeTransaction($pb.ServerContext ctx, $17.DecodeTransactionRequest request);
   $async.Future<$17.BumpFeeResponse> bumpFee($pb.ServerContext ctx, $17.BumpFeeRequest request);
+  $async.Future<$17.PreviewBumpFeeResponse> previewBumpFee($pb.ServerContext ctx, $17.PreviewBumpFeeRequest request);
   $async.Future<$17.CreateCpfpResponse> createCpfp($pb.ServerContext ctx, $17.CreateCpfpRequest request);
   $async.Future<$17.DeriveAddressesResponse> deriveAddresses($pb.ServerContext ctx, $17.DeriveAddressesRequest request);
   $async.Future<$17.CreatePsbtResponse> createPsbt($pb.ServerContext ctx, $17.CreatePsbtRequest request);
@@ -133,6 +134,7 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
       case 'GetTransactionDetails': return $17.GetTransactionDetailsRequest();
       case 'DecodeTransaction': return $17.DecodeTransactionRequest();
       case 'BumpFee': return $17.BumpFeeRequest();
+      case 'PreviewBumpFee': return $17.PreviewBumpFeeRequest();
       case 'CreateCpfp': return $17.CreateCpfpRequest();
       case 'DeriveAddresses': return $17.DeriveAddressesRequest();
       case 'CreatePsbt': return $17.CreatePsbtRequest();
@@ -207,6 +209,7 @@ abstract class WalletManagerServiceBase extends $pb.GeneratedService {
       case 'GetTransactionDetails': return this.getTransactionDetails(ctx, request as $17.GetTransactionDetailsRequest);
       case 'DecodeTransaction': return this.decodeTransaction(ctx, request as $17.DecodeTransactionRequest);
       case 'BumpFee': return this.bumpFee(ctx, request as $17.BumpFeeRequest);
+      case 'PreviewBumpFee': return this.previewBumpFee(ctx, request as $17.PreviewBumpFeeRequest);
       case 'CreateCpfp': return this.createCpfp(ctx, request as $17.CreateCpfpRequest);
       case 'DeriveAddresses': return this.deriveAddresses(ctx, request as $17.DeriveAddressesRequest);
       case 'CreatePsbt': return this.createPsbt(ctx, request as $17.CreatePsbtRequest);

--- a/sidechain_core/lib/rpcs/orchestrator_wallet_rpc.dart
+++ b/sidechain_core/lib/rpcs/orchestrator_wallet_rpc.dart
@@ -616,16 +616,38 @@ class OrchestratorWalletRPC {
     );
   }
 
+  /// Replaces [txid] with a transaction that pays more. [feeFromVout] takes the
+  /// higher fee from that output instead of the change output.
   Future<wmpb.BumpFeeResponse> bumpFee({
     required String walletId,
     required String txid,
     int? newFeeRate,
+    int? feeFromVout,
   }) {
     return _unaryClient.bumpFee(
       wmpb.BumpFeeRequest(
         walletId: walletId,
         txid: txid,
         newFeeRate: Int64(newFeeRate ?? 0),
+        feeFromVout: feeFromVout,
+      ),
+    );
+  }
+
+  /// Reports what a fee bump of [txid] costs, and which output pays it.
+  /// Broadcasts nothing.
+  Future<wmpb.PreviewBumpFeeResponse> previewBumpFee({
+    required String walletId,
+    required String txid,
+    int? newFeeRate,
+    int? feeFromVout,
+  }) {
+    return _unaryClient.previewBumpFee(
+      wmpb.PreviewBumpFeeRequest(
+        walletId: walletId,
+        txid: txid,
+        newFeeRate: Int64(newFeeRate ?? 0),
+        feeFromVout: feeFromVout,
       ),
     );
   }


### PR DESCRIPTION
A wallet with its seed in bitwindow could not replace a transaction that paid too little. Only Core wallets had an RBF menu item, and it broadcast at once with no preview and no fee choice.

The transaction table now carries a Bump fee button on every unconfirmed transaction the wallet sent, and the same item stays in the right-click menu. The dialog reports the fee now, takes a new fee rate, and names the output that pays, before it replaces anything. The higher fee comes from the change output. A transaction with no change output offers CPFP instead, and an override that takes the fee from a payment output, which tells the user what the recipient loses.

Core wallets keep using bumpfee; electrum wallets rebuild the transaction with the same inputs and outputs and sign it again.