### PR TITLE
bitwindow: move the QR inside the receive card

### DIFF
--- a/bitwindow/lib/pages/wallet/wallet_receive.dart
+++ b/bitwindow/lib/pages/wallet/wallet_receive.dart
@@ -45,9 +45,14 @@ class ReceiveTab extends StatelessWidget {
                         child: SailCard(
                           title: 'Receive Bitcoin on L1',
                           error: model.modelError,
-                          // A wallet that derives one kind has nothing to choose.
-                          widgetHeaderEnd: model.addressTypes.length > 1
-                              ? SailDropdownButton<wmpb.AddressType>(
+                          child: SailColumn(
+                            spacing: SailStyleValues.padding16,
+                            mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              // A wallet that derives one kind has nothing to choose.
+                              if (model.addressTypes.length > 1)
+                                SailDropdownButton<wmpb.AddressType>(
                                   value: model.addressType,
                                   onChanged: (type) {
                                     if (type != null) {
@@ -62,13 +67,7 @@ class ReceiveTab extends StatelessWidget {
                                         ),
                                       )
                                       .toList(),
-                                )
-                              : null,
-                          child: SailColumn(
-                            spacing: SailStyleValues.padding16,
-                            mainAxisSize: MainAxisSize.min,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
+                                ),
                               SailRow(
                                 spacing: SailStyleValues.padding08,
                                 crossAxisAlignment: CrossAxisAlignment.start,

--- a/bitwindow/lib/pages/wallet/wallet_receive.dart
+++ b/bitwindow/lib/pages/wallet/wallet_receive.dart
@@ -45,14 +45,9 @@ class ReceiveTab extends StatelessWidget {
                         child: SailCard(
                           title: 'Receive Bitcoin on L1',
                           error: model.modelError,
-                          child: SailColumn(
-                            spacing: SailStyleValues.padding16,
-                            mainAxisSize: MainAxisSize.min,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              // A wallet that derives one kind has nothing to choose.
-                              if (model.addressTypes.length > 1)
-                                SailDropdownButton<wmpb.AddressType>(
+                          // A wallet that derives one kind has nothing to choose.
+                          widgetHeaderEnd: model.addressTypes.length > 1
+                              ? SailDropdownButton<wmpb.AddressType>(
                                   value: model.addressType,
                                   onChanged: (type) {
                                     if (type != null) {
@@ -67,9 +62,16 @@ class ReceiveTab extends StatelessWidget {
                                         ),
                                       )
                                       .toList(),
-                                ),
+                                )
+                              : null,
+                          child: SailColumn(
+                            spacing: SailStyleValues.padding16,
+                            mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
                               SailRow(
                                 spacing: SailStyleValues.padding08,
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
                                   Expanded(
                                     child: SailTextField(
@@ -80,32 +82,34 @@ class ReceiveTab extends StatelessWidget {
                                       controller: TextEditingController(text: model.address),
                                       hintText: 'A Drivechain address',
                                       readOnly: true,
-                                      suffixWidget: CopyButton(text: model.address),
+                                      suffixWidget: SailRow(
+                                        spacing: SailStyleValues.padding08,
+                                        children: [
+                                          if (model.addressDerivationPath.isNotEmpty)
+                                            SailText.secondary12(model.addressDerivationPath, monospace: true),
+                                          CopyButton(text: model.address),
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                  SizedBox(
+                                    width: 128,
+                                    child: SailCard(
+                                      padding: true,
+                                      child: QrImageView(
+                                        padding: EdgeInsets.zero,
+                                        eyeStyle: QrEyeStyle(color: theme.colors.text, eyeShape: QrEyeShape.square),
+                                        dataModuleStyle: QrDataModuleStyle(color: theme.colors.text),
+                                        data: model.address,
+                                        version: QrVersions.auto,
+                                      ),
                                     ),
                                   ),
                                 ],
                               ),
-                              if (model.addressDerivationPath.isNotEmpty)
-                                SailText.secondary12(model.addressDerivationPath, monospace: true),
                               if (model.address.isEmpty)
-                                SailButton(
-                                  label: 'Generate new address',
-                                  onPressed: model.generateNewAddress,
-                                ),
+                                SailButton(label: 'Generate new address', onPressed: model.generateNewAddress),
                             ],
-                          ),
-                        ),
-                      ),
-                      SizedBox(
-                        width: 128,
-                        child: SailCard(
-                          padding: true,
-                          child: QrImageView(
-                            padding: EdgeInsets.zero,
-                            eyeStyle: QrEyeStyle(color: theme.colors.text, eyeShape: QrEyeShape.square),
-                            dataModuleStyle: QrDataModuleStyle(color: theme.colors.text),
-                            data: model.address,
-                            version: QrVersions.auto,
                           ),
                         ),
                       ),
@@ -113,10 +117,7 @@ class ReceiveTab extends StatelessWidget {
                   );
 
                   if (constraints.maxWidth < _claimBesideAddress) {
-                    return SailColumn(
-                      spacing: SailStyleValues.padding16,
-                      children: [addressRow, const ClaimEcxCard()],
-                    );
+                    return SailColumn(spacing: SailStyleValues.padding16, children: [addressRow, const ClaimEcxCard()]);
                   }
 
                   return SailRow(
@@ -304,10 +305,7 @@ class _ReceiveAddressesTableState extends State<ReceiveAddressesTable> {
                     SailTableHeaderCell(name: 'Type', onSort: () => onSort('type')),
                     SailTableHeaderCell(name: 'Change', onSort: () => onSort('chain')),
                     SailTableHeaderCell(name: 'Label', onSort: () => onSort('label')),
-                    SailTableHeaderCell(
-                      name: 'Balance',
-                      onSort: () => onSort('current_balance_sat'),
-                    ),
+                    SailTableHeaderCell(name: 'Balance', onSort: () => onSort('current_balance_sat')),
                   ],
                   rowBuilder: (context, row, selected) {
                     final utxo = entries[row];
@@ -377,9 +375,7 @@ class _ReceiveAddressesTableState extends State<ReceiveAddressesTable> {
                             );
                           });
                         },
-                        child: SailText.primary12(
-                          entry.label.isEmpty ? 'Add Label' : 'Update Label',
-                        ),
+                        child: SailText.primary12(entry.label.isEmpty ? 'Add Label' : 'Update Label'),
                       ),
                       SailMenuItem(
                         onSelected: () => launchUrl(Uri.parse(mempoolAddressUrl(entry.address, network))),
@@ -436,12 +432,7 @@ class ReceivePageViewModel extends BaseViewModel {
 
   AddressBookEntry get matchingEntry => _addressBookProvider.receiveEntries.firstWhere(
     (e) => e.address == address,
-    orElse: () => AddressBookEntry(
-      id: Int64(0),
-      label: '',
-      address: '',
-      direction: Direction.DIRECTION_RECEIVE,
-    ),
+    orElse: () => AddressBookEntry(id: Int64(0), label: '', address: '', direction: Direction.DIRECTION_RECEIVE),
   );
   bool get hasExistingLabel => matchingEntry.label.isNotEmpty;
 

--- a/bitwindow/lib/pages/wallet/wallet_receive.dart
+++ b/bitwindow/lib/pages/wallet/wallet_receive.dart
@@ -18,6 +18,9 @@ const _claimCardWidth = 420.0;
 /// Below this the claim card drops under the address card instead of beside it.
 const _claimBesideAddress = 1100.0;
 
+/// Below this the derivation path drops under the address field instead of into it.
+const _pathBesideAddress = 600.0;
+
 class ReceiveTab extends StatelessWidget {
   const ReceiveTab({super.key});
 
@@ -68,43 +71,66 @@ class ReceiveTab extends StatelessWidget {
                                       )
                                       .toList(),
                                 ),
-                              SailRow(
-                                spacing: SailStyleValues.padding08,
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Expanded(
-                                    child: SailTextField(
-                                      loading: LoadingDetails(
-                                        enabled: model.address.isEmpty,
-                                        description: 'Waiting for enforcer to start and wallet to sync..',
-                                      ),
-                                      controller: TextEditingController(text: model.address),
-                                      hintText: 'A Drivechain address',
-                                      readOnly: true,
-                                      suffixWidget: SailRow(
+                              LayoutBuilder(
+                                builder: (context, addressConstraints) {
+                                  final pathBesideAddress =
+                                      addressConstraints.maxWidth >= _pathBesideAddress &&
+                                      model.addressDerivationPath.isNotEmpty;
+
+                                  return SailColumn(
+                                    spacing: SailStyleValues.padding08,
+                                    mainAxisSize: MainAxisSize.min,
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: [
+                                      SailRow(
                                         spacing: SailStyleValues.padding08,
+                                        crossAxisAlignment: CrossAxisAlignment.start,
                                         children: [
-                                          if (model.addressDerivationPath.isNotEmpty)
-                                            SailText.secondary12(model.addressDerivationPath, monospace: true),
-                                          CopyButton(text: model.address),
+                                          Expanded(
+                                            child: SailTextField(
+                                              loading: LoadingDetails(
+                                                enabled: model.address.isEmpty,
+                                                description: 'Waiting for enforcer to start and wallet to sync..',
+                                              ),
+                                              controller: TextEditingController(text: model.address),
+                                              hintText: 'A Drivechain address',
+                                              readOnly: true,
+                                              suffixWidget: SailRow(
+                                                spacing: SailStyleValues.padding08,
+                                                children: [
+                                                  if (pathBesideAddress)
+                                                    SailText.secondary12(
+                                                      model.addressDerivationPath,
+                                                      monospace: true,
+                                                    ),
+                                                  CopyButton(text: model.address),
+                                                ],
+                                              ),
+                                            ),
+                                          ),
+                                          SizedBox(
+                                            width: 128,
+                                            child: SailCard(
+                                              padding: true,
+                                              child: QrImageView(
+                                                padding: EdgeInsets.zero,
+                                                eyeStyle: QrEyeStyle(
+                                                  color: theme.colors.text,
+                                                  eyeShape: QrEyeShape.square,
+                                                ),
+                                                dataModuleStyle: QrDataModuleStyle(color: theme.colors.text),
+                                                data: model.address,
+                                                version: QrVersions.auto,
+                                              ),
+                                            ),
+                                          ),
                                         ],
                                       ),
-                                    ),
-                                  ),
-                                  SizedBox(
-                                    width: 128,
-                                    child: SailCard(
-                                      padding: true,
-                                      child: QrImageView(
-                                        padding: EdgeInsets.zero,
-                                        eyeStyle: QrEyeStyle(color: theme.colors.text, eyeShape: QrEyeShape.square),
-                                        dataModuleStyle: QrDataModuleStyle(color: theme.colors.text),
-                                        data: model.address,
-                                        version: QrVersions.auto,
-                                      ),
-                                    ),
-                                  ),
-                                ],
+                                      if (!pathBesideAddress && model.addressDerivationPath.isNotEmpty)
+                                        SailText.secondary12(model.addressDerivationPath, monospace: true),
+                                    ],
+                                  );
+                                },
                               ),
                               if (model.address.isEmpty)
                                 SailButton(label: 'Generate new address', onPressed: model.generateNewAddress),

--- a/bitwindow/test/receive_qr_layout_test.dart
+++ b/bitwindow/test/receive_qr_layout_test.dart
@@ -14,6 +14,7 @@ import 'test_utils.dart';
 
 const _address = 'bcrt1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
 const _cardTitle = 'Receive Bitcoin on L1';
+const _derivationPath = "m/84'/1'/0'/0/0";
 
 class _FakeBitwindow extends ChangeNotifier implements BitwindowRPC {
   @override
@@ -46,7 +47,7 @@ class _FakeTransactions extends ChangeNotifier implements TransactionProvider {
   String address = _address;
 
   @override
-  String addressDerivationPath = "m/84'/1'/0'/0/0";
+  String addressDerivationPath = _derivationPath;
 
   @override
   final List<wmpb.AddressType> addressTypes;
@@ -172,8 +173,22 @@ void main() {
   testWidgets('the derivation path sits beside the copy button', (tester) async {
     await _pumpReceiveTab(tester);
 
-    final path = find.descendant(of: _addressCard(), matching: find.text("m/84'/1'/0'/0/0"));
+    final path = find.descendant(of: _addressCard(), matching: find.text(_derivationPath));
     expect(path, findsOneWidget);
     expect(tester.getTopLeft(path).dx, lessThan(tester.getTopLeft(_qr()).dx));
+  });
+
+  testWidgets('the derivation path drops below the field at the narrow window minimum', (tester) async {
+    await _pumpReceiveTab(tester);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.binding.setSurfaceSize(const Size(400, 900));
+    await tester.pump();
+    await tester.pump();
+
+    final path = find.descendant(of: _addressCard(), matching: find.text(_derivationPath));
+    expect(path, findsOneWidget);
+    expect(tester.getTopLeft(path).dy, greaterThan(tester.getBottomLeft(_addressField()).dy));
+    expect(tester.takeException(), isNull);
+    expect(tester.getSize(_addressField()).width, greaterThan(200));
   });
 }

--- a/bitwindow/test/receive_qr_layout_test.dart
+++ b/bitwindow/test/receive_qr_layout_test.dart
@@ -1,0 +1,179 @@
+import 'package:bitwindow/pages/wallet/wallet_receive.dart';
+import 'package:bitwindow/providers/address_book_provider.dart';
+import 'package:bitwindow/providers/hd_wallet_provider.dart';
+import 'package:bitwindow/providers/transactions_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart';
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+
+import 'test_utils.dart';
+
+const _address = 'bcrt1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+const _cardTitle = 'Receive Bitcoin on L1';
+
+class _FakeBitwindow extends ChangeNotifier implements BitwindowRPC {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeAddressBook extends ChangeNotifier implements AddressBookProvider {
+  @override
+  List<AddressBookEntry> get receiveEntries => const [];
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeHDWallet extends ChangeNotifier implements HDWalletProvider {
+  @override
+  bool get isInitialized => true;
+
+  @override
+  String get bip47PaymentCode => '';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeTransactions extends ChangeNotifier implements TransactionProvider {
+  _FakeTransactions(this.addressTypes);
+
+  @override
+  String address = _address;
+
+  @override
+  String addressDerivationPath = "m/84'/1'/0'/0/0";
+
+  @override
+  final List<wmpb.AddressType> addressTypes;
+
+  @override
+  wmpb.AddressType get addressType => addressTypes.first;
+
+  @override
+  List<ReceiveAddress> receiveAddresses = [];
+
+  @override
+  Future<void> fetch() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeWalletReader extends ChangeNotifier implements WalletReaderProvider {
+  @override
+  String? activeWalletId = 'wallet-1';
+
+  @override
+  WalletData? get activeWallet => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeOrchestratorWallet implements OrchestratorWalletRPC {
+  @override
+  Future<wmpb.GetNewAddressResponse> getNewAddress(String walletId, {wmpb.AddressType? addressType}) async {
+    return wmpb.GetNewAddressResponse(address: _address);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeOrchestrator implements OrchestratorRPC {
+  @override
+  OrchestratorWalletRPC wallet = _FakeOrchestratorWallet();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeConf implements BitcoinConfProvider {
+  @override
+  BitcoinNetwork get network => BitcoinNetwork.BITCOIN_NETWORK_REGTEST;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<void> _pumpReceiveTab(
+  WidgetTester tester, {
+  List<wmpb.AddressType> addressTypes = const [wmpb.AddressType.ADDRESS_TYPE_SEGWIT],
+}) async {
+  GetIt.I.registerSingleton<BitwindowRPC>(_FakeBitwindow());
+  GetIt.I.registerSingleton<AddressBookProvider>(_FakeAddressBook());
+  GetIt.I.registerSingleton<HDWalletProvider>(_FakeHDWallet());
+  GetIt.I.registerSingleton<TransactionProvider>(_FakeTransactions(addressTypes));
+  GetIt.I.registerSingleton<WalletReaderProvider>(_FakeWalletReader());
+  GetIt.I.registerSingleton<OrchestratorRPC>(_FakeOrchestrator());
+  GetIt.I.registerSingleton<BitcoinConfProvider>(_FakeConf());
+
+  await tester.pumpSailPage(const ReceiveTab());
+  await tester.pump();
+}
+
+Finder _addressCard() => find.widgetWithText(SailCard, _cardTitle);
+
+Finder _qr() => find.descendant(of: _addressCard(), matching: find.byType(QrImageView));
+
+Finder _addressField() => find.descendant(of: _addressCard(), matching: find.byType(SailTextField)).first;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized({
+    'flutter.test.automatic_wait_for_timers': 'false',
+  });
+
+  setUp(() async {
+    await GetIt.I.reset();
+  });
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  testWidgets('the QR code sits inside the address card', (tester) async {
+    await _pumpReceiveTab(tester);
+
+    expect(_addressCard(), findsOneWidget);
+    expect(_qr(), findsOneWidget);
+  });
+
+  testWidgets('the QR code sits to the right of the address field', (tester) async {
+    await _pumpReceiveTab(tester);
+
+    expect(tester.getTopLeft(_qr()).dx, greaterThanOrEqualTo(tester.getTopRight(_addressField()).dx));
+  });
+
+  testWidgets('the address type dropdown sits in the card header', (tester) async {
+    await _pumpReceiveTab(
+      tester,
+      addressTypes: const [wmpb.AddressType.ADDRESS_TYPE_SEGWIT, wmpb.AddressType.ADDRESS_TYPE_TAPROOT],
+    );
+
+    final dropdown = find.descendant(
+      of: _addressCard(),
+      matching: find.byType(SailDropdownButton<wmpb.AddressType>),
+    );
+    expect(dropdown, findsOneWidget);
+    expect(tester.getTopLeft(dropdown).dy, lessThan(tester.getTopLeft(_addressField()).dy));
+  });
+
+  testWidgets('a wallet with one address type shows no dropdown', (tester) async {
+    await _pumpReceiveTab(tester);
+
+    expect(find.byType(SailDropdownButton<wmpb.AddressType>), findsNothing);
+  });
+
+  testWidgets('the derivation path sits beside the copy button', (tester) async {
+    await _pumpReceiveTab(tester);
+
+    final path = find.descendant(of: _addressCard(), matching: find.text("m/84'/1'/0'/0/0"));
+    expect(path, findsOneWidget);
+    expect(tester.getTopLeft(path).dx, lessThan(tester.getTopLeft(_qr()).dx));
+  });
+}

--- a/bitwindow/test/receive_qr_layout_test.dart
+++ b/bitwindow/test/receive_qr_layout_test.dart
@@ -149,7 +149,7 @@ void main() {
     expect(tester.getTopLeft(_qr()).dx, greaterThanOrEqualTo(tester.getTopRight(_addressField()).dx));
   });
 
-  testWidgets('the address type dropdown sits in the card header', (tester) async {
+  testWidgets('the address type dropdown sits above the address field', (tester) async {
     await _pumpReceiveTab(
       tester,
       addressTypes: const [wmpb.AddressType.ADDRESS_TYPE_SEGWIT, wmpb.AddressType.ADDRESS_TYPE_TAPROOT],


### PR DESCRIPTION
Takes #2112 from @proof-of-reality, and keeps the commit under their name.

The QR moves to the right of the address field, because the address is the primary control on a desktop wallet. The address type dropdown moves into the card header.