### PR TITLE
Keep binary paths inside the app home

### DIFF
--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -101,6 +101,11 @@ func main() {
 				Value:   orchestrator.DefaultBitwindowDir(),
 				EnvVars: []string{"ORCHESTRATOR_BITWINDOW_DIR"},
 			},
+			&cli.StringFlag{
+				Name:    "app-home",
+				Usage:   "home directory every binary's data directory resolves against (default: the user's home)",
+				EnvVars: []string{"ORCHESTRATOR_APP_HOME"},
+			},
 			&cli.BoolFlag{
 				Name:    "local-auth",
 				Usage:   "write a per-session cookie token to <bitwindow-dir>/.auth.cookie and require it on every RPC (bitcoind-style local auth)",
@@ -171,6 +176,11 @@ func run(cctx *cli.Context) error {
 	listenAddr := cctx.String("rpclisten")
 	bitwindowDir := cctx.String("bitwindow-dir")
 	localAuth := cctx.Bool("local-auth")
+
+	if appHome := cctx.String("app-home"); appHome != "" {
+		config.SetHomeDir(appHome)
+		log.Info().Str("app_home", appHome).Msg("binary paths resolve against app-home")
+	}
 
 	log.Info().
 		Str("datadir", dataDir).

--- a/sidechain-orchestrator/config/binaries.go
+++ b/sidechain-orchestrator/config/binaries.go
@@ -64,7 +64,7 @@ type BinaryDirConfig struct {
 // AppDir returns the platform base directory for this binary.
 // Dart: Binary.appdir() (L1495-1514)
 func (b BinaryDirConfig) AppDir() string {
-	home, _ := os.UserHomeDir()
+	home := HomeDir()
 
 	switch currentOSName() {
 	case osLinux:
@@ -154,7 +154,7 @@ func (b BinaryDirConfig) RootDir() string {
 // FlutterFrontendPath returns the Flutter app's getApplicationSupportDirectory() path.
 // Dart: flutterFrontendDir() (L1306-1353)
 func (b BinaryDirConfig) FlutterFrontendPath() string {
-	home, _ := os.UserHomeDir()
+	home := HomeDir()
 	subdir := b.FlutterFrontendDir[currentOSName()]
 	if subdir == "" {
 		return ""

--- a/sidechain-orchestrator/config/homedir.go
+++ b/sidechain-orchestrator/config/homedir.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"os"
+	"sync"
+)
+
+var (
+	homeMu       sync.RWMutex
+	homeOverride string
+)
+
+// SetHomeDir points every binary path at dir instead of the user's home
+// directory. An empty dir restores the user's home.
+//
+// A process confined to one install must resolve every other binary's data
+// directory inside that install. Without this a daemon told to use a temp
+// directory still reaches the real home, and a wipe there moves the user's
+// own wallet aside.
+func SetHomeDir(dir string) {
+	homeMu.Lock()
+	homeOverride = dir
+	homeMu.Unlock()
+}
+
+// HomeDir returns the directory every binary path resolves against.
+func HomeDir() string {
+	homeMu.RLock()
+	dir := homeOverride
+	homeMu.RUnlock()
+	if dir != "" {
+		return dir
+	}
+	home, _ := os.UserHomeDir()
+	return home
+}

--- a/sidechain-orchestrator/config/homedir_test.go
+++ b/sidechain-orchestrator/config/homedir_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetHomeDirMovesEveryBinaryPath(t *testing.T) {
+	realHome, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	fake := t.TempDir()
+	SetHomeDir(fake)
+	t.Cleanup(func() { SetHomeDir("") })
+
+	require.Equal(t, fake, HomeDir())
+
+	for _, dc := range AllDirConfigs() {
+		require.True(t, strings.HasPrefix(dc.AppDir(), fake),
+			"%s AppDir escaped the override: %s", dc.BinaryName, dc.AppDir())
+
+		if frontend := dc.FlutterFrontendPath(); frontend != "" {
+			require.True(t, strings.HasPrefix(frontend, fake),
+				"%s FlutterFrontendPath escaped the override: %s", dc.BinaryName, frontend)
+			require.False(t, strings.HasPrefix(frontend, filepath.Join(realHome, "Library")),
+				"%s FlutterFrontendPath still points at the real home", dc.BinaryName)
+		}
+	}
+}
+
+func TestHomeDirFallsBackToTheUserHome(t *testing.T) {
+	realHome, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	SetHomeDir(t.TempDir())
+	SetHomeDir("")
+	require.Equal(t, realHome, HomeDir())
+}

--- a/sidechain-orchestrator/reset_home_containment_test.go
+++ b/sidechain-orchestrator/reset_home_containment_test.go
@@ -1,0 +1,64 @@
+package orchestrator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/stretchr/testify/require"
+)
+
+// A daemon confined to one install must never list a wallet outside it. The
+// wallet service moves every path this returns to wallet_backups/, so a path
+// that escapes takes the user's own wallet.json with it.
+func TestBinaryWalletPathsStayInsideTheAppHome(t *testing.T) {
+	appHome := t.TempDir()
+	config.SetHomeDir(appHome)
+	t.Cleanup(func() { config.SetHomeDir("") })
+
+	o := newResetTestOrchestrator(t)
+
+	frontend := config.BitWindowDirs.FlutterFrontendPath()
+	require.NotEmpty(t, frontend)
+	seedFile(t, filepath.Join(frontend, "wallet.json"))
+
+	paths := o.BinaryWalletPaths()
+	require.Contains(t, paths, filepath.Join(frontend, "wallet.json"))
+
+	for _, p := range paths {
+		require.True(t, strings.HasPrefix(p, appHome) || strings.HasPrefix(p, o.BitwindowDir),
+			"wallet path escaped the app home: %s", p)
+	}
+}
+
+// The same containment holds for the reset gather, which feeds DeleteFiles.
+func TestGatherWalletFilesStayInsideTheAppHome(t *testing.T) {
+	appHome := t.TempDir()
+	config.SetHomeDir(appHome)
+	t.Cleanup(func() { config.SetHomeDir("") })
+
+	o := newResetTestOrchestrator(t)
+
+	frontend := config.BitWindowDirs.FlutterFrontendPath()
+	seedFile(t, filepath.Join(frontend, "wallet.json"))
+
+	files, err := o.GatherFilesToDelete([]GatherSpec{
+		{Binary: ResetBinaryBitwindowd, Categories: allCategories()},
+	})
+	require.NoError(t, err)
+
+	for _, f := range files {
+		require.True(t, strings.HasPrefix(f.Path, appHome) || strings.HasPrefix(f.Path, o.BitwindowDir),
+			"gathered path escaped the app home: %s", f.Path)
+	}
+}
+
+// Without an override the real user home is still the base, so a normal
+// install keeps working.
+func TestAppHomeDefaultsToTheUserHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(config.BitWindowDirs.FlutterFrontendPath(), home))
+}

--- a/sidechain-orchestrator/testharness/node.go
+++ b/sidechain-orchestrator/testharness/node.go
@@ -153,6 +153,8 @@ port=%d
 	orchCmd := exec.Command(orchBin,
 		"--datadir", bitwindowDir,
 		"--bitwindow-dir", bitwindowDir,
+		// Keeps every binary path this node resolves inside its own temp tree.
+		"--app-home", nodeDir,
 		"--network", "regtest",
 		"--rpclisten", fmt.Sprintf("127.0.0.1:%d", grpcPort),
 		"--loglevel", "info",


### PR DESCRIPTION
A test moved a real wallet. `go test -tags integration ./wallet/` starts harness nodes with their own temp datadir, then calls DeleteAllWallets. The wallet service asks the orchestrator for every binary's wallet paths, and `FlutterFrontendPath()` read `os.UserHomeDir()` instead of the directory the node owns. So a node renamed the user's own wallet.json into their real wallet_backups/.

Binary paths now resolve against one seam. drivechaind sets it from a new --app-home flag, and the harness gives each node its own. Without the flag the user's home stays the base, so a normal install is unchanged.

The containment tests fail on the old code with the exact escaped path.