### PR TITLE
Land the user on the split they just made

### DIFF
--- a/bitwindow/lib/pages/wallet/wallet_page.dart
+++ b/bitwindow/lib/pages/wallet/wallet_page.dart
@@ -104,6 +104,10 @@ class WalletPage extends StatelessWidget {
     _sendViewModel?.handleBitcoinURI(uri);
   }
 
+  static void selectSendDraft(String draftId) {
+    _sendViewModel?.selectDraftById(draftId);
+  }
+
   static void setSubtab(int index) {
     tabKey.currentState?.setIndex(index, null);
   }

--- a/bitwindow/lib/pages/wallet/wallet_send.dart
+++ b/bitwindow/lib/pages/wallet/wallet_send.dart
@@ -532,6 +532,16 @@ class SendPageViewModel extends BaseViewModel {
   /// 0 is Create Transaction; a draft sits at its list index + 1.
   int sendTabIndex = 0;
 
+  /// The send tab a draft sits on: 0 is Create Transaction, a draft is at its
+  /// list index plus one. An unknown id falls back to the create form.
+  static int draftTabIndex(List<PsbtDraft> drafts, String id) {
+    final index = drafts.indexWhere((d) => d.id == id);
+    return index >= 0 ? index + 1 : 0;
+  }
+
+  /// Opens the draft's own panel.
+  void selectDraftById(String id) => selectSendTab(draftTabIndex(drafts, id));
+
   void selectSendTab(int index) {
     sendTabIndex = index;
     notifyListeners();

--- a/bitwindow/lib/providers/fork_provider.dart
+++ b/bitwindow/lib/providers/fork_provider.dart
@@ -127,6 +127,7 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
   /// Coins of a split this session still builds. They hold from the click, so
   /// a second click cannot build a conflicting draft of the same coins.
   final Set<String> _splitsInFlight = {};
+  final Set<String> _splitWalletsInFlight = {};
 
   /// Transactions this session sent without protection. Their outputs exist on
   /// both chains, so spending one replays again.
@@ -219,6 +220,7 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
     pendingSplits = [];
     _readPsbtByDraft.clear();
     _splitsInFlight.clear();
+    _splitWalletsInFlight.clear();
     replayedTxids.clear();
     _dismissedClaimOutpoints.clear();
     walletsWithUnreadDrafts = {};
@@ -414,6 +416,11 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
   bool canSelect(WalletClaim claim, bwpb.UnspentOutput u) =>
       isSelectable(u) && !pendingSplitOutpoints.contains(u.output) && !walletsWithUnreadDrafts.contains(claim.walletId);
 
+  /// True while a split of this wallet's coins builds. The reservation hides
+  /// every coin of the wallet, so the card that started the split must outlive
+  /// its own claims or it unmounts under the user mid-build.
+  bool splitInFlightFor(String? walletId) => walletId != null && _splitWalletsInFlight.contains(walletId);
+
   /// The coins of one claim the user can still pick.
   List<bwpb.UnspentOutput> selectableInputs(WalletClaim claim) =>
       claim.utxos.where((u) => canSelect(claim, u)).toList();
@@ -467,11 +474,13 @@ class ForkProvider extends ChangeNotifier implements NetworkScoped {
     }
     // Hold the coins from here, so a second click builds nothing.
     _splitsInFlight.addAll(reserved);
+    _splitWalletsInFlight.add(walletId);
     notifyListeners();
     try {
       return await _buildSplitDraft(claim, inputs);
     } finally {
       _splitsInFlight.removeAll(reserved);
+      _splitWalletsInFlight.remove(walletId);
       notifyListeners();
     }
   }

--- a/bitwindow/lib/widgets/fork_mode_banner.dart
+++ b/bitwindow/lib/widgets/fork_mode_banner.dart
@@ -1,5 +1,8 @@
+import 'package:bitwindow/pages/wallet/wallet_page.dart';
 import 'package:bitwindow/providers/fork_provider.dart';
+import 'package:bitwindow/providers/psbt_draft_provider.dart';
 import 'package:bitwindow/providers/transactions_provider.dart';
+import 'package:bitwindow/utils/navigation_registry.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
 import 'package:sail_ui/sail_ui.dart';
@@ -9,6 +12,31 @@ import 'package:sail_ui/sail_ui.dart';
 /// - after the fork, with un-swept pre-fork coins: the big "claim your eCash"
 ///   hero card,
 /// - otherwise nothing.
+/// Whether the claim card renders. A split reserves every coin it spends
+/// before its first await, so the claims go empty mid-build; the card has to
+/// outlive that or it unmounts under the user and drops the result.
+bool showClaimCard({
+  required bool hasFundsToClaim,
+  required bool hasClaims,
+  required bool dismissed,
+  required bool splitInFlight,
+}) {
+  if (splitInFlight) {
+    return true;
+  }
+  return hasFundsToClaim && hasClaims && !dismissed;
+}
+
+/// The wallet subtab to open after a claim run, or null to stay put. A split
+/// ends as a draft the cosigners sign on the send tab, so a clean run that
+/// drafted one takes the user there.
+int? forwardSubtabAfterClaim({required int drafted, required Object? firstError}) {
+  if (firstError != null || drafted == 0) {
+    return null;
+  }
+  return WalletSubtabs.send;
+}
+
 class ForkModeBanner extends StatelessWidget {
   const ForkModeBanner({super.key});
 
@@ -27,7 +55,13 @@ class ForkModeBanner extends StatelessWidget {
         // ForkCountdownTimer, and is hidden by the engine while coins are
         // unclaimed, so the two never overlap.
         final active = walletReader.activeWalletId;
-        if (!_fork.hasFundsToClaim || _fork.claimsForWallet(active).isEmpty || _fork.claimCardDismissedFor(active)) {
+        final show = showClaimCard(
+          hasFundsToClaim: _fork.hasFundsToClaim,
+          hasClaims: _fork.claimsForWallet(active).isNotEmpty,
+          dismissed: _fork.claimCardDismissedFor(active),
+          splitInFlight: _fork.splitInFlightFor(active),
+        );
+        if (!show) {
           return const SizedBox.shrink();
         }
         // The key drops the previous wallet's selection with its card.
@@ -54,6 +88,7 @@ class _ClaimEcashCard extends StatefulWidget {
 class _ClaimEcashCardState extends State<_ClaimEcashCard> {
   final Map<String, Set<String>> _selected = {};
   final Map<String, Set<String>> _seen = {};
+  bool _busy = false;
 
   TransactionProvider get _transactions => GetIt.I<TransactionProvider>();
 
@@ -168,9 +203,11 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
                           children: [
                             ...claims.map((c) => _coinPicker(context, c, formatter)),
                             const SizedBox(height: 8),
-                            if (_selectionValid)
+                            if (_selectionValid || _busy)
                               SailButton(
                                 label: _buttonLabel(formatter, selectedSats, claims),
+                                loadingLabel: 'Creating transaction',
+                                loading: _busy,
                                 icon: SailSVGAsset.iconCoins,
                                 onPressed: () => _claim(context),
                               ),
@@ -369,22 +406,42 @@ class _ClaimEcashCardState extends State<_ClaimEcashCard> {
 
     var broadcast = 0;
     var drafted = 0;
+    String? lastDraftId;
     Object? firstError;
-    for (final p in planned) {
-      try {
-        if (p.multisig) {
-          await widget.fork.createSplitDraft(p.walletId, outpoints: p.outpoints);
-          drafted++;
-        } else {
-          await widget.fork.claim(p.walletId, outpoints: p.outpoints);
-          broadcast++;
+    setState(() => _busy = true);
+    try {
+      for (final p in planned) {
+        try {
+          if (p.multisig) {
+            lastDraftId = await widget.fork.createSplitDraft(p.walletId, outpoints: p.outpoints);
+            drafted++;
+          } else {
+            await widget.fork.claim(p.walletId, outpoints: p.outpoints);
+            broadcast++;
+          }
+        } catch (e) {
+          firstError ??= e;
         }
-      } catch (e) {
-        firstError ??= e;
+      }
+      if (drafted > 0) {
+        // The send tab lists the drafts it last loaded, so a fresh split only
+        // appears after this refetch.
+        await GetIt.I<PsbtDraftProvider>().fetch();
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _busy = false);
       }
     }
     if (!context.mounted) {
       return;
+    }
+    final forwardTo = forwardSubtabAfterClaim(drafted: drafted, firstError: firstError);
+    if (forwardTo != null) {
+      WalletPage.setSubtab(forwardTo);
+      if (lastDraftId != null) {
+        WalletPage.selectSendDraft(lastDraftId);
+      }
     }
     if (firstError != null) {
       showSailToast(

--- a/bitwindow/lib/widgets/multisig_sign_panel.dart
+++ b/bitwindow/lib/widgets/multisig_sign_panel.dart
@@ -43,7 +43,7 @@ class _MultisigSignPanelState extends State<MultisigSignPanel> {
   Set<String> _walletAddresses = {};
   String? _busyKey;
   String? _error;
-  bool _showDiagram = true;
+  bool _showDiagram = false;
   String _decodedForPsbt = '';
   final Map<int, DateTime> _signedAt = {};
 

--- a/bitwindow/test/multisig_sign_panel_test.dart
+++ b/bitwindow/test/multisig_sign_panel_test.dart
@@ -4,6 +4,7 @@ import 'package:bitwindow/providers/address_book_provider.dart';
 import 'package:bitwindow/providers/psbt_draft_provider.dart';
 import 'package:bitwindow/providers/transactions_provider.dart';
 import 'package:bitwindow/widgets/multisig_sign_panel.dart';
+import 'package:bitwindow/widgets/tx_flow_diagram.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
@@ -144,6 +145,23 @@ void main() {
       find.byWidgetPredicate((w) => w is SailButton && w.label == 'Broadcast'),
     );
   }
+
+  testWidgets('the flow diagram stays hidden until the user asks', (tester) async {
+    final draftId = await setUpPanelDeps();
+
+    await tester.pumpSailPage(MultisigSignPanel(walletId: 'wallet-1', draftId: draftId));
+    await tester.pumpAndSettle();
+
+    final toggle = find.byWidgetPredicate((w) => w is SailButton && w.label == 'Show diagram');
+    expect(find.byType(TxFlowDiagram), findsNothing);
+    expect(toggle, findsOneWidget);
+
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TxFlowDiagram), findsOneWidget);
+    expect(find.byWidgetPredicate((w) => w is SailButton && w.label == 'Hide diagram'), findsOneWidget);
+  });
 
   testWidgets('the keys table renders one row per cosigner', (tester) async {
     final draftId = await setUpPanelDeps();

--- a/bitwindow/test/split_forward_test.dart
+++ b/bitwindow/test/split_forward_test.dart
@@ -1,0 +1,66 @@
+import 'package:bitwindow/pages/wallet/wallet_send.dart';
+import 'package:bitwindow/utils/navigation_registry.dart';
+import 'package:bitwindow/widgets/fork_mode_banner.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/gen/walletpsbt/v1/walletpsbt.pb.dart';
+
+void main() {
+  group('forwardSubtabAfterClaim', () {
+    test('a clean split run forwards to the send tab', () {
+      expect(forwardSubtabAfterClaim(drafted: 1, firstError: null), WalletSubtabs.send);
+    });
+
+    test('a broadcast-only run stays on the current tab', () {
+      expect(forwardSubtabAfterClaim(drafted: 0, firstError: null), isNull);
+    });
+
+    test('a failed run stays put so the user reads the error', () {
+      expect(forwardSubtabAfterClaim(drafted: 1, firstError: Exception('boom')), isNull);
+    });
+  });
+
+  group('showClaimCard', () {
+    // A split reserves every coin it spends before its first await, so the
+    // claims read empty while the build runs.
+    test('the card outlives its own claims while a split builds', () {
+      expect(
+        showClaimCard(hasFundsToClaim: false, hasClaims: false, dismissed: true, splitInFlight: true),
+        isTrue,
+      );
+    });
+
+    test('the card shows while claimable coins wait', () {
+      expect(
+        showClaimCard(hasFundsToClaim: true, hasClaims: true, dismissed: false, splitInFlight: false),
+        isTrue,
+      );
+    });
+
+    test('the card hides once every coin is swept', () {
+      expect(
+        showClaimCard(hasFundsToClaim: true, hasClaims: false, dismissed: false, splitInFlight: false),
+        isFalse,
+      );
+    });
+
+    test('the card hides when the user dismissed it', () {
+      expect(
+        showClaimCard(hasFundsToClaim: true, hasClaims: true, dismissed: true, splitInFlight: false),
+        isFalse,
+      );
+    });
+  });
+
+  group('draftTabIndex', () {
+    final drafts = [PsbtDraft(id: 'a'), PsbtDraft(id: 'b'), PsbtDraft(id: 'c')];
+
+    test('a draft sits at its list index plus one', () {
+      expect(SendPageViewModel.draftTabIndex(drafts, 'a'), 1);
+      expect(SendPageViewModel.draftTabIndex(drafts, 'c'), 3);
+    });
+
+    test('an unknown draft falls back to the create form', () {
+      expect(SendPageViewModel.draftTabIndex(drafts, 'gone'), 0);
+    });
+  });
+}


### PR DESCRIPTION
Three fixes to the multisig split flow.

The claim card holds the coins while it builds the PSBT, so the selection read invalid and the button disappeared under the user mid-build. The button now stays and shows its loading state.

The send tab lists the drafts it last loaded, so a fresh split did not appear until something else refetched. The claim run now refreshes the drafts, then forwards to the send tab where the draft waits. A failed or broadcast-only run stays put.

The flow diagram on the sign panel starts hidden. The Show diagram button opens it.