### PR TITLE
Read animated key QR codes

### DIFF
--- a/bitwindow/lib/pages/welcome/multisig_config_step.dart
+++ b/bitwindow/lib/pages/welcome/multisig_config_step.dart
@@ -4,14 +4,15 @@ import 'dart:io';
 
 import 'package:bitwindow/main.dart' show restoreBitwindowWalletFromFile;
 import 'package:bitwindow/pages/welcome/wallet_backup_page.dart';
+import 'package:bitwindow/utils/ur_key.dart';
 import 'package:bitwindow/routing/router.dart';
 import 'package:bitwindow/widgets/hardware_device_picker.dart';
+import 'package:bitwindow/widgets/key_qr_scanner.dart';
 import 'package:bitwindow/widgets/ur_qr_scanner.dart' show urCameraScanSupported;
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
-import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:sidechain_core/gen/multisiglounge/v1/multisiglounge.pb.dart' as mlpb;
 import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
 import 'package:sail_ui/sail_ui.dart';
@@ -229,6 +230,10 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
 
   /// One key is a single-sig wallet; the quorum slider is what makes it multisig.
   bool get _isSingle => _total == 1;
+
+  /// The policy's script type, used to pick a key out of a multi-key export.
+  /// Single-sig holds wpkh|sh-wpkh|pkh|tr here, multisig holds wsh|sh-wsh|sh|tr.
+  String get _activeScriptType => _scriptType;
   bool _building = false;
   String? _error;
   bool _restoringBackup = false;
@@ -1587,7 +1592,7 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
         return;
       }
       final content = await File(path).readAsString();
-      final parsed = _parseKeyFile(content);
+      final parsed = _parseKeyFile(content, _activeScriptType);
       if (parsed == null) {
         setState(() => _error = 'No extended public key found in that file');
         return;
@@ -1599,19 +1604,12 @@ class _MultisigConfigStepState extends State<MultisigConfigStep> with AutomaticK
   }
 
   Future<void> _addFromQr(BuildContext context, int index) async {
-    final raw = await showThemedDialog<String>(
-      context: context,
-      builder: (context) => const _XpubQrScannerDialog(),
-    );
-    if (raw == null) {
+    setState(() => _error = null);
+    final key = await showKeyQrScanner(context, scriptType: _activeScriptType);
+    if (key == null) {
       return;
     }
-    final k = _keystoreFromRaw(raw, 'Key ${index + 1}');
-    if (k == null) {
-      setState(() => _error = 'Scanned code is not an extended public key');
-      return;
-    }
-    _setKeystore(index, k);
+    _setKeystore(index, _keystoreFromUrKey(key, 'Key ${index + 1}', CosignerSource.qr));
   }
 
   Future<void> _addFromDevice(BuildContext context, int index) async {
@@ -1664,24 +1662,27 @@ CosignerKeystore? _keystoreFromRaw(String raw, String owner) {
     ..source = CosignerSource.qr;
 }
 
-/// Parses a JSON key export (Coldcard-style fields) into a keystore, or null.
-CosignerKeystore? _parseKeyFile(String content) {
+/// Builds a keystore from a scanned or imported key.
+CosignerKeystore _keystoreFromUrKey(UrKey key, String fallbackOwner, CosignerSource source) {
+  final name = key.name ?? '';
+  final origin = (key.originPath ?? '').isEmpty ? null : key.originPath;
+  return CosignerKeystore(owner: name.isEmpty ? fallbackOwner : name)
+    ..xpub = key.xpub
+    ..fingerprint = key.fingerprint
+    ..originPath = origin
+    ..derivationPath = origin == null ? '' : 'm/$origin'
+    ..isWallet = false
+    ..source = source;
+}
+
+/// Parses a wallet export file into a keystore, or null when it holds no key.
+CosignerKeystore? _parseKeyFile(String content, String scriptType) {
   try {
-    final json = jsonDecode(content) as Map<String, dynamic>;
-    final xpub = (json['xpub'] ?? json['extended_public_key'] ?? json['pubkey'] ?? '') as String;
-    if (!isPlausibleXpub(xpub)) {
+    final key = pickKeyForScriptType(parseWalletExportJson(content), scriptType);
+    if (key == null || !isPlausibleXpub(key.xpub)) {
       return null;
     }
-    final path = (json['path'] ?? json['derivation_path'] ?? json['bip32_path'] ?? '') as String;
-    final origin =
-        (json['origin_path'] ?? json['origin'] ?? (path.startsWith('m/') ? path.substring(2) : path)) as String;
-    return CosignerKeystore(owner: (json['owner'] ?? json['name'] ?? '') as String)
-      ..xpub = xpub
-      ..derivationPath = path
-      ..originPath = origin.isEmpty ? null : origin
-      ..fingerprint = (json['fingerprint'] ?? json['master_fingerprint']) as String?
-      ..isWallet = false
-      ..source = CosignerSource.file;
+    return _keystoreFromUrKey(key, '', CosignerSource.file);
   } catch (_) {
     return null;
   }
@@ -1882,76 +1883,6 @@ class _PasteXpubDialogState extends State<_PasteXpubDialog> {
                     k.source = CosignerSource.xpub;
                     Navigator.of(context).pop(k);
                   },
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-/// Dialog that scans a single QR frame containing an xpub or descriptor string.
-class _XpubQrScannerDialog extends StatefulWidget {
-  const _XpubQrScannerDialog();
-
-  @override
-  State<_XpubQrScannerDialog> createState() => _XpubQrScannerDialogState();
-}
-
-class _XpubQrScannerDialogState extends State<_XpubQrScannerDialog> {
-  final MobileScannerController _controller = MobileScannerController(
-    formats: const [BarcodeFormat.qrCode],
-  );
-  bool _done = false;
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  void _onDetect(BarcodeCapture capture) {
-    if (_done) {
-      return;
-    }
-    for (final b in capture.barcodes) {
-      final raw = b.rawValue;
-      if (raw == null || raw.isEmpty) {
-        continue;
-      }
-      _done = true;
-      Navigator.of(context).pop(raw.trim());
-      return;
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return SailModal(
-      constraints: const BoxConstraints(maxWidth: 420),
-      child: SailCard(
-        title: 'Scan key QR',
-        child: SailColumn(
-          spacing: SailStyleValues.padding16,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (urCameraScanSupported)
-              SizedBox(
-                width: 320,
-                height: 320,
-                child: MobileScanner(controller: _controller, onDetect: _onDetect),
-              )
-            else
-              SailText.secondary13('Camera scanning is not available on this platform.'),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                SailButton(
-                  label: 'Cancel',
-                  variant: ButtonVariant.ghost,
-                  onPressed: () async => Navigator.of(context).pop(),
                 ),
               ],
             ),

--- a/bitwindow/lib/utils/ur_key.dart
+++ b/bitwindow/lib/utils/ur_key.dart
@@ -1,0 +1,457 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bs58/bs58.dart';
+import 'package:crypto/crypto.dart';
+
+/// One extended public key read out of a `crypto-hdkey` / `crypto-account` UR.
+class UrKey {
+  final String xpub;
+  final String? fingerprint;
+  final String? originPath;
+  final String? name;
+
+  /// UR output script tag (400-410) that wrapped the key, or null when the key
+  /// arrived on its own.
+  final int? scriptTag;
+
+  const UrKey({required this.xpub, this.fingerprint, this.originPath, this.name, this.scriptTag});
+}
+
+/// bcr-2023 moved the metadata tags into the 403xx range; devices send either.
+int _canonicalTag(int tag) {
+  if (tag >= 40303 && tag <= 40311) {
+    return tag - 40000;
+  }
+  return tag;
+}
+
+bool _isScriptTag(int tag) => tag >= 400 && tag <= 410;
+
+/// UR script tags that hold [scriptType], best first.
+List<int> preferredScriptTags(String scriptType) {
+  switch (scriptType) {
+    case 'wsh':
+      return const [401, 410, 407, 406];
+    case 'sh-wsh':
+    case 'sh':
+      return const [400];
+    case 'tr':
+      return const [409];
+    case 'sh-wpkh':
+      return const [400, 404];
+    case 'pkh':
+      return const [403];
+    default:
+      return const [404];
+  }
+}
+
+/// Picks the key that matches [scriptType], or the first key when none match.
+UrKey? pickKeyForScriptType(List<UrKey> keys, String scriptType) {
+  if (keys.isEmpty) {
+    return null;
+  }
+  for (final tag in preferredScriptTags(scriptType)) {
+    for (final key in keys) {
+      if (key.scriptTag == tag) {
+        return key;
+      }
+    }
+  }
+  return keys.first;
+}
+
+/// Reads every extended public key out of an assembled UR message.
+///
+/// Handles `crypto-hdkey`, `crypto-output`, `crypto-account`, and a `bytes`
+/// message that carries a wallet export as JSON or as a plain key string.
+/// Returns an empty list when the message holds no key.
+List<UrKey> parseUrKeyMessage(Uint8List message, {String? urType}) {
+  final Object? root = _CborReader(message).readValue();
+  final keys = <UrKey>[];
+  if (_isUntaggedAccount(root, urType)) {
+    _collectAccount(root, keys);
+  } else {
+    _collectKeys(root, null, null, keys);
+  }
+  if (keys.isNotEmpty) {
+    return keys;
+  }
+  if (root is Uint8List) {
+    return parseKeyText(utf8.decode(root, allowMalformed: true));
+  }
+  if (root is String) {
+    return parseKeyText(root);
+  }
+  return const [];
+}
+
+/// Reads every key out of a wallet export file.
+///
+/// Covers the nested Coldcard/Passport export (top-level `xfp` plus one
+/// `bip44`/`bip49`/`bip84`/`bip86` block per script type) and the flat
+/// single-key form that carries `xpub` at the top level.
+List<UrKey> parseWalletExportJson(String text) {
+  final keys = <UrKey>[];
+  final trimmed = text.trim();
+  if (!trimmed.startsWith('{')) {
+    return keys;
+  }
+  final Object? decoded = jsonDecode(trimmed);
+  if (decoded is! Map<String, dynamic>) {
+    return keys;
+  }
+  final masterFingerprint = _stringField(decoded, const ['xfp', 'master_fingerprint', 'fingerprint']);
+
+  final flatXpub = _stringField(decoded, const ['xpub', 'extended_public_key', 'pubkey']);
+  if (flatXpub != null && flatXpub.isNotEmpty) {
+    final flatPath = _stringField(decoded, const [
+      'deriv',
+      'path',
+      'derivation_path',
+      'bip32_path',
+      'origin_path',
+      'origin',
+    ]);
+    keys.add(
+      UrKey(
+        xpub: flatXpub,
+        fingerprint: masterFingerprint,
+        originPath: flatPath == null ? null : _stripMasterPrefix(flatPath),
+        name: _stringField(decoded, const ['owner', 'name']),
+      ),
+    );
+  }
+
+  for (final entry in decoded.entries) {
+    final value = entry.value;
+    if (value is! Map<String, dynamic>) {
+      continue;
+    }
+    final xpub = value['xpub'];
+    if (xpub is! String || xpub.isEmpty) {
+      continue;
+    }
+    final deriv = value['deriv'];
+    keys.add(
+      UrKey(
+        xpub: xpub,
+        fingerprint: _stringField(value, const ['xfp']) ?? masterFingerprint,
+        originPath: deriv is String ? _stripMasterPrefix(deriv) : null,
+        name: _stringField(value, const ['name']),
+        scriptTag: _scriptTagForName(value['name']),
+      ),
+    );
+  }
+  return keys;
+}
+
+String? _stringField(Map<String, dynamic> map, List<String> names) {
+  for (final name in names) {
+    final value = map[name];
+    if (value is String && value.isNotEmpty) {
+      return value;
+    }
+  }
+  return null;
+}
+
+/// Maps a Coldcard/Passport script name (`p2wpkh`, `p2wsh`, ...) onto the UR
+/// output script tag, so a file import and a QR import rank keys the same way.
+int? _scriptTagForName(Object? name) {
+  if (name is! String) {
+    return null;
+  }
+  switch (name.toLowerCase()) {
+    case 'p2pkh':
+      return 403;
+    case 'p2sh':
+    case 'p2wpkh-p2sh':
+    case 'p2sh-p2wpkh':
+    case 'p2wsh-p2sh':
+    case 'p2sh-p2wsh':
+      return 400;
+    case 'p2wpkh':
+      return 404;
+    case 'p2wsh':
+      return 401;
+    case 'p2tr':
+      return 409;
+    default:
+      return null;
+  }
+}
+
+String _stripMasterPrefix(String path) {
+  if (path.startsWith('m/') || path.startsWith('M/')) {
+    return path.substring(2);
+  }
+  return path;
+}
+
+void _collectKeys(Object? node, int? scriptTag, int? accountFingerprint, List<UrKey> out) {
+  if (node is _CborTag) {
+    final tag = _canonicalTag(node.tag);
+    if (tag == 311) {
+      _collectAccount(node.value, out);
+      return;
+    }
+    // The outer tag names the whole expression: sh(wsh(...)) is nested segwit,
+    // and the inner wsh alone would read as native.
+    _collectKeys(node.value, scriptTag ?? (_isScriptTag(tag) ? tag : null), accountFingerprint, out);
+    return;
+  }
+  if (node is List) {
+    for (final item in node) {
+      _collectKeys(item, scriptTag, accountFingerprint, out);
+    }
+    return;
+  }
+  if (node is Map) {
+    final key = _hdKeyFromMap(node, scriptTag, accountFingerprint);
+    if (key != null) {
+      out.add(key);
+      return;
+    }
+    // A multi or sortedmulti descriptor holds its cosigner keys in a map value.
+    for (final value in node.values) {
+      _collectKeys(value, scriptTag, accountFingerprint, out);
+    }
+  }
+}
+
+/// A `ur:crypto-account` carries its map untagged, because the UR type already
+/// names the registry entry. Key 2 holds the output list there, where an hdkey
+/// holds a bool.
+bool _isUntaggedAccount(Object? node, String? urType) {
+  if (node is! Map || node.containsKey(3)) {
+    return false;
+  }
+  if (node[2] is! List) {
+    return false;
+  }
+  return urType == null || urType.endsWith('account');
+}
+
+void _collectAccount(Object? value, List<UrKey> out) {
+  if (value is! Map) {
+    return;
+  }
+  final fingerprint = _fingerprintHex(value[1]);
+  _collectKeys(value[2], null, fingerprint, out);
+}
+
+UrKey? _hdKeyFromMap(Map<Object?, Object?> map, int? scriptTag, int? accountFingerprint) {
+  final keyData = map[3];
+  final chainCode = map[4];
+  if (keyData is! Uint8List || keyData.length != 33) {
+    return null;
+  }
+  if (chainCode is! Uint8List || chainCode.length != 32) {
+    return null;
+  }
+  if (map[2] == true) {
+    return null; // a private key never belongs in a watch-only import
+  }
+
+  final origin = _untag(map[6]);
+  final components = origin is Map ? origin[1] : null;
+  final path = components is List ? _keyPath(components) : null;
+  final depth = origin is Map && origin[3] is int
+      ? origin[3]! as int
+      : (components is List ? components.length ~/ 2 : 0);
+  final childNumber = components is List ? _lastChildNumber(components) : 0;
+
+  final originFingerprint = origin is Map ? _fingerprintHex(origin[2]) : null;
+  final parentFingerprint = map[8] is int ? map[8]! as int : 0;
+
+  final useInfo = _untag(map[5]);
+  final testnet = useInfo is Map && useInfo[2] == 1;
+
+  final serialized = _serializeExtendedKey(
+    version: testnet ? 0x043587cf : 0x0488b21e,
+    depth: depth,
+    parentFingerprint: parentFingerprint,
+    childNumber: childNumber,
+    chainCode: chainCode,
+    keyData: keyData,
+  );
+
+  final fingerprint = originFingerprint ?? accountFingerprint;
+  return UrKey(
+    xpub: serialized,
+    fingerprint: fingerprint == null ? null : _hex32(fingerprint),
+    originPath: path,
+    name: map[9] is String ? map[9]! as String : null,
+    scriptTag: scriptTag,
+  );
+}
+
+Object? _untag(Object? node) => node is _CborTag ? node.value : node;
+
+int? _fingerprintHex(Object? value) => value is int ? value : null;
+
+String _hex32(int value) => value.toRadixString(16).padLeft(8, '0');
+
+/// Renders keypath components as `48'/0'/0'/2'`, or null when a component is
+/// a range or a wildcard rather than a plain index.
+String? _keyPath(List<Object?> components) {
+  final parts = <String>[];
+  for (var i = 0; i + 1 < components.length; i += 2) {
+    final index = components[i];
+    if (index is! int) {
+      return null;
+    }
+    parts.add(components[i + 1] == true ? "$index'" : '$index');
+  }
+  return parts.join('/');
+}
+
+int _lastChildNumber(List<Object?> components) {
+  if (components.length < 2) {
+    return 0;
+  }
+  final index = components[components.length - 2];
+  if (index is! int) {
+    return 0;
+  }
+  final hardened = components[components.length - 1] == true;
+  return hardened ? index | 0x80000000 : index;
+}
+
+String _serializeExtendedKey({
+  required int version,
+  required int depth,
+  required int parentFingerprint,
+  required int childNumber,
+  required Uint8List chainCode,
+  required Uint8List keyData,
+}) {
+  final payload = Uint8List(78);
+  final view = ByteData.view(payload.buffer);
+  view.setUint32(0, version);
+  payload[4] = depth & 0xff;
+  view.setUint32(5, parentFingerprint);
+  view.setUint32(9, childNumber);
+  payload.setRange(13, 45, chainCode);
+  payload.setRange(45, 78, keyData);
+
+  final checksum = sha256.convert(sha256.convert(payload).bytes).bytes.sublist(0, 4);
+  return base58.encode(Uint8List.fromList([...payload, ...checksum]));
+}
+
+class _CborTag {
+  final int tag;
+  final Object? value;
+  const _CborTag(this.tag, this.value);
+}
+
+/// Reader for the CBOR subset the UR key types use.
+class _CborReader {
+  final Uint8List _data;
+  int _pos = 0;
+  _CborReader(this._data);
+
+  Object? readValue() {
+    final initial = _data[_pos++];
+    final major = initial >> 5;
+    switch (major) {
+      case 0:
+        return _argument(initial);
+      case 1:
+        return -1 - _argument(initial);
+      case 2:
+        return _bytes(_argument(initial));
+      case 3:
+        return utf8.decode(_bytes(_argument(initial)), allowMalformed: true);
+      case 4:
+        return List<Object?>.generate(_argument(initial), (_) => readValue(), growable: false);
+      case 5:
+        final length = _argument(initial);
+        final map = <Object?, Object?>{};
+        for (var i = 0; i < length; i++) {
+          final key = readValue();
+          map[key] = readValue();
+        }
+        return map;
+      case 6:
+        return _CborTag(_argument(initial), readValue());
+      default:
+        return _simple(initial);
+    }
+  }
+
+  Object? _simple(int initial) {
+    final value = initial & 0x1f;
+    switch (value) {
+      case 20:
+        return false;
+      case 21:
+        return true;
+      case 22:
+      case 23:
+        return null;
+      default:
+        throw const FormatException('unsupported cbor simple value');
+    }
+  }
+
+  Uint8List _bytes(int length) {
+    final out = Uint8List.fromList(Uint8List.sublistView(_data, _pos, _pos + length));
+    _pos += length;
+    return out;
+  }
+
+  int _argument(int initial) {
+    final ai = initial & 0x1f;
+    if (ai < 24) {
+      return ai;
+    }
+    if (ai == 24) {
+      return _data[_pos++];
+    }
+    if (ai == 25) {
+      final v = (_data[_pos] << 8) | _data[_pos + 1];
+      _pos += 2;
+      return v;
+    }
+    if (ai == 26) {
+      final v = (_data[_pos] << 24) | (_data[_pos + 1] << 16) | (_data[_pos + 2] << 8) | _data[_pos + 3];
+      _pos += 4;
+      return v;
+    }
+    if (ai == 27) {
+      var v = 0;
+      for (var i = 0; i < 8; i++) {
+        v = (v << 8) | _data[_pos++];
+      }
+      return v;
+    }
+    throw const FormatException('unsupported cbor argument');
+  }
+}
+
+final RegExp _xpubPattern = RegExp(r'^[xyztuvYZUV]pub[1-9A-HJ-NP-Za-km-z]{50,120}$');
+final RegExp _keyExpressionPattern = RegExp(r'^\[([0-9a-fA-F]{8})(?:/([^\]]*))?\](.+)$');
+
+/// Reads a single-frame QR body: `[fingerprint/origin]xpub`, a bare xpub, or a
+/// wallet export in JSON. Returns null when the text holds no key.
+List<UrKey> parseKeyText(String raw) {
+  final trimmed = raw.trim();
+  if (trimmed.startsWith('{')) {
+    return parseWalletExportJson(trimmed);
+  }
+  final match = _keyExpressionPattern.firstMatch(trimmed);
+  if (match != null) {
+    final xpub = match.group(3)!.trim();
+    if (!_xpubPattern.hasMatch(xpub)) {
+      return const [];
+    }
+    return [UrKey(xpub: xpub, fingerprint: match.group(1)?.toLowerCase(), originPath: match.group(2))];
+  }
+  if (_xpubPattern.hasMatch(trimmed)) {
+    return [UrKey(xpub: trimmed)];
+  }
+  return const [];
+}

--- a/bitwindow/lib/widgets/key_qr_scanner.dart
+++ b/bitwindow/lib/widgets/key_qr_scanner.dart
@@ -1,0 +1,163 @@
+import 'package:bitwindow/utils/ur_key.dart';
+import 'package:bitwindow/widgets/ur_qr_scanner.dart' show urCameraScanSupported;
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+/// Shows the key scanner and returns the picked key, or null on cancel.
+///
+/// [scriptType] selects which key a multi-key export gives back: the multisig
+/// policy's own script type, e.g. `wsh`.
+Future<UrKey?> showKeyQrScanner(BuildContext context, {required String scriptType}) {
+  return showThemedDialog<UrKey>(
+    context: context,
+    builder: (context) => KeyQrScannerDialog(scriptType: scriptType),
+  );
+}
+
+/// Camera scanner for an extended public key.
+///
+/// Reads a single QR that holds `[fingerprint/origin]xpub`, a bare xpub, or a
+/// wallet export in JSON. Reads an animated UR sequence as well: airgap
+/// signers send `crypto-hdkey`, `crypto-account`, or a `bytes` export over
+/// many frames, and the scanner joins them.
+class KeyQrScannerDialog extends StatefulWidget {
+  final String scriptType;
+
+  const KeyQrScannerDialog({super.key, required this.scriptType});
+
+  @override
+  State<KeyQrScannerDialog> createState() => _KeyQrScannerDialogState();
+}
+
+class _KeyQrScannerDialogState extends State<KeyQrScannerDialog> {
+  final MobileScannerController _controller = MobileScannerController(
+    formats: const [BarcodeFormat.qrCode],
+  );
+  URDecoder _decoder = URDecoder();
+  bool _done = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onDetect(BarcodeCapture capture) {
+    if (_done) {
+      return;
+    }
+    for (final barcode in capture.barcodes) {
+      final raw = barcode.rawValue?.trim();
+      if (raw == null || raw.isEmpty) {
+        continue;
+      }
+      if (raw.toLowerCase().startsWith('ur:')) {
+        _receiveUrFrame(raw);
+      } else {
+        _finish(parseKeyText(raw), 'That QR code holds no extended public key');
+      }
+      if (_done) {
+        return;
+      }
+    }
+  }
+
+  void _receiveUrFrame(String frame) {
+    try {
+      _decoder.receive(frame);
+    } on FormatException {
+      // A frame from a different export would otherwise hold the scanner on a
+      // set it can never complete. Restart and read this frame as the first.
+      _decoder = URDecoder();
+      try {
+        _decoder.receive(frame);
+      } on FormatException {
+        return;
+      }
+    }
+
+    if (_decoder.type == 'crypto-psbt') {
+      _setError('That QR code holds a transaction, not a key');
+      return;
+    }
+    if (!_decoder.isComplete) {
+      _setError(null);
+      return;
+    }
+
+    try {
+      _finish(
+        parseUrKeyMessage(_decoder.messageBytes(), urType: _decoder.type),
+        'That QR code holds no extended public key',
+      );
+    } on FormatException catch (e) {
+      _decoder = URDecoder();
+      _setError('Could not read the QR code: ${e.message}');
+    }
+  }
+
+  void _finish(List<UrKey> keys, String emptyMessage) {
+    final key = pickKeyForScriptType(keys, widget.scriptType);
+    if (key == null) {
+      _setError(emptyMessage);
+      return;
+    }
+    _done = true;
+    Navigator.of(context).pop(key);
+  }
+
+  void _setError(String? message) {
+    if (!mounted || _error == message) {
+      return;
+    }
+    setState(() => _error = message);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final received = _decoder.receivedCount;
+    final expected = _decoder.expectedCount;
+
+    return SailModal(
+      constraints: const BoxConstraints(maxWidth: 420),
+      child: SailCard(
+        title: 'Scan key QR',
+        error: _error,
+        child: SailColumn(
+          spacing: SailStyleValues.padding16,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (urCameraScanSupported)
+              SizedBox(
+                width: 320,
+                height: 320,
+                child: MobileScanner(
+                  controller: _controller,
+                  onDetect: _onDetect,
+                  errorBuilder: (context, error) => Center(
+                    child: SailText.secondary13('Camera error: ${error.errorCode.name}'),
+                  ),
+                ),
+              )
+            else
+              SailText.secondary13('Camera scanning is not available on this platform.'),
+            if (urCameraScanSupported && expected != null && expected > 1)
+              SailText.secondary12('Scanned $received of $expected parts'),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                SailButton(
+                  label: 'Cancel',
+                  variant: ButtonVariant.ghost,
+                  onPressed: () async => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/bitwindow/test/ur_key_test.dart
+++ b/bitwindow/test/ur_key_test.dart
@@ -1,0 +1,394 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bitwindow/utils/ur_key.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/utils/ur_psbt.dart';
+
+// BIP32 test vector 1, chain m/0'. The parser must rebuild exactly this xpub
+// from the raw key material a crypto-hdkey carries.
+const _bip32Vector1Account0Xpub =
+    'xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw';
+const _chainCodeHex = '47fdacbd0f1097043b78c63c20c34ef4ed9a111d980047ad16282c7ae6236141';
+const _keyDataHex = '035a784662a4a20a65bf6aab9ae98a6c068a81c52e4b032c0fb5400c706cfccc56';
+const _masterFingerprint = 0x3442193e;
+
+Uint8List _hex(String s) {
+  final out = Uint8List(s.length ~/ 2);
+  for (var i = 0; i < out.length; i++) {
+    out[i] = int.parse(s.substring(i * 2, i * 2 + 2), radix: 16);
+  }
+  return out;
+}
+
+/// Minimal CBOR writer for the UR shapes the tests build.
+class _Cbor {
+  final BytesBuilder _b = BytesBuilder();
+
+  Uint8List bytes() => _b.toBytes();
+
+  void _header(int major, int value) {
+    final mt = major << 5;
+    if (value < 24) {
+      _b.addByte(mt | value);
+    } else if (value < 0x100) {
+      _b.addByte(mt | 24);
+      _b.addByte(value);
+    } else if (value < 0x10000) {
+      _b.addByte(mt | 25);
+      _b.addByte((value >> 8) & 0xff);
+      _b.addByte(value & 0xff);
+    } else {
+      _b.addByte(mt | 26);
+      for (var shift = 24; shift >= 0; shift -= 8) {
+        _b.addByte((value >> shift) & 0xff);
+      }
+    }
+  }
+
+  void uint(int v) => _header(0, v);
+  void byteString(Uint8List v) {
+    _header(2, v.length);
+    _b.add(v);
+  }
+
+  void array(int n) => _header(4, n);
+  void map(int n) => _header(5, n);
+  void tag(int n) => _header(6, n);
+  void boolean(bool v) => _b.addByte(v ? 0xf5 : 0xf4);
+}
+
+/// Writes a crypto-hdkey holding the BIP32 vector-1 account key.
+void _writeHdKey(_Cbor c) {
+  c.map(4);
+  c.uint(3);
+  c.byteString(_hex(_keyDataHex));
+  c.uint(4);
+  c.byteString(_hex(_chainCodeHex));
+  c.uint(6);
+  c.tag(304);
+  c.map(3);
+  c.uint(1);
+  c.array(2);
+  c.uint(0);
+  c.boolean(true);
+  c.uint(2);
+  c.uint(_masterFingerprint);
+  c.uint(3);
+  c.uint(1);
+  c.uint(8);
+  c.uint(_masterFingerprint);
+}
+
+Uint8List _hdKeyMessage() {
+  final c = _Cbor();
+  _writeHdKey(c);
+  return c.bytes();
+}
+
+/// Writes a crypto-account whose descriptor list holds the same key twice,
+/// once under wpkh (404) and once under wsh (401).
+Uint8List _accountMessage() {
+  final c = _Cbor();
+  c.tag(311);
+  c.map(2);
+  c.uint(1);
+  c.uint(_masterFingerprint);
+  c.uint(2);
+  c.array(2);
+  c.tag(404);
+  _writeHdKey(c);
+  c.tag(401);
+  _writeHdKey(c);
+  return c.bytes();
+}
+
+const _passportExport =
+    '''
+{
+  "xfp": "3442193E",
+  "account": 0,
+  "bip84": {
+    "name": "p2wpkh",
+    "xfp": "AABBCCDD",
+    "deriv": "m/84'/0'/0'",
+    "xpub": "$_bip32Vector1Account0Xpub"
+  },
+  "bip48_2": {
+    "name": "p2wsh",
+    "deriv": "m/48'/0'/0'/2'",
+    "xpub": "$_bip32Vector1Account0Xpub"
+  }
+}
+''';
+
+/// The form a `ur:crypto-account` carries: the UR type names the registry
+/// entry, so the account map itself is untagged.
+Uint8List _untaggedAccountMessage() {
+  final c = _Cbor();
+  c.map(2);
+  c.uint(1);
+  c.uint(_masterFingerprint);
+  c.uint(2);
+  c.array(2);
+  c.tag(404);
+  _writeHdKey(c);
+  c.tag(401);
+  _writeHdKey(c);
+  return c.bytes();
+}
+
+/// Rebuilds one multi-part frame with a new sequence number, so a test can
+/// send the fountain part a UR v2 encoder emits past seqLen.
+String _reframeWithSeqNum(String frame, int seqNum) {
+  if (seqNum >= 24) {
+    throw ArgumentError('the test only rebuilds a one-byte sequence number');
+  }
+  final body = frame.substring(frame.indexOf('/') + 1);
+  final header = body.substring(0, body.indexOf('/'));
+  final seqLen = int.parse(header.split('-')[1]);
+  final payload = ByteWords.decode(body.substring(body.indexOf('/') + 1));
+
+  // The part is cbor([seqNum, seqLen, messageLen, checksum, fragment]) and the
+  // array header comes first, so only byte 1 carries the sequence number.
+  final rebuilt = Uint8List.fromList(payload);
+  rebuilt[1] = seqNum;
+  return 'ur:crypto-psbt/$seqNum-$seqLen/${ByteWords.encode(rebuilt)}';
+}
+
+/// An account whose first output nests the key: sh(wsh(hdkey)), the shape a
+/// nested-segwit multisig export carries.
+Uint8List _nestedAccountMessage() {
+  final c = _Cbor();
+  c.map(2);
+  c.uint(1);
+  c.uint(_masterFingerprint);
+  c.uint(2);
+  c.array(2);
+  c.tag(400);
+  c.tag(401);
+  _writeHdKey(c);
+  c.tag(401);
+  _writeHdKey(c);
+  return c.bytes();
+}
+
+/// An account whose output is wsh(sortedmulti(2, hdkey, hdkey)): the script tag
+/// wraps a map that holds the cosigner keys.
+Uint8List _sortedMultiAccountMessage() {
+  final c = _Cbor();
+  c.map(2);
+  c.uint(1);
+  c.uint(_masterFingerprint);
+  c.uint(2);
+  c.array(1);
+  c.tag(401);
+  c.tag(407);
+  c.map(2);
+  c.uint(1);
+  c.uint(2);
+  c.uint(2);
+  c.array(2);
+  _writeHdKey(c);
+  _writeHdKey(c);
+  return c.bytes();
+}
+
+void main() {
+  group('parseUrKeyMessage', () {
+    test('rebuilds the xpub from a crypto-hdkey', () {
+      final keys = parseUrKeyMessage(_hdKeyMessage());
+
+      expect(keys, hasLength(1));
+      expect(keys.single.xpub, _bip32Vector1Account0Xpub);
+      expect(keys.single.originPath, "0'");
+      expect(keys.single.fingerprint, '3442193e');
+      expect(keys.single.scriptTag, isNull);
+    });
+
+    test('reads every output of a crypto-account and tags each script type', () {
+      final keys = parseUrKeyMessage(_accountMessage());
+
+      expect(keys, hasLength(2));
+      expect(keys.map((k) => k.scriptTag), [404, 401]);
+      expect(keys.every((k) => k.xpub == _bip32Vector1Account0Xpub), isTrue);
+    });
+
+    test('reads a wallet export carried in a bytes payload', () {
+      final c = _Cbor();
+      c.byteString(Uint8List.fromList(utf8.encode(_passportExport)));
+
+      final keys = parseUrKeyMessage(c.bytes());
+
+      expect(keys, hasLength(2));
+      expect(keys.first.originPath, "84'/0'/0'");
+    });
+
+    test('reads an untagged crypto-account, the form a UR carries', () {
+      final keys = parseUrKeyMessage(_untaggedAccountMessage(), urType: 'crypto-account');
+
+      expect(keys, hasLength(2));
+      expect(keys.map((k) => k.scriptTag), [404, 401]);
+      expect(keys.first.fingerprint, '3442193e');
+    });
+
+    test('reads an untagged crypto-account without a type hint', () {
+      expect(parseUrKeyMessage(_untaggedAccountMessage()), hasLength(2));
+    });
+
+    test('keeps the outer wrapper of a nested output', () {
+      final keys = parseUrKeyMessage(_nestedAccountMessage(), urType: 'crypto-account');
+
+      expect(keys, hasLength(2));
+      expect(keys.map((k) => k.scriptTag), [400, 401]);
+      expect(pickKeyForScriptType(keys, 'sh-wsh')!.scriptTag, 400);
+      expect(pickKeyForScriptType(keys, 'wsh')!.scriptTag, 401);
+    });
+
+    test('reads a bare key carried in a bytes payload', () {
+      final c = _Cbor();
+      c.byteString(Uint8List.fromList(utf8.encode("[3442193E/48'/0'/0'/2']$_bip32Vector1Account0Xpub")));
+
+      final keys = parseUrKeyMessage(c.bytes(), urType: 'bytes');
+
+      expect(keys.single.xpub, _bip32Vector1Account0Xpub);
+      expect(keys.single.originPath, "48'/0'/0'/2'");
+    });
+
+    test('reads the cosigner keys of a sortedmulti output', () {
+      final keys = parseUrKeyMessage(_sortedMultiAccountMessage(), urType: 'crypto-account');
+
+      expect(keys, hasLength(2));
+      expect(keys.map((k) => k.scriptTag), [401, 401]);
+      expect(keys.first.xpub, _bip32Vector1Account0Xpub);
+    });
+
+    test('returns nothing for a message that holds no key', () {
+      final c = _Cbor();
+      c.map(1);
+      c.uint(1);
+      c.uint(7);
+
+      expect(parseUrKeyMessage(c.bytes()), isEmpty);
+    });
+  });
+
+  group('URDecoder', () {
+    test('joins a multi-part sequence and learns the type', () {
+      final psbt = Uint8List.fromList(List<int>.generate(600, (i) => i % 256));
+      final frames = URPsbt.encode(psbt, maxFragmentLen: 100);
+      expect(frames.length, greaterThan(1));
+
+      final decoder = URDecoder();
+      for (final frame in frames) {
+        decoder.receive(frame);
+      }
+
+      expect(decoder.type, 'crypto-psbt');
+      expect(decoder.expectedCount, frames.length);
+      expect(decoder.isComplete, isTrue);
+      expect(decoder.result(), psbt);
+    });
+
+    test('carries a single-frame crypto-hdkey through to the parser', () {
+      final message = _hdKeyMessage();
+      final decoder = URDecoder();
+
+      decoder.receive('ur:crypto-hdkey/${ByteWords.encode(message)}');
+
+      expect(decoder.type, 'crypto-hdkey');
+      expect(decoder.isComplete, isTrue);
+      expect(parseUrKeyMessage(decoder.messageBytes()).single.xpub, _bip32Vector1Account0Xpub);
+    });
+
+    test('keeps the parts it holds when a fountain part arrives', () {
+      final psbt = Uint8List.fromList(List<int>.generate(600, (i) => i % 256));
+      final frames = URPsbt.encode(psbt, maxFragmentLen: 100);
+      final decoder = URDecoder();
+      decoder.receive(frames.first);
+
+      // A UR v2 encoder emits mixed parts past seqLen. They must not wipe the
+      // pure parts already received.
+      expect(decoder.receive(_reframeWithSeqNum(frames.first, frames.length + 1)), isFalse);
+      expect(decoder.receivedCount, 1);
+
+      for (final frame in frames.skip(1)) {
+        decoder.receive(frame);
+      }
+      expect(decoder.result(), psbt);
+    });
+
+    test('refuses a frame whose type the caller did not ask for', () {
+      final decoder = URPsbt.decoder();
+
+      expect(() => decoder.receive('ur:crypto-hdkey/aeaeae'), throwsFormatException);
+    });
+
+    test('refuses a second type mid-sequence', () {
+      final decoder = URDecoder();
+      decoder.receive('ur:crypto-hdkey/${ByteWords.encode(_hdKeyMessage())}');
+
+      expect(() => decoder.receive('ur:crypto-account/aeaeae'), throwsFormatException);
+    });
+  });
+
+  group('parseWalletExportJson', () {
+    test('reads every block of a nested Passport export', () {
+      final keys = parseWalletExportJson(_passportExport);
+
+      expect(keys, hasLength(2));
+      expect(keys[0].originPath, "84'/0'/0'");
+      expect(keys[0].fingerprint, 'AABBCCDD');
+      expect(keys[0].scriptTag, 404);
+      expect(keys[1].originPath, "48'/0'/0'/2'");
+      expect(keys[1].fingerprint, '3442193E');
+      expect(keys[1].scriptTag, 401);
+    });
+
+    test('reads the flat single-key export', () {
+      final keys = parseWalletExportJson(
+        "{\"xpub\":\"$_bip32Vector1Account0Xpub\",\"path\":\"m/84'/0'/0'\",\"master_fingerprint\":\"3442193e\"}",
+      );
+
+      expect(keys, hasLength(1));
+      expect(keys.single.originPath, "84'/0'/0'");
+      expect(keys.single.fingerprint, '3442193e');
+    });
+  });
+
+  group('pickKeyForScriptType', () {
+    test('picks the block that matches the policy', () {
+      final keys = parseWalletExportJson(_passportExport);
+
+      expect(pickKeyForScriptType(keys, 'wsh')!.originPath, "48'/0'/0'/2'");
+      expect(pickKeyForScriptType(keys, 'wpkh')!.originPath, "84'/0'/0'");
+    });
+
+    test('falls back to the first key when no block matches', () {
+      final keys = parseWalletExportJson(_passportExport);
+
+      expect(pickKeyForScriptType(keys, 'pkh')!.originPath, "84'/0'/0'");
+    });
+
+    test('returns null for an empty list', () {
+      expect(pickKeyForScriptType(const [], 'wsh'), isNull);
+    });
+  });
+
+  group('parseKeyText', () {
+    test('reads a key expression', () {
+      final keys = parseKeyText("[3442193E/48'/0'/0'/2']$_bip32Vector1Account0Xpub");
+
+      expect(keys.single.fingerprint, '3442193e');
+      expect(keys.single.originPath, "48'/0'/0'/2'");
+    });
+
+    test('reads a bare xpub', () {
+      expect(parseKeyText(_bip32Vector1Account0Xpub).single.xpub, _bip32Vector1Account0Xpub);
+    });
+
+    test('rejects text that is not a key', () {
+      expect(parseKeyText('hello'), isEmpty);
+    });
+  });
+}

--- a/sidechain_core/lib/utils/ur_psbt.dart
+++ b/sidechain_core/lib/utils/ur_psbt.dart
@@ -56,17 +56,27 @@ class URPsbt {
     return encode(base64.decode(psbtBase64.trim()), maxFragmentLen: maxFragmentLen);
   }
 
-  static URDecoder decoder() => URDecoder();
+  static URDecoder decoder() => URDecoder(acceptTypes: const {type});
 }
 
-/// Stateful reassembler for multi-part `ur:crypto-psbt` frames. Feed frames as
-/// they are scanned; [isComplete] flips once enough distinct parts arrive.
+/// Stateful reassembler for multi-part `ur:` frames. Feed frames as they are
+/// scanned; [isComplete] flips once every part arrives.
+///
+/// [acceptTypes] limits the UR types the decoder takes; a null set takes any
+/// type. The first accepted frame fixes [type] for the rest of the capture.
 class URDecoder {
+  final Set<String>? acceptTypes;
+  String? _type;
   int? _seqLen;
   int? _messageLen;
   int? _checksum;
   final Map<int, Uint8List> _parts = {};
   Uint8List? _single;
+
+  URDecoder({this.acceptTypes});
+
+  /// The UR type of the frames seen so far, or null before the first frame.
+  String? get type => _type;
 
   /// Number of distinct parts received so far.
   int get receivedCount => _single != null ? 1 : _parts.length;
@@ -87,15 +97,30 @@ class URDecoder {
   /// Feed one `ur:...` frame. Returns true if this frame was accepted (correct
   /// type and well-formed). Throws [FormatException] on a malformed frame.
   bool receive(String frame) {
-    final lower = frame.trim().toLowerCase();
-    if (!lower.startsWith('ur:${URPsbt.type}/')) {
-      throw const FormatException('not a ur:crypto-psbt frame');
+    final trimmed = frame.trim();
+    final lower = trimmed.toLowerCase();
+    if (!lower.startsWith('ur:')) {
+      throw const FormatException('not a ur frame');
     }
-    final body = frame.trim().substring('ur:${URPsbt.type}/'.length);
+    final typeEnd = lower.indexOf('/', 3);
+    if (typeEnd == -1) {
+      throw const FormatException('ur frame has no body');
+    }
+    final frameType = lower.substring(3, typeEnd);
+    final accept = acceptTypes;
+    if (accept != null && !accept.contains(frameType)) {
+      throw FormatException('unexpected ur type "$frameType"');
+    }
+    if (_type != null && _type != frameType) {
+      throw FormatException('ur type changed to "$frameType"');
+    }
+    _type = frameType;
+
+    final body = trimmed.substring(typeEnd + 1);
     final slash = body.indexOf('/');
 
     if (slash == -1) {
-      _single = _cborUnwrapBytes(ByteWords.decode(body));
+      _single = ByteWords.decode(body);
       return true;
     }
 
@@ -115,15 +140,22 @@ class URDecoder {
     if (part.seqLen != _seqLen || part.messageLen != _messageLen || part.checksum != _checksum) {
       throw const FormatException('mismatched multipart frame');
     }
-    if (seqNum != part.seqNum || seqNum < 1 || seqNum > _seqLen!) {
+    if (seqNum != part.seqNum || seqNum < 1) {
       throw const FormatException('bad sequence number');
+    }
+    if (seqNum > _seqLen!) {
+      // A fountain part mixes several fragments and this decoder reads the
+      // pure parts only. Keeping what already arrived lets the sequence
+      // finish on its next pass.
+      return false;
     }
     _parts[seqNum] = part.fragment;
     return true;
   }
 
-  /// Assembled PSBT bytes. Throws if not yet [isComplete] or checksum fails.
-  Uint8List result() {
+  /// The assembled CBOR message. Throws if not yet [isComplete] or the
+  /// checksum fails.
+  Uint8List messageBytes() {
     if (_single != null) {
       return _single!;
     }
@@ -144,8 +176,11 @@ class URDecoder {
     if (_crc32(message) != _checksum) {
       throw const FormatException('checksum mismatch');
     }
-    return _cborUnwrapBytes(message);
+    return message;
   }
+
+  /// Assembled PSBT bytes, unwrapped from the CBOR byte string.
+  Uint8List result() => _cborUnwrapBytes(messageBytes());
 
   /// Assembled PSBT as base64.
   String resultBase64() => base64.encode(result());


### PR DESCRIPTION
The key scanner in wallet setup read one QR frame only. An airgap signer such as Passport, Sparrow or Nunchuk sends the key over an animated UR sequence, so the scan never completed.

The scanner now joins a multi-part UR and reads crypto-hdkey, crypto-account and a bytes payload, and it still reads a plain xpub frame. The file import reads the nested Coldcard/Passport export too. Both pick the key that matches the policy script type.