### PR TITLE
Read the wallet file before every write

### DIFF
--- a/bitassets/pubspec.yaml
+++ b/bitassets/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitassets
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.317
+version: 1.0.318
 
 environment:
   sdk: 3.12.2

--- a/bitnames/pubspec.yaml
+++ b/bitnames/pubspec.yaml
@@ -2,7 +2,7 @@ name: bitnames
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.317
+version: 1.0.318
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/pubspec.yaml
+++ b/bitwindow/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   "A frontend for interacting with a Drivechain-enabled layer 1 bitcoin network."
 publish_to: "none"
 
-version: 0.2.185
+version: 0.2.186
 
 environment:
   sdk: 3.12.2

--- a/bitwindow/server/engines/backup_engine.go
+++ b/bitwindow/server/engines/backup_engine.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/models/multisig"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/walletfile"
 	"github.com/rs/zerolog"
 )
 
@@ -189,8 +190,8 @@ func (e *BackupEngine) RestoreBackup(ctx context.Context, data []byte, filename 
 	}
 
 	// Restore wallet.json
-	walletPath := filepath.Join(e.walletDir, "wallet.json")
-	if err := os.WriteFile(walletPath, walletJSON, 0600); err != nil {
+	walletPath := filepath.Join(e.walletDir, walletfile.Name)
+	if err := walletfile.Write(walletPath, walletJSON, walletfile.Options{}); err != nil {
 		return fmt.Errorf("write wallet.json: %w", err)
 	}
 	log.Info().Msg("restore: wrote wallet.json")

--- a/photon/pubspec.yaml
+++ b/photon/pubspec.yaml
@@ -2,7 +2,7 @@ name: photon
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.190
+version: 1.0.191
 
 environment:
   sdk: 3.12.2

--- a/sail_ui/lib/widgets/wallet_backup_restore.dart
+++ b/sail_ui/lib/widgets/wallet_backup_restore.dart
@@ -28,30 +28,6 @@ Future<String> createWalletBackup({
   return destinationPath;
 }
 
-/// Restore wallet files from a validated backup.
-///
-/// DEPRECATED: Use WalletAPI.restoreBackup() RPC instead, which handles
-/// wallet.json restoration and imports multisig/transaction data into the DB.
-@Deprecated('Use WalletAPI.restoreBackup() RPC instead')
-Future<void> restoreWalletFiles({
-  required Directory tempDir,
-  required Logger log,
-  required WalletWriterProvider walletProvider,
-}) async {
-  final bitwindowAppDir = walletProvider.bitwindowAppDir;
-
-  // wallet.json is mandatory — fail hard if missing
-  final tempWalletJson = File(path.join(tempDir.path, 'wallet.json'));
-  if (!await tempWalletJson.exists()) {
-    throw Exception('Restore failed: wallet.json is missing from backup');
-  }
-  final destWalletJson = File(path.join(bitwindowAppDir.path, 'wallet.json'));
-  await tempWalletJson.copy(destWalletJson.path);
-  log.i('Restored: wallet.json');
-
-  log.i('Wallet files restored successfully');
-}
-
 /// Result of backup validation
 class BackupValidationResult {
   final bool isValid;

--- a/sidechain-orchestrator/wallet/metadata.go
+++ b/sidechain-orchestrator/wallet/metadata.go
@@ -246,7 +246,7 @@ func (s *Service) restoreWalletBackup(backupID, password string, progress Restor
 	}
 
 	if err := runStep(restoreStepRestoreFiles, func() error {
-		if err := copyExistingFile(walletSrc, s.walletFilePath()); err != nil {
+		if err := s.restoreWalletFileLocked(walletSrc); err != nil {
 			return fmt.Errorf("restore wallet.json: %w", err)
 		}
 		if fileExists(encryptionSrc) {

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -10,15 +10,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47send"
-	"github.com/btcsuite/btcd/chaincfg"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47send"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/walletfile"
+	"github.com/btcsuite/btcd/chaincfg"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/rs/zerolog"
@@ -46,6 +48,11 @@ type Service struct {
 	starterWalletID string
 	encryptionKey   []byte
 	unlockedPass    string
+
+	// The wallet file content this process last read. Every write compares
+	// against it, so a write can never drop a change made behind our back.
+	lastWalletDigest      walletfile.Digest
+	lastWalletDigestKnown bool
 
 	// Callbacks
 	// Dart: deleteAllWallets stops all binaries before wiping (L560-575)
@@ -136,12 +143,16 @@ func (s *Service) moveToBackup(path string) (string, error) {
 
 func (s *Service) moveMasterWalletFilesToBackup() error {
 	backupRoot := filepath.Join(s.bitwindowDir, "wallet_backups", time.Now().UTC().Format("20060102-150405"))
-	for _, p := range s.MasterWalletPaths() {
-		if _, err := s.moveToBackupRoot(p, backupRoot); err != nil {
-			return fmt.Errorf("back up current wallet path %s: %w", p, err)
+	// Take the write lock across the move. A writer that already passed its
+	// compare would otherwise put the wallet back after the wipe ran.
+	return walletfile.WithLock(s.walletFilePath(), func() error {
+		for _, p := range s.MasterWalletPaths() {
+			if _, err := s.moveToBackupRoot(p, backupRoot); err != nil {
+				return fmt.Errorf("back up current wallet path %s: %w", p, err)
+			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 func (s *Service) moveToBackupRoot(path, backupRoot string) (string, error) {
@@ -197,6 +208,7 @@ func (s *Service) ClearInMemoryState() {
 	s.activeWalletID = ""
 	s.encryptionKey = nil
 	s.unlockedPass = ""
+	s.setWalletDigestLocked(nil)
 	s.mu.Unlock()
 }
 
@@ -1193,7 +1205,8 @@ func (s *Service) EncryptWallet(password string) error {
 		return fmt.Errorf("encrypt: %w", err)
 	}
 
-	if err := atomicWrite(walletPath, []byte(encrypted)); err != nil {
+	s.setWalletDigestLocked(plaintext)
+	if err := s.writeWalletFileLocked([]byte(encrypted)); err != nil {
 		s.log.Error().Err(err).Msg("failed to write encrypted wallet")
 		return fmt.Errorf("write encrypted wallet: %w", err)
 	}
@@ -1264,7 +1277,8 @@ func (s *Service) ChangePassword(oldPassword, newPassword string) error {
 		return fmt.Errorf("encrypt: %w", err)
 	}
 
-	if err := atomicWrite(s.walletFilePath(), []byte(encrypted)); err != nil {
+	s.setWalletDigestLocked(data)
+	if err := s.writeWalletFileLocked([]byte(encrypted)); err != nil {
 		return fmt.Errorf("write wallet: %w", err)
 	}
 
@@ -1349,7 +1363,8 @@ func (s *Service) RemoveEncryption(password string) error {
 	s.log.Debug().Str("backup_path", backupPath).Msg("wallet backed up before decryption")
 
 	// Write plaintext
-	if err := atomicWrite(walletPath, []byte(plaintext)); err != nil {
+	s.setWalletDigestLocked(data)
+	if err := s.writeWalletFileLocked([]byte(plaintext)); err != nil {
 		return fmt.Errorf("write wallet: %w", err)
 	}
 
@@ -1471,7 +1486,7 @@ func (s *Service) DeleteWallet(walletID string) error {
 
 	s.deleteElectrumScan(walletID)
 	s.log.Info().Str("wallet_id", walletID).Int("remaining", len(s.wallets)).Msg("wallet deleted")
-	return s.saveWalletFile()
+	return s.saveWalletFileAllowingDrop()
 }
 
 // DeleteAllWallets performs a full wallet wipe matching Dart's deleteAllWallets (L554-653).
@@ -1543,6 +1558,7 @@ func (s *Service) DeleteAllWallets(onStatusUpdate func(string), beforeBoot func(
 	s.activeWalletID = ""
 	s.encryptionKey = nil
 	s.unlockedPass = ""
+	s.setWalletDigestLocked(nil)
 	s.mu.Unlock()
 	s.wipeElectrumScans()
 
@@ -1734,6 +1750,7 @@ func (s *Service) loadWalletFile() error {
 			s.log.Debug().Msg("wallet file does not exist yet")
 			s.wallets = nil
 			s.activeWalletID = ""
+			s.setWalletDigestLocked(nil)
 			return nil
 		}
 		return fmt.Errorf("read wallet file: %w", err)
@@ -1771,6 +1788,9 @@ func (s *Service) loadWalletFile() error {
 	s.wallets = wf.Wallets
 	s.activeWalletID = wf.ActiveWalletID
 	s.starterWalletID = wf.StarterWalletID
+	// Only a file this process read, decrypted, and parsed stands as the state
+	// a later write compares against.
+	s.setWalletDigestLocked(data)
 
 	// Backfill missing wallet_type for wallets created before the field was
 	// introduced. Anything with a Master.Mnemonic but no type is the original
@@ -1907,8 +1927,15 @@ func (s *Service) enforcerLegacyWallet(w *WalletData, target WalletType) (*Walle
 	return &legacy, nil
 }
 
-// saveWalletFile writes wallet.json atomically. Must be called with mu held.
-func (s *Service) saveWalletFile() error {
+// saveWalletFile writes wallet.json atomically, keeping every wallet the file
+// on disk holds. Must be called with mu held.
+func (s *Service) saveWalletFile() error { return s.saveWalletFileWithOptions(false) }
+
+// saveWalletFileAllowingDrop writes wallet.json for a caller that takes a
+// wallet away on purpose. Must be called with mu held.
+func (s *Service) saveWalletFileAllowingDrop() error { return s.saveWalletFileWithOptions(true) }
+
+func (s *Service) saveWalletFileWithOptions(allowDrop bool) error {
 	// Locking clears s.wallets and the key, so saving now would write a wallet
 	// file missing every locked wallet, in plaintext over the encrypted one.
 	if s.locked() {
@@ -1939,7 +1966,7 @@ func (s *Service) saveWalletFile() error {
 	}
 
 	s.log.Debug().Str("path", s.walletFilePath()).Int("data_len", len(data)).Msg("saving wallet file")
-	if err := atomicWrite(s.walletFilePath(), []byte(data)); err != nil {
+	if err := s.writeWalletFileWithOptionsLocked([]byte(data), allowDrop); err != nil {
 		return err
 	}
 	s.notifyChanged()

--- a/sidechain-orchestrator/wallet/walletfile.go
+++ b/sidechain-orchestrator/wallet/walletfile.go
@@ -1,0 +1,66 @@
+package wallet
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/walletfile"
+)
+
+// writeWalletFileLocked writes the wallet file through the one gate and
+// records what it wrote. It keeps every wallet the file on disk holds. Must be
+// called with mu held.
+func (s *Service) writeWalletFileLocked(content []byte) error {
+	return s.writeWalletFileWithOptionsLocked(content, false)
+}
+
+// writeWalletFileAllowingDropLocked writes the wallet file and lets the write
+// take away a wallet the file on disk holds. Only a delete and a restore use
+// it. Must be called with mu held.
+func (s *Service) writeWalletFileAllowingDropLocked(content []byte) error {
+	return s.writeWalletFileWithOptionsLocked(content, true)
+}
+
+func (s *Service) writeWalletFileWithOptionsLocked(content []byte, allowDrop bool) error {
+	opts := walletfile.Options{
+		Expected:      s.lastWalletDigest,
+		ExpectedKnown: s.lastWalletDigestKnown,
+		AllowDrop:     allowDrop,
+	}
+	if err := walletfile.Write(s.walletFilePath(), content, opts); err != nil {
+		s.log.Error().Err(err).Str("path", s.walletFilePath()).Msg("wallet file write refused")
+		return err
+	}
+	s.setWalletDigestLocked(content)
+	return nil
+}
+
+// setWalletDigestLocked records the wallet file content this process read or
+// wrote. Must be called with mu held.
+func (s *Service) setWalletDigestLocked(content []byte) {
+	s.lastWalletDigest = walletfile.DigestOf(content)
+	s.lastWalletDigestKnown = true
+}
+
+// restoreWalletFileLocked puts a backup's wallet file in place. It reads the
+// backup and the file it replaces first. Must be called with mu held.
+func (s *Service) restoreWalletFileLocked(src string) error {
+	content, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("read the backup wallet file: %w", err)
+	}
+	if err := walletfile.Validate(content); err != nil {
+		return fmt.Errorf("backup %s: %w", src, err)
+	}
+
+	current, err := os.ReadFile(s.walletFilePath())
+	switch {
+	case err == nil:
+		s.setWalletDigestLocked(current)
+	case os.IsNotExist(err):
+		s.setWalletDigestLocked(nil)
+	default:
+		return fmt.Errorf("read the wallet file before the restore: %w", err)
+	}
+	return s.writeWalletFileAllowingDropLocked(content)
+}

--- a/sidechain-orchestrator/wallet/walletfile_test.go
+++ b/sidechain-orchestrator/wallet/walletfile_test.go
@@ -1,0 +1,42 @@
+package wallet
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/walletfile"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// walletFileWith builds a plaintext wallet file holding the given wallet ids.
+func walletFileWith(ids ...string) []byte {
+	body := `{"version":1,"activeWalletId":"` + ids[0] + `","wallets":[`
+	for i, id := range ids {
+		if i > 0 {
+			body += ","
+		}
+		body += `{"version":1,"master":{},"l1":{},"sidechains":[],"id":"` + id + `","name":"` + id + `","gradient":null,"wallet_type":"electrum"}`
+	}
+	return []byte(body + `]}`)
+}
+
+func TestLoadWalletFileKeepsTheDigestWhenTheFileDoesNotParse(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	service := NewService(dir, zerolog.Nop())
+	path := filepath.Join(dir, "wallet.json")
+	good := walletFileWith("A")
+	require.NoError(t, os.WriteFile(path, good, 0600))
+	require.NoError(t, service.loadWalletFile())
+	require.Equal(t, walletfile.DigestOf(good), service.lastWalletDigest)
+
+	// A file this process cannot read must not stand as the state it holds.
+	require.NoError(t, os.WriteFile(path, []byte("data"), 0600))
+	require.Error(t, service.loadWalletFile())
+
+	assert.Equal(t, walletfile.DigestOf(good), service.lastWalletDigest)
+}

--- a/sidechain-orchestrator/walletfile/lock_unix.go
+++ b/sidechain-orchestrator/walletfile/lock_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package walletfile
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// lock takes an exclusive lock on the wallet file and returns the release. Two
+// processes that touch the same wallet file take it in turn.
+func lock(path string) (func(), error) {
+	file, err := os.OpenFile(path+LockSuffix, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("open the wallet lock: %w", err)
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("take the wallet lock: %w", err)
+	}
+	return func() {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		_ = file.Close()
+	}, nil
+}

--- a/sidechain-orchestrator/walletfile/lock_windows.go
+++ b/sidechain-orchestrator/walletfile/lock_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package walletfile
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// lock takes an exclusive lock on the wallet file and returns the release. Two
+// processes that touch the same wallet file take it in turn.
+func lock(path string) (func(), error) {
+	file, err := os.OpenFile(path+LockSuffix, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("open the wallet lock: %w", err)
+	}
+	handle := windows.Handle(file.Fd())
+	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, new(windows.Overlapped)); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("take the wallet lock: %w", err)
+	}
+	return func() {
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, new(windows.Overlapped))
+		_ = file.Close()
+	}, nil
+}

--- a/sidechain-orchestrator/walletfile/walletfile.go
+++ b/sidechain-orchestrator/walletfile/walletfile.go
@@ -1,0 +1,269 @@
+// Package walletfile owns every write to the bitwindow wallet file.
+//
+// The wallet file holds the seeds. Two processes once shared one, each wrote
+// the whole file from its own memory, and a wallet create took away the
+// wallets the other process held. [Write] is the single way in, and it is the
+// place every safeguard lives.
+package walletfile
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Name of the wallet file inside the bitwindow directory.
+const Name = "wallet.json"
+
+// LockSuffix names the lock file [Write] takes before it touches the wallet
+// file. PreviousSuffix names the copy of the file each write replaces.
+const (
+	LockSuffix     = ".lock"
+	PreviousSuffix = ".prev"
+)
+
+// ErrChanged reports that the wallet file on disk no longer holds what the
+// caller read. Another writer changed or removed it.
+var ErrChanged = errors.New("wallet file changed on disk since it was last read")
+
+// ErrUnread reports a write over a wallet file the caller never read. Every
+// caller reads the file first, so this is a bug in the caller.
+var ErrUnread = errors.New("wallet file was never read, refusing to overwrite it")
+
+// ErrDropsWallets reports a write that would take away a wallet the file on
+// disk holds. Only a delete and a restore may do that.
+var ErrDropsWallets = errors.New("refusing a write that drops wallets")
+
+// Digest identifies wallet file content for the compare before a write.
+type Digest [sha256.Size]byte
+
+// DigestOf returns the mark a reader keeps. A reader that finds no file marks
+// it with DigestOf(nil), and [Write] takes that as an expected absence.
+func DigestOf(content []byte) Digest { return sha256.Sum256(content) }
+
+// Options carries what the caller knows about the file it replaces.
+type Options struct {
+	// Expected is the content the caller read off disk, and ExpectedKnown says
+	// the caller read it at all.
+	Expected      Digest
+	ExpectedKnown bool
+	// AllowDrop lets the write remove wallets the current file holds.
+	AllowDrop bool
+}
+
+// Validate reports whether content reads back as a wallet file: the encrypted
+// form (base64 iv, colon, base64 ciphertext), the current shape with a
+// `wallets` list, or the legacy shape with `master` and `l1`.
+func Validate(content []byte) error {
+	if len(content) == 0 {
+		return errors.New("wallet file is empty")
+	}
+	if IsEncrypted(content) {
+		return nil
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(content, &raw); err != nil {
+		return fmt.Errorf("wallet file does not parse: %w", err)
+	}
+	if wallets, ok := raw["wallets"]; ok {
+		if !isArrayOrNull(wallets) {
+			return errors.New("wallet file carries no wallet list")
+		}
+		return nil
+	}
+	_, hasMaster := raw["master"]
+	_, hasL1 := raw["l1"]
+	if hasMaster && hasL1 {
+		return nil
+	}
+	return errors.New("wallet file carries neither a wallet list nor a master key")
+}
+
+// IsEncrypted reports whether content is the encrypted wallet form.
+func IsEncrypted(content []byte) bool {
+	iv, ciphertext, found := strings.Cut(string(content), ":")
+	if !found || iv == "" || ciphertext == "" {
+		return false
+	}
+	if _, err := base64.StdEncoding.DecodeString(iv); err != nil {
+		return false
+	}
+	_, err := base64.StdEncoding.DecodeString(ciphertext)
+	return err == nil
+}
+
+func isArrayOrNull(value json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(value)
+	return bytes.Equal(trimmed, []byte("null")) || (len(trimmed) > 0 && trimmed[0] == '[')
+}
+
+// WalletIDs returns the wallet ids in content. It reports false when content
+// is not plaintext wallet JSON, so an encrypted file compares against nothing.
+func WalletIDs(content []byte) ([]string, bool) {
+	if IsEncrypted(content) {
+		return nil, false
+	}
+	var parsed struct {
+		Wallets []struct {
+			ID string `json:"id"`
+		} `json:"wallets"`
+	}
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		return nil, false
+	}
+	ids := make([]string, 0, len(parsed.Wallets))
+	for _, w := range parsed.Wallets {
+		ids = append(ids, w.ID)
+	}
+	return ids, true
+}
+
+// DroppedWalletIDs returns the wallet ids current holds and next does not.
+func DroppedWalletIDs(current, next []byte) []string {
+	currentIDs, ok := WalletIDs(current)
+	if !ok {
+		return nil
+	}
+	nextIDs, ok := WalletIDs(next)
+	if !ok {
+		return nil
+	}
+	kept := make(map[string]struct{}, len(nextIDs))
+	for _, id := range nextIDs {
+		kept[id] = struct{}{}
+	}
+	var dropped []string
+	for _, id := range currentIDs {
+		if _, ok := kept[id]; !ok {
+			dropped = append(dropped, id)
+		}
+	}
+	return dropped
+}
+
+// Write replaces the wallet file at path. It is the only way to write that
+// file, and it holds every safeguard:
+//
+//  1. content reads back as a wallet file.
+//  2. A lock covers the read, the compare, and the replacement, so two
+//     processes take turns.
+//  3. The file on disk still holds what the caller read, and a file another
+//     process removed counts as a change.
+//  4. The write keeps every wallet the current file holds, unless the caller
+//     asks to drop one.
+//  5. The replaced file stays at path+[PreviousSuffix], and never as plaintext
+//     beside an encrypted wallet.
+//  6. The written file parses; a file that does not is rolled back.
+func Write(path string, content []byte, opts Options) error {
+	if err := Validate(content); err != nil {
+		return fmt.Errorf("refusing to write wallet file: %w", err)
+	}
+
+	unlock, err := lock(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	current, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		currentValid := Validate(current) == nil
+		if !opts.ExpectedKnown && currentValid {
+			return ErrUnread
+		}
+		if opts.ExpectedKnown && DigestOf(current) != opts.Expected {
+			return ErrChanged
+		}
+		if dropped := DroppedWalletIDs(current, content); !opts.AllowDrop && len(dropped) > 0 {
+			return fmt.Errorf("%w: %s", ErrDropsWallets, strings.Join(dropped, ", "))
+		}
+		if err := keepPrevious(path, current, content, currentValid); err != nil {
+			return err
+		}
+	case os.IsNotExist(err):
+		// A file this process read and another process removed is a change. A
+		// write here would bring back the wallets a wipe took away.
+		if opts.ExpectedKnown && opts.Expected != DigestOf(nil) {
+			return ErrChanged
+		}
+	default:
+		return fmt.Errorf("read the wallet file before the write: %w", err)
+	}
+
+	if err := atomicWrite(path, content); err != nil {
+		return err
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read the wallet file back: %w", err)
+	}
+	// Content that differs is a later writer's work, and it is valid, so it
+	// stays. Only an unreadable file calls for the copy to go back.
+	if err := Validate(written); err != nil {
+		return rollback(path, fmt.Errorf("the wallet file does not read back: %w", err))
+	}
+	return nil
+}
+
+// keepPrevious stores the file the write replaces, so a bad write leaves a way
+// back. It stores nothing that would leave a seed in the clear.
+func keepPrevious(path string, current, content []byte, currentValid bool) error {
+	if !currentValid {
+		return nil
+	}
+	if IsEncrypted(content) && !IsEncrypted(current) {
+		// Encryption starts here. A plaintext copy beside the encrypted file
+		// hands the seed to anyone who reads the disk.
+		if err := os.Remove(path + PreviousSuffix); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove the plaintext wallet copy: %w", err)
+		}
+		return nil
+	}
+	if err := atomicWrite(path+PreviousSuffix, current); err != nil {
+		return fmt.Errorf("keep the previous wallet file: %w", err)
+	}
+	return nil
+}
+
+// rollback puts the kept copy back and reports cause. A missing copy leaves
+// cause alone: there is nothing better to put in place.
+func rollback(path string, cause error) error {
+	previous, err := os.ReadFile(path + PreviousSuffix)
+	if err != nil || Validate(previous) != nil {
+		return cause
+	}
+	if err := atomicWrite(path, previous); err != nil {
+		return fmt.Errorf("%w, and the previous file did not go back: %v", cause, err)
+	}
+	return fmt.Errorf("%w, the previous wallet file went back in place", cause)
+}
+
+func atomicWrite(path string, content []byte) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, content, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// WithLock runs fn while this process holds the wallet file lock. A caller
+// that moves, renames, or removes the wallet file takes the lock the same way
+// [Write] does, so a wipe and a save never overlap.
+//
+// Do not call [Write] inside fn: the lock is not reentrant.
+func WithLock(path string, fn func() error) error {
+	unlock, err := lock(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return fn()
+}

--- a/sidechain-orchestrator/walletfile/walletfile_test.go
+++ b/sidechain-orchestrator/walletfile/walletfile_test.go
@@ -1,0 +1,361 @@
+package walletfile
+
+import (
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// walletFileWith builds a plaintext wallet file holding the given wallet ids.
+func walletFileWith(ids ...string) []byte {
+	body := `{"version":1,"activeWalletId":"` + firstOr(ids, "") + `","wallets":[`
+	for i, id := range ids {
+		if i > 0 {
+			body += ","
+		}
+		body += `{"version":1,"master":{},"l1":{},"sidechains":[],"id":"` + id + `","name":"` + id + `","gradient":null,"wallet_type":"electrum"}`
+	}
+	return []byte(body + `]}`)
+}
+
+func firstOr(ids []string, fallback string) string {
+	if len(ids) == 0 {
+		return fallback
+	}
+	return ids[0]
+}
+
+func encryptedWalletFile() []byte {
+	iv := base64.StdEncoding.EncodeToString([]byte("0123456789ab"))
+	ciphertext := base64.StdEncoding.EncodeToString([]byte("not really a ciphertext"))
+	return []byte(iv + ":" + ciphertext)
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content []byte
+		wantErr bool
+	}{
+		{name: "plaintext wallet file", content: walletFileWith("A", "B")},
+		{name: "encrypted wallet file", content: encryptedWalletFile()},
+		{name: "empty wallet file", content: nil, wantErr: true},
+		// The exact content a lost wallet file held in the field.
+		{name: "the word data", content: []byte("data"), wantErr: true},
+		{name: "truncated json", content: []byte(`{"version":1,"wallets":[`), wantErr: true},
+		{name: "a colon but not base64", content: []byte(`hello: world`), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := Validate(tt.content)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestDroppedWalletIDs(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"B"}, DroppedWalletIDs(walletFileWith("A", "B"), walletFileWith("A")))
+	assert.Empty(t, DroppedWalletIDs(walletFileWith("A"), walletFileWith("A", "B")))
+	assert.Empty(t, DroppedWalletIDs(walletFileWith("A"), walletFileWith("A")))
+	// An encrypted side compares against nothing, so it never blocks a write.
+	assert.Empty(t, DroppedWalletIDs(encryptedWalletFile(), walletFileWith("A")))
+}
+
+func TestWriteCreatesAMissingFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	content := walletFileWith("A")
+
+	// DigestOf(nil) is what a reader records when the file does not exist.
+	require.NoError(t, Write(path, content, Options{
+		Expected:      DigestOf(nil),
+		ExpectedKnown: true,
+	}))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+func TestWriteRefusesContentThatDoesNotParse(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	original := walletFileWith("A", "B")
+	require.NoError(t, os.WriteFile(path, original, 0600))
+
+	err := Write(path, []byte("data"), Options{
+		Expected:      DigestOf(original),
+		ExpectedKnown: true,
+	})
+
+	require.Error(t, err)
+	got, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, original, got, "the wallet file must survive a refused write")
+}
+
+func TestWriteRefusesAFileAnotherWriterChanged(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	read := walletFileWith("A")
+	require.NoError(t, os.WriteFile(path, walletFileWith("A", "B"), 0600))
+
+	err := Write(path, walletFileWith("A", "C"), Options{
+		Expected:      DigestOf(read),
+		ExpectedKnown: true,
+		AllowDrop:     true,
+	})
+
+	assert.ErrorIs(t, err, ErrChanged)
+	got, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, walletFileWith("A", "B"), got)
+}
+
+func TestWriteRefusesAFileItNeverRead(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	require.NoError(t, os.WriteFile(path, walletFileWith("A"), 0600))
+
+	err := Write(path, walletFileWith("A", "B"), Options{ExpectedKnown: false})
+
+	assert.ErrorIs(t, err, ErrUnread)
+}
+
+func TestWriteRefusesAWriteThatDropsAWallet(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	original := walletFileWith("A", "B", "C")
+	require.NoError(t, os.WriteFile(path, original, 0600))
+
+	err := Write(path, walletFileWith("A"), Options{
+		Expected:      DigestOf(original),
+		ExpectedKnown: true,
+	})
+
+	require.ErrorIs(t, err, ErrDropsWallets)
+	assert.Contains(t, err.Error(), "B")
+	assert.Contains(t, err.Error(), "C")
+
+	got, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, original, got)
+}
+
+func TestWriteDropsAWalletWhenTheCallerAsks(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	original := walletFileWith("A", "B")
+	require.NoError(t, os.WriteFile(path, original, 0600))
+	next := walletFileWith("A")
+
+	require.NoError(t, Write(path, next, Options{
+		Expected:      DigestOf(original),
+		ExpectedKnown: true,
+		AllowDrop:     true,
+	}))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, next, got)
+}
+
+func TestWriteKeepsTheFileItReplaces(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	original := walletFileWith("A")
+	require.NoError(t, os.WriteFile(path, original, 0600))
+
+	require.NoError(t, Write(path, walletFileWith("A", "B"), Options{
+		Expected:      DigestOf(original),
+		ExpectedKnown: true,
+	}))
+
+	previous, err := os.ReadFile(path + PreviousSuffix)
+	require.NoError(t, err)
+	assert.Equal(t, original, previous)
+}
+
+func TestWriteOverwritesAFileThatDoesNotParse(t *testing.T) {
+	t.Parallel()
+
+	// A wallet file already lost to a bad write must not block the repair.
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	require.NoError(t, os.WriteFile(path, []byte("data"), 0600))
+	content := walletFileWith("A")
+
+	require.NoError(t, Write(path, content, Options{ExpectedKnown: false}))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+	_, statErr := os.Stat(path + PreviousSuffix)
+	assert.True(t, errors.Is(statErr, os.ErrNotExist), "an unreadable file is not worth keeping")
+}
+
+func TestWriteKeepsNoPlaintextOnceEncrypted(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	plaintext := walletFileWith("A")
+	require.NoError(t, os.WriteFile(path, plaintext, 0600))
+	// A copy from an earlier write is plaintext too, and it must go.
+	require.NoError(t, os.WriteFile(path+PreviousSuffix, plaintext, 0600))
+
+	require.NoError(t, Write(path, encryptedWalletFile(), Options{
+		Expected:      DigestOf(plaintext),
+		ExpectedKnown: true,
+	}))
+
+	_, err := os.Stat(path + PreviousSuffix)
+	assert.True(t, errors.Is(err, os.ErrNotExist), "a plaintext copy beside an encrypted wallet hands out the seed")
+}
+
+func TestWriteKeepsTheCopyBetweenTwoEncryptedFiles(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	first := encryptedWalletFile()
+	require.NoError(t, os.WriteFile(path, first, 0600))
+
+	second := []byte(base64.StdEncoding.EncodeToString([]byte("another iv!!")) + ":" +
+		base64.StdEncoding.EncodeToString([]byte("another ciphertext")))
+	require.NoError(t, Write(path, second, Options{
+		Expected:      DigestOf(first),
+		ExpectedKnown: true,
+	}))
+
+	previous, err := os.ReadFile(path + PreviousSuffix)
+	require.NoError(t, err)
+	assert.Equal(t, first, previous)
+}
+
+func TestWriteLetsOnlyOneOfTwoWritersWin(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	read := walletFileWith("A")
+	require.NoError(t, os.WriteFile(path, read, 0600))
+
+	// Both writers read the same file, so both carry the same digest. The lock
+	// serializes them and the second one finds a file it did not read.
+	results := make(chan error, 2)
+	var start sync.WaitGroup
+	start.Add(1)
+	for _, id := range []string{"B", "C"} {
+		go func(id string) {
+			start.Wait()
+			results <- Write(path, walletFileWith("A", id), Options{
+				Expected:      DigestOf(read),
+				ExpectedKnown: true,
+			})
+		}(id)
+	}
+	start.Done()
+
+	first, second := <-results, <-results
+	if first != nil {
+		first, second = second, first
+	}
+	assert.NoError(t, first, "one writer must win")
+	assert.ErrorIs(t, second, ErrChanged, "the other must find the file changed")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NoError(t, Validate(got))
+}
+
+func TestWriteLeavesALaterValidWriteAlone(t *testing.T) {
+	t.Parallel()
+
+	// A file another writer replaced with valid content stays as it is. Putting
+	// the kept copy back would take away that writer's wallet.
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	original := walletFileWith("A")
+	require.NoError(t, os.WriteFile(path, original, 0600))
+
+	require.NoError(t, Write(path, walletFileWith("A", "B"), Options{
+		Expected:      DigestOf(original),
+		ExpectedKnown: true,
+	}))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, walletFileWith("A", "B"), got)
+}
+
+func TestWriteRefusesAFileAnotherWriterDeleted(t *testing.T) {
+	t.Parallel()
+
+	// The wipe took the file away. Writing here brings back the seeds it removed.
+	path := filepath.Join(t.TempDir(), "wallet.json")
+	read := walletFileWith("A")
+
+	err := Write(path, walletFileWith("A", "B"), Options{
+		Expected:      DigestOf(read),
+		ExpectedKnown: true,
+	})
+
+	assert.ErrorIs(t, err, ErrChanged)
+	_, statErr := os.Stat(path)
+	assert.True(t, errors.Is(statErr, os.ErrNotExist))
+}
+
+func TestWithLockKeepsAWriteOutUntilItReturns(t *testing.T) {
+	t.Parallel()
+
+	// A wipe moves the file away under the lock. A writer that starts at the
+	// same time must see the move, not write over it.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wallet.json")
+	read := walletFileWith("A")
+	require.NoError(t, os.WriteFile(path, read, 0600))
+
+	writeDone := make(chan error, 1)
+	inLock := make(chan struct{})
+	release := make(chan struct{})
+
+	go func() {
+		_ = WithLock(path, func() error {
+			close(inLock)
+			<-release
+			return os.Rename(path, filepath.Join(dir, "wallet.json.moved"))
+		})
+	}()
+
+	<-inLock
+	go func() {
+		writeDone <- Write(path, walletFileWith("A", "B"), Options{
+			Expected:      DigestOf(read),
+			ExpectedKnown: true,
+		})
+	}()
+
+	close(release)
+	assert.ErrorIs(t, <-writeDone, ErrChanged)
+	_, err := os.Stat(path)
+	assert.True(t, errors.Is(err, os.ErrNotExist), "the wipe must hold")
+}

--- a/thunder/pubspec.yaml
+++ b/thunder/pubspec.yaml
@@ -2,7 +2,7 @@ name: thunder
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.319
+version: 1.0.320
 
 environment:
   sdk: 3.12.2

--- a/truthcoin/pubspec.yaml
+++ b/truthcoin/pubspec.yaml
@@ -2,7 +2,7 @@ name: truthcoin
 description: UI for Bitcoin Hivemind prediction market sidechain
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.190
+version: 1.0.191
 
 environment:
   sdk: 3.12.2

--- a/zside/pubspec.yaml
+++ b/zside/pubspec.yaml
@@ -2,7 +2,7 @@ name: zside
 description: UI for Drivechain (BIP300/301) based sidechains
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.317
+version: 1.0.318
 
 environment:
   sdk: 3.12.2


### PR DESCRIPTION
A second orchestratord, left over from an older run, held the same wallet.json. Each process writes the whole file from its own memory, so a wallet create wiped the wallets the other process held.

Every writer now reads the file first. A write is refused when the file on disk no longer holds what the writer read, when the new content does not parse as a wallet file, or when it would take away a wallet the file holds. A delete and a restore say so and keep their drop. The replaced file stays at wallet.json.prev.