### PR TITLE
Repair multisig hardware signing

### DIFF
--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -1834,10 +1834,10 @@ func (p *ElectrumBackend) multisigSigningDescriptorFor(w *WalletData, onlyXpub s
 			Xpub:        c.Xpub,
 			Fingerprint: c.Fingerprint,
 			OriginPath:  c.OriginPath,
-			// Emit a [fingerprint/origin] prefix whenever we have the origin, so
-			// every cosigner's key-origin lands in the PSBT (needed to attribute
-			// signatures and for external-wallet interop) — not just held keys.
-			IsWallet: c.Fingerprint != "" && c.OriginPath != "",
+			// Emit a key-origin prefix for every cosigner we know a fingerprint
+			// for, so each origin lands in the PSBT. A hardware signer needs all
+			// of them to rebuild the multisig script it signs over.
+			IsWallet: c.Fingerprint != "",
 		})
 		if !c.Held() {
 			continue

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -1159,6 +1159,9 @@ func (p *ElectrumBackend) SignPSBTWithCosigner(ctx context.Context, walletID, ps
 		if out == nil {
 			return "", fmt.Errorf("psbt input %d missing prevout", i)
 		}
+		if !bytes.Equal(sa.scriptPubKey, out.PkScript) {
+			return "", fmt.Errorf("psbt input %d does not pay an address of this multisig wallet", i)
+		}
 		inputs[i] = psbtInput{
 			outpoint: packet.UnsignedTx.TxIn[i].PreviousOutPoint,
 			amount:   out.Value,

--- a/sidechain-orchestrator/wallet/multisiglounge.go
+++ b/sidechain-orchestrator/wallet/multisiglounge.go
@@ -32,14 +32,29 @@ type MultisigLoungeGroup struct {
 	Keys []MultisigLoungeKey
 }
 
-// keyDescriptor renders one key expression, mirroring the BitWindow Dart
-// MultisigDescriptorBuilder: wallet keys get a [fingerprint/origin] prefix, all
-// others are the bare xpub.
+// keyDescriptor renders one key expression: a key with a known fingerprint gets
+// a [fingerprint/origin] prefix, all others are the bare xpub. A master xpub has
+// no origin path, so it gets a bare [fingerprint] prefix. Every key origin must
+// reach the PSBT, or a hardware signer cannot rebuild the multisig script.
 func (k MultisigLoungeKey) keyDescriptor() string {
-	if k.IsWallet && k.Fingerprint != "" && k.OriginPath != "" {
+	if !k.IsWallet || k.Fingerprint == "" {
+		return k.Xpub
+	}
+	if k.OriginPath != "" {
 		return fmt.Sprintf("[%s/%s]%s", k.Fingerprint, k.OriginPath, k.Xpub)
 	}
-	return k.Xpub
+	// Only a master key sits at the fingerprint with no path. An account key
+	// with no path cannot say where it sits, so it stays a bare xpub rather
+	// than claim a derivation that reaches a different child.
+	if !isMasterKey(k.Xpub) {
+		return k.Xpub
+	}
+	return fmt.Sprintf("[%s]%s", k.Fingerprint, k.Xpub)
+}
+
+func isMasterKey(xpub string) bool {
+	key, err := hdkeychain.NewKeyFromString(xpub)
+	return err == nil && key.Depth() == 0
 }
 
 // sortKeysByBIP67 sorts the group's keys lexicographically by xpub string,

--- a/sidechain-orchestrator/wallet/multisiglounge_test.go
+++ b/sidechain-orchestrator/wallet/multisiglounge_test.go
@@ -1092,3 +1092,70 @@ func TestValidateDescriptor(t *testing.T) {
 		assert.Error(t, err, "descriptor %q must be rejected", bad)
 	}
 }
+
+// TestMasterKeyCosignerKeepsOrigin: a cosigner whose xpub is a master key has no
+// origin path, but it still needs its [fingerprint] prefix. Without the prefix
+// the PSBT carries no global xpub for that leg, and a hardware signer cannot
+// rebuild the multisig script it must sign over. The prefix must not move a
+// single address.
+func TestMasterKeyCosignerKeepsOrigin(t *testing.T) {
+	net := &chaincfg.SigNetParams
+	group, _ := loungeTestKeys(t)
+
+	master, err := hdkeychain.NewMaster(MnemonicToSeed(testMnemonic, "master"), net)
+	require.NoError(t, err)
+	pub, err := master.Neuter()
+	require.NoError(t, err)
+	mpub, err := master.ECPubKey()
+	require.NoError(t, err)
+	fp := hex.EncodeToString(btcutil.Hash160(mpub.SerializeCompressed())[:4])
+
+	group.Keys[0] = MultisigLoungeKey{Xpub: pub.String(), Fingerprint: fp, IsWallet: true}
+
+	receive, _, err := BuildMultisigLoungeDescriptorsTyped(group, "wsh")
+	require.NoError(t, err)
+	assert.Contains(t, receive, "["+fp+"]"+pub.String())
+
+	d, err := ParseDescriptor(receive)
+	require.NoError(t, err)
+	assert.Len(t, multisigGlobalXpubs(d), 3, "every cosigner must reach the PSBT as a global xpub")
+
+	bare := group
+	bare.Keys = append([]MultisigLoungeKey(nil), group.Keys...)
+	bare.Keys[0].IsWallet = false
+	bareReceive, _, err := BuildMultisigLoungeDescriptorsTyped(bare, "wsh")
+	require.NoError(t, err)
+	bareDesc, err := ParseDescriptor(bareReceive)
+	require.NoError(t, err)
+
+	for i := uint32(0); i < 3; i++ {
+		with, _, err := d.DeriveScript(false, i, net)
+		require.NoError(t, err)
+		without, _, err := bareDesc.DeriveScript(false, i, net)
+		require.NoError(t, err)
+		assert.Equal(t, without.address.String(), with.address.String())
+	}
+}
+
+// TestAccountKeyWithoutOriginStaysBare: an account key with a fingerprint but no
+// path must not claim a master origin. That origin names a child the device
+// never derives, and every input then fails on the device.
+func TestAccountKeyWithoutOriginStaysBare(t *testing.T) {
+	group, accts := loungeTestKeys(t)
+	require.Greater(t, accts[0].Depth(), uint8(0))
+
+	group.Keys[0] = MultisigLoungeKey{
+		Xpub:        accts[0].String(),
+		Fingerprint: group.Keys[0].Fingerprint,
+		IsWallet:    true,
+	}
+
+	receive, _, err := BuildMultisigLoungeDescriptorsTyped(group, "wsh")
+	require.NoError(t, err)
+	assert.NotContains(t, receive, "["+group.Keys[0].Fingerprint+"]"+accts[0].String())
+	assert.Contains(t, receive, accts[0].String()+"/0/*")
+
+	d, err := ParseDescriptor(receive)
+	require.NoError(t, err)
+	assert.Len(t, multisigGlobalXpubs(d), 2)
+}

--- a/sidechain-orchestrator/wallet/multisiglounge_test.go
+++ b/sidechain-orchestrator/wallet/multisiglounge_test.go
@@ -1137,6 +1137,17 @@ func TestMasterKeyCosignerKeepsOrigin(t *testing.T) {
 	}
 }
 
+// TestFinalizeNamesTheFingerprint: the failure message must name the signer the
+// way the key table shows it, so the user knows which device to sign on again.
+func TestFinalizeNamesTheFingerprint(t *testing.T) {
+	packet := loungeMultisigPSBT(t, loungeTestAccts(t), 2)
+	packet.UnsignedTx.TxOut[0].Value -= 1
+
+	_, err := finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "key 73c5da0a signed a different transaction")
+}
+
 // TestAccountKeyWithoutOriginStaysBare: an account key with a fingerprint but no
 // path must not claim a master origin. That origin names a child the device
 // never derives, and every input then fails on the device.

--- a/sidechain-orchestrator/wallet/psbt.go
+++ b/sidechain-orchestrator/wallet/psbt.go
@@ -2,12 +2,15 @@ package wallet
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
@@ -306,6 +309,9 @@ func prevOutForInput(packet *psbt.Packet, i int) *wire.TxOut {
 
 // finalizeAndExtract finalizes a fully-signed PSBT and returns the raw tx hex.
 func finalizeAndExtract(packet *psbt.Packet) (string, error) {
+	if err := verifySignatures(packet); err != nil {
+		return "", err
+	}
 	// tr(sortedmulti_a) inputs are finalized by assembling the tapscript witness
 	// ourselves; the generic finalizer then sees them as already final.
 	for i := range packet.Inputs {
@@ -327,6 +333,382 @@ func finalizeAndExtract(packet *psbt.Packet) (string, error) {
 		return "", fmt.Errorf("serialize final tx: %w", err)
 	}
 	return hex.EncodeToString(buf.Bytes()), nil
+}
+
+// verifySignatures checks every signature against the sighash it must cover. A
+// signer that covers the wrong transaction, script, or amount still returns a
+// well-formed signature, and the network then rejects the spend for a failed
+// script check. Catch it here and name the key that produced it.
+func verifySignatures(packet *psbt.Packet) error {
+	tx := packet.UnsignedTx
+	prevOuts := make(map[wire.OutPoint]*wire.TxOut, len(packet.Inputs))
+	for i := range packet.Inputs {
+		out, err := authenticatedPrevOut(packet, i)
+		if err != nil {
+			return fmt.Errorf("psbt input %d %w", i, err)
+		}
+		if out == nil {
+			return fmt.Errorf("psbt input %d missing prevout", i)
+		}
+		prevOuts[tx.TxIn[i].PreviousOutPoint] = out
+	}
+	fetcher := txscript.NewMultiPrevOutFetcher(prevOuts)
+	sigHashes := txscript.NewTxSigHashes(tx, fetcher)
+	for i := range packet.Inputs {
+		in := &packet.Inputs[i]
+		prevOut := prevOuts[tx.TxIn[i].PreviousOutPoint]
+		if in.FinalScriptSig != nil || in.FinalScriptWitness != nil {
+			if err := verifyFinalInput(tx, fetcher, i, in, prevOut); err != nil {
+				return fmt.Errorf("psbt input %d: %w", i, err)
+			}
+			continue
+		}
+		for _, ps := range in.PartialSigs {
+			if err := verifyPartialSig(tx, sigHashes, i, in, prevOut, ps); err != nil {
+				return fmt.Errorf("psbt input %d: %w", i, err)
+			}
+		}
+		if err := verifyTaprootSigs(tx, sigHashes, fetcher, i, in, prevOut); err != nil {
+			return fmt.Errorf("psbt input %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// verifyFinalInput runs script verification over an input that already carries a
+// final scriptSig or witness, so a cosigner that finalized for another
+// transaction cannot reach the network. A prevout the standard rules do not
+// describe — a BIP300 treasury output — is left to the chain.
+func verifyFinalInput(
+	tx *wire.MsgTx,
+	fetcher txscript.PrevOutputFetcher,
+	i int,
+	in *psbt.PInput,
+	prevOut *wire.TxOut,
+) error {
+	if !standardPrevOut(prevOut.PkScript) {
+		return nil
+	}
+	final := tx.Copy()
+	final.TxIn[i].SignatureScript = in.FinalScriptSig
+	if len(in.FinalScriptWitness) > 0 {
+		witness, err := readWitnessStack(in.FinalScriptWitness)
+		if err != nil {
+			return err
+		}
+		final.TxIn[i].Witness = witness
+	}
+	vm, err := txscript.NewEngine(
+		prevOut.PkScript, final, i, txscript.StandardVerifyFlags, nil,
+		txscript.NewTxSigHashes(final, fetcher), prevOut.Value, fetcher,
+	)
+	if err != nil {
+		return fmt.Errorf("the final script is not spendable: %w", err)
+	}
+	if err := vm.Execute(); err != nil {
+		return fmt.Errorf("the final script does not spend this output: %w", err)
+	}
+	return nil
+}
+
+func standardPrevOut(pkScript []byte) bool {
+	switch txscript.GetScriptClass(pkScript) {
+	case txscript.PubKeyTy, txscript.PubKeyHashTy, txscript.MultiSigTy, txscript.ScriptHashTy,
+		txscript.WitnessV0PubKeyHashTy, txscript.WitnessV0ScriptHashTy, txscript.WitnessV1TaprootTy:
+		return true
+	}
+	return false
+}
+
+// maxWitnessItems caps a witness stack read from an imported PSBT.
+const maxWitnessItems = 1000
+
+func readWitnessStack(raw []byte) (wire.TxWitness, error) {
+	r := bytes.NewReader(raw)
+	count, err := wire.ReadVarInt(r, 0)
+	if err != nil {
+		return nil, fmt.Errorf("read witness count: %w", err)
+	}
+	if count > maxWitnessItems {
+		return nil, fmt.Errorf("the witness holds %d items", count)
+	}
+	stack := make(wire.TxWitness, count)
+	for j := range stack {
+		item, err := wire.ReadVarBytes(r, 0, txscript.MaxScriptSize, "witness item")
+		if err != nil {
+			return nil, fmt.Errorf("read witness item %d: %w", j, err)
+		}
+		stack[j] = item
+	}
+	return stack, nil
+}
+
+// verifyTaprootSigs checks a taproot input's schnorr signatures, key-path and
+// script-path alike, and binds every revealed leaf to the output it spends.
+func verifyTaprootSigs(
+	tx *wire.MsgTx,
+	sigHashes *txscript.TxSigHashes,
+	fetcher txscript.PrevOutputFetcher,
+	i int,
+	in *psbt.PInput,
+	prevOut *wire.TxOut,
+) error {
+	if len(in.TaprootKeySpendSig) == 0 && len(in.TaprootScriptSpendSig) == 0 {
+		return nil
+	}
+	if !txscript.IsPayToTaproot(prevOut.PkScript) {
+		return errors.New("the input carries a taproot signature but spends no taproot output")
+	}
+	outputKey := prevOut.PkScript[2:34]
+	if err := verifyTaprootLeaves(in, outputKey); err != nil {
+		return err
+	}
+	if len(in.TaprootKeySpendSig) > 0 {
+		pub, err := schnorr.ParsePubKey(outputKey)
+		if err != nil {
+			return fmt.Errorf("the output key is not a public key: %w", err)
+		}
+		sig, hashType, err := splitSchnorrSig(in.TaprootKeySpendSig)
+		if err != nil {
+			return err
+		}
+		// The finalizer appends the input's sighash type to a bare 64-byte
+		// signature, so the two must agree or the witness commits to another
+		// hash than the signer covered.
+		if len(in.TaprootKeySpendSig) == schnorr.SignatureSize && in.SighashType != txscript.SigHashDefault {
+			return errors.New("the key-spend signature and the input sighash type disagree")
+		}
+		hash, err := txscript.CalcTaprootSignatureHash(sigHashes, hashType, tx, i, fetcher)
+		if err != nil {
+			return err
+		}
+		if !sig.Verify(hash, pub) {
+			return fmt.Errorf("key %x signed a different transaction", outputKey)
+		}
+	}
+	for _, s := range in.TaprootScriptSpendSig {
+		leaf, err := tapLeafForHash(in, s.LeafHash)
+		if err != nil {
+			return err
+		}
+		pub, err := schnorr.ParsePubKey(s.XOnlyPubKey)
+		if err != nil {
+			return fmt.Errorf("key %x is not a public key: %w", s.XOnlyPubKey, err)
+		}
+		// The decoder splits a tapscript signature: 64 bytes here, the sighash
+		// type in its own field.
+		sig, err := schnorr.ParseSignature(s.Signature)
+		if err != nil {
+			return fmt.Errorf("key %x gave a malformed signature: %w", s.XOnlyPubKey, err)
+		}
+		if !validTaprootSigHashType(s.SigHash) {
+			return fmt.Errorf("key %x used an unknown sighash type %#x", s.XOnlyPubKey, byte(s.SigHash))
+		}
+		hash, err := txscript.CalcTapscriptSignaturehash(sigHashes, s.SigHash, tx, i, fetcher, leaf)
+		if err != nil {
+			return err
+		}
+		if !sig.Verify(hash, pub) {
+			return fmt.Errorf("key %x signed a different transaction", s.XOnlyPubKey)
+		}
+	}
+	return nil
+}
+
+// oddYPrefix is the compressed-key header byte for an odd y coordinate.
+const oddYPrefix = 0x03
+
+// verifyTaprootLeaves makes sure each revealed leaf and its control block commit
+// to the output key the input spends.
+func verifyTaprootLeaves(in *psbt.PInput, outputKey []byte) error {
+	for _, l := range in.TaprootLeafScript {
+		cb, err := txscript.ParseControlBlock(l.ControlBlock)
+		if err != nil {
+			return fmt.Errorf("parse taproot control block: %w", err)
+		}
+		// The witness carries the control block, so its leaf version is the one
+		// the network hashes with. A leaf that names another version signs one
+		// script and spends another.
+		if l.LeafVersion != cb.LeafVersion {
+			return errors.New("the leaf version does not match its control block")
+		}
+		key := txscript.ComputeTaprootOutputKey(cb.InternalKey, cb.RootHash(l.Script))
+		if !bytes.Equal(schnorr.SerializePubKey(key), outputKey) {
+			return errors.New("the leaf script does not match the output it spends")
+		}
+		// Script execution also reads the parity bit, so the control block must
+		// state the parity of the key it commits to.
+		if cb.OutputKeyYIsOdd != (key.SerializeCompressed()[0] == oddYPrefix) {
+			return errors.New("the control block states the wrong output key parity")
+		}
+	}
+	return nil
+}
+
+func tapLeafForHash(in *psbt.PInput, leafHash []byte) (txscript.TapLeaf, error) {
+	for _, l := range in.TaprootLeafScript {
+		leaf := txscript.NewTapLeaf(l.LeafVersion, l.Script)
+		hash := leaf.TapHash()
+		if bytes.Equal(hash[:], leafHash) {
+			return leaf, nil
+		}
+	}
+	return txscript.TapLeaf{}, errors.New("the signature names a leaf script the input does not carry")
+}
+
+// validSigHashType reports whether a sighash byte is one script verification
+// accepts: a base type of ALL, NONE, or SINGLE, plus the optional ANYONECANPAY bit.
+func validSigHashType(t txscript.SigHashType) bool {
+	switch t &^ txscript.SigHashAnyOneCanPay {
+	case txscript.SigHashAll, txscript.SigHashNone, txscript.SigHashSingle:
+		return true
+	}
+	return false
+}
+
+// validTaprootSigHashType is validSigHashType plus the BIP341 default type.
+func validTaprootSigHashType(t txscript.SigHashType) bool {
+	return t == txscript.SigHashDefault || validSigHashType(t)
+}
+
+// splitSchnorrSig separates a key-path signature from its optional sighash byte.
+func splitSchnorrSig(raw []byte) (*schnorr.Signature, txscript.SigHashType, error) {
+	hashType := txscript.SigHashDefault
+	switch len(raw) {
+	case schnorr.SignatureSize:
+	case schnorr.SignatureSize + 1:
+		hashType = txscript.SigHashType(raw[schnorr.SignatureSize])
+		// Script verification takes the default type only in the 64-byte form.
+		if hashType == txscript.SigHashDefault {
+			return nil, 0, errors.New("a signature must drop the default sighash byte")
+		}
+		raw = raw[:schnorr.SignatureSize]
+	default:
+		return nil, 0, fmt.Errorf("a schnorr signature is not %d bytes long", len(raw))
+	}
+	if !validTaprootSigHashType(hashType) {
+		return nil, 0, fmt.Errorf("unknown sighash type %#x", byte(hashType))
+	}
+	sig, err := schnorr.ParseSignature(raw)
+	if err != nil {
+		return nil, 0, fmt.Errorf("malformed schnorr signature: %w", err)
+	}
+	return sig, hashType, nil
+}
+
+func verifyPartialSig(
+	tx *wire.MsgTx,
+	sigHashes *txscript.TxSigHashes,
+	i int,
+	in *psbt.PInput,
+	prevOut *wire.TxOut,
+	ps *psbt.PartialSig,
+) error {
+	if len(ps.Signature) < 2 {
+		return fmt.Errorf("key %s gave an empty signature", signerName(in, ps.PubKey))
+	}
+	pub, err := btcec.ParsePubKey(ps.PubKey)
+	if err != nil {
+		return fmt.Errorf("key %s is not a public key: %w", signerName(in, ps.PubKey), err)
+	}
+	der := ps.Signature[:len(ps.Signature)-1]
+	sig, err := ecdsa.ParseDERSignature(der)
+	if err != nil {
+		return fmt.Errorf("key %s gave a malformed signature: %w", signerName(in, ps.PubKey), err)
+	}
+	// A standard node refuses a high-S signature, and the finalizer copies these
+	// bytes through unchanged.
+	if err := ecdsa.VerifyLowS(der); err != nil {
+		return fmt.Errorf("key %s gave a signature a standard node refuses: %w", signerName(in, ps.PubKey), err)
+	}
+	hashType := txscript.SigHashType(ps.Signature[len(ps.Signature)-1])
+	if !validSigHashType(hashType) {
+		return fmt.Errorf("key %s used an unknown sighash type %#x", signerName(in, ps.PubKey), byte(hashType))
+	}
+	hash, err := partialSigHash(tx, sigHashes, i, in, prevOut, ps.PubKey, hashType)
+	if err != nil {
+		return err
+	}
+	if !sig.Verify(hash, pub) {
+		return fmt.Errorf("key %s signed a different transaction", signerName(in, ps.PubKey))
+	}
+	return nil
+}
+
+// signerName identifies a partial signature's signer the way the key table
+// shows it: the master fingerprint when the input records one, else the pubkey.
+func signerName(in *psbt.PInput, pubKey []byte) string {
+	for _, d := range in.Bip32Derivation {
+		if !bytes.Equal(d.PubKey, pubKey) {
+			continue
+		}
+		var fp [4]byte
+		binary.LittleEndian.PutUint32(fp[:], d.MasterKeyFingerprint)
+		return hex.EncodeToString(fp[:])
+	}
+	return hex.EncodeToString(pubKey)
+}
+
+// partialSigHash recomputes the sighash one partial signature must cover. Every
+// script the PSBT supplies must hash to the output it spends, so an imported
+// PSBT cannot point the check at a script of its own choice.
+func partialSigHash(
+	tx *wire.MsgTx,
+	sigHashes *txscript.TxSigHashes,
+	i int,
+	in *psbt.PInput,
+	prevOut *wire.TxOut,
+	pubKey []byte,
+	hashType txscript.SigHashType,
+) ([]byte, error) {
+	script := prevOut.PkScript
+	if len(in.RedeemScript) > 0 {
+		if !txscript.IsPayToScriptHash(script) {
+			return nil, errors.New("the input carries a redeem script but spends no script hash")
+		}
+		if !bytes.Equal(btcutil.Hash160(in.RedeemScript), script[2:22]) {
+			return nil, errors.New("the redeem script does not match the output it spends")
+		}
+		script = in.RedeemScript
+	}
+	switch {
+	case txscript.IsPayToWitnessScriptHash(script):
+		hash := sha256.Sum256(in.WitnessScript)
+		if len(in.WitnessScript) == 0 || !bytes.Equal(hash[:], script[2:34]) {
+			return nil, errors.New("the witness script does not match the output it spends")
+		}
+		return txscript.CalcWitnessSigHash(in.WitnessScript, sigHashes, hashType, tx, i, prevOut.Value)
+	case txscript.IsPayToWitnessPubKeyHash(script):
+		hash := btcutil.Hash160(pubKey)
+		if !bytes.Equal(hash, script[2:22]) {
+			return nil, errors.New("the key does not match the output it spends")
+		}
+		code, err := p2wpkhScriptCode(hash)
+		if err != nil {
+			return nil, err
+		}
+		return txscript.CalcWitnessSigHash(code, sigHashes, hashType, tx, i, prevOut.Value)
+	default:
+		// The finalizer picks its witness path whenever a witness utxo is set,
+		// so a legacy input signed against one lands in the wrong field.
+		if in.NonWitnessUtxo == nil {
+			return nil, errors.New("a legacy input needs its previous transaction")
+		}
+		if txscript.IsPayToPubKeyHash(script) && !bytes.Equal(btcutil.Hash160(pubKey), script[3:23]) {
+			return nil, errors.New("the key does not match the output it spends")
+		}
+		return txscript.CalcSignatureHash(script, hashType, tx, i)
+	}
+}
+
+func p2wpkhScriptCode(keyHash []byte) ([]byte, error) {
+	return txscript.NewScriptBuilder().
+		AddOp(txscript.OP_DUP).
+		AddOp(txscript.OP_HASH160).
+		AddData(keyHash).
+		AddOp(txscript.OP_EQUALVERIFY).
+		AddOp(txscript.OP_CHECKSIG).
+		Script()
 }
 
 // signMultisigInput adds this wallet's partial signature(s) to a P2WSH multisig
@@ -396,6 +778,12 @@ func hasPartialSig(sigs []*psbt.PartialSig, pub []byte) bool {
 // base. All packets must describe the same unsigned transaction.
 func combinePSBT(base *psbt.Packet, others ...*psbt.Packet) error {
 	for _, o := range others {
+		if o.UnsignedTx == nil || base.UnsignedTx == nil {
+			return errors.New("psbt has no unsigned transaction")
+		}
+		if o.UnsignedTx.TxHash() != base.UnsignedTx.TxHash() {
+			return errors.New("the psbts describe different transactions")
+		}
 		if len(o.Inputs) != len(base.Inputs) {
 			return errors.New("psbt input count mismatch")
 		}

--- a/sidechain-orchestrator/wallet/psbt_test.go
+++ b/sidechain-orchestrator/wallet/psbt_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/btcutil/psbt"
@@ -399,4 +401,664 @@ func TestPSBTSignSidechainDeposit(t *testing.T) {
 		txscript.StandardVerifyFlags|txscript.ScriptVerifyTaproot, nil, sigHashes, walletAmount, prevOuts)
 	require.NoError(t, err)
 	require.NoError(t, vmWallet.Execute(), "wallet must validly sign the sidechain deposit")
+}
+
+// multisigPacket builds a 2-of-3 P2WSH spend signed by two of the three keys.
+func multisigPacket(t *testing.T) (*psbt.Packet, derivedScript, int64) {
+	t.Helper()
+	net := &chaincfg.SigNetParams
+	const amount = int64(100_000)
+	const dest = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+	acct := func(pass string) *hdkeychain.ExtendedKey {
+		a, err := accountKeyFromSeed(hex.EncodeToString(MnemonicToSeed(testMnemonic, pass)), ScriptNativeSegwit, net)
+		require.NoError(t, err)
+		return a
+	}
+	priv := func(a *hdkeychain.ExtendedKey) *btcec.PrivateKey {
+		p, ok, err := deriveChildPrivIfPossible(a, 0, 0)
+		require.NoError(t, err)
+		require.True(t, ok)
+		return p
+	}
+	a, b, c := acct("a"), acct("b"), acct("c")
+	d := &Descriptor{Kind: ScriptMultisig, Threshold: 2, Keys: []DescriptorKey{{Account: a}, {Account: b}, {Account: c}}}
+	ds, _, err := d.DeriveScript(false, 0, net)
+	require.NoError(t, err)
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	prevTx.AddTxOut(wire.NewTxOut(amount, ds.scriptPubKey))
+	in := psbtInput{
+		outpoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 0},
+		amount:   amount,
+		addr: scannedAddr{
+			scriptPubKey: ds.scriptPubKey, witnessScript: ds.witnessScript,
+			kind: ScriptMultisig, multisigPrivs: []*btcec.PrivateKey{priv(a), priv(b)},
+		},
+	}
+	out := []TxOutSpec{{Address: dest, AmountBTC: float64(amount-1000) / 1e8}}
+	packet, err := buildPSBT([]psbtInput{in}, out, net, func(string) (*wire.MsgTx, error) { return prevTx, nil })
+	require.NoError(t, err)
+	_, err = signPSBT(packet, []psbtInput{in}, net)
+	require.NoError(t, err)
+	return packet, ds, amount
+}
+
+// TestFinalizeRejectsSignatureForAnotherTx: a partial signature that covers a
+// different transaction must fail before the broadcast, naming the key. Without
+// this the finalizer builds a witness the network rejects for a failed
+// CHECKMULTISIG, and the user only learns of it from the node.
+func TestFinalizeRejectsSignatureForAnotherTx(t *testing.T) {
+	packet, _, _ := multisigPacket(t)
+	require.Len(t, packet.Inputs[0].PartialSigs, 2)
+
+	packet.UnsignedTx.TxOut[0].Value -= 1
+
+	_, err := finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signed a different transaction")
+}
+
+// TestFinalizeRejectsSignatureOverAnotherScript: a signer that covers the wrong
+// k-of-n script — the shape a hardware wallet produces when it rebuilds the
+// multisig from incomplete PSBT metadata — is caught before the broadcast.
+func TestFinalizeRejectsSignatureOverAnotherScript(t *testing.T) {
+	net := &chaincfg.SigNetParams
+	packet, ds, amount := multisigPacket(t)
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	fetcher := txscript.NewCannedPrevOutputFetcher(ds.scriptPubKey, amount)
+	sigHashes := txscript.NewTxSigHashes(packet.UnsignedTx, fetcher)
+	wrong, err := multisigWitnessScript(2, []*btcec.PublicKey{priv.PubKey(), priv.PubKey()}, net)
+	require.NoError(t, err)
+	sig, err := txscript.RawTxInWitnessSignature(packet.UnsignedTx, sigHashes, 0, amount, wrong, txscript.SigHashAll, priv)
+	require.NoError(t, err)
+	packet.Inputs[0].PartialSigs[1] = &psbt.PartialSig{PubKey: priv.PubKey().SerializeCompressed(), Signature: sig}
+
+	_, err = finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signed a different transaction")
+}
+
+// TestCombinePSBTRejectsDifferentTx: an imported cosigner PSBT for another
+// transaction must not donate its signatures to this one.
+func TestCombinePSBTRejectsDifferentTx(t *testing.T) {
+	base, _, _ := multisigPacket(t)
+	other, _, _ := multisigPacket(t)
+	other.UnsignedTx.TxOut[0].Value -= 1
+
+	err := combinePSBT(base, other)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "different transactions")
+}
+
+// TestFinalizeRejectsForeignWitnessScript: an imported PSBT can carry any
+// witness script. The check must bind it to the output it spends, or a signer
+// that signed the wrong script passes.
+func TestFinalizeRejectsForeignWitnessScript(t *testing.T) {
+	net := &chaincfg.SigNetParams
+	packet, _, _ := multisigPacket(t)
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	foreign, err := multisigWitnessScript(2, []*btcec.PublicKey{priv.PubKey(), priv.PubKey()}, net)
+	require.NoError(t, err)
+	packet.Inputs[0].WitnessScript = foreign
+
+	_, err = finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match the output it spends")
+}
+
+// TestFinalizeRejectsForeignRedeemScript: the same binding must hold for the
+// P2SH redeem script a nested or legacy input carries.
+func TestFinalizeRejectsForeignRedeemScript(t *testing.T) {
+	net := &chaincfg.SigNetParams
+	const amount = int64(100_000)
+	const dest = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+	acct := func(pass string) *hdkeychain.ExtendedKey {
+		a, err := accountKeyFromSeed(hex.EncodeToString(MnemonicToSeed(testMnemonic, pass)), ScriptNativeSegwit, net)
+		require.NoError(t, err)
+		return a
+	}
+	priv := func(a *hdkeychain.ExtendedKey) *btcec.PrivateKey {
+		p, ok, err := deriveChildPrivIfPossible(a, 0, 0)
+		require.NoError(t, err)
+		require.True(t, ok)
+		return p
+	}
+	a, b, c := acct("a"), acct("b"), acct("c")
+	d := &Descriptor{Kind: ScriptMultisigNested, Threshold: 2, Keys: []DescriptorKey{{Account: a}, {Account: b}, {Account: c}}}
+	ds, _, err := d.DeriveScript(false, 0, net)
+	require.NoError(t, err)
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	prevTx.AddTxOut(wire.NewTxOut(amount, ds.scriptPubKey))
+	in := psbtInput{
+		outpoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 0},
+		amount:   amount,
+		addr: scannedAddr{
+			scriptPubKey: ds.scriptPubKey, redeem: ds.redeemScript, witnessScript: ds.witnessScript,
+			kind: ScriptMultisigNested, multisigPrivs: []*btcec.PrivateKey{priv(a), priv(b)},
+		},
+	}
+	out := []TxOutSpec{{Address: dest, AmountBTC: float64(amount-1000) / 1e8}}
+	packet, err := buildPSBT([]psbtInput{in}, out, net, func(string) (*wire.MsgTx, error) { return prevTx, nil })
+	require.NoError(t, err)
+	_, err = signPSBT(packet, []psbtInput{in}, net)
+	require.NoError(t, err)
+
+	other, _, err := (&Descriptor{Kind: ScriptMultisigNested, Threshold: 2, Keys: []DescriptorKey{{Account: b}, {Account: c}, {Account: a}}}).DeriveScript(true, 7, net)
+	require.NoError(t, err)
+	packet.Inputs[0].RedeemScript = other.redeemScript
+
+	_, err = finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "redeem script does not match the output it spends")
+}
+
+// taprootMultisigPacket builds a 2-of-3 tr(sortedmulti_a) spend signed by two keys.
+func taprootMultisigPacket(t *testing.T) *psbt.Packet {
+	t.Helper()
+	net := &chaincfg.SigNetParams
+	const amount = int64(100_000)
+	const dest = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+	acct := func(pass string) *hdkeychain.ExtendedKey {
+		a, err := accountKeyFromSeed(hex.EncodeToString(MnemonicToSeed(testMnemonic, pass)), ScriptTaproot, net)
+		require.NoError(t, err)
+		return a
+	}
+	priv := func(a *hdkeychain.ExtendedKey) *btcec.PrivateKey {
+		p, ok, err := deriveChildPrivIfPossible(a, 0, 0)
+		require.NoError(t, err)
+		require.True(t, ok)
+		return p
+	}
+	a, b, c := acct("a"), acct("b"), acct("c")
+	d := &Descriptor{Kind: ScriptMultisigTaproot, Threshold: 2, Keys: []DescriptorKey{{Account: a}, {Account: b}, {Account: c}}}
+	ds, _, err := d.DeriveScript(false, 0, net)
+	require.NoError(t, err)
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	prevTx.AddTxOut(wire.NewTxOut(amount, ds.scriptPubKey))
+	in := psbtInput{
+		outpoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 0},
+		amount:   amount,
+		addr: scannedAddr{
+			scriptPubKey:    ds.scriptPubKey,
+			tapLeafScript:   ds.tapLeafScript,
+			tapControlBlock: ds.tapControlBlock,
+			tapInternal:     ds.tapInternal,
+			kind:            ScriptMultisigTaproot,
+			multisigPrivs:   []*btcec.PrivateKey{priv(a), priv(b)},
+		},
+	}
+	out := []TxOutSpec{{Address: dest, AmountBTC: float64(amount-1000) / 1e8}}
+	packet, err := buildPSBT([]psbtInput{in}, out, net, nil)
+	require.NoError(t, err)
+	_, err = signPSBT(packet, []psbtInput{in}, net)
+	require.NoError(t, err)
+	require.Len(t, packet.Inputs[0].TaprootScriptSpendSig, 2)
+	return packet
+}
+
+// TestFinalizeTaprootMultisig: the good path still extracts and verifies through
+// txscript, with the signature check in place.
+func TestFinalizeTaprootMultisig(t *testing.T) {
+	packet := taprootMultisigPacket(t)
+	prevOut := prevOutForInput(packet, 0)
+	require.NotNil(t, prevOut)
+
+	rawHex, err := finalizeAndExtract(packet)
+	require.NoError(t, err)
+
+	var final wire.MsgTx
+	raw, err := hex.DecodeString(rawHex)
+	require.NoError(t, err)
+	require.NoError(t, final.Deserialize(bytes.NewReader(raw)))
+	fetcher := txscript.NewCannedPrevOutputFetcher(prevOut.PkScript, prevOut.Value)
+	vm, err := txscript.NewEngine(prevOut.PkScript, &final, 0, txscript.StandardVerifyFlags, nil,
+		txscript.NewTxSigHashes(&final, fetcher), prevOut.Value, fetcher)
+	require.NoError(t, err)
+	require.NoError(t, vm.Execute())
+}
+
+// TestFinalizeRejectsTaprootSignatureForAnotherTx: a schnorr signature over
+// another transaction must fail before the broadcast, like an ECDSA one.
+func TestFinalizeRejectsTaprootSignatureForAnotherTx(t *testing.T) {
+	packet := taprootMultisigPacket(t)
+	packet.UnsignedTx.TxOut[0].Value -= 1
+
+	_, err := finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signed a different transaction")
+}
+
+// TestFinalizeRejectsForeignLeafScript: an imported PSBT can name any leaf. The
+// control block must commit to the output the input spends.
+func TestFinalizeRejectsForeignLeafScript(t *testing.T) {
+	packet := taprootMultisigPacket(t)
+	other := taprootMultisigPacket(t)
+	other.Inputs[0].TaprootLeafScript[0].Script = append([]byte{txscript.OP_1, txscript.OP_DROP}, other.Inputs[0].TaprootLeafScript[0].Script...)
+	packet.Inputs[0].TaprootLeafScript = other.Inputs[0].TaprootLeafScript
+
+	_, err := finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match the output it spends")
+}
+
+// TestFinalizeRejectsForeignKeyForP2PKH: a legacy signature from a key that does
+// not hash to the output it spends must fail before the broadcast.
+func TestFinalizeRejectsForeignKeyForP2PKH(t *testing.T) {
+	net := &chaincfg.SigNetParams
+	const amount = int64(100_000)
+	const dest = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+	acct, err := accountKeyFromSeed(hex.EncodeToString(MnemonicToSeed(testMnemonic, "")), ScriptLegacy, net)
+	require.NoError(t, err)
+	d := &Descriptor{Kind: ScriptLegacy, Threshold: 1, Keys: []DescriptorKey{{Account: acct}}}
+	ds, _, err := d.DeriveScript(false, 0, net)
+	require.NoError(t, err)
+	priv, ok, err := deriveChildPrivIfPossible(acct, 0, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	prevTx.AddTxOut(wire.NewTxOut(amount, ds.scriptPubKey))
+	in := psbtInput{
+		outpoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 0},
+		amount:   amount,
+		addr:     scannedAddr{scriptPubKey: ds.scriptPubKey, priv: priv, pub: priv.PubKey(), kind: ScriptLegacy},
+	}
+	out := []TxOutSpec{{Address: dest, AmountBTC: float64(amount-1000) / 1e8}}
+	packet, err := buildPSBT([]psbtInput{in}, out, net, func(string) (*wire.MsgTx, error) { return prevTx, nil })
+	require.NoError(t, err)
+	_, err = signPSBT(packet, []psbtInput{in}, net)
+	require.NoError(t, err)
+	require.Len(t, packet.Inputs[0].PartialSigs, 1)
+
+	foreign, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	sig, err := txscript.RawTxInSignature(packet.UnsignedTx, 0, ds.scriptPubKey, txscript.SigHashAll, foreign)
+	require.NoError(t, err)
+	packet.Inputs[0].PartialSigs[0] = &psbt.PartialSig{PubKey: foreign.PubKey().SerializeCompressed(), Signature: sig}
+
+	_, err = finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "the key does not match the output it spends")
+}
+
+// TestFinalizeRejectsLeafVersionMismatch: the network hashes with the control
+// block's leaf version, so a leaf that names another version is refused.
+func TestFinalizeRejectsLeafVersionMismatch(t *testing.T) {
+	packet := taprootMultisigPacket(t)
+	packet.Inputs[0].TaprootLeafScript[0].LeafVersion = txscript.BaseLeafVersion + 2
+
+	_, err := finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "leaf version does not match its control block")
+}
+
+// TestFinalizeRejectsForeignPreviousTx: an imported PSBT can carry any previous
+// transaction. It must be the one the input spends.
+func TestFinalizeRejectsForeignPreviousTx(t *testing.T) {
+	net := &chaincfg.SigNetParams
+	const amount = int64(100_000)
+	const dest = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+	acct, err := accountKeyFromSeed(hex.EncodeToString(MnemonicToSeed(testMnemonic, "")), ScriptLegacy, net)
+	require.NoError(t, err)
+	d := &Descriptor{Kind: ScriptLegacy, Threshold: 1, Keys: []DescriptorKey{{Account: acct}}}
+	ds, _, err := d.DeriveScript(false, 0, net)
+	require.NoError(t, err)
+	priv, ok, err := deriveChildPrivIfPossible(acct, 0, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	prevTx.AddTxOut(wire.NewTxOut(amount, ds.scriptPubKey))
+	in := psbtInput{
+		outpoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 0},
+		amount:   amount,
+		addr:     scannedAddr{scriptPubKey: ds.scriptPubKey, priv: priv, pub: priv.PubKey(), kind: ScriptLegacy},
+	}
+	out := []TxOutSpec{{Address: dest, AmountBTC: float64(amount-1000) / 1e8}}
+	packet, err := buildPSBT([]psbtInput{in}, out, net, func(string) (*wire.MsgTx, error) { return prevTx, nil })
+	require.NoError(t, err)
+	_, err = signPSBT(packet, []psbtInput{in}, net)
+	require.NoError(t, err)
+
+	foreign := wire.NewMsgTx(2)
+	foreign.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xfffffffe}, []byte{0x01}, nil))
+	foreign.AddTxOut(wire.NewTxOut(amount, ds.scriptPubKey))
+	packet.Inputs[0].NonWitnessUtxo = foreign
+
+	_, err = finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not the one it spends")
+}
+
+// TestFinalizeTaprootSigHashAll: an external signer can use a non-default
+// sighash type. The check must honour it, and the witness must carry the byte.
+func TestFinalizeTaprootSigHashAll(t *testing.T) {
+	net := &chaincfg.SigNetParams
+	const amount = int64(100_000)
+	const dest = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+	acct := func(pass string) *hdkeychain.ExtendedKey {
+		a, err := accountKeyFromSeed(hex.EncodeToString(MnemonicToSeed(testMnemonic, pass)), ScriptTaproot, net)
+		require.NoError(t, err)
+		return a
+	}
+	priv := func(a *hdkeychain.ExtendedKey) *btcec.PrivateKey {
+		p, ok, err := deriveChildPrivIfPossible(a, 0, 0)
+		require.NoError(t, err)
+		require.True(t, ok)
+		return p
+	}
+	a, b, c := acct("a"), acct("b"), acct("c")
+	d := &Descriptor{Kind: ScriptMultisigTaproot, Threshold: 2, Keys: []DescriptorKey{{Account: a}, {Account: b}, {Account: c}}}
+	ds, _, err := d.DeriveScript(false, 0, net)
+	require.NoError(t, err)
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	prevTx.AddTxOut(wire.NewTxOut(amount, ds.scriptPubKey))
+	in := psbtInput{
+		outpoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 0},
+		amount:   amount,
+		addr: scannedAddr{
+			scriptPubKey:    ds.scriptPubKey,
+			tapLeafScript:   ds.tapLeafScript,
+			tapControlBlock: ds.tapControlBlock,
+			tapInternal:     ds.tapInternal,
+			kind:            ScriptMultisigTaproot,
+		},
+	}
+	out := []TxOutSpec{{Address: dest, AmountBTC: float64(amount-1000) / 1e8}}
+	packet, err := buildPSBT([]psbtInput{in}, out, net, nil)
+	require.NoError(t, err)
+
+	leaf := txscript.NewBaseTapLeaf(ds.tapLeafScript)
+	leafHash := leaf.TapHash()
+	fetcher := txscript.NewCannedPrevOutputFetcher(ds.scriptPubKey, amount)
+	sigHashes := txscript.NewTxSigHashes(packet.UnsignedTx, fetcher)
+	for _, p := range []*btcec.PrivateKey{priv(a), priv(b)} {
+		// Store it the way the PSBT decoder does: 64 bytes plus the type apart.
+		raw, err := txscript.RawTxInTapscriptSignature(
+			packet.UnsignedTx, sigHashes, 0, amount, ds.scriptPubKey, leaf, txscript.SigHashAll, p,
+		)
+		require.NoError(t, err)
+		require.Len(t, raw, 65)
+		packet.Inputs[0].TaprootScriptSpendSig = append(packet.Inputs[0].TaprootScriptSpendSig, &psbt.TaprootScriptSpendSig{
+			XOnlyPubKey: schnorr.SerializePubKey(p.PubKey()),
+			LeafHash:    leafHash[:],
+			Signature:   raw[:64],
+			SigHash:     txscript.SigHashAll,
+		})
+	}
+
+	rawHex, err := finalizeAndExtract(packet)
+	require.NoError(t, err)
+
+	var final wire.MsgTx
+	decoded, err := hex.DecodeString(rawHex)
+	require.NoError(t, err)
+	require.NoError(t, final.Deserialize(bytes.NewReader(decoded)))
+	vm, err := txscript.NewEngine(ds.scriptPubKey, &final, 0, txscript.StandardVerifyFlags, nil,
+		txscript.NewTxSigHashes(&final, fetcher), amount, fetcher)
+	require.NoError(t, err)
+	require.NoError(t, vm.Execute())
+}
+
+// taprootKeySpendPacket builds a signed single-key taproot spend.
+func taprootKeySpendPacket(t *testing.T) (*psbt.Packet, derivedScript, int64) {
+	t.Helper()
+	net := &chaincfg.SigNetParams
+	const amount = int64(100_000)
+	const dest = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+	acct, err := accountKeyFromSeed(hex.EncodeToString(MnemonicToSeed(testMnemonic, "")), ScriptTaproot, net)
+	require.NoError(t, err)
+	d := &Descriptor{Kind: ScriptTaproot, Threshold: 1, Keys: []DescriptorKey{{Account: acct}}}
+	ds, pub, err := d.DeriveScript(false, 0, net)
+	require.NoError(t, err)
+	priv, ok, err := deriveChildPrivIfPossible(acct, 0, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	prevTx.AddTxOut(wire.NewTxOut(amount, ds.scriptPubKey))
+	in := psbtInput{
+		outpoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 0},
+		amount:   amount,
+		addr:     scannedAddr{scriptPubKey: ds.scriptPubKey, priv: priv, pub: pub, tapInternal: pub, kind: ScriptTaproot},
+	}
+	out := []TxOutSpec{{Address: dest, AmountBTC: float64(amount-1000) / 1e8}}
+	packet, err := buildPSBT([]psbtInput{in}, out, net, nil)
+	require.NoError(t, err)
+	_, err = signPSBT(packet, []psbtInput{in}, net)
+	require.NoError(t, err)
+	require.Len(t, packet.Inputs[0].TaprootKeySpendSig, 64)
+	return packet, ds, amount
+}
+
+// TestFinalizeTaprootKeySpend: the good path extracts and verifies.
+func TestFinalizeTaprootKeySpend(t *testing.T) {
+	packet, ds, amount := taprootKeySpendPacket(t)
+
+	rawHex, err := finalizeAndExtract(packet)
+	require.NoError(t, err)
+
+	var final wire.MsgTx
+	raw, err := hex.DecodeString(rawHex)
+	require.NoError(t, err)
+	require.NoError(t, final.Deserialize(bytes.NewReader(raw)))
+	fetcher := txscript.NewCannedPrevOutputFetcher(ds.scriptPubKey, amount)
+	vm, err := txscript.NewEngine(ds.scriptPubKey, &final, 0, txscript.StandardVerifyFlags, nil,
+		txscript.NewTxSigHashes(&final, fetcher), amount, fetcher)
+	require.NoError(t, err)
+	require.NoError(t, vm.Execute())
+}
+
+// TestFinalizeRejectsKeySpendSigHashMismatch: the finalizer appends the input's
+// sighash type to a bare signature, so a disagreement must fail here.
+func TestFinalizeRejectsKeySpendSigHashMismatch(t *testing.T) {
+	packet, _, _ := taprootKeySpendPacket(t)
+	packet.Inputs[0].SighashType = txscript.SigHashAll
+
+	_, err := finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "input sighash type disagree")
+}
+
+// TestFinalizeRejectsWrongControlBlockParity: script execution reads the parity
+// bit, so a flipped bit must fail here and not at the broadcast.
+func TestFinalizeRejectsWrongControlBlockParity(t *testing.T) {
+	packet := taprootMultisigPacket(t)
+	packet.Inputs[0].TaprootLeafScript[0].ControlBlock[0] ^= 1
+
+	_, err := finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "wrong output key parity")
+}
+
+// TestFinalizeRejectsExplicitDefaultSigHash: script verification takes the
+// default taproot sighash only in the 64-byte form.
+func TestFinalizeRejectsExplicitDefaultSigHash(t *testing.T) {
+	packet, _, _ := taprootKeySpendPacket(t)
+	packet.Inputs[0].TaprootKeySpendSig = append(packet.Inputs[0].TaprootKeySpendSig, 0x00)
+
+	_, err := finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drop the default sighash byte")
+}
+
+// TestFinalizeRejectsUnknownSigHashType: a standard node refuses an undefined
+// sighash byte, so the check must refuse it first.
+func TestFinalizeRejectsUnknownSigHashType(t *testing.T) {
+	packet, _, _ := multisigPacket(t)
+	sig := packet.Inputs[0].PartialSigs[0].Signature
+	packet.Inputs[0].PartialSigs[0].Signature = append(append([]byte(nil), sig[:len(sig)-1]...), 0x04)
+
+	_, err := finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown sighash type 0x4")
+}
+
+// TestFinalizeRejectsForeignFinalWitness: a cosigner can hand back a PSBT it
+// finalized itself. That witness must still spend this transaction's input.
+func TestFinalizeRejectsForeignFinalWitness(t *testing.T) {
+	packet, _, _ := multisigPacket(t)
+	require.NoError(t, psbt.MaybeFinalizeAll(packet))
+	require.NotEmpty(t, packet.Inputs[0].FinalScriptWitness)
+
+	packet.UnsignedTx.TxOut[0].Value -= 1
+
+	_, err := finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not spend this output")
+}
+
+// TestFinalizeAcceptsOwnFinalWitness: the good path stays green once an input
+// carries its final witness.
+func TestFinalizeAcceptsOwnFinalWitness(t *testing.T) {
+	packet, _, _ := multisigPacket(t)
+	require.NoError(t, psbt.MaybeFinalizeAll(packet))
+
+	_, err := finalizeAndExtract(packet)
+	require.NoError(t, err)
+}
+
+// TestFinalizeRejectsLegacyInputWithoutPreviousTx: the finalizer takes its
+// witness path whenever a witness utxo is set, so a legacy input signed against
+// one lands in the wrong field.
+func TestFinalizeRejectsLegacyInputWithoutPreviousTx(t *testing.T) {
+	net := &chaincfg.SigNetParams
+	const amount = int64(100_000)
+	const dest = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+	acct, err := accountKeyFromSeed(hex.EncodeToString(MnemonicToSeed(testMnemonic, "")), ScriptLegacy, net)
+	require.NoError(t, err)
+	d := &Descriptor{Kind: ScriptLegacy, Threshold: 1, Keys: []DescriptorKey{{Account: acct}}}
+	ds, _, err := d.DeriveScript(false, 0, net)
+	require.NoError(t, err)
+	priv, ok, err := deriveChildPrivIfPossible(acct, 0, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	prevTx.AddTxOut(wire.NewTxOut(amount, ds.scriptPubKey))
+	in := psbtInput{
+		outpoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 0},
+		amount:   amount,
+		addr:     scannedAddr{scriptPubKey: ds.scriptPubKey, priv: priv, pub: priv.PubKey(), kind: ScriptLegacy},
+	}
+	out := []TxOutSpec{{Address: dest, AmountBTC: float64(amount-1000) / 1e8}}
+	packet, err := buildPSBT([]psbtInput{in}, out, net, func(string) (*wire.MsgTx, error) { return prevTx, nil })
+	require.NoError(t, err)
+	_, err = signPSBT(packet, []psbtInput{in}, net)
+	require.NoError(t, err)
+
+	packet.Inputs[0].NonWitnessUtxo = nil
+	packet.Inputs[0].WitnessUtxo = wire.NewTxOut(amount, ds.scriptPubKey)
+
+	_, err = finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "needs its previous transaction")
+}
+
+// TestFinalizeVerifiesBarePubKeyScript: a bare standard output is verified like
+// any other, so a final scriptSig that does not spend it fails here.
+func TestFinalizeVerifiesBarePubKeyScript(t *testing.T) {
+	const amount = int64(100_000)
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	pkScript, err := txscript.NewScriptBuilder().
+		AddData(priv.PubKey().SerializeCompressed()).
+		AddOp(txscript.OP_CHECKSIG).
+		Script()
+	require.NoError(t, err)
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	prevTx.AddTxOut(wire.NewTxOut(amount, pkScript))
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Hash: prevTx.TxHash(), Index: 0}, nil, nil))
+	tx.AddTxOut(wire.NewTxOut(amount-1000, pkScript))
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+	packet.Inputs[0].NonWitnessUtxo = prevTx
+
+	other, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	sig, err := txscript.RawTxInSignature(tx, 0, pkScript, txscript.SigHashAll, other)
+	require.NoError(t, err)
+	packet.Inputs[0].FinalScriptSig, err = txscript.NewScriptBuilder().AddData(sig).Script()
+	require.NoError(t, err)
+
+	_, err = finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not spend this output")
+}
+
+// TestFinalizeRejectsHighSSignature: a high-S signature still verifies by
+// mathematics, but a standard node refuses it, and the finalizer copies the
+// bytes through unchanged.
+func TestFinalizeRejectsHighSSignature(t *testing.T) {
+	packet, _, _ := multisigPacket(t)
+	ps := packet.Inputs[0].PartialSigs[0]
+	der := ps.Signature[:len(ps.Signature)-1]
+	sig, err := ecdsa.ParseDERSignature(der)
+	require.NoError(t, err)
+
+	require.NoError(t, ecdsa.VerifyLowS(der))
+	high := highSDER(t, sig)
+	require.Error(t, ecdsa.VerifyLowS(high))
+	packet.Inputs[0].PartialSigs[0].Signature = append(high, ps.Signature[len(ps.Signature)-1])
+
+	_, err = finalizeAndExtract(packet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "a standard node refuses")
+}
+
+// highSDER re-encodes a signature with the mirrored s value, the form a
+// standard node refuses. The library serializer always writes the low form, so
+// the DER is built by hand.
+func highSDER(t *testing.T, sig *ecdsa.Signature) []byte {
+	t.Helper()
+	order, ok := new(big.Int).SetString(
+		"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16,
+	)
+	require.True(t, ok)
+	r := sig.R()
+	s := sig.S()
+	rBytes := r.Bytes()
+	sBytes := s.Bytes()
+	high := new(big.Int).Sub(order, new(big.Int).SetBytes(sBytes[:]))
+
+	body := append(derInt(rBytes[:]), derInt(high.Bytes())...)
+	return append([]byte{0x30, byte(len(body))}, body...)
+}
+
+func derInt(value []byte) []byte {
+	for len(value) > 1 && value[0] == 0 {
+		value = value[1:]
+	}
+	if value[0]&0x80 != 0 {
+		value = append([]byte{0x00}, value...)
+	}
+	return append([]byte{0x02, byte(len(value))}, value...)
 }

--- a/sidechain-orchestrator/wallet/scripttype_taproot.go
+++ b/sidechain-orchestrator/wallet/scripttype_taproot.go
@@ -268,7 +268,12 @@ func finalizeTaprootMultisigInput(packet *psbt.Packet, i int) error {
 	}
 	sigByPub := make(map[string][]byte, len(in.TaprootScriptSpendSig))
 	for _, s := range in.TaprootScriptSpendSig {
-		sigByPub[hex.EncodeToString(s.XOnlyPubKey)] = s.Signature
+		// The witness carries the sighash byte; the PSBT keeps it apart.
+		sig := s.Signature
+		if s.SigHash != txscript.SigHashDefault {
+			sig = append(append([]byte(nil), sig...), byte(s.SigHash))
+		}
+		sigByPub[hex.EncodeToString(s.XOnlyPubKey)] = sig
 	}
 
 	// A multi_a leaf ends in <m> OP_NUMEQUAL — the witness must carry EXACTLY m


### PR DESCRIPTION
A cosigner that holds a master xpub has no origin path, so the descriptor dropped its key origin and the PSBT carried no global xpub for that leg. HWI then hands the device a stub node and the device cannot rebuild the multisig script it signs over.

The finalizer now checks every partial signature against the sighash it must cover, so a bad signature fails locally and names the fingerprint instead of reaching the node as a script-verify error. Combine also refuses two PSBTs for different transactions, and the per-cosigner sign path refuses an input that does not pay this wallet.