### PR TITLE
orchestrator: take a custom mainnet as mainnet

### DIFF
--- a/bitwindow/server/api/runtime.go
+++ b/bitwindow/server/api/runtime.go
@@ -473,7 +473,12 @@ func (rt *Runtime) runZMQ(ctx context.Context, log *zerolog.Logger) {
 // orchestrator, the getters route per call to it for electrum wallets and to
 // the local clients otherwise; without a hosted instance they're always local.
 func (s *Server) buildDataSource(conf config.Config) datasource.DataSource {
-	remoteURL := orchconfig.RemoteOrchestratorURLForNetwork(orchconfig.NetworkFromString(string(conf.BitcoinCoreNetwork)))
+	// A runtime without a network has no remote orchestrator either, which is
+	// the state a test server starts in.
+	var remoteURL string
+	if n, known := orchconfig.LookupNetwork(string(conf.BitcoinCoreNetwork)); known {
+		remoteURL = orchconfig.RemoteOrchestratorURLForNetwork(n)
+	}
 	if remoteURL == "" || s.svcs.OrchestratorAddr == "" {
 		return datasource.NewLocal(s.Bitcoind.Get, s.Enforcer.Get)
 	}
@@ -638,7 +643,8 @@ func chainParamsFor(network config.Network) *chaincfg.Params {
 		return &chaincfg.SigNetParams
 	case config.NetworkRegtest:
 		return &chaincfg.RegressionNetParams
-	default:
-		return &chaincfg.SigNetParams
 	}
+	// These params name the coin every address and key path takes, so a guess
+	// here is a wrong address, not a small mistake.
+	panic(fmt.Sprintf("unknown network %q", network))
 }

--- a/bitwindow/server/tests/apitests/apitests.go
+++ b/bitwindow/server/tests/apitests/apitests.go
@@ -155,6 +155,10 @@ func API(t *testing.T, database *sql.DB, options ...ServerOpt) (connect.HTTPClie
 	}
 
 	srv, err := api.New(ctx, services, config.Config{
+		// The name picks the data source and the coin news set, and regtest has
+		// no hosted orchestrator, so every read stays on the mocks above. The
+		// ChainParams above pick the address encoding the fixtures use.
+		BitcoinCoreNetwork: config.NetworkRegtest,
 		GuiBootedMainchain: false,
 		GuiBootedEnforcer:  false,
 	}, func(shutdownCtx context.Context) {

--- a/sidechain-orchestrator/api/bitcoin_conf_handler.go
+++ b/sidechain-orchestrator/api/bitcoin_conf_handler.go
@@ -96,8 +96,14 @@ func (h *BitcoinConfHandler) GetBitcoinConfig(ctx context.Context, req *connect.
 }
 
 func (h *BitcoinConfHandler) PrepareNetworkChange(ctx context.Context, req *connect.Request[pb.PrepareNetworkChangeRequest]) (*connect.Response[pb.NetworkChangePlan], error) {
+	network := strings.TrimSpace(req.Msg.Network)
+	if _, known := h.orch.NetworkForOption(network); !known {
+		if _, named := config.LookupNetwork(network); network != "" && !named {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unknown network %q", network))
+		}
+	}
 	plan := h.orch.PlanNetworkChange(orchestrator.NetworkChangeRequest{
-		Network:       strings.TrimSpace(req.Msg.Network),
+		Network:       network,
 		WalletBackend: walletBackendFromProto(req.Msg.WalletBackend),
 		WalletID:      strings.TrimSpace(req.Msg.WalletId),
 	})

--- a/sidechain-orchestrator/api/bitcoin_conf_handler.go
+++ b/sidechain-orchestrator/api/bitcoin_conf_handler.go
@@ -164,6 +164,9 @@ func (h *BitcoinConfHandler) SetBitcoinConfigNetwork(ctx context.Context, req *c
 		}
 	}
 
+	if _, known := config.LookupNetwork(networkStr); networkStr != "" && !known {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unknown network %q", networkStr))
+	}
 	// Apply is authoritative: re-plan so a stale prepare can't smuggle through a
 	// requirement the user never resolved.
 	plan := h.orch.PlanNetworkChange(orchestrator.NetworkChangeRequest{Network: networkStr})
@@ -238,7 +241,10 @@ func (h *BitcoinConfHandler) SetBitcoinConfigDataDir(ctx context.Context, req *c
 	if networkStr == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("network is required"))
 	}
-	forNetwork := config.NetworkFromString(networkStr)
+	forNetwork, known := config.LookupNetwork(networkStr)
+	if !known {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unknown network %q", networkStr))
+	}
 
 	dataDir := strings.TrimSpace(req.Msg.DataDir)
 

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -57,7 +57,6 @@ import (
 	truthcoinsvc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/truthcoin"
 	zsidesvc "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain/zside"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47send"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47state"
 )
 
@@ -350,15 +349,15 @@ func run(cctx *cli.Context) error {
 	// Every key path, address and hardware request takes its coin from these
 	// params. A guess reaches a device as the wrong coin, so an unknown network
 	// stops the daemon here rather than deeper, one wrong answer at a time.
-	if _, perr := bip47send.NetworkParams(currentNetwork()); perr != nil {
-		return fmt.Errorf("unknown network %q: %w", currentNetwork(), perr)
+	if _, known := config.LookupNetwork(currentNetwork()); !known {
+		return fmt.Errorf("unknown network %q", currentNetwork())
 	}
 	netParams := wallet.ParamsFunc(func() *chaincfg.Params {
-		params, err := bip47send.NetworkParams(currentNetwork())
-		if err != nil {
-			panic(fmt.Sprintf("network %q became unknown after startup: %v", currentNetwork(), err))
+		n, known := config.LookupNetwork(currentNetwork())
+		if !known {
+			panic(fmt.Sprintf("network %q became unknown after startup", currentNetwork()))
 		}
-		return params
+		return config.ChainParamsFor(n)
 	})
 	orch.NetParams = netParams
 

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -347,17 +347,20 @@ func run(cctx *cli.Context) error {
 		}
 		return network
 	}
+	// Every key path, address and hardware request takes its coin from these
+	// params. A guess reaches a device as the wrong coin, so an unknown network
+	// stops the daemon here rather than deeper, one wrong answer at a time.
+	if _, perr := bip47send.NetworkParams(currentNetwork()); perr != nil {
+		return fmt.Errorf("unknown network %q: %w", currentNetwork(), perr)
+	}
 	netParams := wallet.ParamsFunc(func() *chaincfg.Params {
 		params, err := bip47send.NetworkParams(currentNetwork())
 		if err != nil {
-			return nil
+			panic(fmt.Sprintf("network %q became unknown after startup: %v", currentNetwork(), err))
 		}
 		return params
 	})
 	orch.NetParams = netParams
-	if _, perr := bip47send.NetworkParams(currentNetwork()); perr != nil {
-		log.Warn().Err(perr).Str("network", currentNetwork()).Msg("unrecognised network; BIP47 features will be disabled")
-	}
 
 	// Chain wallet provider — CoreBackend today; electrum/btcd providers
 	// slot in behind the same wallet.Backend interface.

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -1,13 +1,14 @@
 package config
 
 import (
-	"github.com/samber/lo"
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
+	"github.com/samber/lo"
 )
 
 // Network represents the Bitcoin network type.
@@ -473,7 +474,10 @@ func NetworkFromConfig(conf *BitcoinConfig, fallback Network) Network {
 // NetworkFromString converts a string (e.g. CLI flag) to a Network value,
 // falling back to signet for anything it does not recognise.
 func NetworkFromString(s string) Network {
-	n, _ := LookupNetwork(s)
+	n, ok := LookupNetwork(s)
+	if !ok {
+		panic(fmt.Sprintf("unknown network %q", s))
+	}
 	return n
 }
 
@@ -492,7 +496,7 @@ func LookupNetwork(s string) (Network, bool) {
 	// boot a different network than the caller asked for.
 	case "ecash", "drynet":
 		return NetworkECash, true
-	case "testnet", "test":
+	case "testnet", "test", "testnet4":
 		return NetworkTestnet, true
 	case "signet":
 		return NetworkSignet, true

--- a/sidechain-orchestrator/config/network.go
+++ b/sidechain-orchestrator/config/network.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config/netcatalog"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/samber/lo"
 )
 
@@ -505,6 +506,24 @@ func LookupNetwork(s string) (Network, bool) {
 	default:
 		return NetworkSignet, false
 	}
+}
+
+// ChainParamsFor gives the address encoding and coin type a network takes.
+// Every Network value has params; a value outside the set is a programming
+// error, and a guess here is a wrong address.
+func ChainParamsFor(n Network) *chaincfg.Params {
+	switch n {
+	// Forknet and eCash run on mainnet params: same encoding, same coin type.
+	case NetworkMainnet, NetworkForknet, NetworkECash:
+		return &chaincfg.MainNetParams
+	case NetworkTestnet:
+		return &chaincfg.TestNet3Params
+	case NetworkSignet:
+		return &chaincfg.SigNetParams
+	case NetworkRegtest:
+		return &chaincfg.RegressionNetParams
+	}
+	panic(fmt.Sprintf("no chain params for network %q", n))
 }
 
 // SupportsLightMode reports whether a network can run without a local node.

--- a/sidechain-orchestrator/config/network_params_test.go
+++ b/sidechain-orchestrator/config/network_params_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+// Every network the daemon accepts must have params, testnet included: BIP47
+// support is a narrower question, and a network without BIP47 sends still runs.
+func TestChainParamsForEveryNetwork(t *testing.T) {
+	for _, n := range []Network{
+		NetworkMainnet, NetworkForknet, NetworkECash,
+		NetworkTestnet, NetworkSignet, NetworkRegtest,
+	} {
+		require.NotNil(t, ChainParamsFor(n), "network %q", n)
+	}
+	require.Equal(t, &chaincfg.MainNetParams, ChainParamsFor(NetworkECash))
+	require.Equal(t, &chaincfg.TestNet3Params, ChainParamsFor(NetworkTestnet))
+	require.Panics(t, func() { ChainParamsFor(Network("nosuchnet")) })
+}

--- a/sidechain-orchestrator/health.go
+++ b/sidechain-orchestrator/health.go
@@ -299,7 +299,8 @@ func (c *CoreStatusClient) IsHeaderSyncComplete(ctx context.Context) (bool, erro
 
 	// Regtest has no peers feeding headers — the "<10 headers" peer-driven
 	// guard would block enforcer startup forever. Empty regtest is steady state.
-	if config.NetworkFromString(info.Chain) == config.NetworkRegtest {
+	chain, known := config.LookupNetwork(info.Chain)
+	if known && chain == config.NetworkRegtest {
 		if info.InitialBlockDownload && info.Blocks == 0 {
 			return true, nil
 		}

--- a/sidechain-orchestrator/network_change_plan.go
+++ b/sidechain-orchestrator/network_change_plan.go
@@ -47,8 +47,12 @@ func (o *Orchestrator) PlanNetworkChange(req NetworkChangeRequest) NetworkChange
 	if req.Network != "" {
 		if resolved, ok := o.NetworkForOption(req.Network); ok {
 			target = resolved
+		} else if resolved, ok := config.LookupNetwork(req.Network); ok {
+			target = resolved
 		} else {
-			target = config.NetworkFromString(req.Network)
+			// A request names this, and a handler checks it. Signet here would
+			// plan a switch to a chain nobody asked for.
+			panic(fmt.Sprintf("unknown network %q", req.Network))
 		}
 		if plan, err := o.PlanECashSwitch(req.Network); err == nil {
 			ecashSwitch = plan.FromID != "" && plan.FromID != plan.ToID

--- a/sidechain-orchestrator/wallet/descriptor.go
+++ b/sidechain-orchestrator/wallet/descriptor.go
@@ -284,8 +284,9 @@ func (d *Descriptor) DeriveScript(change bool, index uint32, net *chaincfg.Param
 // deriveChildPub derives account/chain/index and returns the child public key.
 // derivations returns the PSBT key-derivation records for the address at
 // (change, index): one per descriptor key, each with the child pubkey, master
-// fingerprint, and full path. Keys with no parseable origin fall back to the
-// account key's own fingerprint and a path of just [chain, index].
+// fingerprint, and full path. A key whose origin is unknown gets a record only
+// when its account key is a master key, where [chain, index] is the true path
+// from it.
 func (d *Descriptor) derivations(change bool, index uint32) ([]keyDerivation, error) {
 	chain := chainIndex(change)
 	out := make([]keyDerivation, 0, len(d.Keys))
@@ -295,11 +296,16 @@ func (d *Descriptor) derivations(change bool, index uint32) ([]keyDerivation, er
 			return nil, err
 		}
 		fp, path, ok := parseOrigin(k.Origin)
-		if ok {
+		switch {
+		case ok:
 			path = append(path, chain, index)
-		} else {
+		case k.Account.Depth() == 0:
 			fp = keyFingerprint(k.Account)
 			path = []uint32{chain, index}
+		default:
+			// A hardware signer checks every path in the packet before it signs
+			// any of them, so one made-up path fails the whole transaction.
+			continue
 		}
 		out = append(out, keyDerivation{pub: pub, fingerprint: fp, path: path})
 	}

--- a/sidechain-orchestrator/wallet/hwi.go
+++ b/sidechain-orchestrator/wallet/hwi.go
@@ -42,6 +42,9 @@ func NewHWIRunner(net *chaincfg.Params) *HWIRunner {
 	return &HWIRunner{chain: hwiChainArg(net), call: hwiCall}
 }
 
+// hwiChainArg names the coin a device validates against. A custom network takes
+// the coin its address encoding belongs to: the device refuses a coin type 0h
+// path under any coin but mainnet, and it shows an address in that coin's form.
 func hwiChainArg(net *chaincfg.Params) string {
 	switch net.Name {
 	case "mainnet":
@@ -50,9 +53,19 @@ func hwiChainArg(net *chaincfg.Params) string {
 		return "signet"
 	case "regtest", "simnet":
 		return "regtest"
-	default:
-		return "test"
 	}
+	switch net.Bech32HRPSegwit {
+	case chaincfg.MainNetParams.Bech32HRPSegwit:
+		return "main"
+	case chaincfg.TestNet3Params.Bech32HRPSegwit:
+		return "test"
+	case chaincfg.RegressionNetParams.Bech32HRPSegwit:
+		return "regtest"
+	}
+	// A guess here reaches the device as the wrong coin, and it costs a refused
+	// path or a signature over the wrong script.
+	panic(fmt.Sprintf("hwi: unknown network %q with address prefix %q",
+		net.Name, net.Bech32HRPSegwit))
 }
 
 func (r *HWIRunner) request(cmd string, sel HardwareSelector) map[string]any {

--- a/sidechain-orchestrator/wallet/hwi_test.go
+++ b/sidechain-orchestrator/wallet/hwi_test.go
@@ -95,3 +95,26 @@ func TestSignPSBTEmptyResult(t *testing.T) {
 	_, err := r.SignPSBT(context.Background(), HardwareSelector{}, "cHNidP8")
 	require.Error(t, err)
 }
+
+// A custom network that keeps mainnet's address encoding is mainnet to a
+// device. Told any other coin, the device refuses a coin type 0h path.
+func TestHwiChainArgCustomMainnet(t *testing.T) {
+	alpha := chaincfg.MainNetParams
+	alpha.Name = "ecash"
+	require.Equal(t, "main", hwiChainArg(&alpha))
+
+	custom := chaincfg.TestNet3Params
+	custom.Name = "somethingelse"
+	require.Equal(t, "test", hwiChainArg(&custom))
+
+	// A guess reaches the device as the wrong coin, so an unknown encoding stops
+	// the process rather than picking one.
+	unknown := chaincfg.MainNetParams
+	unknown.Name = "nosuchnet"
+	unknown.Bech32HRPSegwit = "zz"
+	require.Panics(t, func() { hwiChainArg(&unknown) })
+
+	require.Equal(t, "main", hwiChainArg(&chaincfg.MainNetParams))
+	require.Equal(t, "signet", hwiChainArg(&chaincfg.SigNetParams))
+	require.Equal(t, "regtest", hwiChainArg(&chaincfg.RegressionNetParams))
+}

--- a/sidechain-orchestrator/wallet/keys.go
+++ b/sidechain-orchestrator/wallet/keys.go
@@ -19,7 +19,10 @@ import (
 // match the network. go-bip32 hardcodes mainnet xprv version bytes; for any
 // other chain Core rejects the serialized key, so we strip + replace + re-sum.
 func serializeKeyForNetwork(key *bip32.Key, network *chaincfg.Params) string {
-	if network == nil || network.HDPrivateKeyID == chaincfg.MainNetParams.HDPrivateKeyID {
+	if network == nil {
+		panic("serializeKeyForNetwork: no network; a key's version bytes name its chain")
+	}
+	if network.HDPrivateKeyID == chaincfg.MainNetParams.HDPrivateKeyID {
 		return key.String()
 	}
 

--- a/sidechain-orchestrator/wallet/multisiglounge_test.go
+++ b/sidechain-orchestrator/wallet/multisiglounge_test.go
@@ -393,25 +393,19 @@ func TestValidatePsbtCosignerChildMismatch(t *testing.T) {
 // the group. A changed child on that record must still fail.
 func TestValidatePsbtBareCosignerChildMismatch(t *testing.T) {
 	group, _ := loungeTestKeys(t)
-	for i := 1; i < len(group.Keys); i++ {
-		group.Keys[i] = MultisigLoungeKey{Xpub: group.Keys[i].Xpub}
-	}
+	// Only the last cosigner is bare, so a second record survives to tamper with.
+	group.Keys[len(group.Keys)-1] = MultisigLoungeKey{Xpub: group.Keys[len(group.Keys)-1].Xpub}
 	accts := loungeTestAccts(t)
 
-	packet := loungeBareCosignerPSBT(t, accts)
+	packet := loungeBareCosignerPSBT(t, accts, 2)
 	_, err := ValidateMultisigPsbt(psbtToBase64(t, packet), 2, &group)
 	require.NoError(t, err)
 
 	// The first record still carries the true child, so the script check reads
 	// the right hint and the tampered record reaches the origin check.
-	var bare *psbt.Bip32Derivation
-	for _, d := range packet.Inputs[0].Bip32Derivation[1:] {
-		if len(d.Bip32Path) == 2 {
-			bare = d
-		}
-	}
-	require.NotNil(t, bare, "the group carries a bare-xpub cosigner record")
-	bare.Bip32Path[len(bare.Bip32Path)-1] = 6
+	require.Len(t, packet.Inputs[0].Bip32Derivation, 2)
+	rec := packet.Inputs[0].Bip32Derivation[1]
+	rec.Bip32Path[len(rec.Bip32Path)-1] = 6
 
 	_, err = ValidateMultisigPsbt(psbtToBase64(t, packet), 2, &group)
 	require.Error(t, err)
@@ -463,7 +457,7 @@ func TestValidatePsbtStrippedOriginsCrossGroup(t *testing.T) {
 // bare-xpub cosigners produces: only the wallet key carries a [fp/origin], so the
 // other two derivation records fall back to the xpub's own self-root fingerprint
 // and a chain/index-only path — what Core emits for a prefix-less descriptor key.
-func loungeBareCosignerPSBT(t *testing.T, accts []*hdkeychain.ExtendedKey) *psbt.Packet {
+func loungeBareCosignerPSBT(t *testing.T, accts []*hdkeychain.ExtendedKey, origins int) *psbt.Packet {
 	t.Helper()
 	net := &chaincfg.SigNetParams
 	const amount = int64(100_000)
@@ -473,7 +467,9 @@ func loungeBareCosignerPSBT(t *testing.T, accts []*hdkeychain.ExtendedKey) *psbt
 	for i, a := range accts {
 		keys[i] = DescriptorKey{Account: a}
 	}
-	keys[0].Origin = "73c5da0a/48h/1h/0h/2h"
+	for i := 0; i < origins; i++ {
+		keys[i].Origin = fmt.Sprintf("73c5da0a/48h/1h/0h/%dh", i+2)
+	}
 	d := &Descriptor{Kind: ScriptMultisig, Threshold: 2, Keys: keys}
 	ds, _, err := d.DeriveScript(false, 0, net)
 	require.NoError(t, err)
@@ -509,14 +505,10 @@ func TestValidatePsbtBareXpubCosigners(t *testing.T) {
 	}
 	accts := loungeTestAccts(t)
 
-	packet := loungeBareCosignerPSBT(t, accts)
-	bare := 0
-	for _, d := range packet.Inputs[0].Bip32Derivation {
-		if len(d.Bip32Path) == 2 {
-			bare++
-		}
-	}
-	require.Equal(t, 2, bare, "the two bare-xpub cosigners carry chain/index-only paths")
+	packet := loungeBareCosignerPSBT(t, accts, 1)
+	// A bare cosigner carries no derivation record: a made-up path fails a
+	// hardware signer, which checks every path in the packet.
+	require.Len(t, packet.Inputs[0].Bip32Derivation, 1)
 
 	res, err := ValidateMultisigPsbt(psbtToBase64(t, packet), 2, &group)
 	require.NoError(t, err, "a group's own spend must not be rejected over external cosigner metadata")

--- a/sidechain-orchestrator/wallet/psbt_test.go
+++ b/sidechain-orchestrator/wallet/psbt_test.go
@@ -559,6 +559,42 @@ func TestFinalizeRejectsForeignRedeemScript(t *testing.T) {
 	_, err = finalizeAndExtract(packet)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "redeem script does not match the output it spends")
+// A cosigner pasted as a bare xpub has no origin, and a made-up path fails a
+// hardware signer: it checks every path in the packet before it signs any of
+// them. A master account key is the one case where [chain, index] is true.
+func TestDerivationsSkipUnknownOrigin(t *testing.T) {
+	seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, ""))
+	net := &chaincfg.SigNetParams
+
+	master, err := hdkeychain.NewMaster(mustHex(t, seedHex), net)
+	require.NoError(t, err)
+	masterPub, err := master.Neuter()
+	require.NoError(t, err)
+
+	deepStr, err := DeriveAccountXpub(seedHex, "m/48h/1h/0h/2h", net)
+	require.NoError(t, err)
+	deep, err := hdkeychain.NewKeyFromString(deepStr)
+	require.NoError(t, err)
+
+	d := &Descriptor{Kind: ScriptMultisig, Threshold: 2, Keys: []DescriptorKey{
+		{Origin: "abcd1234/48h/1h/0h/2h", Account: deep},
+		{Origin: "", Account: deep},
+		{Origin: "", Account: masterPub},
+	}}
+
+	derivs, err := d.derivations(false, 0)
+	require.NoError(t, err)
+	require.Len(t, derivs, 2, "the origin-less deep key gets no record")
+	require.Equal(t, []uint32{hdkeychain.HardenedKeyStart + 48, hdkeychain.HardenedKeyStart + 1,
+		hdkeychain.HardenedKeyStart, hdkeychain.HardenedKeyStart + 2, 0, 0}, derivs[0].path)
+	require.Equal(t, []uint32{0, 0}, derivs[1].path, "a master key's path is true")
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return b
 }
 
 // taprootMultisigPacket builds a 2-of-3 tr(sortedmulti_a) spend signed by two keys.

--- a/sidechain-orchestrator/wallet/psbt_test.go
+++ b/sidechain-orchestrator/wallet/psbt_test.go
@@ -559,6 +559,8 @@ func TestFinalizeRejectsForeignRedeemScript(t *testing.T) {
 	_, err = finalizeAndExtract(packet)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "redeem script does not match the output it spends")
+}
+
 // A cosigner pasted as a bare xpub has no origin, and a made-up path fails a
 // hardware signer: it checks every path in the packet before it signs any of
 // them. A master account key is the one case where [chain, index] is true.

--- a/sidechain-orchestrator/wallet/replay_protect.go
+++ b/sidechain-orchestrator/wallet/replay_protect.go
@@ -6,5 +6,6 @@ import "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
 // eCash node reads that locktime as final, so no other network stamps it. A
 // caller that wants the transaction on both chains sets allowReplay.
 func ReplayProtect(network string, allowReplay bool) bool {
-	return config.NetworkFromString(network) == config.NetworkECash && !allowReplay
+	n, known := config.LookupNetwork(network)
+	return known && n == config.NetworkECash && !allowReplay
 }

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -2078,7 +2078,10 @@ func (s *Service) derivesEnforcerAccount(w *WalletData) bool {
 	// mainnet reads their coin type as 1 and skips the companion they need.
 	net, err := bip47send.NetworkParams(s.network)
 	if err != nil {
-		net = &chaincfg.TestNet3Params
+		// Testnet params here read the coin type as 1, which is the answer this
+		// function exists to avoid. The daemon refuses an unknown network at
+		// startup, so this cannot happen.
+		panic(fmt.Sprintf("unknown network %q: %v", s.network, err))
 	}
 	ap, err := accountPathFor(w, walletReceiveKind(w), net)
 	if err != nil {


### PR DESCRIPTION
A device validates a path against the coin it is told, and hwiChainArg called every unnamed network testnet — so alphanet, which uses mainnet addresses and coin type 0h, made a Trezor refuse the path and sign against the wrong coin.

The coin now comes from the address encoding, PSBT records no longer carry made-up paths for a cosigner with no origin, and a network we cannot name stops the daemon instead of taking a default.