### PR TITLE
Ask whether Bitcoin holds the coin

### DIFF
--- a/sidechain-orchestrator/engines/split_engine.go
+++ b/sidechain-orchestrator/engines/split_engine.go
@@ -34,9 +34,11 @@ type UnspentSource interface {
 	WalletUnspent(ctx context.Context) ([]fork.Utxo, error)
 }
 
-// OutspendSource answers BTC-mainnet spend status per output.
+// OutspendSource answers BTC-mainnet spend status per output, and whether a
+// transaction exists there at all.
 type OutspendSource interface {
 	Outspend(ctx context.Context, txid string, vout int) (wallet.EsploraOutspend, bool, error)
+	TxKnown(ctx context.Context, txid string) (bool, error)
 }
 
 // SplitStore persists the per-outpoint split status.
@@ -213,9 +215,18 @@ func checkReplayStatus(ctx context.Context, btc OutspendSource, outpoint string)
 		return btcPending, nil
 	case out.Spent:
 		return btcSpent, nil
-	default:
-		return btcUnspent, nil
 	}
+	// A server that never saw the transaction reports the same "not spent" as
+	// one holding a live output, so the coin counts as shared only once the
+	// transaction itself turns up.
+	known, err := btc.TxKnown(ctx, txid)
+	if err != nil {
+		return btcUnknown, err
+	}
+	if !known {
+		return btcUnknown, nil
+	}
+	return btcUnspent, nil
 }
 
 func parseOutpoint(outpoint string) (string, int, bool) {

--- a/sidechain-orchestrator/engines/split_engine_test.go
+++ b/sidechain-orchestrator/engines/split_engine_test.go
@@ -23,6 +23,11 @@ type fakeOutspend struct {
 	mempoolSpent map[string]bool
 	missing      map[string]bool
 	fail         map[string]bool
+	// unknownTx names transactions Bitcoin never saw. Their outputs still read
+	// as "not spent", the way a real server answers.
+	unknownTx map[string]bool
+	txCalls   map[string]int
+	txFail    map[string]bool
 }
 
 func newFakeOutspend() *fakeOutspend {
@@ -32,7 +37,18 @@ func newFakeOutspend() *fakeOutspend {
 		mempoolSpent: map[string]bool{},
 		missing:      map[string]bool{},
 		fail:         map[string]bool{},
+		unknownTx:    map[string]bool{},
+		txCalls:      map[string]int{},
+		txFail:       map[string]bool{},
 	}
+}
+
+func (f *fakeOutspend) TxKnown(_ context.Context, txid string) (bool, error) {
+	f.txCalls[txid]++
+	if f.txFail[txid] {
+		return false, errors.New("boom")
+	}
+	return !f.unknownTx[txid], nil
 }
 
 func (f *fakeOutspend) Outspend(_ context.Context, txid string, vout int) (wallet.EsploraOutspend, bool, error) {
@@ -344,4 +360,50 @@ func TestCheckReplayStatusReturnsTheLookupError(t *testing.T) {
 func (e *SplitEngine) passRecheckInterval() {
 	base := e.now()
 	e.now = func() time.Time { return base.Add(absentRecheckInterval) }
+}
+
+// TestSplitEngineIgnoresCoinBitcoinNeverSaw: a server answers "not spent" for a
+// transaction it never saw, exactly as it does for a live output. A coin this
+// chain alone made must not read as a coin both chains hold.
+func TestSplitEngineIgnoresCoinBitcoinNeverSaw(t *testing.T) {
+	btc := newFakeOutspend()
+	btc.unknownTx["aa"] = true
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "ecash")
+
+	e.tick(context.Background())
+
+	require.Equal(t, 1, btc.txCalls["aa"])
+	require.Empty(t, store.statuses)
+}
+
+// TestSplitEngineAsksNothingMoreForASpentCoin: a spend proves the transaction
+// exists, so the second lookup is wasted.
+func TestSplitEngineAsksNothingMoreForASpentCoin(t *testing.T) {
+	btc := newFakeOutspend()
+	btc.spent["aa:0"] = true
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "ecash")
+
+	e.tick(context.Background())
+
+	require.Equal(t, 0, btc.txCalls["aa"])
+	require.Equal(t, map[string]bool{"aa:0": false}, store.statuses)
+}
+
+// TestSplitEngineRetriesAfterTxLookupError: a dead provider must leave the coin
+// open for the next tick, not cache a guess.
+func TestSplitEngineRetriesAfterTxLookupError(t *testing.T) {
+	btc := newFakeOutspend()
+	btc.txFail["aa"] = true
+	store := &fakeSplitStore{statuses: map[string]bool{}}
+	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "ecash")
+
+	e.tick(context.Background())
+	require.Empty(t, store.statuses)
+
+	btc.txFail["aa"] = false
+	e.tick(context.Background())
+
+	require.Equal(t, map[string]bool{"aa:0": true}, store.statuses)
 }

--- a/sidechain-orchestrator/wallet/esplora.go
+++ b/sidechain-orchestrator/wallet/esplora.go
@@ -485,11 +485,10 @@ type EsploraOutspend struct {
 	Status EsploraStatus `json:"status"`
 }
 
-// Outspend reports the spend status of one output. found is false only when
-// every configured server answers 404 — one server's 404 is not authoritative
+// getAcrossRoots asks each configured server in turn for path. found is false
+// only when every server answers 404 — one server's 404 is not authoritative
 // (a provider with a broken index serves 404 for everything).
-func (c *EsploraClient) Outspend(ctx context.Context, txid string, vout int) (EsploraOutspend, bool, error) {
-	path := "/tx/" + txid + "/outspend/" + strconv.Itoa(vout)
+func (c *EsploraClient) getAcrossRoots(ctx context.Context, path string) ([]byte, bool, error) {
 	roots := c.BaseURLs()
 	notFound := 0
 	var lastErr error
@@ -506,19 +505,39 @@ func (c *EsploraClient) Outspend(ctx context.Context, txid string, vout int) (Es
 			lastErr = err
 			continue
 		}
-		var o EsploraOutspend
-		if err := json.Unmarshal(body, &o); err != nil {
-			return EsploraOutspend{}, false, fmt.Errorf("decode %s: %w", path, err)
-		}
-		return o, true, nil
+		return body, true, nil
 	}
 	if notFound == len(roots) && notFound > 0 {
-		return EsploraOutspend{}, false, nil
+		return nil, false, nil
 	}
 	if lastErr == nil {
 		lastErr = fmt.Errorf("no server configured")
 	}
-	return EsploraOutspend{}, false, fmt.Errorf("outspend %s: %w", path, lastErr)
+	return nil, false, fmt.Errorf("get %s: %w", path, lastErr)
+}
+
+// Outspend reports the spend status of one output. found is false only when
+// every configured server answers 404.
+//
+// A "not spent" answer is not proof the output exists: a server that never saw
+// the transaction answers the same way. Pair it with TxKnown.
+func (c *EsploraClient) Outspend(ctx context.Context, txid string, vout int) (EsploraOutspend, bool, error) {
+	path := "/tx/" + txid + "/outspend/" + strconv.Itoa(vout)
+	body, found, err := c.getAcrossRoots(ctx, path)
+	if err != nil || !found {
+		return EsploraOutspend{}, false, err
+	}
+	var o EsploraOutspend
+	if err := json.Unmarshal(body, &o); err != nil {
+		return EsploraOutspend{}, false, fmt.Errorf("decode %s: %w", path, err)
+	}
+	return o, true, nil
+}
+
+// TxKnown reports whether the servers hold this transaction at all.
+func (c *EsploraClient) TxKnown(ctx context.Context, txid string) (bool, error) {
+	_, found, err := c.getAcrossRoots(ctx, "/tx/"+txid+"/status")
+	return found, err
 }
 
 // TxHex returns the raw transaction hex.


### PR DESCRIPTION
An esplora server answers `200 {"spent":false}` for a transaction it never saw, exactly as it does for a live output. `/tx/<txid>` gives 404 for the same transaction.

The split engine read that as "the coin exists on Bitcoin", so every coin this chain alone made looked shared, and the send asked about replay protection for coins that cannot replay.

A spend still proves the transaction exists, so that path costs no extra request. Only the "not spent" answer now asks `/tx/<txid>/status`.