### PR TITLE
Ask one server both replay questions

### DIFF
--- a/sidechain-orchestrator/engines/split_engine.go
+++ b/sidechain-orchestrator/engines/split_engine.go
@@ -34,11 +34,10 @@ type UnspentSource interface {
 	WalletUnspent(ctx context.Context) ([]fork.Utxo, error)
 }
 
-// OutspendSource answers BTC-mainnet spend status per output, and whether a
-// transaction exists there at all.
+// OutspendSource answers BTC-mainnet spend status per output. The bool reports
+// whether Bitcoin holds the transaction at all.
 type OutspendSource interface {
 	Outspend(ctx context.Context, txid string, vout int) (wallet.EsploraOutspend, bool, error)
-	TxKnown(ctx context.Context, txid string) (bool, error)
 }
 
 // SplitStore persists the per-outpoint split status.
@@ -215,18 +214,9 @@ func checkReplayStatus(ctx context.Context, btc OutspendSource, outpoint string)
 		return btcPending, nil
 	case out.Spent:
 		return btcSpent, nil
+	default:
+		return btcUnspent, nil
 	}
-	// A server that never saw the transaction reports the same "not spent" as
-	// one holding a live output, so the coin counts as shared only once the
-	// transaction itself turns up.
-	known, err := btc.TxKnown(ctx, txid)
-	if err != nil {
-		return btcUnknown, err
-	}
-	if !known {
-		return btcUnknown, nil
-	}
-	return btcUnspent, nil
 }
 
 func parseOutpoint(outpoint string) (string, int, bool) {

--- a/sidechain-orchestrator/engines/split_engine_test.go
+++ b/sidechain-orchestrator/engines/split_engine_test.go
@@ -23,11 +23,8 @@ type fakeOutspend struct {
 	mempoolSpent map[string]bool
 	missing      map[string]bool
 	fail         map[string]bool
-	// unknownTx names transactions Bitcoin never saw. Their outputs still read
-	// as "not spent", the way a real server answers.
+	// unknownTx names transactions Bitcoin never saw.
 	unknownTx map[string]bool
-	txCalls   map[string]int
-	txFail    map[string]bool
 }
 
 func newFakeOutspend() *fakeOutspend {
@@ -38,17 +35,7 @@ func newFakeOutspend() *fakeOutspend {
 		missing:      map[string]bool{},
 		fail:         map[string]bool{},
 		unknownTx:    map[string]bool{},
-		txCalls:      map[string]int{},
-		txFail:       map[string]bool{},
 	}
-}
-
-func (f *fakeOutspend) TxKnown(_ context.Context, txid string) (bool, error) {
-	f.txCalls[txid]++
-	if f.txFail[txid] {
-		return false, errors.New("boom")
-	}
-	return !f.unknownTx[txid], nil
 }
 
 func (f *fakeOutspend) Outspend(_ context.Context, txid string, vout int) (wallet.EsploraOutspend, bool, error) {
@@ -57,7 +44,7 @@ func (f *fakeOutspend) Outspend(_ context.Context, txid string, vout int) (walle
 	if f.fail[op] {
 		return wallet.EsploraOutspend{}, false, errors.New("boom")
 	}
-	if f.missing[op] {
+	if f.missing[op] || f.unknownTx[txid] {
 		return wallet.EsploraOutspend{}, false, nil
 	}
 	if f.mempoolSpent[op] {
@@ -373,37 +360,6 @@ func TestSplitEngineIgnoresCoinBitcoinNeverSaw(t *testing.T) {
 
 	e.tick(context.Background())
 
-	require.Equal(t, 1, btc.txCalls["aa"])
+	require.Equal(t, 1, btc.calls["aa:0"])
 	require.Empty(t, store.statuses)
-}
-
-// TestSplitEngineAsksNothingMoreForASpentCoin: a spend proves the transaction
-// exists, so the second lookup is wasted.
-func TestSplitEngineAsksNothingMoreForASpentCoin(t *testing.T) {
-	btc := newFakeOutspend()
-	btc.spent["aa:0"] = true
-	store := &fakeSplitStore{statuses: map[string]bool{}}
-	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "ecash")
-
-	e.tick(context.Background())
-
-	require.Equal(t, 0, btc.txCalls["aa"])
-	require.Equal(t, map[string]bool{"aa:0": false}, store.statuses)
-}
-
-// TestSplitEngineRetriesAfterTxLookupError: a dead provider must leave the coin
-// open for the next tick, not cache a guess.
-func TestSplitEngineRetriesAfterTxLookupError(t *testing.T) {
-	btc := newFakeOutspend()
-	btc.txFail["aa"] = true
-	store := &fakeSplitStore{statuses: map[string]bool{}}
-	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "ecash")
-
-	e.tick(context.Background())
-	require.Empty(t, store.statuses)
-
-	btc.txFail["aa"] = false
-	e.tick(context.Background())
-
-	require.Equal(t, map[string]bool{"aa:0": true}, store.statuses)
 }

--- a/sidechain-orchestrator/wallet/esplora.go
+++ b/sidechain-orchestrator/wallet/esplora.go
@@ -485,59 +485,67 @@ type EsploraOutspend struct {
 	Status EsploraStatus `json:"status"`
 }
 
-// getAcrossRoots asks each configured server in turn for path. found is false
-// only when every server answers 404 — one server's 404 is not authoritative
-// (a provider with a broken index serves 404 for everything).
-func (c *EsploraClient) getAcrossRoots(ctx context.Context, path string) ([]byte, bool, error) {
+func isNotFound(err error) bool {
+	var statusErr *esploraStatusError
+	return errors.As(err, &statusErr) && statusErr.code == http.StatusNotFound
+}
+
+// getFrom asks one server for path. One attempt only — a dead host must fail
+// over at once, and the engine tick is the retry mechanism.
+func (c *EsploraClient) getFrom(ctx context.Context, root, path string) ([]byte, error) {
+	return c.doWith(ctx, []string{root}, 1, http.MethodGet, path, nil)
+}
+
+// Outspend reports the spend status of one output, and whether the server that
+// answered holds the transaction at all. known is false only when every server
+// answers 404 for the transaction.
+//
+// A "not spent" answer alone proves nothing: a server that never saw the
+// transaction answers the same way as one holding a live output. Both facts
+// therefore come from one server, so they describe the same view of the chain.
+func (c *EsploraClient) Outspend(ctx context.Context, txid string, vout int) (EsploraOutspend, bool, error) {
+	status := "/tx/" + txid + "/status"
+	spend := "/tx/" + txid + "/outspend/" + strconv.Itoa(vout)
 	roots := c.BaseURLs()
 	notFound := 0
 	var lastErr error
 	for _, root := range roots {
-		// One attempt per root — a dead host must fail over at once, and the
-		// engine tick is the retry mechanism.
-		body, err := c.doWith(ctx, []string{root}, 1, http.MethodGet, path, nil)
+		body, err := c.getFrom(ctx, root, spend)
 		if err != nil {
-			var statusErr *esploraStatusError
-			if errors.As(err, &statusErr) && statusErr.code == http.StatusNotFound {
+			if isNotFound(err) {
 				notFound++
 				continue
 			}
 			lastErr = err
 			continue
 		}
-		return body, true, nil
+		var o EsploraOutspend
+		if err := json.Unmarshal(body, &o); err != nil {
+			return EsploraOutspend{}, false, fmt.Errorf("decode %s: %w", spend, err)
+		}
+		// A spend proves this server holds the transaction.
+		if o.Spent {
+			return o, true, nil
+		}
+		// The spend answer comes first, so a transaction that drops out of the
+		// mempool between the two reads shows up as absent, not as unspent.
+		if _, err := c.getFrom(ctx, root, status); err != nil {
+			if isNotFound(err) {
+				notFound++
+				continue
+			}
+			lastErr = err
+			continue
+		}
+		return o, true, nil
 	}
 	if notFound == len(roots) && notFound > 0 {
-		return nil, false, nil
+		return EsploraOutspend{}, false, nil
 	}
 	if lastErr == nil {
 		lastErr = fmt.Errorf("no server configured")
 	}
-	return nil, false, fmt.Errorf("get %s: %w", path, lastErr)
-}
-
-// Outspend reports the spend status of one output. found is false only when
-// every configured server answers 404.
-//
-// A "not spent" answer is not proof the output exists: a server that never saw
-// the transaction answers the same way. Pair it with TxKnown.
-func (c *EsploraClient) Outspend(ctx context.Context, txid string, vout int) (EsploraOutspend, bool, error) {
-	path := "/tx/" + txid + "/outspend/" + strconv.Itoa(vout)
-	body, found, err := c.getAcrossRoots(ctx, path)
-	if err != nil || !found {
-		return EsploraOutspend{}, false, err
-	}
-	var o EsploraOutspend
-	if err := json.Unmarshal(body, &o); err != nil {
-		return EsploraOutspend{}, false, fmt.Errorf("decode %s: %w", path, err)
-	}
-	return o, true, nil
-}
-
-// TxKnown reports whether the servers hold this transaction at all.
-func (c *EsploraClient) TxKnown(ctx context.Context, txid string) (bool, error) {
-	_, found, err := c.getAcrossRoots(ctx, "/tx/"+txid+"/status")
-	return found, err
+	return EsploraOutspend{}, false, fmt.Errorf("outspend %s: %w", spend, lastErr)
 }
 
 // TxHex returns the raw transaction hex.

--- a/sidechain-orchestrator/wallet/esplora_outspend_test.go
+++ b/sidechain-orchestrator/wallet/esplora_outspend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -22,8 +23,12 @@ func outspendServer(t *testing.T, status int, body string) *httptest.Server {
 }
 
 func TestEsploraOutspendUnspent(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/tx/aa/outspend/1", r.URL.Path)
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"spent":false}`))
 	}))
@@ -36,6 +41,8 @@ func TestEsploraOutspendUnspent(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.False(t, out.Spent)
+	// One server answers both questions, so the two facts agree.
+	require.Equal(t, []string{"/api/tx/aa/outspend/1", "/api/tx/aa/status"}, paths)
 }
 
 // A 404 from every server means the transaction is not on the chain.

--- a/sidechain-orchestrator/wallet/esplora_test.go
+++ b/sidechain-orchestrator/wallet/esplora_test.go
@@ -47,3 +47,81 @@ func TestEsploraAddressTxsPaginationUsesConfirmedCursor(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, txs, 27, "all pages must be fetched via the confirmed cursor")
 }
+
+// outspendStub answers the status and outspend paths for one transaction.
+func outspendStub(t *testing.T, txid string, knowsTx bool, spent string, hits *int) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*hits++
+		switch r.URL.Path {
+		case "/api/tx/" + txid + "/status":
+			if !knowsTx {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			_, _ = w.Write([]byte(`{"confirmed":true}`))
+		case "/api/tx/" + txid + "/outspend/0":
+			_, _ = w.Write([]byte(spent))
+		default:
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL + "/api"
+}
+
+// TestEsploraOutspendKeepsOneProvider: a server answers "not spent" for a
+// transaction it never saw. Taking that answer from one server and the
+// transaction from another reports a spent coin as unspent.
+func TestEsploraOutspendKeepsOneProvider(t *testing.T) {
+	const txid = "aa"
+	var blindHits, knowingHits int
+	blind := outspendStub(t, txid, false, `{"spent":false}`, &blindHits)
+	knowing := outspendStub(t, txid, true, `{"spent":true,"status":{"confirmed":true}}`, &knowingHits)
+
+	client := NewEsploraClient([]string{blind, knowing}, zerolog.Nop())
+	out, found, err := client.Outspend(context.Background(), txid, 0)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.True(t, out.Spent, "the answer must come from the server that holds the transaction")
+	// The spend answer comes first, then the transaction check exposes the
+	// server that does not hold it.
+	require.Equal(t, 2, blindHits)
+}
+
+// TestEsploraOutspendUnknownEverywhere: no server holds the transaction, so the
+// coin is not one Bitcoin knows.
+func TestEsploraOutspendUnknownEverywhere(t *testing.T) {
+	const txid = "aa"
+	var a, b int
+	client := NewEsploraClient([]string{
+		outspendStub(t, txid, false, `{"spent":false}`, &a),
+		outspendStub(t, txid, false, `{"spent":false}`, &b),
+	}, zerolog.Nop())
+
+	_, found, err := client.Outspend(context.Background(), txid, 0)
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Equal(t, 2, a)
+	require.Equal(t, 2, b)
+}
+
+// TestEsploraOutspendEvictedTransaction: a transaction can drop out of the
+// mempool between the two reads. The coin must read as absent, because the
+// engine caches an "unspent" answer forever.
+func TestEsploraOutspendEvictedTransaction(t *testing.T) {
+	const txid = "aa"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/tx/"+txid+"/status" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{"spent":false}`))
+	}))
+	defer srv.Close()
+
+	client := NewEsploraClient([]string{srv.URL + "/api"}, zerolog.Nop())
+	_, found, err := client.Outspend(context.Background(), txid, 0)
+	require.NoError(t, err)
+	require.False(t, found)
+}


### PR DESCRIPTION
A server that never saw a transaction answers `{"spent":false}` for its outputs. #2123 asked a second question to tell that apart, but the two answers could come from two different servers: the primary can report a generic "not spent" for a transaction it lacks, while the secondary holds it and knows the output is spent. The engine then cached the coin as splittable forever.

`Outspend` now walks the servers and asks one of them both questions. A server that does not hold the transaction moves to the next.

Fixes the P1 that Codex raised on #2123.