### PR TITLE
orchestrator: catch a hardware signer fault at the device

### DIFF
--- a/sidechain-orchestrator/api/wallet_handler.go
+++ b/sidechain-orchestrator/api/wallet_handler.go
@@ -473,6 +473,9 @@ func (h *WalletHandler) CreateMultisigWallet(ctx context.Context, req *connect.R
 			}
 			xpub = derived
 		}
+		if err := wallet.CheckCosignerKeyMatchesOrigin(xpub, c.OriginPath); err != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		}
 		cosigners = append(cosigners, wallet.MultisigCosigner{
 			Xpub:               xpub,
 			OriginPath:         c.OriginPath,

--- a/sidechain-orchestrator/engines/split_engine.go
+++ b/sidechain-orchestrator/engines/split_engine.go
@@ -34,11 +34,10 @@ type UnspentSource interface {
 	WalletUnspent(ctx context.Context) ([]fork.Utxo, error)
 }
 
-// OutspendSource answers BTC-mainnet spend status per output, and whether a
-// transaction exists there at all.
+// OutspendSource answers BTC-mainnet spend status per output. The bool reports
+// whether Bitcoin holds the transaction at all.
 type OutspendSource interface {
 	Outspend(ctx context.Context, txid string, vout int) (wallet.EsploraOutspend, bool, error)
-	TxKnown(ctx context.Context, txid string) (bool, error)
 }
 
 // SplitStore persists the per-outpoint split status.
@@ -215,18 +214,9 @@ func checkReplayStatus(ctx context.Context, btc OutspendSource, outpoint string)
 		return btcPending, nil
 	case out.Spent:
 		return btcSpent, nil
+	default:
+		return btcUnspent, nil
 	}
-	// A server that never saw the transaction reports the same "not spent" as
-	// one holding a live output, so the coin counts as shared only once the
-	// transaction itself turns up.
-	known, err := btc.TxKnown(ctx, txid)
-	if err != nil {
-		return btcUnknown, err
-	}
-	if !known {
-		return btcUnknown, nil
-	}
-	return btcUnspent, nil
 }
 
 func parseOutpoint(outpoint string) (string, int, bool) {

--- a/sidechain-orchestrator/engines/split_engine_test.go
+++ b/sidechain-orchestrator/engines/split_engine_test.go
@@ -23,11 +23,8 @@ type fakeOutspend struct {
 	mempoolSpent map[string]bool
 	missing      map[string]bool
 	fail         map[string]bool
-	// unknownTx names transactions Bitcoin never saw. Their outputs still read
-	// as "not spent", the way a real server answers.
+	// unknownTx names transactions Bitcoin never saw.
 	unknownTx map[string]bool
-	txCalls   map[string]int
-	txFail    map[string]bool
 }
 
 func newFakeOutspend() *fakeOutspend {
@@ -38,17 +35,7 @@ func newFakeOutspend() *fakeOutspend {
 		missing:      map[string]bool{},
 		fail:         map[string]bool{},
 		unknownTx:    map[string]bool{},
-		txCalls:      map[string]int{},
-		txFail:       map[string]bool{},
 	}
-}
-
-func (f *fakeOutspend) TxKnown(_ context.Context, txid string) (bool, error) {
-	f.txCalls[txid]++
-	if f.txFail[txid] {
-		return false, errors.New("boom")
-	}
-	return !f.unknownTx[txid], nil
 }
 
 func (f *fakeOutspend) Outspend(_ context.Context, txid string, vout int) (wallet.EsploraOutspend, bool, error) {
@@ -57,7 +44,7 @@ func (f *fakeOutspend) Outspend(_ context.Context, txid string, vout int) (walle
 	if f.fail[op] {
 		return wallet.EsploraOutspend{}, false, errors.New("boom")
 	}
-	if f.missing[op] {
+	if f.missing[op] || f.unknownTx[txid] {
 		return wallet.EsploraOutspend{}, false, nil
 	}
 	if f.mempoolSpent[op] {
@@ -373,37 +360,6 @@ func TestSplitEngineIgnoresCoinBitcoinNeverSaw(t *testing.T) {
 
 	e.tick(context.Background())
 
-	require.Equal(t, 1, btc.txCalls["aa"])
+	require.Equal(t, 1, btc.calls["aa:0"])
 	require.Empty(t, store.statuses)
-}
-
-// TestSplitEngineAsksNothingMoreForASpentCoin: a spend proves the transaction
-// exists, so the second lookup is wasted.
-func TestSplitEngineAsksNothingMoreForASpentCoin(t *testing.T) {
-	btc := newFakeOutspend()
-	btc.spent["aa:0"] = true
-	store := &fakeSplitStore{statuses: map[string]bool{}}
-	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "ecash")
-
-	e.tick(context.Background())
-
-	require.Equal(t, 0, btc.txCalls["aa"])
-	require.Equal(t, map[string]bool{"aa:0": false}, store.statuses)
-}
-
-// TestSplitEngineRetriesAfterTxLookupError: a dead provider must leave the coin
-// open for the next tick, not cache a guess.
-func TestSplitEngineRetriesAfterTxLookupError(t *testing.T) {
-	btc := newFakeOutspend()
-	btc.txFail["aa"] = true
-	store := &fakeSplitStore{statuses: map[string]bool{}}
-	e := newTestSplitEngine(forkStateWith(), preFork("aa:0"), btc, store, "ecash")
-
-	e.tick(context.Background())
-	require.Empty(t, store.statuses)
-
-	btc.txFail["aa"] = false
-	e.tick(context.Background())
-
-	require.Equal(t, map[string]bool{"aa:0": true}, store.statuses)
 }

--- a/sidechain-orchestrator/hwi-daemon/hwi_daemon.py
+++ b/sidechain-orchestrator/hwi-daemon/hwi_daemon.py
@@ -7,6 +7,7 @@ firmware, so promptpin and sendpin are two independent opens.
 """
 
 import json
+import os
 import sys
 
 from hwilib import commands
@@ -19,6 +20,27 @@ CHAINS = {
     "signet": Chain.SIGNET,
     "regtest": Chain.REGTEST,
 }
+
+
+def _enable_protocol_log():
+    """Write every message the host sends to the device, and every answer.
+
+    A device that signs a transaction the host did not build shows the fault
+    only in the messages between them. The messages carry the PIN and the
+    passphrase, so the log stays off until HWI_PROTOCOL_LOG asks for it.
+    """
+    if not os.environ.get("HWI_PROTOCOL_LOG"):
+        return
+    try:
+        import logging
+
+        from trezorlib import log as trezor_log
+
+        trezor_log.enable_debug_output()
+        logging.getLogger("trezorlib").setLevel(logging.DEBUG)
+        _log("protocol log enabled")
+    except Exception as e:  # A device library the build leaves out must not stop the daemon.
+        _log("protocol log unavailable: %s" % e)
 
 
 def _chain(req):
@@ -102,6 +124,7 @@ def _write(obj):
 
 
 def main():
+    _enable_protocol_log()
     for line in sys.stdin:
         line = line.strip()
         if not line:

--- a/sidechain-orchestrator/wallet/cosigner_origin.go
+++ b/sidechain-orchestrator/wallet/cosigner_origin.go
@@ -1,0 +1,60 @@
+package wallet
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+)
+
+// CheckCosignerKeyMatchesOrigin makes sure a cosigner key belongs at the path
+// the wallet records for it. A key and a path that disagree build a correct
+// script with a wrong label, and a hardware signer then derives a key the
+// script does not hold and signs for it. The depth of an extended key counts
+// the steps from the master, so it must equal the length of the origin path.
+func CheckCosignerKeyMatchesOrigin(xpub, originPath string) error {
+	trimmed := strings.TrimSpace(xpub)
+	if trimmed == "" {
+		return nil
+	}
+	steps, err := countPathSteps(originPath)
+	if err != nil {
+		return err
+	}
+	// A cosigner pasted as a bare xpub gives no origin, so it claims no
+	// derivation, and no path contradicts its depth.
+	if steps == 0 {
+		return nil
+	}
+	key, err := hdkeychain.NewKeyFromString(trimmed)
+	if err != nil {
+		return fmt.Errorf("read the cosigner key: %w", err)
+	}
+	if int(key.Depth()) == steps {
+		return nil
+	}
+	return fmt.Errorf(
+		"the cosigner key sits %d steps from its master key, and the origin %s names %d; the key does not come from that path, so a hardware signer derives a key this wallet does not hold",
+		key.Depth(), displayOrigin(originPath), steps)
+}
+
+// countPathSteps counts the elements of an origin path, with or without the
+// leading "m/".
+func countPathSteps(originPath string) (int, error) {
+	path, ok := parseOriginPath(originPath)
+	if !ok {
+		return 0, fmt.Errorf("the origin path %q is not a derivation path", originPath)
+	}
+	return len(path), nil
+}
+
+func displayOrigin(originPath string) string {
+	p := strings.Trim(strings.TrimSpace(originPath), "/")
+	if p == "" {
+		return "m"
+	}
+	if strings.HasPrefix(p, "m/") {
+		return p
+	}
+	return "m/" + p
+}

--- a/sidechain-orchestrator/wallet/cosigner_origin_test.go
+++ b/sidechain-orchestrator/wallet/cosigner_origin_test.go
@@ -1,0 +1,41 @@
+package wallet
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCosignerKeyMustMatchItsOrigin: a key and a path that disagree build a
+// correct script with a wrong label, and only the label fails a hardware signer.
+func TestCosignerKeyMustMatchItsOrigin(t *testing.T) {
+	net := &chaincfg.MainNetParams
+	seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, ""))
+	account, err := DeriveAccountXpub(seedHex, "m/48'/0'/0'/2'", net)
+	require.NoError(t, err)
+	seed, err := hex.DecodeString(seedHex)
+	require.NoError(t, err)
+	root, err := hdkeychain.NewMaster(seed, net)
+	require.NoError(t, err)
+	rootPub, err := root.Neuter()
+	require.NoError(t, err)
+	master := rootPub.String()
+
+	require.NoError(t, CheckCosignerKeyMatchesOrigin(account, "48'/0'/0'/2'"))
+	require.NoError(t, CheckCosignerKeyMatchesOrigin(account, "m/48'/0'/1'/2'"),
+		"the depth cannot tell one account from another")
+	require.NoError(t, CheckCosignerKeyMatchesOrigin(master, ""))
+	require.NoError(t, CheckCosignerKeyMatchesOrigin("", "48'/0'/0'/2'"))
+	// A cosigner pasted as a bare xpub gives an account key and no origin, and
+	// the wallet supports it.
+	require.NoError(t, CheckCosignerKeyMatchesOrigin(account, ""))
+	require.NoError(t, CheckCosignerKeyMatchesOrigin(account, "m/"))
+
+	err = CheckCosignerKeyMatchesOrigin(master, "48'/0'/0'/2'")
+	require.ErrorContains(t, err, "sits 0 steps")
+	err = CheckCosignerKeyMatchesOrigin(account, "48'/0'")
+	require.ErrorContains(t, err, "sits 4 steps")
+}

--- a/sidechain-orchestrator/wallet/descriptor.go
+++ b/sidechain-orchestrator/wallet/descriptor.go
@@ -327,8 +327,28 @@ func parseOrigin(origin string) (uint32, []uint32, bool) {
 	if err != nil || len(fpBytes) != 4 {
 		return 0, nil, false
 	}
-	path := make([]uint32, 0, len(parts)-1)
-	for _, seg := range parts[1:] {
+	path, ok := parsePathSegments(parts[1:])
+	if !ok {
+		return 0, nil, false
+	}
+	return binary.LittleEndian.Uint32(fpBytes), path, true
+}
+
+// parseOriginPath parses a derivation path, with or without a leading "m/",
+// into the hardened-aware elements a descriptor origin records.
+func parseOriginPath(path string) ([]uint32, bool) {
+	segs := strings.Split(strings.TrimSpace(path), "/")
+	if segs[0] == "m" || segs[0] == "M" || segs[0] == "" {
+		segs = segs[1:]
+	}
+	return parsePathSegments(segs)
+}
+
+// parsePathSegments parses "84h/0h/0h" written as its segments. A hardened
+// segment ends in h, H, or an apostrophe.
+func parsePathSegments(segs []string) ([]uint32, bool) {
+	path := make([]uint32, 0, len(segs))
+	for _, seg := range segs {
 		if seg == "" {
 			continue
 		}
@@ -339,7 +359,7 @@ func parseOrigin(origin string) (uint32, []uint32, bool) {
 		}
 		n, err := strconv.ParseUint(seg, 10, 32)
 		if err != nil {
-			return 0, nil, false
+			return nil, false
 		}
 		v := uint32(n)
 		if hardened {
@@ -347,7 +367,7 @@ func parseOrigin(origin string) (uint32, []uint32, bool) {
 		}
 		path = append(path, v)
 	}
-	return binary.LittleEndian.Uint32(fpBytes), path, true
+	return path, true
 }
 
 // keyFingerprint computes an extended key's own fingerprint (hash160 of its

--- a/sidechain-orchestrator/wallet/descriptor.go
+++ b/sidechain-orchestrator/wallet/descriptor.go
@@ -303,9 +303,12 @@ func (d *Descriptor) derivations(change bool, index uint32) ([]keyDerivation, er
 			fp = keyFingerprint(k.Account)
 			path = []uint32{chain, index}
 		default:
-			// A hardware signer checks every path in the packet before it signs
-			// any of them, so one made-up path fails the whole transaction.
-			continue
+			// The key stands, but its path from a master does not. An empty path
+			// names the key without claiming a derivation: a made-up path fails
+			// a hardware signer, and no record at all leaves it a script with a
+			// key missing.
+			fp = keyFingerprint(k.Account)
+			path = nil
 		}
 		out = append(out, keyDerivation{pub: pub, fingerprint: fp, path: path})
 	}

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -1024,11 +1024,9 @@ func (p *ElectrumBackend) buildSendPSBT(ctx context.Context, walletID string, sc
 		effect.change = &changeAddr
 		effect.changeSats = changeSats
 		outputs = append(outputs, TxOutSpec{
-			Address:     changeAddr.address,
-			AmountBTC:   float64(changeSats) / 1e8,
-			Kind:        changeAddr.kind,
-			Derivations: changeAddr.derivations,
-		})
+			Address:   changeAddr.address,
+			AmountBTC: float64(changeSats) / 1e8,
+		}.describeOwned(changeAddr))
 	}
 
 	// External inputs come first (e.g. the CTIP at input 0), then wallet inputs.
@@ -1494,8 +1492,7 @@ func (p *ElectrumBackend) BumpFee(ctx context.Context, walletID string, req Bump
 		}
 		spec.Address = vout.ScriptPubKeyAddress
 		if sa, owned := scan.byAddr[vout.ScriptPubKeyAddress]; owned {
-			spec.Kind = sa.kind
-			spec.Derivations = sa.derivations
+			spec = spec.describeOwned(sa)
 			// Every output this wallet owns goes back into the cache, not only
 			// the change one: a consolidation pays itself on the receive branch.
 			effect.credited = append(effect.credited, walletCredit{addr: sa, sats: amount, vout: len(outputs)})

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -1167,6 +1167,36 @@ func (p *ElectrumBackend) SignPSBTWithCosigner(ctx context.Context, walletID, ps
 			amount:   out.Value,
 			addr:     sa,
 		}
+		// A hardware signer refuses a multisig path that is not BIP48 or BIP45,
+		// and it names neither the key nor the path in its answer.
+		paths := make([]string, 0, len(packet.Inputs[i].Bip32Derivation))
+		for _, d := range packet.Inputs[i].Bip32Derivation {
+			var fp [4]byte
+			binary.LittleEndian.PutUint32(fp[:], d.MasterKeyFingerprint)
+			paths = append(paths, fmt.Sprintf("%x=%s", fp, pathString(d.Bip32Path)))
+		}
+		// The device signs over the amount the packet carries; this backend checks
+		// the signature against the amount it looks up. A difference between the
+		// two reads as a bad signature and says nothing about the cause.
+		var packetAmount int64 = -1
+		if wu := packet.Inputs[i].WitnessUtxo; wu != nil {
+			packetAmount = wu.Value
+		}
+		p.log.Info().
+			Str("wallet", walletID).
+			Int("input", i).
+			Str("kind", sa.kind.String()).
+			Int64("amount", out.Value).
+			Int64("packet_amount", packetAmount).
+			Int("witness_script_bytes", len(packet.Inputs[i].WitnessScript)).
+			Uint32("sighash", uint32(packet.Inputs[i].SighashType)).
+			Bool("change", change).
+			Uint32("index", index).
+			Int("keys", len(desc.Keys)).
+			Int("derivations", len(sa.derivations)).
+			Int("global_xpubs", len(packet.XPubs)).
+			Strs("paths", paths).
+			Msg("multisig input ready to sign")
 	}
 	if _, err := signPSBT(packet, inputs, net); err != nil {
 		return "", err

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -641,6 +642,7 @@ func (p *ElectrumBackend) signAndBroadcast(ctx context.Context, walletID string,
 	}
 	hexToSend, err := finalizeAndExtract(packet)
 	if err != nil {
+		p.logRejectedPacket(packet, err)
 		return "", err
 	}
 	txid, err := p.client.Broadcast(ctx, hexToSend)
@@ -1218,7 +1220,43 @@ func (p *ElectrumBackend) FinalizePSBT(psbtBase64 string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return finalizeAndExtract(packet)
+	raw, err := finalizeAndExtract(packet)
+	if err != nil {
+		p.logRejectedPacket(packet, err)
+		return "", err
+	}
+	return raw, nil
+}
+
+// logRejectedPacket writes what a finalizer rejected. A signature a device gives
+// and this backend refuses is the one failure the packet alone explains, so the
+// report carries the packet, the transaction, and every key the input names.
+func (p *ElectrumBackend) logRejectedPacket(packet *psbt.Packet, cause error) {
+	event := p.log.Error().Err(cause)
+	if b64, err := packet.B64Encode(); err == nil {
+		event = event.Str("psbt", b64)
+	}
+	if packet.UnsignedTx != nil {
+		event = event.Str("txid", packet.UnsignedTx.TxHash().String())
+	}
+	for i := range packet.Inputs {
+		in := &packet.Inputs[i]
+		keys := make([]string, 0, len(in.Bip32Derivation))
+		for _, d := range in.Bip32Derivation {
+			var fp [4]byte
+			binary.LittleEndian.PutUint32(fp[:], d.MasterKeyFingerprint)
+			keys = append(keys, fmt.Sprintf("%x=%s=%x", fp, pathString(d.Bip32Path), d.PubKey))
+		}
+		sigs := make([]string, 0, len(in.PartialSigs))
+		for _, ps := range in.PartialSigs {
+			sigs = append(sigs, fmt.Sprintf("%x=%x", ps.PubKey, ps.Signature))
+		}
+		event = event.
+			Strs(fmt.Sprintf("input%d_keys", i), keys).
+			Strs(fmt.Sprintf("input%d_sigs", i), sigs).
+			Str(fmt.Sprintf("input%d_witness_script", i), hex.EncodeToString(in.WitnessScript))
+	}
+	event.Msg("the finalizer rejected this packet")
 }
 
 // psbtInputsFromPacket reconstructs the per-input signing metadata for a PSBT by

--- a/sidechain-orchestrator/wallet/electrum_backend.go
+++ b/sidechain-orchestrator/wallet/electrum_backend.go
@@ -1820,6 +1820,14 @@ func (p *ElectrumBackend) multisigSigningDescriptor(w *WalletData) (*Descriptor,
 	return p.multisigSigningDescriptorFor(w, "")
 }
 
+// shortXpub names a key in a log line without printing the whole thing.
+func shortXpub(xpub string) string {
+	if len(xpub) <= 16 {
+		return xpub
+	}
+	return xpub[:12] + "…" + xpub[len(xpub)-4:]
+}
+
 // multisigSigningDescriptorFor builds the multisig descriptor with held cosigners
 // substituted as their xprv. When onlyXpub is non-empty, only that cosigner's
 // xprv is substituted (the rest stay xpubs), so signing adds a single cosigner's
@@ -1832,7 +1840,14 @@ func (p *ElectrumBackend) multisigSigningDescriptorFor(w *WalletData, onlyXpub s
 	}
 	group := MultisigLoungeGroup{M: ms.M, N: ms.N}
 	signWithXprv := map[string]string{}
+	// A cosigner with no origin reaches the PSBT as a bare key, and a hardware
+	// signer cannot place it in the script it rebuilds. Name it here: the device
+	// reports only a bad signature, which says nothing about which leg is short.
+	var noOrigin []string
 	for _, c := range ms.Cosigners {
+		if c.Fingerprint == "" {
+			noOrigin = append(noOrigin, shortXpub(c.Xpub))
+		}
 		group.Keys = append(group.Keys, MultisigLoungeKey{
 			Xpub:        c.Xpub,
 			Fingerprint: c.Fingerprint,
@@ -1858,6 +1873,20 @@ func (p *ElectrumBackend) multisigSigningDescriptorFor(w *WalletData, onlyXpub s
 			xprv = x
 		}
 		signWithXprv[c.Xpub] = xprv
+	}
+
+	p.log.Info().
+		Str("wallet", w.ID).
+		Int("m", ms.M).
+		Int("n", ms.N).
+		Int("with_origin", len(ms.Cosigners)-len(noOrigin)).
+		Strs("without_origin", noOrigin).
+		Msg("multisig signing descriptor")
+	if len(noOrigin) > 0 {
+		p.log.Warn().
+			Str("wallet", w.ID).
+			Strs("cosigners", noOrigin).
+			Msg("cosigner has no key origin; a hardware signer cannot rebuild this script")
 	}
 
 	scriptType := multisigTypeString(w.scriptKind())

--- a/sidechain-orchestrator/wallet/esplora.go
+++ b/sidechain-orchestrator/wallet/esplora.go
@@ -485,59 +485,67 @@ type EsploraOutspend struct {
 	Status EsploraStatus `json:"status"`
 }
 
-// getAcrossRoots asks each configured server in turn for path. found is false
-// only when every server answers 404 — one server's 404 is not authoritative
-// (a provider with a broken index serves 404 for everything).
-func (c *EsploraClient) getAcrossRoots(ctx context.Context, path string) ([]byte, bool, error) {
+func isNotFound(err error) bool {
+	var statusErr *esploraStatusError
+	return errors.As(err, &statusErr) && statusErr.code == http.StatusNotFound
+}
+
+// getFrom asks one server for path. One attempt only — a dead host must fail
+// over at once, and the engine tick is the retry mechanism.
+func (c *EsploraClient) getFrom(ctx context.Context, root, path string) ([]byte, error) {
+	return c.doWith(ctx, []string{root}, 1, http.MethodGet, path, nil)
+}
+
+// Outspend reports the spend status of one output, and whether the server that
+// answered holds the transaction at all. known is false only when every server
+// answers 404 for the transaction.
+//
+// A "not spent" answer alone proves nothing: a server that never saw the
+// transaction answers the same way as one holding a live output. Both facts
+// therefore come from one server, so they describe the same view of the chain.
+func (c *EsploraClient) Outspend(ctx context.Context, txid string, vout int) (EsploraOutspend, bool, error) {
+	status := "/tx/" + txid + "/status"
+	spend := "/tx/" + txid + "/outspend/" + strconv.Itoa(vout)
 	roots := c.BaseURLs()
 	notFound := 0
 	var lastErr error
 	for _, root := range roots {
-		// One attempt per root — a dead host must fail over at once, and the
-		// engine tick is the retry mechanism.
-		body, err := c.doWith(ctx, []string{root}, 1, http.MethodGet, path, nil)
+		body, err := c.getFrom(ctx, root, spend)
 		if err != nil {
-			var statusErr *esploraStatusError
-			if errors.As(err, &statusErr) && statusErr.code == http.StatusNotFound {
+			if isNotFound(err) {
 				notFound++
 				continue
 			}
 			lastErr = err
 			continue
 		}
-		return body, true, nil
+		var o EsploraOutspend
+		if err := json.Unmarshal(body, &o); err != nil {
+			return EsploraOutspend{}, false, fmt.Errorf("decode %s: %w", spend, err)
+		}
+		// A spend proves this server holds the transaction.
+		if o.Spent {
+			return o, true, nil
+		}
+		// The spend answer comes first, so a transaction that drops out of the
+		// mempool between the two reads shows up as absent, not as unspent.
+		if _, err := c.getFrom(ctx, root, status); err != nil {
+			if isNotFound(err) {
+				notFound++
+				continue
+			}
+			lastErr = err
+			continue
+		}
+		return o, true, nil
 	}
 	if notFound == len(roots) && notFound > 0 {
-		return nil, false, nil
+		return EsploraOutspend{}, false, nil
 	}
 	if lastErr == nil {
 		lastErr = fmt.Errorf("no server configured")
 	}
-	return nil, false, fmt.Errorf("get %s: %w", path, lastErr)
-}
-
-// Outspend reports the spend status of one output. found is false only when
-// every configured server answers 404.
-//
-// A "not spent" answer is not proof the output exists: a server that never saw
-// the transaction answers the same way. Pair it with TxKnown.
-func (c *EsploraClient) Outspend(ctx context.Context, txid string, vout int) (EsploraOutspend, bool, error) {
-	path := "/tx/" + txid + "/outspend/" + strconv.Itoa(vout)
-	body, found, err := c.getAcrossRoots(ctx, path)
-	if err != nil || !found {
-		return EsploraOutspend{}, false, err
-	}
-	var o EsploraOutspend
-	if err := json.Unmarshal(body, &o); err != nil {
-		return EsploraOutspend{}, false, fmt.Errorf("decode %s: %w", path, err)
-	}
-	return o, true, nil
-}
-
-// TxKnown reports whether the servers hold this transaction at all.
-func (c *EsploraClient) TxKnown(ctx context.Context, txid string) (bool, error) {
-	_, found, err := c.getAcrossRoots(ctx, "/tx/"+txid+"/status")
-	return found, err
+	return EsploraOutspend{}, false, fmt.Errorf("outspend %s: %w", spend, lastErr)
 }
 
 // TxHex returns the raw transaction hex.

--- a/sidechain-orchestrator/wallet/esplora_outspend_test.go
+++ b/sidechain-orchestrator/wallet/esplora_outspend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -22,8 +23,12 @@ func outspendServer(t *testing.T, status int, body string) *httptest.Server {
 }
 
 func TestEsploraOutspendUnspent(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/tx/aa/outspend/1", r.URL.Path)
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"spent":false}`))
 	}))
@@ -36,6 +41,8 @@ func TestEsploraOutspendUnspent(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.False(t, out.Spent)
+	// One server answers both questions, so the two facts agree.
+	require.Equal(t, []string{"/api/tx/aa/outspend/1", "/api/tx/aa/status"}, paths)
 }
 
 // A 404 from every server means the transaction is not on the chain.

--- a/sidechain-orchestrator/wallet/esplora_test.go
+++ b/sidechain-orchestrator/wallet/esplora_test.go
@@ -47,3 +47,81 @@ func TestEsploraAddressTxsPaginationUsesConfirmedCursor(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, txs, 27, "all pages must be fetched via the confirmed cursor")
 }
+
+// outspendStub answers the status and outspend paths for one transaction.
+func outspendStub(t *testing.T, txid string, knowsTx bool, spent string, hits *int) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*hits++
+		switch r.URL.Path {
+		case "/api/tx/" + txid + "/status":
+			if !knowsTx {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			_, _ = w.Write([]byte(`{"confirmed":true}`))
+		case "/api/tx/" + txid + "/outspend/0":
+			_, _ = w.Write([]byte(spent))
+		default:
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL + "/api"
+}
+
+// TestEsploraOutspendKeepsOneProvider: a server answers "not spent" for a
+// transaction it never saw. Taking that answer from one server and the
+// transaction from another reports a spent coin as unspent.
+func TestEsploraOutspendKeepsOneProvider(t *testing.T) {
+	const txid = "aa"
+	var blindHits, knowingHits int
+	blind := outspendStub(t, txid, false, `{"spent":false}`, &blindHits)
+	knowing := outspendStub(t, txid, true, `{"spent":true,"status":{"confirmed":true}}`, &knowingHits)
+
+	client := NewEsploraClient([]string{blind, knowing}, zerolog.Nop())
+	out, found, err := client.Outspend(context.Background(), txid, 0)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.True(t, out.Spent, "the answer must come from the server that holds the transaction")
+	// The spend answer comes first, then the transaction check exposes the
+	// server that does not hold it.
+	require.Equal(t, 2, blindHits)
+}
+
+// TestEsploraOutspendUnknownEverywhere: no server holds the transaction, so the
+// coin is not one Bitcoin knows.
+func TestEsploraOutspendUnknownEverywhere(t *testing.T) {
+	const txid = "aa"
+	var a, b int
+	client := NewEsploraClient([]string{
+		outspendStub(t, txid, false, `{"spent":false}`, &a),
+		outspendStub(t, txid, false, `{"spent":false}`, &b),
+	}, zerolog.Nop())
+
+	_, found, err := client.Outspend(context.Background(), txid, 0)
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Equal(t, 2, a)
+	require.Equal(t, 2, b)
+}
+
+// TestEsploraOutspendEvictedTransaction: a transaction can drop out of the
+// mempool between the two reads. The coin must read as absent, because the
+// engine caches an "unspent" answer forever.
+func TestEsploraOutspendEvictedTransaction(t *testing.T) {
+	const txid = "aa"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/tx/"+txid+"/status" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{"spent":false}`))
+	}))
+	defer srv.Close()
+
+	client := NewEsploraClient([]string{srv.URL + "/api"}, zerolog.Nop())
+	_, found, err := client.Outspend(context.Background(), txid, 0)
+	require.NoError(t, err)
+	require.False(t, found)
+}

--- a/sidechain-orchestrator/wallet/hwi.go
+++ b/sidechain-orchestrator/wallet/hwi.go
@@ -131,6 +131,9 @@ func (r *HWIRunner) SignPSBT(ctx context.Context, sel HardwareSelector, psbtBase
 	if err := checkDeviceCanSignPaths(packet, sel.Fingerprint); err != nil {
 		return "", err
 	}
+	if err := r.checkDeviceHoldsWalletKeys(ctx, sel, packet); err != nil {
+		return "", err
+	}
 	req := r.request("signtx", sel)
 	req["psbt"] = psbtBase64
 	raw, err := r.call(ctx, req)

--- a/sidechain-orchestrator/wallet/hwi.go
+++ b/sidechain-orchestrator/wallet/hwi.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
 )
 
@@ -122,6 +124,13 @@ func (r *HWIRunner) GetXpub(ctx context.Context, sel HardwareSelector, path stri
 
 // SignPSBT sends a base64 PSBT to the device and returns the signed PSBT.
 func (r *HWIRunner) SignPSBT(ctx context.Context, sel HardwareSelector, psbtBase64 string) (string, error) {
+	packet, err := psbt.NewFromRawBytes(strings.NewReader(psbtBase64), true)
+	if err != nil {
+		return "", fmt.Errorf("read psbt for the device: %w", err)
+	}
+	if err := checkDeviceCanSignPaths(packet, sel.Fingerprint); err != nil {
+		return "", err
+	}
 	req := r.request("signtx", sel)
 	req["psbt"] = psbtBase64
 	raw, err := r.call(ctx, req)

--- a/sidechain-orchestrator/wallet/hwi.go
+++ b/sidechain-orchestrator/wallet/hwi.go
@@ -150,7 +150,46 @@ func (r *HWIRunner) SignPSBT(ctx context.Context, sel HardwareSelector, psbtBase
 	if res.PSBT == "" {
 		return "", errors.New("hwi signtx returned no psbt")
 	}
+	if err := checkDeviceSignatures(res.PSBT); err != nil {
+		return "", err
+	}
 	return res.PSBT, nil
+}
+
+// checkDeviceSignatures rejects a signature the device gives for another
+// transaction. The broadcast is the next step that reads a signature, so a
+// device fault reaches the user as a broadcast failure and names no device.
+func checkDeviceSignatures(psbtBase64 string) error {
+	packet, err := psbt.NewFromRawBytes(strings.NewReader(psbtBase64), true)
+	if err != nil {
+		return fmt.Errorf("read the psbt the device signed: %w", err)
+	}
+	// A packet the device gives back can lack a prevout this check needs. Check
+	// the signatures it carries, and leave the rest to the finalizer.
+	if !packetHasSignedPrevOuts(packet) {
+		return nil
+	}
+	if err := verifySignatures(packet); err != nil {
+		return fmt.Errorf("the device signed a different transaction: %w", err)
+	}
+	return nil
+}
+
+// packetHasSignedPrevOuts reports whether every input names the output it
+// spends and at least one input carries a signature.
+func packetHasSignedPrevOuts(packet *psbt.Packet) bool {
+	signed := false
+	for i := range packet.Inputs {
+		out, err := authenticatedPrevOut(packet, i)
+		if err != nil || out == nil {
+			return false
+		}
+		in := &packet.Inputs[i]
+		if len(in.PartialSigs) > 0 || len(in.TaprootKeySpendSig) > 0 || len(in.TaprootScriptSpendSig) > 0 {
+			signed = true
+		}
+	}
+	return signed
 }
 
 // DisplayAddress shows an address for the given output descriptor on the device.

--- a/sidechain-orchestrator/wallet/hwi_paths.go
+++ b/sidechain-orchestrator/wallet/hwi_paths.go
@@ -1,0 +1,83 @@
+package wallet
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+)
+
+const hardenedKey uint32 = 0x80000000
+
+// checkDeviceCanSignPaths rejects a packet a hardware device refuses. Trezor
+// firmware accepts only BIP45 and BIP48 paths for a multisig input, and it
+// reports every other path as a forbidden key path. The device names neither the
+// input nor the path, so this check names both before the device sees them.
+func checkDeviceCanSignPaths(packet *psbt.Packet, fingerprint string) error {
+	want, ok := parseFingerprint(fingerprint)
+	if !ok {
+		return nil
+	}
+	for i := range packet.Inputs {
+		in := &packet.Inputs[i]
+		if len(in.WitnessScript) == 0 {
+			continue
+		}
+		for _, d := range in.Bip32Derivation {
+			if d.MasterKeyFingerprint != want {
+				continue
+			}
+			if multisigPathIsStandard(d.Bip32Path) {
+				continue
+			}
+			return fmt.Errorf(
+				"the device holds key %s at %s in psbt input %d, and a hardware signer signs a multisig input only at m/48'/coin'/account'/2'/change/index or m/45'/…; re-import this cosigner with its key origin",
+				fingerprint, pathString(d.Bip32Path), i)
+		}
+	}
+	return nil
+}
+
+// multisigPathIsStandard reports whether a path is one a hardware signer accepts
+// for a multisig input: BIP48 (…/48'/coin'/account'/script'/change/index) or
+// BIP45 (…/45'/cosigner/change/index).
+func multisigPathIsStandard(path []uint32) bool {
+	hard := func(n uint32) bool { return n >= hardenedKey }
+	switch len(path) {
+	case 6:
+		return path[0] == 48|hardenedKey && hard(path[1]) && hard(path[2]) && hard(path[3]) &&
+			!hard(path[4]) && !hard(path[5])
+	case 4:
+		return path[0] == 45|hardenedKey && !hard(path[1]) && !hard(path[2]) && !hard(path[3])
+	default:
+		return false
+	}
+}
+
+// pathString writes a derivation path the way a descriptor does.
+func pathString(path []uint32) string {
+	if len(path) == 0 {
+		return "m (no path)"
+	}
+	parts := make([]string, 0, len(path)+1)
+	parts = append(parts, "m")
+	for _, n := range path {
+		if n >= hardenedKey {
+			parts = append(parts, fmt.Sprintf("%d'", n-hardenedKey))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%d", n))
+	}
+	return strings.Join(parts, "/")
+}
+
+// parseFingerprint reads a master key fingerprint written as 8 hex characters.
+func parseFingerprint(s string) (uint32, bool) {
+	raw, err := hex.DecodeString(strings.TrimSpace(s))
+	if err != nil || len(raw) != 4 {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint32(raw), true
+}

--- a/sidechain-orchestrator/wallet/hwi_paths.go
+++ b/sidechain-orchestrator/wallet/hwi_paths.go
@@ -1,11 +1,14 @@
 package wallet
 
 import (
+	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"strings"
 
+	"github.com/btcsuite/btcd/btcutil/base58"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 )
 
@@ -80,4 +83,79 @@ func parseFingerprint(s string) (uint32, bool) {
 		return 0, false
 	}
 	return binary.LittleEndian.Uint32(raw), true
+}
+
+// checkDeviceHoldsWalletKeys makes sure the device carries the keys this packet
+// files under its fingerprint. A signer returns a signature for the key it
+// derives, and the caller files that signature under the key the packet names.
+// A device whose seed or passphrase differs gives a valid signature for a key
+// this wallet does not hold, and only a check of the keys names that cause.
+func (r *HWIRunner) checkDeviceHoldsWalletKeys(
+	ctx context.Context,
+	sel HardwareSelector,
+	packet *psbt.Packet,
+) error {
+	want, ok := parseFingerprint(sel.Fingerprint)
+	if !ok {
+		return nil
+	}
+	for _, x := range packet.XPubs {
+		if x.MasterKeyFingerprint != want || len(x.ExtendedKey) < 78 {
+			continue
+		}
+		path := pathString(x.Bip32Path)
+		got, err := r.GetXpub(ctx, sel, path)
+		if err != nil {
+			return fmt.Errorf("read the device key at %s: %w", path, err)
+		}
+		raw := base58.Decode(got)
+		if len(raw) < 82 {
+			return fmt.Errorf("the device gave a key at %s this wallet cannot read", path)
+		}
+		if bytes.Equal(raw[13:78], x.ExtendedKey[13:78]) {
+			continue
+		}
+		if real, ok := r.findKeyOnDevice(ctx, sel, x.Bip32Path, x.ExtendedKey); ok {
+			return fmt.Errorf(
+				"this wallet records cosigner %s at %s, but the device holds that key at %s; the wallet stored the wrong path when it imported the key, so correct the cosigner origin to %s and the device signs the same script",
+				sel.Fingerprint, path, real, real)
+		}
+		return fmt.Errorf(
+			"the device holds a different key at %s than wallet fingerprint %s names, and no nearby account holds it either; the device seed or passphrase does not match the key this wallet stored",
+			path, sel.Fingerprint)
+	}
+	return nil
+}
+
+// findKeyOnDevice names the path a stored key really lives at. A wallet that
+// imports a cosigner at one path and records another gives a signer a key it
+// cannot derive, and the script stays correct, so the path alone needs a fix.
+// The search stays near the recorded path: the account and the script type.
+func (r *HWIRunner) findKeyOnDevice(
+	ctx context.Context,
+	sel HardwareSelector,
+	recorded []uint32,
+	want []byte,
+) (string, bool) {
+	if len(recorded) != 4 || len(want) < 78 {
+		return "", false
+	}
+	for account := uint32(0); account < 6; account++ {
+		for kind := uint32(0); kind < 4; kind++ {
+			try := []uint32{recorded[0], recorded[1], account | hardenedKey, kind | hardenedKey}
+			if try[2] == recorded[2] && try[3] == recorded[3] {
+				continue
+			}
+			path := pathString(try)
+			got, err := r.GetXpub(ctx, sel, path)
+			if err != nil {
+				continue
+			}
+			raw := base58.Decode(got)
+			if len(raw) >= 78 && bytes.Equal(raw[13:78], want[13:78]) {
+				return path, true
+			}
+		}
+	}
+	return "", false
 }

--- a/sidechain-orchestrator/wallet/hwi_paths_test.go
+++ b/sidechain-orchestrator/wallet/hwi_paths_test.go
@@ -1,9 +1,15 @@
 package wallet
 
 import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcutil/base58"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
 )
@@ -42,4 +48,100 @@ func TestDeviceRefusesNonStandardMultisigPath(t *testing.T) {
 
 	// Another device's key is not this device's problem.
 	require.NoError(t, checkDeviceCanSignPaths(packetWithPath([]uint32{0, 0}), "aabbccdd"))
+}
+
+// TestDeviceKeyMustMatchTheWallet: a signer files its signature under the key
+// the packet names for its fingerprint. A device with another seed gives a
+// valid signature for a key this wallet does not hold, so the keys must match
+// before the device signs.
+func TestDeviceKeyMustMatchTheWallet(t *testing.T) {
+	net := &chaincfg.MainNetParams
+	xpubAt := func(pass string) (*hdkeychain.ExtendedKey, string) {
+		seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, pass))
+		acct, err := accountKeyFromSeed(seedHex, ScriptNativeSegwit, net)
+		require.NoError(t, err)
+		pub, err := acct.Neuter()
+		require.NoError(t, err)
+		return pub, pub.String()
+	}
+	walletKey, walletXpub := xpubAt("wallet")
+	_, otherXpub := xpubAt("another device")
+
+	packetFor := func(key *hdkeychain.ExtendedKey) *psbt.Packet {
+		tx := wire.NewMsgTx(2)
+		tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, nil, nil))
+		tx.AddTxOut(wire.NewTxOut(1000, make([]byte, 22)))
+		packet, err := psbt.NewFromUnsignedTx(tx)
+		require.NoError(t, err)
+		raw := base58.Decode(key.String())
+		packet.XPubs = []psbt.XPub{{
+			ExtendedKey:          raw[:78],
+			MasterKeyFingerprint: 0x26f9d3d8,
+			Bip32Path:            []uint32{48 | hardenedKey, hardenedKey, 1 | hardenedKey, 2 | hardenedKey},
+		}}
+		return packet
+	}
+
+	runner := func(xpub string, seen *string) *HWIRunner {
+		return &HWIRunner{chain: "main", call: func(_ context.Context, req map[string]any) (json.RawMessage, error) {
+			if seen != nil {
+				*seen, _ = req["derivation_path"].(string)
+			}
+			return json.RawMessage(`{"xpub":"` + xpub + `"}`), nil
+		}}
+	}
+	sel := HardwareSelector{Type: "trezor", Fingerprint: "d8d3f926"}
+
+	var asked string
+	require.NoError(t, runner(walletXpub, &asked).
+		checkDeviceHoldsWalletKeys(context.Background(), sel, packetFor(walletKey)))
+	require.Equal(t, "m/48'/0'/1'/2'", asked)
+
+	err := runner(otherXpub, nil).
+		checkDeviceHoldsWalletKeys(context.Background(), sel, packetFor(walletKey))
+	require.ErrorContains(t, err, "seed or passphrase does not match the key this wallet stored")
+	require.ErrorContains(t, err, "m/48'/0'/1'/2'")
+}
+
+// TestDeviceKeyFoundAtAnotherPath: a wallet that imports a cosigner at one path
+// and records another leaves the script correct and the path wrong. The report
+// must name the real path, because that alone repairs the wallet.
+func TestDeviceKeyFoundAtAnotherPath(t *testing.T) {
+	net := &chaincfg.MainNetParams
+	seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, "device"))
+
+	at := func(path string) *hdkeychain.ExtendedKey {
+		xpub, err := DeriveAccountXpub(seedHex, path, net)
+		require.NoError(t, err)
+		key, err := hdkeychain.NewKeyFromString(xpub)
+		require.NoError(t, err)
+		return key
+	}
+	// The wallet stored the account 0 key but recorded the account 1 path.
+	stored := at("m/48'/0'/0'/2'")
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, nil, nil))
+	tx.AddTxOut(wire.NewTxOut(1000, make([]byte, 22)))
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+	packet.XPubs = []psbt.XPub{{
+		ExtendedKey:          base58.Decode(stored.String())[:78],
+		MasterKeyFingerprint: 0x26f9d3d8,
+		Bip32Path:            []uint32{48 | hardenedKey, hardenedKey, 1 | hardenedKey, 2 | hardenedKey},
+	}}
+
+	r := &HWIRunner{chain: "main", call: func(_ context.Context, req map[string]any) (json.RawMessage, error) {
+		path, _ := req["derivation_path"].(string)
+		xpub, err := DeriveAccountXpub(seedHex, path, net)
+		if err != nil {
+			return nil, err
+		}
+		return json.RawMessage(`{"xpub":"` + xpub + `"}`), nil
+	}}
+
+	err = r.checkDeviceHoldsWalletKeys(context.Background(),
+		HardwareSelector{Type: "trezor", Fingerprint: "d8d3f926"}, packet)
+	require.ErrorContains(t, err, "records cosigner d8d3f926 at m/48'/0'/1'/2'")
+	require.ErrorContains(t, err, "device holds that key at m/48'/0'/0'/2'")
 }

--- a/sidechain-orchestrator/wallet/hwi_paths_test.go
+++ b/sidechain-orchestrator/wallet/hwi_paths_test.go
@@ -1,0 +1,45 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeviceRefusesNonStandardMultisigPath: a hardware signer accepts a multisig
+// input only at a BIP48 or a BIP45 path. The check must name the key, the path,
+// and the input, because the device names none of them.
+func TestDeviceRefusesNonStandardMultisigPath(t *testing.T) {
+	h := func(n uint32) uint32 { return n | hardenedKey }
+	packetWithPath := func(path []uint32) *psbt.Packet {
+		tx := wire.NewMsgTx(2)
+		tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, nil, nil))
+		tx.AddTxOut(wire.NewTxOut(1000, make([]byte, 22)))
+		packet, err := psbt.NewFromUnsignedTx(tx)
+		require.NoError(t, err)
+		packet.Inputs[0].WitnessScript = []byte{0x52, 0x53, 0xae}
+		packet.Inputs[0].Bip32Derivation = []*psbt.Bip32Derivation{{
+			PubKey:               make([]byte, 33),
+			MasterKeyFingerprint: 0x26f9d3d8, // d8d3f926 little-endian
+			Bip32Path:            path,
+		}}
+		return packet
+	}
+
+	good := []uint32{h(48), h(0), h(0), h(2), 0, 0}
+	require.NoError(t, checkDeviceCanSignPaths(packetWithPath(good), "d8d3f926"))
+	require.NoError(t, checkDeviceCanSignPaths(packetWithPath([]uint32{h(45), 0, 0, 0}), "d8d3f926"))
+
+	err := checkDeviceCanSignPaths(packetWithPath([]uint32{0, 0}), "d8d3f926")
+	require.ErrorContains(t, err, "m/0/0")
+	require.ErrorContains(t, err, "psbt input 0")
+
+	// A BIP84 single-key account is not a multisig path.
+	err = checkDeviceCanSignPaths(packetWithPath([]uint32{h(84), h(0), h(0), 0, 0}), "d8d3f926")
+	require.ErrorContains(t, err, "m/84'/0'/0'/0/0")
+
+	// Another device's key is not this device's problem.
+	require.NoError(t, checkDeviceCanSignPaths(packetWithPath([]uint32{0, 0}), "aabbccdd"))
+}

--- a/sidechain-orchestrator/wallet/hwi_paths_test.go
+++ b/sidechain-orchestrator/wallet/hwi_paths_test.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/base58"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
 )
@@ -144,4 +146,55 @@ func TestDeviceKeyFoundAtAnotherPath(t *testing.T) {
 		HardwareSelector{Type: "trezor", Fingerprint: "d8d3f926"}, packet)
 	require.ErrorContains(t, err, "records cosigner d8d3f926 at m/48'/0'/1'/2'")
 	require.ErrorContains(t, err, "device holds that key at m/48'/0'/0'/2'")
+}
+
+// TestDeviceSignatureCheckedAtTheDevice: a device that signs another
+// transaction must fail at the device call. The broadcast is otherwise the
+// first step that reads the signature, and it names no device.
+func TestDeviceSignatureCheckedAtTheDevice(t *testing.T) {
+	net := &chaincfg.MainNetParams
+	seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, ""))
+	acct, err := accountKeyFromSeed(seedHex, ScriptNativeSegwit, net)
+	require.NoError(t, err)
+	priv, ok, err := deriveChildPrivIfPossible(acct, 0, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	pkh := btcutil.Hash160(priv.PubKey().SerializeCompressed())
+	spk, err := txscript.NewScriptBuilder().AddOp(txscript.OP_0).AddData(pkh).Script()
+	require.NoError(t, err)
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0}, nil, nil))
+	tx.AddTxOut(wire.NewTxOut(900, spk))
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+	packet.Inputs[0].WitnessUtxo = wire.NewTxOut(1000, spk)
+
+	// A signature over another transaction: the same input, another amount.
+	other := wire.NewMsgTx(2)
+	other.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0}, nil, nil))
+	other.AddTxOut(wire.NewTxOut(500, spk))
+	f := txscript.NewCannedPrevOutputFetcher(spk, 1000)
+	wrong, err := txscript.RawTxInWitnessSignature(
+		other, txscript.NewTxSigHashes(other, f), 0, 1000, spk, txscript.SigHashAll, priv)
+	require.NoError(t, err)
+	packet.Inputs[0].PartialSigs = []*psbt.PartialSig{
+		{PubKey: priv.PubKey().SerializeCompressed(), Signature: wrong},
+	}
+	b64, err := packet.B64Encode()
+	require.NoError(t, err)
+
+	err = checkDeviceSignatures(b64)
+	require.ErrorContains(t, err, "the device signed a different transaction")
+
+	// A taproot key-path spend carries its signature in one field of its own,
+	// and it reaches the same check.
+	taproot, err := psbt.NewFromUnsignedTx(tx.Copy())
+	require.NoError(t, err)
+	taproot.Inputs[0].WitnessUtxo = wire.NewTxOut(1000, spk)
+	taproot.Inputs[0].TaprootKeySpendSig = wrong
+	b64, err = taproot.B64Encode()
+	require.NoError(t, err)
+	require.Error(t, checkDeviceSignatures(b64))
 }

--- a/sidechain-orchestrator/wallet/hwi_test.go
+++ b/sidechain-orchestrator/wallet/hwi_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,12 +67,26 @@ func TestGetXpub(t *testing.T) {
 
 func TestSignPSBT(t *testing.T) {
 	var req map[string]any
-	r := fakeRunner("regtest", `{"psbt":"cHNidP8signed","signed":true}`, nil, &req)
-	signed, err := r.SignPSBT(context.Background(), HardwareSelector{Fingerprint: "1a2b3c4d"}, "cHNidP8unsigned")
+	r := &HWIRunner{chain: "regtest", call: func(_ context.Context, q map[string]any) (json.RawMessage, error) {
+		req = q
+		// The device gives back the packet it signed; an unsigned one carries no
+		// signature to check.
+		return json.RawMessage(`{"psbt":"` + q["psbt"].(string) + `","signed":true}`), nil
+	}}
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, nil, nil))
+	tx.AddTxOut(wire.NewTxOut(1000, make([]byte, 22)))
+	packet, err := psbt.NewFromUnsignedTx(tx)
 	require.NoError(t, err)
-	require.Equal(t, "cHNidP8signed", signed)
+	unsigned, err := packet.B64Encode()
+	require.NoError(t, err)
+
+	signed, err := r.SignPSBT(context.Background(), HardwareSelector{Fingerprint: "1a2b3c4d"}, unsigned)
+	require.NoError(t, err)
+	require.Equal(t, unsigned, signed)
 	require.Equal(t, "signtx", req["cmd"])
-	require.Equal(t, "cHNidP8unsigned", req["psbt"])
+	require.Equal(t, unsigned, req["psbt"])
 }
 
 func TestPinFlow(t *testing.T) {

--- a/sidechain-orchestrator/wallet/multisiglounge.go
+++ b/sidechain-orchestrator/wallet/multisiglounge.go
@@ -737,6 +737,11 @@ func isCosignerRecord(fingerprint uint32, path []uint32, pubKey []byte, origins 
 // derived. A record for another child leaves that cosigner unable to sign the
 // input this gate accepts.
 func verifyChildPath(path []uint32, bound boundInput) error {
+	// A cosigner with no key origin claims no derivation, so it names no child
+	// at all. The script binding still holds it to the group.
+	if len(path) == 0 {
+		return nil
+	}
 	c, i, ok := chainIndexFromPath(path)
 	if !ok || c != bound.change || i != bound.index {
 		return errors.New("carries a cosigner derivation for another child of the group")

--- a/sidechain-orchestrator/wallet/multisiglounge_test.go
+++ b/sidechain-orchestrator/wallet/multisiglounge_test.go
@@ -403,8 +403,13 @@ func TestValidatePsbtBareCosignerChildMismatch(t *testing.T) {
 
 	// The first record still carries the true child, so the script check reads
 	// the right hint and the tampered record reaches the origin check.
-	require.Len(t, packet.Inputs[0].Bip32Derivation, 2)
-	rec := packet.Inputs[0].Bip32Derivation[1]
+	var rec *psbt.Bip32Derivation
+	for _, d := range packet.Inputs[0].Bip32Derivation[1:] {
+		if len(d.Bip32Path) > 2 {
+			rec = d
+		}
+	}
+	require.NotNil(t, rec, "a second record carries a real path")
 	rec.Bip32Path[len(rec.Bip32Path)-1] = 6
 
 	_, err = ValidateMultisigPsbt(psbtToBase64(t, packet), 2, &group)
@@ -506,9 +511,16 @@ func TestValidatePsbtBareXpubCosigners(t *testing.T) {
 	accts := loungeTestAccts(t)
 
 	packet := loungeBareCosignerPSBT(t, accts, 1)
-	// A bare cosigner carries no derivation record: a made-up path fails a
-	// hardware signer, which checks every path in the packet.
-	require.Len(t, packet.Inputs[0].Bip32Derivation, 1)
+	// A bare cosigner carries a record with an empty path: a made-up path fails
+	// a hardware signer, and no record leaves it a script with a key missing.
+	require.Len(t, packet.Inputs[0].Bip32Derivation, 3)
+	empty := 0
+	for _, d := range packet.Inputs[0].Bip32Derivation {
+		if len(d.Bip32Path) == 0 {
+			empty++
+		}
+	}
+	require.Equal(t, 2, empty, "the two bare cosigners claim no derivation")
 
 	res, err := ValidateMultisigPsbt(psbtToBase64(t, packet), 2, &group)
 	require.NoError(t, err, "a group's own spend must not be rejected over external cosigner metadata")

--- a/sidechain-orchestrator/wallet/origin_path_test.go
+++ b/sidechain-orchestrator/wallet/origin_path_test.go
@@ -1,0 +1,54 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOrigin(t *testing.T) {
+	h := func(n uint32) uint32 { return n + hdkeychain.HardenedKeyStart }
+
+	fp, path, ok := parseOrigin("abcd1234/84h/0'/0H/1/2")
+	require.True(t, ok)
+	require.Equal(t, uint32(0x3412cdab), fp, "the fingerprint reads little-endian")
+	require.Equal(t, []uint32{h(84), h(0), h(0), 1, 2}, path)
+
+	_, path, ok = parseOrigin("abcd1234")
+	require.True(t, ok, "a fingerprint with no path is an account key")
+	require.Empty(t, path)
+
+	for _, bad := range []string{"", "abcd12/0", "abcd1234/x", "abcd1234/m/0", "zzzz1234/0"} {
+		_, _, ok = parseOrigin(bad)
+		require.False(t, ok, bad)
+	}
+}
+
+func TestParseOriginPath(t *testing.T) {
+	h := func(n uint32) uint32 { return n + hdkeychain.HardenedKeyStart }
+
+	for _, in := range []string{"48'/0'/0'/2'", "m/48'/0'/0'/2'", "M/48h/0h/0h/2h"} {
+		path, ok := parseOriginPath(in)
+		require.True(t, ok, in)
+		require.Equal(t, []uint32{h(48), h(0), h(0), h(2)}, path)
+	}
+
+	for _, in := range []string{"", "m", "m/", "/"} {
+		path, ok := parseOriginPath(in)
+		require.True(t, ok, in)
+		require.Empty(t, path, in)
+	}
+
+	// A trailing separator names no step, the way a descriptor origin reads it.
+	path, ok := parseOriginPath("48'/0'/")
+	require.True(t, ok)
+	require.Len(t, path, 2)
+
+	// A path that reads as a path only after a stripped "m" is malformed, and
+	// the wallet cannot store it.
+	for _, bad := range []string{"m48'/0'/0'/2'", "48'/x", "48''", "48'/-1"} {
+		_, ok := parseOriginPath(bad)
+		require.False(t, ok, bad)
+	}
+}

--- a/sidechain-orchestrator/wallet/psbt.go
+++ b/sidechain-orchestrator/wallet/psbt.go
@@ -191,9 +191,22 @@ func buildPSBT(inputs []psbtInput, outputs []TxOutSpec, net *chaincfg.Params, pr
 		}
 	}
 
-	// Mark owned change outputs so a signer can verify them as its own.
+	// Mark owned change outputs so a signer can verify them as its own. The
+	// scripts go with the paths: a signer that gets a change path alone rebuilds
+	// the output as a single-key one, and it then signs a transaction that pays
+	// somewhere else.
 	for i, out := range outputs {
 		addBip32Derivations(nil, &packet.Outputs[i], out.Kind, out.Derivations)
+		if len(out.RedeemScript) > 0 {
+			if err := updater.AddOutRedeemScript(out.RedeemScript, i); err != nil {
+				return nil, err
+			}
+		}
+		if len(out.WitnessScript) > 0 {
+			if err := updater.AddOutWitnessScript(out.WitnessScript, i); err != nil {
+				return nil, err
+			}
+		}
 	}
 	return packet, nil
 }

--- a/sidechain-orchestrator/wallet/psbt.go
+++ b/sidechain-orchestrator/wallet/psbt.go
@@ -652,9 +652,219 @@ func verifyPartialSig(
 		return err
 	}
 	if !sig.Verify(hash, pub) {
-		return fmt.Errorf("key %s signed a different transaction", signerName(in, ps.PubKey))
+		// A hardware signer rebuilds a multisig script from the packet's
+		// derivation records, so a key it cannot place gives it a script nobody
+		// else holds. Name what the signature covers, or the report says only
+		// that a key is wrong.
+		return fmt.Errorf("key %s signed a different transaction: %s; %d of %d keys in this input carry a key origin, witness script %x",
+			signerName(in, ps.PubKey), signedInstead(tx, sigHashes, i, in, prevOut, ps.PubKey, sig, pub, hashType),
+			keysWithOrigin(in), len(in.Bip32Derivation), sha256.Sum256(in.WitnessScript))
 	}
 	return nil
+}
+
+// signedInstead names what a rejected signature covers. A hardware signer builds
+// its own sighash from the packet, so the way its result differs from this
+// packet identifies the fault: a signer that treats a multisig input as
+// single-sig, one that keeps the cosigner order the descriptor sorts, one that
+// takes a different amount or a different sighash type.
+func signedInstead(
+	tx *wire.MsgTx,
+	sigHashes *txscript.TxSigHashes,
+	i int,
+	in *psbt.PInput,
+	prevOut *wire.TxOut,
+	pubKey []byte,
+	sig *ecdsa.Signature,
+	pub *btcec.PublicKey,
+	hashType txscript.SigHashType,
+) string {
+	covers := func(hash []byte, err error) bool {
+		return err == nil && sig.Verify(hash, pub)
+	}
+
+	if code, err := p2wpkhScriptCode(btcutil.Hash160(pubKey)); err == nil {
+		if covers(txscript.CalcWitnessSigHash(code, sigHashes, hashType, tx, i, prevOut.Value)) {
+			return "it signed this input as single-key p2wpkh, not as multisig"
+		}
+	}
+	if covers(txscript.CalcSignatureHash(in.WitnessScript, hashType, tx, i)) {
+		return "it signed the legacy sighash, which omits the input amount"
+	}
+	if order, ok := multisigKeyOrderThatMatches(tx, sigHashes, i, in, prevOut, hashType, covers); ok {
+		return fmt.Sprintf("it built the multisig script with the keys in the order %v; this wallet sorts them", order)
+	}
+	if name, ok := anotherKeyInScript(in, pubKey, sig, tx, sigHashes, i, prevOut, hashType); ok {
+		return fmt.Sprintf("the signature belongs to %s, another key in this script", name)
+	}
+	for _, t := range []txscript.SigHashType{
+		txscript.SigHashAll, txscript.SigHashNone, txscript.SigHashSingle,
+		txscript.SigHashAll | txscript.SigHashAnyOneCanPay,
+		txscript.SigHashNone | txscript.SigHashAnyOneCanPay,
+		txscript.SigHashSingle | txscript.SigHashAnyOneCanPay,
+	} {
+		if t == hashType {
+			continue
+		}
+		if covers(txscript.CalcWitnessSigHash(in.WitnessScript, sigHashes, t, tx, i, prevOut.Value)) {
+			return fmt.Sprintf("it signed sighash type %#x and reported %#x", byte(t), byte(hashType))
+		}
+	}
+	var paid int64
+	for _, o := range tx.TxOut {
+		paid += o.Value
+	}
+	for _, v := range []int64{0, paid} {
+		if v == prevOut.Value {
+			continue
+		}
+		if covers(txscript.CalcWitnessSigHash(in.WitnessScript, sigHashes, hashType, tx, i, v)) {
+			return fmt.Sprintf("it signed the amount %d, and this input holds %d", v, prevOut.Value)
+		}
+	}
+	return "no known signer fault matches the signature"
+}
+
+// multisigKeyOrderThatMatches finds a key order whose script the signature
+// covers. A descriptor with sortedmulti sorts its keys; a signer that builds
+// the script in any other order signs a script this wallet never holds.
+func multisigKeyOrderThatMatches(
+	tx *wire.MsgTx,
+	sigHashes *txscript.TxSigHashes,
+	i int,
+	in *psbt.PInput,
+	prevOut *wire.TxOut,
+	hashType txscript.SigHashType,
+	covers func([]byte, error) bool,
+) ([]int, bool) {
+	m, n, ok := multisigLimits(in.WitnessScript)
+	if !ok || n != len(in.Bip32Derivation) || n > 6 {
+		return nil, false
+	}
+	keys := make([][]byte, n)
+	for k, d := range in.Bip32Derivation {
+		keys[k] = d.PubKey
+	}
+	order := make([]int, n)
+	for k := range order {
+		order[k] = k
+	}
+	var found []int
+	permute(order, 0, func(p []int) bool {
+		b := txscript.NewScriptBuilder().AddInt64(int64(m))
+		for _, k := range p {
+			b.AddData(keys[k])
+		}
+		script, err := b.AddInt64(int64(n)).AddOp(txscript.OP_CHECKMULTISIG).Script()
+		if err != nil || bytes.Equal(script, in.WitnessScript) {
+			return false
+		}
+		if !covers(txscript.CalcWitnessSigHash(script, sigHashes, hashType, tx, i, prevOut.Value)) {
+			return false
+		}
+		found = append([]int(nil), p...)
+		return true
+	})
+	return found, found != nil
+}
+
+// permute calls fn for each order of xs and stops at the first true answer.
+func permute(xs []int, k int, fn func([]int) bool) bool {
+	if k == len(xs) {
+		return fn(xs)
+	}
+	for j := k; j < len(xs); j++ {
+		xs[k], xs[j] = xs[j], xs[k]
+		if permute(xs, k+1, fn) {
+			return true
+		}
+		xs[k], xs[j] = xs[j], xs[k]
+	}
+	return false
+}
+
+// anotherKeyInScript names the key a signature really covers when the packet
+// files it under a different one. A signer that derives one key and reports
+// another gives a signature no key in the packet explains.
+func anotherKeyInScript(
+	in *psbt.PInput,
+	pubKey []byte,
+	sig *ecdsa.Signature,
+	tx *wire.MsgTx,
+	sigHashes *txscript.TxSigHashes,
+	i int,
+	prevOut *wire.TxOut,
+	hashType txscript.SigHashType,
+) (string, bool) {
+	hash, err := txscript.CalcWitnessSigHash(in.WitnessScript, sigHashes, hashType, tx, i, prevOut.Value)
+	if err != nil {
+		return "", false
+	}
+	for _, d := range in.Bip32Derivation {
+		if bytes.Equal(d.PubKey, pubKey) {
+			continue
+		}
+		pub, err := btcec.ParsePubKey(d.PubKey)
+		if err != nil || !sig.Verify(hash, pub) {
+			continue
+		}
+		return signerName(in, d.PubKey), true
+	}
+	return "", false
+}
+
+// multisigInRecordOrder rebuilds a bare multisig script from an input's
+// derivation records, keeping the order the packet lists them in. A descriptor
+// with sortedmulti sorts its keys, so a signer that keeps packet order builds
+// this script instead.
+func multisigInRecordOrder(in *psbt.PInput) ([]byte, bool) {
+	m, n, ok := multisigLimits(in.WitnessScript)
+	if !ok || n != len(in.Bip32Derivation) {
+		return nil, false
+	}
+	b := txscript.NewScriptBuilder().AddInt64(int64(m))
+	for _, d := range in.Bip32Derivation {
+		b.AddData(d.PubKey)
+	}
+	script, err := b.AddInt64(int64(n)).AddOp(txscript.OP_CHECKMULTISIG).Script()
+	if err != nil {
+		return nil, false
+	}
+	return script, true
+}
+
+// multisigLimits reads the m and the n of a bare multisig script.
+func multisigLimits(script []byte) (int, int, bool) {
+	if len(script) < 3 || script[len(script)-1] != txscript.OP_CHECKMULTISIG {
+		return 0, 0, false
+	}
+	small := func(op byte) (int, bool) {
+		if op < txscript.OP_1 || op > txscript.OP_16 {
+			return 0, false
+		}
+		return int(op-txscript.OP_1) + 1, true
+	}
+	m, ok := small(script[0])
+	if !ok {
+		return 0, 0, false
+	}
+	n, ok := small(script[len(script)-2])
+	if !ok {
+		return 0, 0, false
+	}
+	return m, n, true
+}
+
+// keysWithOrigin counts an input's derivation records that name a real path. A
+// bare xpub cosigner has none, and a signer cannot place that key.
+func keysWithOrigin(in *psbt.PInput) int {
+	n := 0
+	for _, d := range in.Bip32Derivation {
+		if len(d.Bip32Path) > 2 {
+			n++
+		}
+	}
+	return n
 }
 
 // signerName identifies a partial signature's signer the way the key table

--- a/sidechain-orchestrator/wallet/psbt_test.go
+++ b/sidechain-orchestrator/wallet/psbt_test.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -1114,4 +1116,79 @@ func TestFinalizeRejectsUncompressedKey(t *testing.T) {
 	_, err = finalizeAndExtract(packet)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "compressed public key")
+}
+
+// TestChangeOutputCarriesItsScript: a multisig change output must carry its
+// witness script beside its derivation records. A hardware signer that gets the
+// paths alone rebuilds the output as a single-key one, and it then signs a
+// transaction that pays somewhere else.
+func TestChangeOutputCarriesItsScript(t *testing.T) {
+	net := &chaincfg.SigNetParams
+	const amount = int64(100_000)
+	const dest = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+	acct := func(pass string) *hdkeychain.ExtendedKey {
+		seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, pass))
+		k, err := accountKeyFromSeed(seedHex, ScriptNativeSegwit, net)
+		require.NoError(t, err)
+		return k
+	}
+	d := &Descriptor{Kind: ScriptMultisig, Threshold: 2,
+		Keys: []DescriptorKey{{Account: acct("a")}, {Account: acct("b")}, {Account: acct("c")}}}
+	spend, _, err := d.DeriveScript(false, 0, net)
+	require.NoError(t, err)
+	change, _, err := d.DeriveScript(true, 0, net)
+	require.NoError(t, err)
+	sum := sha256.Sum256(change.witnessScript)
+	changeWSH, err := btcutil.NewAddressWitnessScriptHash(sum[:], net)
+	require.NoError(t, err)
+	changeAddr := changeWSH.EncodeAddress()
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	prevTx.AddTxOut(wire.NewTxOut(amount, spend.scriptPubKey))
+
+	in := psbtInput{
+		outpoint: wire.OutPoint{Hash: prevTx.TxHash(), Index: 0},
+		amount:   amount,
+		addr: scannedAddr{scriptPubKey: spend.scriptPubKey, witnessScript: spend.witnessScript,
+			kind: ScriptMultisig},
+	}
+	derivations, err := d.derivations(true, 0)
+	require.NoError(t, err)
+	outs := []TxOutSpec{
+		{Address: dest, AmountBTC: 0.0005},
+		{
+			Address: changeAddr, AmountBTC: 0.0004,
+			Kind: ScriptMultisig, Derivations: derivations,
+			WitnessScript: change.witnessScript,
+		},
+	}
+
+	packet, err := buildPSBT([]psbtInput{in}, outs, net, nil)
+	require.NoError(t, err)
+	require.Empty(t, packet.Outputs[0].WitnessScript, "a payment output is not ours to describe")
+	require.Equal(t, change.witnessScript, packet.Outputs[1].WitnessScript,
+		"the change output must carry the script its paths describe")
+
+	// The script must hash to the output it pays, or a signer rebuilds another.
+	require.Equal(t, change.scriptPubKey[2:34], sum[:])
+}
+
+// TestOwnedOutputTakesPathsAndScriptsTogether: an owned output takes its paths
+// and its scripts from one place, so no builder describes one without the other.
+func TestOwnedOutputTakesPathsAndScriptsTogether(t *testing.T) {
+	sa := scannedAddr{
+		kind:          ScriptMultisig,
+		redeem:        []byte{0x01},
+		witnessScript: []byte{0x02},
+		derivations:   []keyDerivation{{fingerprint: 7}},
+	}
+	got := TxOutSpec{Address: "x", AmountSats: 5}.describeOwned(sa)
+	require.Equal(t, ScriptMultisig, got.Kind)
+	require.Equal(t, sa.derivations, got.Derivations)
+	require.Equal(t, sa.redeem, got.RedeemScript)
+	require.Equal(t, sa.witnessScript, got.WitnessScript)
+	require.Equal(t, "x", got.Address, "describing an output keeps what it pays")
+	require.Equal(t, int64(5), got.AmountSats)
 }

--- a/sidechain-orchestrator/wallet/psbt_test.go
+++ b/sidechain-orchestrator/wallet/psbt_test.go
@@ -561,9 +561,10 @@ func TestFinalizeRejectsForeignRedeemScript(t *testing.T) {
 	assert.Contains(t, err.Error(), "redeem script does not match the output it spends")
 }
 
-// A cosigner pasted as a bare xpub has no origin, and a made-up path fails a
-// hardware signer: it checks every path in the packet before it signs any of
-// them. A master account key is the one case where [chain, index] is true.
+// A cosigner pasted as a bare xpub has no origin. Its record carries an empty
+// path: a made-up path fails a hardware signer, and no record at all leaves the
+// signer a script with a key missing. A master account key is the one case
+// where [chain, index] is true.
 func TestDerivationsSkipUnknownOrigin(t *testing.T) {
 	seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, ""))
 	net := &chaincfg.SigNetParams
@@ -586,10 +587,11 @@ func TestDerivationsSkipUnknownOrigin(t *testing.T) {
 
 	derivs, err := d.derivations(false, 0)
 	require.NoError(t, err)
-	require.Len(t, derivs, 2, "the origin-less deep key gets no record")
+	require.Len(t, derivs, 3, "every key reaches the signer")
 	require.Equal(t, []uint32{hdkeychain.HardenedKeyStart + 48, hdkeychain.HardenedKeyStart + 1,
 		hdkeychain.HardenedKeyStart, hdkeychain.HardenedKeyStart + 2, 0, 0}, derivs[0].path)
-	require.Equal(t, []uint32{0, 0}, derivs[1].path, "a master key's path is true")
+	require.Empty(t, derivs[1].path, "the origin-less deep key claims no derivation")
+	require.Equal(t, []uint32{0, 0}, derivs[2].path, "a master key's path is true")
 }
 
 func mustHex(t *testing.T, s string) []byte {

--- a/sidechain-orchestrator/wallet/psbt_test.go
+++ b/sidechain-orchestrator/wallet/psbt_test.go
@@ -1118,6 +1118,75 @@ func TestFinalizeRejectsUncompressedKey(t *testing.T) {
 	assert.Contains(t, err.Error(), "compressed public key")
 }
 
+// TestFinalizeNamesTheSignerFault: a hardware signer that builds its own sighash
+// gives a signature this packet cannot explain. The report must name the fault,
+// not report only a wrong key.
+func TestFinalizeNamesTheSignerFault(t *testing.T) {
+	net := &chaincfg.SigNetParams
+	const amount = int64(100_000)
+	const dest = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+	acctXprv := func(pass string) *hdkeychain.ExtendedKey {
+		seedHex := hex.EncodeToString(MnemonicToSeed(testMnemonic, pass))
+		acct, err := accountKeyFromSeed(seedHex, ScriptNativeSegwit, net)
+		require.NoError(t, err)
+		return acct
+	}
+	a, b, c := acctXprv("a"), acctXprv("b"), acctXprv("c")
+	d := &Descriptor{Kind: ScriptMultisig, Threshold: 2, Keys: []DescriptorKey{{Account: a}, {Account: b}, {Account: c}}}
+	ds, _, err := d.DeriveScript(false, 0, net)
+	require.NoError(t, err)
+
+	privAt := func(acct *hdkeychain.ExtendedKey) *btcec.PrivateKey {
+		priv, ok, err := deriveChildPrivIfPossible(acct, 0, 0)
+		require.NoError(t, err)
+		require.True(t, ok)
+		return priv
+	}
+	priv := privAt(a)
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0xffffffff}, []byte{0x00}, nil))
+	prevTx.AddTxOut(wire.NewTxOut(amount, ds.scriptPubKey))
+	outpoint := wire.OutPoint{Hash: prevTx.TxHash(), Index: 0}
+	out := []TxOutSpec{{Address: dest, AmountBTC: float64(amount-1000) / 1e8}}
+
+	packetWithSig := func(script []byte) *psbt.Packet {
+		in := psbtInput{outpoint: outpoint, amount: amount, addr: scannedAddr{
+			scriptPubKey: ds.scriptPubKey, witnessScript: ds.witnessScript,
+			kind: ScriptMultisig, multisigPrivs: []*btcec.PrivateKey{priv, privAt(b)},
+		}}
+		packet, err := buildPSBT([]psbtInput{in}, out, net, nil)
+		require.NoError(t, err)
+		_, err = signPSBT(packet, []psbtInput{in}, net)
+		require.NoError(t, err)
+
+		fetcher := txscript.NewCannedPrevOutputFetcher(ds.scriptPubKey, amount)
+		sigHashes := txscript.NewTxSigHashes(packet.UnsignedTx, fetcher)
+		wrong, err := txscript.RawTxInWitnessSignature(
+			packet.UnsignedTx, sigHashes, 0, amount, script, txscript.SigHashAll, priv)
+		require.NoError(t, err)
+		for _, ps := range packet.Inputs[0].PartialSigs {
+			if bytes.Equal(ps.PubKey, priv.PubKey().SerializeCompressed()) {
+				ps.Signature = wrong
+			}
+		}
+		return packet
+	}
+
+	code, err := p2wpkhScriptCode(btcutil.Hash160(priv.PubKey().SerializeCompressed()))
+	require.NoError(t, err)
+	_, err = finalizeAndExtract(packetWithSig(code))
+	require.ErrorContains(t, err, "signed this input as single-key p2wpkh")
+
+	// A packet without derivation records cannot name a cosigner order.
+	if unsorted, ok := multisigInRecordOrder(&packetWithSig(ds.witnessScript).Inputs[0]); ok &&
+		!bytes.Equal(unsorted, ds.witnessScript) {
+		_, err = finalizeAndExtract(packetWithSig(unsorted))
+		require.ErrorContains(t, err, "built the multisig script with the keys in the order")
+	}
+}
+
 // TestChangeOutputCarriesItsScript: a multisig change output must carry its
 // witness script beside its derivation records. A hardware signer that gets the
 // paths alone rebuilds the output as a single-key one, and it then signs a

--- a/sidechain-orchestrator/wallet/tx.go
+++ b/sidechain-orchestrator/wallet/tx.go
@@ -30,6 +30,22 @@ type TxOutSpec struct {
 	// Set for an owned change output so the PSBT carries its derivation records.
 	Kind        ScriptKind
 	Derivations []keyDerivation
+	// The scripts an owned change output pays to. A signer that gets a change
+	// path without them rebuilds the output as a single-key one, and it then
+	// signs a transaction that pays somewhere else.
+	RedeemScript  []byte
+	WitnessScript []byte
+}
+
+// describeOwned marks an output this wallet owns, so a signer can check it as
+// its own. It takes the paths and the scripts together, because a signer that
+// gets the paths alone rebuilds the output as a single-key one.
+func (o TxOutSpec) describeOwned(sa scannedAddr) TxOutSpec {
+	o.Kind = sa.kind
+	o.Derivations = sa.derivations
+	o.RedeemScript = sa.redeem
+	o.WitnessScript = sa.witnessScript
+	return o
 }
 
 // BuildUnsignedTransaction assembles a raw unsigned transaction in-process,


### PR DESCRIPTION
A hardware signer rebuilds the script from the packet, so a packet that leaves out a script or a key origin makes the device sign a script this wallet never held. Today that fault reaches the user as a broadcast failure that names no device.

These commits give the packet the scripts and the paths a device reads, check the device keys and the signatures it returns before the transaction leaves, and name the fault when a signature still fails. One commit is unrelated: an Esplora replay check now takes both answers from one server.