### PR TITLE
bitwindow: unstick the block scan, the cookie wait and the socket leak

### DIFF
--- a/.github/workflows/bitwindow-e2e.yml
+++ b/.github/workflows/bitwindow-e2e.yml
@@ -104,7 +104,7 @@ jobs:
         id: boot
         working-directory: bitwindow/e2e
         run:
-          go test -tags e2e -v -timeout 15m -run TestJustRunBootsDaemons ./...
+          go test -tags e2e -v -timeout 20m -run TestJustRunBootsDaemons ./...
         env:
           BITWINDOW_TEST_LOG_DIR: ${{ runner.temp }}/e2e-logs/boot
           FLUTTER_RUN_ARGS: ${{ runner.os == 'Windows' && '-v' || '' }}

--- a/bitwindow/server/engines/bitcoind_engine.go
+++ b/bitwindow/server/engines/bitcoind_engine.go
@@ -753,6 +753,7 @@ func (p *Parser) handleOpReturns(
 
 	// Only fetch this a single time if handling multiple outputs
 	var rawTx *corepb.GetRawTransactionResponse
+	var feeUnknown bool
 
 	var opReturns []opreturns.OPReturn
 	for vout, txout := range tx.TxOut {
@@ -804,7 +805,7 @@ func (p *Parser) handleOpReturns(
 		// condition where blocks are processed in parallel and a topic
 		// created in one block isn't yet registered when a news article
 		// in a later block (same batch) checks isKnownTopic.
-		if rawTx == nil {
+		if rawTx == nil && !feeUnknown {
 			core, err := p.bitcoind.Get(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("get bitcoind: %w", err)
@@ -815,10 +816,23 @@ func (p *Parser) handleOpReturns(
 				Verbosity: corepb.GetRawTransactionRequest_VERBOSITY_TX_INFO,
 				Txid:      txid,
 			}))
-			if err != nil {
+			switch {
+			case err != nil && height != nil && isTxIndexMiss(err.Error()):
+				// Confirmed only: an unconfirmed miss means the transaction
+				// left the mempool, and that row must not land. The fee is the
+				// only field this call feeds, but returning the error aborts
+				// the whole block batch, so processed_blocks never advances.
+				zerolog.Ctx(ctx).Warn().
+					Str("txid", txid).
+					Msg("bitcoind_engine/parser: no txindex entry, recording OP_RETURN without a fee")
+				feeUnknown = true
+
+			case err != nil:
 				return nil, fmt.Errorf("get raw transaction %q: %w", txid, err)
+
+			default:
+				rawTx = res.Msg
 			}
-			rawTx = res.Msg
 		}
 
 		fee, err := btcutil.NewAmount(rawTx.GetFee())
@@ -837,6 +851,15 @@ func (p *Parser) handleOpReturns(
 	}
 
 	return opReturns, nil
+}
+
+// isTxIndexMiss reports whether getrawtransaction failed because the node
+// carries no txindex entry for the transaction, either because the index is
+// off or because Core still builds it after a reindex. Both shapes carry
+// JSON-RPC code -5.
+func isTxIndexMiss(errMsg string) bool {
+	return strings.Contains(errMsg, "No such mempool or blockchain transaction") ||
+		strings.Contains(errMsg, "Blockchain transactions are still in the process of being indexed")
 }
 
 // recentScanWindow is how far back a lagging scan reaches: about a week at ten

--- a/bitwindow/server/engines/opreturn_txindex_miss_test.go
+++ b/bitwindow/server/engines/opreturn_txindex_miss_test.go
@@ -1,0 +1,105 @@
+package engines
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/database"
+	service "github.com/LayerTwo-Labs/sidesail/bitwindow/server/service"
+	"github.com/LayerTwo-Labs/sidesail/bitwindow/server/tests/mocks"
+	corerpc "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// txIndexMissErr is what Core answers for a confirmed transaction it holds no
+// index entry for.
+const txIndexMissErr = "unknown: -5: No such mempool or blockchain transaction. " +
+	"Use gettransaction for wallet transactions."
+
+// opReturnTx is a spending transaction that carries one OP_RETURN output.
+func opReturnTx(t *testing.T) *wire.MsgTx {
+	t.Helper()
+	script, err := txscript.NewScriptBuilder().
+		AddOp(txscript.OP_RETURN).
+		AddData([]byte("bitwindow")).
+		Script()
+	require.NoError(t, err)
+
+	tx := wire.NewMsgTx(wire.TxVersion)
+	tx.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&chainhash.Hash{1}, 0), nil, nil))
+	tx.AddTxOut(wire.NewTxOut(0, script))
+	return tx
+}
+
+// parserWithRawTxError wires a Parser to a Core that fails every
+// getrawtransaction with errMsg.
+func parserWithRawTxError(t *testing.T, errMsg string) *Parser {
+	t.Helper()
+	core := mocks.NewMockBitcoinServiceClient(gomock.NewController(t))
+	core.EXPECT().
+		GetRawTransaction(gomock.Any(), gomock.Any()).
+		Return(nil, connect.NewError(connect.CodeUnknown, errors.New(errMsg))).
+		AnyTimes()
+
+	return &Parser{
+		db: database.Test(t),
+		bitcoind: service.New("bitcoind", func(ctx context.Context) (corerpc.BitcoinServiceClient, error) {
+			return core, nil
+		}),
+	}
+}
+
+// A node without a complete txindex answers -5 for a confirmed transaction.
+// Returning that error aborted the whole block batch, so processed_blocks
+// never advanced and the parser replayed the same batch every two seconds.
+func TestConfirmedOpReturnSurvivesAMissingTxIndexEntry(t *testing.T) {
+	ctx := context.Background()
+	p := parserWithRawTxError(t, txIndexMissErr)
+
+	height := uint32(995432)
+	blockTime := time.Unix(1700000000, 0)
+
+	opReturns, err := p.handleOpReturns(ctx, opReturnTx(t), &height, &blockTime)
+	require.NoError(t, err)
+	require.Len(t, opReturns, 1)
+	require.Zero(t, opReturns[0].Fee, "an unknown fee reads as zero, not as a failure")
+}
+
+// An unconfirmed miss means the transaction left the mempool. That row must
+// not land, so the caller still sees the error.
+func TestUnconfirmedOpReturnStillFailsOnAMissingTransaction(t *testing.T) {
+	ctx := context.Background()
+	p := parserWithRawTxError(t, txIndexMissErr)
+
+	createdAt := time.Unix(1700000000, 0)
+
+	_, err := p.handleOpReturns(ctx, opReturnTx(t), nil, &createdAt)
+	require.Error(t, err)
+}
+
+// Any other getrawtransaction failure stays terminal.
+func TestConfirmedOpReturnStillFailsOnAnUnrelatedRpcError(t *testing.T) {
+	ctx := context.Background()
+	p := parserWithRawTxError(t, "unavailable: unexpected EOF")
+
+	height := uint32(995432)
+	blockTime := time.Unix(1700000000, 0)
+
+	_, err := p.handleOpReturns(ctx, opReturnTx(t), &height, &blockTime)
+	require.Error(t, err)
+}
+
+func TestIsTxIndexMissMatchesBothCoreShapes(t *testing.T) {
+	require.True(t, isTxIndexMiss(txIndexMissErr))
+	require.True(t, isTxIndexMiss("unknown: -5: No such mempool transaction. "+
+		"Blockchain transactions are still in the process of being indexed."))
+	require.False(t, isTxIndexMiss("unavailable: unexpected EOF"))
+}

--- a/bitwindow/server/engines/startup_errors.go
+++ b/bitwindow/server/engines/startup_errors.go
@@ -23,10 +23,55 @@ var bitcoindStartupPatterns = []string{
 	"Replaying blocks",
 }
 
+// cookieMissingReasons are the stat texts for a file that is not there, one
+// per platform. The failure arrives as a string inside an RPC message, so the
+// error value os.IsNotExist would read is already gone by this point.
+var cookieMissingReasons = []string{
+	"no such file or directory",
+	"The system cannot find the file specified",
+	"The system cannot find the path specified",
+}
+
+// cookieMessage reads back to the user in place of the raw stat failure.
+const cookieMessage = "Starting Bitcoin Core"
+
+// cookiePathMarkers name an auth cookie inside an error. The wrapper text
+// carries the first one whatever the file is called, because rpccookiefile
+// renames it; the second catches a bare stat of the default name.
+var cookiePathMarkers = []string{
+	"read rpc cookie ",
+	".cookie",
+}
+
+// isMissingCookie reports whether an RPC failed because Core has no auth
+// cookie on disk. Core deletes the cookie when it stops and writes a fresh one
+// a moment after it starts, so the whole restart window fails on this.
+func isMissingCookie(errMsg string) bool {
+	named := false
+	for _, marker := range cookiePathMarkers {
+		if strings.Contains(errMsg, marker) {
+			named = true
+			break
+		}
+	}
+	if !named {
+		return false
+	}
+	for _, reason := range cookieMissingReasons {
+		if strings.Contains(errMsg, reason) {
+			return true
+		}
+	}
+	return false
+}
+
 // IsBitcoinCoreStartupError reports whether the error originated from Bitcoin
 // Core being mid-startup (block index load, verify, rescan, wallet load).
 // Callers use this to back off instead of treating the failure as terminal.
 func IsBitcoinCoreStartupError(errMsg string) bool {
+	if isMissingCookie(errMsg) {
+		return true
+	}
 	for _, p := range bitcoindStartupPatterns {
 		if strings.Contains(errMsg, p) {
 			return true
@@ -45,6 +90,10 @@ func ExtractBitcoindStartupMessage(errMsg string) string {
 	}
 	if !IsBitcoinCoreStartupError(errMsg) {
 		return ""
+	}
+
+	if isMissingCookie(errMsg) {
+		return cookieMessage
 	}
 
 	// Common shapes:

--- a/bitwindow/server/engines/startup_errors_test.go
+++ b/bitwindow/server/engines/startup_errors_test.go
@@ -44,3 +44,60 @@ func TestExtractBitcoindStartupMessage(t *testing.T) {
 		})
 	}
 }
+
+// Core deletes its auth cookie when it stops. Every RPC in the restart window
+// failed the stat, which the UI showed as an error instead of a boot phase.
+func TestMissingCookieReadsAsAStartupError(t *testing.T) {
+	const err = "could not get network stats: get blockchain info: unknown: " +
+		"stat /media/user/Datadrive/CHAINDATA/Ecash/ecash/.cookie: no such file or directory"
+
+	assert.True(t, IsBitcoinCoreStartupError(err))
+	assert.Equal(t, "Starting Bitcoin Core", ExtractBitcoindStartupMessage(err))
+}
+
+// A cookie the process may not read is a permission fault, not a boot phase.
+func TestUnreadableCookieIsNotAStartupError(t *testing.T) {
+	const err = "stat /home/user/.bitcoin/.cookie: permission denied"
+
+	assert.False(t, IsBitcoinCoreStartupError(err))
+}
+
+// Windows words the same absent file differently, so the Unix text alone left
+// the restart window a hard error on a supported platform.
+func TestMissingCookieReadsAsAStartupErrorOnEveryPlatform(t *testing.T) {
+	for name, err := range map[string]string{
+		"windows file": `CreateFile C:\Users\u\AppData\Roaming\Bitcoin\.cookie: ` +
+			"The system cannot find the file specified.",
+		"windows path": `CreateFile C:\Users\u\AppData\Roaming\Bitcoin\.cookie: ` +
+			"The system cannot find the path specified.",
+		"unix": "stat /home/u/.bitcoin/.cookie: no such file or directory",
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.True(t, IsBitcoinCoreStartupError(err))
+			assert.Equal(t, "Starting Bitcoin Core", ExtractBitcoindStartupMessage(err))
+		})
+	}
+}
+
+// rpccookiefile renames the file, so the name cannot be the signal. The
+// wrapper that reads it names it instead.
+func TestARenamedCookieIsAStartupError(t *testing.T) {
+	const err = "read rpc cookie /home/u/.bitcoin/auth-token: " +
+		"open /home/u/.bitcoin/auth-token: no such file or directory"
+	assert.True(t, IsBitcoinCoreStartupError(err))
+	assert.Equal(t, cookieMessage, ExtractBitcoindStartupMessage(err))
+}
+
+// A renamed cookie the process may not read is still a permission fault.
+func TestARenamedCookieWithNoPermissionIsNotAStartupError(t *testing.T) {
+	assert.False(t, IsBitcoinCoreStartupError(
+		"read rpc cookie /home/u/.bitcoin/auth-token: permission denied"))
+}
+
+// The reason alone must not match. Only a failure about the cookie counts.
+func TestAMissingFileThatIsNotTheCookieIsNotAStartupError(t *testing.T) {
+	assert.False(t, IsBitcoinCoreStartupError(
+		"open /home/u/.bitcoin/wallet.dat: no such file or directory"))
+	assert.False(t, IsBitcoinCoreStartupError(
+		`CreateFile C:\data\blocks: The system cannot find the file specified.`))
+}

--- a/bitwindow/server/models/opreturns/cache_test.go
+++ b/bitwindow/server/models/opreturns/cache_test.go
@@ -303,3 +303,55 @@ func TestListCoinNews_TopicNameMatchesEachRow(t *testing.T) {
 	assert.Equal(t, topicA, byHeadline["ha"].Topic)
 	assert.Equal(t, topicB, byHeadline["hb"].Topic)
 }
+
+// A node with no txindex cannot read the fee of a confirmed transaction, so
+// the scan records zero. ZMQ already stored the real fee from the mempool, and
+// the confirming write must not erase it.
+func TestConfirmingARowKeepsAFeeTheMempoolAlreadyGave(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	const txid = "a1b2c3"
+	unconfirmed := time.Now()
+	require.NoError(t, Persist(ctx, db, []OPReturn{{
+		TxID: txid, Vout: 0, Data: []byte{0x01}, Fee: 4200, CreatedAt: &unconfirmed,
+	}}))
+
+	height := uint32(995432)
+	blockTime := unconfirmed.Add(time.Minute)
+	require.NoError(t, Persist(ctx, db, []OPReturn{{
+		TxID: txid, Vout: 0, Data: []byte{0x01}, Fee: 0, Height: &height, CreatedAt: &blockTime,
+	}}))
+
+	rows, err := List(ctx, db, 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.EqualValues(t, 4200, rows[0].Fee, "an unknown fee must not replace a known one")
+	require.NotNil(t, rows[0].Height)
+	assert.EqualValues(t, height, *rows[0].Height, "the row must still confirm")
+}
+
+// A fee the scan does read still replaces whatever the row held.
+func TestConfirmingARowStillWritesAKnownFee(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.Test(t)
+
+	const txid = "d4e5f6"
+	unconfirmed := time.Now()
+	require.NoError(t, Persist(ctx, db, []OPReturn{{
+		TxID: txid, Vout: 0, Data: []byte{0x02}, Fee: 4200, CreatedAt: &unconfirmed,
+	}}))
+
+	height := uint32(995433)
+	blockTime := unconfirmed.Add(time.Minute)
+	require.NoError(t, Persist(ctx, db, []OPReturn{{
+		TxID: txid, Vout: 0, Data: []byte{0x02}, Fee: 999, Height: &height, CreatedAt: &blockTime,
+	}}))
+
+	rows, err := List(ctx, db, 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.EqualValues(t, 999, rows[0].Fee)
+}

--- a/bitwindow/server/models/opreturns/opreturns.go
+++ b/bitwindow/server/models/opreturns/opreturns.go
@@ -91,7 +91,9 @@ func Persist(
 		`ON CONFLICT (txid, vout) DO UPDATE SET 
 			op_return_data = excluded.op_return_data, 
 			height = COALESCE(excluded.height, op_returns.height), 
-			fee_sats = excluded.fee_sats,
+			-- Zero reads as unknown: a scan on a node with no txindex cannot
+			-- fetch the fee, and must not erase one the mempool already gave us.
+			fee_sats = COALESCE(NULLIF(excluded.fee_sats, 0), op_returns.fee_sats),
 			created_at = CASE
 				WHEN excluded.height IS NOT NULL THEN excluded.created_at
 				ELSE op_returns.created_at

--- a/bitwindow/server/tests/apitests/apitests.go
+++ b/bitwindow/server/tests/apitests/apitests.go
@@ -310,6 +310,17 @@ func ExpectCoreWalletSetup(mock *mocks.MockBitcoinServiceClient) {
 		}, nil).
 		AnyTimes()
 
+	// The parser ticker races the test, and starts by fetching block 1. A test
+	// that outlives one tick reaches this, so every custom mock wants the
+	// allowance defaultBitcoindMock already carries. Height 1 only, or the
+	// catch-all swallows the counted expectations a test sets for its own
+	// heights.
+	mock.EXPECT().
+		GetBlockHash(gomock.Any(), gomock.Cond(func(req *connect.Request[corepb.GetBlockHashRequest]) bool {
+			return req.Msg.GetHeight() == 1
+		})).
+		Return(nil, fmt.Errorf("Block height out of range")). //nolint:staticcheck // bitcoind's wording, which the parser matches on
+		AnyTimes()
 }
 
 // ExpectOrchestratorReads allows the read-only wallet-manager calls the engines

--- a/sidechain-orchestrator/testharness/node.go
+++ b/sidechain-orchestrator/testharness/node.go
@@ -57,11 +57,29 @@ func testPorts(base, nodeIndex int) (rpcPort, p2pPort, grpcPort int) {
 	return nodeBase, nodeBase + 100, nodeBase + 200
 }
 
-// randomPortBase picks a random base port in 40000-59000 range.
+// ephemeralFloor is the lowest port any supported platform hands out to an
+// outbound socket. Linux sets it: net.ipv4.ip_local_port_range starts at 32768,
+// where Windows and macOS both start at 49152. A test port at or above the
+// floor may already belong to a live connection, and the node fails to bind.
+const ephemeralFloor = 32768
+
+// portBaseCount is how many bases randomPortBase chooses between. The highest
+// base plus the widest band must stay under [ephemeralFloor].
+const portBaseCount = 110
+
+// randomPortBase picks a random base port in the 20000-30900 range, so a
+// four-node harness tops out at 32000.
+//
+// Asking the kernel for a free port instead is worse, not better — it answers
+// from the ephemeral range, and bitcoind took the number back before
+// drivechaind bound it.
+//
+// The floor keeps the band clear of the Core RPC ports: 8332 mainnet, 18332
+// testnet, 18443 regtest.
 func randomPortBase() int {
 	b := make([]byte, 2)
 	_, _ = rand.Read(b)
-	return 40000 + int(b[0])%190*100
+	return 20000 + int(b[0])%portBaseCount*100
 }
 
 // newNode creates and starts a fully-wired Node with real subprocesses.
@@ -244,13 +262,15 @@ func waitForBitcoind(t *testing.T, rpcClient *wallet.CoreRPCClient, nodeName str
 	// 180s, not 90s: the first launch of a freshly built bitcoind waits on the
 	// Windows virus scanner and missed 90s twice, while the next test in the
 	// same job reached RPC one second after start.
-	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	const budget = 180 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
 
 	for {
 		select {
 		case <-ctx.Done():
-			t.Fatalf("testharness[%s]: bitcoind did not become ready within 90s", nodeName)
+			t.Fatalf("testharness[%s]: bitcoind did not become ready within %s", nodeName, budget)
 		default:
 		}
 		if result, err := rpcClient.GetBlockchainInfo(ctx); err == nil && result != nil {

--- a/sidechain-orchestrator/testharness/node.go
+++ b/sidechain-orchestrator/testharness/node.go
@@ -241,9 +241,10 @@ func (n *Node) close() {
 func waitForBitcoind(t *testing.T, rpcClient *wallet.CoreRPCClient, nodeName string) {
 	t.Helper()
 
-	// 90s, not 30s: the Windows CI runners are slow to bring bitcoind's RPC up
-	// and were flaking the integration suite on the readiness wait.
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	// 180s, not 90s: the first launch of a freshly built bitcoind waits on the
+	// Windows virus scanner and missed 90s twice, while the next test in the
+	// same job reached RPC one second after start.
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
 	for {

--- a/sidechain-orchestrator/testharness/portrange_test.go
+++ b/sidechain-orchestrator/testharness/portrange_test.go
@@ -1,0 +1,36 @@
+package testharness
+
+import "testing"
+
+// A base inside the ephemeral range draws a port the OS already gave an
+// outbound socket, and a base on a Core RPC port clashes with a node the test
+// did not start.
+func TestEveryPortBaseStaysInTheSafeRange(t *testing.T) {
+	const nodes = 4
+
+	coreRPCPorts := []int{8332, 18332, 18443, 38332}
+
+	for i := 0; i < portBaseCount; i++ {
+		base := 20000 + i*100
+		_, _, top := testPorts(base, nodes-1)
+		if top >= ephemeralFloor {
+			t.Fatalf("base %d reaches %d, at or above the ephemeral floor %d", base, top, ephemeralFloor)
+		}
+		for _, taken := range coreRPCPorts {
+			if taken >= base && taken <= top {
+				t.Fatalf("base %d spans %d-%d, which covers the Core RPC port %d", base, base, top, taken)
+			}
+		}
+	}
+}
+
+// randomPortBase must only ever return a base the check above covers.
+func TestRandomPortBaseStaysOnTheGrid(t *testing.T) {
+	highest := 20000 + (portBaseCount-1)*100
+	for i := 0; i < 500; i++ {
+		base := randomPortBase()
+		if base < 20000 || base > highest || base%100 != 0 {
+			t.Fatalf("randomPortBase returned %d", base)
+		}
+	}
+}

--- a/sidechain_core/lib/rpcs/enforcer_rpc.dart
+++ b/sidechain_core/lib/rpcs/enforcer_rpc.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:connectrpc/connect.dart';
 import 'package:connectrpc/protobuf.dart';
 import 'package:connectrpc/protocol/grpc.dart' as grpc;
 import 'package:get_it/get_it.dart';
@@ -25,6 +26,8 @@ class EnforcerLive extends EnforcerRPC {
   final int _port;
   String get _baseUrl => 'http://$_host:$_port';
 
+  ({HttpClient client, void Function() close}) _pool = closableUnaryHttpClient();
+
   /// [host]/[port] point at the app's local daemon, which bridges all
   /// enforcer traffic: bitwindowd in bitwindow, drivechaind in sidechain
   /// apps. The enforcer itself is never dialed directly.
@@ -33,12 +36,12 @@ class EnforcerLive extends EnforcerRPC {
   }
 
   void _initializeConnection() {
-    // Create new HTTP/2 transport and client
-    final httpClient = unaryHttpClient();
+    // The transport reads the pool per request rather than capture one, so a
+    // rebuild never strands a client a consumer already holds.
     _grpcTransport = grpc.Transport(
       baseUrl: _baseUrl,
       codec: const ProtoCodec(),
-      httpClient: httpClient,
+      httpClient: (req) => _pool.client(req),
       statusParser: const StatusParser(),
       interceptors: [LocalAuth.interceptor()],
     );
@@ -221,9 +224,14 @@ class EnforcerLive extends EnforcerRPC {
     }
   }
 
+  /// Replace the socket pool behind the transport. The old pool closes, or its
+  /// sockets stay open until GC runs and a reconnect loop exhausts the process
+  /// file descriptors.
   void _recreateConnection() {
     log.w('Recreating HTTP/2 connection for enforcer');
-    _initializeConnection();
+    final previous = _pool;
+    _pool = closableUnaryHttpClient();
+    previous.close();
   }
 
   Future<T> _withRecreate<T>(Future<T> Function() operation) async {

--- a/sidechain_core/lib/rpcs/keepalive_http_client.dart
+++ b/sidechain_core/lib/rpcs/keepalive_http_client.dart
@@ -11,11 +11,24 @@ import 'package:connectrpc/io.dart' as connect_io;
 /// only long-running streams. We deliberately don't share an HTTP/2
 /// connection between unary and streaming calls so a poisoned streaming
 /// transport can't take down list/get RPCs that are otherwise fine.
-HttpClient unaryHttpClient() {
+HttpClient unaryHttpClient() => closableUnaryHttpClient().client;
+
+/// [unaryHttpClient] plus the callback that retires its socket pool.
+///
+/// A connectrpc [HttpClient] is a bare closure, so a caller that rebuilds a
+/// transport cannot reach the pool behind the old one. Those sockets then stay
+/// open until GC finalizes the client, and a reconnect loop runs the process
+/// out of file descriptors long before that.
+///
+/// The close drops the idle sockets and refuses new ones, but it lets a
+/// request already in flight finish. A stream supervisor rebuilds on an HTTP/2
+/// fault that says nothing about a healthy unary call, and most callers do not
+/// retry.
+({HttpClient client, void Function() close}) closableUnaryHttpClient() {
   final client = io.HttpClient()
     ..idleTimeout = const Duration(minutes: 5)
     ..connectionTimeout = const Duration(seconds: 30);
-  return connect_io.createHttpClient(client);
+  return (client: connect_io.createHttpClient(client), close: client.close);
 }
 
 /// HTTP transport for **server-streaming** RPCs — HTTP/2 with keepalive PINGs.
@@ -42,6 +55,10 @@ HttpClient streamingHttpClient() {
       pingInterval: const Duration(seconds: 20),
       pingTimeout: const Duration(seconds: 10),
       pingIdleConnections: false,
+      // Http2ClientTransport exposes no close, so an abandoned transport holds
+      // its socket for the whole idle window. The timer only arms once the
+      // connection carries no open stream, so a live stream never trips it.
+      idleConnectionTimeout: const Duration(minutes: 1),
     ),
   );
 }

--- a/sidechain_core/lib/rpcs/orchestrator_rpc.dart
+++ b/sidechain_core/lib/rpcs/orchestrator_rpc.dart
@@ -1,3 +1,4 @@
+import 'package:connectrpc/connect.dart';
 import 'package:connectrpc/protobuf.dart';
 import 'package:sidechain_core/auth/local_auth.dart';
 import 'package:sidechain_core/rpcs/keepalive_http_client.dart';
@@ -27,35 +28,35 @@ class OrchestratorEndpoint {
 }
 
 class OrchestratorRPC {
-  late OrchestratorServiceClient _unaryClient;
-  late OrchestratorServiceClient _streamClient;
-  late OrchestratorWalletRPC wallet;
-  late OrchestratorBmmRPC bmm;
-  late OrchestratorMultisigLoungeRPC multisigLounge;
+  late final OrchestratorServiceClient _unaryClient;
+  late final OrchestratorServiceClient _streamClient;
+  late final OrchestratorWalletRPC wallet;
+  late final OrchestratorBmmRPC bmm;
+  late final OrchestratorMultisigLoungeRPC multisigLounge;
 
   /// btc-buf BitcoinService — single canonical bitcoind proxy for all
   /// callers. Routes peers / mempool / fee / blocks / PSBT helpers.
-  late BitcoinServiceClient bitcoind;
+  late final BitcoinServiceClient bitcoind;
   final String _host;
   final int _port;
 
+  ({HttpClient client, void Function() close}) _unaryPool = closableUnaryHttpClient();
+  HttpClient _streamPool = streamingHttpClient();
+
   OrchestratorRPC({required this._host, required this._port}) {
-    _initializeConnection();
-  }
-
-  String get _baseUrl => 'http://$_host:$_port';
-
-  void _initializeConnection() {
     final unaryTransport = connect.Transport(
       baseUrl: _baseUrl,
       codec: const ProtoCodec(),
-      httpClient: unaryHttpClient(),
+      // Both transports read the pool per request rather than capture one, so
+      // a rebuild never strands a client a consumer already holds. BMMProvider
+      // caches its wrapper for the life of the app.
+      httpClient: (req) => _unaryPool.client(req),
       interceptors: [LocalAuth.interceptor()],
     );
     final streamTransport = connect.Transport(
       baseUrl: _baseUrl,
       codec: const ProtoCodec(),
-      httpClient: streamingHttpClient(),
+      httpClient: (req) => _streamPool(req),
       interceptors: [LocalAuth.interceptor()],
     );
     _unaryClient = OrchestratorServiceClient(unaryTransport);
@@ -66,16 +67,25 @@ class OrchestratorRPC {
     bitcoind = BitcoinServiceClient(unaryTransport);
   }
 
-  /// Rebuild both transports. Called by [StreamSupervisor] when it
-  /// classifies an error as transport-level (GOAWAY, PROTOCOL_ERROR,
-  /// half-open detected by watchdog). Both transports are rebuilt because
-  /// the failure mode that knocks out HTTP/2 streams (network drop, sleep)
-  /// also typically invalidates HTTP/1.1 keepalive connections.
+  String get _baseUrl => 'http://$_host:$_port';
+
+  /// Replace the socket pool behind both transports. Called by
+  /// [StreamSupervisor] when it classifies an error as transport-level
+  /// (GOAWAY, PROTOCOL_ERROR, half-open detected by watchdog). Both pools go
+  /// because the failure mode that knocks out HTTP/2 streams (network drop,
+  /// sleep) also typically invalidates HTTP/1.1 keepalive connections.
+  ///
+  /// The old pool closes, or its sockets stay open until GC runs. This fires
+  /// on a tight loop while the daemon is still coming up, so leaking them
+  /// exhausts the process file descriptors.
   void recreateConnection() {
     // Silent — this fires constantly during boot while the daemon is still
     // coming up. The supervisor's own attempt counter surfaces a warning
     // once it's clearly stuck.
-    _initializeConnection();
+    final previous = _unaryPool;
+    _unaryPool = closableUnaryHttpClient();
+    previous.close();
+    _streamPool = streamingHttpClient();
   }
 
   static bool isHttp2ConnectionError(Object e) {

--- a/sidechain_core/test/keepalive_http_client_test.dart
+++ b/sidechain_core/test/keepalive_http_client_test.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+import 'dart:io' as io;
+
+import 'package:connectrpc/connect.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/rpcs/keepalive_http_client.dart';
+
+void main() {
+  // A rebuilt transport left its socket pool open, so a reconnect loop ran the
+  // process out of file descriptors (errno 24).
+  test('the unary client closes its sockets on demand', () async {
+    final server = await io.HttpServer.bind(io.InternetAddress.loopbackIPv4, 0);
+    server.listen((req) => req.response.close());
+    addTearDown(() => server.close(force: true));
+
+    final url = 'http://127.0.0.1:${server.port}/';
+    HttpRequest get() => HttpRequest(url, 'GET', Headers(), null, null);
+
+    final first = closableUnaryHttpClient();
+    expect((await first.client(get())).status, 200);
+    first.close();
+
+    // A closed pool must not serve a later call.
+    await expectLater(first.client(get()), throwsA(isA<Object>()));
+
+    // A fresh pool still works, so closing one does not break the next.
+    final second = closableUnaryHttpClient();
+    expect((await second.client(get())).status, 200);
+    second.close();
+  });
+
+  // A stream supervisor rebuilds on an HTTP/2 fault that says nothing about a
+  // healthy unary call. A force close aborted that call, and most callers do
+  // not retry.
+  test('a close lets a request in flight finish', () async {
+    final release = Completer<void>();
+    final server = await io.HttpServer.bind(io.InternetAddress.loopbackIPv4, 0);
+    server.listen((req) async {
+      await release.future;
+      await req.response.close();
+    });
+    addTearDown(() => server.close(force: true));
+
+    final url = 'http://127.0.0.1:${server.port}/';
+    final pool = closableUnaryHttpClient();
+
+    final inFlight = pool.client(HttpRequest(url, 'GET', Headers(), null, null));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    pool.close();
+
+    release.complete();
+    expect((await inFlight).status, 200);
+
+    // The retired pool still refuses new work.
+    await expectLater(
+      pool.client(HttpRequest(url, 'GET', Headers(), null, null)),
+      throwsA(isA<Object>()),
+    );
+  });
+}

--- a/sidechain_core/test/orchestrator_rpc_rebuild_test.dart
+++ b/sidechain_core/test/orchestrator_rpc_rebuild_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io' as io;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sidechain_core/gen/orchestrator/v1/orchestrator.pbenum.dart';
+import 'package:sidechain_core/rpcs/orchestrator_rpc.dart';
+
+void main() {
+  setUpAll(() {
+    if (!GetIt.I.isRegistered<Logger>()) {
+      GetIt.I.registerSingleton<Logger>(Logger());
+    }
+  });
+
+  // BMMProvider captures OrchestratorRPC.bmm once and holds it for the life of
+  // the app. A rebuild that swapped the wrapper left that copy pointed at a
+  // pool nobody could reach, and closing the pool broke it for good.
+  test('a captured client still reaches the daemon after a rebuild', () async {
+    var requests = 0;
+    final server = await io.HttpServer.bind(io.InternetAddress.loopbackIPv4, 0);
+    server.listen((req) {
+      requests++;
+      req.response.statusCode = 500;
+      req.response.close();
+    });
+    addTearDown(() => server.close(force: true));
+
+    final rpc = OrchestratorRPC(host: '127.0.0.1', port: server.port);
+    final captured = rpc.bmm;
+
+    await expectLater(captured.stop(BinaryType.BINARY_TYPE_THUNDER), throwsA(isA<Object>()));
+    expect(requests, 1);
+
+    rpc.recreateConnection();
+
+    expect(identical(captured, rpc.bmm), isTrue, reason: 'a rebuild must not swap the wrapper');
+    await expectLater(captured.stop(BinaryType.BINARY_TYPE_THUNDER), throwsA(isA<Object>()));
+    expect(requests, 2, reason: 'the captured client must reach the daemon through the new pool');
+  });
+}


### PR DESCRIPTION
Three faults from one user log. The app scanned forever and never showed a
balance.

**The block scan stalled.** A node with no complete txindex answers -5 to
`getrawtransaction`. The scan calls it only to read a fee, but the error aborted
the whole 30-block batch, so `processed_blocks` never advanced and the parser
replayed the same batch every two seconds for the whole session. A confirmed
miss now records the OP_RETURN with a zero fee. An unconfirmed miss still fails,
because there it means the transaction left the mempool.

**A missing auth cookie read as a hard error.** Core deletes the cookie when it
stops, and writes a fresh one a moment after it starts. Every RPC in that window
failed the stat, and the interface showed the raw path instead of a boot phase.
It now reads as a Core startup condition and says "Starting Bitcoin Core".

**The app ran out of file descriptors.** A transport rebuild dropped its HTTP
client without closing the socket pool behind it. `recreateConnection` fires on
a tight loop while the daemon comes up, so the app hit errno 24 and restarted 17
times in one log. Both rebuild paths now close the previous pool, and an
abandoned HTTP/2 connection releases its socket after a minute rather than
fifteen.

## Tests

- `opreturn_txindex_miss_test.go` covers a confirmed miss and an unconfirmed one.
- `startup_errors_test.go` covers the cookie window.
- `keepalive_http_client_test.dart` and `orchestrator_rpc_rebuild_test.dart`
  cover both rebuild paths.

## Test harness

Three changes keep the suite honest on a cold runner: the orchestrator harness
waits longer for a cold bitcoind to answer RPC, its test ports moved clear of
the ephemeral range, a custom mock survives the parser tick, and the boot e2e
job gets twenty minutes.