### PR TITLE
BitWindow CoinNews & dc-hub modules: 5 fixes from a security review

### DIFF
--- a/bitwindow/server/config/config.go
+++ b/bitwindow/server/config/config.go
@@ -83,6 +83,15 @@ func Parse() (Config, error) {
 		conf.Datadir = datadir
 	}
 
+	// Absolute so everything downstream — including the value we forward to
+	// drivechaind, which launches children with a different working directory —
+	// resolves against our cwd and not theirs.
+	datadir, err := filepath.Abs(conf.Datadir)
+	if err != nil {
+		return Config{}, fmt.Errorf("resolve data directory %q: %w", conf.Datadir, err)
+	}
+	conf.Datadir = datadir
+
 	return conf, nil
 }
 

--- a/coinnews/server/go.mod
+++ b/coinnews/server/go.mod
@@ -6,6 +6,7 @@ require (
 	connectrpc.com/connect v1.19.0
 	connectrpc.com/grpcreflect v1.3.0
 	github.com/LayerTwo-Labs/sidesail/coinnews/codec v0.0.0
+	github.com/btcsuite/btcd/btcec/v2 v2.3.6
 	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
@@ -14,7 +15,6 @@ require (
 )
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.6 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect

--- a/coinnews/server/scanner/reorg_test.go
+++ b/coinnews/server/scanner/reorg_test.go
@@ -1,0 +1,132 @@
+package scanner
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	codec "github.com/LayerTwo-Labs/sidesail/coinnews/codec"
+	"github.com/LayerTwo-Labs/sidesail/coinnews/server/store"
+)
+
+// forkCore serves a one-block chain whose hash at height 1 the test can swap,
+// modelling a reorg that replaces the block the cursor sits on.
+type forkCore struct {
+	blocks map[string]string // block hash -> getblock result
+
+	mu     sync.Mutex
+	hashAt string
+}
+
+func (f *forkCore) setHash(hash string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.hashAt = hash
+}
+
+func (f *forkCore) hash() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.hashAt
+}
+
+func (f *forkCore) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string            `json:"method"`
+			Params []json.RawMessage `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		w.Header().Set("content-type", "application/json")
+
+		switch req.Method {
+		case "getblockcount":
+			_, _ = fmt.Fprint(w, `{"result":1,"error":null}`)
+		case "getblockhash":
+			_, _ = fmt.Fprintf(w, `{"result":%q,"error":null}`, f.hash())
+		case "getblock":
+			var hash string
+			require.NoError(t, json.Unmarshal(req.Params[0], &hash))
+			_, _ = fmt.Fprintf(w, `{"result":%s,"error":null}`, f.blocks[hash])
+		default:
+			t.Errorf("unexpected method %q", req.Method)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// opReturnScript wraps a payload in a single-push OP_RETURN, display hex.
+func opReturnScript(payload []byte) string {
+	script := []byte{0x6a}
+	if len(payload) <= 75 {
+		script = append(script, byte(len(payload)))
+	} else {
+		script = append(script, 0x4c, byte(len(payload)))
+	}
+	return hex.EncodeToString(append(script, payload...))
+}
+
+// A reorg that replaces the block at the cursor keeps the height, so the
+// scanner must catch it by hash and drop the story the orphan carried.
+func TestScannerReorgAtCursorPurgesOrphanedStory(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db, err := store.Open(ctx, t.TempDir()+"/coinnews.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	storyBytes, err := codec.EncodeStory(codec.Story{
+		Topic:    codec.Topic{1, 2, 3, 4},
+		Headline: "orphaned by the reorg",
+	})
+	require.NoError(t, err)
+
+	oldHash, newHash := "aa"+hexZero(62), "bb"+hexZero(62)
+	txid := "cc" + hexZero(62)
+	core := &forkCore{
+		hashAt: oldHash,
+		blocks: map[string]string{
+			oldHash: fmt.Sprintf(
+				`{"hash":%q,"height":1,"time":1,"mediantime":1,"tx":[{"txid":%q,"vout":[{"scriptPubKey":{"hex":%q,"type":"nulldata"}}]}]}`,
+				oldHash, txid, opReturnScript(storyBytes)),
+			newHash: fmt.Sprintf(`{"hash":%q,"height":1,"time":1,"mediantime":1,"tx":[]}`, newHash),
+		},
+	}
+	srv := core.start(t)
+	s := &Scanner{
+		Client: &Client{URL: srv.URL, HTTP: srv.Client()},
+		DB:     db,
+		Log:    zerolog.Nop(),
+	}
+
+	require.NoError(t, s.catchUp(ctx))
+	feed, err := store.ListFeed(ctx, db, store.FeedFilter{Sort: store.SortNewest})
+	require.NoError(t, err)
+	require.Len(t, feed, 1)
+
+	core.setHash(newHash)
+	require.NoError(t, s.catchUp(ctx))
+
+	feed, err = store.ListFeed(ctx, db, store.FeedFilter{Sort: store.SortNewest})
+	require.NoError(t, err)
+	assert.Empty(t, feed, "the orphaned story is gone")
+
+	height, hash, err := store.LoadCursor(ctx, db)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), height)
+	want, err := decodeHashLE(newHash)
+	require.NoError(t, err)
+	assert.Equal(t, want, hash, "cursor tracks the replacement block")
+}

--- a/coinnews/server/scanner/scanner.go
+++ b/coinnews/server/scanner/scanner.go
@@ -59,9 +59,25 @@ func (s *Scanner) catchUp(ctx context.Context) error {
 		return fmt.Errorf("getblockcount: %w", err)
 	}
 
-	cursor, _, err := store.LoadCursor(ctx, s.DB)
+	cursor, cursorHash, err := store.LoadCursor(ctx, s.DB)
 	if err != nil {
 		return fmt.Errorf("load cursor: %w", err)
+	}
+	// A reorg that replaces the cursor block leaves its height alone, so only
+	// the hash says the chain moved under us.
+	if cursor > 0 && cursor <= tip {
+		same, err := s.coreHoldsBlock(ctx, cursor, cursorHash)
+		if err != nil {
+			return err
+		}
+		if !same {
+			s.Log.Warn().Uint32("height", cursor).
+				Msg("coinnews-scanner: the chain forked at the cursor, purging and replaying from there")
+			if err := store.PurgeAtOrAbove(ctx, s.DB, cursor); err != nil {
+				return fmt.Errorf("purge at or above %d: %w", cursor, err)
+			}
+			cursor--
+		}
 	}
 	if s.FromHeight > 0 && cursor+1 < s.FromHeight {
 		s.Log.Info().Uint32("cursor", cursor).Uint32("from_height", s.FromHeight).
@@ -85,6 +101,23 @@ func (s *Scanner) catchUp(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// coreHoldsBlock reports whether Core's block at height is the one we
+// recorded. A zero stored hash is nothing to compare against, so it passes.
+func (s *Scanner) coreHoldsBlock(ctx context.Context, height uint32, stored [32]byte) (bool, error) {
+	if stored == ([32]byte{}) {
+		return true, nil
+	}
+	hash, err := s.Client.GetBlockHash(ctx, height)
+	if err != nil {
+		return false, fmt.Errorf("getblockhash %d: %w", height, err)
+	}
+	canonical, err := decodeHashLE(hash)
+	if err != nil {
+		return false, err
+	}
+	return canonical == stored, nil
 }
 
 func (s *Scanner) indexHeight(ctx context.Context, height uint32) error {

--- a/coinnews/server/scanner/scanner.go
+++ b/coinnews/server/scanner/scanner.go
@@ -214,7 +214,7 @@ func parsePush(b []byte) ([]byte, bool) {
 	switch {
 	case op >= 0x01 && op <= 0x4b:
 		n := int(op)
-		if len(b) < 1+n {
+		if len(b) != 1+n {
 			return nil, false
 		}
 		return b[1 : 1+n], true
@@ -223,7 +223,7 @@ func parsePush(b []byte) ([]byte, bool) {
 			return nil, false
 		}
 		n := int(b[1])
-		if len(b) < 2+n {
+		if len(b) != 2+n {
 			return nil, false
 		}
 		return b[2 : 2+n], true
@@ -232,7 +232,7 @@ func parsePush(b []byte) ([]byte, bool) {
 			return nil, false
 		}
 		n := int(b[1]) | int(b[2])<<8
-		if len(b) < 3+n {
+		if len(b) != 3+n {
 			return nil, false
 		}
 		return b[3 : 3+n], true

--- a/coinnews/server/scanner/scanner.go
+++ b/coinnews/server/scanner/scanner.go
@@ -159,9 +159,9 @@ func (s *Scanner) indexHeight(ctx context.Context, height uint32) error {
 }
 
 // indexPayload classifies one OP_RETURN payload and persists it.
-// Mirrors bitwindow's engine hook: signature verification gates
-// persistence, malformed and non-CoinNews payloads are dropped
-// silently.
+// Mirrors bitwindow's engine hook: signature verification and
+// reference resolvability gate persistence, malformed and
+// non-CoinNews payloads are dropped silently.
 func (s *Scanner) indexPayload(ctx context.Context, data []byte, pos store.BlockPos) error {
 	tag, msg, err := codec.DecodeMessage(data)
 	if err != nil {
@@ -172,15 +172,49 @@ func (s *Scanner) indexPayload(ctx context.Context, data []byte, pos store.Block
 			Msg("coinnews-scanner: malformed payload, dropping")
 		return nil
 	}
+	self := store.ItemRef{BlockHeight: pos.BlockHeight, TxIndex: pos.TxIndex, VoutIndex: pos.VoutIndex}
+
 	switch m := msg.(type) {
 	case *codec.Comment:
 		if err := codec.VerifyComment(m); err != nil {
 			s.Log.Debug().Err(err).Str("txid", pos.TxID).Msg("coinnews-scanner: comment sig invalid")
 			return nil
 		}
+		// §7: drop Comments whose parent is unresolvable. §4.2: the
+		// parent must be earlier than the comment in scan order.
+		parent, ok, err := store.ResolveItem(ctx, s.DB, m.Parent)
+		if err != nil {
+			return err
+		}
+		if !ok || !parent.Before(self) {
+			s.Log.Debug().Str("txid", pos.TxID).Msg("coinnews-scanner: comment parent unresolvable")
+			return nil
+		}
 	case *codec.Vote:
 		if err := codec.VerifyVote(m); err != nil {
 			s.Log.Debug().Err(err).Str("txid", pos.TxID).Msg("coinnews-scanner: vote sig invalid")
+			return nil
+		}
+		// §8: drop Votes against an unresolvable target. §4.2: a vote
+		// against a same-tx target must sit at a higher vout_index —
+		// covered by requiring the target to be strictly earlier.
+		target, ok, err := store.ResolveItem(ctx, s.DB, m.Target)
+		if err != nil {
+			return err
+		}
+		if !ok || !target.Before(self) {
+			s.Log.Debug().Str("txid", pos.TxID).Msg("coinnews-scanner: vote target unresolvable")
+			return nil
+		}
+	case *codec.Continuation:
+		// §9: continuations live in the head's tx or a later tx in the
+		// same block, after the head in scan order.
+		head, ok, err := store.ResolveItem(ctx, s.DB, m.Head)
+		if err != nil {
+			return err
+		}
+		if !ok || head.BlockHeight != pos.BlockHeight || !head.Before(self) {
+			s.Log.Debug().Str("txid", pos.TxID).Msg("coinnews-scanner: continuation head unresolvable")
 			return nil
 		}
 	}

--- a/coinnews/server/scanner/scanner_test.go
+++ b/coinnews/server/scanner/scanner_test.go
@@ -64,6 +64,29 @@ func TestParsePush_UnsupportedOp(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestParsePush_TrailingPush(t *testing.T) {
+	t.Parallel()
+	// PUSH 5 "hello" followed by a second push — multi-push is not a payload.
+	_, ok := parsePush([]byte{0x05, 'h', 'e', 'l', 'l', 'o', 0x01, 0x99})
+	assert.False(t, ok)
+}
+
+func TestParsePush_PushData1_TrailingPush(t *testing.T) {
+	t.Parallel()
+	payload := make([]byte, 200)
+	b := append([]byte{0x4c, byte(len(payload))}, payload...)
+	_, ok := parsePush(append(b, 0x01, 0x99))
+	assert.False(t, ok)
+}
+
+func TestParsePush_PushData2_TrailingPush(t *testing.T) {
+	t.Parallel()
+	payload := make([]byte, 1000)
+	b := append([]byte{0x4d, byte(1000 & 0xff), byte(1000 >> 8)}, payload...)
+	_, ok := parsePush(append(b, 0x01, 0x99))
+	assert.False(t, ok)
+}
+
 func TestOpReturnPayload_NotNullData(t *testing.T) {
 	t.Parallel()
 	_, ok := opReturnPayload("6a05hello", "scripthash")
@@ -90,6 +113,26 @@ func TestOpReturnPayload_OK(t *testing.T) {
 	got, ok := opReturnPayload(hex.EncodeToString(script), "nulldata")
 	require.True(t, ok)
 	assert.Equal(t, []byte("hello"), got)
+}
+
+// A real encoded story is accepted on its own, and rejected once a
+// second push is appended — a multi-push script is not a payload.
+func TestOpReturnPayload_Story_TrailingPush(t *testing.T) {
+	t.Parallel()
+	storyBytes, err := codec.EncodeStory(codec.Story{
+		Topic:    codec.Topic{1, 2, 3, 4},
+		Headline: "multi-push",
+	})
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(storyBytes), 0x4b)
+
+	script := append([]byte{0x6a, byte(len(storyBytes))}, storyBytes...)
+	got, ok := opReturnPayload(hex.EncodeToString(script), "nulldata")
+	require.True(t, ok)
+	assert.Equal(t, storyBytes, got)
+
+	_, ok = opReturnPayload(hex.EncodeToString(append(script, 0x01, 0x99)), "nulldata")
+	assert.False(t, ok)
 }
 
 func TestDecodeHashLE(t *testing.T) {

--- a/coinnews/server/scanner/scanner_test.go
+++ b/coinnews/server/scanner/scanner_test.go
@@ -2,10 +2,14 @@ package scanner
 
 import (
 	"context"
+	"database/sql"
 	"encoding/hex"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -198,6 +202,171 @@ func TestIndexPayload_NotCoinNews_Drops(t *testing.T) {
 	feed, err := store.ListFeed(ctx, db, store.FeedFilter{Sort: store.SortNewest})
 	require.NoError(t, err)
 	assert.Empty(t, feed)
+}
+
+// TestIndexPayload_DropsUnresolvableComment: a validly-signed Comment
+// whose parent was never indexed MUST be dropped (spec §4.1, §7).
+func TestIndexPayload_DropsUnresolvableComment(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, s := newScanner(t)
+
+	var parent codec.ItemID
+	parent[0] = 0xde // never indexed
+	require.NoError(t, s.indexPayload(ctx, signedComment(t, parent), posAt(9, 0, 0)))
+
+	assert.Zero(t, countRows(t, db, "cn_comments"), "comment with unresolvable parent MUST NOT persist")
+	assert.Zero(t, countRows(t, db, "cn_items"), "no cn_items row for a dropped comment")
+}
+
+// TestIndexPayload_DropsUnresolvableVote: a validly-signed Vote against
+// a target that was never indexed MUST be dropped (spec §4.1, §8).
+func TestIndexPayload_DropsUnresolvableVote(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, s := newScanner(t)
+
+	var target codec.ItemID
+	target[0] = 0xad // never indexed
+	require.NoError(t, s.indexPayload(ctx, signedVote(t, target), posAt(9, 0, 0)))
+
+	assert.Zero(t, countRows(t, db, "cn_votes"), "vote against unresolvable target MUST NOT persist")
+	assert.Zero(t, countRows(t, db, "cn_items"), "no cn_items row for a dropped vote")
+}
+
+// TestIndexPayload_DropsCommentOnLaterParent: a parent that exists but
+// sits later in canonical scan order is not "earlier" (spec §4.2), so
+// the Comment MUST be dropped.
+func TestIndexPayload_DropsCommentOnLaterParent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, s := newScanner(t)
+
+	storyPos := posAt(20, 0, 0)
+	require.NoError(t, s.indexPayload(ctx, story(t, "later story"), storyPos))
+
+	// Comment sits in an earlier block than the story it replies to.
+	require.NoError(t, s.indexPayload(ctx, signedComment(t, itemIDAt(t, storyPos)), posAt(10, 0, 0)))
+
+	assert.Zero(t, countRows(t, db, "cn_comments"), "comment referencing a later parent MUST NOT persist")
+	assert.Equal(t, 1, countRows(t, db, "cn_items"), "only the story is indexed")
+}
+
+// TestIndexPayload_DropsContinuationInOtherBlock: §9 confines a
+// Continuation to the head's own block, after it in scan order.
+func TestIndexPayload_DropsContinuationInOtherBlock(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, s := newScanner(t)
+
+	headPos := posAt(30, 0, 0)
+	require.NoError(t, s.indexPayload(ctx, story(t, "head story"), headPos))
+
+	chunk, err := codec.EncodeContinuation(codec.Continuation{Head: itemIDAt(t, headPos), Seq: 0, Chunk: []byte{0x02, 0x01, 'x'}})
+	require.NoError(t, err)
+	require.NoError(t, s.indexPayload(ctx, chunk, posAt(31, 0, 0)))
+
+	assert.Zero(t, countRows(t, db, "cn_continuations"), "continuation in a different block MUST NOT persist")
+}
+
+// TestIndexPayload_IndexesResolvableRefs is the positive control: an
+// earlier, resolvable reference still gets indexed.
+func TestIndexPayload_IndexesResolvableRefs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, s := newScanner(t)
+
+	storyPos := posAt(40, 0, 0)
+	require.NoError(t, s.indexPayload(ctx, story(t, "root story"), storyPos))
+	storyID := itemIDAt(t, storyPos)
+
+	require.NoError(t, s.indexPayload(ctx, signedComment(t, storyID), posAt(41, 0, 0)))
+	require.NoError(t, s.indexPayload(ctx, signedVote(t, storyID), posAt(42, 0, 0)))
+
+	chunk, err := codec.EncodeContinuation(codec.Continuation{Head: storyID, Seq: 0, Chunk: []byte{0x02, 0x01, 'x'}})
+	require.NoError(t, err)
+	require.NoError(t, s.indexPayload(ctx, chunk, posAt(40, 0, 1)))
+
+	assert.Equal(t, 1, countRows(t, db, "cn_comments"), "comment on an earlier parent persists")
+	assert.Equal(t, 1, countRows(t, db, "cn_votes"), "vote on an earlier target persists")
+	assert.Equal(t, 1, countRows(t, db, "cn_continuations"), "continuation after its same-block head persists")
+}
+
+func newScanner(t *testing.T) (*sql.DB, *Scanner) {
+	t.Helper()
+	db, err := store.Open(context.Background(), t.TempDir()+"/coinnews.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db, &Scanner{DB: db, Log: zerolog.Nop()}
+}
+
+// posAt returns a BlockPos whose txid is unique to the scan position,
+// so cn_items rows don't collide across a scenario.
+func posAt(height, txIdx, voutIdx uint32) store.BlockPos {
+	return store.BlockPos{
+		BlockHeight: height,
+		TxIndex:     txIdx,
+		VoutIndex:   voutIdx,
+		BlockTime:   time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC),
+		TxID:        fmt.Sprintf("%064x", uint64(height)<<32|uint64(txIdx)<<16|uint64(voutIdx)),
+	}
+}
+
+// itemIDAt is the ItemID a message at `pos` is indexed under.
+func itemIDAt(t *testing.T, pos store.BlockPos) codec.ItemID {
+	t.Helper()
+	natural, err := store.HashTxIDLE(pos.TxID)
+	require.NoError(t, err)
+	return codec.ComputeItemID(natural, pos.VoutIndex)
+}
+
+func story(t *testing.T, headline string) []byte {
+	t.Helper()
+	out, err := codec.EncodeStory(codec.Story{Topic: codec.Topic{1, 2, 3, 4}, Headline: headline})
+	require.NoError(t, err)
+	return out
+}
+
+func signedComment(t *testing.T, parent codec.ItemID) []byte {
+	t.Helper()
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	tlvs := []codec.TLV{{Tag: codec.TLVBody, Value: []byte("reply")}}
+	blob, err := codec.SerialiseTLVs(tlvs)
+	require.NoError(t, err)
+	digest := codec.CommentSigHash(parent, blob)
+	sig, err := schnorr.Sign(priv, digest[:])
+	require.NoError(t, err)
+
+	c := codec.Comment{Parent: parent, TLVs: tlvs}
+	copy(c.AuthorXPK[:], schnorr.SerializePubKey(priv.PubKey()))
+	copy(c.Sig[:], sig.Serialize())
+	out, err := codec.EncodeComment(c)
+	require.NoError(t, err)
+	return out
+}
+
+func signedVote(t *testing.T, target codec.ItemID) []byte {
+	t.Helper()
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	digest := codec.VoteSigHash(codec.TypeUpvote, target)
+	sig, err := schnorr.Sign(priv, digest[:])
+	require.NoError(t, err)
+
+	v := codec.Vote{Kind: codec.TypeUpvote, Target: target}
+	copy(v.AuthorXPK[:], schnorr.SerializePubKey(priv.PubKey()))
+	copy(v.Sig[:], sig.Serialize())
+	out, err := codec.EncodeVote(v)
+	require.NoError(t, err)
+	return out
+}
+
+func countRows(t *testing.T, db *sql.DB, table string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM `+table).Scan(&n))
+	return n
 }
 
 func hexZero(n int) string {

--- a/coinnews/server/store/store.go
+++ b/coinnews/server/store/store.go
@@ -77,8 +77,49 @@ type IndexEnv struct {
 	Payload []byte // the raw OP_RETURN bytes Msg was decoded from
 }
 
+// ItemRef is an indexed Item's canonical scan position (spec §4.2):
+// (block_height, tx_index, vout_index).
+type ItemRef struct {
+	BlockHeight uint32
+	TxIndex     uint32
+	VoutIndex   uint32
+}
+
+// Before reports whether a is strictly earlier than b in canonical scan
+// order. This is the spec's only notion of "earlier" (spec §4.2).
+func (a ItemRef) Before(b ItemRef) bool {
+	if a.BlockHeight != b.BlockHeight {
+		return a.BlockHeight < b.BlockHeight
+	}
+	if a.TxIndex != b.TxIndex {
+		return a.TxIndex < b.TxIndex
+	}
+	return a.VoutIndex < b.VoutIndex
+}
+
+// ResolveItem looks up an ItemID in the index (items_by_id, spec §4.1)
+// and returns its scan position plus whether it is present. References
+// to absent ItemIDs are unresolvable and the referring Message MUST be
+// dropped (spec §4.1, §7, §8).
+func ResolveItem(ctx context.Context, db *sql.DB, id codec.ItemID) (ItemRef, bool, error) {
+	var ref ItemRef
+	err := db.QueryRowContext(ctx,
+		`SELECT block_height, tx_index, vout_index FROM cn_items WHERE item_id = ?`,
+		id[:],
+	).Scan(&ref.BlockHeight, &ref.TxIndex, &ref.VoutIndex)
+	switch err {
+	case nil:
+		return ref, true, nil
+	case sql.ErrNoRows:
+		return ItemRef{}, false, nil
+	default:
+		return ItemRef{}, false, fmt.Errorf("coinnews: resolve item: %w", err)
+	}
+}
+
 // Index dispatches one decoded CoinNews Message into the right table(s).
-// Caller MUST have already verified Comment and Vote signatures.
+// Caller MUST have already verified Comment and Vote signatures, and the
+// resolvability of any parent/target/head reference (spec §4.1).
 func Index(ctx context.Context, db *sql.DB, env IndexEnv) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {

--- a/coinnews/server/store/store_test.go
+++ b/coinnews/server/store/store_test.go
@@ -151,6 +151,45 @@ func TestStore_Cursor(t *testing.T) {
 	assert.Equal(t, saved, hash)
 }
 
+// TestResolveItem: an indexed Item resolves to its canonical scan
+// position; an ItemID that was never indexed does not resolve, which
+// is what makes a referring Message droppable (spec §4.1).
+func TestResolveItem(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := Open(ctx, t.TempDir()+"/coinnews.db")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	p := pos(500, 3, 2)
+	require.NoError(t, Index(ctx, db, IndexEnv{
+		Pos: p, TypeTag: codec.TypeStory, Payload: testPayload,
+		Msg: &codec.Story{Topic: codec.Topic{1, 2, 3, 4}, Headline: "resolvable"},
+	}))
+
+	natural, err := HashTxIDLE(p.TxID)
+	require.NoError(t, err)
+	ref, ok, err := ResolveItem(ctx, db, codec.ComputeItemID(natural, p.VoutIndex))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, ItemRef{BlockHeight: 500, TxIndex: 3, VoutIndex: 2}, ref)
+
+	_, ok, err = ResolveItem(ctx, db, codec.ItemID{0xff})
+	require.NoError(t, err)
+	assert.False(t, ok, "an ItemID that was never indexed MUST NOT resolve")
+}
+
+func TestItemRef_Before(t *testing.T) {
+	t.Parallel()
+	self := ItemRef{BlockHeight: 10, TxIndex: 5, VoutIndex: 1}
+	assert.True(t, ItemRef{BlockHeight: 9, TxIndex: 99, VoutIndex: 99}.Before(self))
+	assert.True(t, ItemRef{BlockHeight: 10, TxIndex: 4, VoutIndex: 99}.Before(self))
+	assert.True(t, ItemRef{BlockHeight: 10, TxIndex: 5, VoutIndex: 0}.Before(self))
+	assert.False(t, self.Before(self), "an Item is not before itself")
+	assert.False(t, ItemRef{BlockHeight: 10, TxIndex: 5, VoutIndex: 2}.Before(self))
+	assert.False(t, ItemRef{BlockHeight: 11, TxIndex: 0, VoutIndex: 0}.Before(self))
+}
+
 func TestOpReturnPayload_RoundTrip(t *testing.T) {
 	t.Parallel()
 	// Ensure the scanner/store agree on a known-good Story that we

--- a/dc-hub/server/api/faucet/api_faucet.go
+++ b/dc-hub/server/api/faucet/api_faucet.go
@@ -42,9 +42,10 @@ type Server struct {
 }
 
 const (
-	MaxCoinsPer5Min    = 100
-	MaxCoinsPerRequest = 5
-	ResetInterval      = 5 * time.Minute
+	MaxCoinsPer5Min           = 100
+	MaxCoinsPerAddressPer5Min = 10
+	MaxCoinsPerRequest        = 5
+	ResetInterval             = 5 * time.Minute
 )
 
 // resetIfWindowElapsed clears the dispensation counters and starts a new
@@ -109,9 +110,16 @@ func (s *Server) DispenseCoins(ctx context.Context, c *connect.Request[pb.Dispen
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	if s.totalDispensed > MaxCoinsPer5Min {
+	if s.totalDispensed+amount.ToBTC() > MaxCoinsPer5Min {
 		return nil, connect.NewError(connect.CodeResourceExhausted, fmt.Errorf(
 			"the faucet has hit its dispensation limit, try again in %s",
+			formatDuration(time.Until(s.windowEnds)),
+		))
+	}
+
+	if s.dispensed[c.Msg.Destination]+amount.ToBTC() > MaxCoinsPerAddressPer5Min {
+		return nil, connect.NewError(connect.CodeResourceExhausted, fmt.Errorf(
+			"this address has hit its dispensation limit, try again in %s",
 			formatDuration(time.Until(s.windowEnds)),
 		))
 	}

--- a/dc-hub/server/api/faucet/api_faucet_test.go
+++ b/dc-hub/server/api/faucet/api_faucet_test.go
@@ -1,0 +1,78 @@
+package api_faucet
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	pb "github.com/LayerTwo-Labs/sidesail/dc-hub/server/gen/hub/v1"
+	btcpb "github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha"
+	"github.com/barebitcoin/btc-buf/gen/bitcoin/bitcoind/v1alpha/bitcoindv1alphaconnect"
+)
+
+// stubBitcoind accepts every send, and counts them.
+type stubBitcoind struct {
+	bitcoindv1alphaconnect.BitcoinServiceClient
+	sends int
+}
+
+func (s *stubBitcoind) SendToAddress(ctx context.Context, req *connect.Request[btcpb.SendToAddressRequest]) (*connect.Response[btcpb.SendToAddressResponse], error) {
+	s.sends++
+	return connect.NewResponse(&btcpb.SendToAddressResponse{Txid: "txid"}), nil
+}
+
+func dispense(s *Server, destination string, amount float64) error {
+	_, err := s.DispenseCoins(context.Background(), connect.NewRequest(&pb.DispenseCoinsRequest{
+		Destination: destination,
+		Amount:      amount,
+	}))
+	return err
+}
+
+func TestDispenseCoinsPerAddressLimit(t *testing.T) {
+	bitcoind := new(stubBitcoind)
+	faucet := New(bitcoind)
+
+	const addr = "bcrt1qexhausted"
+
+	// The per-address cap allows this many max-size requests.
+	for i := 0; i < MaxCoinsPerAddressPer5Min/MaxCoinsPerRequest; i++ {
+		if err := dispense(faucet, addr, MaxCoinsPerRequest); err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+	}
+
+	err := dispense(faucet, addr, MaxCoinsPerRequest)
+	if got := connect.CodeOf(err); got != connect.CodeResourceExhausted {
+		t.Fatalf("expected resource exhausted, got %v (%v)", got, err)
+	}
+
+	// The address is capped long before the faucet-wide limit.
+	if faucet.totalDispensed != MaxCoinsPerAddressPer5Min {
+		t.Fatalf("dispensed %f, want %d", faucet.totalDispensed, MaxCoinsPerAddressPer5Min)
+	}
+
+	// Another address is unaffected within the same window.
+	if err := dispense(faucet, "bcrt1qfresh", MaxCoinsPerRequest); err != nil {
+		t.Fatalf("unrelated address: %v", err)
+	}
+
+	if bitcoind.sends != 3 {
+		t.Fatalf("sent %d times, want 3", bitcoind.sends)
+	}
+}
+
+func TestDispenseCoinsGlobalLimit(t *testing.T) {
+	faucet := New(new(stubBitcoind))
+
+	// Open a window, then place the faucet just under the global cap.
+	faucet.resetIfWindowElapsed(time.Now())
+	faucet.totalDispensed = MaxCoinsPer5Min - MaxCoinsPerRequest + 1
+
+	// The pending amount must not be allowed to exceed the cap.
+	err := dispense(faucet, "bcrt1qglobal", MaxCoinsPerRequest)
+	if got := connect.CodeOf(err); got != connect.CodeResourceExhausted {
+		t.Fatalf("expected resource exhausted, got %v (%v)", got, err)
+	}
+}

--- a/sidechain-orchestrator/cmd/drivechaind/main.go
+++ b/sidechain-orchestrator/cmd/drivechaind/main.go
@@ -170,10 +170,18 @@ func run(cctx *cli.Context) error {
 		Timestamp().
 		Logger()
 
-	dataDir := cctx.String("datadir")
+	// Absolute up front: we launch children with cmd.Dir set elsewhere, so a
+	// relative path here would re-resolve against the wrong directory.
+	dataDir, err := filepath.Abs(cctx.String("datadir"))
+	if err != nil {
+		return fmt.Errorf("resolve --datadir: %w", err)
+	}
 	network := cctx.String("network")
 	listenAddr := cctx.String("rpclisten")
-	bitwindowDir := cctx.String("bitwindow-dir")
+	bitwindowDir, err := filepath.Abs(cctx.String("bitwindow-dir"))
+	if err != nil {
+		return fmt.Errorf("resolve --bitwindow-dir: %w", err)
+	}
 	localAuth := cctx.Bool("local-auth")
 
 	if appHome := cctx.String("app-home"); appHome != "" {

--- a/sidechain-orchestrator/process.go
+++ b/sidechain-orchestrator/process.go
@@ -269,6 +269,11 @@ func (pm *ProcessManager) StartWithOptions(_ context.Context, config BinaryConfi
 	}()
 
 	binPath, pidName := pm.resolvePaths(config, opts.ForceBackend)
+	// cmd.Dir is set below, so a relative binPath would be re-resolved against
+	// the child's working directory rather than ours.
+	if abs, err := filepath.Abs(binPath); err == nil {
+		binPath = abs
+	}
 	if opts.PidName != "" {
 		pidName = opts.PidName
 	}

--- a/sidechain-orchestrator/process_test.go
+++ b/sidechain-orchestrator/process_test.go
@@ -30,6 +30,29 @@ func TestProcessManager_StartAndStop(t *testing.T) {
 	assert.False(t, pm.IsRunning("sleep-test"))
 }
 
+// A relative data dir must still launch: cmd.Dir is set to it, so an
+// unresolved binary path would be looked up under <dataDir>/<dataDir>.
+func TestProcessManager_StartWithRelativeDataDir(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	const dir = "orchestrator"
+	log := testLogger(t)
+	pm := NewProcessManager(dir, NewPidFileManager(dir, log), log)
+	t.Cleanup(func() {
+		_ = pm.StopAll(context.Background(), true)
+		pm.WaitForExit("sleep-test", 5*time.Second)
+	})
+	symlinkSystemBinary(t, dir, "sleep")
+
+	pid, err := pm.Start(context.Background(), BinaryConfig{
+		Name: "sleep-test", BinaryName: "sleep",
+	}, []string{"30"}, nil)
+	require.NoError(t, err)
+	assert.Greater(t, pid, 0)
+
+	require.NoError(t, pm.Stop(context.Background(), "sleep-test", false))
+}
+
 func TestProcessManager_ConcurrentStartSpawnsOnce(t *testing.T) {
 	pm, dir := newTestProcessManager(t)
 	symlinkSystemBinary(t, dir, "sleep")


### PR DESCRIPTION
A set of **5 independent fixes** to the BitWindow CoinNews & dc-hub modules, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`12 files changed, 637 insertions(+), 15 deletions(-)`).

## Fixes (oldest first)

- **`b7d7f5a3c`** drivechain-frontends faucet rate-limit dimensionally disabled (BTC accumulator vs satoshi-sized constant) + dead per-address limit
- **`4fad80576`** CoinNews scanner serves orphaned stories after same-height reorg
- **`3a345fa82`** CoinNews indexer accepts multi-push OP_RETURN scripts as valid messages
- **`e13b1dc50`** CoinNews standalone scanner skips parent/target/head resolvability checks, diverges from BitWindow engine
- **`e466443ab`** Relative orchestrator datadir makes downloaded binaries unlaunchable

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.