### PR TITLE
BitWindow Flutter UI: 5 fixes from a security review

### DIFF
--- a/bitwindow/lib/models/chat_models.dart
+++ b/bitwindow/lib/models/chat_models.dart
@@ -76,7 +76,9 @@ class ChatContact {
   final String name;
   final String? plaintextName;
   final String encryptionPubkey;
-  final String address;
+
+  /// Address holding the contact's BitName. Null when it could not be resolved.
+  final String? address;
   final int? paymailFeeSats;
   final String? lastMessage;
   final DateTime? lastMessageTime;
@@ -87,7 +89,7 @@ class ChatContact {
     required this.name,
     this.plaintextName,
     required this.encryptionPubkey,
-    required this.address,
+    this.address,
     this.paymailFeeSats,
     this.lastMessage,
     this.lastMessageTime,
@@ -101,7 +103,7 @@ class ChatContact {
     name: json['name'] ?? '',
     plaintextName: json['plaintext_name'],
     encryptionPubkey: json['encryption_pubkey'] ?? '',
-    address: json['address'] ?? '',
+    address: json['address'],
     paymailFeeSats: json['paymail_fee_sats'],
     lastMessage: json['last_message'],
     lastMessageTime: json['last_message_time'] != null

--- a/bitwindow/lib/pages/wallet/check_detail_page.dart
+++ b/bitwindow/lib/pages/wallet/check_detail_page.dart
@@ -70,10 +70,12 @@ class CheckDetailViewModel extends BaseViewModel {
   }
 
   Future<void> fundWithWallet(BuildContext context) async {
-    if (_check == null) {
+    // A second tap while the send is in flight would pay the cheque twice.
+    if (_check == null || isBusy) {
       return;
     }
 
+    setBusy(true);
     try {
       final walletId = _walletReader.activeWalletId;
       if (walletId == null) {
@@ -109,10 +111,26 @@ class CheckDetailViewModel extends BaseViewModel {
         context,
         'Failed to fund check: $e',
       );
+    } finally {
+      setBusy(false);
     }
   }
 
   Future<void> sweepCheck(BuildContext context) async {
+    // A second tap while the sweep is in flight would broadcast it twice.
+    if (isBusy) {
+      return;
+    }
+
+    setBusy(true);
+    try {
+      await _sweepCheck(context);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  Future<void> _sweepCheck(BuildContext context) async {
     if (_check == null || _check!.fundedTxids.isEmpty) {
       return;
     }
@@ -166,7 +184,7 @@ class CheckDetailViewModel extends BaseViewModel {
             return;
           }
           if (_walletReader.isWalletUnlocked) {
-            await sweepCheck(context);
+            await _sweepCheck(context);
           }
         } else {
           showSailToast(context, 'Backend wallet not initialized. Please restart the app.');
@@ -443,7 +461,7 @@ class CheckDetailPage extends StatelessWidget {
                                   ],
                                 ),
                                 child: SailTappable(
-                                  onTap: () async => model.fundWithWallet(context),
+                                  onTap: model.isBusy ? null : () async => model.fundWithWallet(context),
                                   borderRadius: BorderRadius.circular(8),
                                   child: Center(
                                     child: SailText.primary15(
@@ -479,7 +497,7 @@ class CheckDetailPage extends StatelessWidget {
                                   ],
                                 ),
                                 child: SailTappable(
-                                  onTap: () async => model.sweepCheck(context),
+                                  onTap: model.isBusy ? null : () async => model.sweepCheck(context),
                                   borderRadius: BorderRadius.circular(8),
                                   child: Center(
                                     child: SailText.primary15(

--- a/bitwindow/lib/pages/wallet/wallet_send.dart
+++ b/bitwindow/lib/pages/wallet/wallet_send.dart
@@ -841,6 +841,41 @@ class SendPageViewModel extends BaseViewModel {
     }
   }
 
+  /// The inputs this send pins, so the backend funds from them alone.
+  List<UnspentOutput> get _sendInputs => unfrozenInputs(
+    selected: selectedUtxos,
+    allUtxos: allUtxos,
+    frozenOutpoints: frozenOutpoints,
+    targetSats: _sendTotalSats,
+    formatSats: (sats) => formatBitcoinWithUnit(satoshiToBTC(sats), currentUnit),
+  );
+
+  /// The inputs a send must name to keep a frozen coin out of it: the backend
+  /// knows nothing of bitwindow's freezes, so it funds from every coin unless
+  /// the send picks its own. A coin the user picked stays in, frozen or not.
+  /// Throws [InsufficientFundsException] when the unfrozen coins fall short.
+  static List<UnspentOutput> unfrozenInputs({
+    required List<UnspentOutput> selected,
+    required List<UnspentOutput> allUtxos,
+    required Set<String> frozenOutpoints,
+    required int targetSats,
+    required String Function(int) formatSats,
+  }) {
+    if (!allUtxos.any((u) => frozenOutpoints.contains(u.output))) {
+      return selected;
+    }
+    return CoinSelector.select(
+      allUtxos: allUtxos,
+      frozenOutpoints: frozenOutpoints,
+      // The fee is fixed and already inside the target, so the selector adds
+      // none of its own — the same target the backend fills to.
+      targetSats: targetSats,
+      feeSatsPerVbyte: 0,
+      formatSats: formatSats,
+      requiredUtxos: selected,
+    ).inputs;
+  }
+
   Future<void> sendTransaction(BuildContext context) async {
     final plan = await askReplayProtect(context);
     if (plan == null || !context.mounted) {
@@ -903,7 +938,7 @@ class SendPageViewModel extends BaseViewModel {
         destinations: destinations,
         fixedFeeSats: feeSats,
         subtractFeeFromAmount: _subtractFeeFromAmount,
-        requiredInputs: selectedUtxos,
+        requiredInputs: _sendInputs,
         allowReplay: allowReplay,
       )).txid;
       if (plan.risky && allowReplay) {
@@ -1010,7 +1045,7 @@ class SendPageViewModel extends BaseViewModel {
         destinations: destinations,
         fixedFeeSats: feeSats,
         subtractFeeFromAmount: _subtractFeeFromAmount,
-        requiredInputs: selectedUtxos,
+        requiredInputs: _sendInputs,
         allowReplay: allowReplay,
       );
     } catch (error) {

--- a/bitwindow/lib/providers/bitwindow_settings_provider.dart
+++ b/bitwindow/lib/providers/bitwindow_settings_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:bitwindow/models/settings.dart';
 import 'package:bitwindow/settings/bitwindow_settings.dart';
 import 'package:flutter/foundation.dart';
@@ -5,6 +7,10 @@ import 'package:get_it/get_it.dart';
 import 'package:sail_ui/sail_ui.dart';
 
 class BitwindowSettingsProvider extends ChangeNotifier {
+  /// Homepage state used to live under the key sidechain_core's global
+  /// BitwindowSettings owns, and each write clobbered the other.
+  static const _legacyKey = 'bitwindow_settings';
+
   final ClientSettings _clientSettings = GetIt.I.get<ClientSettings>();
 
   Settings _settings = Settings();
@@ -22,6 +28,7 @@ class BitwindowSettingsProvider extends ChangeNotifier {
     notifyListeners();
 
     try {
+      await _migrateLegacySettings();
       final settingValue = BitwindowSettingsValue();
       final loaded = await _clientSettings.getValue(settingValue);
       _settings = loaded.value;
@@ -30,6 +37,32 @@ class BitwindowSettingsProvider extends ChangeNotifier {
     } finally {
       _isLoading = false;
       notifyListeners();
+    }
+  }
+
+  /// Salvage homepage state written under [_legacyKey] before it got its own
+  /// key. The old blob is left alone: it may be the global BitwindowSettings.
+  Future<void> _migrateLegacySettings() async {
+    final settingValue = BitwindowSettingsValue();
+    try {
+      if (await _clientSettings.store.getString(settingValue.key) != null) {
+        return;
+      }
+
+      final legacy = await _clientSettings.store.getString(_legacyKey);
+      if (legacy == null) {
+        return;
+      }
+
+      final decoded = json.decode(legacy);
+      if (decoded is! Map<String, dynamic> ||
+          (!decoded.containsKey('hasConfiguredHomepage') && !decoded.containsKey('configureHomeButtonPressCount'))) {
+        return;
+      }
+
+      await _clientSettings.setValue(BitwindowSettingsValue(newValue: Settings.fromMap(decoded)));
+    } catch (e) {
+      // A missing key throws on some platforms, and a corrupt blob is not worth salvaging.
     }
   }
 

--- a/bitwindow/lib/providers/chat_provider.dart
+++ b/bitwindow/lib/providers/chat_provider.dart
@@ -376,8 +376,8 @@ class ChatProvider extends ChangeNotifier {
       return;
     }
 
-    // Get an address for sending to this contact
-    final address = await bitnamesRPC.getNewAddress();
+    // The contact's own address, never one of ours
+    final address = await bitnamesRPC.resolveOwnerAddress(entry.hash);
 
     final contact = ChatContact(
       id: entry.hash,
@@ -503,21 +503,28 @@ class ChatProvider extends ChangeNotifier {
     notifyListeners();
 
     try {
-      // 1. Encrypt the message with recipient's pubkey
+      // 1. Re-resolve the destination, the BitName UTXO moves when it is updated
+      final dest = await bitnamesRPC.resolveOwnerAddress(_selectedContact!.id);
+      if (dest == null) {
+        _error = 'No address found for ${_selectedContact!.displayName}, cannot send';
+        return null;
+      }
+
+      // 2. Encrypt the message with recipient's pubkey
       final ciphertext = await bitnamesRPC.encryptMsg(
         msg: content,
         encryptionPubkey: _selectedContact!.encryptionPubkey,
       );
 
-      // 2. Send as transfer with memo
+      // 3. Send as transfer with memo
       final txid = await bitnamesRPC.transfer(
-        dest: _selectedContact!.address,
+        dest: dest,
         value: _selectedContact!.paymailFeeSats ?? 1000,
         fee: 100,
         memo: ciphertext,
       );
 
-      // 3. Add to local message list
+      // 4. Add to local message list
       final message = ChatMessage(
         id: txid,
         content: content,
@@ -530,10 +537,11 @@ class ChatProvider extends ChangeNotifier {
       );
       _messages.add(message);
 
-      // 4. Update contact's last message
+      // 5. Update contact's last message and cache the address we just resolved
       final contactIndex = _contacts.indexWhere((c) => c.id == _selectedContact!.id);
       if (contactIndex >= 0) {
         _contacts[contactIndex] = _contacts[contactIndex].copyWith(
+          address: dest,
           lastMessage: content,
           lastMessageTime: DateTime.now(),
         );
@@ -575,11 +583,12 @@ class ChatProvider extends ChangeNotifier {
         return null;
       }
 
-      // Get an address for this identity
-      final address = await bitnamesRPC.getNewAddress();
+      // Contacts are keyed by hash so their address can be re-resolved
+      final hash = searchBitNameByPlaintext(nameOrHash)?.hash ?? nameOrHash;
+      final address = await bitnamesRPC.resolveOwnerAddress(hash);
 
       return ChatContact(
-        id: nameOrHash,
+        id: hash,
         name: nameOrHash,
         plaintextName: nameOrHash,
         encryptionPubkey: data.encryptionPubkey!,

--- a/bitwindow/lib/settings/bitwindow_settings.dart
+++ b/bitwindow/lib/settings/bitwindow_settings.dart
@@ -1,9 +1,11 @@
 import 'package:bitwindow/models/settings.dart';
 import 'package:sail_ui/sail_ui.dart';
 
+/// Local homepage/UI state. Distinct from sidechain_core's [BitwindowSettingValue],
+/// which owns the global 'bitwindow_settings' blob over the same store.
 class BitwindowSettingsValue extends SettingValue<Settings> {
   @override
-  String get key => 'bitwindow_settings';
+  String get key => 'bitwindow_homepage_settings';
 
   BitwindowSettingsValue({super.newValue});
 

--- a/bitwindow/lib/widgets/import_txid_modal.dart
+++ b/bitwindow/lib/widgets/import_txid_modal.dart
@@ -257,6 +257,7 @@ class ImportTxidModalViewModel extends BaseViewModel {
 
       await _saveImportedGroup(multisigData);
 
+      Object? syncError;
       try {
         loadingStatus = 'Setting up watch wallet...';
         notifyListeners();
@@ -282,16 +283,21 @@ class ImportTxidModalViewModel extends BaseViewModel {
         notifyListeners();
         await BalanceManager.updateGroupBalance(group);
       } catch (e) {
-        // Failed to restore transaction history - not critical for import
+        // Best-effort: the group is saved, but the wallet is not usable until it syncs.
+        syncError = e;
+        _logger.w('Failed to sync imported multisig group: $e');
       }
 
       loadingStatus = null;
 
       if (context.mounted) {
+        final name = multisigData['name'] ?? 'Unknown';
         showSailToast(
           context,
-          'Successfully imported multisig: ${multisigData['name'] ?? 'Unknown'}',
-          variant: SailToastVariant.success,
+          syncError == null
+              ? 'Successfully imported multisig: $name'
+              : 'Imported multisig: $name, but watch-wallet/history sync failed: $syncError - open the group to retry',
+          variant: syncError == null ? SailToastVariant.success : SailToastVariant.warning,
         );
         Navigator.of(context).pop(true);
       }

--- a/bitwindow/test/bitwindow_settings_key_test.dart
+++ b/bitwindow/test/bitwindow_settings_key_test.dart
@@ -1,0 +1,80 @@
+import 'package:bitwindow/models/settings.dart';
+import 'package:bitwindow/providers/bitwindow_settings_provider.dart';
+import 'package:bitwindow/settings/bitwindow_settings.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+import 'mocks/store_mock.dart';
+
+/// main.dart backs both settings objects with one store, so a shared key
+/// makes the two settings clobber each other.
+void _register() {
+  final store = MockStore();
+  final log = Logger();
+  GetIt.I.registerLazySingleton<Logger>(() => log);
+  GetIt.I.registerLazySingleton<ClientSettings>(() => ClientSettings(store: store, log: log));
+  GetIt.I.registerLazySingleton<BitwindowClientSettings>(() => BitwindowClientSettings(store: store, log: log));
+}
+
+Future<BitwindowSettingsProvider> _loadedProvider() async {
+  final provider = BitwindowSettingsProvider();
+  while (provider.isLoading) {
+    await Future<void>.delayed(Duration.zero);
+  }
+  return provider;
+}
+
+void main() {
+  setUp(_register);
+  tearDown(() => GetIt.I.reset());
+
+  test('saving homepage state leaves paranoid mode intact', () async {
+    final settingsProvider = await SettingsProvider.create();
+    await settingsProvider.updateParanoidMode(true);
+
+    final provider = await _loadedProvider();
+    await provider.markHomepageAsConfigured();
+
+    final global = await GetIt.I.get<BitwindowClientSettings>().getValue(BitwindowSettingValue());
+    expect(global.value.paranoidMode, isTrue);
+
+    final homepage = await GetIt.I.get<ClientSettings>().getValue(BitwindowSettingsValue());
+    expect(homepage.value.hasConfiguredHomepage, isTrue);
+  });
+
+  test('updating paranoid mode leaves homepage state intact', () async {
+    final provider = await _loadedProvider();
+    await provider.markHomepageAsConfigured();
+
+    final settingsProvider = await SettingsProvider.create();
+    await settingsProvider.updateParanoidMode(true);
+
+    final reloaded = await _loadedProvider();
+    expect(reloaded.settings.hasConfiguredHomepage, isTrue);
+  });
+
+  test('homepage state stored under the old key is migrated', () async {
+    final store = GetIt.I.get<ClientSettings>().store;
+    await store.setString(
+      'bitwindow_settings',
+      Settings(configureHomeButtonPressCount: 3, hasConfiguredHomepage: true).toJson(),
+    );
+
+    final provider = await _loadedProvider();
+    expect(provider.settings.hasConfiguredHomepage, isTrue);
+    expect(provider.settings.configureHomeButtonPressCount, 3);
+  });
+
+  test('a global settings blob under the old key is not migrated or dropped', () async {
+    final store = GetIt.I.get<ClientSettings>().store;
+    await store.setString('bitwindow_settings', BitwindowSettings(paranoidMode: true).toJson());
+
+    final provider = await _loadedProvider();
+    expect(provider.settings.hasConfiguredHomepage, isFalse);
+
+    final global = await GetIt.I.get<BitwindowClientSettings>().getValue(BitwindowSettingValue());
+    expect(global.value.paranoidMode, isTrue);
+  });
+}

--- a/bitwindow/test/chat_provider_test.dart
+++ b/bitwindow/test/chat_provider_test.dart
@@ -1,0 +1,139 @@
+import 'package:bitwindow/models/chat_models.dart';
+import 'package:bitwindow/providers/chat_provider.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/mocks/mocks.dart';
+
+import 'mocks/store_mock.dart';
+
+const _recipientHash = 'aaaabbbbccccdddd';
+
+/// A chain UTXO holding a BitName, as list_utxos returns it.
+BitnamesUTXO bitnameUTXO(String hash, String address) => BitnamesUTXO.fromJson({
+  'outpoint': {
+    'Regular': {'txid': 'deadbeef', 'vout': 0},
+  },
+  'output': {
+    'address': address,
+    'content': {'BitName': hash},
+  },
+});
+
+class _FakeBitnames extends MockBitnamesRPC {
+  List<SidechainUTXO> chainUTXOs = [];
+  final List<String> transferDests = [];
+  int newAddressCalls = 0;
+
+  @override
+  Future<List<SidechainUTXO>> listAllUTXOs() async => chainUTXOs;
+
+  @override
+  Future<String> getNewAddress() async {
+    newAddressCalls++;
+    return super.getNewAddress();
+  }
+
+  @override
+  Future<String> transfer({
+    required String dest,
+    required int value,
+    required int fee,
+    String? memo,
+  }) async {
+    transferDests.add(dest);
+    return 'txid_transfer';
+  }
+}
+
+class _FakeBalance extends ChangeNotifier implements BalanceProvider {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late _FakeBitnames bitnames;
+  late ChatProvider provider;
+
+  BitnameEntry entry(String hash) => BitnameEntry(
+    hash: hash,
+    details: BitnameDetails(seqId: '0', encryptionPubkey: 'pubkey_$hash'),
+  );
+
+  ChatContact contact({String? address}) => ChatContact(
+    id: _recipientHash,
+    name: _recipientHash,
+    encryptionPubkey: 'pubkey_$_recipientHash',
+    address: address,
+  );
+
+  setUp(() async {
+    await GetIt.I.reset();
+    final log = Logger();
+    GetIt.I.registerSingleton<Logger>(log);
+    GetIt.I.registerSingleton<ClientSettings>(ClientSettings(store: MockStore(), log: log));
+    bitnames = _FakeBitnames();
+    GetIt.I.registerSingleton<BitnamesRPC>(bitnames);
+    GetIt.I.registerSingleton<BalanceProvider>(_FakeBalance());
+    provider = ChatProvider();
+    provider.selectIdentity(entry('my_own_identity'));
+  });
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  test('sends to the address that holds the recipient BitName', () async {
+    bitnames.chainUTXOs = [bitnameUTXO(_recipientHash, 'recipient_address')];
+    provider.selectContact(contact());
+
+    final txid = await provider.sendMessage('hello');
+
+    expect(txid, 'txid_transfer');
+    expect(bitnames.transferDests, ['recipient_address']);
+    expect(bitnames.newAddressCalls, 0, reason: 'our own wallet never supplies the destination');
+  });
+
+  // The BitName UTXO moves every time its owner updates it, so a cached
+  // address goes stale.
+  test('re-resolves the destination instead of reusing the stored address', () async {
+    bitnames.chainUTXOs = [bitnameUTXO(_recipientHash, 'moved_to_address')];
+    provider.selectContact(contact(address: 'stale_address'));
+
+    await provider.sendMessage('hello');
+
+    expect(bitnames.transferDests, ['moved_to_address']);
+  });
+
+  // Paying an address we cannot resolve means paying ourselves.
+  test('refuses to send when the recipient address cannot be resolved', () async {
+    bitnames.chainUTXOs = [];
+    provider.selectContact(contact(address: 'stale_address'));
+
+    final txid = await provider.sendMessage('hello');
+
+    expect(txid, isNull);
+    expect(bitnames.transferDests, isEmpty);
+    expect(provider.error, contains('cannot send'));
+    expect(provider.messages, isEmpty);
+  });
+
+  test('stores the owner address of a contact added from a BitName', () async {
+    bitnames.chainUTXOs = [bitnameUTXO(_recipientHash, 'recipient_address')];
+
+    await provider.addContactFromEntry(entry(_recipientHash));
+
+    expect(provider.contacts.single.address, 'recipient_address');
+    expect(bitnames.newAddressCalls, 0);
+  });
+
+  test('leaves the address unset when the BitName is not on chain', () async {
+    bitnames.chainUTXOs = [bitnameUTXO('some_other_bitname', 'someone_elses_address')];
+
+    await provider.addContactFromEntry(entry(_recipientHash));
+
+    expect(provider.contacts.single.address, isNull);
+  });
+}

--- a/bitwindow/test/check_detail_page_double_tap_test.dart
+++ b/bitwindow/test/check_detail_page_double_tap_test.dart
@@ -1,0 +1,154 @@
+import 'dart:async';
+
+import 'package:bitwindow/pages/wallet/check_detail_page.dart';
+import 'package:bitwindow/providers/check_provider.dart';
+import 'package:bitwindow/providers/transactions_provider.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart' as bwpb;
+import 'package:sidechain_core/gen/walletmanager/v1/walletmanager.pb.dart' as wmpb;
+
+import 'test_utils.dart';
+
+const _address = 'bcrt1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+const _wif = 'cVjzvdHGfQDtBEq7oddDRZ9uHt6EWWSuUJHfXKgL9pUAmL7Hzc4v';
+
+bwpb.Cheque _check({bool funded = false}) => bwpb.Cheque(
+  id: Int64(1),
+  derivationIndex: 1,
+  address: _address,
+  expectedAmountSats: Int64(210000000),
+  fundedTxids: funded ? ['deadbeef'] : const [],
+  privateKeyWif: _wif,
+);
+
+class _FakeCheckProvider extends ChangeNotifier implements CheckProvider {
+  _FakeCheckProvider(this._cheque);
+
+  final bwpb.Cheque _cheque;
+  int sweepCalls = 0;
+  final Completer<String> sweepCompleter = Completer<String>();
+
+  @override
+  Future<bwpb.Cheque?> getCheck(int id) async => _cheque;
+
+  @override
+  void startPolling(int checkId, {Duration interval = const Duration(seconds: 5)}) {}
+
+  @override
+  Future<String> sweepCheck(String privateKeyWif, String destinationAddress, int feeSatPerVbyte) {
+    sweepCalls++;
+    return sweepCompleter.future;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeTransactions extends ChangeNotifier implements TransactionProvider {
+  @override
+  String address = _address;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeWalletReader extends ChangeNotifier implements WalletReaderProvider {
+  @override
+  String? activeWalletId = 'wallet-1';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeOrchestratorWallet implements OrchestratorWalletRPC {
+  int sendCalls = 0;
+  final Completer<wmpb.SendTransactionResponse> sendCompleter = Completer<wmpb.SendTransactionResponse>();
+
+  @override
+  Future<wmpb.SendTransactionResponse> sendTransaction({
+    required String walletId,
+    required Map<String, int> destinations,
+    int? feeRateSatPerVbyte,
+    int? fixedFeeSats,
+    bool subtractFeeFromAmount = false,
+    String? opReturnMessage,
+    String? opReturnHex,
+    List<bwpb.UnspentOutput>? requiredInputs,
+    bool allowReplay = false,
+  }) {
+    sendCalls++;
+    return sendCompleter.future;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeOrchestrator implements OrchestratorRPC {
+  @override
+  OrchestratorWalletRPC wallet = _FakeOrchestratorWallet();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeConf implements BitcoinConfProvider {
+  @override
+  BitcoinNetwork get network => BitcoinNetwork.BITCOIN_NETWORK_REGTEST;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<_FakeCheckProvider> _pumpCheckDetail(WidgetTester tester, {required bool funded}) async {
+  final checkProvider = _FakeCheckProvider(_check(funded: funded));
+  GetIt.I.registerSingleton<CheckProvider>(checkProvider);
+  GetIt.I.registerSingleton<TransactionProvider>(_FakeTransactions());
+  GetIt.I.registerSingleton<WalletReaderProvider>(_FakeWalletReader());
+  GetIt.I.registerSingleton<OrchestratorRPC>(_FakeOrchestrator());
+  GetIt.I.registerSingleton<BitcoinConfProvider>(_FakeConf());
+
+  await tester.pumpSailPage(const CheckDetailPage(checkId: 1));
+  await tester.pump();
+  await tester.pump();
+
+  return checkProvider;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized({
+    'flutter.test.automatic_wait_for_timers': 'false',
+  });
+
+  setUp(() async {
+    await GetIt.I.reset();
+  });
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  testWidgets('tapping Fund with Wallet twice sends one transaction', (tester) async {
+    await _pumpCheckDetail(tester, funded: false);
+    final wallet = GetIt.I.get<OrchestratorRPC>().wallet as _FakeOrchestratorWallet;
+
+    // Both taps land before the send resolves — the second must be dropped.
+    await tester.tap(find.text('Fund with Wallet'));
+    await tester.tap(find.text('Fund with Wallet'));
+
+    expect(wallet.sendCalls, 1);
+  });
+
+  testWidgets('tapping Sweep Check to Wallet twice sweeps once', (tester) async {
+    final checkProvider = await _pumpCheckDetail(tester, funded: true);
+
+    await tester.tap(find.text('Sweep Check to Wallet'));
+    await tester.tap(find.text('Sweep Check to Wallet'));
+
+    expect(checkProvider.sweepCalls, 1);
+  });
+}

--- a/bitwindow/test/send_frozen_utxo_test.dart
+++ b/bitwindow/test/send_frozen_utxo_test.dart
@@ -1,0 +1,66 @@
+import 'package:bitwindow/pages/wallet/wallet_send.dart';
+import 'package:bitwindow/utils/coin_selection.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sidechain_core/gen/wallet/v1/wallet.pb.dart';
+
+UnspentOutput coin(String output, int sats) => UnspentOutput(output: output, valueSats: Int64(sats));
+
+String formatSats(int sats) => '$sats sats';
+
+void main() {
+  test('a send picks its inputs around a frozen coin', () {
+    final frozen = coin('aa:0', 200_000);
+    final free = coin('bb:0', 100_000);
+    expect(
+      SendPageViewModel.unfrozenInputs(
+        selected: const [],
+        allUtxos: [frozen, free],
+        frozenOutpoints: {'aa:0'},
+        targetSats: 50_000,
+        formatSats: formatSats,
+      ),
+      [free],
+    );
+  });
+
+  test('a send with nothing frozen pins no inputs', () {
+    expect(
+      SendPageViewModel.unfrozenInputs(
+        selected: const [],
+        allUtxos: [coin('aa:0', 200_000)],
+        frozenOutpoints: const {},
+        targetSats: 50_000,
+        formatSats: formatSats,
+      ),
+      isEmpty,
+    );
+  });
+
+  test('a frozen coin the user picked is still spent', () {
+    final frozen = coin('aa:0', 200_000);
+    expect(
+      SendPageViewModel.unfrozenInputs(
+        selected: [frozen],
+        allUtxos: [frozen, coin('bb:0', 100_000)],
+        frozenOutpoints: {'aa:0'},
+        targetSats: 50_000,
+        formatSats: formatSats,
+      ),
+      [frozen],
+    );
+  });
+
+  test('a send the unfrozen coins cannot pay fails instead of thawing one', () {
+    expect(
+      () => SendPageViewModel.unfrozenInputs(
+        selected: const [],
+        allUtxos: [coin('aa:0', 200_000), coin('bb:0', 10_000)],
+        frozenOutpoints: {'aa:0'},
+        targetSats: 50_000,
+        formatSats: formatSats,
+      ),
+      throwsA(isA<InsufficientFundsException>()),
+    );
+  });
+}

--- a/sidechain_core/lib/rpcs/bitnames_rpc.dart
+++ b/sidechain_core/lib/rpcs/bitnames_rpc.dart
@@ -120,6 +120,25 @@ abstract class BitnamesRPC extends SidechainRPC {
   /// Resolve a commitment from a BitName
   Future<String> resolveCommit(String bitname);
 
+  /// Address holding the BitName UTXO, or null when the BitName is unknown.
+  Future<String?> resolveOwnerAddress(String bitnameHash) async {
+    final utxos = await listAllUTXOs();
+    for (final utxo in utxos) {
+      if (utxo.type != OutpointType.bitname || utxo is! BitnamesUTXO) {
+        continue;
+      }
+      try {
+        final content = jsonDecode(utxo.content) as Map<String, dynamic>;
+        if (content['BitName'] == bitnameHash) {
+          return utxo.address;
+        }
+      } catch (e) {
+        // Skip malformed content
+      }
+    }
+    return null;
+  }
+
   /// Sign an arbitrary message with the specified verifying key
   Future<String> signArbitraryMsg({
     required String msg,


### PR DESCRIPTION
A set of **5 independent fixes** to the BitWindow Flutter UI, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`12 files changed, 586 insertions(+), 23 deletions(-)`).

## Fixes (oldest first)

- **`ca8746257`** BitWindow cheque "Fund with Wallet" can pay the same cheque twice
- **`07607fb04`** BitWindow's "Freeze UTXO" action is not enforced on the default "Any UTXO" send path: the orchestrator WalletManager.SendTransaction RPC has no frozen/excluded-outpoint field and is called with an empty required_inputs set, so a frozen outpoint can be auto-selected and spent.
- **`42aef1ff3`** BitWindow `ImportTxidModalViewModel.importFromTxid` broad try swallows watch-wallet setup, tx history, and balance-sync failures
- **`19bc4cd30`** BitWindow chat sends Paymail to sender-owned address
- **`52b7fa49c`** Homepage settings overwrite BitWindow paranoid mode

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.