### PR TITLE
BitWindow orchestrator: 3 fixes from a security review

### DIFF
--- a/sidechain-orchestrator/sidechain/coinshift/handler.go
+++ b/sidechain-orchestrator/sidechain/coinshift/handler.go
@@ -2,6 +2,7 @@ package coinshift
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -245,25 +246,31 @@ func (h *Handler) OpenapiSchema(ctx context.Context, req *connect.Request[pb.Ope
 // --- Swap methods ---
 
 func (h *Handler) CreateSwap(ctx context.Context, req *connect.Request[pb.CreateSwapRequest]) (*connect.Response[pb.CreateSwapResponse], error) {
-	var result struct {
-		SwapID string `json:"swap_id"`
-		Txid   string `json:"txid"`
-	}
 	params := []any{
-		req.Msg.L2AmountSats,
-		req.Msg.L1AmountSats,
-		req.Msg.L1RecipientAddress,
 		req.Msg.ParentChain,
+		req.Msg.L1RecipientAddress,
+		req.Msg.L1AmountSats,
 		req.Msg.L2Recipient,
+		req.Msg.L2AmountSats,
 		req.Msg.RequiredConfirmations,
 		req.Msg.FeeSats,
 	}
-	if err := h.proxy.Client.Call(ctx, "create_swap", params, &result); err != nil {
+	// The backend returns a (SwapId, Txid) tuple, with the swap id as 32 bytes.
+	var tuple [2]json.RawMessage
+	if err := h.proxy.Client.Call(ctx, "create_swap", params, &tuple); err != nil {
 		return nil, err
 	}
+	var swapID [32]byte
+	if err := json.Unmarshal(tuple[0], &swapID); err != nil {
+		return nil, fmt.Errorf("unmarshal swap id: %w", err)
+	}
+	var txid string
+	if err := json.Unmarshal(tuple[1], &txid); err != nil {
+		return nil, fmt.Errorf("unmarshal txid: %w", err)
+	}
 	return connect.NewResponse(&pb.CreateSwapResponse{
-		SwapId: result.SwapID,
-		Txid:   result.Txid,
+		SwapId: hex.EncodeToString(swapID[:]),
+		Txid:   txid,
 	}), nil
 }
 

--- a/sidechain-orchestrator/sidechain/coinshift/handler_test.go
+++ b/sidechain-orchestrator/sidechain/coinshift/handler_test.go
@@ -1,0 +1,80 @@
+package coinshift
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/gen/coinshift/v1"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/rpc"
+	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/sidechain"
+)
+
+// handlerFromServer builds a Handler whose JSON-RPC proxy targets srv.
+func handlerFromServer(t *testing.T, srv *httptest.Server) *Handler {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	host, port, err := net.SplitHostPort(u.Host)
+	require.NoError(t, err)
+	portNum, err := strconv.Atoi(port)
+	require.NoError(t, err)
+	return NewHandler(&sidechain.JSONRPCProxy{Client: rpc.New(host, portNum)})
+}
+
+func TestCreateSwap(t *testing.T) {
+	var gotMethod string
+	var gotParams json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotMethod, gotParams = req.Method, req.Params
+
+		// Backend returns a (SwapId, Txid) tuple; the swap id is 32 bytes.
+		swapID := make([]int, 32)
+		swapID[0], swapID[31] = 1, 255
+		result, err := json.Marshal([]any{swapID, "abc123"})
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(rpcResponse{Result: result}))
+	}))
+	defer srv.Close()
+
+	l2Recipient := "cs1qrecipient"
+	requiredConfirmations := int32(6)
+
+	h := handlerFromServer(t, srv)
+	resp, err := h.CreateSwap(context.Background(), connect.NewRequest(&pb.CreateSwapRequest{
+		L2AmountSats:          2_000,
+		L1AmountSats:          1_000,
+		L1RecipientAddress:    "bc1qrecipient",
+		ParentChain:           "Signet",
+		L2Recipient:           &l2Recipient,
+		RequiredConfirmations: &requiredConfirmations,
+		FeeSats:               10,
+	}))
+	require.NoError(t, err)
+
+	assert.Equal(t, "create_swap", gotMethod)
+	assert.JSONEq(t,
+		`["Signet","bc1qrecipient",1000,"cs1qrecipient",2000,6,10]`,
+		string(gotParams))
+	assert.Equal(t, "01"+strings.Repeat("00", 30)+"ff", resp.Msg.SwapId)
+	assert.Equal(t, "abc123", resp.Msg.Txid)
+}

--- a/sidechain-orchestrator/wallet/bip47/derive.go
+++ b/sidechain-orchestrator/wallet/bip47/derive.go
@@ -11,8 +11,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 )
 
-// AddressType selects between P2PKH (BIP47 v1 default) and P2WPKH (segwit
-// feature, recipient code byte 79 == 0x01).
+// AddressType selects between P2PKH (BIP47 v1 default) and P2WPKH.
 type AddressType int
 
 const (

--- a/sidechain-orchestrator/wallet/bip47/paymentcode.go
+++ b/sidechain-orchestrator/wallet/bip47/paymentcode.go
@@ -56,6 +56,17 @@ func parseFromCheckDecoded(b []byte) (*PaymentCode, error) {
 	if pc.SignByte != 0x02 && pc.SignByte != 0x03 {
 		return nil, fmt.Errorf("invalid sign byte 0x%02x", pc.SignByte)
 	}
+	// v1 fixes the features byte and bytes 67-79 at zero. Accepting anything
+	// else would let one key pair have several encodings, each deriving the
+	// same addresses off its own send-index counter.
+	if pc.Features != 0x00 {
+		return nil, fmt.Errorf("unsupported features byte 0x%02x", pc.Features)
+	}
+	for i, v := range pc.Reserved {
+		if v != 0x00 {
+			return nil, fmt.Errorf("reserved byte %d must be zero, got 0x%02x", 67+i, v)
+		}
+	}
 	if _, err := pc.PubKey(); err != nil {
 		return nil, fmt.Errorf("invalid pubkey: %w", err)
 	}

--- a/sidechain-orchestrator/wallet/bip47/paymentcode_test.go
+++ b/sidechain-orchestrator/wallet/bip47/paymentcode_test.go
@@ -62,6 +62,32 @@ func TestPaymentCode_RejectsWrongVersionByte(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestPaymentCode_RejectsNonCanonicalEncodings pins that a second encoding of
+// the same key material — features byte set, or any reserved byte non-zero —
+// does not parse. Such a code derives exactly the same addresses as the
+// canonical one, so accepting it splits the send-index state and reuses them.
+func TestPaymentCode_RejectsNonCanonicalEncodings(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(*PaymentCode)
+	}{
+		{"features byte set", func(pc *PaymentCode) { pc.Features = 0x01 }},
+		{"first reserved byte set", func(pc *PaymentCode) { pc.Reserved[0] = 0x01 }},
+		{"last reserved byte set", func(pc *PaymentCode) { pc.Reserved[12] = 0x01 }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			pc, err := ParsePaymentCode(bobPaymentCode)
+			require.NoError(t, err)
+			tt.mutate(pc)
+
+			alias := pc.Base58()
+			require.NotEqual(t, bobPaymentCode, alias)
+			_, err = ParsePaymentCode(alias)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestNotificationAddress_AliceMainnet(t *testing.T) {
 	pc, err := ParsePaymentCode(alicePaymentCode)
 	require.NoError(t, err)

--- a/sidechain-orchestrator/wallet/bip47send/bip47send.go
+++ b/sidechain-orchestrator/wallet/bip47send/bip47send.go
@@ -209,8 +209,8 @@ type SubstituteResult struct {
 	// by a derived per-payment address. Identity to the input when no BIP47
 	// code is present.
 	Destinations map[string]int64
-	// RecipientCode is the BIP47 code of the recipient, or "" when no BIP47
-	// destination was found.
+	// RecipientCode is the recipient's canonical BIP47 code, or "" when no
+	// BIP47 destination was found.
 	RecipientCode string
 	// Recipient is the parsed payment code, nil when no BIP47 destination.
 	Recipient *bip47.PaymentCode
@@ -270,7 +270,11 @@ func SubstituteBip47Destination(
 		return nil, ErrSelfSend
 	}
 
-	idx, err := reserver.ReserveNextIndex(walletID, bip47Addr)
+	// Key persistent state on the code's canonical encoding, not on whatever
+	// string the caller passed, so one recipient always gets one counter.
+	recipientCode := recipient.Base58()
+
+	idx, err := reserver.ReserveNextIndex(walletID, recipientCode)
 	if err != nil {
 		return nil, fmt.Errorf("reserve next index: %w", err)
 	}
@@ -282,7 +286,7 @@ func SubstituteBip47Destination(
 
 	return &SubstituteResult{
 		Destinations:  map[string]int64{derived.EncodeAddress(): bip47Sats},
-		RecipientCode: bip47Addr,
+		RecipientCode: recipientCode,
 		Recipient:     recipient,
 		Index:         idx,
 		IsBip47:       true,

--- a/sidechain-orchestrator/wallet/bip47send/bip47send_test.go
+++ b/sidechain-orchestrator/wallet/bip47send/bip47send_test.go
@@ -176,6 +176,27 @@ func TestSubstituteBip47Destination_AlignsWithVectors(t *testing.T) {
 	}
 }
 
+// TestSubstituteBip47Destination_ReservedByteAliasGetsNoCounter pins that a
+// re-encoding of Bob's code with a reserved byte set never opens a second
+// send-index row: it derives the same addresses as the canonical code, so its
+// own counter would hand out addresses already paid to.
+func TestSubstituteBip47Destination_ReservedByteAliasGetsNoCounter(t *testing.T) {
+	bob, err := bip47.ParsePaymentCode(bobPM)
+	require.NoError(t, err)
+	bob.Reserved[12] = 0x01
+	alias := bob.Base58()
+
+	reserver := &fakeReserver{}
+	r, err := SubstituteBip47Destination(aliceSeedHex, "w1", map[string]int64{bobPM: 100_000}, &chaincfg.MainNetParams, reserver)
+	require.NoError(t, err)
+	require.True(t, r.IsBip47)
+
+	r2, err := SubstituteBip47Destination(aliceSeedHex, "w1", map[string]int64{alias: 100_000}, &chaincfg.MainNetParams, reserver)
+	require.NoError(t, err)
+	assert.False(t, r2.IsBip47, "a non-canonical encoding must not read as a payment code")
+	assert.Len(t, reserver.counters, 1, "the alias must not get a counter of its own")
+}
+
 func TestSubstituteBip47Destination_PassthroughForNonBip47(t *testing.T) {
 	reserver := &fakeReserver{}
 	dest := map[string]int64{

--- a/sidechain-orchestrator/wallet/enforcer_companion_test.go
+++ b/sidechain-orchestrator/wallet/enforcer_companion_test.go
@@ -48,6 +48,14 @@ func TestNoCompanionWhereTheEnforcerAccountIsStandard(t *testing.T) {
 	assert.Len(t, svc.GetAllWallets(), 1, "the wallet already looks where the coins are")
 }
 
+// Testnet's coin type is also 1, so the enforcer's account is standard there
+// too. Reading the network off a map of the networks BIP47 sends support
+// instead panicked the daemon before it ever finished starting.
+func TestNoCompanionOnTestnet(t *testing.T) {
+	svc := loadEnforcerWallet(t, config.NetworkTestnet, "")
+	assert.Len(t, svc.GetAllWallets(), 1, "the wallet already looks where the coins are")
+}
+
 // On mainnet the enforcer's coin type 1 is not the standard account, so its
 // coins live in a tree the wallet would never scan.
 func TestCompanionOnMainnetWhereTheAccountDiffers(t *testing.T) {

--- a/sidechain-orchestrator/wallet/service.go
+++ b/sidechain-orchestrator/wallet/service.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/config"
-	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/wallet/bip47send"
 	"github.com/LayerTwo-Labs/sidesail/sidechain-orchestrator/walletfile"
 	"github.com/btcsuite/btcd/chaincfg"
 
@@ -2076,14 +2075,12 @@ func (s *Service) StarterWalletID() string {
 func (s *Service) derivesEnforcerAccount(w *WalletData) bool {
 	// Forknet and ecash run on mainnet params, so a string compare against
 	// mainnet reads their coin type as 1 and skips the companion they need.
-	net, err := bip47send.NetworkParams(s.network)
-	if err != nil {
-		// Testnet params here read the coin type as 1, which is the answer this
-		// function exists to avoid. The daemon refuses an unknown network at
-		// startup, so this cannot happen.
-		panic(fmt.Sprintf("unknown network %q: %v", s.network, err))
+	n, known := config.LookupNetwork(s.network)
+	if !known {
+		// The daemon refuses an unknown network at startup, so this cannot happen.
+		panic(fmt.Sprintf("unknown network %q", s.network))
 	}
-	ap, err := accountPathFor(w, walletReceiveKind(w), net)
+	ap, err := accountPathFor(w, walletReceiveKind(w), config.ChainParamsFor(n))
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
A set of **3 independent fixes** to the BitWindow orchestrator, stacked on one branch so they can be reviewed together and cherry-picked individually. Based on current `master`; the branch builds and its tests pass at the tip (`9 files changed, 177 insertions(+), 24 deletions(-)`).

## Fixes (oldest first)

- **`156a894ea`** CoinShift typed Create Swap cannot create or broadcast a swap
- **`cd777556d`** BIP47 reserved-byte aliases split state and reuse payment addresses
- **`c75971e7d`** testnet startup panics while migrating a matching legacy enforcer wallet

---
Each commit is self-contained — `git cherry-pick <sha>` works for any of them. Happy to split, reorder, or drop any. Finding reports for individual fixes available on request.